### PR TITLE
[ty] Run benchmarks for a packed Type representation

### DIFF
--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -303,9 +303,10 @@ impl<'a> CallSitesFinder<'a, '_> {
     /// accessor: a read calls the getter, a write calls the setter, and a
     /// `del` calls the deleter.
     fn check_property_access(&mut self, attribute: &'a ast::ExprAttribute) {
-        let Some(Type::PropertyInstance(property)) =
-            static_member_type_for_attribute(self.model, attribute)
-        else {
+        let Some(ty) = static_member_type_for_attribute(self.model, attribute) else {
+            return;
+        };
+        let ty_python_semantic::types::TypeData::PropertyInstance(property) = ty.data() else {
             return;
         };
 

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -455,18 +455,12 @@ impl<'db> CompletionBuilder<'db> {
             if ctx.is_in_class_def() {
                 self.is_context_specific |= ty.is_class_literal()
                     || matches!(
-                        {
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (
-                            _,
-                            ty_python_semantic::types::TypeData::SpecialForm(
-                                SpecialFormType::Protocol
-                                    | SpecialFormType::Generic
-                                    | SpecialFormType::TypedDict
-                                    | SpecialFormType::NamedTuple
-                            )
+                        ty.data(),
+                        ty_python_semantic::types::TypeData::SpecialForm(
+                            SpecialFormType::Protocol
+                                | SpecialFormType::Generic
+                                | SpecialFormType::TypedDict
+                                | SpecialFormType::NamedTuple
                         )
                     );
             }
@@ -2824,86 +2818,53 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
         ty: Type<'db>,
         visitor: &CompletionKindVisitor<'db>,
     ) -> Option<CompletionKind> {
-        Some(
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::FunctionLiteral(_)
-                    | ty_python_semantic::types::TypeData::DataclassDecorator(_)
-                    | ty_python_semantic::types::TypeData::WrapperDescriptor(_)
-                    | ty_python_semantic::types::TypeData::DataclassTransformer(_)
-                    | ty_python_semantic::types::TypeData::Callable(_),
-                ) => CompletionKind::Function,
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::BoundMethod(_)
-                    | ty_python_semantic::types::TypeData::KnownBoundMethod(_),
-                ) => CompletionKind::Method,
-                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
-                    CompletionKind::Module
-                }
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::ClassLiteral(_)
-                    | ty_python_semantic::types::TypeData::GenericAlias(_)
-                    | ty_python_semantic::types::TypeData::SubclassOf(_),
-                ) => CompletionKind::Class,
-                // This is a little weird for "struct." I'm mostly interpreting
-                // "struct" here as a more general "object." ---AG
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::NominalInstance(_)
-                    | ty_python_semantic::types::TypeData::PropertyInstance(_)
-                    | ty_python_semantic::types::TypeData::BoundSuper(_)
-                    | ty_python_semantic::types::TypeData::TypedDict(_)
-                    | ty_python_semantic::types::TypeData::NewTypeInstance(_)
-                    | ty_python_semantic::types::TypeData::EnumComplement(_),
-                ) => CompletionKind::Struct,
-                (_, ty_python_semantic::types::TypeData::LiteralValue(literal))
-                    if literal.is_enum() =>
-                {
-                    CompletionKind::Enum
-                }
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::LiteralValue(_)
-                    | ty_python_semantic::types::TypeData::TypeIs(_)
-                    | ty_python_semantic::types::TypeData::TypeGuard(_)
-                    | ty_python_semantic::types::TypeData::TypeForm(_),
-                ) => CompletionKind::Value,
-                (_, ty_python_semantic::types::TypeData::ProtocolInstance(_)) => {
-                    CompletionKind::Interface
-                }
-                (_, ty_python_semantic::types::TypeData::TypeVar(_)) => {
-                    CompletionKind::TypeParameter
-                }
-                (_, ty_python_semantic::types::TypeData::Union(union)) => union
-                    .elements(db)
-                    .iter()
-                    .find_map(|&ty| imp(db, ty, visitor))?,
-                (_, ty_python_semantic::types::TypeData::Intersection(intersection)) => {
-                    intersection
-                        .iter_positive(db)
-                        .find_map(|ty| imp(db, ty, visitor))?
-                }
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::Dynamic(_)
-                    | ty_python_semantic::types::TypeData::Divergent(_)
-                    | ty_python_semantic::types::TypeData::Never
-                    | ty_python_semantic::types::TypeData::SpecialForm(_)
-                    | ty_python_semantic::types::TypeData::KnownInstance(_)
-                    | ty_python_semantic::types::TypeData::AlwaysTruthy
-                    | ty_python_semantic::types::TypeData::AlwaysFalsy,
-                ) => return None,
-                (_, ty_python_semantic::types::TypeData::TypeAlias(alias)) => {
-                    visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
-                }
-            },
-        )
+        Some(match ty.data() {
+            ty_python_semantic::types::TypeData::FunctionLiteral(_)
+            | ty_python_semantic::types::TypeData::DataclassDecorator(_)
+            | ty_python_semantic::types::TypeData::WrapperDescriptor(_)
+            | ty_python_semantic::types::TypeData::DataclassTransformer(_)
+            | ty_python_semantic::types::TypeData::Callable(_) => CompletionKind::Function,
+            ty_python_semantic::types::TypeData::BoundMethod(_)
+            | ty_python_semantic::types::TypeData::KnownBoundMethod(_) => CompletionKind::Method,
+            ty_python_semantic::types::TypeData::ModuleLiteral(_) => CompletionKind::Module,
+            ty_python_semantic::types::TypeData::ClassLiteral(_)
+            | ty_python_semantic::types::TypeData::GenericAlias(_)
+            | ty_python_semantic::types::TypeData::SubclassOf(_) => CompletionKind::Class,
+            // This is a little weird for "struct." I'm mostly interpreting
+            // "struct" here as a more general "object." ---AG
+            ty_python_semantic::types::TypeData::NominalInstance(_)
+            | ty_python_semantic::types::TypeData::PropertyInstance(_)
+            | ty_python_semantic::types::TypeData::BoundSuper(_)
+            | ty_python_semantic::types::TypeData::TypedDict(_)
+            | ty_python_semantic::types::TypeData::NewTypeInstance(_)
+            | ty_python_semantic::types::TypeData::EnumComplement(_) => CompletionKind::Struct,
+            ty_python_semantic::types::TypeData::LiteralValue(literal) if literal.is_enum() => {
+                CompletionKind::Enum
+            }
+            ty_python_semantic::types::TypeData::LiteralValue(_)
+            | ty_python_semantic::types::TypeData::TypeIs(_)
+            | ty_python_semantic::types::TypeData::TypeGuard(_)
+            | ty_python_semantic::types::TypeData::TypeForm(_) => CompletionKind::Value,
+            ty_python_semantic::types::TypeData::ProtocolInstance(_) => CompletionKind::Interface,
+            ty_python_semantic::types::TypeData::TypeVar(_) => CompletionKind::TypeParameter,
+            ty_python_semantic::types::TypeData::Union(union) => union
+                .elements(db)
+                .iter()
+                .find_map(|&ty| imp(db, ty, visitor))?,
+            ty_python_semantic::types::TypeData::Intersection(intersection) => intersection
+                .iter_positive(db)
+                .find_map(|ty| imp(db, ty, visitor))?,
+            ty_python_semantic::types::TypeData::Dynamic(_)
+            | ty_python_semantic::types::TypeData::Divergent(_)
+            | ty_python_semantic::types::TypeData::Never
+            | ty_python_semantic::types::TypeData::SpecialForm(_)
+            | ty_python_semantic::types::TypeData::KnownInstance(_)
+            | ty_python_semantic::types::TypeData::AlwaysTruthy
+            | ty_python_semantic::types::TypeData::AlwaysFalsy => return None,
+            ty_python_semantic::types::TypeData::TypeAlias(alias) => {
+                visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
+            }
+        })
     }
     imp(db, ty, &CompletionKindVisitor::default())
 }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -455,12 +455,18 @@ impl<'db> CompletionBuilder<'db> {
             if ctx.is_in_class_def() {
                 self.is_context_specific |= ty.is_class_literal()
                     || matches!(
-                        ty,
-                        Type::SpecialForm(
-                            SpecialFormType::Protocol
-                                | SpecialFormType::Generic
-                                | SpecialFormType::TypedDict
-                                | SpecialFormType::NamedTuple
+                        {
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (
+                            _,
+                            ty_python_semantic::types::TypeData::SpecialForm(
+                                SpecialFormType::Protocol
+                                    | SpecialFormType::Generic
+                                    | SpecialFormType::TypedDict
+                                    | SpecialFormType::NamedTuple
+                            )
                         )
                     );
             }
@@ -904,10 +910,14 @@ impl<'m> ContextCursor<'m> {
             ast::AnyNodeRef::StmtAnnAssign(stmt) => {
                 contains(&stmt.annotation)
                     || (stmt.value.as_deref().is_some_and(contains)
-                        && matches!(
-                            stmt.annotation.inferred_type(model),
-                            Some(Type::SpecialForm(SpecialFormType::TypeAlias))
-                        ))
+                        && stmt.annotation.inferred_type(model).is_some_and(|ty| {
+                            matches!(
+                                ty.data(),
+                                ty_python_semantic::types::TypeData::SpecialForm(
+                                    SpecialFormType::TypeAlias
+                                )
+                            )
+                        }))
             }
             ast::AnyNodeRef::StmtFunctionDef(stmt) => stmt.returns.as_deref().is_some_and(contains),
             ast::AnyNodeRef::StmtTypeAlias(stmt) => contains(&stmt.value),
@@ -2681,7 +2691,9 @@ fn add_import_completions<'db>(
     semantic_completions: impl IntoIterator<Item = SemanticCompletion<'db>>,
 ) {
     add_import_completions_impl(db, completions, semantic_completions, |semantic| {
-        if let Some(Type::ModuleLiteral(module_literal)) = semantic.ty {
+        if let Some(ty_python_semantic::types::TypeData::ModuleLiteral(module_literal)) =
+            semantic.ty.map(Type::data)
+        {
             Some(ModuleDependencyKind::from_module(
                 db,
                 module_literal.module(db),
@@ -2812,49 +2824,86 @@ fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Comp
         ty: Type<'db>,
         visitor: &CompletionKindVisitor<'db>,
     ) -> Option<CompletionKind> {
-        Some(match ty {
-            Type::FunctionLiteral(_)
-            | Type::DataclassDecorator(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassTransformer(_)
-            | Type::Callable(_) => CompletionKind::Function,
-            Type::BoundMethod(_) | Type::KnownBoundMethod(_) => CompletionKind::Method,
-            Type::ModuleLiteral(_) => CompletionKind::Module,
-            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
-                CompletionKind::Class
-            }
-            // This is a little weird for "struct." I'm mostly interpreting
-            // "struct" here as a more general "object." ---AG
-            Type::NominalInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::BoundSuper(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_)
-            | Type::EnumComplement(_) => CompletionKind::Struct,
-            Type::LiteralValue(literal) if literal.is_enum() => CompletionKind::Enum,
-            Type::LiteralValue(_) | Type::TypeIs(_) | Type::TypeGuard(_) | Type::TypeForm(_) => {
-                CompletionKind::Value
-            }
-            Type::ProtocolInstance(_) => CompletionKind::Interface,
-            Type::TypeVar(_) => CompletionKind::TypeParameter,
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .find_map(|&ty| imp(db, ty, visitor))?,
-            Type::Intersection(intersection) => intersection
-                .iter_positive(db)
-                .find_map(|ty| imp(db, ty, visitor))?,
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy => return None,
-            Type::TypeAlias(alias) => {
-                visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
-            }
-        })
+        Some(
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::FunctionLiteral(_)
+                    | ty_python_semantic::types::TypeData::DataclassDecorator(_)
+                    | ty_python_semantic::types::TypeData::WrapperDescriptor(_)
+                    | ty_python_semantic::types::TypeData::DataclassTransformer(_)
+                    | ty_python_semantic::types::TypeData::Callable(_),
+                ) => CompletionKind::Function,
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::BoundMethod(_)
+                    | ty_python_semantic::types::TypeData::KnownBoundMethod(_),
+                ) => CompletionKind::Method,
+                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
+                    CompletionKind::Module
+                }
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::ClassLiteral(_)
+                    | ty_python_semantic::types::TypeData::GenericAlias(_)
+                    | ty_python_semantic::types::TypeData::SubclassOf(_),
+                ) => CompletionKind::Class,
+                // This is a little weird for "struct." I'm mostly interpreting
+                // "struct" here as a more general "object." ---AG
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::NominalInstance(_)
+                    | ty_python_semantic::types::TypeData::PropertyInstance(_)
+                    | ty_python_semantic::types::TypeData::BoundSuper(_)
+                    | ty_python_semantic::types::TypeData::TypedDict(_)
+                    | ty_python_semantic::types::TypeData::NewTypeInstance(_)
+                    | ty_python_semantic::types::TypeData::EnumComplement(_),
+                ) => CompletionKind::Struct,
+                (_, ty_python_semantic::types::TypeData::LiteralValue(literal))
+                    if literal.is_enum() =>
+                {
+                    CompletionKind::Enum
+                }
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::LiteralValue(_)
+                    | ty_python_semantic::types::TypeData::TypeIs(_)
+                    | ty_python_semantic::types::TypeData::TypeGuard(_)
+                    | ty_python_semantic::types::TypeData::TypeForm(_),
+                ) => CompletionKind::Value,
+                (_, ty_python_semantic::types::TypeData::ProtocolInstance(_)) => {
+                    CompletionKind::Interface
+                }
+                (_, ty_python_semantic::types::TypeData::TypeVar(_)) => {
+                    CompletionKind::TypeParameter
+                }
+                (_, ty_python_semantic::types::TypeData::Union(union)) => union
+                    .elements(db)
+                    .iter()
+                    .find_map(|&ty| imp(db, ty, visitor))?,
+                (_, ty_python_semantic::types::TypeData::Intersection(intersection)) => {
+                    intersection
+                        .iter_positive(db)
+                        .find_map(|ty| imp(db, ty, visitor))?
+                }
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::Dynamic(_)
+                    | ty_python_semantic::types::TypeData::Divergent(_)
+                    | ty_python_semantic::types::TypeData::Never
+                    | ty_python_semantic::types::TypeData::SpecialForm(_)
+                    | ty_python_semantic::types::TypeData::KnownInstance(_)
+                    | ty_python_semantic::types::TypeData::AlwaysTruthy
+                    | ty_python_semantic::types::TypeData::AlwaysFalsy,
+                ) => return None,
+                (_, ty_python_semantic::types::TypeData::TypeAlias(alias)) => {
+                    visitor.visit(ty, || imp(db, alias.value_type(db), visitor))?
+                }
+            },
+        )
     }
     imp(db, ty, &CompletionKindVisitor::default())
 }

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -1293,10 +1293,12 @@ fn property_getter_definitions<'db>(
     for decorator in &function.decorator_list {
         if let Some(attr_expr) = decorator.expression.as_attribute_expr()
             && matches!(attr_expr.attr.as_str(), "setter" | "deleter")
-            && matches!(
-                attr_expr.value.inferred_type(model),
-                Some(Type::PropertyInstance(_))
-            )
+            && attr_expr.value.inferred_type(model).is_some_and(|ty| {
+                matches!(
+                    ty.data(),
+                    ty_python_semantic::types::TypeData::PropertyInstance(_)
+                )
+            })
         {
             return definitions_for_expression(model, (&*attr_expr.value).into(), alias_resolution);
         }

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -80,16 +80,10 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
     } else if let Some(ty) = goto_target.inferred_type(&model) {
         tracing::debug!("Inferred type of covering node is {}", ty.display(db));
         let qualifiers = goto_target.type_qualifiers(&model);
-        let inferred_type_hover_content = match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(
-                    typevar,
-                )),
-            ) => typevar.bind_pep695(db).map_or(
+        let inferred_type_hover_content = match ty.data() {
+            ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(
+                typevar,
+            )) => typevar.bind_pep695(db).map_or(
                 HoverContent::Type {
                     ty,
                     variance: None,
@@ -101,13 +95,10 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
                     qualifiers,
                 },
             ),
-            (
-                _,
-                ty_python_semantic::types::TypeData::KnownInstance(
-                    KnownInstanceType::TypeAliasType(alias),
-                )
-                | ty_python_semantic::types::TypeData::TypeAlias(alias),
-            ) => {
+            ty_python_semantic::types::TypeData::KnownInstance(
+                KnownInstanceType::TypeAliasType(alias),
+            )
+            | ty_python_semantic::types::TypeData::TypeAlias(alias) => {
                 let value_ty = alias.value_type(db);
 
                 alias_docstring = Definitions::from_ty(db, ty)
@@ -118,12 +109,12 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
 
                 HoverContent::TypeAlias { alias, qualifiers }
             }
-            (_, ty_python_semantic::types::TypeData::TypeVar(typevar)) => HoverContent::Type {
+            ty_python_semantic::types::TypeData::TypeVar(typevar) => HoverContent::Type {
                 ty,
                 variance: Some(typevar.variance(db)),
                 qualifiers,
             },
-            (_, _) => HoverContent::Type {
+            _ => HoverContent::Type {
                 ty,
                 variance: None,
                 qualifiers,

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -80,23 +80,34 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
     } else if let Some(ty) = goto_target.inferred_type(&model) {
         tracing::debug!("Inferred type of covering node is {}", ty.display(db));
         let qualifiers = goto_target.type_qualifiers(&model);
-        let inferred_type_hover_content = match ty {
-            Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                typevar.bind_pep695(db).map_or(
-                    HoverContent::Type {
-                        ty,
-                        variance: None,
-                        qualifiers,
-                    },
-                    |typevar| HoverContent::Type {
-                        ty: Type::TypeVar(typevar),
-                        variance: Some(typevar.variance(db)),
-                        qualifiers,
-                    },
+        let inferred_type_hover_content = match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(
+                    typevar,
+                )),
+            ) => typevar.bind_pep695(db).map_or(
+                HoverContent::Type {
+                    ty,
+                    variance: None,
+                    qualifiers,
+                },
+                |typevar| HoverContent::Type {
+                    ty: Type::TypeVar(typevar),
+                    variance: Some(typevar.variance(db)),
+                    qualifiers,
+                },
+            ),
+            (
+                _,
+                ty_python_semantic::types::TypeData::KnownInstance(
+                    KnownInstanceType::TypeAliasType(alias),
                 )
-            }
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(alias))
-            | Type::TypeAlias(alias) => {
+                | ty_python_semantic::types::TypeData::TypeAlias(alias),
+            ) => {
                 let value_ty = alias.value_type(db);
 
                 alias_docstring = Definitions::from_ty(db, ty)
@@ -107,12 +118,12 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
 
                 HoverContent::TypeAlias { alias, qualifiers }
             }
-            Type::TypeVar(typevar) => HoverContent::Type {
+            (_, ty_python_semantic::types::TypeData::TypeVar(typevar)) => HoverContent::Type {
                 ty,
                 variance: Some(typevar.variance(db)),
                 qualifiers,
             },
-            _ => HoverContent::Type {
+            (_, _) => HoverContent::Type {
                 ty,
                 variance: None,
                 qualifiers,

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -670,13 +670,14 @@ impl<'a> ImportRequest<'a> {
             //
             // ... unless the module symbol we found here is
             // actually a module symbol.
-            (
-                Some(&MemberInScope {
-                    ty: Type::ModuleLiteral(_),
-                    ..
-                }),
-                None,
-            ) => self,
+            (Some(member), None)
+                if matches!(
+                    member.ty.data(),
+                    ty_python_semantic::types::TypeData::ModuleLiteral(_)
+                ) =>
+            {
+                self
+            }
             (Some(_), None) => Self {
                 style: ImportStyle::ImportFrom,
                 force_style: true,

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -281,10 +281,7 @@ pub trait HasNavigationTargets {
 
 impl HasNavigationTargets for Type<'_> {
     fn navigation_targets(&self, db: &dyn Db) -> NavigationTargets {
-        match {
-            let __ty_view_value = self;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match self.view() {
             (_, ty_python_semantic::types::TypeData::Union(union)) => union
                 .elements(db)
                 .iter()

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -281,14 +281,17 @@ pub trait HasNavigationTargets {
 
 impl HasNavigationTargets for Type<'_> {
     fn navigation_targets(&self, db: &dyn Db) -> NavigationTargets {
-        match self {
-            Type::Union(union) => union
+        match {
+            let __ty_view_value = self;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, ty_python_semantic::types::TypeData::Union(union)) => union
                 .elements(db)
                 .iter()
                 .flat_map(|target| target.navigation_targets(db))
                 .collect(),
 
-            Type::Intersection(intersection) => {
+            (_, ty_python_semantic::types::TypeData::Intersection(intersection)) => {
                 if let Some(alternatives) = intersection.finite_alternatives(db) {
                     return alternatives
                         .iter()
@@ -313,13 +316,13 @@ impl HasNavigationTargets for Type<'_> {
                 }
             }
 
-            Type::EnumComplement(complement) => complement
+            (_, ty_python_semantic::types::TypeData::EnumComplement(complement)) => complement
                 .remaining_literal_types(db)
                 .iter()
                 .flat_map(|alternative| alternative.navigation_targets(db))
                 .collect(),
 
-            ty => ty
+            (ty, _) => ty
                 .definition(db)
                 .map(|definition| definition.navigation_targets(db))
                 .unwrap_or_else(NavigationTargets::empty),

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -318,12 +318,17 @@ impl<'db> SemanticTokenVisitor<'db> {
                 let ty = parameter.node(&parsed.load(db)).inferred_type(&model);
 
                 if let Some(ty) = ty {
-                    let type_var = match ty {
-                        Type::TypeVar(type_var) => Some((type_var, false)),
-                        Type::SubclassOf(subclass_of) => {
+                    let type_var = match {
+                        let __ty_view_value = ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, ty_python_semantic::types::TypeData::TypeVar(type_var)) => {
+                            Some((type_var, false))
+                        }
+                        (_, ty_python_semantic::types::TypeData::SubclassOf(subclass_of)) => {
                             subclass_of.into_type_var().map(|var| (var, true))
                         }
-                        _ => None,
+                        (_, _) => None,
                     };
 
                     if let Some((type_var, is_cls)) = type_var
@@ -367,7 +372,18 @@ impl<'db> SemanticTokenVisitor<'db> {
                 if let Some(value) = value
                     && let Some(value_ty) = value.inferred_type(&model)
                 {
-                    if matches!(value_ty, Type::KnownInstance(KnownInstanceType::TypeVar(_))) {
+                    if matches!(
+                        {
+                            let __ty_view_value = value_ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (
+                            _,
+                            ty_python_semantic::types::TypeData::KnownInstance(
+                                KnownInstanceType::TypeVar(_)
+                            )
+                        )
+                    ) {
                         modifiers.remove(SemanticTokenModifier::READONLY);
                         return Some((SemanticTokenType::TypeParameter, modifiers));
                     }
@@ -400,31 +416,47 @@ impl<'db> SemanticTokenVisitor<'db> {
             return Some(classification);
         }
 
-        Some(match ty {
-            Type::ClassLiteral(_) => (SemanticTokenType::Class, modifiers),
-            Type::TypeVar(_) => (SemanticTokenType::TypeParameter, modifiers),
-            Type::KnownInstance(KnownInstanceType::TypeVar(_)) => {
-                (SemanticTokenType::TypeParameter, modifiers)
-            }
-            Type::FunctionLiteral(_) => {
-                // Check if this is a method based on current scope
-                if self.in_class_scope {
+        Some(
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, ty_python_semantic::types::TypeData::ClassLiteral(_)) => {
+                    (SemanticTokenType::Class, modifiers)
+                }
+                (_, ty_python_semantic::types::TypeData::TypeVar(_)) => {
+                    (SemanticTokenType::TypeParameter, modifiers)
+                }
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(
+                        _,
+                    )),
+                ) => (SemanticTokenType::TypeParameter, modifiers),
+                (_, ty_python_semantic::types::TypeData::FunctionLiteral(_)) => {
+                    // Check if this is a method based on current scope
+                    if self.in_class_scope {
+                        (SemanticTokenType::Method, modifiers)
+                    } else {
+                        (SemanticTokenType::Function, modifiers)
+                    }
+                }
+                (_, ty_python_semantic::types::TypeData::BoundMethod(_)) => {
                     (SemanticTokenType::Method, modifiers)
-                } else {
-                    (SemanticTokenType::Function, modifiers)
                 }
-            }
-            Type::BoundMethod(_) => (SemanticTokenType::Method, modifiers),
-            Type::ModuleLiteral(_) => (SemanticTokenType::Namespace, modifiers),
-            _ => {
-                // Check for constant naming convention
-                if Self::is_constant_name(name_str) {
-                    modifiers |= SemanticTokenModifier::READONLY;
+                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
+                    (SemanticTokenType::Namespace, modifiers)
                 }
-                // For other types (variables, modules, etc.), assume variable
-                (SemanticTokenType::Variable, modifiers)
-            }
-        })
+                (_, _) => {
+                    // Check for constant naming convention
+                    if Self::is_constant_name(name_str) {
+                        modifiers |= SemanticTokenModifier::READONLY;
+                    }
+                    // For other types (variables, modules, etc.), assume variable
+                    (SemanticTokenType::Variable, modifiers)
+                }
+            },
+        )
     }
 
     fn classify_type_form_expr(
@@ -437,15 +469,19 @@ impl<'db> SemanticTokenVisitor<'db> {
 
         // In type-form contexts, these types all denote class-like type expressions that should be
         // highlighted like `int` in `x: int`, even if their inferred type is instance-shaped.
-        match ty {
-            Type::ClassLiteral(_)
-            | Type::GenericAlias(_)
-            | Type::SubclassOf(_)
-            | Type::NominalInstance(_)
-            | Type::ProtocolInstance(_) => {
-                Some((SemanticTokenType::Class, SemanticTokenModifier::empty()))
-            }
-            _ => None,
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                ty_python_semantic::types::TypeData::ClassLiteral(_)
+                | ty_python_semantic::types::TypeData::GenericAlias(_)
+                | ty_python_semantic::types::TypeData::SubclassOf(_)
+                | ty_python_semantic::types::TypeData::NominalInstance(_)
+                | ty_python_semantic::types::TypeData::ProtocolInstance(_),
+            ) => Some((SemanticTokenType::Class, SemanticTokenModifier::empty())),
+            (_, _) => None,
         }
     }
 
@@ -502,27 +538,34 @@ impl<'db> SemanticTokenVisitor<'db> {
 
         for element in elements {
             // Classify based on the inferred type of the attribute
-            match element {
-                Type::ClassLiteral(_) => {
+            match {
+                let __ty_view_value = element;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, ty_python_semantic::types::TypeData::ClassLiteral(_)) => {
                     token_type.add(SemanticTokenType::Class);
                 }
-                Type::FunctionLiteral(_) => {
+                (_, ty_python_semantic::types::TypeData::FunctionLiteral(_)) => {
                     // This is a function accessed as an attribute, likely a method
                     token_type.add(SemanticTokenType::Method);
                 }
-                Type::BoundMethod(_) | Type::KnownBoundMethod(_) => {
+                (
+                    _,
+                    ty_python_semantic::types::TypeData::BoundMethod(_)
+                    | ty_python_semantic::types::TypeData::KnownBoundMethod(_),
+                ) => {
                     // Method bound to an instance
                     token_type.add(SemanticTokenType::Method);
                 }
-                Type::ModuleLiteral(_) => {
+                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
                     // Module accessed as an attribute (e.g., from os import path)
                     token_type.add(SemanticTokenType::Namespace);
                 }
-                Type::PropertyInstance(property) => {
+                (_, ty_python_semantic::types::TypeData::PropertyInstance(property)) => {
                     token_type.add(SemanticTokenType::Property);
                     all_properties_are_readonly &= property.setter(db).is_none();
                 }
-                _ => {
+                (_, _) => {
                     token_type = UnifiedTokenType::Fallback;
                 }
             }
@@ -575,10 +618,12 @@ impl<'db> SemanticTokenVisitor<'db> {
             return SemanticTokenType::Function;
         }
 
-        if matches!(
-            func.inferred_type(self.model),
-            Some(Type::PropertyInstance(_))
-        ) {
+        if func.inferred_type(self.model).is_some_and(|ty| {
+            matches!(
+                ty.data(),
+                ty_python_semantic::types::TypeData::PropertyInstance(_)
+            )
+        }) {
             SemanticTokenType::Property
         } else {
             SemanticTokenType::Method
@@ -859,10 +904,18 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
                 if let Some(value) = &assignment.value {
                     // PEP 613 alias values are type forms even though they appear as annotated
                     // assignments rather than dedicated `type` statements.
-                    if matches!(
-                        assignment.annotation.inferred_type(self.model),
-                        Some(Type::SpecialForm(SpecialFormType::TypeAlias))
-                    ) {
+                    if assignment
+                        .annotation
+                        .inferred_type(self.model)
+                        .is_some_and(|ty| {
+                            matches!(
+                                ty.data(),
+                                ty_python_semantic::types::TypeData::SpecialForm(
+                                    SpecialFormType::TypeAlias
+                                )
+                            )
+                        })
+                    {
                         self.visit_annotation(value);
                     } else {
                         self.visit_expr(value);
@@ -1007,10 +1060,14 @@ impl SourceOrderVisitor<'_> for SemanticTokenVisitor<'_> {
                 }
             }
             ast::Expr::Subscript(subscript)
-                if matches!(
-                    subscript.value.inferred_type(self.model),
-                    Some(Type::SpecialForm(SpecialFormType::Annotated))
-                ) =>
+                if subscript.value.inferred_type(self.model).is_some_and(|ty| {
+                    matches!(
+                        ty.data(),
+                        ty_python_semantic::types::TypeData::SpecialForm(
+                            SpecialFormType::Annotated
+                        )
+                    )
+                }) =>
             {
                 self.visit_expr(subscript.value.as_ref());
                 self.visit_annotated_arguments(subscript.slice.as_ref());

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -318,17 +318,14 @@ impl<'db> SemanticTokenVisitor<'db> {
                 let ty = parameter.node(&parsed.load(db)).inferred_type(&model);
 
                 if let Some(ty) = ty {
-                    let type_var = match {
-                        let __ty_view_value = ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, ty_python_semantic::types::TypeData::TypeVar(type_var)) => {
+                    let type_var = match ty.data() {
+                        ty_python_semantic::types::TypeData::TypeVar(type_var) => {
                             Some((type_var, false))
                         }
-                        (_, ty_python_semantic::types::TypeData::SubclassOf(subclass_of)) => {
+                        ty_python_semantic::types::TypeData::SubclassOf(subclass_of) => {
                             subclass_of.into_type_var().map(|var| (var, true))
                         }
-                        (_, _) => None,
+                        _ => None,
                     };
 
                     if let Some((type_var, is_cls)) = type_var
@@ -373,15 +370,9 @@ impl<'db> SemanticTokenVisitor<'db> {
                     && let Some(value_ty) = value.inferred_type(&model)
                 {
                     if matches!(
-                        {
-                            let __ty_view_value = value_ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (
-                            _,
-                            ty_python_semantic::types::TypeData::KnownInstance(
-                                KnownInstanceType::TypeVar(_)
-                            )
+                        value_ty.data(),
+                        ty_python_semantic::types::TypeData::KnownInstance(
+                            KnownInstanceType::TypeVar(_)
                         )
                     ) {
                         modifiers.remove(SemanticTokenModifier::READONLY);
@@ -416,47 +407,39 @@ impl<'db> SemanticTokenVisitor<'db> {
             return Some(classification);
         }
 
-        Some(
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, ty_python_semantic::types::TypeData::ClassLiteral(_)) => {
-                    (SemanticTokenType::Class, modifiers)
-                }
-                (_, ty_python_semantic::types::TypeData::TypeVar(_)) => {
-                    (SemanticTokenType::TypeParameter, modifiers)
-                }
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(
-                        _,
-                    )),
-                ) => (SemanticTokenType::TypeParameter, modifiers),
-                (_, ty_python_semantic::types::TypeData::FunctionLiteral(_)) => {
-                    // Check if this is a method based on current scope
-                    if self.in_class_scope {
-                        (SemanticTokenType::Method, modifiers)
-                    } else {
-                        (SemanticTokenType::Function, modifiers)
-                    }
-                }
-                (_, ty_python_semantic::types::TypeData::BoundMethod(_)) => {
+        Some(match ty.data() {
+            ty_python_semantic::types::TypeData::ClassLiteral(_) => {
+                (SemanticTokenType::Class, modifiers)
+            }
+            ty_python_semantic::types::TypeData::TypeVar(_) => {
+                (SemanticTokenType::TypeParameter, modifiers)
+            }
+            ty_python_semantic::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(_)) => {
+                (SemanticTokenType::TypeParameter, modifiers)
+            }
+            ty_python_semantic::types::TypeData::FunctionLiteral(_) => {
+                // Check if this is a method based on current scope
+                if self.in_class_scope {
                     (SemanticTokenType::Method, modifiers)
+                } else {
+                    (SemanticTokenType::Function, modifiers)
                 }
-                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
-                    (SemanticTokenType::Namespace, modifiers)
+            }
+            ty_python_semantic::types::TypeData::BoundMethod(_) => {
+                (SemanticTokenType::Method, modifiers)
+            }
+            ty_python_semantic::types::TypeData::ModuleLiteral(_) => {
+                (SemanticTokenType::Namespace, modifiers)
+            }
+            _ => {
+                // Check for constant naming convention
+                if Self::is_constant_name(name_str) {
+                    modifiers |= SemanticTokenModifier::READONLY;
                 }
-                (_, _) => {
-                    // Check for constant naming convention
-                    if Self::is_constant_name(name_str) {
-                        modifiers |= SemanticTokenModifier::READONLY;
-                    }
-                    // For other types (variables, modules, etc.), assume variable
-                    (SemanticTokenType::Variable, modifiers)
-                }
-            },
-        )
+                // For other types (variables, modules, etc.), assume variable
+                (SemanticTokenType::Variable, modifiers)
+            }
+        })
     }
 
     fn classify_type_form_expr(
@@ -469,19 +452,15 @@ impl<'db> SemanticTokenVisitor<'db> {
 
         // In type-form contexts, these types all denote class-like type expressions that should be
         // highlighted like `int` in `x: int`, even if their inferred type is instance-shaped.
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                ty_python_semantic::types::TypeData::ClassLiteral(_)
-                | ty_python_semantic::types::TypeData::GenericAlias(_)
-                | ty_python_semantic::types::TypeData::SubclassOf(_)
-                | ty_python_semantic::types::TypeData::NominalInstance(_)
-                | ty_python_semantic::types::TypeData::ProtocolInstance(_),
-            ) => Some((SemanticTokenType::Class, SemanticTokenModifier::empty())),
-            (_, _) => None,
+        match ty.data() {
+            ty_python_semantic::types::TypeData::ClassLiteral(_)
+            | ty_python_semantic::types::TypeData::GenericAlias(_)
+            | ty_python_semantic::types::TypeData::SubclassOf(_)
+            | ty_python_semantic::types::TypeData::NominalInstance(_)
+            | ty_python_semantic::types::TypeData::ProtocolInstance(_) => {
+                Some((SemanticTokenType::Class, SemanticTokenModifier::empty()))
+            }
+            _ => None,
         }
     }
 
@@ -538,34 +517,28 @@ impl<'db> SemanticTokenVisitor<'db> {
 
         for element in elements {
             // Classify based on the inferred type of the attribute
-            match {
-                let __ty_view_value = element;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, ty_python_semantic::types::TypeData::ClassLiteral(_)) => {
+            match element.data() {
+                ty_python_semantic::types::TypeData::ClassLiteral(_) => {
                     token_type.add(SemanticTokenType::Class);
                 }
-                (_, ty_python_semantic::types::TypeData::FunctionLiteral(_)) => {
+                ty_python_semantic::types::TypeData::FunctionLiteral(_) => {
                     // This is a function accessed as an attribute, likely a method
                     token_type.add(SemanticTokenType::Method);
                 }
-                (
-                    _,
-                    ty_python_semantic::types::TypeData::BoundMethod(_)
-                    | ty_python_semantic::types::TypeData::KnownBoundMethod(_),
-                ) => {
+                ty_python_semantic::types::TypeData::BoundMethod(_)
+                | ty_python_semantic::types::TypeData::KnownBoundMethod(_) => {
                     // Method bound to an instance
                     token_type.add(SemanticTokenType::Method);
                 }
-                (_, ty_python_semantic::types::TypeData::ModuleLiteral(_)) => {
+                ty_python_semantic::types::TypeData::ModuleLiteral(_) => {
                     // Module accessed as an attribute (e.g., from os import path)
                     token_type.add(SemanticTokenType::Namespace);
                 }
-                (_, ty_python_semantic::types::TypeData::PropertyInstance(property)) => {
+                ty_python_semantic::types::TypeData::PropertyInstance(property) => {
                     token_type.add(SemanticTokenType::Property);
                     all_properties_are_readonly &= property.setter(db).is_none();
                 }
-                (_, _) => {
+                _ => {
                     token_type = UnifiedTokenType::Fallback;
                 }
             }

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -83,10 +83,9 @@ impl<'db> DunderAllNamesCollector<'db> {
                 if attr != "__all__" {
                     return false;
                 }
-                let (_, crate::types::TypeData::ModuleLiteral(module_literal)) = ({
-                    let __ty_view_value = self.standalone_expression_type(value);
-                    (__ty_view_value, __ty_view_value.data())
-                }) else {
+                let crate::types::TypeData::ModuleLiteral(module_literal) =
+                    self.standalone_expression_type(value).data()
+                else {
                     return false;
                 };
                 let Some(module_dunder_all_names) = module_literal

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -83,8 +83,10 @@ impl<'db> DunderAllNamesCollector<'db> {
                 if attr != "__all__" {
                     return false;
                 }
-                let Type::ModuleLiteral(module_literal) = self.standalone_expression_type(value)
-                else {
+                let (_, crate::types::TypeData::ModuleLiteral(module_literal)) = ({
+                    let __ty_view_value = self.standalone_expression_type(value);
+                    (__ty_view_value, __ty_view_value.data())
+                }) else {
                     return false;
                 };
                 let Some(module_dunder_all_names) = module_literal

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1738,21 +1738,17 @@ impl<'db> PublicTypeBuilder<'db> {
     }
 
     fn add(&mut self, element: Type<'db>, reachability: Truthiness) -> bool {
-        match {
-            let __ty_view_value = element;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(function)) => {
+        match element.data() {
+            crate::types::TypeData::FunctionLiteral(function) => {
                 let last_definition = function.literal(self.db).last_definition;
                 if last_definition.is_overload(self.db) {
                     // Distinct overloaded function values can be assigned to the same public
                     // symbol in separate branches. Preserve the queued value unless the next
                     // overload belongs to the same place.
                     if !self.queue.is_some_and(|queued| {
-                        let (_, crate::types::TypeData::FunctionLiteral(queued_function)) = ({
-                            let __ty_view_value = queued;
-                            (__ty_view_value, __ty_view_value.data())
-                        }) else {
+                        let crate::types::TypeData::FunctionLiteral(queued_function) =
+                            queued.data()
+                        else {
                             return false;
                         };
                         function.has_same_place_as(self.db, queued_function)
@@ -1768,10 +1764,9 @@ impl<'db> PublicTypeBuilder<'db> {
                     // several, so keep any unrelated queued overloaded function in the union.
                     if reachability.is_always_true()
                         || self.queue.is_some_and(|queued| {
-                            let (_, crate::types::TypeData::FunctionLiteral(queued_function)) = ({
-                                let __ty_view_value = queued;
-                                (__ty_view_value, __ty_view_value.data())
-                            }) else {
+                            let crate::types::TypeData::FunctionLiteral(queued_function) =
+                                queued.data()
+                            else {
                                 return false;
                             };
                             let queued_definition = queued_function.last_definition(self.db);
@@ -1786,7 +1781,7 @@ impl<'db> PublicTypeBuilder<'db> {
                     true
                 }
             }
-            (_, _) => {
+            _ => {
                 self.drain_queue();
                 self.add_to_union(element);
                 true
@@ -2023,10 +2018,9 @@ pub(crate) mod implicit_globals {
         {
             return Place::Undefined.into();
         }
-        let (_, crate::types::TypeData::ClassLiteral(module_type_class)) = ({
-            let __ty_view_value = KnownClass::ModuleType.to_class_literal(db);
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::ClassLiteral(module_type_class) =
+            KnownClass::ModuleType.to_class_literal(db).data()
+        else {
             return Place::Undefined.into();
         };
         let Some(class) = module_type_class.as_static() else {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -334,37 +334,36 @@ impl<'db> Place<'db> {
     /// This is used to resolve (potential) descriptor attributes.
     pub(crate) fn try_call_dunder_get(self, db: &'db dyn Db, owner: Type<'db>) -> Place<'db> {
         match self {
-            Place::Defined(
-                place @ DefinedPlace {
-                    ty: Type::Union(union),
-                    ..
-                },
-            ) => union.map_with_boundness(db, |elem| {
-                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
-            }),
-
-            Place::Defined(
-                place @ DefinedPlace {
-                    ty: Type::Intersection(intersection),
-                    ..
-                },
-            ) => intersection.map_with_boundness(db, |elem| {
-                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
-            }),
-
-            Place::Defined(defined) => {
-                if let Some((dunder_get_return_ty, _)) =
-                    defined.ty.try_call_dunder_get(db, None, owner)
-                {
+            Place::Defined(defined) => match defined.ty.data() {
+                crate::types::TypeData::Union(union) => union.map_with_boundness(db, |elem| {
                     Place::Defined(DefinedPlace {
-                        ty: dunder_get_return_ty,
-                        provenance: Provenance::Unknown,
+                        ty: *elem,
                         ..defined
                     })
-                } else {
-                    self
+                    .try_call_dunder_get(db, owner)
+                }),
+                crate::types::TypeData::Intersection(intersection) => intersection
+                    .map_with_boundness(db, |elem| {
+                        Place::Defined(DefinedPlace {
+                            ty: *elem,
+                            ..defined
+                        })
+                        .try_call_dunder_get(db, owner)
+                    }),
+                _ => {
+                    if let Some((dunder_get_return_ty, _)) =
+                        defined.ty.try_call_dunder_get(db, None, owner)
+                    {
+                        Place::Defined(DefinedPlace {
+                            ty: dunder_get_return_ty,
+                            provenance: Provenance::Unknown,
+                            ..defined
+                        })
+                    } else {
+                        self
+                    }
                 }
-            }
+            },
 
             Place::Undefined => Place::Undefined,
         }
@@ -1028,14 +1027,19 @@ pub(crate) fn place_by_id<'db>(
         PlaceAndQualifiers {
             place:
                 Place::Defined(DefinedPlace {
-                    ty: Type::Dynamic(DynamicType::Unknown),
+                    ty,
                     origin,
                     definedness,
                     provenance: declared_provenance,
                     ..
                 }),
             qualifiers,
-        } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
+        } if qualifiers.contains(TypeQualifiers::CLASS_VAR)
+            && matches!(
+                ty.data(),
+                crate::types::TypeData::Dynamic(DynamicType::Unknown)
+            ) =>
+        {
             let bindings = all_considered_bindings();
             match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place {
                 Place::Defined(DefinedPlace {
@@ -1734,15 +1738,21 @@ impl<'db> PublicTypeBuilder<'db> {
     }
 
     fn add(&mut self, element: Type<'db>, reachability: Truthiness) -> bool {
-        match element {
-            Type::FunctionLiteral(function) => {
+        match {
+            let __ty_view_value = element;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => {
                 let last_definition = function.literal(self.db).last_definition;
                 if last_definition.is_overload(self.db) {
                     // Distinct overloaded function values can be assigned to the same public
                     // symbol in separate branches. Preserve the queued value unless the next
                     // overload belongs to the same place.
                     if !self.queue.is_some_and(|queued| {
-                        let Type::FunctionLiteral(queued_function) = queued else {
+                        let (_, crate::types::TypeData::FunctionLiteral(queued_function)) = ({
+                            let __ty_view_value = queued;
+                            (__ty_view_value, __ty_view_value.data())
+                        }) else {
                             return false;
                         };
                         function.has_same_place_as(self.db, queued_function)
@@ -1758,7 +1768,10 @@ impl<'db> PublicTypeBuilder<'db> {
                     // several, so keep any unrelated queued overloaded function in the union.
                     if reachability.is_always_true()
                         || self.queue.is_some_and(|queued| {
-                            let Type::FunctionLiteral(queued_function) = queued else {
+                            let (_, crate::types::TypeData::FunctionLiteral(queued_function)) = ({
+                                let __ty_view_value = queued;
+                                (__ty_view_value, __ty_view_value.data())
+                            }) else {
                                 return false;
                             };
                             let queued_definition = queued_function.last_definition(self.db);
@@ -1773,7 +1786,7 @@ impl<'db> PublicTypeBuilder<'db> {
                     true
                 }
             }
-            _ => {
+            (_, _) => {
                 self.drain_queue();
                 self.add_to_union(element);
                 true
@@ -2010,8 +2023,10 @@ pub(crate) mod implicit_globals {
         {
             return Place::Undefined.into();
         }
-        let Type::ClassLiteral(module_type_class) = KnownClass::ModuleType.to_class_literal(db)
-        else {
+        let (_, crate::types::TypeData::ClassLiteral(module_type_class)) = ({
+            let __ty_view_value = KnownClass::ModuleType.to_class_literal(db);
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return Place::Undefined.into();
         };
         let Some(class) = module_type_class.as_static() else {
@@ -2381,10 +2396,10 @@ mod tests {
         assert!(matches!(
             symbol,
             Place::Defined(DefinedPlace {
-                ty: Type::NominalInstance(_),
+                ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
-            })
+            }) if matches!(ty.data(), crate::types::TypeData::NominalInstance(_))
         ));
         assert_eq!(symbol.expect_type(), KnownClass::Str.to_instance(db));
     }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -313,17 +313,22 @@ fn enum_literal_subject_names<'db>(
     let mut enum_class = None;
     let mut names = FxHashSet::default();
 
-    match subject_ty {
-        Type::LiteralValue(_) => {
+    match {
+        let __ty_view_value = subject_ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::LiteralValue(_)) => {
             add_enum_literal(db, &mut enum_class, &mut names, subject_ty)?;
         }
-        Type::Union(union) => {
+        (_, crate::types::TypeData::Union(union)) => {
             for element in union.elements(db) {
                 add_enum_literal(db, &mut enum_class, &mut names, *element)?;
             }
         }
-        Type::TypeAlias(alias) => return enum_literal_subject_names(db, alias.value_type(db)),
-        _ => return None,
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
+            return enum_literal_subject_names(db, alias.value_type(db));
+        }
+        (_, _) => return None,
     }
 
     Some((enum_class?, names))
@@ -1028,16 +1033,20 @@ fn analyze_single_pattern_predicate_kind<'db>(
             truthiness
         }
         PatternPredicateKind::Class(class_expr, kind) => {
-            let class_ty =
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
-                        Some(Type::instance(db, class.top_materialization(db)))
-                    }
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        Some(callable_pattern_type(db))
-                    }
-                    _ => None,
-                };
+            let class_ty = match {
+                let __ty_view_value =
+                    infer_same_file_expression_type(db, *class_expr, TypeContext::default());
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::ClassLiteral(class)) => {
+                    Some(Type::instance(db, class.top_materialization(db)))
+                }
+                (
+                    _,
+                    crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable),
+                ) => Some(callable_pattern_type(db)),
+                (_, _) => None,
+            };
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {
@@ -1122,7 +1131,13 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
             // very few dynamic types, in which case Salsa's sharding the locks by value
             // doesn't help much.
             // See <https://github.com/astral-sh/ty/issues/968>.
-            if matches!(ty, Type::Dynamic(_)) {
+            if matches!(
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::Dynamic(_))
+            ) {
                 return Truthiness::AlwaysTrue.negate_if(!predicate.is_positive);
             }
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -313,22 +313,19 @@ fn enum_literal_subject_names<'db>(
     let mut enum_class = None;
     let mut names = FxHashSet::default();
 
-    match {
-        let __ty_view_value = subject_ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::LiteralValue(_)) => {
+    match subject_ty.data() {
+        crate::types::TypeData::LiteralValue(_) => {
             add_enum_literal(db, &mut enum_class, &mut names, subject_ty)?;
         }
-        (_, crate::types::TypeData::Union(union)) => {
+        crate::types::TypeData::Union(union) => {
             for element in union.elements(db) {
                 add_enum_literal(db, &mut enum_class, &mut names, *element)?;
             }
         }
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             return enum_literal_subject_names(db, alias.value_type(db));
         }
-        (_, _) => return None,
+        _ => return None,
     }
 
     Some((enum_class?, names))
@@ -1033,20 +1030,18 @@ fn analyze_single_pattern_predicate_kind<'db>(
             truthiness
         }
         PatternPredicateKind::Class(class_expr, kind) => {
-            let class_ty = match {
-                let __ty_view_value =
-                    infer_same_file_expression_type(db, *class_expr, TypeContext::default());
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::ClassLiteral(class)) => {
-                    Some(Type::instance(db, class.top_materialization(db)))
-                }
-                (
-                    _,
-                    crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable),
-                ) => Some(callable_pattern_type(db)),
-                (_, _) => None,
-            };
+            let class_ty =
+                match infer_same_file_expression_type(db, *class_expr, TypeContext::default())
+                    .data()
+                {
+                    crate::types::TypeData::ClassLiteral(class) => {
+                        Some(Type::instance(db, class.top_materialization(db)))
+                    }
+                    crate::types::TypeData::SpecialForm(
+                        SpecialFormType::CollectionsAbcCallable,
+                    ) => Some(callable_pattern_type(db)),
+                    _ => None,
+                };
 
             class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
                 if subject_ty.is_subtype_of(db, class_ty) {
@@ -1131,13 +1126,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
             // very few dynamic types, in which case Salsa's sharding the locks by value
             // doesn't help much.
             // See <https://github.com/astral-sh/ty/issues/968>.
-            if matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::Dynamic(_))
-            ) {
+            if matches!(ty.data(), crate::types::TypeData::Dynamic(_)) {
                 return Truthiness::AlwaysTrue.negate_if(!predicate.is_positive);
             }
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -519,11 +519,8 @@ impl<'db> SemanticModel<'db> {
             ty: Type<'db>,
             visitor: &StringLiteralCandidatesVisitor<'db>,
         ) -> Vec<ExpectedStringLiteralCompletion<'db>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::LiteralValue(literal)) => literal
+            match ty.data() {
+                crate::types::TypeData::LiteralValue(literal) => literal
                     .as_string()
                     .map(|string_literal| {
                         let value = string_literal.value(db).to_string();
@@ -533,20 +530,20 @@ impl<'db> SemanticModel<'db> {
                         }]
                     })
                     .unwrap_or_default(),
-                (_, crate::types::TypeData::Union(union)) => union
+                crate::types::TypeData::Union(union) => union
                     .elements(db)
                     .iter()
                     .flat_map(|element| collect(db, *element, visitor))
                     .collect(),
-                (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                crate::types::TypeData::Intersection(intersection) => intersection
                     .positive(db)
                     .iter()
                     .flat_map(|element| collect(db, *element, visitor))
                     .collect(),
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                crate::types::TypeData::TypeAlias(alias) => {
                     visitor.visit(ty, || collect(db, alias.value_type(db), visitor))
                 }
-                (_, _) => Vec::new(),
+                _ => Vec::new(),
             }
         }
 

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -519,8 +519,11 @@ impl<'db> SemanticModel<'db> {
             ty: Type<'db>,
             visitor: &StringLiteralCandidatesVisitor<'db>,
         ) -> Vec<ExpectedStringLiteralCompletion<'db>> {
-            match ty {
-                Type::LiteralValue(literal) => literal
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::LiteralValue(literal)) => literal
                     .as_string()
                     .map(|string_literal| {
                         let value = string_literal.value(db).to_string();
@@ -530,20 +533,20 @@ impl<'db> SemanticModel<'db> {
                         }]
                     })
                     .unwrap_or_default(),
-                Type::Union(union) => union
+                (_, crate::types::TypeData::Union(union)) => union
                     .elements(db)
                     .iter()
                     .flat_map(|element| collect(db, *element, visitor))
                     .collect(),
-                Type::Intersection(intersection) => intersection
+                (_, crate::types::TypeData::Intersection(intersection)) => intersection
                     .positive(db)
                     .iter()
                     .flat_map(|element| collect(db, *element, visitor))
                     .collect(),
-                Type::TypeAlias(alias) => {
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
                     visitor.visit(ty, || collect(db, alias.value_type(db), visitor))
                 }
-                _ => Vec::new(),
+                (_, _) => Vec::new(),
             }
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -84,7 +84,7 @@ pub(crate) use crate::types::narrow::{NarrowingConstraint, infer_narrowing_const
 use crate::types::newtype::NewType;
 use crate::types::signatures::walk_signature;
 pub(crate) use crate::types::signatures::{Parameter, Parameters};
-use crate::types::special_form::TypeQualifier;
+use crate::types::special_form::{LegacyStdlibAlias, TypeQualifier};
 use crate::types::tuple::TupleSpec;
 pub use crate::types::type_alias::TypeAliasType;
 pub use crate::types::type_form::TypeFormType;
@@ -100,7 +100,7 @@ use crate::types::visitor::any_over_type;
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
-use instance::Protocol;
+use instance::{NominalInstanceInner, Protocol};
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
 pub(crate) use literal::{
     BytesLiteralType, EnumLiteralType, LiteralValueType, LiteralValueTypeKind, StringLiteralType,
@@ -879,8 +879,8 @@ impl<'db> DataclassParams<'db> {
 
 /// Representation of a type: a set of possible values at runtime.
 ///
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub enum Type<'db> {
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
+pub enum TypeData<'db> {
     /// The dynamic type: a statically unknown set of values
     Dynamic(DynamicType<'db>),
     /// A cycle marker used during recursive type inference.
@@ -986,6 +986,1176 @@ pub enum Type<'db> {
     NewTypeInstance(NewType<'db>),
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::Update)]
+#[repr(u8)]
+enum TypeTag {
+    Dynamic,
+    Divergent,
+    Never,
+    FunctionLiteral,
+    BoundMethod,
+    KnownBoundMethod,
+    WrapperDescriptor,
+    DataclassDecorator,
+    DataclassTransformer,
+    Callable,
+    ModuleLiteral,
+    ClassLiteral,
+    GenericAlias,
+    SubclassOf,
+    NominalInstance,
+    ProtocolInstance,
+    SpecialForm,
+    KnownInstance,
+    PropertyInstance,
+    Union,
+    Intersection,
+    EnumComplement,
+    AlwaysTruthy,
+    AlwaysFalsy,
+    LiteralValue,
+    TypeVar,
+    BoundSuper,
+    TypeIs,
+    TypeGuard,
+    TypeForm,
+    TypedDict,
+    TypeAlias,
+    NewTypeInstance,
+}
+
+#[repr(u8)]
+enum PackedDynamicTag {
+    Any,
+    Unknown,
+    UnknownGeneric,
+    UnspecializedTypeVar,
+    InvalidConcatenateUnknown,
+    AmbiguousOverload,
+    Todo,
+    TodoUnpack,
+    TodoStarredExpression,
+    TodoTypeVarTuple,
+}
+
+#[repr(u8)]
+enum PackedKnownBoundMethodTag {
+    FunctionTypeDunderGet,
+    FunctionTypeDunderCall,
+    PropertyDunderGet,
+    PropertyDunderSet,
+    PropertyDunderDelete,
+    StrStartswith,
+    ConstraintSetRange,
+    ConstraintSetAlways,
+    ConstraintSetNever,
+    ConstraintSetImpliesSubtypeOf,
+    ConstraintSetSatisfies,
+    ConstraintSetSatisfiedByAllTypeVars,
+    ConstraintSetWithDetailedDisplay,
+}
+
+#[repr(u8)]
+enum PackedClassLiteralTag {
+    Static,
+    Dynamic,
+    DynamicNamedTuple,
+    DynamicTypedDict,
+    DynamicEnum,
+}
+
+#[repr(u8)]
+enum PackedClassTypeTag {
+    NonGeneric,
+    Generic,
+}
+
+#[repr(u8)]
+enum PackedSubclassTag {
+    Class,
+    Dynamic,
+    TypeVar,
+}
+
+#[repr(u8)]
+enum PackedNominalInstanceTag {
+    Object,
+    ExactTuple,
+    NonTuple,
+    SysVersionInfo,
+}
+
+#[repr(u8)]
+enum PackedProtocolTag {
+    FromClass,
+    Synthesized,
+}
+
+#[repr(u8)]
+enum PackedKnownInstanceTag {
+    SubscriptedProtocol,
+    SubscriptedGeneric,
+    TypeVar,
+    TypeAliasType,
+    Deprecated,
+    Field,
+    ConstraintSet,
+    GenericContext,
+    Specialization,
+    UnionType,
+    Literal,
+    Annotated,
+    TypeGenericAlias,
+    Callable,
+    LiteralStringAlias,
+    NewType,
+    Sentinel,
+    NamedTupleSpec,
+    FunctoolsPartial,
+}
+
+#[repr(u8)]
+enum PackedLiteralTag {
+    Int,
+    Bool,
+    String,
+    Enum,
+    Bytes,
+    LiteralString,
+}
+
+#[repr(u8)]
+enum PackedTypedDictTag {
+    Class,
+    Synthesized,
+}
+
+#[repr(u8)]
+enum PackedTypeAliasTag {
+    Pep695,
+    ManualPep695,
+}
+
+#[repr(u8)]
+enum PackedSpecialFormTag {
+    LegacyStdlibAlias,
+    TypeQualifier,
+    Tuple,
+    Type,
+    TypeForm,
+    TypingCallable,
+    CollectionsAbcCallable,
+    Any,
+    Annotated,
+    Literal,
+    LiteralString,
+    Optional,
+    Union,
+    NoReturn,
+    Never,
+    Unknown,
+    AlwaysTruthy,
+    AlwaysFalsy,
+    Not,
+    Intersection,
+    TypeOf,
+    CallableTypeOf,
+    RegularCallableTypeOf,
+    Top,
+    Bottom,
+    TypingSelf,
+    Concatenate,
+    Unpack,
+    TypeAlias,
+    TypeGuard,
+    TypedDict,
+    TypeIs,
+    Protocol,
+    Generic,
+    NamedTuple,
+}
+
+#[repr(u8)]
+enum PackedLegacyStdlibAliasTag {
+    List,
+    Dict,
+    Set,
+    FrozenSet,
+    ChainMap,
+    Counter,
+    DefaultDict,
+    Deque,
+    OrderedDict,
+}
+
+#[repr(u8)]
+enum PackedTypeQualifierTag {
+    ReadOnly,
+    Final,
+    ClassVar,
+    Required,
+    NotRequired,
+    InitVar,
+}
+
+/// Compact physical representation of a type.
+///
+/// The tag is stored separately from an eight-byte payload. Literal kinds are flattened into the
+/// tag because [`LiteralValueType`] is itself larger than the payload. Use [`Type::data`] to access
+/// the logical enum representation.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, salsa::Update)]
+pub struct Type<'db> {
+    payload: TypePayload,
+    tag: TypeTag,
+    detail: [u8; 3],
+    _marker: std::marker::PhantomData<&'db ()>,
+}
+
+#[cfg(debug_assertions)]
+type TypePayload = [u32; 4];
+#[cfg(not(debug_assertions))]
+type TypePayload = [u32; 2];
+
+impl std::fmt::Debug for Type<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.data().fmt(f)
+    }
+}
+
+impl get_size2::GetSize for Type<'_> {}
+
+macro_rules! type_payload_variants {
+    ($($variant:ident($payload:ty)),* $(,)?) => {
+        #[allow(non_snake_case)]
+        impl<'db> Type<'db> {
+            $(
+                pub const fn $variant(value: $payload) -> Self {
+                    Self::from_payload(TypeTag::$variant, value)
+                }
+            )*
+        }
+    };
+}
+
+type_payload_variants! {
+    FunctionLiteral(FunctionType<'db>),
+    BoundMethod(BoundMethodType<'db>),
+    WrapperDescriptor(WrapperDescriptorKind),
+    DataclassDecorator(DataclassParams<'db>),
+    DataclassTransformer(DataclassTransformerParams<'db>),
+    Callable(CallableType<'db>),
+    ModuleLiteral(ModuleLiteralType<'db>),
+    GenericAlias(GenericAlias<'db>),
+    PropertyInstance(PropertyInstanceType<'db>),
+    Union(UnionType<'db>),
+    Intersection(IntersectionType<'db>),
+    EnumComplement(EnumComplementType<'db>),
+    TypeVar(BoundTypeVarInstance<'db>),
+    BoundSuper(BoundSuperType<'db>),
+    TypeIs(TypeIsType<'db>),
+    TypeGuard(TypeGuardType<'db>),
+    TypeForm(TypeFormType<'db>),
+    NewTypeInstance(NewType<'db>),
+}
+
+impl<'db> Type<'db> {
+    #[allow(non_upper_case_globals)]
+    pub const Never: Self = Self::without_payload(TypeTag::Never);
+    #[allow(non_upper_case_globals)]
+    pub const AlwaysTruthy: Self = Self::without_payload(TypeTag::AlwaysTruthy);
+    #[allow(non_upper_case_globals)]
+    pub const AlwaysFalsy: Self = Self::without_payload(TypeTag::AlwaysFalsy);
+
+    #[allow(non_snake_case)]
+    pub fn SpecialForm(value: SpecialFormType) -> Self {
+        let mut result = Self::without_payload(TypeTag::SpecialForm);
+        match value {
+            SpecialFormType::LegacyStdlibAlias(alias) => {
+                result.detail[0] = PackedSpecialFormTag::LegacyStdlibAlias as u8;
+                result.detail[1] = match alias {
+                    LegacyStdlibAlias::List => PackedLegacyStdlibAliasTag::List,
+                    LegacyStdlibAlias::Dict => PackedLegacyStdlibAliasTag::Dict,
+                    LegacyStdlibAlias::Set => PackedLegacyStdlibAliasTag::Set,
+                    LegacyStdlibAlias::FrozenSet => PackedLegacyStdlibAliasTag::FrozenSet,
+                    LegacyStdlibAlias::ChainMap => PackedLegacyStdlibAliasTag::ChainMap,
+                    LegacyStdlibAlias::Counter => PackedLegacyStdlibAliasTag::Counter,
+                    LegacyStdlibAlias::DefaultDict => PackedLegacyStdlibAliasTag::DefaultDict,
+                    LegacyStdlibAlias::Deque => PackedLegacyStdlibAliasTag::Deque,
+                    LegacyStdlibAlias::OrderedDict => PackedLegacyStdlibAliasTag::OrderedDict,
+                } as u8;
+            }
+            SpecialFormType::TypeQualifier(qualifier) => {
+                result.detail[0] = PackedSpecialFormTag::TypeQualifier as u8;
+                result.detail[1] = match qualifier {
+                    TypeQualifier::ReadOnly => PackedTypeQualifierTag::ReadOnly,
+                    TypeQualifier::Final => PackedTypeQualifierTag::Final,
+                    TypeQualifier::ClassVar => PackedTypeQualifierTag::ClassVar,
+                    TypeQualifier::Required => PackedTypeQualifierTag::Required,
+                    TypeQualifier::NotRequired => PackedTypeQualifierTag::NotRequired,
+                    TypeQualifier::InitVar => PackedTypeQualifierTag::InitVar,
+                } as u8;
+            }
+            SpecialFormType::Tuple => result.detail[0] = PackedSpecialFormTag::Tuple as u8,
+            SpecialFormType::Type => result.detail[0] = PackedSpecialFormTag::Type as u8,
+            SpecialFormType::TypeForm => result.detail[0] = PackedSpecialFormTag::TypeForm as u8,
+            SpecialFormType::TypingCallable => {
+                result.detail[0] = PackedSpecialFormTag::TypingCallable as u8;
+            }
+            SpecialFormType::CollectionsAbcCallable => {
+                result.detail[0] = PackedSpecialFormTag::CollectionsAbcCallable as u8;
+            }
+            SpecialFormType::Any => result.detail[0] = PackedSpecialFormTag::Any as u8,
+            SpecialFormType::Annotated => result.detail[0] = PackedSpecialFormTag::Annotated as u8,
+            SpecialFormType::Literal => result.detail[0] = PackedSpecialFormTag::Literal as u8,
+            SpecialFormType::LiteralString => {
+                result.detail[0] = PackedSpecialFormTag::LiteralString as u8;
+            }
+            SpecialFormType::Optional => result.detail[0] = PackedSpecialFormTag::Optional as u8,
+            SpecialFormType::Union => result.detail[0] = PackedSpecialFormTag::Union as u8,
+            SpecialFormType::NoReturn => result.detail[0] = PackedSpecialFormTag::NoReturn as u8,
+            SpecialFormType::Never => result.detail[0] = PackedSpecialFormTag::Never as u8,
+            SpecialFormType::Unknown => result.detail[0] = PackedSpecialFormTag::Unknown as u8,
+            SpecialFormType::AlwaysTruthy => {
+                result.detail[0] = PackedSpecialFormTag::AlwaysTruthy as u8;
+            }
+            SpecialFormType::AlwaysFalsy => {
+                result.detail[0] = PackedSpecialFormTag::AlwaysFalsy as u8;
+            }
+            SpecialFormType::Not => result.detail[0] = PackedSpecialFormTag::Not as u8,
+            SpecialFormType::Intersection => {
+                result.detail[0] = PackedSpecialFormTag::Intersection as u8;
+            }
+            SpecialFormType::TypeOf => result.detail[0] = PackedSpecialFormTag::TypeOf as u8,
+            SpecialFormType::CallableTypeOf => {
+                result.detail[0] = PackedSpecialFormTag::CallableTypeOf as u8;
+            }
+            SpecialFormType::RegularCallableTypeOf => {
+                result.detail[0] = PackedSpecialFormTag::RegularCallableTypeOf as u8;
+            }
+            SpecialFormType::Top => result.detail[0] = PackedSpecialFormTag::Top as u8,
+            SpecialFormType::Bottom => result.detail[0] = PackedSpecialFormTag::Bottom as u8,
+            SpecialFormType::TypingSelf => {
+                result.detail[0] = PackedSpecialFormTag::TypingSelf as u8;
+            }
+            SpecialFormType::Concatenate => {
+                result.detail[0] = PackedSpecialFormTag::Concatenate as u8;
+            }
+            SpecialFormType::Unpack => result.detail[0] = PackedSpecialFormTag::Unpack as u8,
+            SpecialFormType::TypeAlias => result.detail[0] = PackedSpecialFormTag::TypeAlias as u8,
+            SpecialFormType::TypeGuard => result.detail[0] = PackedSpecialFormTag::TypeGuard as u8,
+            SpecialFormType::TypedDict => result.detail[0] = PackedSpecialFormTag::TypedDict as u8,
+            SpecialFormType::TypeIs => result.detail[0] = PackedSpecialFormTag::TypeIs as u8,
+            SpecialFormType::Protocol => result.detail[0] = PackedSpecialFormTag::Protocol as u8,
+            SpecialFormType::Generic => result.detail[0] = PackedSpecialFormTag::Generic as u8,
+            SpecialFormType::NamedTuple => {
+                result.detail[0] = PackedSpecialFormTag::NamedTuple as u8
+            }
+        }
+        result
+    }
+
+    const fn without_payload(tag: TypeTag) -> Self {
+        Self {
+            payload: [0; std::mem::size_of::<TypePayload>() / std::mem::size_of::<u32>()],
+            tag,
+            detail: [0; 3],
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    #[expect(unsafe_code)]
+    const fn from_payload<T: Copy>(tag: TypeTag, value: T) -> Self {
+        const {
+            assert!(std::mem::size_of::<T>() <= std::mem::size_of::<TypePayload>());
+        }
+        let mut result = Self::without_payload(tag);
+        // SAFETY: The size assertion guarantees that `value` fits in the payload. The payload is
+        // initially zeroed, so bytes not occupied by `T` remain initialized and deterministic.
+        unsafe {
+            std::ptr::write_unaligned(result.payload.as_mut_ptr().cast::<T>(), value);
+        }
+        result
+    }
+
+    #[expect(unsafe_code)]
+    fn payload<T: Copy>(self) -> T {
+        const {
+            assert!(std::mem::size_of::<T>() <= std::mem::size_of::<TypePayload>());
+        }
+        // SAFETY: Every tag is constructed with and decoded as the same payload type.
+        unsafe { std::ptr::read_unaligned(self.payload.as_ptr().cast::<T>()) }
+    }
+
+    fn with_detail<T: Copy>(tag: TypeTag, detail: [u8; 3], value: T) -> Self {
+        let mut result = Self::from_payload(tag, value);
+        result.detail = detail;
+        result
+    }
+
+    fn from_dynamic_at(
+        tag: TypeTag,
+        mut detail: [u8; 3],
+        index: usize,
+        value: DynamicType<'db>,
+    ) -> Self {
+        match value {
+            DynamicType::Any => {
+                detail[index] = PackedDynamicTag::Any as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::Unknown => {
+                detail[index] = PackedDynamicTag::Unknown as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::UnknownGeneric(value) => {
+                detail[index] = PackedDynamicTag::UnknownGeneric as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            DynamicType::UnspecializedTypeVar => {
+                detail[index] = PackedDynamicTag::UnspecializedTypeVar as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::InvalidConcatenateUnknown => {
+                detail[index] = PackedDynamicTag::InvalidConcatenateUnknown as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::AmbiguousOverload => {
+                detail[index] = PackedDynamicTag::AmbiguousOverload as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::Todo(value) => {
+                detail[index] = PackedDynamicTag::Todo as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            DynamicType::TodoUnpack => {
+                detail[index] = PackedDynamicTag::TodoUnpack as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::TodoStarredExpression => {
+                detail[index] = PackedDynamicTag::TodoStarredExpression as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+            DynamicType::TodoTypeVarTuple => {
+                detail[index] = PackedDynamicTag::TodoTypeVarTuple as u8;
+                Self {
+                    detail,
+                    ..Self::without_payload(tag)
+                }
+            }
+        }
+    }
+
+    fn dynamic_at(self, index: usize) -> DynamicType<'db> {
+        match self.detail[index] {
+            x if x == PackedDynamicTag::Any as u8 => DynamicType::Any,
+            x if x == PackedDynamicTag::Unknown as u8 => DynamicType::Unknown,
+            x if x == PackedDynamicTag::UnknownGeneric as u8 => {
+                DynamicType::UnknownGeneric(self.payload())
+            }
+            x if x == PackedDynamicTag::UnspecializedTypeVar as u8 => {
+                DynamicType::UnspecializedTypeVar
+            }
+            x if x == PackedDynamicTag::InvalidConcatenateUnknown as u8 => {
+                DynamicType::InvalidConcatenateUnknown
+            }
+            x if x == PackedDynamicTag::AmbiguousOverload as u8 => DynamicType::AmbiguousOverload,
+            x if x == PackedDynamicTag::Todo as u8 => DynamicType::Todo(self.payload()),
+            x if x == PackedDynamicTag::TodoUnpack as u8 => DynamicType::TodoUnpack,
+            x if x == PackedDynamicTag::TodoStarredExpression as u8 => {
+                DynamicType::TodoStarredExpression
+            }
+            x if x == PackedDynamicTag::TodoTypeVarTuple as u8 => DynamicType::TodoTypeVarTuple,
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_class_literal_at(
+        tag: TypeTag,
+        mut detail: [u8; 3],
+        index: usize,
+        value: ClassLiteral<'db>,
+    ) -> Self {
+        match value {
+            ClassLiteral::Static(value) => {
+                detail[index] = PackedClassLiteralTag::Static as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            ClassLiteral::Dynamic(value) => {
+                detail[index] = PackedClassLiteralTag::Dynamic as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            ClassLiteral::DynamicNamedTuple(value) => {
+                detail[index] = PackedClassLiteralTag::DynamicNamedTuple as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            ClassLiteral::DynamicTypedDict(value) => {
+                detail[index] = PackedClassLiteralTag::DynamicTypedDict as u8;
+                Self::with_detail(tag, detail, value)
+            }
+            ClassLiteral::DynamicEnum(value) => {
+                detail[index] = PackedClassLiteralTag::DynamicEnum as u8;
+                Self::with_detail(tag, detail, value)
+            }
+        }
+    }
+
+    fn class_literal_at(self, index: usize) -> ClassLiteral<'db> {
+        match self.detail[index] {
+            x if x == PackedClassLiteralTag::Static as u8 => ClassLiteral::Static(self.payload()),
+            x if x == PackedClassLiteralTag::Dynamic as u8 => ClassLiteral::Dynamic(self.payload()),
+            x if x == PackedClassLiteralTag::DynamicNamedTuple as u8 => {
+                ClassLiteral::DynamicNamedTuple(self.payload())
+            }
+            x if x == PackedClassLiteralTag::DynamicTypedDict as u8 => {
+                ClassLiteral::DynamicTypedDict(self.payload())
+            }
+            x if x == PackedClassLiteralTag::DynamicEnum as u8 => {
+                ClassLiteral::DynamicEnum(self.payload())
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn from_class_type_at(
+        tag: TypeTag,
+        mut detail: [u8; 3],
+        class_index: usize,
+        literal_index: usize,
+        value: ClassType<'db>,
+    ) -> Self {
+        match value {
+            ClassType::NonGeneric(value) => {
+                detail[class_index] = PackedClassTypeTag::NonGeneric as u8;
+                Self::from_class_literal_at(tag, detail, literal_index, value)
+            }
+            ClassType::Generic(value) => {
+                detail[class_index] = PackedClassTypeTag::Generic as u8;
+                Self::with_detail(tag, detail, value)
+            }
+        }
+    }
+
+    fn class_type_at(self, class_index: usize, literal_index: usize) -> ClassType<'db> {
+        match self.detail[class_index] {
+            x if x == PackedClassTypeTag::NonGeneric as u8 => {
+                ClassType::NonGeneric(self.class_literal_at(literal_index))
+            }
+            x if x == PackedClassTypeTag::Generic as u8 => ClassType::Generic(self.payload()),
+            _ => unreachable!(),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn Dynamic(value: DynamicType<'db>) -> Self {
+        Self::from_dynamic_at(TypeTag::Dynamic, [0; 3], 0, value)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn Divergent(value: DivergentType) -> Self {
+        let detail = [
+            match value.materialization {
+                None => 0,
+                Some(MaterializationKind::Top) => 1,
+                Some(MaterializationKind::Bottom) => 2,
+            },
+            0,
+            0,
+        ];
+        Self::with_detail(TypeTag::Divergent, detail, value.id)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn ClassLiteral(value: ClassLiteral<'db>) -> Self {
+        Self::from_class_literal_at(TypeTag::ClassLiteral, [0; 3], 0, value)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn SubclassOf(value: SubclassOfType<'db>) -> Self {
+        match value.packed_inner() {
+            SubclassOfInner::Class(value) => Self::from_class_type_at(
+                TypeTag::SubclassOf,
+                [PackedSubclassTag::Class as u8, 0, 0],
+                1,
+                2,
+                value,
+            ),
+            SubclassOfInner::Dynamic(value) => Self::from_dynamic_at(
+                TypeTag::SubclassOf,
+                [PackedSubclassTag::Dynamic as u8, 0, 0],
+                1,
+                value,
+            ),
+            SubclassOfInner::TypeVar(value) => Self::with_detail(
+                TypeTag::SubclassOf,
+                [PackedSubclassTag::TypeVar as u8, 0, 0],
+                value,
+            ),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn NominalInstance(value: NominalInstanceType<'db>) -> Self {
+        match value.0 {
+            NominalInstanceInner::Object => Self {
+                detail: [PackedNominalInstanceTag::Object as u8, 0, 0],
+                ..Self::without_payload(TypeTag::NominalInstance)
+            },
+            NominalInstanceInner::ExactTuple(value) => Self::with_detail(
+                TypeTag::NominalInstance,
+                [PackedNominalInstanceTag::ExactTuple as u8, 0, 0],
+                value,
+            ),
+            NominalInstanceInner::NonTuple(value) => Self::from_class_type_at(
+                TypeTag::NominalInstance,
+                [PackedNominalInstanceTag::NonTuple as u8, 0, 0],
+                1,
+                2,
+                value,
+            ),
+            NominalInstanceInner::SysVersionInfo => Self {
+                detail: [PackedNominalInstanceTag::SysVersionInfo as u8, 0, 0],
+                ..Self::without_payload(TypeTag::NominalInstance)
+            },
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn ProtocolInstance(value: ProtocolInstanceType<'db>) -> Self {
+        match value.packed_inner() {
+            Protocol::FromClass(value) => Self::from_class_type_at(
+                TypeTag::ProtocolInstance,
+                [PackedProtocolTag::FromClass as u8, 0, 0],
+                1,
+                2,
+                value.0,
+            ),
+            Protocol::Synthesized(value) => Self::with_detail(
+                TypeTag::ProtocolInstance,
+                [PackedProtocolTag::Synthesized as u8, 0, 0],
+                value,
+            ),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn KnownBoundMethod(value: KnownBoundMethodType<'db>) -> Self {
+        macro_rules! payload {
+            ($tag:ident, $value:expr) => {
+                Self::with_detail(
+                    TypeTag::KnownBoundMethod,
+                    [PackedKnownBoundMethodTag::$tag as u8, 0, 0],
+                    $value,
+                )
+            };
+        }
+        macro_rules! unit {
+            ($tag:ident) => {
+                Self {
+                    detail: [PackedKnownBoundMethodTag::$tag as u8, 0, 0],
+                    ..Self::without_payload(TypeTag::KnownBoundMethod)
+                }
+            };
+        }
+        match value {
+            KnownBoundMethodType::FunctionTypeDunderGet(value) => {
+                payload!(FunctionTypeDunderGet, value)
+            }
+            KnownBoundMethodType::FunctionTypeDunderCall(value) => {
+                payload!(FunctionTypeDunderCall, value)
+            }
+            KnownBoundMethodType::PropertyDunderGet(value) => payload!(PropertyDunderGet, value),
+            KnownBoundMethodType::PropertyDunderSet(value) => payload!(PropertyDunderSet, value),
+            KnownBoundMethodType::PropertyDunderDelete(value) => {
+                payload!(PropertyDunderDelete, value)
+            }
+            KnownBoundMethodType::StrStartswith(value) => payload!(StrStartswith, value),
+            KnownBoundMethodType::ConstraintSetRange => unit!(ConstraintSetRange),
+            KnownBoundMethodType::ConstraintSetAlways => unit!(ConstraintSetAlways),
+            KnownBoundMethodType::ConstraintSetNever => unit!(ConstraintSetNever),
+            KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(value) => {
+                payload!(ConstraintSetImpliesSubtypeOf, value)
+            }
+            KnownBoundMethodType::ConstraintSetSatisfies(value) => {
+                payload!(ConstraintSetSatisfies, value)
+            }
+            KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(value) => {
+                payload!(ConstraintSetSatisfiedByAllTypeVars, value)
+            }
+            KnownBoundMethodType::ConstraintSetWithDetailedDisplay(value) => {
+                payload!(ConstraintSetWithDetailedDisplay, value)
+            }
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn KnownInstance(value: KnownInstanceType<'db>) -> Self {
+        macro_rules! payload {
+            ($tag:ident, $value:expr) => {
+                Self::with_detail(
+                    TypeTag::KnownInstance,
+                    [PackedKnownInstanceTag::$tag as u8, 0, 0],
+                    $value,
+                )
+            };
+        }
+        match value {
+            KnownInstanceType::SubscriptedProtocol(value) => payload!(SubscriptedProtocol, value),
+            KnownInstanceType::SubscriptedGeneric(value) => payload!(SubscriptedGeneric, value),
+            KnownInstanceType::TypeVar(value) => payload!(TypeVar, value),
+            KnownInstanceType::TypeAliasType(value) => match value {
+                TypeAliasType::PEP695(value) => Self::with_detail(
+                    TypeTag::KnownInstance,
+                    [
+                        PackedKnownInstanceTag::TypeAliasType as u8,
+                        PackedTypeAliasTag::Pep695 as u8,
+                        0,
+                    ],
+                    value,
+                ),
+                TypeAliasType::ManualPEP695(value) => Self::with_detail(
+                    TypeTag::KnownInstance,
+                    [
+                        PackedKnownInstanceTag::TypeAliasType as u8,
+                        PackedTypeAliasTag::ManualPep695 as u8,
+                        0,
+                    ],
+                    value,
+                ),
+            },
+            KnownInstanceType::Deprecated(value) => payload!(Deprecated, value),
+            KnownInstanceType::Field(value) => payload!(Field, value),
+            KnownInstanceType::ConstraintSet(value) => payload!(ConstraintSet, value),
+            KnownInstanceType::GenericContext(value) => payload!(GenericContext, value),
+            KnownInstanceType::Specialization(value) => payload!(Specialization, value),
+            KnownInstanceType::UnionType(value) => payload!(UnionType, value),
+            KnownInstanceType::Literal(value) => payload!(Literal, value),
+            KnownInstanceType::Annotated(value) => payload!(Annotated, value),
+            KnownInstanceType::TypeGenericAlias(value) => payload!(TypeGenericAlias, value),
+            KnownInstanceType::Callable(value) => payload!(Callable, value),
+            KnownInstanceType::LiteralStringAlias(value) => payload!(LiteralStringAlias, value),
+            KnownInstanceType::NewType(value) => payload!(NewType, value),
+            KnownInstanceType::Sentinel(value) => payload!(Sentinel, value),
+            KnownInstanceType::NamedTupleSpec(value) => payload!(NamedTupleSpec, value),
+            KnownInstanceType::FunctoolsPartial(value) => payload!(FunctoolsPartial, value),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn TypedDict(value: TypedDictType<'db>) -> Self {
+        match value {
+            TypedDictType::Class(value) => Self::from_class_type_at(
+                TypeTag::TypedDict,
+                [PackedTypedDictTag::Class as u8, 0, 0],
+                1,
+                2,
+                value,
+            ),
+            TypedDictType::Synthesized(value) => Self::with_detail(
+                TypeTag::TypedDict,
+                [PackedTypedDictTag::Synthesized as u8, 0, 0],
+                value,
+            ),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn TypeAlias(value: TypeAliasType<'db>) -> Self {
+        match value {
+            TypeAliasType::PEP695(value) => Self::with_detail(
+                TypeTag::TypeAlias,
+                [PackedTypeAliasTag::Pep695 as u8, 0, 0],
+                value,
+            ),
+            TypeAliasType::ManualPEP695(value) => Self::with_detail(
+                TypeTag::TypeAlias,
+                [PackedTypeAliasTag::ManualPep695 as u8, 0, 0],
+                value,
+            ),
+        }
+    }
+
+    #[allow(non_snake_case)]
+    pub fn LiteralValue(literal: LiteralValueType<'db>) -> Self {
+        use set_theoretic::RecursivelyDefined;
+
+        let promotable = literal.is_promotable();
+        let recursive = literal.recursively_defined() == RecursivelyDefined::Yes;
+        let flags = u8::from(promotable) | (u8::from(recursive) << 1);
+        match literal.kind() {
+            LiteralValueTypeKind::Int(value) => Self::with_detail(
+                TypeTag::LiteralValue,
+                [PackedLiteralTag::Int as u8, flags, 0],
+                value,
+            ),
+            LiteralValueTypeKind::Bool(value) => Self::with_detail(
+                TypeTag::LiteralValue,
+                [PackedLiteralTag::Bool as u8, flags, 0],
+                value,
+            ),
+            LiteralValueTypeKind::String(value) => Self::with_detail(
+                TypeTag::LiteralValue,
+                [PackedLiteralTag::String as u8, flags, 0],
+                value,
+            ),
+            LiteralValueTypeKind::Enum(value) => Self::with_detail(
+                TypeTag::LiteralValue,
+                [PackedLiteralTag::Enum as u8, flags, 0],
+                value,
+            ),
+            LiteralValueTypeKind::Bytes(value) => Self::with_detail(
+                TypeTag::LiteralValue,
+                [PackedLiteralTag::Bytes as u8, flags, 0],
+                value,
+            ),
+            LiteralValueTypeKind::LiteralString => Self {
+                detail: [PackedLiteralTag::LiteralString as u8, flags, 0],
+                ..Self::without_payload(TypeTag::LiteralValue)
+            },
+        }
+    }
+
+    pub fn data(self) -> TypeData<'db> {
+        use set_theoretic::RecursivelyDefined;
+
+        match self.tag {
+            TypeTag::Dynamic => TypeData::Dynamic(self.dynamic_at(0)),
+            TypeTag::Divergent => TypeData::Divergent(DivergentType {
+                id: self.payload(),
+                materialization: match self.detail[0] {
+                    0 => None,
+                    1 => Some(MaterializationKind::Top),
+                    2 => Some(MaterializationKind::Bottom),
+                    _ => unreachable!(),
+                },
+            }),
+            TypeTag::Never => TypeData::Never,
+            TypeTag::FunctionLiteral => TypeData::FunctionLiteral(self.payload()),
+            TypeTag::BoundMethod => TypeData::BoundMethod(self.payload()),
+            TypeTag::KnownBoundMethod => TypeData::KnownBoundMethod(match self.detail[0] {
+                x if x == PackedKnownBoundMethodTag::FunctionTypeDunderGet as u8 => {
+                    KnownBoundMethodType::FunctionTypeDunderGet(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::FunctionTypeDunderCall as u8 => {
+                    KnownBoundMethodType::FunctionTypeDunderCall(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::PropertyDunderGet as u8 => {
+                    KnownBoundMethodType::PropertyDunderGet(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::PropertyDunderSet as u8 => {
+                    KnownBoundMethodType::PropertyDunderSet(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::PropertyDunderDelete as u8 => {
+                    KnownBoundMethodType::PropertyDunderDelete(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::StrStartswith as u8 => {
+                    KnownBoundMethodType::StrStartswith(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetRange as u8 => {
+                    KnownBoundMethodType::ConstraintSetRange
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetAlways as u8 => {
+                    KnownBoundMethodType::ConstraintSetAlways
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetNever as u8 => {
+                    KnownBoundMethodType::ConstraintSetNever
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetImpliesSubtypeOf as u8 => {
+                    KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetSatisfies as u8 => {
+                    KnownBoundMethodType::ConstraintSetSatisfies(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetSatisfiedByAllTypeVars as u8 => {
+                    KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(self.payload())
+                }
+                x if x == PackedKnownBoundMethodTag::ConstraintSetWithDetailedDisplay as u8 => {
+                    KnownBoundMethodType::ConstraintSetWithDetailedDisplay(self.payload())
+                }
+                _ => unreachable!(),
+            }),
+            TypeTag::WrapperDescriptor => TypeData::WrapperDescriptor(self.payload()),
+            TypeTag::DataclassDecorator => TypeData::DataclassDecorator(self.payload()),
+            TypeTag::DataclassTransformer => TypeData::DataclassTransformer(self.payload()),
+            TypeTag::Callable => TypeData::Callable(self.payload()),
+            TypeTag::ModuleLiteral => TypeData::ModuleLiteral(self.payload()),
+            TypeTag::ClassLiteral => TypeData::ClassLiteral(self.class_literal_at(0)),
+            TypeTag::GenericAlias => TypeData::GenericAlias(self.payload()),
+            TypeTag::SubclassOf => {
+                TypeData::SubclassOf(SubclassOfType::from_packed_inner(match self.detail[0] {
+                    x if x == PackedSubclassTag::Class as u8 => {
+                        SubclassOfInner::Class(self.class_type_at(1, 2))
+                    }
+                    x if x == PackedSubclassTag::Dynamic as u8 => {
+                        SubclassOfInner::Dynamic(self.dynamic_at(1))
+                    }
+                    x if x == PackedSubclassTag::TypeVar as u8 => {
+                        SubclassOfInner::TypeVar(self.payload())
+                    }
+                    _ => unreachable!(),
+                }))
+            }
+            TypeTag::NominalInstance => TypeData::NominalInstance(NominalInstanceType(match self
+                .detail[0]
+            {
+                x if x == PackedNominalInstanceTag::Object as u8 => NominalInstanceInner::Object,
+                x if x == PackedNominalInstanceTag::ExactTuple as u8 => {
+                    NominalInstanceInner::ExactTuple(self.payload())
+                }
+                x if x == PackedNominalInstanceTag::NonTuple as u8 => {
+                    NominalInstanceInner::NonTuple(self.class_type_at(1, 2))
+                }
+                x if x == PackedNominalInstanceTag::SysVersionInfo as u8 => {
+                    NominalInstanceInner::SysVersionInfo
+                }
+                _ => unreachable!(),
+            })),
+            TypeTag::ProtocolInstance => TypeData::ProtocolInstance(
+                ProtocolInstanceType::from_packed_inner(match self.detail[0] {
+                    x if x == PackedProtocolTag::FromClass as u8 => {
+                        Protocol::FromClass(protocol_class::ProtocolClass(self.class_type_at(1, 2)))
+                    }
+                    x if x == PackedProtocolTag::Synthesized as u8 => {
+                        Protocol::Synthesized(self.payload())
+                    }
+                    _ => unreachable!(),
+                }),
+            ),
+            TypeTag::SpecialForm => TypeData::SpecialForm(match self.detail[0] {
+                x if x == PackedSpecialFormTag::LegacyStdlibAlias as u8 => {
+                    SpecialFormType::LegacyStdlibAlias(match self.detail[1] {
+                        x if x == PackedLegacyStdlibAliasTag::List as u8 => LegacyStdlibAlias::List,
+                        x if x == PackedLegacyStdlibAliasTag::Dict as u8 => LegacyStdlibAlias::Dict,
+                        x if x == PackedLegacyStdlibAliasTag::Set as u8 => LegacyStdlibAlias::Set,
+                        x if x == PackedLegacyStdlibAliasTag::FrozenSet as u8 => {
+                            LegacyStdlibAlias::FrozenSet
+                        }
+                        x if x == PackedLegacyStdlibAliasTag::ChainMap as u8 => {
+                            LegacyStdlibAlias::ChainMap
+                        }
+                        x if x == PackedLegacyStdlibAliasTag::Counter as u8 => {
+                            LegacyStdlibAlias::Counter
+                        }
+                        x if x == PackedLegacyStdlibAliasTag::DefaultDict as u8 => {
+                            LegacyStdlibAlias::DefaultDict
+                        }
+                        x if x == PackedLegacyStdlibAliasTag::Deque as u8 => {
+                            LegacyStdlibAlias::Deque
+                        }
+                        x if x == PackedLegacyStdlibAliasTag::OrderedDict as u8 => {
+                            LegacyStdlibAlias::OrderedDict
+                        }
+                        _ => unreachable!(),
+                    })
+                }
+                x if x == PackedSpecialFormTag::TypeQualifier as u8 => {
+                    SpecialFormType::TypeQualifier(match self.detail[1] {
+                        x if x == PackedTypeQualifierTag::ReadOnly as u8 => TypeQualifier::ReadOnly,
+                        x if x == PackedTypeQualifierTag::Final as u8 => TypeQualifier::Final,
+                        x if x == PackedTypeQualifierTag::ClassVar as u8 => TypeQualifier::ClassVar,
+                        x if x == PackedTypeQualifierTag::Required as u8 => TypeQualifier::Required,
+                        x if x == PackedTypeQualifierTag::NotRequired as u8 => {
+                            TypeQualifier::NotRequired
+                        }
+                        x if x == PackedTypeQualifierTag::InitVar as u8 => TypeQualifier::InitVar,
+                        _ => unreachable!(),
+                    })
+                }
+                x if x == PackedSpecialFormTag::Tuple as u8 => SpecialFormType::Tuple,
+                x if x == PackedSpecialFormTag::Type as u8 => SpecialFormType::Type,
+                x if x == PackedSpecialFormTag::TypeForm as u8 => SpecialFormType::TypeForm,
+                x if x == PackedSpecialFormTag::TypingCallable as u8 => {
+                    SpecialFormType::TypingCallable
+                }
+                x if x == PackedSpecialFormTag::CollectionsAbcCallable as u8 => {
+                    SpecialFormType::CollectionsAbcCallable
+                }
+                x if x == PackedSpecialFormTag::Any as u8 => SpecialFormType::Any,
+                x if x == PackedSpecialFormTag::Annotated as u8 => SpecialFormType::Annotated,
+                x if x == PackedSpecialFormTag::Literal as u8 => SpecialFormType::Literal,
+                x if x == PackedSpecialFormTag::LiteralString as u8 => {
+                    SpecialFormType::LiteralString
+                }
+                x if x == PackedSpecialFormTag::Optional as u8 => SpecialFormType::Optional,
+                x if x == PackedSpecialFormTag::Union as u8 => SpecialFormType::Union,
+                x if x == PackedSpecialFormTag::NoReturn as u8 => SpecialFormType::NoReturn,
+                x if x == PackedSpecialFormTag::Never as u8 => SpecialFormType::Never,
+                x if x == PackedSpecialFormTag::Unknown as u8 => SpecialFormType::Unknown,
+                x if x == PackedSpecialFormTag::AlwaysTruthy as u8 => SpecialFormType::AlwaysTruthy,
+                x if x == PackedSpecialFormTag::AlwaysFalsy as u8 => SpecialFormType::AlwaysFalsy,
+                x if x == PackedSpecialFormTag::Not as u8 => SpecialFormType::Not,
+                x if x == PackedSpecialFormTag::Intersection as u8 => SpecialFormType::Intersection,
+                x if x == PackedSpecialFormTag::TypeOf as u8 => SpecialFormType::TypeOf,
+                x if x == PackedSpecialFormTag::CallableTypeOf as u8 => {
+                    SpecialFormType::CallableTypeOf
+                }
+                x if x == PackedSpecialFormTag::RegularCallableTypeOf as u8 => {
+                    SpecialFormType::RegularCallableTypeOf
+                }
+                x if x == PackedSpecialFormTag::Top as u8 => SpecialFormType::Top,
+                x if x == PackedSpecialFormTag::Bottom as u8 => SpecialFormType::Bottom,
+                x if x == PackedSpecialFormTag::TypingSelf as u8 => SpecialFormType::TypingSelf,
+                x if x == PackedSpecialFormTag::Concatenate as u8 => SpecialFormType::Concatenate,
+                x if x == PackedSpecialFormTag::Unpack as u8 => SpecialFormType::Unpack,
+                x if x == PackedSpecialFormTag::TypeAlias as u8 => SpecialFormType::TypeAlias,
+                x if x == PackedSpecialFormTag::TypeGuard as u8 => SpecialFormType::TypeGuard,
+                x if x == PackedSpecialFormTag::TypedDict as u8 => SpecialFormType::TypedDict,
+                x if x == PackedSpecialFormTag::TypeIs as u8 => SpecialFormType::TypeIs,
+                x if x == PackedSpecialFormTag::Protocol as u8 => SpecialFormType::Protocol,
+                x if x == PackedSpecialFormTag::Generic as u8 => SpecialFormType::Generic,
+                x if x == PackedSpecialFormTag::NamedTuple as u8 => SpecialFormType::NamedTuple,
+                _ => unreachable!(),
+            }),
+            TypeTag::KnownInstance => TypeData::KnownInstance(match self.detail[0] {
+                x if x == PackedKnownInstanceTag::SubscriptedProtocol as u8 => {
+                    KnownInstanceType::SubscriptedProtocol(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::SubscriptedGeneric as u8 => {
+                    KnownInstanceType::SubscriptedGeneric(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::TypeVar as u8 => {
+                    KnownInstanceType::TypeVar(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::TypeAliasType as u8 => {
+                    KnownInstanceType::TypeAliasType(match self.detail[1] {
+                        x if x == PackedTypeAliasTag::Pep695 as u8 => {
+                            TypeAliasType::PEP695(self.payload())
+                        }
+                        x if x == PackedTypeAliasTag::ManualPep695 as u8 => {
+                            TypeAliasType::ManualPEP695(self.payload())
+                        }
+                        _ => unreachable!(),
+                    })
+                }
+                x if x == PackedKnownInstanceTag::Deprecated as u8 => {
+                    KnownInstanceType::Deprecated(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Field as u8 => {
+                    KnownInstanceType::Field(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::ConstraintSet as u8 => {
+                    KnownInstanceType::ConstraintSet(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::GenericContext as u8 => {
+                    KnownInstanceType::GenericContext(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Specialization as u8 => {
+                    KnownInstanceType::Specialization(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::UnionType as u8 => {
+                    KnownInstanceType::UnionType(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Literal as u8 => {
+                    KnownInstanceType::Literal(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Annotated as u8 => {
+                    KnownInstanceType::Annotated(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::TypeGenericAlias as u8 => {
+                    KnownInstanceType::TypeGenericAlias(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Callable as u8 => {
+                    KnownInstanceType::Callable(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::LiteralStringAlias as u8 => {
+                    KnownInstanceType::LiteralStringAlias(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::NewType as u8 => {
+                    KnownInstanceType::NewType(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::Sentinel as u8 => {
+                    KnownInstanceType::Sentinel(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::NamedTupleSpec as u8 => {
+                    KnownInstanceType::NamedTupleSpec(self.payload())
+                }
+                x if x == PackedKnownInstanceTag::FunctoolsPartial as u8 => {
+                    KnownInstanceType::FunctoolsPartial(self.payload())
+                }
+                _ => unreachable!(),
+            }),
+            TypeTag::PropertyInstance => TypeData::PropertyInstance(self.payload()),
+            TypeTag::Union => TypeData::Union(self.payload()),
+            TypeTag::Intersection => TypeData::Intersection(self.payload()),
+            TypeTag::EnumComplement => TypeData::EnumComplement(self.payload()),
+            TypeTag::AlwaysTruthy => TypeData::AlwaysTruthy,
+            TypeTag::AlwaysFalsy => TypeData::AlwaysFalsy,
+            TypeTag::TypeVar => TypeData::TypeVar(self.payload()),
+            TypeTag::BoundSuper => TypeData::BoundSuper(self.payload()),
+            TypeTag::TypeIs => TypeData::TypeIs(self.payload()),
+            TypeTag::TypeGuard => TypeData::TypeGuard(self.payload()),
+            TypeTag::TypeForm => TypeData::TypeForm(self.payload()),
+            TypeTag::TypedDict => TypeData::TypedDict(match self.detail[0] {
+                x if x == PackedTypedDictTag::Class as u8 => {
+                    TypedDictType::Class(self.class_type_at(1, 2))
+                }
+                x if x == PackedTypedDictTag::Synthesized as u8 => {
+                    TypedDictType::Synthesized(self.payload())
+                }
+                _ => unreachable!(),
+            }),
+            TypeTag::TypeAlias => TypeData::TypeAlias(match self.detail[0] {
+                x if x == PackedTypeAliasTag::Pep695 as u8 => TypeAliasType::PEP695(self.payload()),
+                x if x == PackedTypeAliasTag::ManualPep695 as u8 => {
+                    TypeAliasType::ManualPEP695(self.payload())
+                }
+                _ => unreachable!(),
+            }),
+            TypeTag::NewTypeInstance => TypeData::NewTypeInstance(self.payload()),
+            TypeTag::LiteralValue => {
+                let kind = match self.detail[0] {
+                    x if x == PackedLiteralTag::Int as u8 => {
+                        LiteralValueTypeKind::Int(self.payload())
+                    }
+                    x if x == PackedLiteralTag::Bool as u8 => {
+                        LiteralValueTypeKind::Bool(self.payload())
+                    }
+                    x if x == PackedLiteralTag::String as u8 => {
+                        LiteralValueTypeKind::String(self.payload())
+                    }
+                    x if x == PackedLiteralTag::Enum as u8 => {
+                        LiteralValueTypeKind::Enum(self.payload())
+                    }
+                    x if x == PackedLiteralTag::Bytes as u8 => {
+                        LiteralValueTypeKind::Bytes(self.payload())
+                    }
+                    x if x == PackedLiteralTag::LiteralString as u8 => {
+                        LiteralValueTypeKind::LiteralString
+                    }
+                    _ => unreachable!(),
+                };
+                let literal = LiteralValueType::new(kind, self.detail[1] & 1 != 0)
+                    .with_recursively_defined(if self.detail[1] & 2 != 0 {
+                        RecursivelyDefined::Yes
+                    } else {
+                        RecursivelyDefined::No
+                    });
+                TypeData::LiteralValue(literal)
+            }
+        }
+    }
+}
+
 /// Helper for `recursive_type_normalized_impl` for `TypeGuardLike` types.
 fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
     db: &'db dyn Db,
@@ -1020,11 +2190,11 @@ fn object_type_form(db: &dyn Db) -> Type<'_> {
 
 #[salsa::tracked]
 impl<'db> Type<'db> {
-    pub(crate) const fn any() -> Self {
+    pub(crate) fn any() -> Self {
         Self::Dynamic(DynamicType::Any)
     }
 
-    pub const fn unknown() -> Self {
+    pub fn unknown() -> Self {
         Self::Dynamic(DynamicType::Unknown)
     }
 
@@ -1032,13 +2202,13 @@ impl<'db> Type<'db> {
         Self::Divergent(DivergentType::new(id))
     }
 
-    pub(crate) const fn is_divergent(&self) -> bool {
-        matches!(self, Type::Divergent(_))
+    pub(crate) fn is_divergent(&self) -> bool {
+        matches!((self).data(), TypeData::Divergent(_))
     }
 
-    pub(crate) const fn as_divergent(self) -> Option<DivergentType> {
-        match self {
-            Type::Divergent(divergent) => Some(divergent),
+    pub(crate) fn as_divergent(self) -> Option<DivergentType> {
+        match (self).data() {
+            TypeData::Divergent(divergent) => Some(divergent),
             _ => None,
         }
     }
@@ -1046,8 +2216,8 @@ impl<'db> Type<'db> {
     /// Returns `true` if both `self` and `other` are `Divergent` types originating from the
     /// same cycle (i.e., sharing the same query ID), regardless of materialization state.
     fn same_divergent_marker(self, other: Type<'db>) -> bool {
-        match (self, other) {
-            (Type::Divergent(left), Type::Divergent(right)) => left.same_marker(right),
+        match ((self).data(), (other).data()) {
+            (TypeData::Divergent(left), TypeData::Divergent(right)) => left.same_marker(right),
             _ => false,
         }
     }
@@ -1056,7 +2226,7 @@ impl<'db> Type<'db> {
     /// behave as: `object` for top-materialized, `Never` for bottom-materialized.
     /// Returns `None` if `self` is not `Divergent` or has not been materialized.
     fn materialized_divergent_fallback(self) -> Option<Type<'db>> {
-        let Type::Divergent(divergent) = self else {
+        let TypeData::Divergent(divergent) = (self).data() else {
             return None;
         };
 
@@ -1069,7 +2239,7 @@ impl<'db> Type<'db> {
 
     /// Negating a divergent marker preserves the marker and flips its materialization, if any.
     fn negated_divergent(self) -> Option<Type<'db>> {
-        let Type::Divergent(divergent) = self else {
+        let TypeData::Divergent(divergent) = (self).data() else {
             return None;
         };
 
@@ -1081,10 +2251,10 @@ impl<'db> Type<'db> {
         })
     }
 
-    pub const fn is_unknown(&self) -> bool {
+    pub fn is_unknown(&self) -> bool {
         matches!(
-            self,
-            Type::Dynamic(
+            (self).data(),
+            TypeData::Dynamic(
                 DynamicType::Unknown
                     | DynamicType::UnknownGeneric(_)
                     | DynamicType::AmbiguousOverload
@@ -1092,11 +2262,11 @@ impl<'db> Type<'db> {
         )
     }
 
-    pub(crate) const fn is_never(&self) -> bool {
+    pub(crate) fn is_never(&self) -> bool {
         matches!(
-            self,
-            Type::Never
-                | Type::Divergent(DivergentType {
+            (self).data(),
+            TypeData::Never
+                | TypeData::Divergent(DivergentType {
                     materialization: Some(MaterializationKind::Bottom),
                     ..
                 })
@@ -1115,9 +2285,11 @@ impl<'db> Type<'db> {
     /// `FunctionLiteral`, `BoundMethod`, and function-like `Callable` types return `false`
     /// because their `Self` binding is deferred to call time via the signature binding path.
     fn supports_self_binding(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::FunctionLiteral(_) | Type::BoundMethod(_) | Type::KnownBoundMethod(_) => false,
-            Type::Callable(callable) if callable.is_function_like(db) => false,
+        match (self).data() {
+            TypeData::FunctionLiteral(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::KnownBoundMethod(_) => false,
+            TypeData::Callable(callable) if callable.is_function_like(db) => false,
             _ => self.contains_self(db),
         }
     }
@@ -1142,8 +2314,8 @@ impl<'db> Type<'db> {
     }
 
     /// Returns `true` if `self` is [`Type::Callable`].
-    pub(crate) const fn is_callable_type(&self) -> bool {
-        matches!(self, Type::Callable(..))
+    pub(crate) fn is_callable_type(&self) -> bool {
+        matches!((self).data(), TypeData::Callable(..))
     }
 
     pub(crate) fn cycle_normalized(
@@ -1168,7 +2340,10 @@ impl<'db> Type<'db> {
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
                 any_over_type(db, self, false, |ty| {
-                    matches!(ty, Type::Dynamic(DynamicType::AmbiguousOverload))
+                    matches!(
+                        (ty).data(),
+                        TypeData::Dynamic(DynamicType::AmbiguousOverload)
+                    )
                 }) && !any_over_type(db, self, false, |ty| ty.is_divergent())
                     && any_over_type(db, previous, false, |ty| ty.is_divergent());
             // Generally, the precision of type inference improves with each iteration.
@@ -1204,7 +2379,10 @@ impl<'db> Type<'db> {
     }
 
     fn is_typealias_special_form(&self) -> bool {
-        matches!(self, Type::SpecialForm(SpecialFormType::TypeAlias))
+        matches!(
+            (self).data(),
+            TypeData::SpecialForm(SpecialFormType::TypeAlias)
+        )
     }
 
     /// Return true if this type overrides __eq__ or __ne__ methods
@@ -1254,8 +2432,8 @@ impl<'db> Type<'db> {
         })
     }
 
-    pub const fn is_generic_alias(&self) -> bool {
-        matches!(self, Type::GenericAlias(_))
+    pub fn is_generic_alias(&self) -> bool {
+        matches!((self).data(), TypeData::GenericAlias(_))
     }
 
     /// Returns whether this type represents a specialization of a generic type.
@@ -1263,12 +2441,12 @@ impl<'db> Type<'db> {
     /// For example, whereas `<class 'list'>` is a generic type, `<class 'list[int]'>`
     /// is a specialization of that type.
     pub(crate) fn is_specialized_generic(self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::Union(union) => union
+        match (self).data() {
+            TypeData::Union(union) => union
                 .elements(db)
                 .iter()
                 .any(|ty| ty.is_specialized_generic(db)),
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 intersection
                     .positive(db)
                     .iter()
@@ -1278,35 +2456,35 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|ty| ty.is_specialized_generic(db))
             }
-            Type::NominalInstance(instance_type) => instance_type.is_definition_generic(),
-            Type::ProtocolInstance(protocol) => {
+            TypeData::NominalInstance(instance_type) => instance_type.is_definition_generic(),
+            TypeData::ProtocolInstance(protocol) => {
                 matches!(protocol.inner, Protocol::FromClass(class) if class.is_generic())
             }
-            Type::TypedDict(typed_dict) => typed_dict
+            TypeData::TypedDict(typed_dict) => typed_dict
                 .defining_class()
                 .is_some_and(ClassType::is_generic),
-            Type::Dynamic(dynamic) => {
+            TypeData::Dynamic(dynamic) => {
                 matches!(dynamic, DynamicType::UnknownGeneric(_))
             }
             // Due to inheritance rules, enums cannot be generic.
-            Type::LiteralValue(literal) if literal.is_enum() => false,
+            TypeData::LiteralValue(literal) if literal.is_enum() => false,
             // Once generic NewType is officially specified, handle it.
             _ => false,
         }
     }
 
-    pub(crate) const fn is_dynamic(&self) -> bool {
+    pub(crate) fn is_dynamic(&self) -> bool {
         matches!(
-            self,
-            Type::Dynamic(_)
-                | Type::Divergent(DivergentType {
+            (self).data(),
+            TypeData::Dynamic(_)
+                | TypeData::Divergent(DivergentType {
                     materialization: None,
                     ..
                 })
         )
     }
 
-    const fn is_non_divergent_dynamic(&self) -> bool {
+    fn is_non_divergent_dynamic(&self) -> bool {
         self.is_dynamic() && !self.is_divergent()
     }
 
@@ -1316,17 +2494,17 @@ impl<'db> Type<'db> {
     /// Unions are considered awaitable only if every element is awaitable.
     /// Intersections are considered awaitable if any positive element is awaitable.
     pub(crate) fn is_awaitable(self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::NominalInstance(instance) => {
+        match (self).data() {
+            TypeData::NominalInstance(instance) => {
                 matches!(instance.known_class(db), Some(KnownClass::CoroutineType))
             }
-            Type::Union(union) => {
+            TypeData::Union(union) => {
                 let elements = union.elements(db);
                 // Guard against empty unions (`Never`), since `all()` on an empty
                 // iterator returns `true`.
                 !elements.is_empty() && elements.iter().all(|ty| ty.is_awaitable(db))
             }
-            Type::Intersection(intersection) => intersection
+            TypeData::Intersection(intersection) => intersection
                 .positive(db)
                 .iter()
                 .any(|ty| ty.is_awaitable(db)),
@@ -1336,9 +2514,9 @@ impl<'db> Type<'db> {
 
     /// Is a value of this type only usable in typing contexts?
     pub fn is_type_check_only(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::ClassLiteral(class_literal) => class_literal.type_check_only(db),
-            Type::FunctionLiteral(f) => {
+        match (self).data() {
+            TypeData::ClassLiteral(class_literal) => class_literal.type_check_only(db),
+            TypeData::FunctionLiteral(f) => {
                 f.has_known_decorator(db, FunctionDecorators::TYPE_CHECK_ONLY)
             }
             _ => false,
@@ -1347,9 +2525,9 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is marked as deprecated via `@warnings.deprecated`.
     pub fn is_deprecated(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::FunctionLiteral(f) => f.implementation_deprecated(db).is_some(),
-            Type::ClassLiteral(c) => c.deprecated(db).is_some(),
+        match (self).data() {
+            TypeData::FunctionLiteral(f) => f.implementation_deprecated(db).is_some(),
+            TypeData::ClassLiteral(c) => c.deprecated(db).is_some(),
             _ => false,
         }
     }
@@ -1388,12 +2566,14 @@ impl<'db> Type<'db> {
 
     /// If this type is a class instance, returns its class.
     pub(crate) fn nominal_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
-        match self {
-            Type::NominalInstance(instance) => Some(instance.class(db)),
-            Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
-            Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
-            Type::TypeVar(typevar) => {
+        match (self).data() {
+            TypeData::NominalInstance(instance) => Some(instance.class(db)),
+            TypeData::ProtocolInstance(instance) => {
+                instance.to_nominal_instance().map(|i| i.class(db))
+            }
+            TypeData::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
+            TypeData::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
+            TypeData::TypeVar(typevar) => {
                 let TypeVarBoundOrConstraints::UpperBound(bound) =
                     typevar.typevar(db).bound_or_constraints(db)?
                 else {
@@ -1401,8 +2581,10 @@ impl<'db> Type<'db> {
                 };
                 bound.nominal_class(db)
             }
-            Type::LiteralValue(literal) => literal.fallback_instance(db).nominal_class(db),
-            Type::PropertyInstance(property) => property.instance_fallback(db).nominal_class(db),
+            TypeData::LiteralValue(literal) => literal.fallback_instance(db).nominal_class(db),
+            TypeData::PropertyInstance(property) => {
+                property.instance_fallback(db).nominal_class(db)
+            }
             _ => None,
         }
     }
@@ -1497,30 +2679,32 @@ impl<'db> Type<'db> {
         any_over_type(db, self, false, |ty| ty.is_dynamic())
     }
 
-    pub(crate) const fn as_special_form(self) -> Option<SpecialFormType> {
-        match self {
-            Type::SpecialForm(special_form) => Some(special_form),
+    pub(crate) fn as_special_form(self) -> Option<SpecialFormType> {
+        match (self).data() {
+            TypeData::SpecialForm(special_form) => Some(special_form),
             _ => None,
         }
     }
 
-    pub const fn as_property_instance(self) -> Option<PropertyInstanceType<'db>> {
-        match self {
-            Type::PropertyInstance(property) => Some(property),
+    pub fn as_property_instance(self) -> Option<PropertyInstanceType<'db>> {
+        match (self).data() {
+            TypeData::PropertyInstance(property) => Some(property),
             _ => None,
         }
     }
 
-    pub const fn as_class_literal(self) -> Option<ClassLiteral<'db>> {
-        match self {
-            Type::ClassLiteral(class_type) => Some(class_type),
+    pub fn as_class_literal(self) -> Option<ClassLiteral<'db>> {
+        match (self).data() {
+            TypeData::ClassLiteral(class_type) => Some(class_type),
             _ => None,
         }
     }
 
-    pub(crate) const fn as_type_alias(self) -> Option<TypeAliasType<'db>> {
-        match self {
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => Some(type_alias),
+    pub(crate) fn as_type_alias(self) -> Option<TypeAliasType<'db>> {
+        match (self).data() {
+            TypeData::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
+                Some(type_alias)
+            }
             _ => None,
         }
     }
@@ -1529,7 +2713,7 @@ impl<'db> Type<'db> {
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
         let mut ty = self;
-        while let Type::TypeAlias(alias) = ty {
+        while let TypeData::TypeAlias(alias) = (ty).data() {
             ty = alias.value_type(db);
         }
         ty
@@ -1538,74 +2722,74 @@ impl<'db> Type<'db> {
     /// Returns `Some(UnionType)` if this type behaves like a union. Apart from explicit unions,
     /// this returns `Some` for `TypeAlias`es of unions and `NewType`s of `float` and `complex`.
     pub(crate) fn as_union_like(self, db: &'db dyn Db) -> Option<UnionType<'db>> {
-        match self.resolve_type_alias(db) {
-            Type::Union(union) => Some(union),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).as_union_like(db),
+        match (self.resolve_type_alias(db)).data() {
+            TypeData::Union(union) => Some(union),
+            TypeData::NewTypeInstance(newtype) => newtype.concrete_base_type(db).as_union_like(db),
             _ => None,
         }
     }
 
-    pub(crate) const fn as_dynamic(self) -> Option<DynamicType<'db>> {
-        match self {
-            Type::Dynamic(dynamic_type) => Some(dynamic_type),
+    pub(crate) fn as_dynamic(self) -> Option<DynamicType<'db>> {
+        match (self).data() {
+            TypeData::Dynamic(dynamic_type) => Some(dynamic_type),
             _ => None,
         }
     }
 
-    pub(crate) const fn as_callable(self) -> Option<CallableType<'db>> {
-        match self {
-            Type::Callable(callable_type) => Some(callable_type),
+    pub(crate) fn as_callable(self) -> Option<CallableType<'db>> {
+        match (self).data() {
+            TypeData::Callable(callable_type) => Some(callable_type),
             _ => None,
         }
     }
 
-    pub(crate) const fn expect_dynamic(self) -> DynamicType<'db> {
+    pub(crate) fn expect_dynamic(self) -> DynamicType<'db> {
         self.as_dynamic().expect("Expected a Type::Dynamic variant")
     }
 
-    pub(crate) const fn as_protocol_instance(self) -> Option<ProtocolInstanceType<'db>> {
-        match self {
-            Type::ProtocolInstance(instance) => Some(instance),
+    pub(crate) fn as_protocol_instance(self) -> Option<ProtocolInstanceType<'db>> {
+        match (self).data() {
+            TypeData::ProtocolInstance(instance) => Some(instance),
             _ => None,
         }
     }
 
     #[cfg(test)]
     #[track_caller]
-    pub(crate) const fn expect_class_literal(self) -> ClassLiteral<'db> {
+    pub(crate) fn expect_class_literal(self) -> ClassLiteral<'db> {
         self.as_class_literal()
             .expect("Expected a Type::ClassLiteral variant")
     }
 
-    pub const fn is_subclass_of(&self) -> bool {
-        matches!(self, Type::SubclassOf(..))
+    pub fn is_subclass_of(&self) -> bool {
+        matches!((self).data(), TypeData::SubclassOf(..))
     }
 
-    pub const fn is_class_literal(&self) -> bool {
-        matches!(self, Type::ClassLiteral(..))
+    pub fn is_class_literal(&self) -> bool {
+        matches!((self).data(), TypeData::ClassLiteral(..))
     }
 
-    pub(crate) const fn as_literal_value(self) -> Option<LiteralValueType<'db>> {
-        match self {
-            Type::LiteralValue(literal) => Some(literal),
+    pub(crate) fn as_literal_value(self) -> Option<LiteralValueType<'db>> {
+        match (self).data() {
+            TypeData::LiteralValue(literal) => Some(literal),
             _ => None,
         }
     }
 
     pub(crate) fn as_literal_value_kind(self) -> Option<LiteralValueTypeKind<'db>> {
-        match self {
-            Type::LiteralValue(literal) => Some(literal.kind()),
+        match (self).data() {
+            TypeData::LiteralValue(literal) => Some(literal.kind()),
             _ => None,
         }
     }
 
-    pub(crate) const fn is_typed_dict(&self) -> bool {
-        matches!(self, Type::TypedDict(..))
+    pub(crate) fn is_typed_dict(&self) -> bool {
+        matches!((self).data(), TypeData::TypedDict(..))
     }
 
-    pub(crate) const fn as_typed_dict(self) -> Option<TypedDictType<'db>> {
-        match self {
-            Type::TypedDict(typed_dict) => Some(typed_dict),
+    pub(crate) fn as_typed_dict(self) -> Option<TypedDictType<'db>> {
+        match (self).data() {
+            TypeData::TypedDict(typed_dict) => Some(typed_dict),
             _ => None,
         }
     }
@@ -1614,15 +2798,15 @@ impl<'db> Type<'db> {
     /// Since a `ClassType` must be specialized, apply the default specialization to any
     /// unspecialized generic class literal.
     pub(crate) fn to_class_type(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
-        match self {
-            Type::ClassLiteral(class_literal) => Some(class_literal.default_specialization(db)),
-            Type::GenericAlias(alias) => Some(ClassType::Generic(alias)),
+        match (self).data() {
+            TypeData::ClassLiteral(class_literal) => Some(class_literal.default_specialization(db)),
+            TypeData::GenericAlias(alias) => Some(ClassType::Generic(alias)),
             _ => None,
         }
     }
 
-    pub const fn is_property_instance(&self) -> bool {
-        matches!(self, Type::PropertyInstance(..))
+    pub fn is_property_instance(&self) -> bool {
+        matches!((self).data(), TypeData::PropertyInstance(..))
     }
 
     pub(crate) fn module_literal(
@@ -1637,41 +2821,41 @@ impl<'db> Type<'db> {
         ))
     }
 
-    pub(crate) const fn is_union(self) -> bool {
-        matches!(self, Type::Union(_))
+    pub(crate) fn is_union(self) -> bool {
+        matches!((self).data(), TypeData::Union(_))
     }
 
-    pub const fn as_union(self) -> Option<UnionType<'db>> {
-        match self {
-            Type::Union(union_type) => Some(union_type),
+    pub fn as_union(self) -> Option<UnionType<'db>> {
+        match (self).data() {
+            TypeData::Union(union_type) => Some(union_type),
             _ => None,
         }
     }
 
     #[track_caller]
-    pub(crate) const fn expect_union(self) -> UnionType<'db> {
+    pub(crate) fn expect_union(self) -> UnionType<'db> {
         self.as_union().expect("Expected a Type::Union variant")
     }
 
-    pub(crate) const fn is_intersection(self) -> bool {
-        matches!(self, Type::Intersection(_))
+    pub(crate) fn is_intersection(self) -> bool {
+        matches!((self).data(), TypeData::Intersection(_))
     }
 
     /// Returns whether this is a "real" intersection type. (Negated types are represented by an
     /// intersection containing a single negative branch, which this method does _not_ consider a
     /// "real" intersection.)
     pub(crate) fn is_nontrivial_intersection(self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::Intersection(intersection) => !intersection.is_simple_negation(db),
+        match (self).data() {
+            TypeData::Intersection(intersection) => !intersection.is_simple_negation(db),
             _ => false,
         }
     }
 
     /// Returns the number of union clauses in this type. If the type is not a union, returns 1.
     pub(crate) fn union_size(self, db: &'db dyn Db) -> usize {
-        match self {
-            Type::Union(union_type) => union_type.elements(db).len(),
-            Type::Never => 0,
+        match (self).data() {
+            TypeData::Union(union_type) => union_type.elements(db).len(),
+            TypeData::Never => 0,
             _ => 1,
         }
     }
@@ -1680,11 +2864,11 @@ impl<'db> Type<'db> {
     /// the maximum of the `intersection_size` of each union element. If the type is not a union
     /// nor an intersection, returns 1.
     pub(crate) fn intersection_size(self, db: &'db dyn Db) -> usize {
-        match self {
-            Type::Intersection(intersection) => {
+        match (self).data() {
+            TypeData::Intersection(intersection) => {
                 intersection.positive(db).len() + intersection.negative(db).len()
             }
-            Type::Union(union_type) => union_type
+            TypeData::Union(union_type) => union_type
                 .elements(db)
                 .iter()
                 .map(|element| element.intersection_size(db))
@@ -1694,9 +2878,9 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub const fn as_function_literal(self) -> Option<FunctionType<'db>> {
-        match self {
-            Type::FunctionLiteral(function_type) => Some(function_type),
+    pub fn as_function_literal(self) -> Option<FunctionType<'db>> {
+        match (self).data() {
+            TypeData::FunctionLiteral(function_type) => Some(function_type),
             _ => None,
         }
     }
@@ -1708,20 +2892,20 @@ impl<'db> Type<'db> {
             .expect("Expected a Type::FunctionLiteral variant")
     }
 
-    pub(crate) const fn is_function_literal(&self) -> bool {
-        matches!(self, Type::FunctionLiteral(..))
+    pub(crate) fn is_function_literal(&self) -> bool {
+        matches!((self).data(), TypeData::FunctionLiteral(..))
     }
 
     pub(crate) fn as_string_literal(self) -> Option<StringLiteralType<'db>> {
-        match self {
-            Type::LiteralValue(literal) => literal.as_string(),
+        match (self).data() {
+            TypeData::LiteralValue(literal) => literal.as_string(),
             _ => None,
         }
     }
 
     pub(crate) fn as_int_literal(self) -> Option<i64> {
-        match self {
-            Type::LiteralValue(literal) => literal.as_int(),
+        match (self).data() {
+            TypeData::LiteralValue(literal) => literal.as_int(),
             _ => None,
         }
     }
@@ -1735,8 +2919,8 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn as_enum_literal(self) -> Option<EnumLiteralType<'db>> {
-        match self {
-            Type::LiteralValue(literal) => literal.as_enum(),
+        match (self).data() {
+            TypeData::LiteralValue(literal) => literal.as_enum(),
             _ => None,
         }
     }
@@ -1757,12 +2941,12 @@ impl<'db> Type<'db> {
 
     /// Detects types which are valid to appear inside a `Literal[…]` type annotation.
     pub(crate) fn is_literal_or_union_of_literals(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::Union(union) => union
+        match (self).data() {
+            TypeData::Union(union) => union
                 .elements(db)
                 .iter()
                 .all(|ty| ty.is_literal_or_union_of_literals(db)),
-            Type::LiteralValue(literal) => match literal.kind() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::String(_)
                 | LiteralValueTypeKind::Bytes(_)
                 | LiteralValueTypeKind::Int(_)
@@ -1770,7 +2954,9 @@ impl<'db> Type<'db> {
                 | LiteralValueTypeKind::Enum(_) => true,
                 LiteralValueTypeKind::LiteralString => false,
             },
-            Type::NominalInstance(_) => self.is_none(db) || self.is_bool(db) || self.is_enum(db),
+            TypeData::NominalInstance(_) => {
+                self.is_none(db) || self.is_bool(db) || self.is_enum(db)
+            }
             _ => false,
         }
     }
@@ -1831,50 +3017,50 @@ impl<'db> Type<'db> {
         // We verify that this always produces the same result as
         // `IntersectionBuilder::new(db).add_negative(*self).build()` via the
         // property test `all_negated_types_identical_to_intersection_with_single_negated_element`
-        match self {
-            Type::Never => Type::object(),
+        match (self).data() {
+            TypeData::Never => Type::object(),
 
-            Type::Dynamic(_) => *self,
+            TypeData::Dynamic(_) => *self,
 
-            Type::Divergent(_) => (*self)
+            TypeData::Divergent(_) => (*self)
                 .negated_divergent()
                 .expect("matched `Type::Divergent` above"),
 
-            Type::NominalInstance(instance) if instance.is_object() => Type::Never,
+            TypeData::NominalInstance(instance) if instance.is_object() => Type::Never,
 
-            Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::KnownBoundMethod(_)
-            | Type::KnownInstance(_)
-            | Type::SpecialForm(_)
-            | Type::BoundSuper(_)
-            | Type::FunctionLiteral(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypeVar(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_)
-            | Type::NominalInstance(_)
-            | Type::ProtocolInstance(_)
-            | Type::ModuleLiteral(_)
-            | Type::ClassLiteral(_)
-            | Type::GenericAlias(_)
-            | Type::SubclassOf(_)
-            | Type::PropertyInstance(_)
-            | Type::LiteralValue(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::Callable(_)
-            | Type::WrapperDescriptor(_)
-            | Type::TypeAlias(_)
-            | Type::BoundMethod(_) => Type::Intersection(IntersectionType::new(
+            TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::KnownInstance(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::FunctionLiteral(_)
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::TypeVar(_)
+            | TypeData::TypedDict(_)
+            | TypeData::NewTypeInstance(_)
+            | TypeData::NominalInstance(_)
+            | TypeData::ProtocolInstance(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::ClassLiteral(_)
+            | TypeData::GenericAlias(_)
+            | TypeData::SubclassOf(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::Callable(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::TypeAlias(_)
+            | TypeData::BoundMethod(_) => Type::Intersection(IntersectionType::new(
                 db,
                 FxOrderSet::default(),
                 NegativeIntersectionElements::Single(*self),
             )),
 
-            Type::Union(_) | Type::Intersection(_) | Type::EnumComplement(_) => {
+            TypeData::Union(_) | TypeData::Intersection(_) | TypeData::EnumComplement(_) => {
                 IntersectionBuilder::new(db).add_negative(*self).build()
             }
         }
@@ -1888,105 +3074,107 @@ impl<'db> Type<'db> {
     /// Return `true` if it is possible to spell an equivalent type to this one
     /// in user annotations without nonstandard extensions to the type system
     pub(crate) fn is_spellable(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::LiteralValue(_)
-            | Type::Never
-            | Type::NewTypeInstance(_)
-            | Type::NominalInstance(_)
+        match (self).data() {
+            TypeData::LiteralValue(_)
+            | TypeData::Never
+            | TypeData::NewTypeInstance(_)
+            | TypeData::NominalInstance(_)
             // `TypedDict` and `Protocol` can be synthesized,
             // but it's always possible to create an equivalent type using a class definition.
-            | Type::TypedDict(_)
-            | Type::ProtocolInstance(_)
+            | TypeData::TypedDict(_)
+            | TypeData::ProtocolInstance(_)
             // Not all `Callable` types are spellable using the `Callable` type form,
             // but they are all spellable using callback protocols.
-            | Type::Callable(_)
+            | TypeData::Callable(_)
             // `Unknown` and `@Todo` are nonstandard extensions,
             // but they are both exactly equivalent to `Any`
-            | Type::Dynamic(_)
-            | Type::TypeVar(_)
-            | Type::TypeAlias(_)
-            | Type::SubclassOf(_) => true,
-            Type::TypeForm(typeform) => typeform.type_argument(db).is_spellable(db),
-            Type::Intersection(_) => false,
-            Type::EnumComplement(complement) => complement.is_spellable(db),
-            Type::Divergent(_)
-            | Type::SpecialForm(_)
-            | Type::BoundSuper(_)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::PropertyInstance(_)
-            | Type::FunctionLiteral(_)
-            | Type::ModuleLiteral(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ClassLiteral(_)
-            | Type::GenericAlias(_)
-            | Type::KnownInstance(_) => false,
-            Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_spellable(db)),
+            | TypeData::Dynamic(_)
+            | TypeData::TypeVar(_)
+            | TypeData::TypeAlias(_)
+            | TypeData::SubclassOf(_) => true,
+            TypeData::TypeForm(typeform) => typeform.type_argument(db).is_spellable(db),
+            TypeData::Intersection(_) => false,
+            TypeData::EnumComplement(complement) => complement.is_spellable(db),
+            TypeData::Divergent(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::FunctionLiteral(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ClassLiteral(_)
+            | TypeData::GenericAlias(_)
+            | TypeData::KnownInstance(_) => false,
+            TypeData::Union(union) => union.elements(db).iter().all(|ty| ty.is_spellable(db)),
         }
     }
 
     /// Return `true` if `self` is a type that is suitable for displaying
     /// in a "Did you mean...?" hint message in diagnostics
     fn is_hintable(&self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::NominalInstance(_)
-            | Type::NewTypeInstance(_)
-            | Type::LiteralValue(_)
-            | Type::TypeAlias(_) => true,
+        match (self).data() {
+            TypeData::NominalInstance(_)
+            | TypeData::NewTypeInstance(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::TypeAlias(_) => true,
 
-            Type::Intersection(_)
-            | Type::EnumComplement(_)
-            | Type::Divergent(_)
-            | Type::SpecialForm(_)
-            | Type::BoundSuper(_)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::PropertyInstance(_)
-            | Type::FunctionLiteral(_)
-            | Type::ModuleLiteral(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ClassLiteral(_)
-            | Type::GenericAlias(_)
-            | Type::KnownInstance(_) => false,
+            TypeData::Intersection(_)
+            | TypeData::EnumComplement(_)
+            | TypeData::Divergent(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::FunctionLiteral(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ClassLiteral(_)
+            | TypeData::GenericAlias(_)
+            | TypeData::KnownInstance(_) => false,
 
             // `Never` is spellable and could result from an explicit type annotation,
             // but also could just be the result of us inferring an unreachable region.
             // Best to avoid showing it in hints.
-            Type::Never => false,
+            TypeData::Never => false,
 
             // All `Callable` types are spellable in some way,
             // but they're generally not spellable with the syntax we use by default
             // in our type display
-            Type::Callable(_) => false,
+            TypeData::Callable(_) => false,
 
-            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+            TypeData::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(_) => true,
                 SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic).is_hintable(db),
                 SubclassOfInner::TypeVar(tvar) => Type::TypeVar(tvar).is_hintable(db),
             },
 
-            Type::TypeVar(tvar) => tvar.typevar(db).definition(db).is_some(),
+            TypeData::TypeVar(tvar) => tvar.typevar(db).definition(db).is_some(),
 
-            Type::Union(union) => union.elements(db).iter().all(|ty| ty.is_hintable(db)),
+            TypeData::Union(union) => union.elements(db).iter().all(|ty| ty.is_hintable(db)),
 
-            Type::TypedDict(td) => td.defining_class().is_some(),
+            TypeData::TypedDict(td) => td.defining_class().is_some(),
 
-            Type::ProtocolInstance(ProtocolInstanceType { inner, .. }) => !inner.is_synthesized(),
+            TypeData::ProtocolInstance(ProtocolInstanceType { inner, .. }) => {
+                !inner.is_synthesized()
+            }
 
-            Type::Dynamic(dynamic) => match dynamic {
+            TypeData::Dynamic(dynamic) => match dynamic {
                 DynamicType::Any => true,
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
@@ -2010,7 +3198,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         f: impl FnMut(&Type<'db>) -> bool,
     ) -> Type<'db> {
-        if let Type::Union(union) = self.resolve_type_alias(db) {
+        if let TypeData::Union(union) = (self.resolve_type_alias(db)).data() {
             union.filter(db, f)
         } else {
             self
@@ -2041,10 +3229,10 @@ impl<'db> Type<'db> {
         // falling back to `type[X]`, for instance. For now, there is not much rigorous thought put
         // into what's included vs not; this is just an empirical choice that makes our ecosystem
         // report look better until we have proper bidirectional type inference.
-        match self {
-            Type::ModuleLiteral(_) => Some(KnownClass::ModuleType.to_instance(db)),
-            Type::FunctionLiteral(_) => Some(KnownClass::FunctionType.to_instance(db)),
-            Type::LiteralValue(literal) => Some(literal.fallback_instance(db)),
+        match (self).data() {
+            TypeData::ModuleLiteral(_) => Some(KnownClass::ModuleType.to_instance(db)),
+            TypeData::FunctionLiteral(_) => Some(KnownClass::FunctionType.to_instance(db)),
+            TypeData::LiteralValue(literal) => Some(literal.fallback_instance(db)),
             _ => None,
         }
     }
@@ -2081,17 +3269,19 @@ impl<'db> Type<'db> {
 
     /// Like [`Type::promote`], but does not recurse into nested types.
     fn promote_impl(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::LiteralValue(literal) if literal.is_promotable() => literal.fallback_instance(db),
-            Type::FunctionLiteral(literal) => Type::Callable(literal.into_callable_type(db)),
+        match (self).data() {
+            TypeData::LiteralValue(literal) if literal.is_promotable() => {
+                literal.fallback_instance(db)
+            }
+            TypeData::FunctionLiteral(literal) => Type::Callable(literal.into_callable_type(db)),
             _ => self,
         }
     }
 
     /// Like [`Type::promote_singletons_recursively`], but does not recurse into nested types.
     fn promote_singletons_impl(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::NominalInstance(instance) if instance.is_singleton(db) => {
+        match (self).data() {
+            TypeData::NominalInstance(instance) if instance.is_singleton(db) => {
                 UnionType::from_two_elements(db, self, Type::unknown())
             }
             _ => self,
@@ -2145,80 +3335,80 @@ impl<'db> Type<'db> {
         if nested && self.same_divergent_marker(div) {
             return None;
         }
-        match self {
-            Type::Union(union) => union.recursive_type_normalized_impl(db, div, nested),
-            Type::Intersection(intersection) => intersection
+        match (self).data() {
+            TypeData::Union(union) => union.recursive_type_normalized_impl(db, div, nested),
+            TypeData::Intersection(intersection) => intersection
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::Intersection),
-            Type::EnumComplement(complement) => complement
+            TypeData::EnumComplement(complement) => complement
                 .to_intersection(db)
                 .recursive_type_normalized_impl(db, div, nested),
-            Type::Callable(callable) => callable
+            TypeData::Callable(callable) => callable
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::Callable),
-            Type::ProtocolInstance(protocol) => protocol
+            TypeData::ProtocolInstance(protocol) => protocol
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::ProtocolInstance),
-            Type::NominalInstance(instance) => instance
+            TypeData::NominalInstance(instance) => instance
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::NominalInstance),
-            Type::FunctionLiteral(function) => function
+            TypeData::FunctionLiteral(function) => function
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::FunctionLiteral),
-            Type::PropertyInstance(property) => property
+            TypeData::PropertyInstance(property) => property
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::PropertyInstance),
-            Type::KnownBoundMethod(method_kind) => method_kind
+            TypeData::KnownBoundMethod(method_kind) => method_kind
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::KnownBoundMethod),
-            Type::BoundMethod(method) => method
+            TypeData::BoundMethod(method) => method
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::BoundMethod),
-            Type::BoundSuper(bound_super) => bound_super
+            TypeData::BoundSuper(bound_super) => bound_super
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::BoundSuper),
-            Type::GenericAlias(generic) => generic
+            TypeData::GenericAlias(generic) => generic
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::GenericAlias),
-            Type::ClassLiteral(class) => class
+            TypeData::ClassLiteral(class) => class
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::ClassLiteral),
-            Type::SubclassOf(subclass_of) => subclass_of
+            TypeData::SubclassOf(subclass_of) => subclass_of
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::SubclassOf),
-            Type::TypeVar(_) => Some(self),
-            Type::KnownInstance(known_instance) => known_instance
+            TypeData::TypeVar(_) => Some(self),
+            TypeData::KnownInstance(known_instance) => known_instance
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::KnownInstance),
-            Type::TypeIs(type_is) => {
+            TypeData::TypeIs(type_is) => {
                 recursive_type_normalize_type_guard_like(db, type_is, div, nested)
             }
-            Type::TypeGuard(type_guard) => {
+            TypeData::TypeGuard(type_guard) => {
                 recursive_type_normalize_type_guard_like(db, type_guard, div, nested)
             }
-            Type::TypeForm(typeform) => typeform
+            TypeData::TypeForm(typeform) => typeform
                 .type_argument(db)
                 .recursive_type_normalized_impl(db, div, true)
                 .map(|ty| TypeFormType::from_type_expression(db, ty)),
-            Type::Divergent(_) => Some(self),
-            Type::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
-            Type::TypedDict(_) => {
+            TypeData::Divergent(_) => Some(self),
+            TypeData::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
+            TypeData::TypedDict(_) => {
                 // TODO: Normalize TypedDicts
                 Some(self)
             }
-            Type::TypeAlias(_) => Some(self),
-            Type::NewTypeInstance(newtype) => newtype
+            TypeData::TypeAlias(_) => Some(self),
+            TypeData::NewTypeInstance(newtype) => newtype
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::NewTypeInstance),
-            Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::Never
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::SpecialForm(_)
-            | Type::LiteralValue(_) => Some(self),
+            TypeData::AlwaysFalsy
+            | TypeData::AlwaysTruthy
+            | TypeData::Never
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::LiteralValue(_) => Some(self),
         }
     }
 
@@ -2246,23 +3436,23 @@ impl<'db> Type<'db> {
         visitor: &SpecializationVisitor<'db>,
     ) {
         let Some((_, specialization)) = self.class_specialization(db) else {
-            match self {
-                Type::Union(union) => {
+            match (self).data() {
+                TypeData::Union(union) => {
                     for element in union.elements(db) {
                         element.visit_specialization_impl(db, polarity, f, visitor);
                     }
                 }
-                Type::Intersection(intersection) => {
+                TypeData::Intersection(intersection) => {
                     for element in intersection.positive(db) {
                         element.visit_specialization_impl(db, polarity, f, visitor);
                     }
                 }
-                Type::TypeAlias(alias) => visitor.visit(self, || {
+                TypeData::TypeAlias(alias) => visitor.visit(self, || {
                     alias
                         .value_type(db)
                         .visit_specialization_impl(db, polarity, f, visitor);
                 }),
-                Type::Callable(callable) => {
+                TypeData::Callable(callable) => {
                     for signature in callable.signatures(db) {
                         for parameter in signature.parameters() {
                             let variance = TypeVarVariance::Contravariant.compose(polarity);
@@ -2308,10 +3498,10 @@ impl<'db> Type<'db> {
     /// Note: This function aims to have no false positives, but might return `false`
     /// for more complicated types that are actually singletons.
     pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
-        match self {
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
+        match (self).data() {
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => false,
 
-            Type::LiteralValue(literal) => match literal.kind() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(..)
                 | LiteralValueTypeKind::String(..)
                 | LiteralValueTypeKind::Bytes(..)
@@ -2325,7 +3515,7 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::Bool(_) | LiteralValueTypeKind::Enum(_) => true,
             },
 
-            Type::ProtocolInstance(..) => {
+            TypeData::ProtocolInstance(..) => {
                 // It *might* be possible to have a singleton protocol-instance type...?
                 //
                 // E.g.:
@@ -2350,7 +3540,7 @@ impl<'db> Type<'db> {
             // the bound is a final singleton class, since it can still be specialized to `Never`.
             // A constrained typevar is a singleton if all of its constraints are singletons. (Note
             // that you cannot specialize a constrained typevar to a subtype of a constraint.)
-            Type::TypeVar(bound_typevar) => {
+            TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => false,
                     Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
@@ -2362,14 +3552,14 @@ impl<'db> Type<'db> {
             }
 
             // We eagerly transform `SubclassOf` to `ClassLiteral` for final types, so `SubclassOf` is never a singleton.
-            Type::SubclassOf(..) => false,
-            Type::BoundSuper(..) => false,
-            Type::GenericAlias(..) => false,
-            Type::FunctionLiteral(..)
-            | Type::WrapperDescriptor(..)
-            | Type::ClassLiteral(..)
-            | Type::ModuleLiteral(..) => true,
-            Type::SpecialForm(special_form) => {
+            TypeData::SubclassOf(..) => false,
+            TypeData::BoundSuper(..) => false,
+            TypeData::GenericAlias(..) => false,
+            TypeData::FunctionLiteral(..)
+            | TypeData::WrapperDescriptor(..)
+            | TypeData::ClassLiteral(..)
+            | TypeData::ModuleLiteral(..) => true,
+            TypeData::SpecialForm(special_form) => {
                 // Nearly all `SpecialForm` types are singletons, but if a symbol could validly
                 // originate from either `typing` or `typing_extensions` then this is not guaranteed.
                 // E.g. `typing.TypeGuard` is equivalent to `typing_extensions.TypeGuard`, so both are treated
@@ -2378,15 +3568,15 @@ impl<'db> Type<'db> {
                 !(special_form.check_module(KnownModule::Typing)
                     && special_form.check_module(KnownModule::TypingExtensions))
             }
-            Type::KnownInstance(KnownInstanceType::Sentinel(_)) => true,
-            Type::KnownInstance(_) => false,
-            Type::Callable(_) => {
+            TypeData::KnownInstance(KnownInstanceType::Sentinel(_)) => true,
+            TypeData::KnownInstance(_) => false,
+            TypeData::Callable(_) => {
                 // A callable type is never a singleton because for any given signature,
                 // there could be any number of distinct objects that are all callable with that
                 // signature.
                 false
             }
-            Type::BoundMethod(..) => {
+            TypeData::BoundMethod(..) => {
                 // `BoundMethod` types are single-valued types, but not singleton types:
                 // ```pycon
                 // >>> class Foo:
@@ -2397,50 +3587,50 @@ impl<'db> Type<'db> {
                 // ```
                 false
             }
-            Type::KnownBoundMethod(_) => {
+            TypeData::KnownBoundMethod(_) => {
                 // Just a special case of `BoundMethod` really
                 // (this variant represents `f.__get__`, where `f` is any function)
                 false
             }
-            Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => false,
-            Type::NominalInstance(instance) => instance.is_singleton(db),
-            Type::PropertyInstance(_) => false,
-            Type::Union(..) => {
+            TypeData::DataclassDecorator(_) | TypeData::DataclassTransformer(_) => false,
+            TypeData::NominalInstance(instance) => instance.is_singleton(db),
+            TypeData::PropertyInstance(_) => false,
+            TypeData::Union(..) => {
                 // A single-element union, where the sole element was a singleton, would itself
                 // be a singleton type. However, unions with length < 2 should never appear in
                 // our model due to [`UnionBuilder::build`].
                 false
             }
-            Type::Intersection(intersection) => intersection
+            TypeData::Intersection(intersection) => intersection
                 .enum_complement(db)
                 .is_some_and(|complement| complement.is_singleton(db)),
-            Type::EnumComplement(complement) => complement.is_singleton(db),
-            Type::AlwaysTruthy | Type::AlwaysFalsy => false,
-            Type::TypeIs(type_is) => type_is.is_bound(db),
-            Type::TypeGuard(type_guard) => type_guard.is_bound(db),
-            Type::TypeForm(_) => false,
-            Type::TypedDict(_) => false,
-            Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
+            TypeData::EnumComplement(complement) => complement.is_singleton(db),
+            TypeData::AlwaysTruthy | TypeData::AlwaysFalsy => false,
+            TypeData::TypeIs(type_is) => type_is.is_bound(db),
+            TypeData::TypeGuard(type_guard) => type_guard.is_bound(db),
+            TypeData::TypeForm(_) => false,
+            TypeData::TypedDict(_) => false,
+            TypeData::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
+            TypeData::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
         }
     }
 
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
-        match self {
+        match (self).data() {
             // Each `partial()` call creates a distinct object at runtime.
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
+            TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
 
-            Type::FunctionLiteral(..)
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(_)
-            | Type::ModuleLiteral(..)
-            | Type::ClassLiteral(..)
-            | Type::GenericAlias(..)
-            | Type::SpecialForm(..)
-            | Type::KnownInstance(..) => true,
+            TypeData::FunctionLiteral(..)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::ModuleLiteral(..)
+            | TypeData::ClassLiteral(..)
+            | TypeData::GenericAlias(..)
+            | TypeData::SpecialForm(..)
+            | TypeData::KnownInstance(..) => true,
 
-            Type::LiteralValue(literal) => match literal.kind() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(..) => !self.overrides_equality(db),
 
                 LiteralValueTypeKind::Int(..)
@@ -2451,7 +3641,7 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::LiteralString => false,
             },
 
-            Type::ProtocolInstance(..) => {
+            TypeData::ProtocolInstance(..) => {
                 // See comment in the `Type::ProtocolInstance` branch for `Type::is_singleton`.
                 false
             }
@@ -2462,7 +3652,7 @@ impl<'db> Type<'db> {
             // `Never`. A constrained typevar is single-valued if all of its constraints are
             // single-valued. (Note that you cannot specialize a constrained typevar to a subtype
             // of a constraint.)
-            Type::TypeVar(bound_typevar) => {
+            TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => false,
                     Some(TypeVarBoundOrConstraints::UpperBound(_)) => false,
@@ -2473,46 +3663,48 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::SubclassOf(..) => {
+            TypeData::SubclassOf(..) => {
                 // TODO: Same comment as above for `is_singleton`
                 false
             }
 
-            Type::NominalInstance(instance) => instance.is_single_valued(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_single_valued(db),
+            TypeData::NominalInstance(instance) => instance.is_single_valued(db),
+            TypeData::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).is_single_valued(db)
+            }
 
-            Type::BoundSuper(_) => {
+            TypeData::BoundSuper(_) => {
                 // At runtime two super instances never compare equal, even if their arguments are identical.
                 false
             }
 
-            Type::BoundMethod(_) => {
+            TypeData::BoundMethod(_) => {
                 // Binding the same method to different instances yields different objects: `[].sort != [].sort`
                 false
             }
 
-            Type::TypeIs(type_is) => type_is.is_bound(db),
-            Type::TypeGuard(type_guard) => type_guard.is_bound(db),
-            Type::TypeForm(_) => false,
+            TypeData::TypeIs(type_is) => type_is.is_bound(db),
+            TypeData::TypeGuard(type_guard) => type_guard.is_bound(db),
+            TypeData::TypeForm(_) => false,
 
-            Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
+            TypeData::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
 
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::Union(..)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::Callable(_)
-            | Type::PropertyInstance(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypedDict(_) => false,
+            TypeData::Dynamic(_)
+            | TypeData::Divergent(_)
+            | TypeData::Never
+            | TypeData::Union(..)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::Callable(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::TypedDict(_) => false,
 
-            Type::Intersection(intersection) => intersection
+            TypeData::Intersection(intersection) => intersection
                 .enum_complement(db)
                 .is_some_and(|complement| complement.is_single_valued(db)),
-            Type::EnumComplement(complement) => complement.is_single_valued(db),
+            TypeData::EnumComplement(complement) => complement.is_single_valued(db),
         }
     }
 
@@ -2537,8 +3729,8 @@ impl<'db> Type<'db> {
             return fallback.find_name_in_mro_with_policy(db, name, policy);
         }
 
-        match self {
-            Type::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
+        match (self).data() {
+            TypeData::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.find_name_in_mro_with_policy(db, name, policy)
                     // If some elements are classes, and some are not, we simply fall back to `Unbound` for the non-class
                     // elements instead of short-circuiting the whole result to `None`. We would need a more detailed
@@ -2546,7 +3738,7 @@ impl<'db> Type<'db> {
                     // not a problem.
                     .unwrap_or_default()
             })),
-            Type::Intersection(inter) => {
+            TypeData::Intersection(inter) => {
                 Some(inter.map_with_boundness_and_qualifiers(db, |elem| {
                     elem.find_name_in_mro_with_policy(db, name, policy)
                         // Fall back to Unbound, similar to the union case (see above).
@@ -2554,13 +3746,15 @@ impl<'db> Type<'db> {
                 }))
             }
 
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(Place::bound(self).into()),
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => {
+                Some(Place::bound(self).into())
+            }
 
-            Type::ClassLiteral(class) if class.is_typed_dict(db) => {
+            TypeData::ClassLiteral(class) if class.is_typed_dict(db) => {
                 Some(class.typed_dict_member(db, None, name, policy))
             }
 
-            Type::ClassLiteral(class) => {
+            TypeData::ClassLiteral(class) => {
                 match (class.known(db), name) {
                     (Some(KnownClass::FunctionType), "__get__") => Some(
                         Place::bound(Type::WrapperDescriptor(
@@ -2595,21 +3789,21 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::GenericAlias(alias) if alias.is_typed_dict(db) => {
+            TypeData::GenericAlias(alias) if alias.is_typed_dict(db) => {
                 Some(alias.origin(db).typed_dict_member(db, None, name, policy))
             }
 
-            Type::GenericAlias(alias) => {
-                Some(ClassType::from(*alias).class_member(db, name, policy))
+            TypeData::GenericAlias(alias) => {
+                Some(ClassType::from(alias).class_member(db, name, policy))
             }
 
-            Type::SubclassOf(subclass_of_ty) => {
+            TypeData::SubclassOf(subclass_of_ty) => {
                 subclass_of_ty.find_name_in_mro_with_policy(db, name, policy)
             }
 
             // Note: `super(pivot, owner).__class__` is `builtins.super`, not the owner's class.
             // `BoundSuper` should look up the name in the MRO of `builtins.super`.
-            Type::BoundSuper(_) => KnownClass::Super
+            TypeData::BoundSuper(_) => KnownClass::Super
                 .to_class_literal(db)
                 .find_name_in_mro_with_policy(db, name, policy),
 
@@ -2617,7 +3811,9 @@ impl<'db> Type<'db> {
             // i.e. Type::NominalInstance(type). So looking up a name in the MRO of
             // `Type::NominalInstance(type)` is equivalent to looking up the name in the
             // MRO of the class `object`.
-            Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Type) => {
+            TypeData::NominalInstance(instance)
+                if instance.has_known_class(db, KnownClass::Type) =>
+            {
                 if policy.mro_no_object_fallback() {
                     Some(Place::Undefined.into())
                 } else {
@@ -2627,33 +3823,33 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypeAlias(alias) => alias
+            TypeData::TypeAlias(alias) => alias
                 .value_type(db)
                 .find_name_in_mro_with_policy(db, name, policy),
 
-            Type::FunctionLiteral(_)
-            | Type::Callable(_)
-            | Type::BoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::LiteralValue(_)
-            | Type::TypeVar(_)
-            | Type::NominalInstance(_)
-            | Type::ProtocolInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_)
-            | Type::EnumComplement(_)
-            | Type::NewTypeInstance(_) => None,
+            TypeData::FunctionLiteral(_)
+            | TypeData::Callable(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::KnownInstance(_)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::LiteralValue(_)
+            | TypeData::TypeVar(_)
+            | TypeData::NominalInstance(_)
+            | TypeData::ProtocolInstance(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::TypedDict(_)
+            | TypeData::EnumComplement(_)
+            | TypeData::NewTypeInstance(_) => None,
         }
     }
 
@@ -2701,20 +3897,20 @@ impl<'db> Type<'db> {
             return fallback.class_member_with_policy(db, name, policy);
         }
 
-        match self {
-            Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
+        match (self).data() {
+            TypeData::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name.clone(), policy)
             }),
-            Type::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, |elem| {
+            TypeData::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, |elem| {
                 elem.class_member_with_policy(db, name.clone(), policy)
             }),
             // TODO: Once `to_meta_type` for the synthesized protocol is fully implemented, this handling should be removed.
-            Type::ProtocolInstance(ProtocolInstanceType {
+            TypeData::ProtocolInstance(ProtocolInstanceType {
                 inner: Protocol::Synthesized(_),
                 ..
             }) => self.instance_member(db, &name),
 
-            Type::LiteralValue(literal) if name == "__len__" => {
+            TypeData::LiteralValue(literal) if name == "__len__" => {
                 if let Some(length) = match literal.kind() {
                     LiteralValueTypeKind::Bytes(bytes) => Some(bytes.python_len(db)),
                     LiteralValueTypeKind::String(string) => Some(string.python_len(db)),
@@ -2744,7 +3940,7 @@ impl<'db> Type<'db> {
             // metaclasses inherit from `type`. Check `type`'s class-level attributes
             // first so that data descriptors like `__mro__` and `__bases__` resolve to
             // their correct types instead of collapsing to `Any`/`Unknown`.
-            Type::SubclassOf(subclass_of) if subclass_of.is_dynamic() => {
+            TypeData::SubclassOf(subclass_of) if subclass_of.is_dynamic() => {
                 let type_result = KnownClass::Type
                     .to_class_literal(db)
                     .find_name_in_mro_with_policy(db, name.as_str(), policy)
@@ -2760,7 +3956,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => self
+            TypeData::ClassLiteral(_) | TypeData::GenericAlias(_) | TypeData::SubclassOf(_) => self
                 .to_meta_type(db)
                 .class_object_member(db, name.as_str(), policy),
 
@@ -2788,8 +3984,8 @@ impl<'db> Type<'db> {
             "Calling `class_object_member` on class literals and subclass-of types should always find an MRO",
         );
 
-        let own_class = match self {
-            Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
+        let own_class = match (self).data() {
+            TypeData::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
             _ => self.to_class_type(db),
         };
         let own_class_attr = own_class.map(|class| class.own_class_member(db, None, name).inner);
@@ -2845,12 +4041,12 @@ impl<'db> Type<'db> {
     ///         self.b: str = "a"
     /// ```
     fn instance_member(&self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
-        match self {
-            Type::Union(union) => {
+        match (self).data() {
+            TypeData::Union(union) => {
                 union.map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name))
             }
 
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 if let Some(complement) = intersection.enum_complement(db) {
                     enums::instance_member_for_enum_complement(db, complement, name)
                 } else {
@@ -2860,40 +4056,42 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::EnumComplement(complement) => {
-                enums::instance_member_for_enum_complement(db, *complement, name)
+            TypeData::EnumComplement(complement) => {
+                enums::instance_member_for_enum_complement(db, complement, name)
             }
 
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => {
+                Place::bound(self).into()
+            }
 
-            Type::NominalInstance(instance) => instance.class(db).instance_member(db, name),
-            Type::NewTypeInstance(newtype) => {
+            TypeData::NominalInstance(instance) => instance.class(db).instance_member(db, name),
+            TypeData::NewTypeInstance(newtype) => {
                 newtype.concrete_base_type(db).instance_member(db, name)
             }
 
-            Type::ProtocolInstance(protocol) => protocol.instance_member(db, name),
+            TypeData::ProtocolInstance(protocol) => protocol.instance_member(db, name),
 
-            Type::FunctionLiteral(_) => KnownClass::FunctionType
+            TypeData::FunctionLiteral(_) => KnownClass::FunctionType
                 .to_instance(db)
                 .instance_member(db, name),
 
-            Type::BoundMethod(_) => KnownClass::MethodType
+            TypeData::BoundMethod(_) => KnownClass::MethodType
                 .to_instance(db)
                 .instance_member(db, name),
-            Type::KnownBoundMethod(method) => {
+            TypeData::KnownBoundMethod(method) => {
                 method.class().to_instance(db).instance_member(db, name)
             }
-            Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
+            TypeData::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
                 .to_instance(db)
                 .instance_member(db, name),
-            Type::DataclassDecorator(_) => KnownClass::FunctionType
+            TypeData::DataclassDecorator(_) => KnownClass::FunctionType
                 .to_instance(db)
                 .instance_member(db, name),
-            Type::Callable(_) | Type::DataclassTransformer(_) => {
+            TypeData::Callable(_) | TypeData::DataclassTransformer(_) => {
                 Type::object().instance_member(db, name)
             }
 
-            Type::TypeVar(bound_typevar) => {
+            TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => Type::object().instance_member(db, name),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -2906,22 +4104,24 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypeIs(_) | Type::TypeGuard(_) => {
+            TypeData::TypeIs(_) | TypeData::TypeGuard(_) => {
                 KnownClass::Bool.to_instance(db).instance_member(db, name)
             }
 
-            Type::LiteralValue(literal) => literal.fallback_instance(db).instance_member(db, name),
+            TypeData::LiteralValue(literal) => {
+                literal.fallback_instance(db).instance_member(db, name)
+            }
 
-            Type::AlwaysTruthy | Type::AlwaysFalsy | Type::TypeForm(_) => {
+            TypeData::AlwaysTruthy | TypeData::AlwaysFalsy | TypeData::TypeForm(_) => {
                 Type::object().instance_member(db, name)
             }
-            Type::ModuleLiteral(_) => KnownClass::ModuleType
+            TypeData::ModuleLiteral(_) => KnownClass::ModuleType
                 .to_instance(db)
                 .instance_member(db, name),
 
-            Type::SpecialForm(_) | Type::KnownInstance(_) => Place::Undefined.into(),
+            TypeData::SpecialForm(_) | TypeData::KnownInstance(_) => Place::Undefined.into(),
 
-            Type::PropertyInstance(property) => {
+            TypeData::PropertyInstance(property) => {
                 property.instance_fallback(db).instance_member(db, name)
             }
 
@@ -2930,19 +4130,19 @@ impl<'db> Type<'db> {
             // This means we should only look up instance members defined on the `builtins.super()` instance itself.
             // If you want to look up a member in the MRO of the `super`'s owner,
             // refer to [`Type::member`] instead.
-            Type::BoundSuper(_) => KnownClass::Super.to_instance(db).instance_member(db, name),
+            TypeData::BoundSuper(_) => KnownClass::Super.to_instance(db).instance_member(db, name),
 
             // TODO: we currently don't model the fact that class literals and subclass-of types have
             // a `__dict__` that is filled with class level attributes. Modeling this is currently not
             // required, as `instance_member` is only called for instance-like types through `member`,
             // but we might want to add this in the future.
-            Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
+            TypeData::ClassLiteral(_) | TypeData::GenericAlias(_) | TypeData::SubclassOf(_) => {
                 Place::Undefined.into()
             }
 
-            Type::TypedDict(_) => Place::Undefined.into(),
+            TypeData::TypedDict(_) => Place::Undefined.into(),
 
-            Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
+            TypeData::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
         }
     }
 
@@ -2951,7 +4151,7 @@ impl<'db> Type<'db> {
     ///
     /// See also: [`Type::member`]
     fn static_member(&self, db: &'db dyn Db, name: &str) -> Place<'db> {
-        if let Type::ModuleLiteral(module) = self {
+        if let TypeData::ModuleLiteral(module) = (self).data() {
             module.static_member(db, name).place
         } else if let place @ Place::Defined(_) = self.class_member(db, name.into()).place {
             place
@@ -2989,13 +4189,13 @@ impl<'db> Type<'db> {
                 return fallback.try_call_dunder_get(db, instance, owner);
             }
 
-            match ty {
-                Type::Callable(callable) if callable.is_staticmethod_like(db) => {
+            match (ty).data() {
+                TypeData::Callable(callable) if callable.is_staticmethod_like(db) => {
                     // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
                     // The underlying function is returned as-is, without binding self.
                     return Some((ty, AttributeKind::NormalOrNonDataDescriptor));
                 }
-                Type::Callable(callable)
+                TypeData::Callable(callable)
                     if callable.is_function_like(db) || callable.is_classmethod_like(db) =>
                 {
                     // For "function-like" or "classmethod-like" callables, model the behavior of
@@ -3066,7 +4266,7 @@ impl<'db> Type<'db> {
 
         // Function descriptors have fixed binding behavior, so avoid retaining a tracked query
         // for every function and access context.
-        if let Type::FunctionLiteral(function) = self {
+        if let TypeData::FunctionLiteral(function) = (self).data() {
             let descriptor_result = if function.is_classmethod(db) {
                 Type::BoundMethod(BoundMethodType::new(db, function, owner))
             } else if let Some(instance) = instance
@@ -3121,74 +4321,24 @@ impl<'db> Type<'db> {
         }
 
         match attribute {
-            // This branch is not strictly needed, but it short-circuits the lookup of various dunder
-            // methods and calls that would otherwise be made.
-            //
-            // Note that attribute accesses on dynamic types always succeed. For this reason, they also
-            // have `__get__`, `__set__`, and `__delete__` methods and are therefore considered to be
-            // data descriptors.
-            //
-            // The same is true for `Never`.
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
-                        ..
-                    }),
-                qualifiers: _,
-            } => (attribute, AttributeKind::DataDescriptor),
-
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: Type::Union(union),
-                        origin,
-                        definedness: boundness,
-                        public_type_policy,
-                        provenance: attribute_provenance,
-                    }),
-                qualifiers,
-            } => (
-                union
-                    .map_with_boundness(db, |elem| {
-                        Place::Defined(DefinedPlace {
-                            ty: elem
-                                .try_call_dunder_get(db, instance, owner)
-                                .map_or(*elem, |(ty, _)| ty),
-                            origin,
-                            definedness: boundness,
-                            public_type_policy,
-                            provenance: Provenance::Unknown,
-                        })
-                    })
-                    .with_provenance(attribute_provenance)
-                    .with_qualifiers(qualifiers),
-                // TODO: avoid the duplication here:
-                if union.elements(db).iter().all(|elem| {
-                    elem.try_call_dunder_get(db, instance, owner)
-                        .is_some_and(|(_, kind)| kind.is_data())
-                }) {
-                    AttributeKind::DataDescriptor
-                } else {
-                    AttributeKind::NormalOrNonDataDescriptor
-                },
-            ),
-
             attribute @ PlaceAndQualifiers {
                 place:
                     Place::Defined(DefinedPlace {
-                        ty: Type::Intersection(intersection),
+                        ty: attribute_ty,
                         origin,
                         definedness,
                         public_type_policy,
-                        provenance: attribute_provenance,
+                        provenance,
                     }),
                 qualifiers,
-            } => (
-                if intersection.positive(db).is_empty() {
-                    attribute
-                } else {
-                    intersection
+            } => match attribute_ty.data() {
+                // Attribute accesses on dynamic types always succeed, so they also have `__get__`,
+                // `__set__`, and `__delete__` methods. The same is true for `Never`.
+                TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => {
+                    (attribute, AttributeKind::DataDescriptor)
+                }
+                TypeData::Union(union) => (
+                    union
                         .map_with_boundness(db, |elem| {
                             Place::Defined(DefinedPlace {
                                 ty: elem
@@ -3200,42 +4350,60 @@ impl<'db> Type<'db> {
                                 provenance: Provenance::Unknown,
                             })
                         })
-                        .with_provenance(attribute_provenance)
-                        .with_qualifiers(qualifiers)
-                },
-                // TODO: Discover data descriptors in intersections.
-                AttributeKind::NormalOrNonDataDescriptor,
-            ),
-
-            PlaceAndQualifiers {
-                place:
-                    Place::Defined(DefinedPlace {
-                        ty: attribute_ty,
-                        origin,
-                        definedness: boundness,
-                        public_type_policy,
-                        provenance,
-                    }),
-                qualifiers: _,
-            } => {
-                if let Some((return_ty, attribute_kind)) =
-                    attribute_ty.try_call_dunder_get(db, instance, owner)
-                {
-                    (
-                        Place::Defined(DefinedPlace {
-                            ty: return_ty,
-                            origin,
-                            definedness: boundness,
-                            public_type_policy,
-                            provenance,
-                        })
-                        .into(),
-                        attribute_kind,
-                    )
-                } else {
-                    (attribute, AttributeKind::NormalOrNonDataDescriptor)
+                        .with_provenance(provenance)
+                        .with_qualifiers(qualifiers),
+                    // TODO: avoid the duplication here:
+                    if union.elements(db).iter().all(|elem| {
+                        elem.try_call_dunder_get(db, instance, owner)
+                            .is_some_and(|(_, kind)| kind.is_data())
+                    }) {
+                        AttributeKind::DataDescriptor
+                    } else {
+                        AttributeKind::NormalOrNonDataDescriptor
+                    },
+                ),
+                TypeData::Intersection(intersection) => (
+                    if intersection.positive(db).is_empty() {
+                        attribute
+                    } else {
+                        intersection
+                            .map_with_boundness(db, |elem| {
+                                Place::Defined(DefinedPlace {
+                                    ty: elem
+                                        .try_call_dunder_get(db, instance, owner)
+                                        .map_or(*elem, |(ty, _)| ty),
+                                    origin,
+                                    definedness,
+                                    public_type_policy,
+                                    provenance: Provenance::Unknown,
+                                })
+                            })
+                            .with_provenance(provenance)
+                            .with_qualifiers(qualifiers)
+                    },
+                    // TODO: Discover data descriptors in intersections.
+                    AttributeKind::NormalOrNonDataDescriptor,
+                ),
+                _ => {
+                    if let Some((return_ty, attribute_kind)) =
+                        attribute_ty.try_call_dunder_get(db, instance, owner)
+                    {
+                        (
+                            Place::Defined(DefinedPlace {
+                                ty: return_ty,
+                                origin,
+                                definedness,
+                                public_type_policy,
+                                provenance,
+                            })
+                            .into(),
+                            attribute_kind,
+                        )
+                    } else {
+                        (attribute, AttributeKind::NormalOrNonDataDescriptor)
+                    }
                 }
-            }
+            },
 
             _ => (attribute, AttributeKind::NormalOrNonDataDescriptor),
         }
@@ -3259,18 +4427,18 @@ impl<'db> Type<'db> {
     }
 
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
-        match self {
-            Type::Dynamic(_) => !any_of_union,
-            Type::Never | Type::PropertyInstance(_) => true,
-            Type::Union(union) if any_of_union => union
+        match (self).data() {
+            TypeData::Dynamic(_) => !any_of_union,
+            TypeData::Never | TypeData::PropertyInstance(_) => true,
+            TypeData::Union(union) if any_of_union => union
                 .elements(db)
                 .iter()
                 .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
-            Type::Union(union) => union
+            TypeData::Union(union) => union
                 .elements(db)
                 .iter()
                 .all(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
-            Type::Intersection(intersection) => intersection
+            TypeData::Intersection(intersection) => intersection
                 .iter_positive(db)
                 .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
             _ => {
@@ -3478,8 +4646,8 @@ impl<'db> Type<'db> {
 
             let name_str = name.as_str();
 
-            match this {
-                Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
+            match (this).data() {
+                TypeData::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
                     elem.member_lookup_with_policy_and_receiver(
                         db,
                         name_str.into(),
@@ -3488,7 +4656,7 @@ impl<'db> Type<'db> {
                     )
                 }),
 
-                Type::Intersection(intersection) => {
+                TypeData::Intersection(intersection) => {
                     if let Some(complement) = intersection.enum_complement(db) {
                         enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                     } else {
@@ -3504,34 +4672,36 @@ impl<'db> Type<'db> {
                     }
                 }
 
-                Type::EnumComplement(complement) => {
+                TypeData::EnumComplement(complement) => {
                     enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                 }
 
-                Type::Dynamic(..) | Type::Divergent(_) | Type::Never => Place::bound(this).into(),
+                TypeData::Dynamic(..) | TypeData::Divergent(_) | TypeData::Never => {
+                    Place::bound(this).into()
+                }
 
-                Type::FunctionLiteral(function) if name == "__get__" => Place::bound(
+                TypeData::FunctionLiteral(function) if name == "__get__" => Place::bound(
                     Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)),
                 )
                 .into(),
-                Type::FunctionLiteral(function) if name == "__call__" => Place::bound(
+                TypeData::FunctionLiteral(function) if name == "__call__" => Place::bound(
                     Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function)),
                 )
                 .into(),
-                Type::PropertyInstance(property) if name == "__get__" => Place::bound(
+                TypeData::PropertyInstance(property) if name == "__get__" => Place::bound(
                     Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)),
                 )
                 .into(),
-                Type::PropertyInstance(property) if name == "__set__" => Place::bound(
+                TypeData::PropertyInstance(property) if name == "__set__" => Place::bound(
                     Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)),
                 )
                 .into(),
-                Type::PropertyInstance(property) if name == "__delete__" => Place::bound(
+                TypeData::PropertyInstance(property) if name == "__delete__" => Place::bound(
                     Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)),
                 )
                 .into(),
 
-                Type::LiteralValue(literal) if literal.is_string() && name == "startswith" => {
+                TypeData::LiteralValue(literal) if literal.is_string() && name == "startswith" => {
                     let string_literal = literal.as_string().unwrap();
                     Place::bound(Type::KnownBoundMethod(KnownBoundMethodType::StrStartswith(
                         string_literal,
@@ -3539,7 +4709,7 @@ impl<'db> Type<'db> {
                     .into()
                 }
 
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "range" && class.is_known(db, KnownClass::ConstraintSet) =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3547,7 +4717,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "always" && class.is_known(db, KnownClass::ConstraintSet) =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3555,7 +4725,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "never" && class.is_known(db, KnownClass::ConstraintSet) =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3563,7 +4733,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                TypeData::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "implies_subtype_of" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3571,7 +4741,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                TypeData::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "satisfies" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3579,7 +4749,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                TypeData::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "satisfied_by_all_typevars" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3587,7 +4757,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
+                TypeData::KnownInstance(KnownInstanceType::ConstraintSet(tracked))
                     if name == "with_detailed_display" =>
                 {
                     Place::bound(Type::KnownBoundMethod(
@@ -3596,7 +4766,7 @@ impl<'db> Type<'db> {
                     .into()
                 }
 
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "__get__" && class.is_known(db, KnownClass::FunctionType) =>
                 {
                     Place::bound(Type::WrapperDescriptor(
@@ -3604,7 +4774,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "__get__" && class.is_known(db, KnownClass::Property) =>
                 {
                     Place::bound(Type::WrapperDescriptor(
@@ -3612,7 +4782,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "__set__" && class.is_known(db, KnownClass::Property) =>
                 {
                     Place::bound(Type::WrapperDescriptor(
@@ -3620,7 +4790,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::ClassLiteral(class)
+                TypeData::ClassLiteral(class)
                     if name == "__delete__" && class.is_known(db, KnownClass::Property) =>
                 {
                     Place::bound(Type::WrapperDescriptor(
@@ -3628,7 +4798,7 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
-                Type::BoundMethod(bound_method) => match name_str {
+                TypeData::BoundMethod(bound_method) => match name_str {
                     "__self__" => Place::bound(bound_method.self_instance(db)).into(),
                     "__func__" => {
                         Place::bound(Type::FunctionLiteral(bound_method.function(db))).into()
@@ -3652,31 +4822,33 @@ impl<'db> Type<'db> {
                             })
                     }
                 },
-                Type::KnownBoundMethod(method) => method
+                TypeData::KnownBoundMethod(method) => method
                     .class()
                     .to_instance(db)
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
-                Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
+                TypeData::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
                     .to_instance(db)
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
-                Type::DataclassDecorator(_) => KnownClass::FunctionType
+                TypeData::DataclassDecorator(_) => KnownClass::FunctionType
                     .to_instance(db)
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
-                Type::Callable(_) | Type::DataclassTransformer(_) if name_str == "__call__" => {
+                TypeData::Callable(_) | TypeData::DataclassTransformer(_)
+                    if name_str == "__call__" =>
+                {
                     Place::bound(this).into()
                 }
 
-                Type::Callable(callable) if callable.is_function_like(db) => {
+                TypeData::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType
                         .to_instance(db)
                         .member_lookup_with_policy_and_receiver(db, name, policy, receiver)
                 }
 
-                Type::Callable(_) | Type::DataclassTransformer(_) => Type::object()
+                TypeData::Callable(_) | TypeData::DataclassTransformer(_) => Type::object()
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
-                Type::NominalInstance(instance)
+                TypeData::NominalInstance(instance)
                     if matches!(name.as_str(), "major" | "minor")
                         && instance.is_sys_version_info() =>
                 {
@@ -3689,30 +4861,30 @@ impl<'db> Type<'db> {
                     Place::bound(Type::int_literal(segment.into())).into()
                 }
 
-                Type::PropertyInstance(property) if name == "fget" => {
+                TypeData::PropertyInstance(property) if name == "fget" => {
                     Place::bound(property.getter(db).unwrap_or(Type::none(db))).into()
                 }
-                Type::PropertyInstance(property) if name == "fset" => {
+                TypeData::PropertyInstance(property) if name == "fset" => {
                     Place::bound(property.setter(db).unwrap_or(Type::none(db))).into()
                 }
-                Type::PropertyInstance(property) if name == "fdel" => {
+                TypeData::PropertyInstance(property) if name == "fdel" => {
                     Place::bound(property.deleter(db).unwrap_or(Type::none(db))).into()
                 }
 
-                Type::LiteralValue(literal)
+                TypeData::LiteralValue(literal)
                     if literal.is_int() && matches!(name_str, "real" | "numerator") =>
                 {
                     Place::bound(this).into()
                 }
 
-                Type::LiteralValue(literal)
+                TypeData::LiteralValue(literal)
                     if literal.is_bool() && matches!(name_str, "real" | "numerator") =>
                 {
                     let bool_value = literal.as_bool().unwrap();
                     Place::bound(Type::int_literal(i64::from(bool_value))).into()
                 }
 
-                Type::ModuleLiteral(module) => module.static_member(db, name_str),
+                TypeData::ModuleLiteral(module) => module.static_member(db, name_str),
 
                 // If a protocol does not include a member and the policy disables falling back to
                 // `object`, we return `Place::Undefined` here. This short-circuits attribute lookup
@@ -3722,7 +4894,7 @@ impl<'db> Type<'db> {
                 //
                 // Note that we could do this for *all* protocols, but it's only *necessary* for synthesized
                 // ones, and the standard logic is *probably* more performant for class-based protocols?
-                Type::ProtocolInstance(ProtocolInstanceType {
+                TypeData::ProtocolInstance(ProtocolInstanceType {
                     inner: Protocol::Synthesized(protocol),
                     ..
                 }) if policy.mro_no_object_fallback()
@@ -3738,13 +4910,15 @@ impl<'db> Type<'db> {
                 // `float` and not `int | float`). However, all other `NewType` cases need to fall
                 // through, because we generally do want e.g. methods that return `Self` to return the
                 // `NewType`.
-                Type::NewTypeInstance(new_type_instance) if this.as_union_like(db).is_some() => {
+                TypeData::NewTypeInstance(new_type_instance)
+                    if this.as_union_like(db).is_some() =>
+                {
                     new_type_instance
                         .concrete_base_type(db)
                         .member_lookup_with_policy(db, name, policy)
                 }
 
-                Type::TypeAlias(alias) => alias
+                TypeData::TypeAlias(alias) => alias
                     .value_type(db)
                     .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
 
@@ -3757,7 +4931,7 @@ impl<'db> Type<'db> {
                     policy,
                 ),
 
-                Type::LiteralValue(literal)
+                TypeData::LiteralValue(literal)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
                         && literal.as_enum().is_some_and(|enum_literal| {
                             !enums::class_defines_property(
@@ -3788,20 +4962,20 @@ impl<'db> Type<'db> {
                         .into()
                 }
 
-                Type::TypeVar(typevar) if name_str == "args" && typevar.is_paramspec(db) => {
+                TypeData::TypeVar(typevar) if name_str == "args" && typevar.is_paramspec(db) => {
                     Place::declared(Type::TypeVar(
                         typevar.with_paramspec_attr(db, ParamSpecAttrKind::Args),
                     ))
                     .into()
                 }
-                Type::TypeVar(typevar) if name_str == "kwargs" && typevar.is_paramspec(db) => {
+                TypeData::TypeVar(typevar) if name_str == "kwargs" && typevar.is_paramspec(db) => {
                     Place::declared(Type::TypeVar(
                         typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs),
                     ))
                     .into()
                 }
 
-                Type::NominalInstance(instance)
+                TypeData::NominalInstance(instance)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
                         && enum_metadata(db, instance.class_literal(db)).is_some()
                         && !enums::class_defines_property(
@@ -3826,13 +5000,13 @@ impl<'db> Type<'db> {
                         .into()
                 }
 
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
+                TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
                     if name_str == "__call__" =>
                 {
                     Place::bound(Type::Callable(partial.partial(db))).into()
                 }
 
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
                     let wrapped = partial.wrapped(db).inner(db);
                     let nominal_lookup = partial
                         .partial(db)
@@ -3861,21 +5035,21 @@ impl<'db> Type<'db> {
                     }
                 }
 
-                Type::NominalInstance(..)
-                | Type::ProtocolInstance(..)
-                | Type::NewTypeInstance(..)
-                | Type::LiteralValue(..)
-                | Type::TypeVar(..)
-                | Type::SpecialForm(..)
-                | Type::KnownInstance(..)
-                | Type::PropertyInstance(..)
-                | Type::FunctionLiteral(..)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::TypeIs(..)
-                | Type::TypeGuard(..)
-                | Type::TypeForm(..)
-                | Type::TypedDict(_) => {
+                TypeData::NominalInstance(..)
+                | TypeData::ProtocolInstance(..)
+                | TypeData::NewTypeInstance(..)
+                | TypeData::LiteralValue(..)
+                | TypeData::TypeVar(..)
+                | TypeData::SpecialForm(..)
+                | TypeData::KnownInstance(..)
+                | TypeData::PropertyInstance(..)
+                | TypeData::FunctionLiteral(..)
+                | TypeData::AlwaysTruthy
+                | TypeData::AlwaysFalsy
+                | TypeData::TypeIs(..)
+                | TypeData::TypeGuard(..)
+                | TypeData::TypeForm(..)
+                | TypeData::TypedDict(_) => {
                     let receiver = receiver.unwrap_or(this);
 
                     // Enum members can be accessed through enum instances and other enum members,
@@ -3915,10 +5089,12 @@ impl<'db> Type<'db> {
                     result.map_type(|ty| ty.bind_self_typevars(db, receiver))
                 }
 
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                    let enum_class = match this {
-                        Type::ClassLiteral(literal) => Some(literal),
-                        Type::SubclassOf(subclass_of) => subclass_of
+                TypeData::ClassLiteral(..)
+                | TypeData::GenericAlias(..)
+                | TypeData::SubclassOf(..) => {
+                    let enum_class = match (this).data() {
+                        TypeData::ClassLiteral(literal) => Some(literal),
+                        TypeData::SubclassOf(subclass_of) => subclass_of
                             .subclass_of()
                             .into_class(db)
                             .map(|class| class.class_literal(db)),
@@ -3968,7 +5144,7 @@ impl<'db> Type<'db> {
                     // (which is at least `type`). Attributes resolved via `type`'s descriptors
                     // are intersected with the dynamic type to reflect uncertainty about
                     // whether the unknown metaclass overrides them.
-                    if let Type::SubclassOf(subclass_of) = this
+                    if let TypeData::SubclassOf(subclass_of) = (this).data()
                         && let SubclassOfInner::Dynamic(dynamic) = subclass_of.subclass_of()
                     {
                         result.map_type(|ty| {
@@ -3988,7 +5164,7 @@ impl<'db> Type<'db> {
                 //
                 // 1. Search for the attribute in the MRO, starting just after the pivot class.
                 // 2. If the attribute is a descriptor, invoke its `__get__` method.
-                Type::BoundSuper(bound_super) => {
+                TypeData::BoundSuper(bound_super) => {
                     let owner_attr = bound_super.find_name_in_mro_after_pivot(db, name_str, policy);
 
                     bound_super
@@ -4003,7 +5179,10 @@ impl<'db> Type<'db> {
                 return Place::bound(self.dunder_class(db)).into();
             }
 
-            if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
+            if matches!(
+                (self).data(),
+                TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never
+            ) {
                 return Place::bound(self).into();
             }
         }
@@ -4018,14 +5197,14 @@ impl<'db> Type<'db> {
     /// is used as a fallback.
     fn len(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         fn non_negative_int_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-            match ty {
+            match (ty).data() {
                 // TODO: Emit diagnostic for non-integers and negative integers
-                Type::LiteralValue(literal) => match literal.kind() {
+                TypeData::LiteralValue(literal) => match literal.kind() {
                     LiteralValueTypeKind::Int(value) => (value.as_i64() >= 0).then_some(ty),
                     LiteralValueTypeKind::Bool(value) => Some(Type::int_literal(i64::from(value))),
                     _ => None,
                 },
-                Type::Union(union) => {
+                TypeData::Union(union) => {
                     union.try_map(db, |element| non_negative_int_literal(db, *element))
                 }
                 _ => None,
@@ -4051,8 +5230,8 @@ impl<'db> Type<'db> {
 
     /// If this type is a `ParamSpec` type variable, returns it. Otherwise, returns `None`.
     fn as_paramspec_typevar(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        match self {
-            Type::TypeVar(tv) if tv.is_paramspec(db) => Some(self),
+        match (self).data() {
+            TypeData::TypeVar(tv) if tv.is_paramspec(db) => Some(self),
             _ => None,
         }
     }
@@ -4139,13 +5318,13 @@ impl<'db> Type<'db> {
             return fallback.bindings(db);
         }
 
-        match self {
-            Type::Callable(callable) => {
+        match (self).data() {
+            TypeData::Callable(callable) => {
                 CallableBinding::from_overloads(self, callable.signatures(db).iter().cloned())
                     .into()
             }
 
-            Type::TypeVar(bound_typevar) => {
+            TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
@@ -4158,25 +5337,25 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::BoundMethod(bound_method) => {
+            TypeData::BoundMethod(bound_method) => {
                 let signature = bound_method.function(db).signature(db);
                 CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
                     .with_bound_type(bound_method.self_instance(db))
                     .into()
             }
 
-            Type::KnownBoundMethod(method) => {
+            TypeData::KnownBoundMethod(method) => {
                 CallableBinding::from_overloads(self, method.signatures(db)).into()
             }
 
-            Type::WrapperDescriptor(wrapper_descriptor) => {
+            TypeData::WrapperDescriptor(wrapper_descriptor) => {
                 CallableBinding::from_overloads(self, wrapper_descriptor.signatures(db)).into()
             }
 
             // TODO: We should probably also check the original return type of the function
             // that was decorated with `@dataclass_transform`, to see if it is consistent with
             // with what we configure here.
-            Type::DataclassTransformer(_) => Binding::single(
+            TypeData::DataclassTransformer(_) => Binding::single(
                 self,
                 Signature::new(
                     Parameters::new(
@@ -4189,7 +5368,7 @@ impl<'db> Type<'db> {
             )
             .into(),
 
-            Type::FunctionLiteral(function_type) => match function_type.known(db) {
+            TypeData::FunctionLiteral(function_type) => match function_type.known(db) {
                 Some(KnownFunction::AssertType) => {
                     let val_ty = BoundTypeVarInstance::synthetic(
                         db,
@@ -4330,14 +5509,16 @@ impl<'db> Type<'db> {
                 .into(),
             },
 
-            Type::ClassLiteral(class) => self
+            TypeData::ClassLiteral(class) => self
                 // TODO this should be called from `constructor_bindings` for better consistency
                 .known_class_literal_bindings(db, class)
                 .unwrap_or_else(|| self.constructor_bindings(db, ClassType::NonGeneric(class))),
 
-            Type::GenericAlias(alias) => self.constructor_bindings(db, ClassType::Generic(alias)),
+            TypeData::GenericAlias(alias) => {
+                self.constructor_bindings(db, ClassType::Generic(alias))
+            }
 
-            Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
+            TypeData::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(dynamic_type) => {
                     Binding::single(self, Signature::dynamic(Type::Dynamic(dynamic_type))).into()
                 }
@@ -4378,14 +5559,16 @@ impl<'db> Type<'db> {
                 }
             },
 
-            Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)) => {
+            TypeData::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)) => {
                 let parameter = Parameter::positional_or_keyword(Name::new_static("type"))
                     .with_annotated_type(Type::any());
                 let signature = Signature::new(Parameters::new(db, [parameter]), Type::any());
                 Binding::single(self, signature).into()
             }
 
-            Type::NominalInstance(_) | Type::ProtocolInstance(_) | Type::NewTypeInstance(_) => {
+            TypeData::NominalInstance(_)
+            | TypeData::ProtocolInstance(_)
+            | TypeData::NewTypeInstance(_) => {
                 // Note that for objects that have a (possibly not callable!) `__call__` attribute,
                 // we will get the signature of the `__call__` attribute, but will pass in the type
                 // of the original object as the "callable type". That ensures that we get errors
@@ -4417,12 +5600,12 @@ impl<'db> Type<'db> {
 
             // Dynamic types are callable, and the return type is the same dynamic type. Similarly,
             // `Never` is always callable and returns `Never`.
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => {
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => {
                 Binding::single(self, Signature::dynamic(self)).into()
             }
 
             // Note that this correctly returns `None` if none of the union elements are callable.
-            Type::Union(union) => Bindings::from_union(
+            TypeData::Union(union) => Bindings::from_union(
                 self,
                 union
                     .elements(db)
@@ -4430,16 +5613,16 @@ impl<'db> Type<'db> {
                     .map(|element| element.bindings(db)),
             ),
 
-            Type::Intersection(intersection) => Bindings::from_intersection(
+            TypeData::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
                     .map(|element| element.bindings(db)),
             ),
 
-            Type::EnumComplement(complement) => complement.to_intersection(db).bindings(db),
+            TypeData::EnumComplement(complement) => complement.to_intersection(db).bindings(db),
 
-            Type::DataclassDecorator(_) => {
+            TypeData::DataclassDecorator(_) => {
                 let typevar = BoundTypeVarInstance::synthetic(
                     db,
                     Name::new_static("T"),
@@ -4458,16 +5641,16 @@ impl<'db> Type<'db> {
             }
 
             // TODO: some `SpecialForm`s are callable (e.g. TypedDicts)
-            Type::SpecialForm(_) => CallableBinding::not_callable(self).into(),
+            TypeData::SpecialForm(_) => CallableBinding::not_callable(self).into(),
 
-            Type::LiteralValue(literal) => match literal.kind() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => {
                     enum_literal.enum_class_instance(db).bindings(db)
                 }
                 _ => CallableBinding::not_callable(self).into(),
             },
 
-            Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Binding::single(
+            TypeData::KnownInstance(KnownInstanceType::NewType(newtype)) => Binding::single(
                 self,
                 Signature::new(
                     Parameters::new(
@@ -4480,25 +5663,25 @@ impl<'db> Type<'db> {
             )
             .into(),
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+            TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
                 Type::Callable(partial.partial(db)).bindings(db)
             }
 
-            Type::KnownInstance(known_instance) => {
+            TypeData::KnownInstance(known_instance) => {
                 known_instance.instance_fallback(db).bindings(db)
             }
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db),
+            TypeData::TypeAlias(alias) => alias.value_type(db).bindings(db),
 
-            Type::PropertyInstance(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::BoundSuper(_)
-            | Type::ModuleLiteral(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_) => CallableBinding::not_callable(self).into(),
+            TypeData::PropertyInstance(_)
+            | TypeData::AlwaysFalsy
+            | TypeData::AlwaysTruthy
+            | TypeData::BoundSuper(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::TypedDict(_) => CallableBinding::not_callable(self).into(),
         }
     }
 
@@ -4838,13 +6021,9 @@ impl<'db> Type<'db> {
             // constructor override. This preserves the known nominal constructor result for
             // subclasses of `Any` while still allowing explicitly typed `__new__` callables
             // returning `Any` to keep their annotated behavior.
-            if matches!(
-                place,
-                Place::Defined(DefinedPlace {
-                    ty: Type::Dynamic(DynamicType::Any),
-                    ..
-                })
-            ) {
+            if let Place::Defined(DefinedPlace { ty, .. }) = &place
+                && matches!(ty.data(), TypeData::Dynamic(DynamicType::Any))
+            {
                 return None;
             }
             match place.try_call_dunder_get(db, owner) {
@@ -4939,8 +6118,8 @@ impl<'db> Type<'db> {
         // have the class's typevars still in the method signature when we attempt to call it. To
         // do this, we instead use the _identity_ specialization, which maps each of the class's
         // generic typevars to itself.
-        let self_type = match self {
-            Type::ClassLiteral(class) if class.generic_context(db).is_some() => {
+        let self_type = match (self).data() {
+            TypeData::ClassLiteral(class) if class.generic_context(db).is_some() => {
                 Type::from(class.identity_specialization(db))
             }
             _ => self,
@@ -5156,11 +6335,11 @@ impl<'db> Type<'db> {
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        if let Type::Intersection(intersection) = self {
+        if let TypeData::Intersection(intersection) = (self).data() {
             return intersection.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
         }
 
-        if let Type::Union(union) = self {
+        if let TypeData::Union(union) = (self).data() {
             return union.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
         }
 
@@ -5338,8 +6517,8 @@ impl<'db> Type<'db> {
     /// This only flattens typevars directly in unions and intersections; it does not descend
     /// into generic types or other nested structures.
     fn flatten_typevars(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
+        match (self).data() {
+            TypeData::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.flatten_typevars(db),
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     constraints.as_type(db).flatten_typevars(db)
@@ -5347,14 +6526,14 @@ impl<'db> Type<'db> {
                 // Unbounded typevar is effectively `object`.
                 None => Type::object(),
             },
-            Type::Union(union) => {
+            TypeData::Union(union) => {
                 // Flatten each element and rebuild through the union builder.
                 UnionType::from_elements(
                     db,
                     union.elements(db).iter().map(|e| e.flatten_typevars(db)),
                 )
             }
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 // Flatten each positive element and rebuild through the intersection builder.
                 let mut builder = IntersectionBuilder::new(db);
                 for pos in intersection.positive(db) {
@@ -5436,18 +6615,18 @@ impl<'db> Type<'db> {
             }
         };
 
-        match self {
-            Type::NominalInstance(instance) => {
+        match (self).data() {
+            TypeData::NominalInstance(instance) => {
                 instance.class(db).iter_mro(db).find_map(from_class_base)
             }
-            Type::ProtocolInstance(instance) => {
+            TypeData::ProtocolInstance(instance) => {
                 if let Protocol::FromClass(class) = instance.inner {
                     class.iter_mro(db).find_map(from_class_base)
                 } else {
                     None
                 }
             }
-            Type::Union(union) => {
+            TypeData::Union(union) => {
                 let mut yield_builder = Some(UnionBuilder::new(db));
                 let mut send_builder = Some(UnionBuilder::new(db));
                 let mut return_builder = Some(UnionBuilder::new(db));
@@ -5474,7 +6653,7 @@ impl<'db> Type<'db> {
                     return_ty: return_builder.map(UnionBuilder::build),
                 })
             }
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 // Using `positive()` rather than `positive_elements_or_object()` is safe
                 // here because `object` is not a generator, so falling back to it would
                 // still return `None`.
@@ -5518,11 +6697,13 @@ impl<'db> Type<'db> {
                     return_ty: return_builder.map(IntersectionBuilder::build),
                 })
             }
-            ty @ (Type::Dynamic(_) | Type::Divergent(_) | Type::Never) => Some(GeneratorTypes {
-                yield_ty: Some(ty),
-                send_ty: Some(ty),
-                return_ty: Some(ty),
-            }),
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => {
+                Some(GeneratorTypes {
+                    yield_ty: Some(self),
+                    send_ty: Some(self),
+                    return_ty: Some(self),
+                })
+            }
             _ => None,
         }
     }
@@ -5539,23 +6720,25 @@ impl<'db> Type<'db> {
 
     #[must_use]
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        match self {
-            Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(self),
-            Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
-            Type::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(alias))),
-            Type::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance(db)),
-            Type::KnownInstance(KnownInstanceType::NewType(newtype)) => {
+        match (self).data() {
+            TypeData::Dynamic(_) | TypeData::Divergent(_) | TypeData::Never => Some(self),
+            TypeData::ClassLiteral(class) => {
+                Some(Type::instance(db, class.default_specialization(db)))
+            }
+            TypeData::GenericAlias(alias) => Some(Type::instance(db, ClassType::from(alias))),
+            TypeData::SubclassOf(subclass_of_ty) => Some(subclass_of_ty.to_instance(db)),
+            TypeData::KnownInstance(KnownInstanceType::NewType(newtype)) => {
                 Some(Type::NewTypeInstance(newtype))
             }
-            Type::Union(union) => union.to_instance(db),
+            TypeData::Union(union) => union.to_instance(db),
             // If there is no bound or constraints on a typevar `T`, `T: object` implicitly, which
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
-            Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
-            Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
-            Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
+            TypeData::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
+            TypeData::TypeAlias(alias) => alias.value_type(db).to_instance(db),
+            TypeData::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
-            Type::NominalInstance(instance)
+            TypeData::NominalInstance(instance)
                 if KnownClass::Type
                     .to_class_literal(db)
                     .to_class_type(db)
@@ -5565,29 +6748,29 @@ impl<'db> Type<'db> {
             {
                 Some(Type::object())
             }
-            Type::FunctionLiteral(_)
-            | Type::Callable(..)
-            | Type::KnownBoundMethod(_)
-            | Type::BoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::NominalInstance(_)
-            | Type::ProtocolInstance(_)
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::ModuleLiteral(_)
-            | Type::LiteralValue(_)
-            | Type::BoundSuper(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_)
-            | Type::EnumComplement(_)
-            | Type::NewTypeInstance(_) => None,
+            TypeData::FunctionLiteral(_)
+            | TypeData::Callable(..)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::NominalInstance(_)
+            | TypeData::ProtocolInstance(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::KnownInstance(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::TypedDict(_)
+            | TypeData::EnumComplement(_)
+            | TypeData::NewTypeInstance(_) => None,
         }
     }
 
@@ -5607,10 +6790,10 @@ impl<'db> Type<'db> {
         typevar_binding_context: Option<Definition<'db>>,
         inference_flags: InferenceFlags,
     ) -> Result<Type<'db>, InvalidTypeExpressionError<'db>> {
-        match self {
+        match (self).data() {
             // Special cases for `float` and `complex`
             // https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
-            Type::ClassLiteral(class) => {
+            TypeData::ClassLiteral(class) => {
                 let ty = match class.known(db) {
                     Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
                     Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
@@ -5618,46 +6801,46 @@ impl<'db> Type<'db> {
                 };
                 Ok(ty)
             }
-            Type::GenericAlias(alias) => Ok(Type::instance(db, ClassType::from(*alias))),
+            TypeData::GenericAlias(alias) => Ok(Type::instance(db, ClassType::from(alias))),
 
-            Type::SubclassOf(_)
-            | Type::EnumComplement(_)
-            | Type::LiteralValue(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::ModuleLiteral(_)
-            | Type::TypeVar(_)
-            | Type::Callable(_)
-            | Type::BoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::Never
-            | Type::FunctionLiteral(_)
-            | Type::BoundSuper(_)
-            | Type::ProtocolInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_) => Err(InvalidTypeExpressionError {
+            TypeData::SubclassOf(_)
+            | TypeData::EnumComplement(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::ModuleLiteral(_)
+            | TypeData::TypeVar(_)
+            | TypeData::Callable(_)
+            | TypeData::BoundMethod(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::Never
+            | TypeData::FunctionLiteral(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::ProtocolInstance(_)
+            | TypeData::PropertyInstance(_)
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_)
+            | TypeData::TypedDict(_) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                     *self, scope_id
                 )],
                 fallback_type: Type::unknown(),
             }),
 
-            Type::KnownInstance(known_instance) => match known_instance {
-                KnownInstanceType::TypeAliasType(alias) => Ok(Type::TypeAlias(*alias)),
-                KnownInstanceType::NewType(newtype) => Ok(Type::NewTypeInstance(*newtype)),
+            TypeData::KnownInstance(known_instance) => match known_instance {
+                KnownInstanceType::TypeAliasType(alias) => Ok(Type::TypeAlias(alias)),
+                KnownInstanceType::NewType(newtype) => Ok(Type::NewTypeInstance(newtype)),
                 KnownInstanceType::TypeVar(typevar) => {
                     if !inference_flags.contains(InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR)
                         && typevar.is_paramspec(db)
                     {
                         return Err(InvalidTypeExpressionError {
                             invalid_expressions: smallvec_inline![
-                                InvalidTypeExpression::InvalidBareParamSpec(*typevar)
+                                InvalidTypeExpression::InvalidBareParamSpec(typevar)
                             ],
                             fallback_type: Type::unknown(),
                         });
@@ -5668,7 +6851,7 @@ impl<'db> Type<'db> {
                         index,
                         scope_id.file_scope_id(db),
                         typevar_binding_context,
-                        *typevar,
+                        typevar,
                     )
                     .map(Type::TypeVar)
                     .unwrap_or(*self))
@@ -5723,10 +6906,10 @@ impl<'db> Type<'db> {
 
                     Ok(instance.inner(db).to_meta_type(db))
                 }
-                KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
+                KnownInstanceType::Callable(callable) => Ok(Type::Callable(callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
                 KnownInstanceType::Sentinel(sentinel) => {
-                    Ok(Type::KnownInstance(KnownInstanceType::Sentinel(*sentinel)))
+                    Ok(Type::KnownInstance(KnownInstanceType::Sentinel(sentinel)))
                 }
                 KnownInstanceType::FunctoolsPartial(_) => Err(InvalidTypeExpressionError {
                     invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
@@ -5736,7 +6919,7 @@ impl<'db> Type<'db> {
                 }),
             },
 
-            Type::SpecialForm(special_form) => special_form
+            TypeData::SpecialForm(special_form) => special_form
                 .in_type_expression(db, scope_id, typevar_binding_context, inference_flags)
                 .map_err(|err| {
                     let fallback_type = if matches!(
@@ -5757,7 +6940,7 @@ impl<'db> Type<'db> {
                     }
                 }),
 
-            Type::Union(union) => {
+            TypeData::Union(union) => {
                 let mut builder = UnionBuilder::new(db);
                 let mut invalid_expressions = smallvec::SmallVec::default();
                 for element in union.elements(db) {
@@ -5787,9 +6970,9 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::Dynamic(_) | Type::Divergent(_) => Ok(*self),
+            TypeData::Dynamic(_) | TypeData::Divergent(_) => Ok(*self),
 
-            Type::NominalInstance(instance) => match instance.known_class(db) {
+            TypeData::NominalInstance(instance) => match instance.known_class(db) {
                 Some(KnownClass::NoneType) => Ok(Type::none(db)),
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
@@ -5803,16 +6986,16 @@ impl<'db> Type<'db> {
                 }),
             },
 
-            Type::Intersection(_) => Ok(todo_type!("Type::Intersection.in_type_expression")),
+            TypeData::Intersection(_) => Ok(todo_type!("Type::Intersection.in_type_expression")),
 
-            Type::TypeAlias(alias) => alias.value_type(db).in_type_expression(
+            TypeData::TypeAlias(alias) => alias.value_type(db).in_type_expression(
                 db,
                 scope_id,
                 typevar_binding_context,
                 inference_flags,
             ),
 
-            Type::NewTypeInstance(_) => Err(InvalidTypeExpressionError {
+            TypeData::NewTypeInstance(_) => Err(InvalidTypeExpressionError {
                 invalid_expressions: smallvec_inline![InvalidTypeExpression::InvalidType(
                     *self, scope_id
                 )],
@@ -5833,16 +7016,18 @@ impl<'db> Type<'db> {
     /// See `Self::dunder_class` for more details.
     #[must_use]
     pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::Never => Type::Never,
-            Type::NominalInstance(instance) => instance.to_meta_type(db),
-            Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
-            Type::SpecialForm(special_form) => special_form.to_meta_type(db),
-            Type::PropertyInstance(property) => property.instance_class(db).to_class_literal(db),
-            Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
-            Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
-            Type::TypeForm(_) => Type::object().to_meta_type(db),
-            Type::LiteralValue(literal) => match literal.kind() {
+        match (self).data() {
+            TypeData::Never => Type::Never,
+            TypeData::NominalInstance(instance) => instance.to_meta_type(db),
+            TypeData::KnownInstance(known_instance) => known_instance.to_meta_type(db),
+            TypeData::SpecialForm(special_form) => special_form.to_meta_type(db),
+            TypeData::PropertyInstance(property) => {
+                property.instance_class(db).to_class_literal(db)
+            }
+            TypeData::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
+            TypeData::TypeIs(_) | TypeData::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
+            TypeData::TypeForm(_) => Type::object().to_meta_type(db),
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db),
                 LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db),
                 LiteralValueTypeKind::Int(_) => KnownClass::Int.to_class_literal(db),
@@ -5853,26 +7038,32 @@ impl<'db> Type<'db> {
                     KnownClass::Str.to_class_literal(db)
                 }
             },
-            Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db),
-            Type::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db),
-            Type::KnownBoundMethod(method) => method.class().to_class_literal(db),
-            Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType.to_class_literal(db),
-            Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db),
-            Type::Callable(callable) if callable.is_function_like(db) => {
+            TypeData::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db),
+            TypeData::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db),
+            TypeData::KnownBoundMethod(method) => method.class().to_class_literal(db),
+            TypeData::WrapperDescriptor(_) => {
+                KnownClass::WrapperDescriptorType.to_class_literal(db)
+            }
+            TypeData::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db),
+            TypeData::Callable(callable) if callable.is_function_like(db) => {
                 KnownClass::FunctionType.to_class_literal(db)
             }
-            Type::Callable(_) | Type::DataclassTransformer(_) => KnownClass::Type.to_instance(db),
-            Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db),
-            Type::TypeVar(bound_typevar) => {
+            TypeData::Callable(_) | TypeData::DataclassTransformer(_) => {
+                KnownClass::Type.to_instance(db)
+            }
+            TypeData::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db),
+            TypeData::TypeVar(bound_typevar) => {
                 SubclassOfType::from(db, SubclassOfInner::TypeVar(bound_typevar))
             }
-            Type::ClassLiteral(class) => class.metaclass(db),
-            Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
-            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db),
-            Type::Dynamic(dynamic) => SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic)),
-            Type::Divergent(_) => self,
+            TypeData::ClassLiteral(class) => class.metaclass(db),
+            TypeData::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
+            TypeData::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db),
+            TypeData::Dynamic(dynamic) => {
+                SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic))
+            }
+            TypeData::Divergent(_) => self,
             // TODO intersections
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     alternatives.to_meta_type(db)
                 } else {
@@ -5880,23 +7071,23 @@ impl<'db> Type<'db> {
                         .expect("Type::Todo should be a valid `SubclassOfInner`")
                 }
             }
-            Type::EnumComplement(complement) => {
+            TypeData::EnumComplement(complement) => {
                 complement.remaining_literal_union(db).to_meta_type(db)
             }
-            Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
-            Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
-            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
+            TypeData::AlwaysTruthy | TypeData::AlwaysFalsy => KnownClass::Type.to_instance(db),
+            TypeData::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
+            TypeData::ProtocolInstance(protocol) => protocol.to_meta_type(db),
             // `TypedDict` instances are instances of `dict` at runtime, but its important that we
             // understand a more specific meta type in order to correctly handle `__getitem__`.
-            Type::TypedDict(typed_dict) => match typed_dict {
+            TypeData::TypedDict(typed_dict) => match typed_dict {
                 TypedDictType::Class(class) => SubclassOfType::from(db, class),
                 TypedDictType::Synthesized(_) => SubclassOfType::from(
                     db,
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
+            TypeData::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
+            TypeData::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
         }
     }
 
@@ -5943,21 +7134,21 @@ impl<'db> Type<'db> {
         specialization: Specialization<'db>,
     ) -> Type<'db> {
         if matches!(
-            self,
-            Type::Dynamic(_)
-                | Type::Divergent(_)
-                | Type::Never
-                | Type::WrapperDescriptor(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::SpecialForm(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::LiteralValue(_)
-                | Type::BoundSuper(_)
-                | Type::KnownInstance(
+            (self).data(),
+            TypeData::Dynamic(_)
+                | TypeData::Divergent(_)
+                | TypeData::Never
+                | TypeData::WrapperDescriptor(_)
+                | TypeData::DataclassDecorator(_)
+                | TypeData::DataclassTransformer(_)
+                | TypeData::ModuleLiteral(_)
+                | TypeData::ClassLiteral(_)
+                | TypeData::SpecialForm(_)
+                | TypeData::AlwaysTruthy
+                | TypeData::AlwaysFalsy
+                | TypeData::LiteralValue(_)
+                | TypeData::BoundSuper(_)
+                | TypeData::KnownInstance(
                     KnownInstanceType::SubscriptedProtocol(_)
                         | KnownInstanceType::SubscriptedGeneric(_)
                         | KnownInstanceType::TypeAliasType(_)
@@ -5972,7 +7163,7 @@ impl<'db> Type<'db> {
                         | KnownInstanceType::Sentinel(_)
                         | KnownInstanceType::NamedTupleSpec(_),
                 )
-                | Type::KnownBoundMethod(
+                | TypeData::KnownBoundMethod(
                     KnownBoundMethodType::StrStartswith(_)
                         | KnownBoundMethodType::ConstraintSetRange
                         | KnownBoundMethodType::ConstraintSetAlways
@@ -6043,16 +7234,16 @@ impl<'db> Type<'db> {
         if matches!(
             type_mapping,
             TypeMapping::Promote(_, PromotionKind::SingletonsOnly)
-        ) && !matches!(self, Type::NominalInstance(_))
+        ) && !matches!((self).data(), TypeData::NominalInstance(_))
         {
             return self;
         }
 
-        match self {
-            Type::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, type_mapping, visitor),
-            Type::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+        match (self).data() {
+            TypeData::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, type_mapping, visitor),
+            TypeData::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
 
-            Type::FunctionLiteral(function) => visitor.visit(db, self, type_mapping, || {
+            TypeData::FunctionLiteral(function) => visitor.visit(db, self, type_mapping, || {
                 match type_mapping {
                     // Promote the types within the signature before promoting the signature to its
                     // callable form.
@@ -6074,13 +7265,13 @@ impl<'db> Type<'db> {
                 }
             }),
 
-            Type::BoundMethod(method) => Type::BoundMethod(BoundMethodType::new(
+            TypeData::BoundMethod(method) => Type::BoundMethod(BoundMethodType::new(
                 db,
                 method.function(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 method.self_instance(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor),
             )),
 
-            Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)) => {
+            TypeData::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)) => {
                 match instance.known_class(db) {
                     Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
                     Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
@@ -6088,7 +7279,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly)) => {
+            TypeData::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly)) => {
                 if instance.is_singleton(db) {
                     self.promote_singletons_impl(db)
                 } else {
@@ -6096,17 +7287,17 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::NominalInstance(instance) => {
+            TypeData::NominalInstance(instance) => {
                 instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             },
 
-            Type::NewTypeInstance(newtype) => visitor.visit(db, self, type_mapping, || {
+            TypeData::NewTypeInstance(newtype) => visitor.visit(db, self, type_mapping, || {
                 Type::NewTypeInstance(newtype.map_base_class_type(db, |class_type| {
                     class_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
                 }))
             }),
 
-            Type::ProtocolInstance(instance) => {
+            TypeData::ProtocolInstance(instance) => {
                 // TODO: Add tests for materialization once subtyping/assignability is implemented for
                 // protocols. It _might_ require changing the logic here because:
                 //
@@ -6117,57 +7308,57 @@ impl<'db> Type<'db> {
                 Type::ProtocolInstance(instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
 
-            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
+            TypeData::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
                     function.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
 
-            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function)) => {
+            TypeData::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(
                     function.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
 
-            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)) => {
+            TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(
                     property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
 
-            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)) => {
+            TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(
                     property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
-            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)) => {
+            TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(
                     property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
                 ))
             }
 
-            Type::Callable(callable) => visitor.visit(db, self, type_mapping, || {
+            TypeData::Callable(callable) => visitor.visit(db, self, type_mapping, || {
                 Type::Callable(callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }),
 
-            Type::GenericAlias(generic) => {
+            TypeData::GenericAlias(generic) => {
                 Type::GenericAlias(generic.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
 
-            Type::TypedDict(typed_dict) => {
+            TypeData::TypedDict(typed_dict) => {
                 Type::TypedDict(typed_dict.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
 
-            Type::SubclassOf(subclass_of) => subclass_of.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            TypeData::SubclassOf(subclass_of) => subclass_of.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
 
-            Type::PropertyInstance(property) => {
+            TypeData::PropertyInstance(property) => {
                 Type::PropertyInstance(property.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
 
-            Type::Union(union) => union.map_leave_aliases(db, |element| {
+            TypeData::Union(union) => union.map_leave_aliases(db, |element| {
                 element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
             }),
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
                     builder =
@@ -6185,11 +7376,11 @@ impl<'db> Type<'db> {
                 builder.build()
             }
 
-            Type::EnumComplement(complement) => complement
+            TypeData::EnumComplement(complement) => complement
                 .to_intersection(db)
                 .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
 
-            Type::TypeIs(type_is) => visitor.visit(db, self, type_mapping, || {
+            TypeData::TypeIs(type_is) => visitor.visit(db, self, type_mapping, || {
                 type_is.with_type(
                     db,
                     type_is
@@ -6198,7 +7389,7 @@ impl<'db> Type<'db> {
                 )
             }),
 
-            Type::TypeGuard(type_guard) => visitor.visit(db, self, type_mapping, || {
+            TypeData::TypeGuard(type_guard) => visitor.visit(db, self, type_mapping, || {
                 type_guard.with_type(
                     db,
                     type_guard
@@ -6207,7 +7398,7 @@ impl<'db> Type<'db> {
                 )
             }),
 
-            Type::TypeForm(typeform) => visitor.visit(db, self, type_mapping, || {
+            TypeData::TypeForm(typeform) => visitor.visit(db, self, type_mapping, || {
                 TypeFormType::from_type_expression(
                     db,
                     typeform
@@ -6216,7 +7407,7 @@ impl<'db> Type<'db> {
                 )
             }),
 
-            Type::TypeAlias(alias) => {
+            TypeData::TypeAlias(alias) => {
                 match type_mapping {
                     // For EagerExpansion, expand the raw value type. This path relies on Salsa's cycle
                     // detection rather than the visitor's cycle detection, because the visitor tracks
@@ -6278,7 +7469,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::LiteralValue(_) => match type_mapping {
+            TypeData::LiteralValue(_) => match type_mapping {
                 TypeMapping::ApplySpecialization(_) |
                 TypeMapping::ApplySpecializationWithMaterialization { .. } |
                 TypeMapping::BindLegacyTypevars(_) |
@@ -6294,7 +7485,7 @@ impl<'db> Type<'db> {
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => self.promote_impl(db),
             }
 
-            Type::Dynamic(_) => match type_mapping {
+            TypeData::Dynamic(_) => match type_mapping {
                 TypeMapping::ApplySpecialization(_) |
                 TypeMapping::ApplySpecializationWithMaterialization { .. } |
                 TypeMapping::BindLegacyTypevars(_) |
@@ -6313,19 +7504,19 @@ impl<'db> Type<'db> {
             // `Divergent` is an internal cycle marker rather than a gradual type like `Any` or
             // `Unknown`. Preserve the marker across materialization, while recording whether this
             // occurrence should behave like the top (`object`) or bottom (`Never`) bound.
-            Type::Divergent(divergent) => match type_mapping {
+            TypeData::Divergent(divergent) => match type_mapping {
                 TypeMapping::Materialize(materialization_kind) => {
                     Type::Divergent(divergent.materialized(*materialization_kind))
                 }
                 _ => self,
             },
 
-            Type::Never
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::WrapperDescriptor(_)
-            | Type::ModuleLiteral(_)
-            | Type::KnownBoundMethod(
+            TypeData::Never
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::KnownBoundMethod(
                 KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
@@ -6335,14 +7526,14 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_)
             )
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
             // A non-generic class never needs to be specialized. A generic class is specialized
             // explicitly (via a subscript expression) or implicitly (via a call), and not because
             // some other generic context's specialization is applied to it.
-            | Type::ClassLiteral(_)
-            | Type::BoundSuper(_)
-            | Type::SpecialForm(_) => self,
+            | TypeData::ClassLiteral(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::SpecialForm(_) => self,
         }
     }
 
@@ -6389,21 +7580,21 @@ impl<'db> Type<'db> {
             }
         };
 
-        match self {
-            Type::TypeVar(bound_typevar) => {
+        match (self).data() {
+            TypeData::TypeVar(bound_typevar) => {
                 if let Some(bound_typevar) = matching_typevar(&bound_typevar) {
                     typevars.insert(bound_typevar);
                 }
             }
-            Type::Divergent(_) => {}
+            TypeData::Divergent(_) => {}
 
-            Type::FunctionLiteral(function) => {
+            TypeData::FunctionLiteral(function) => {
                 visitor.visit(self, || {
                     function.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 });
             }
 
-            Type::BoundMethod(method) => visitor.visit(self, || {
+            TypeData::BoundMethod(method) => visitor.visit(self, || {
                 method.self_instance(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
@@ -6418,14 +7609,14 @@ impl<'db> Type<'db> {
                 );
             }),
 
-            Type::KnownBoundMethod(
+            TypeData::KnownBoundMethod(
                 KnownBoundMethodType::FunctionTypeDunderGet(function)
                 | KnownBoundMethodType::FunctionTypeDunderCall(function),
             ) => visitor.visit(self, || {
                 function.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }),
 
-            Type::KnownBoundMethod(
+            TypeData::KnownBoundMethod(
                 KnownBoundMethodType::PropertyDunderGet(property)
                 | KnownBoundMethodType::PropertyDunderSet(property)
                 | KnownBoundMethodType::PropertyDunderDelete(property),
@@ -6433,20 +7624,20 @@ impl<'db> Type<'db> {
                 property.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }),
 
-            Type::Callable(callable) => {
+            TypeData::Callable(callable) => {
                 callable.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
 
-            Type::PropertyInstance(property) => visitor.visit(self, || {
+            TypeData::PropertyInstance(property) => visitor.visit(self, || {
                 property.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }),
 
-            Type::Union(union) => {
+            TypeData::Union(union) => {
                 for element in union.elements(db) {
                     element.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
             }
-            Type::Intersection(intersection) => {
+            TypeData::Intersection(intersection) => {
                 for positive in intersection.positive(db) {
                     positive.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
@@ -6454,35 +7645,35 @@ impl<'db> Type<'db> {
                     negative.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
             }
-            Type::EnumComplement(complement) => {
+            TypeData::EnumComplement(complement) => {
                 for rest in complement.rest(db) {
                     rest.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
                 }
             }
 
-            Type::GenericAlias(alias) => {
+            TypeData::GenericAlias(alias) => {
                 alias.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
 
-            Type::NominalInstance(instance) => {
+            TypeData::NominalInstance(instance) => {
                 instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
 
-            Type::ProtocolInstance(instance) => {
+            TypeData::ProtocolInstance(instance) => {
                 instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
 
-            Type::NewTypeInstance(_) => {
+            TypeData::NewTypeInstance(_) => {
                 // A newtype can never be constructed from an unspecialized generic class, so it is
                 // impossible that we could ever find any legacy typevars in a newtype instance or
                 // its underlying class.
             }
 
-            Type::SubclassOf(subclass_of) => {
+            TypeData::SubclassOf(subclass_of) => {
                 subclass_of.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
 
-            Type::TypeIs(type_is) => {
+            TypeData::TypeIs(type_is) => {
                 type_is.type_argument(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
@@ -6491,7 +7682,7 @@ impl<'db> Type<'db> {
                 );
             }
 
-            Type::TypeGuard(type_guard) => {
+            TypeData::TypeGuard(type_guard) => {
                 type_guard.return_type(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
@@ -6500,7 +7691,7 @@ impl<'db> Type<'db> {
                 );
             }
 
-            Type::TypeForm(typeform) => {
+            TypeData::TypeForm(typeform) => {
                 typeform.type_argument(db).find_legacy_typevars_impl(
                     db,
                     binding_context,
@@ -6509,7 +7700,7 @@ impl<'db> Type<'db> {
                 );
             }
 
-            Type::TypeAlias(alias) => {
+            TypeData::TypeAlias(alias) => {
                 visitor.visit(self, || {
                     alias.value_type(db).find_legacy_typevars_impl(
                         db,
@@ -6520,7 +7711,7 @@ impl<'db> Type<'db> {
                 });
             }
 
-            Type::KnownInstance(known_instance) => match known_instance {
+            TypeData::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::UnionType(instance) => {
                     if let Ok(union_type) = instance.union_type(db) {
                         union_type.find_legacy_typevars_impl(
@@ -6561,7 +7752,7 @@ impl<'db> Type<'db> {
                 }
             },
 
-            Type::Dynamic(DynamicType::UnknownGeneric(generic_context)) => {
+            TypeData::Dynamic(DynamicType::UnknownGeneric(generic_context)) => {
                 for variable in generic_context.variables(db) {
                     if let Some(variable) = matching_typevar(&variable) {
                         typevars.insert(variable);
@@ -6569,12 +7760,12 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::Dynamic(_)
-            | Type::Never
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(
+            TypeData::Dynamic(_)
+            | TypeData::Never
+            | TypeData::AlwaysTruthy
+            | TypeData::AlwaysFalsy
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::KnownBoundMethod(
                 KnownBoundMethodType::StrStartswith(_)
                 | KnownBoundMethodType::ConstraintSetRange
                 | KnownBoundMethodType::ConstraintSetAlways
@@ -6584,14 +7775,14 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::ClassLiteral(_)
-            | Type::LiteralValue(_)
-            | Type::BoundSuper(_)
-            | Type::SpecialForm(_)
-            | Type::TypedDict(_) => {}
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::ClassLiteral(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::BoundSuper(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::TypedDict(_) => {}
         }
     }
 
@@ -6649,8 +7840,8 @@ impl<'db> Type<'db> {
     /// Note: this method is used in the builtins `format`, `print`, `str.format` and `f-strings`.
     #[must_use]
     pub(crate) fn str(&self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::LiteralValue(literal) => match literal.kind() {
+        match (self).data() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => self.repr(db),
                 LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => *self,
                 LiteralValueTypeKind::Enum(enum_literal) => Type::string_literal(
@@ -6663,19 +7854,21 @@ impl<'db> Type<'db> {
                 ),
                 LiteralValueTypeKind::Bytes(_) => KnownClass::Str.to_instance(db),
             },
-            Type::SpecialForm(special_form) => Type::string_literal(db, &special_form.to_string()),
-            Type::KnownInstance(known_instance) => {
+            TypeData::SpecialForm(special_form) => {
+                Type::string_literal(db, &special_form.to_string())
+            }
+            TypeData::KnownInstance(known_instance) => {
                 Type::string_literal(db, &known_instance.repr(db).to_string())
             }
-            ty if ty.is_subtype_of(db, Type::literal_string()) => Type::literal_string(),
-            Type::Intersection(intersection) => {
+            _ if (*self).is_subtype_of(db, Type::literal_string()) => Type::literal_string(),
+            TypeData::Intersection(intersection) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     alternatives.str(db)
                 } else {
                     KnownClass::Str.to_instance(db)
                 }
             }
-            Type::EnumComplement(complement) => complement.remaining_literal_union(db).str(db),
+            TypeData::EnumComplement(complement) => complement.remaining_literal_union(db).str(db),
             // TODO: handle more complex types
             _ => KnownClass::Str.to_instance(db),
         }
@@ -6685,8 +7878,8 @@ impl<'db> Type<'db> {
     /// method at runtime.
     #[must_use]
     pub(crate) fn repr(&self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::LiteralValue(literal) => match literal.kind() {
+        match (self).data() {
+            TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(number) => Type::string_literal(db, &number.to_string()),
                 LiteralValueTypeKind::Bool(true) => Type::string_literal(db, "True"),
                 LiteralValueTypeKind::Bool(false) => Type::string_literal(db, "False"),
@@ -6696,8 +7889,10 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::LiteralString => Type::literal_string(),
                 _ => KnownClass::Str.to_instance(db),
             },
-            Type::SpecialForm(special_form) => Type::string_literal(db, &special_form.to_string()),
-            Type::KnownInstance(known_instance) => {
+            TypeData::SpecialForm(special_form) => {
+                Type::string_literal(db, &special_form.to_string())
+            }
+            TypeData::KnownInstance(known_instance) => {
                 Type::string_literal(db, &known_instance.repr(db).to_string())
             }
             // TODO: handle more complex types
@@ -6715,18 +7910,20 @@ impl<'db> Type<'db> {
     /// specific to the call site. Exact singleton finite intersections delegate to
     /// their only alternative, since there is no ambiguity to preserve there.
     pub fn definition(&self, db: &'db dyn Db) -> Option<TypeDefinition<'db>> {
-        match self {
-            Self::BoundMethod(method) => {
+        match (self).data() {
+            TypeData::BoundMethod(method) => {
                 Some(TypeDefinition::Function(method.function(db).definition(db)))
             }
-            Self::FunctionLiteral(function) => {
+            TypeData::FunctionLiteral(function) => {
                 Some(TypeDefinition::Function(function.definition(db)))
             }
-            Self::ModuleLiteral(module) => Some(TypeDefinition::Module(module.module(db))),
-            Self::ClassLiteral(class_literal) => class_literal.type_definition(db),
-            Self::GenericAlias(alias) => Some(TypeDefinition::StaticClass(alias.definition(db))),
-            Self::NominalInstance(instance) => instance.class(db).type_definition(db),
-            Self::KnownInstance(instance) => match instance {
+            TypeData::ModuleLiteral(module) => Some(TypeDefinition::Module(module.module(db))),
+            TypeData::ClassLiteral(class_literal) => class_literal.type_definition(db),
+            TypeData::GenericAlias(alias) => {
+                Some(TypeDefinition::StaticClass(alias.definition(db)))
+            }
+            TypeData::NominalInstance(instance) => instance.class(db).type_definition(db),
+            TypeData::KnownInstance(instance) => match instance {
                 KnownInstanceType::TypeVar(var) => {
                     Some(TypeDefinition::TypeVar(var.definition(db)?))
                 }
@@ -6739,7 +7936,7 @@ impl<'db> Type<'db> {
                 _ => None,
             },
 
-            Self::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
+            TypeData::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => None,
                 SubclassOfInner::Class(class) => class.type_definition(db),
                 SubclassOfInner::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
@@ -6747,10 +7944,12 @@ impl<'db> Type<'db> {
                 )),
             },
 
-            Self::TypeAlias(alias) => alias.value_type(db).definition(db),
-            Self::NewTypeInstance(newtype) => Some(TypeDefinition::NewType(newtype.definition(db))),
+            TypeData::TypeAlias(alias) => alias.value_type(db).definition(db),
+            TypeData::NewTypeInstance(newtype) => {
+                Some(TypeDefinition::NewType(newtype.definition(db)))
+            }
 
-            Self::PropertyInstance(property) => property
+            TypeData::PropertyInstance(property) => property
                 .getter(db)
                 .and_then(|getter| getter.definition(db))
                 .or_else(|| property.setter(db).and_then(|setter| setter.definition(db)))
@@ -6760,38 +7959,38 @@ impl<'db> Type<'db> {
                         .and_then(|deleter| deleter.definition(db))
                 }),
 
-            Self::LiteralValue(literal) => literal
+            TypeData::LiteralValue(literal) => literal
                 .as_enum()
                 .and_then(|enum_lit| enum_lit.definition(db))
                 .map(TypeDefinition::EnumMember)
                 .or_else(|| self.to_meta_type(db).definition(db)),
 
-            Self::KnownBoundMethod(_)
-            | Self::WrapperDescriptor(_)
-            | Self::DataclassDecorator(_)
-            | Self::DataclassTransformer(_)
-            | Self::BoundSuper(_) => self.to_meta_type(db).definition(db),
+            TypeData::KnownBoundMethod(_)
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::BoundSuper(_) => self.to_meta_type(db).definition(db),
 
-            Self::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
+            TypeData::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
                 bound_typevar.typevar(db).definition(db)?,
             )),
 
-            Self::ProtocolInstance(protocol) => match protocol.inner {
+            TypeData::ProtocolInstance(protocol) => match protocol.inner {
                 Protocol::FromClass(class) => class.type_definition(db),
                 Protocol::Synthesized(_) => None,
             },
 
-            Self::TypedDict(typed_dict) => typed_dict.type_definition(db),
+            TypeData::TypedDict(typed_dict) => typed_dict.type_definition(db),
 
-            Self::Union(_) => None,
-            Self::Intersection(intersection) => {
+            TypeData::Union(_) => None,
+            TypeData::Intersection(intersection) => {
                 let alternatives = intersection.finite_alternatives(db)?;
                 let [alternative] = alternatives.as_slice() else {
                     return None;
                 };
                 alternative.definition(db)
             }
-            Self::EnumComplement(complement) => {
+            TypeData::EnumComplement(complement) => {
                 let alternatives = complement.remaining_literal_types(db);
                 let [alternative] = alternatives.as_slice() else {
                     return None;
@@ -6799,22 +7998,24 @@ impl<'db> Type<'db> {
                 alternative.definition(db)
             }
 
-            Self::SpecialForm(special_form) => special_form.definition(db),
-            Self::Never => Type::SpecialForm(SpecialFormType::Never).definition(db),
-            Self::Dynamic(DynamicType::Any) => {
+            TypeData::SpecialForm(special_form) => special_form.definition(db),
+            TypeData::Never => Type::SpecialForm(SpecialFormType::Never).definition(db),
+            TypeData::Dynamic(DynamicType::Any) => {
                 Type::SpecialForm(SpecialFormType::Any).definition(db)
             }
-            Self::Dynamic(
+            TypeData::Dynamic(
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::AmbiguousOverload,
             ) => Type::SpecialForm(SpecialFormType::Unknown).definition(db),
-            Self::AlwaysTruthy => Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db),
-            Self::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
+            TypeData::AlwaysTruthy => {
+                Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db)
+            }
+            TypeData::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
 
             // These types have no definition
-            Self::Divergent(_)
-            | Self::Dynamic(
+            TypeData::Divergent(_)
+            | TypeData::Dynamic(
                 DynamicType::Todo(_)
                 | DynamicType::TodoUnpack
                 | DynamicType::TodoStarredExpression
@@ -6822,10 +8023,10 @@ impl<'db> Type<'db> {
                 | DynamicType::InvalidConcatenateUnknown
                 | DynamicType::UnspecializedTypeVar,
             )
-            | Self::Callable(_)
-            | Self::TypeIs(_)
-            | Self::TypeGuard(_)
-            | Self::TypeForm(_) => None,
+            | TypeData::Callable(_)
+            | TypeData::TypeIs(_)
+            | TypeData::TypeGuard(_)
+            | TypeData::TypeForm(_) => None,
         }
     }
 
@@ -6857,9 +8058,11 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         parameter_index: Option<usize>,
     ) -> Option<(Span, Span)> {
-        match self {
-            Type::FunctionLiteral(function) => Some(function.parameter_span(db, parameter_index)),
-            Type::BoundMethod(bound_method) => Some(
+        match (self).data() {
+            TypeData::FunctionLiteral(function) => {
+                Some(function.parameter_span(db, parameter_index))
+            }
+            TypeData::BoundMethod(bound_method) => Some(
                 bound_method
                     .function(db)
                     .parameter_span(db, parameter_index),
@@ -6886,17 +8089,17 @@ impl<'db> Type<'db> {
     /// An example of a good use case is to improve
     /// a diagnostic.
     fn function_spans(&self, db: &'db dyn Db) -> Option<FunctionSpans> {
-        match self {
-            Type::FunctionLiteral(function) => Some(function.spans(db)),
-            Type::BoundMethod(bound_method) => Some(bound_method.function(db).spans(db)),
+        match (self).data() {
+            TypeData::FunctionLiteral(function) => Some(function.spans(db)),
+            TypeData::BoundMethod(bound_method) => Some(bound_method.function(db).spans(db)),
             _ => None,
         }
     }
 
     pub(crate) fn generic_origin(self, db: &'db dyn Db) -> Option<StaticClassLiteral<'db>> {
-        match self {
-            Type::GenericAlias(generic) => Some(generic.origin(db)),
-            Type::NominalInstance(instance) => {
+        match (self).data() {
+            TypeData::GenericAlias(generic) => Some(generic.origin(db)),
+            TypeData::NominalInstance(instance) => {
                 if let ClassType::Generic(generic) = instance.class(db) {
                     Some(generic.origin(db))
                 } else {
@@ -7079,34 +8282,36 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             ty = self.display(db),
         );
 
-        let v = match self {
-            Type::ClassLiteral(class_literal) => class_literal.variance_of(db, typevar),
+        let v = match (self).data() {
+            TypeData::ClassLiteral(class_literal) => class_literal.variance_of(db, typevar),
 
-            Type::FunctionLiteral(function_type) => {
+            TypeData::FunctionLiteral(function_type) => {
                 // TODO: do we need to replace self?
                 function_type.variance_of(db, typevar)
             }
 
-            Type::BoundMethod(method_type) => {
+            TypeData::BoundMethod(method_type) => {
                 // TODO: do we need to replace self?
                 method_type.function(db).variance_of(db, typevar)
             }
 
-            Type::NominalInstance(nominal_instance_type) => {
+            TypeData::NominalInstance(nominal_instance_type) => {
                 nominal_instance_type.variance_of(db, typevar)
             }
-            Type::GenericAlias(generic_alias) => generic_alias.variance_of(db, typevar),
-            Type::Callable(callable_type) => callable_type.signatures(db).variance_of(db, typevar),
+            TypeData::GenericAlias(generic_alias) => generic_alias.variance_of(db, typevar),
+            TypeData::Callable(callable_type) => {
+                callable_type.signatures(db).variance_of(db, typevar)
+            }
             // A type variable is always covariant in itself.
-            Type::TypeVar(other_typevar) if other_typevar == typevar => {
+            TypeData::TypeVar(other_typevar) if other_typevar == typevar => {
                 // type variables are covariant in themselves
                 TypeVarVariance::Covariant
             }
-            Type::ProtocolInstance(protocol_instance_type) => {
+            TypeData::ProtocolInstance(protocol_instance_type) => {
                 protocol_instance_type.variance_of(db, typevar)
             }
             // unions are covariant in their disjuncts
-            Type::Union(union_type) => union_type
+            TypeData::Union(union_type) => union_type
                 .elements(db)
                 .iter()
                 .map(|ty| ty.variance_of(db, typevar))
@@ -7118,7 +8323,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             // `A`, and so is not assignable to `~A`. On the other hand, a value
             // of type `~A` excludes all `A`s, and thus all `B`s, and so _is_
             // assignable to `~B`.
-            Type::Intersection(intersection_type) => intersection_type
+            TypeData::Intersection(intersection_type) => intersection_type
                 .positive(db)
                 .iter()
                 .map(|ty| ty.variance_of(db, typevar))
@@ -7127,38 +8332,38 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
                         .variance_of(db, typevar)
                 }))
                 .collect(),
-            Type::EnumComplement(complement) => {
+            TypeData::EnumComplement(complement) => {
                 complement.to_intersection(db).variance_of(db, typevar)
             }
-            Type::PropertyInstance(property_instance_type) => property_instance_type
+            TypeData::PropertyInstance(property_instance_type) => property_instance_type
                 .getter(db)
                 .iter()
                 .chain(&property_instance_type.setter(db))
                 .chain(&property_instance_type.deleter(db))
                 .map(|ty| ty.variance_of(db, typevar))
                 .collect(),
-            Type::SubclassOf(subclass_of_type) => subclass_of_type.variance_of(db, typevar),
-            Type::TypeIs(type_is_type) => type_is_type.variance_of(db, typevar),
-            Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
-            Type::TypeForm(typeform_type) => typeform_type.variance_of(db, typevar),
-            Type::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
-            Type::TypeAlias(alias) => alias.variance_of(db, typevar),
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::LiteralValue(_)
-            | Type::SpecialForm(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::BoundSuper(_)
-            | Type::TypeVar(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_) => TypeVarVariance::Bivariant,
+            TypeData::SubclassOf(subclass_of_type) => subclass_of_type.variance_of(db, typevar),
+            TypeData::TypeIs(type_is_type) => type_is_type.variance_of(db, typevar),
+            TypeData::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
+            TypeData::TypeForm(typeform_type) => typeform_type.variance_of(db, typevar),
+            TypeData::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
+            TypeData::TypeAlias(alias) => alias.variance_of(db, typevar),
+            TypeData::Dynamic(_)
+            | TypeData::Divergent(_)
+            | TypeData::Never
+            | TypeData::WrapperDescriptor(_)
+            | TypeData::KnownBoundMethod(_)
+            | TypeData::DataclassDecorator(_)
+            | TypeData::DataclassTransformer(_)
+            | TypeData::ModuleLiteral(_)
+            | TypeData::LiteralValue(_)
+            | TypeData::SpecialForm(_)
+            | TypeData::AlwaysFalsy
+            | TypeData::AlwaysTruthy
+            | TypeData::BoundSuper(_)
+            | TypeData::TypeVar(_)
+            | TypeData::TypedDict(_)
+            | TypeData::NewTypeInstance(_) => TypeVarVariance::Bivariant,
         };
 
         tracing::trace!(
@@ -7245,8 +8450,8 @@ impl<'db> SelfBinding<'db> {
         self_type: Type<'db>,
         binding_context: Option<BindingContext<'db>>,
     ) -> Self {
-        let class_literal = match self_type {
-            Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
+        let class_literal = match (self_type).data() {
+            TypeData::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
                 self_typevar_owner_class_literal(db, typevar)
             }
             _ => self_type
@@ -7354,9 +8559,9 @@ impl<'db> TypeMapping<'_, 'db> {
                     context.variables(db).filter(|bound_typevar| {
                         // Keep the type variable if it's not in the specialization
                         // or if it's mapped to itself (still a TypeVar)
-                        match specialization.get(db, *bound_typevar) {
+                        match specialization.get(db, *bound_typevar).map(Type::data) {
                             None => true,
-                            Some(Type::TypeVar(mapped_typevar)) => {
+                            Some(TypeData::TypeVar(mapped_typevar)) => {
                                 // Still a TypeVar, keep it if it's mapping to itself
                                 mapped_typevar.identity(db) == bound_typevar.identity(db)
                             }
@@ -7848,23 +9053,23 @@ impl<'db> InvalidTypeExpression<'db> {
                     InvalidTypeExpression::TypingSelfInMetaclass => {
                         f.write_str("`Self` cannot be used in a metaclass")
                     }
-                    InvalidTypeExpression::InvalidType(Type::FunctionLiteral(function), _) => {
-                        write!(
+                    InvalidTypeExpression::InvalidType(ty, _) => match ty.data() {
+                        TypeData::FunctionLiteral(function) => write!(
                             f,
                             "Function `{function}` is not valid in a {location}",
                             function = function.name(self.db)
-                        )
-                    }
-                    InvalidTypeExpression::InvalidType(Type::ModuleLiteral(module), _) => write!(
-                        f,
-                        "Module `{module}` is not valid in a {location}",
-                        module = module.module(self.db).name(self.db)
-                    ),
-                    InvalidTypeExpression::InvalidType(ty, _) => write!(
-                        f,
-                        "Variable of type `{ty}` is not allowed in a {location}",
-                        ty = ty.display(self.db)
-                    ),
+                        ),
+                        TypeData::ModuleLiteral(module) => write!(
+                            f,
+                            "Module `{module}` is not valid in a {location}",
+                            module = module.module(self.db).name(self.db)
+                        ),
+                        _ => write!(
+                            f,
+                            "Variable of type `{ty}` is not allowed in a {location}",
+                            ty = ty.display(self.db)
+                        ),
+                    },
                     InvalidTypeExpression::InvalidBareParamSpec(paramspec) => write!(
                         f,
                         "Bare ParamSpec `{}` is not valid in this context in a {location}",
@@ -7891,13 +9096,15 @@ impl<'db> InvalidTypeExpression<'db> {
         mut diagnostic: LintDiagnosticGuard,
         node: &impl Ranged,
     ) {
-        if let InvalidTypeExpression::InvalidType(Type::Never, _) = self {
+        if let InvalidTypeExpression::InvalidType(ty, _) = self
+            && ty == Type::Never
+        {
             diagnostic.help(
                 "The variable may have been inferred as `Never` because \
                 its definition was inferred as being unreachable",
             );
-        } else if let InvalidTypeExpression::InvalidType(ty @ Type::ModuleLiteral(module), scope) =
-            self
+        } else if let InvalidTypeExpression::InvalidType(ty, scope) = self
+            && let TypeData::ModuleLiteral(module) = ty.data()
         {
             let module = module.module(db);
             let module_name_final_part = module.name(db).last_component();
@@ -7931,7 +9138,8 @@ impl<'db> InvalidTypeExpression<'db> {
         // but currently doing this would require reimplementing the signature "manually"
         // in `Type::bindings()`, which isn't worth it given that we have no other special
         // casing for this function.
-        } else if let InvalidTypeExpression::InvalidType(Type::FunctionLiteral(function), _) = self
+        } else if let InvalidTypeExpression::InvalidType(ty, _) = self
+            && let TypeData::FunctionLiteral(function) = ty.data()
             && function.name(db) == "callable"
             && let function_body_scope = function.literal(db).last_definition.body_scope(db)
             && function_body_scope
@@ -8233,7 +9441,7 @@ impl<'db> ModuleLiteralType<'db> {
         // definition-site variant (`SpecialFormType::TypingCallable`), so we recover the
         // import-path identity here while it's still observable.
         if let Place::Defined(defined) = place_and_qualifiers.place
-            && let Type::SpecialForm(special) = defined.ty
+            && let TypeData::SpecialForm(special) = (defined.ty).data()
             && let Some(import_module) = self.module(db).known(db)
         {
             let rewrapped = special.rewrap_for_import_module(name, import_module);
@@ -8497,7 +9705,7 @@ pub(super) fn determine_upper_bound<'db>(
 // Make sure that the `Type` enum does not grow unexpectedly.
 #[cfg(not(debug_assertions))]
 #[cfg(target_pointer_width = "64")]
-static_assertions::assert_eq_size!(Type, [u8; 16]);
+static_assertions::assert_eq_size!(Type, [u8; 12]);
 
 // Make sure that `LiteralValueTypeInner` stays at 12 bytes.
 // The `LiteralFlags` byte must fit in the discriminant's padding.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2226,14 +2226,14 @@ impl<'db> Type<'db> {
     /// behave as: `object` for top-materialized, `Never` for bottom-materialized.
     /// Returns `None` if `self` is not `Divergent` or has not been materialized.
     fn materialized_divergent_fallback(self) -> Option<Type<'db>> {
-        let TypeData::Divergent(divergent) = (self).data() else {
+        if self.tag != TypeTag::Divergent {
             return None;
-        };
+        }
 
-        match divergent.materialization_kind() {
-            Some(MaterializationKind::Top) => Some(Type::object()),
-            Some(MaterializationKind::Bottom) => Some(Type::Never),
-            None => None,
+        match self.detail[0] {
+            1 => Some(Type::object()),
+            2 => Some(Type::Never),
+            _ => None,
         }
     }
 
@@ -2433,7 +2433,7 @@ impl<'db> Type<'db> {
     }
 
     pub fn is_generic_alias(&self) -> bool {
-        matches!((self).data(), TypeData::GenericAlias(_))
+        self.tag == TypeTag::GenericAlias
     }
 
     /// Returns whether this type represents a specialization of a generic type.
@@ -2701,19 +2701,55 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn as_type_alias(self) -> Option<TypeAliasType<'db>> {
-        match (self).data() {
-            TypeData::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
-                Some(type_alias)
+        if self.tag != TypeTag::KnownInstance
+            || self.detail[0] != PackedKnownInstanceTag::TypeAliasType as u8
+        {
+            return None;
+        }
+
+        match self.detail[1] {
+            x if x == PackedTypeAliasTag::Pep695 as u8 => {
+                Some(TypeAliasType::PEP695(self.payload()))
+            }
+            x if x == PackedTypeAliasTag::ManualPep695 as u8 => {
+                Some(TypeAliasType::ManualPEP695(self.payload()))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    pub(crate) fn as_legacy_generic_context(self) -> Option<GenericContext<'db>> {
+        if self.tag != TypeTag::KnownInstance {
+            return None;
+        }
+        match self.detail[0] {
+            x if x == PackedKnownInstanceTag::SubscriptedGeneric as u8
+                || x == PackedKnownInstanceTag::SubscriptedProtocol as u8 =>
+            {
+                Some(self.payload())
             }
             _ => None,
         }
+    }
+
+    pub(crate) fn as_lazy_type_alias(self) -> Option<TypeAliasType<'db>> {
+        if self.tag != TypeTag::TypeAlias {
+            return None;
+        }
+        Some(match self.detail[0] {
+            x if x == PackedTypeAliasTag::Pep695 as u8 => TypeAliasType::PEP695(self.payload()),
+            x if x == PackedTypeAliasTag::ManualPep695 as u8 => {
+                TypeAliasType::ManualPEP695(self.payload())
+            }
+            _ => unreachable!(),
+        })
     }
 
     /// If this type is a `Type::TypeAlias`, recursively resolves it to its
     /// underlying value type. Otherwise, returns `self` unchanged.
     pub(crate) fn resolve_type_alias(self, db: &'db dyn Db) -> Type<'db> {
         let mut ty = self;
-        while let TypeData::TypeAlias(alias) = (ty).data() {
+        while let Some(alias) = ty.as_lazy_type_alias() {
             ty = alias.value_type(db);
         }
         ty
@@ -2770,17 +2806,36 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn as_literal_value(self) -> Option<LiteralValueType<'db>> {
-        match (self).data() {
-            TypeData::LiteralValue(literal) => Some(literal),
-            _ => None,
+        use set_theoretic::RecursivelyDefined;
+
+        if self.tag != TypeTag::LiteralValue {
+            return None;
         }
+
+        let kind = match self.detail[0] {
+            x if x == PackedLiteralTag::Int as u8 => LiteralValueTypeKind::Int(self.payload()),
+            x if x == PackedLiteralTag::Bool as u8 => LiteralValueTypeKind::Bool(self.payload()),
+            x if x == PackedLiteralTag::String as u8 => {
+                LiteralValueTypeKind::String(self.payload())
+            }
+            x if x == PackedLiteralTag::Enum as u8 => LiteralValueTypeKind::Enum(self.payload()),
+            x if x == PackedLiteralTag::Bytes as u8 => LiteralValueTypeKind::Bytes(self.payload()),
+            x if x == PackedLiteralTag::LiteralString as u8 => LiteralValueTypeKind::LiteralString,
+            _ => unreachable!(),
+        };
+        Some(
+            LiteralValueType::new(kind, self.detail[1] & 1 != 0).with_recursively_defined(
+                if self.detail[1] & 2 != 0 {
+                    RecursivelyDefined::Yes
+                } else {
+                    RecursivelyDefined::No
+                },
+            ),
+        )
     }
 
     pub(crate) fn as_literal_value_kind(self) -> Option<LiteralValueTypeKind<'db>> {
-        match (self).data() {
-            TypeData::LiteralValue(literal) => Some(literal.kind()),
-            _ => None,
-        }
+        self.as_literal_value().map(LiteralValueType::kind)
     }
 
     pub(crate) fn is_typed_dict(&self) -> bool {
@@ -2822,14 +2877,11 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn is_union(self) -> bool {
-        matches!((self).data(), TypeData::Union(_))
+        self.tag == TypeTag::Union
     }
 
     pub fn as_union(self) -> Option<UnionType<'db>> {
-        match (self).data() {
-            TypeData::Union(union_type) => Some(union_type),
-            _ => None,
-        }
+        (self.tag == TypeTag::Union).then(|| self.payload())
     }
 
     #[track_caller]
@@ -2838,7 +2890,7 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn is_intersection(self) -> bool {
-        matches!((self).data(), TypeData::Intersection(_))
+        self.tag == TypeTag::Intersection
     }
 
     /// Returns whether this is a "real" intersection type. (Negated types are represented by an
@@ -2853,9 +2905,9 @@ impl<'db> Type<'db> {
 
     /// Returns the number of union clauses in this type. If the type is not a union, returns 1.
     pub(crate) fn union_size(self, db: &'db dyn Db) -> usize {
-        match (self).data() {
-            TypeData::Union(union_type) => union_type.elements(db).len(),
-            TypeData::Never => 0,
+        match self.tag {
+            TypeTag::Union => self.payload::<UnionType<'db>>().elements(db).len(),
+            TypeTag::Never => 0,
             _ => 1,
         }
     }
@@ -2864,11 +2916,13 @@ impl<'db> Type<'db> {
     /// the maximum of the `intersection_size` of each union element. If the type is not a union
     /// nor an intersection, returns 1.
     pub(crate) fn intersection_size(self, db: &'db dyn Db) -> usize {
-        match (self).data() {
-            TypeData::Intersection(intersection) => {
+        match self.tag {
+            TypeTag::Intersection => {
+                let intersection = self.payload::<IntersectionType<'db>>();
                 intersection.positive(db).len() + intersection.negative(db).len()
             }
-            TypeData::Union(union_type) => union_type
+            TypeTag::Union => self
+                .payload::<UnionType<'db>>()
                 .elements(db)
                 .iter()
                 .map(|element| element.intersection_size(db))
@@ -2879,10 +2933,7 @@ impl<'db> Type<'db> {
     }
 
     pub fn as_function_literal(self) -> Option<FunctionType<'db>> {
-        match (self).data() {
-            TypeData::FunctionLiteral(function_type) => Some(function_type),
-            _ => None,
-        }
+        (self.tag == TypeTag::FunctionLiteral).then(|| self.payload())
     }
 
     #[cfg(test)]
@@ -3269,11 +3320,18 @@ impl<'db> Type<'db> {
 
     /// Like [`Type::promote`], but does not recurse into nested types.
     fn promote_impl(self, db: &'db dyn Db) -> Type<'db> {
-        match (self).data() {
-            TypeData::LiteralValue(literal) if literal.is_promotable() => {
-                literal.fallback_instance(db)
+        match self.tag {
+            TypeTag::LiteralValue => {
+                let literal = self.as_literal_value().unwrap();
+                if literal.is_promotable() {
+                    literal.fallback_instance(db)
+                } else {
+                    self
+                }
             }
-            TypeData::FunctionLiteral(literal) => Type::Callable(literal.into_callable_type(db)),
+            TypeTag::FunctionLiteral => {
+                Type::Callable(self.payload::<FunctionType<'db>>().into_callable_type(db))
+            }
             _ => self,
         }
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1348,7 +1348,7 @@ impl<'db> Type<'db> {
             SpecialFormType::Protocol => result.detail[0] = PackedSpecialFormTag::Protocol as u8,
             SpecialFormType::Generic => result.detail[0] = PackedSpecialFormTag::Generic as u8,
             SpecialFormType::NamedTuple => {
-                result.detail[0] = PackedSpecialFormTag::NamedTuple as u8
+                result.detail[0] = PackedSpecialFormTag::NamedTuple as u8;
             }
         }
         result
@@ -1833,6 +1833,15 @@ impl<'db> Type<'db> {
                 ..Self::without_payload(TypeTag::LiteralValue)
             },
         }
+    }
+
+    /// Returns both the packed type and its decoded representation.
+    ///
+    /// This supports matches that need to retain the original packed value in
+    /// some arms while inspecting its representation in others.
+    #[inline]
+    pub fn view(self) -> (Self, TypeData<'db>) {
+        (self, self.data())
     }
 
     pub fn data(self) -> TypeData<'db> {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1844,6 +1844,23 @@ impl<'db> Type<'db> {
         (self, self.data())
     }
 
+    fn nominal_instance(self) -> NominalInstanceType<'db> {
+        debug_assert_eq!(self.tag, TypeTag::NominalInstance);
+        NominalInstanceType(match self.detail[0] {
+            x if x == PackedNominalInstanceTag::Object as u8 => NominalInstanceInner::Object,
+            x if x == PackedNominalInstanceTag::ExactTuple as u8 => {
+                NominalInstanceInner::ExactTuple(self.payload())
+            }
+            x if x == PackedNominalInstanceTag::NonTuple as u8 => {
+                NominalInstanceInner::NonTuple(self.class_type_at(1, 2))
+            }
+            x if x == PackedNominalInstanceTag::SysVersionInfo as u8 => {
+                NominalInstanceInner::SysVersionInfo
+            }
+            _ => unreachable!(),
+        })
+    }
+
     pub fn data(self) -> TypeData<'db> {
         use set_theoretic::RecursivelyDefined;
 
@@ -1924,21 +1941,7 @@ impl<'db> Type<'db> {
                     _ => unreachable!(),
                 }))
             }
-            TypeTag::NominalInstance => TypeData::NominalInstance(NominalInstanceType(match self
-                .detail[0]
-            {
-                x if x == PackedNominalInstanceTag::Object as u8 => NominalInstanceInner::Object,
-                x if x == PackedNominalInstanceTag::ExactTuple as u8 => {
-                    NominalInstanceInner::ExactTuple(self.payload())
-                }
-                x if x == PackedNominalInstanceTag::NonTuple as u8 => {
-                    NominalInstanceInner::NonTuple(self.class_type_at(1, 2))
-                }
-                x if x == PackedNominalInstanceTag::SysVersionInfo as u8 => {
-                    NominalInstanceInner::SysVersionInfo
-                }
-                _ => unreachable!(),
-            })),
+            TypeTag::NominalInstance => TypeData::NominalInstance(self.nominal_instance()),
             TypeTag::ProtocolInstance => TypeData::ProtocolInstance(
                 ProtocolInstanceType::from_packed_inner(match self.detail[0] {
                     x if x == PackedProtocolTag::FromClass as u8 => {
@@ -2900,6 +2903,14 @@ impl<'db> Type<'db> {
 
     pub(crate) fn is_intersection(self) -> bool {
         self.tag == TypeTag::Intersection
+    }
+
+    pub(crate) fn as_intersection(self) -> Option<IntersectionType<'db>> {
+        (self.tag == TypeTag::Intersection).then(|| self.payload())
+    }
+
+    pub(crate) fn as_enum_complement(self) -> Option<EnumComplementType<'db>> {
+        (self.tag == TypeTag::EnumComplement).then(|| self.payload())
     }
 
     /// Returns whether this is a "real" intersection type. (Negated types are represented by an

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1201,7 +1201,7 @@ enum PackedTypeQualifierTag {
 /// Compact physical representation of a type.
 ///
 /// The tag is stored separately from an eight-byte payload. Literal kinds are flattened into the
-/// tag because [`LiteralValueType`] is itself larger than the payload. Use [`Type::data`] to access
+/// tag because `LiteralValueType` is itself larger than the payload. Use [`Type::data`] to access
 /// the logical enum representation.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, salsa::Update)]
 pub struct Type<'db> {

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -207,22 +207,16 @@ impl<'db> Type<'db> {
             Ok(truthiness.unwrap_or(Truthiness::Ambiguous))
         };
 
-        let truthiness = match {
-            let __ty_view_value = self;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                crate::types::TypeData::Dynamic(_)
-                | crate::types::TypeData::Divergent(_)
-                | crate::types::TypeData::Never
-                | crate::types::TypeData::Callable(_)
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_),
-            ) => Truthiness::Ambiguous,
+        let truthiness = match self.data() {
+            crate::types::TypeData::Dynamic(_)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_) => Truthiness::Ambiguous,
 
-            (_, crate::types::TypeData::TypedDict(td)) => {
+            crate::types::TypeData::TypedDict(td) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
                 } else if td.openness(db).is_closed()
@@ -234,45 +228,37 @@ impl<'db> Type<'db> {
                 }
             }
 
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(
-                    tracked_set,
-                )),
-            ) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(
+                tracked_set,
+            )) => {
                 let constraints = ConstraintSetBuilder::new();
                 let tracked_set = constraints.load(db, tracked_set.constraints(db));
                 Truthiness::from(tracked_set.is_always_satisfied(db))
             }
 
-            (
-                _,
-                crate::types::TypeData::FunctionLiteral(_)
-                | crate::types::TypeData::BoundMethod(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::KnownBoundMethod(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::ModuleLiteral(_)
-                | crate::types::TypeData::PropertyInstance(_)
-                | crate::types::TypeData::BoundSuper(_)
-                | crate::types::TypeData::KnownInstance(_)
-                | crate::types::TypeData::SpecialForm(_)
-                | crate::types::TypeData::AlwaysTruthy,
-            ) => Truthiness::AlwaysTrue,
+            crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::AlwaysTruthy => Truthiness::AlwaysTrue,
 
-            (_, crate::types::TypeData::AlwaysFalsy) => Truthiness::AlwaysFalse,
+            crate::types::TypeData::AlwaysFalsy => Truthiness::AlwaysFalse,
 
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
-                class
-                    .metaclass_instance_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)?
-            }
-            (_, crate::types::TypeData::GenericAlias(alias)) => ClassType::from(alias)
+            crate::types::TypeData::ClassLiteral(class) => class
+                .metaclass_instance_type(db)
+                .try_bool_impl(db, allow_short_circuit, visitor)?,
+            crate::types::TypeData::GenericAlias(alias) => ClassType::from(alias)
                 .metaclass_instance_type(db)
                 .try_bool_impl(db, allow_short_circuit, visitor)?,
 
-            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
+            crate::types::TypeData::SubclassOf(subclass_of_ty) => {
                 match subclass_of_ty.subclass_of().with_transposed_type_var(db) {
                     SubclassOfInner::Dynamic(_) => Truthiness::Ambiguous,
                     SubclassOfInner::Class(class) => {
@@ -283,7 +269,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+            crate::types::TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => Truthiness::Ambiguous,
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -295,17 +281,17 @@ impl<'db> Type<'db> {
                 }
             }
 
-            (_, crate::types::TypeData::NominalInstance(instance)) => instance
+            crate::types::TypeData::NominalInstance(instance) => instance
                 .known_class(db)
                 .and_then(KnownClass::bool)
                 .map(Ok)
                 .unwrap_or_else(try_dunders)?,
 
-            (_, crate::types::TypeData::ProtocolInstance(_)) => try_dunders()?,
+            crate::types::TypeData::ProtocolInstance(_) => try_dunders()?,
 
-            (_, crate::types::TypeData::Union(union)) => try_union(union)?,
+            crate::types::TypeData::Union(union) => try_union(union)?,
 
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     alternatives.try_bool_impl(db, allow_short_circuit, visitor)?
                 } else {
@@ -314,11 +300,11 @@ impl<'db> Type<'db> {
                 }
             }
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => complement
+            crate::types::TypeData::EnumComplement(complement) => complement
                 .remaining_literal_union(db)
                 .try_bool_impl(db, allow_short_circuit, visitor)?,
 
-            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
+            crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::LiteralString => Truthiness::Ambiguous,
                 LiteralValueTypeKind::Enum(enum_type) => enum_type
                     .enum_class_instance(db)
@@ -330,12 +316,12 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::Bytes(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
             },
 
-            (_, crate::types::TypeData::TypeAlias(alias)) => visitor.visit(*self, || {
+            crate::types::TypeData::TypeAlias(alias) => visitor.visit(*self, || {
                 alias
                     .value_type(db)
                     .try_bool_impl(db, allow_short_circuit, visitor)
             })?,
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => newtype
+            crate::types::TypeData::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
                 .try_bool_impl(db, allow_short_circuit, visitor)?,
         };

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -207,16 +207,22 @@ impl<'db> Type<'db> {
             Ok(truthiness.unwrap_or(Truthiness::Ambiguous))
         };
 
-        let truthiness = match self {
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::Callable(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_) => Truthiness::Ambiguous,
+        let truthiness = match {
+            let __ty_view_value = self;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                crate::types::TypeData::Dynamic(_)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_),
+            ) => Truthiness::Ambiguous,
 
-            Type::TypedDict(td) => {
+            (_, crate::types::TypeData::TypedDict(td)) => {
                 if td.items(db).values().any(TypedDictField::is_required) {
                     Truthiness::AlwaysTrue
                 } else if td.openness(db).is_closed()
@@ -228,37 +234,45 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked_set)) => {
+            (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(
+                    tracked_set,
+                )),
+            ) => {
                 let constraints = ConstraintSetBuilder::new();
                 let tracked_set = constraints.load(db, tracked_set.constraints(db));
                 Truthiness::from(tracked_set.is_always_satisfied(db))
             }
 
-            Type::FunctionLiteral(_)
-            | Type::BoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::PropertyInstance(_)
-            | Type::BoundSuper(_)
-            | Type::KnownInstance(_)
-            | Type::SpecialForm(_)
-            | Type::AlwaysTruthy => Truthiness::AlwaysTrue,
+            (
+                _,
+                crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::AlwaysTruthy,
+            ) => Truthiness::AlwaysTrue,
 
-            Type::AlwaysFalsy => Truthiness::AlwaysFalse,
+            (_, crate::types::TypeData::AlwaysFalsy) => Truthiness::AlwaysFalse,
 
-            Type::ClassLiteral(class) => {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
                 class
                     .metaclass_instance_type(db)
                     .try_bool_impl(db, allow_short_circuit, visitor)?
             }
-            Type::GenericAlias(alias) => ClassType::from(*alias)
+            (_, crate::types::TypeData::GenericAlias(alias)) => ClassType::from(alias)
                 .metaclass_instance_type(db)
                 .try_bool_impl(db, allow_short_circuit, visitor)?,
 
-            Type::SubclassOf(subclass_of_ty) => {
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
                 match subclass_of_ty.subclass_of().with_transposed_type_var(db) {
                     SubclassOfInner::Dynamic(_) => Truthiness::Ambiguous,
                     SubclassOfInner::Class(class) => {
@@ -269,7 +283,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => Truthiness::Ambiguous,
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -281,17 +295,17 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::NominalInstance(instance) => instance
+            (_, crate::types::TypeData::NominalInstance(instance)) => instance
                 .known_class(db)
                 .and_then(KnownClass::bool)
                 .map(Ok)
                 .unwrap_or_else(try_dunders)?,
 
-            Type::ProtocolInstance(_) => try_dunders()?,
+            (_, crate::types::TypeData::ProtocolInstance(_)) => try_dunders()?,
 
-            Type::Union(union) => try_union(*union)?,
+            (_, crate::types::TypeData::Union(union)) => try_union(union)?,
 
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     alternatives.try_bool_impl(db, allow_short_circuit, visitor)?
                 } else {
@@ -300,11 +314,11 @@ impl<'db> Type<'db> {
                 }
             }
 
-            Type::EnumComplement(complement) => complement
+            (_, crate::types::TypeData::EnumComplement(complement)) => complement
                 .remaining_literal_union(db)
                 .try_bool_impl(db, allow_short_circuit, visitor)?,
 
-            Type::LiteralValue(literal) => match literal.kind() {
+            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::LiteralString => Truthiness::Ambiguous,
                 LiteralValueTypeKind::Enum(enum_type) => enum_type
                     .enum_class_instance(db)
@@ -316,16 +330,14 @@ impl<'db> Type<'db> {
                 LiteralValueTypeKind::Bytes(bytes) => Truthiness::from(!bytes.value(db).is_empty()),
             },
 
-            Type::TypeAlias(alias) => visitor.visit(*self, || {
+            (_, crate::types::TypeData::TypeAlias(alias)) => visitor.visit(*self, || {
                 alias
                     .value_type(db)
                     .try_bool_impl(db, allow_short_circuit, visitor)
             })?,
-            Type::NewTypeInstance(newtype) => {
-                newtype
-                    .concrete_base_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)?
-            }
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => newtype
+                .concrete_base_type(db)
+                .try_bool_impl(db, allow_short_circuit, visitor)?,
         };
 
         Ok(truthiness)

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -118,14 +118,17 @@ impl<'db> BoundSuperError<'db> {
             }
             BoundSuperError::InvalidPivotClassType { pivot_class } => {
                 if let Some(builder) = context.report_lint(&INVALID_SUPER_ARGUMENT, node) {
-                    match pivot_class {
-                        Type::GenericAlias(alias) => {
+                    match {
+                        let __ty_view_value = pivot_class;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::GenericAlias(alias)) => {
                             builder.into_diagnostic(format_args!(
                                 "`types.GenericAlias` instance `{}` is not a valid class",
                                 alias.display_with(context.db(), DisplaySettings::default()),
                             ));
                         }
-                        _ => {
+                        (_, _) => {
                             let mut diagnostic =
                                 builder.into_diagnostic("Argument is not a valid class");
                             diagnostic.set_primary_message(format_args!(
@@ -526,9 +529,15 @@ impl<'db> BoundSuperType<'db> {
         //   but are not valid as pivot classes, e.g. `typing.ChainMap`
         // - There are objects that are not valid in a class's bases list
         //   but are valid as pivot classes, e.g. unsubscripted `typing.Generic`
-        let pivot_class = match pivot_class_type {
-            Type::ClassLiteral(class) => ClassBase::Class(ClassType::NonGeneric(class)),
-            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+        let pivot_class = match {
+            let __ty_view_value = pivot_class_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
+                ClassBase::Class(ClassType::NonGeneric(class))
+            }
+            (_, crate::types::TypeData::SubclassOf(subclass_of)) => match subclass_of.subclass_of()
+            {
                 SubclassOfInner::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
                 _ => match subclass_of.subclass_of().into_class(db) {
                     Some(class) => ClassBase::Class(class),
@@ -539,12 +548,18 @@ impl<'db> BoundSuperType<'db> {
                     }
                 },
             },
-            Type::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
-            Type::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
-            Type::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,
-            Type::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
-            Type::Divergent(divergent) => ClassBase::Divergent(divergent),
-            _ => {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)) => {
+                ClassBase::Protocol
+            }
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
+                ClassBase::Generic
+            }
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict)) => {
+                ClassBase::TypedDict
+            }
+            (_, crate::types::TypeData::Dynamic(dynamic)) => ClassBase::Dynamic(dynamic),
+            (_, crate::types::TypeData::Divergent(divergent)) => ClassBase::Divergent(divergent),
+            (_, _) => {
                 return Err(BoundSuperError::InvalidPivotClassType {
                     pivot_class: pivot_class_type,
                 });
@@ -558,9 +573,14 @@ impl<'db> BoundSuperType<'db> {
          -> Result<Type<'db>, BoundSuperError<'db>> {
             let mut builder = UnionBuilder::new(db);
             for constraint in constraints.elements(db) {
-                let class = match constraint {
-                    Type::NominalInstance(instance) => Some(instance.class(db)),
-                    _ => constraint.to_class_type(db),
+                let class = match {
+                    let __ty_view_value = constraint;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::NominalInstance(instance)) => {
+                        Some(instance.class(db))
+                    }
+                    (_, _) => constraint.to_class_type(db),
                 };
                 match class {
                     Some(class) => {
@@ -599,20 +619,29 @@ impl<'db> BoundSuperType<'db> {
             Ok(builder.build())
         };
 
-        let owner = match owner_type {
-            Type::Never => SuperOwnerKind::Dynamic(DynamicType::Unknown),
-            Type::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
-            Type::Divergent(divergent) => SuperOwnerKind::Divergent(divergent),
-            Type::ClassLiteral(class) => SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
-                db,
-                pivot_class,
-                pivot_class_type,
-                owner_type,
-                Type::from(ClassType::NonGeneric(class)),
-                ClassType::NonGeneric(class),
-                None,
-            )?),
-            Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
+        let owner = match {
+            let __ty_view_value = owner_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Never) => SuperOwnerKind::Dynamic(DynamicType::Unknown),
+            (_, crate::types::TypeData::Dynamic(dynamic)) => SuperOwnerKind::Dynamic(dynamic),
+            (_, crate::types::TypeData::Divergent(divergent)) => {
+                SuperOwnerKind::Divergent(divergent)
+            }
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
+                SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
+                    db,
+                    pivot_class,
+                    pivot_class_type,
+                    owner_type,
+                    Type::from(ClassType::NonGeneric(class)),
+                    ClassType::NonGeneric(class),
+                    None,
+                )?)
+            }
+            (_, crate::types::TypeData::SubclassOf(subclass_of_type)) => match subclass_of_type
+                .subclass_of()
+            {
                 SubclassOfInner::Class(class) => {
                     SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
                         db,
@@ -629,12 +658,17 @@ impl<'db> BoundSuperType<'db> {
                     let typevar = bound_typevar.typevar(db);
                     match typevar.bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            let class = match bound {
-                                Type::NominalInstance(instance) => Some(instance.class(db)),
-                                Type::ProtocolInstance(protocol) => protocol
+                            let class = match {
+                                let __ty_view_value = bound;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
+                                (_, crate::types::TypeData::NominalInstance(instance)) => {
+                                    Some(instance.class(db))
+                                }
+                                (_, crate::types::TypeData::ProtocolInstance(protocol)) => protocol
                                     .to_nominal_instance()
                                     .map(|instance| instance.class(db)),
-                                _ => None,
+                                (_, _) => None,
                             };
                             if let Some(class) = class {
                                 SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
@@ -676,7 +710,7 @@ impl<'db> BoundSuperType<'db> {
                     }
                 }
             },
-            Type::NominalInstance(instance) => {
+            (_, crate::types::TypeData::NominalInstance(instance)) => {
                 SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                     db,
                     pivot_class,
@@ -687,7 +721,7 @@ impl<'db> BoundSuperType<'db> {
                 )?)
             }
 
-            Type::ProtocolInstance(protocol) => {
+            (_, crate::types::TypeData::ProtocolInstance(protocol)) => {
                 if let Some(nominal_instance) = protocol.to_nominal_instance() {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
@@ -706,7 +740,7 @@ impl<'db> BoundSuperType<'db> {
                 }
             }
 
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 return Ok(union
                     .elements(db)
                     .iter()
@@ -715,7 +749,7 @@ impl<'db> BoundSuperType<'db> {
                     })?
                     .build());
             }
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 let mut builder = IntersectionBuilder::new(db);
                 let mut one_good_element_found = false;
                 for positive in intersection.positive(db) {
@@ -738,22 +772,27 @@ impl<'db> BoundSuperType<'db> {
                 }
                 return Ok(builder.build());
             }
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 return delegate_to(complement.to_intersection(db));
             }
-            Type::TypeAlias(alias) => {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 return delegate_to(alias.value_type(db));
             }
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 let typevar = bound_typevar.typevar(db);
                 match typevar.bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        let class = match bound {
-                            Type::NominalInstance(instance) => Some(instance.class(db)),
-                            Type::ProtocolInstance(protocol) => protocol
+                        let class = match {
+                            let __ty_view_value = bound;
+                            (__ty_view_value, __ty_view_value.data())
+                        } {
+                            (_, crate::types::TypeData::NominalInstance(instance)) => {
+                                Some(instance.class(db))
+                            }
+                            (_, crate::types::TypeData::ProtocolInstance(protocol)) => protocol
                                 .to_nominal_instance()
                                 .map(|instance| instance.class(db)),
-                            _ => None,
+                            (_, _) => None,
                         };
                         if let Some(class) = class {
                             SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
@@ -790,35 +829,47 @@ impl<'db> BoundSuperType<'db> {
                     }
                 }
             }
-            Type::TypeIs(_) | Type::TypeGuard(_) => {
+            (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)) => {
                 return delegate_to(KnownClass::Bool.to_instance(db));
             }
-            Type::LiteralValue(literal) => return delegate_to(literal.fallback_instance(db)),
-            Type::SpecialForm(special_form) => {
+            (_, crate::types::TypeData::LiteralValue(literal)) => {
+                return delegate_to(literal.fallback_instance(db));
+            }
+            (_, crate::types::TypeData::SpecialForm(special_form)) => {
                 return delegate_to(special_form.instance_fallback(db));
             }
-            Type::KnownInstance(instance) => {
+            (_, crate::types::TypeData::KnownInstance(instance)) => {
                 return delegate_to(instance.instance_fallback(db));
             }
-            Type::FunctionLiteral(_) | Type::DataclassDecorator(_) => {
+            (
+                _,
+                crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::DataclassDecorator(_),
+            ) => {
                 return delegate_to(KnownClass::FunctionType.to_instance(db));
             }
-            Type::WrapperDescriptor(_) => {
+            (_, crate::types::TypeData::WrapperDescriptor(_)) => {
                 return delegate_to(KnownClass::WrapperDescriptorType.to_instance(db));
             }
-            Type::KnownBoundMethod(method) => {
+            (_, crate::types::TypeData::KnownBoundMethod(method)) => {
                 return delegate_to(method.class().to_instance(db));
             }
-            Type::BoundMethod(_) => return delegate_to(KnownClass::MethodType.to_instance(db)),
-            Type::ModuleLiteral(_) => {
+            (_, crate::types::TypeData::BoundMethod(_)) => {
+                return delegate_to(KnownClass::MethodType.to_instance(db));
+            }
+            (_, crate::types::TypeData::ModuleLiteral(_)) => {
                 return delegate_to(KnownClass::ModuleType.to_instance(db));
             }
-            Type::GenericAlias(_) => return delegate_to(KnownClass::GenericAlias.to_instance(db)),
-            Type::PropertyInstance(property) => {
+            (_, crate::types::TypeData::GenericAlias(_)) => {
+                return delegate_to(KnownClass::GenericAlias.to_instance(db));
+            }
+            (_, crate::types::TypeData::PropertyInstance(property)) => {
                 return delegate_to(property.instance_fallback(db));
             }
-            Type::BoundSuper(_) => return delegate_to(KnownClass::Super.to_instance(db)),
-            Type::TypedDict(td) => {
+            (_, crate::types::TypeData::BoundSuper(_)) => {
+                return delegate_to(KnownClass::Super.to_instance(db));
+            }
+            (_, crate::types::TypeData::TypedDict(td)) => {
                 // In general it isn't sound to upcast a `TypedDict` to a `dict`,
                 // but here it seems like it's probably sound?
                 let mut key_builder = UnionBuilder::new(db);
@@ -832,17 +883,20 @@ impl<'db> BoundSuperType<'db> {
                         .to_specialized_instance(db, &[key_builder.build(), value_builder.build()]),
                 );
             }
-            Type::NewTypeInstance(newtype) => {
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                 return delegate_to(newtype.concrete_base_type(db));
             }
-            Type::Callable(callable) if callable.is_function_like(db) => {
+            (_, crate::types::TypeData::Callable(callable)) if callable.is_function_like(db) => {
                 return delegate_to(KnownClass::FunctionType.to_instance(db));
             }
-            Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::Callable(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeForm(_) => {
+            (
+                _,
+                crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::TypeForm(_),
+            ) => {
                 return Err(BoundSuperError::AbstractOwnerType {
                     owner_type,
                     pivot_class: pivot_class_type,

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -118,17 +118,14 @@ impl<'db> BoundSuperError<'db> {
             }
             BoundSuperError::InvalidPivotClassType { pivot_class } => {
                 if let Some(builder) = context.report_lint(&INVALID_SUPER_ARGUMENT, node) {
-                    match {
-                        let __ty_view_value = pivot_class;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::GenericAlias(alias)) => {
+                    match pivot_class.data() {
+                        crate::types::TypeData::GenericAlias(alias) => {
                             builder.into_diagnostic(format_args!(
                                 "`types.GenericAlias` instance `{}` is not a valid class",
                                 alias.display_with(context.db(), DisplaySettings::default()),
                             ));
                         }
-                        (_, _) => {
+                        _ => {
                             let mut diagnostic =
                                 builder.into_diagnostic("Argument is not a valid class");
                             diagnostic.set_primary_message(format_args!(
@@ -529,15 +526,11 @@ impl<'db> BoundSuperType<'db> {
         //   but are not valid as pivot classes, e.g. `typing.ChainMap`
         // - There are objects that are not valid in a class's bases list
         //   but are valid as pivot classes, e.g. unsubscripted `typing.Generic`
-        let pivot_class = match {
-            let __ty_view_value = pivot_class_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
+        let pivot_class = match pivot_class_type.data() {
+            crate::types::TypeData::ClassLiteral(class) => {
                 ClassBase::Class(ClassType::NonGeneric(class))
             }
-            (_, crate::types::TypeData::SubclassOf(subclass_of)) => match subclass_of.subclass_of()
-            {
+            crate::types::TypeData::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
                 _ => match subclass_of.subclass_of().into_class(db) {
                     Some(class) => ClassBase::Class(class),
@@ -548,18 +541,12 @@ impl<'db> BoundSuperType<'db> {
                     }
                 },
             },
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)) => {
-                ClassBase::Protocol
-            }
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
-                ClassBase::Generic
-            }
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict)) => {
-                ClassBase::TypedDict
-            }
-            (_, crate::types::TypeData::Dynamic(dynamic)) => ClassBase::Dynamic(dynamic),
-            (_, crate::types::TypeData::Divergent(divergent)) => ClassBase::Divergent(divergent),
-            (_, _) => {
+            crate::types::TypeData::SpecialForm(SpecialFormType::Protocol) => ClassBase::Protocol,
+            crate::types::TypeData::SpecialForm(SpecialFormType::Generic) => ClassBase::Generic,
+            crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict) => ClassBase::TypedDict,
+            crate::types::TypeData::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
+            crate::types::TypeData::Divergent(divergent) => ClassBase::Divergent(divergent),
+            _ => {
                 return Err(BoundSuperError::InvalidPivotClassType {
                     pivot_class: pivot_class_type,
                 });
@@ -573,14 +560,9 @@ impl<'db> BoundSuperType<'db> {
          -> Result<Type<'db>, BoundSuperError<'db>> {
             let mut builder = UnionBuilder::new(db);
             for constraint in constraints.elements(db) {
-                let class = match {
-                    let __ty_view_value = constraint;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::NominalInstance(instance)) => {
-                        Some(instance.class(db))
-                    }
-                    (_, _) => constraint.to_class_type(db),
+                let class = match constraint.data() {
+                    crate::types::TypeData::NominalInstance(instance) => Some(instance.class(db)),
+                    _ => constraint.to_class_type(db),
                 };
                 match class {
                     Some(class) => {
@@ -619,16 +601,11 @@ impl<'db> BoundSuperType<'db> {
             Ok(builder.build())
         };
 
-        let owner = match {
-            let __ty_view_value = owner_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Never) => SuperOwnerKind::Dynamic(DynamicType::Unknown),
-            (_, crate::types::TypeData::Dynamic(dynamic)) => SuperOwnerKind::Dynamic(dynamic),
-            (_, crate::types::TypeData::Divergent(divergent)) => {
-                SuperOwnerKind::Divergent(divergent)
-            }
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
+        let owner = match owner_type.data() {
+            crate::types::TypeData::Never => SuperOwnerKind::Dynamic(DynamicType::Unknown),
+            crate::types::TypeData::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
+            crate::types::TypeData::Divergent(divergent) => SuperOwnerKind::Divergent(divergent),
+            crate::types::TypeData::ClassLiteral(class) => {
                 SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
                     db,
                     pivot_class,
@@ -639,78 +616,75 @@ impl<'db> BoundSuperType<'db> {
                     None,
                 )?)
             }
-            (_, crate::types::TypeData::SubclassOf(subclass_of_type)) => match subclass_of_type
-                .subclass_of()
-            {
-                SubclassOfInner::Class(class) => {
-                    SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
-                        db,
-                        pivot_class,
-                        pivot_class_type,
-                        owner_type,
-                        Type::from(class),
-                        class,
-                        None,
-                    )?)
-                }
-                SubclassOfInner::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
-                SubclassOfInner::TypeVar(bound_typevar) => {
-                    let typevar = bound_typevar.typevar(db);
-                    match typevar.bound_or_constraints(db) {
-                        Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            let class = match {
-                                let __ty_view_value = bound;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
-                                (_, crate::types::TypeData::NominalInstance(instance)) => {
-                                    Some(instance.class(db))
+            crate::types::TypeData::SubclassOf(subclass_of_type) => {
+                match subclass_of_type.subclass_of() {
+                    SubclassOfInner::Class(class) => {
+                        SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
+                            db,
+                            pivot_class,
+                            pivot_class_type,
+                            owner_type,
+                            Type::from(class),
+                            class,
+                            None,
+                        )?)
+                    }
+                    SubclassOfInner::Dynamic(dynamic) => SuperOwnerKind::Dynamic(dynamic),
+                    SubclassOfInner::TypeVar(bound_typevar) => {
+                        let typevar = bound_typevar.typevar(db);
+                        match typevar.bound_or_constraints(db) {
+                            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                                let class = match bound.data() {
+                                    crate::types::TypeData::NominalInstance(instance) => {
+                                        Some(instance.class(db))
+                                    }
+                                    crate::types::TypeData::ProtocolInstance(protocol) => protocol
+                                        .to_nominal_instance()
+                                        .map(|instance| instance.class(db)),
+                                    _ => None,
+                                };
+                                if let Some(class) = class {
+                                    SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
+                                        db,
+                                        pivot_class,
+                                        pivot_class_type,
+                                        owner_type,
+                                        owner_type,
+                                        class,
+                                        Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
+                                    )?)
+                                } else {
+                                    let subclass_of = SubclassOfType::try_from_instance(db, bound)
+                                        .unwrap_or_else(SubclassOfType::subclass_of_unknown);
+                                    return delegate_with_error_mapped(
+                                        subclass_of,
+                                        Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
+                                    );
                                 }
-                                (_, crate::types::TypeData::ProtocolInstance(protocol)) => protocol
-                                    .to_nominal_instance()
-                                    .map(|instance| instance.class(db)),
-                                (_, _) => None,
-                            };
-                            if let Some(class) = class {
+                            }
+                            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                                return build_constrained_union(
+                                    constraints,
+                                    TypeVarOwnerContext::SubclassOf(bound_typevar),
+                                );
+                            }
+                            None => {
+                                // No bound means the implicit upper bound is `object`.
                                 SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
                                     db,
                                     pivot_class,
                                     pivot_class_type,
                                     owner_type,
                                     owner_type,
-                                    class,
+                                    ClassType::object(db),
                                     Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
                                 )?)
-                            } else {
-                                let subclass_of = SubclassOfType::try_from_instance(db, bound)
-                                    .unwrap_or_else(SubclassOfType::subclass_of_unknown);
-                                return delegate_with_error_mapped(
-                                    subclass_of,
-                                    Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
-                                );
                             }
-                        }
-                        Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                            return build_constrained_union(
-                                constraints,
-                                TypeVarOwnerContext::SubclassOf(bound_typevar),
-                            );
-                        }
-                        None => {
-                            // No bound means the implicit upper bound is `object`.
-                            SuperOwnerKind::Resolved(Self::resolve_class_super_owner(
-                                db,
-                                pivot_class,
-                                pivot_class_type,
-                                owner_type,
-                                owner_type,
-                                ClassType::object(db),
-                                Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
-                            )?)
                         }
                     }
                 }
-            },
-            (_, crate::types::TypeData::NominalInstance(instance)) => {
+            }
+            crate::types::TypeData::NominalInstance(instance) => {
                 SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                     db,
                     pivot_class,
@@ -721,7 +695,7 @@ impl<'db> BoundSuperType<'db> {
                 )?)
             }
 
-            (_, crate::types::TypeData::ProtocolInstance(protocol)) => {
+            crate::types::TypeData::ProtocolInstance(protocol) => {
                 if let Some(nominal_instance) = protocol.to_nominal_instance() {
                     SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
                         db,
@@ -740,7 +714,7 @@ impl<'db> BoundSuperType<'db> {
                 }
             }
 
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 return Ok(union
                     .elements(db)
                     .iter()
@@ -749,7 +723,7 @@ impl<'db> BoundSuperType<'db> {
                     })?
                     .build());
             }
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 let mut one_good_element_found = false;
                 for positive in intersection.positive(db) {
@@ -772,27 +746,24 @@ impl<'db> BoundSuperType<'db> {
                 }
                 return Ok(builder.build());
             }
-            (_, crate::types::TypeData::EnumComplement(complement)) => {
+            crate::types::TypeData::EnumComplement(complement) => {
                 return delegate_to(complement.to_intersection(db));
             }
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+            crate::types::TypeData::TypeAlias(alias) => {
                 return delegate_to(alias.value_type(db));
             }
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+            crate::types::TypeData::TypeVar(bound_typevar) => {
                 let typevar = bound_typevar.typevar(db);
                 match typevar.bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        let class = match {
-                            let __ty_view_value = bound;
-                            (__ty_view_value, __ty_view_value.data())
-                        } {
-                            (_, crate::types::TypeData::NominalInstance(instance)) => {
+                        let class = match bound.data() {
+                            crate::types::TypeData::NominalInstance(instance) => {
                                 Some(instance.class(db))
                             }
-                            (_, crate::types::TypeData::ProtocolInstance(protocol)) => protocol
+                            crate::types::TypeData::ProtocolInstance(protocol) => protocol
                                 .to_nominal_instance()
                                 .map(|instance| instance.class(db)),
-                            (_, _) => None,
+                            _ => None,
                         };
                         if let Some(class) = class {
                             SuperOwnerKind::Resolved(Self::resolve_instance_super_owner(
@@ -829,47 +800,44 @@ impl<'db> BoundSuperType<'db> {
                     }
                 }
             }
-            (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)) => {
+            crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_) => {
                 return delegate_to(KnownClass::Bool.to_instance(db));
             }
-            (_, crate::types::TypeData::LiteralValue(literal)) => {
+            crate::types::TypeData::LiteralValue(literal) => {
                 return delegate_to(literal.fallback_instance(db));
             }
-            (_, crate::types::TypeData::SpecialForm(special_form)) => {
+            crate::types::TypeData::SpecialForm(special_form) => {
                 return delegate_to(special_form.instance_fallback(db));
             }
-            (_, crate::types::TypeData::KnownInstance(instance)) => {
+            crate::types::TypeData::KnownInstance(instance) => {
                 return delegate_to(instance.instance_fallback(db));
             }
-            (
-                _,
-                crate::types::TypeData::FunctionLiteral(_)
-                | crate::types::TypeData::DataclassDecorator(_),
-            ) => {
+            crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::DataclassDecorator(_) => {
                 return delegate_to(KnownClass::FunctionType.to_instance(db));
             }
-            (_, crate::types::TypeData::WrapperDescriptor(_)) => {
+            crate::types::TypeData::WrapperDescriptor(_) => {
                 return delegate_to(KnownClass::WrapperDescriptorType.to_instance(db));
             }
-            (_, crate::types::TypeData::KnownBoundMethod(method)) => {
+            crate::types::TypeData::KnownBoundMethod(method) => {
                 return delegate_to(method.class().to_instance(db));
             }
-            (_, crate::types::TypeData::BoundMethod(_)) => {
+            crate::types::TypeData::BoundMethod(_) => {
                 return delegate_to(KnownClass::MethodType.to_instance(db));
             }
-            (_, crate::types::TypeData::ModuleLiteral(_)) => {
+            crate::types::TypeData::ModuleLiteral(_) => {
                 return delegate_to(KnownClass::ModuleType.to_instance(db));
             }
-            (_, crate::types::TypeData::GenericAlias(_)) => {
+            crate::types::TypeData::GenericAlias(_) => {
                 return delegate_to(KnownClass::GenericAlias.to_instance(db));
             }
-            (_, crate::types::TypeData::PropertyInstance(property)) => {
+            crate::types::TypeData::PropertyInstance(property) => {
                 return delegate_to(property.instance_fallback(db));
             }
-            (_, crate::types::TypeData::BoundSuper(_)) => {
+            crate::types::TypeData::BoundSuper(_) => {
                 return delegate_to(KnownClass::Super.to_instance(db));
             }
-            (_, crate::types::TypeData::TypedDict(td)) => {
+            crate::types::TypeData::TypedDict(td) => {
                 // In general it isn't sound to upcast a `TypedDict` to a `dict`,
                 // but here it seems like it's probably sound?
                 let mut key_builder = UnionBuilder::new(db);
@@ -883,20 +851,17 @@ impl<'db> BoundSuperType<'db> {
                         .to_specialized_instance(db, &[key_builder.build(), value_builder.build()]),
                 );
             }
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+            crate::types::TypeData::NewTypeInstance(newtype) => {
                 return delegate_to(newtype.concrete_base_type(db));
             }
-            (_, crate::types::TypeData::Callable(callable)) if callable.is_function_like(db) => {
+            crate::types::TypeData::Callable(callable) if callable.is_function_like(db) => {
                 return delegate_to(KnownClass::FunctionType.to_instance(db));
             }
-            (
-                _,
-                crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::Callable(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::TypeForm(_),
-            ) => {
+            crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::TypeForm(_) => {
                 return Err(BoundSuperError::AbstractOwnerType {
                     owner_type,
                     pivot_class: pivot_class_type,

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -523,15 +523,12 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
 ///
 /// In other words, it returns `true` if [`expand_type`] returns [`Some`] for the given type.
 pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::EnumComplement(_)) => true,
-        (_, crate::types::TypeData::Intersection(intersection)) => {
+    match ty.data() {
+        crate::types::TypeData::EnumComplement(_) => true,
+        crate::types::TypeData::Intersection(intersection) => {
             intersection.finite_alternatives(db).is_some()
         }
-        (_, crate::types::TypeData::NominalInstance(instance)) => {
+        crate::types::TypeData::NominalInstance(instance) => {
             let class = instance.class(db);
             class.is_known(db, KnownClass::Bool)
                 || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
@@ -542,11 +539,9 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
                 })
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
-        (_, crate::types::TypeData::Union(_)) => true,
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
-            is_expandable_type(db, alias.value_type(db))
-        }
-        (_, _) => false,
+        crate::types::TypeData::Union(_) => true,
+        crate::types::TypeData::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),
+        _ => false,
     }
 }
 
@@ -555,17 +550,12 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 /// Returns [`None`] if the type cannot be expanded.
 fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
     // NOTE: Update `is_expandable_type` if this logic changes accordingly.
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::EnumComplement(complement)) => {
+    match ty.data() {
+        crate::types::TypeData::EnumComplement(complement) => {
             Some(complement.remaining_literal_types(db))
         }
-        (_, crate::types::TypeData::Intersection(intersection)) => {
-            intersection.finite_alternatives(db)
-        }
-        (_, crate::types::TypeData::NominalInstance(instance)) => {
+        crate::types::TypeData::Intersection(intersection) => intersection.finite_alternatives(db),
+        crate::types::TypeData::NominalInstance(instance) => {
             let class = instance.class(db);
 
             if class.is_known(db, KnownClass::Bool) {
@@ -613,31 +603,26 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
 
             None
         }
-        (_, crate::types::TypeData::Union(union)) => Some(
+        crate::types::TypeData::Union(union) => Some(
             union
                 .elements(db)
                 .iter()
-                .flat_map(|element| {
-                    match {
-                        let __ty_view_value = element;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::EnumComplement(complement)) => {
-                            complement.remaining_literal_types(db)
-                        }
-                        (_, crate::types::TypeData::Intersection(intersection)) => intersection
-                            .finite_alternatives(db)
-                            .unwrap_or_else(|| vec![*element]),
-                        (_, _) => vec![*element],
+                .flat_map(|element| match element.data() {
+                    crate::types::TypeData::EnumComplement(complement) => {
+                        complement.remaining_literal_types(db)
                     }
+                    crate::types::TypeData::Intersection(intersection) => intersection
+                        .finite_alternatives(db)
+                        .unwrap_or_else(|| vec![*element]),
+                    _ => vec![*element],
                 })
                 .collect(),
         ),
         // For type aliases, expand the underlying value type.
-        (_, crate::types::TypeData::TypeAlias(alias)) => expand_type(db, alias.value_type(db)),
+        crate::types::TypeData::TypeAlias(alias) => expand_type(db, alias.value_type(db)),
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
-        (_, _) => None,
+        _ => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -523,10 +523,15 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
 ///
 /// In other words, it returns `true` if [`expand_type`] returns [`Some`] for the given type.
 pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty {
-        Type::EnumComplement(_) => true,
-        Type::Intersection(intersection) => intersection.finite_alternatives(db).is_some(),
-        Type::NominalInstance(instance) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::EnumComplement(_)) => true,
+        (_, crate::types::TypeData::Intersection(intersection)) => {
+            intersection.finite_alternatives(db).is_some()
+        }
+        (_, crate::types::TypeData::NominalInstance(instance)) => {
             let class = instance.class(db);
             class.is_known(db, KnownClass::Bool)
                 || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
@@ -537,9 +542,11 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
                 })
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
-        Type::Union(_) => true,
-        Type::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),
-        _ => false,
+        (_, crate::types::TypeData::Union(_)) => true,
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
+            is_expandable_type(db, alias.value_type(db))
+        }
+        (_, _) => false,
     }
 }
 
@@ -548,10 +555,17 @@ pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 /// Returns [`None`] if the type cannot be expanded.
 fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
     // NOTE: Update `is_expandable_type` if this logic changes accordingly.
-    match ty {
-        Type::EnumComplement(complement) => Some(complement.remaining_literal_types(db)),
-        Type::Intersection(intersection) => intersection.finite_alternatives(db),
-        Type::NominalInstance(instance) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::EnumComplement(complement)) => {
+            Some(complement.remaining_literal_types(db))
+        }
+        (_, crate::types::TypeData::Intersection(intersection)) => {
+            intersection.finite_alternatives(db)
+        }
+        (_, crate::types::TypeData::NominalInstance(instance)) => {
             let class = instance.class(db);
 
             if class.is_known(db, KnownClass::Bool) {
@@ -599,24 +613,31 @@ fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
 
             None
         }
-        Type::Union(union) => Some(
+        (_, crate::types::TypeData::Union(union)) => Some(
             union
                 .elements(db)
                 .iter()
-                .flat_map(|element| match element {
-                    Type::EnumComplement(complement) => complement.remaining_literal_types(db),
-                    Type::Intersection(intersection) => intersection
-                        .finite_alternatives(db)
-                        .unwrap_or_else(|| vec![*element]),
-                    _ => vec![*element],
+                .flat_map(|element| {
+                    match {
+                        let __ty_view_value = element;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::EnumComplement(complement)) => {
+                            complement.remaining_literal_types(db)
+                        }
+                        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                            .finite_alternatives(db)
+                            .unwrap_or_else(|| vec![*element]),
+                        (_, _) => vec![*element],
+                    }
                 })
                 .collect(),
         ),
         // For type aliases, expand the underlying value type.
-        Type::TypeAlias(alias) => expand_type(db, alias.value_type(db)),
+        (_, crate::types::TypeData::TypeAlias(alias)) => expand_type(db, alias.value_type(db)),
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
-        _ => None,
+        (_, _) => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1255,10 +1255,7 @@ impl<'db> Bindings<'db> {
         for binding in self.iter_flat_mut() {
             let binding_type = binding.callable_type;
             for (overload_index, overload) in binding.matching_overloads_mut() {
-                match {
-                    let __ty_view_value = binding_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                match binding_type.view() {
                     (
                         _,
                         crate::types::TypeData::KnownBoundMethod(
@@ -1654,8 +1651,8 @@ impl<'db> Bindings<'db> {
                     }
 
                     (_, crate::types::TypeData::DataclassDecorator(params)) => {
-                        match overload.parameter_types() {
-                            [Some(ty)] => match ty.data() {
+                        if let [Some(ty)] = overload.parameter_types() {
+                            match ty.data() {
                                 crate::types::TypeData::ClassLiteral(class_literal) => {
                                     if let Some(target) =
                                         invalid_dataclass_target(db, &class_literal)
@@ -1682,8 +1679,7 @@ impl<'db> Bindings<'db> {
                                     ));
                                 }
                                 _ => {}
-                            },
-                            _ => {}
+                            }
                         }
                     }
 
@@ -1694,10 +1690,9 @@ impl<'db> Bindings<'db> {
                             "setter" => {
                                 if let [Some(_), Some(setter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
-                                        let __ty_view_value = ty_property;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
+                                    if let crate::types::TypeData::PropertyInstance(property) =
+                                        ty_property.data()
+                                    {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -1712,10 +1707,9 @@ impl<'db> Bindings<'db> {
                             "getter" => {
                                 if let [Some(_), Some(getter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
-                                        let __ty_view_value = ty_property;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
+                                    if let crate::types::TypeData::PropertyInstance(property) =
+                                        ty_property.data()
+                                    {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -1730,10 +1724,9 @@ impl<'db> Bindings<'db> {
                             "deleter" => {
                                 if let [Some(_), Some(deleter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
-                                        let __ty_view_value = ty_property;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
+                                    if let crate::types::TypeData::PropertyInstance(property) =
+                                        ty_property.data()
+                                    {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -2060,45 +2053,38 @@ impl<'db> Bindings<'db> {
                                             )
                                         };
 
-                                    let generic_context_for_simple_type = |ty: Type<'db>| match {
-                                        let __ty_view_value = ty;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
-                                        (_, crate::types::TypeData::ClassLiteral(class)) => {
+                                    let generic_context_for_simple_type = |ty: Type<'db>| match ty
+                                        .data()
+                                    {
+                                        crate::types::TypeData::ClassLiteral(class) => {
                                             class.generic_context(db).map(wrap_generic_context)
                                         }
 
-                                        (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                                        crate::types::TypeData::FunctionLiteral(function) => {
                                             signature_generic_context(function.signature(db))
                                         }
 
-                                        (_, crate::types::TypeData::BoundMethod(bound_method)) => {
+                                        crate::types::TypeData::BoundMethod(bound_method) => {
                                             signature_generic_context(
                                                 bound_method.function(db).signature(db),
                                             )
                                         }
 
-                                        (_, crate::types::TypeData::Callable(callable)) => {
+                                        crate::types::TypeData::Callable(callable) => {
                                             signature_generic_context(callable.signatures(db))
                                         }
 
-                                        (
-                                            _,
-                                            crate::types::TypeData::KnownInstance(
-                                                KnownInstanceType::TypeAliasType(
-                                                    TypeAliasType::PEP695(alias),
-                                                ),
+                                        crate::types::TypeData::KnownInstance(
+                                            KnownInstanceType::TypeAliasType(
+                                                TypeAliasType::PEP695(alias),
                                             ),
                                         ) => alias.generic_context(db).map(wrap_generic_context),
 
-                                        (_, _) => None,
+                                        _ => None,
                                     };
 
-                                    let generic_context = match {
-                                        let __ty_view_value = ty;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
-                                        (_, crate::types::TypeData::Union(union_type)) => {
+                                    let generic_context = match ty.data() {
+                                        crate::types::TypeData::Union(union_type) => {
                                             UnionType::try_from_elements(
                                                 db,
                                                 union_type
@@ -2107,7 +2093,7 @@ impl<'db> Bindings<'db> {
                                                     .map(|ty| generic_context_for_simple_type(*ty)),
                                             )
                                         }
-                                        (_, _) => generic_context_for_simple_type(*ty),
+                                        _ => generic_context_for_simple_type(*ty),
                                     };
 
                                     overload.set_return_type(
@@ -2139,53 +2125,37 @@ impl<'db> Bindings<'db> {
 
                             Some(KnownFunction::DunderAllNames) => {
                                 if let [Some(ty)] = overload.parameter_types() {
-                                    overload.set_return_type(
-                                        match {
-                                            let __ty_view_value = ty;
-                                            (__ty_view_value, __ty_view_value.data())
-                                        } {
-                                            (
-                                                _,
-                                                crate::types::TypeData::ModuleLiteral(
-                                                    module_literal,
-                                                ),
-                                            ) => {
-                                                let all_names = module_literal
-                                                    .module(db)
-                                                    .file(db)
-                                                    .map(|file| dunder_all_names(db, file))
-                                                    .unwrap_or_default();
-                                                match all_names {
-                                                    Some(names) => {
-                                                        let mut names =
-                                                            names.iter().collect::<Vec<_>>();
-                                                        names.sort();
-                                                        Type::heterogeneous_tuple(
-                                                            db,
-                                                            names.iter().map(|name| {
-                                                                Type::string_literal(
-                                                                    db,
-                                                                    name.as_str(),
-                                                                )
-                                                            }),
-                                                        )
-                                                    }
-                                                    None => Type::none(db),
+                                    overload.set_return_type(match ty.data() {
+                                        crate::types::TypeData::ModuleLiteral(module_literal) => {
+                                            let all_names = module_literal
+                                                .module(db)
+                                                .file(db)
+                                                .map(|file| dunder_all_names(db, file))
+                                                .unwrap_or_default();
+                                            match all_names {
+                                                Some(names) => {
+                                                    let mut names =
+                                                        names.iter().collect::<Vec<_>>();
+                                                    names.sort();
+                                                    Type::heterogeneous_tuple(
+                                                        db,
+                                                        names.iter().map(|name| {
+                                                            Type::string_literal(db, name.as_str())
+                                                        }),
+                                                    )
                                                 }
+                                                None => Type::none(db),
                                             }
-                                            (_, _) => Type::none(db),
-                                        },
-                                    );
+                                        }
+                                        _ => Type::none(db),
+                                    });
                                 }
                             }
 
                             Some(KnownFunction::EnumMembers) => {
                                 if let [Some(ty)] = overload.parameter_types() {
-                                    let return_ty = match {
-                                        let __ty_view_value = ty;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    } {
-                                        (_, crate::types::TypeData::ClassLiteral(class)) => {
+                                    let return_ty = match ty.data() {
+                                        crate::types::TypeData::ClassLiteral(class) => {
                                             if let Some(metadata) = enums::enum_metadata(db, class)
                                             {
                                                 Type::heterogeneous_tuple(
@@ -2198,7 +2168,7 @@ impl<'db> Bindings<'db> {
                                                 Type::unknown()
                                             }
                                         }
-                                        (_, _) => Type::unknown(),
+                                        _ => Type::unknown(),
                                     };
 
                                     overload.set_return_type(return_ty);
@@ -2567,16 +2537,10 @@ impl<'db> Bindings<'db> {
                                         // Helper to check if return type is class-like.
                                         let returns_class = || {
                                             matches!(
-                                                {
-                                                    let __ty_view_value = overload.return_type();
-                                                    (__ty_view_value, __ty_view_value.data())
-                                                },
-                                                (
-                                                    _,
-                                                    crate::types::TypeData::ClassLiteral(_)
-                                                        | crate::types::TypeData::GenericAlias(_)
-                                                        | crate::types::TypeData::SubclassOf(_)
-                                                )
+                                                overload.return_type().data(),
+                                                crate::types::TypeData::ClassLiteral(_)
+                                                    | crate::types::TypeData::GenericAlias(_)
+                                                    | crate::types::TypeData::SubclassOf(_)
                                             )
                                         };
 
@@ -2636,10 +2600,7 @@ impl<'db> Bindings<'db> {
                         let lower = lower.project_type_form(db);
                         let typevar = typevar.project_type_form(db);
                         let upper = upper.project_type_form(db);
-                        let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                            let __ty_view_value = typevar;
-                            (__ty_view_value, __ty_view_value.data())
-                        }) else {
+                        let crate::types::TypeData::TypeVar(typevar) = typevar.data() else {
                             return;
                         };
                         let constraints = ConstraintSetBuilder::new();
@@ -2739,15 +2700,9 @@ impl<'db> Bindings<'db> {
                         let [Some(other)] = overload.parameter_types() else {
                             continue;
                         };
-                        let (
-                            _,
-                            crate::types::TypeData::KnownInstance(
-                                KnownInstanceType::ConstraintSet(other),
-                            ),
-                        ) = ({
-                            let __ty_view_value = other;
-                            (__ty_view_value, __ty_view_value.data())
-                        })
+                        let crate::types::TypeData::KnownInstance(
+                            KnownInstanceType::ConstraintSet(other),
+                        ) = other.data()
                         else {
                             continue;
                         };
@@ -2790,10 +2745,9 @@ impl<'db> Bindings<'db> {
                             // Caller did not provide argument, so no typevars are inferable.
                             [None] => InferableTypeVars::None,
                             [Some(ty)] => {
-                                let (_, crate::types::TypeData::NominalInstance(instance)) = ({
-                                    let __ty_view_value = ty.project_type_form(db);
-                                    (__ty_view_value, __ty_view_value.data())
-                                }) else {
+                                let crate::types::TypeData::NominalInstance(instance) =
+                                    ty.project_type_form(db).data()
+                                else {
                                     continue;
                                 };
                                 match extract_inferable(&instance) {
@@ -2876,16 +2830,14 @@ impl<'db> Bindings<'db> {
                                 // iterable (it could be a Liskov-uncompliant subtype of the `Iterable` class that sets
                                 // `__iter__ = None`, for example). That would be badly written Python code, but we still
                                 // need to be able to handle it without crashing.
-                                let return_type = if let (_, crate::types::TypeData::Union(union)) = {
-                                    let __ty_view_value = argument;
-                                    (__ty_view_value, __ty_view_value.data())
-                                } {
-                                    union.map(db, |element| {
-                                        Type::tuple(TupleType::new(db, &element.iterate(db)))
-                                    })
-                                } else {
-                                    Type::tuple(TupleType::new(db, &argument.iterate(db)))
-                                };
+                                let return_type =
+                                    if let crate::types::TypeData::Union(union) = argument.data() {
+                                        union.map(db, |element| {
+                                            Type::tuple(TupleType::new(db, &element.iterate(db)))
+                                        })
+                                    } else {
+                                        Type::tuple(TupleType::new(db, &argument.iterate(db)))
+                                    };
                                 overload.set_return_type(return_type);
                             }
                         }
@@ -4060,24 +4012,18 @@ impl<'db> CallableBinding<'db> {
                 // standard function and method calls.
                 //
                 // [1]: https://github.com/astral-sh/ty/issues/274#issuecomment-2881856028
-                let function_type_and_kind = match {
-                    let __ty_view_value = self.signature_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                let function_type_and_kind = match self.signature_type.data() {
+                    crate::types::TypeData::FunctionLiteral(function) => {
                         Some((FunctionKind::Function, function))
                     }
-                    (_, crate::types::TypeData::BoundMethod(bound_method)) => Some((
+                    crate::types::TypeData::BoundMethod(bound_method) => Some((
                         FunctionKind::BoundMethod,
                         bound_method.function(context.db()),
                     )),
-                    (
-                        _,
-                        crate::types::TypeData::KnownBoundMethod(
-                            KnownBoundMethodType::FunctionTypeDunderGet(function),
-                        ),
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::FunctionTypeDunderGet(function),
                     ) => Some((FunctionKind::MethodWrapper, function)),
-                    (_, _) => None,
+                    _ => None,
                 };
 
                 // If only one overload passed arity check, report its errors directly.
@@ -4506,10 +4452,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 // P.args` is matched against, for example, `n: int` and correctly type check when
                 // `*args: P.args` is matched against `*args: P.args` (another `ParamSpec`).
                 Some(paramspec) => VariadicArgumentType::ParamSpec(paramspec),
-                None => match {
-                    let __ty_view_value = argument_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                None => match argument_type.data() {
                     // `Type::iterate` unions tuple specs in a way that can invent additional
                     // arities. Iterate each union element individually and compute per-position
                     // union types, length bounds, and variable element so that the rest of the
@@ -4523,7 +4466,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     // only sound when no later argument can still contribute more positional
                     // slots; otherwise, a later positional argument could shift left differently
                     // for different union members.
-                    (_, crate::types::TypeData::Union(union))
+                    crate::types::TypeData::Union(union)
                         if self.parameters.variadic().is_none()
                             && !self.has_later_positional_input(argument_index) =>
                     {
@@ -4581,7 +4524,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             variable_element,
                         }
                     }
-                    (_, _) => VariadicArgumentType::Other(argument_type.iterate(db)),
+                    _ => VariadicArgumentType::Other(argument_type.iterate(db)),
                 },
             },
             None => VariadicArgumentType::None,
@@ -4906,13 +4849,8 @@ fn validate_keyword_unpack_key_type<'db>(
     argument_type: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
 ) -> KeywordUnpackKeyTypeCheck<'db> {
-    if matches!(
-        {
-            let __ty_view_value = argument_type;
-            (__ty_view_value, __ty_view_value.data())
-        },
-        (_, crate::types::TypeData::TypedDict(_))
-    ) || argument_type.as_paramspec_typevar(db).is_some()
+    if matches!(argument_type.data(), crate::types::TypeData::TypedDict(_))
+        || argument_type.as_paramspec_typevar(db).is_some()
     {
         return KeywordUnpackKeyTypeCheck::NotApplicable;
     }
@@ -5386,11 +5324,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
         matches!(parameters.kind(), ParametersKind::Gradual)
             && matches!(
-                {
-                    let __ty_view_value = parameter.annotated_type();
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::Dynamic(_))
+                parameter.annotated_type().data(),
+                crate::types::TypeData::Dynamic(_)
             )
             && (parameter.is_variadic() || parameter.is_keyword_variadic())
     }
@@ -5415,11 +5350,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             return false;
                         };
 
-                        let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                            let __ty_view_value =
-                                self.signature.parameters()[parameter_index.index].annotated_type();
-                            (__ty_view_value, __ty_view_value.data())
-                        }) else {
+                        let crate::types::TypeData::TypeVar(typevar) = self.signature.parameters()
+                            [parameter_index.index]
+                            .annotated_type()
+                            .data()
+                        else {
                             return false;
                         };
 
@@ -6044,14 +5979,13 @@ impl<'db> Binding<'db> {
             &[],
         );
 
-        let (_, crate::types::TypeData::Callable(callable)) = ({
-            let __ty_view_value = specialized_bindings
-                .single_element()
-                .and_then(|binding| binding.matching_overloads().exactly_one().ok())
-                .and_then(|(_, overload)| overload.specialization())
-                .and_then(|specialization| specialization.get(db, paramspec))?;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::Callable(callable) = specialized_bindings
+            .single_element()
+            .and_then(|binding| binding.matching_overloads().exactly_one().ok())
+            .and_then(|(_, overload)| overload.specialization())
+            .and_then(|specialization| specialization.get(db, paramspec))?
+            .data()
+        else {
             return None;
         };
 
@@ -6207,10 +6141,8 @@ impl<'db> Binding<'db> {
         // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
         // need to reach generic call specialization below, where earlier arguments can
         // specialize the full `ParamSpec`.
-        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-            let __ty_view_value = parameter_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) && !typevar.is_paramspec(db)
+        if let crate::types::TypeData::TypeVar(typevar) = parameter_type.data()
+            && !typevar.is_paramspec(db)
             && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
                 typevar.typevar(db).bound_or_constraints(db)
         {
@@ -6223,10 +6155,9 @@ impl<'db> Binding<'db> {
         // If this is a generic call, attempt to specialize the parameter type using the
         // declared type context, propagating the declared types of any type variables.
         if let Some(generic_context) = self.signature.generic_context {
-            let paramspec = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                let __ty_view_value = original_parameter_type;
-                (__ty_view_value, __ty_view_value.data())
-            }) && typevar.is_paramspec(db)
+            let paramspec = if let crate::types::TypeData::TypeVar(typevar) =
+                original_parameter_type.data()
+                && typevar.is_paramspec(db)
                 && typevar.paramspec_attr(db).is_some()
             {
                 Some(typevar.without_paramspec_attr(db))
@@ -6888,11 +6819,8 @@ impl<'db> CallableDescription<'db> {
             }
         }
 
-        match {
-            let __ty_view_value = callable_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(function)) => Some(CallableDescription {
+        match callable_type.data() {
+            crate::types::TypeData::FunctionLiteral(function) => Some(CallableDescription {
                 kind: Some(if function.name(db) == "__new__" {
                     "constructor"
                 } else {
@@ -6900,11 +6828,11 @@ impl<'db> CallableDescription<'db> {
                 }),
                 name: qualified_function_name(db, function),
             }),
-            (_, crate::types::TypeData::ClassLiteral(class_type)) => Some(CallableDescription {
+            crate::types::TypeData::ClassLiteral(class_type) => Some(CallableDescription {
                 kind: Some("class"),
                 name: Cow::Borrowed(class_type.name(db)),
             }),
-            (_, crate::types::TypeData::BoundMethod(bound_method)) => Some({
+            crate::types::TypeData::BoundMethod(bound_method) => Some({
                 let function = bound_method.function(db);
                 let kind = if function.name(db) == "__init__" {
                     None
@@ -6916,34 +6844,25 @@ impl<'db> CallableDescription<'db> {
                     name: qualified_function_name(db, function),
                 }
             }),
-            (
-                _,
-                crate::types::TypeData::KnownBoundMethod(
-                    KnownBoundMethodType::FunctionTypeDunderGet(function),
-                ),
+            crate::types::TypeData::KnownBoundMethod(
+                KnownBoundMethodType::FunctionTypeDunderGet(function),
             ) => Some(CallableDescription {
                 kind: Some("method wrapper `__get__` of function"),
                 name: Cow::Borrowed(function.name(db)),
             }),
-            (
+            crate::types::TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(
                 _,
-                crate::types::TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(
-                    _,
-                )),
-            ) => Some(CallableDescription {
+            )) => Some(CallableDescription {
                 kind: Some("method wrapper"),
                 name: Cow::Borrowed("`__get__` of property"),
             }),
-            (
-                _,
-                crate::types::TypeData::KnownBoundMethod(
-                    KnownBoundMethodType::PropertyDunderDelete(_),
-                ),
+            crate::types::TypeData::KnownBoundMethod(
+                KnownBoundMethodType::PropertyDunderDelete(_),
             ) => Some(CallableDescription {
                 kind: Some("method wrapper"),
                 name: Cow::Borrowed("`__delete__` of property"),
             }),
-            (_, crate::types::TypeData::WrapperDescriptor(kind)) => Some(CallableDescription {
+            crate::types::TypeData::WrapperDescriptor(kind) => Some(CallableDescription {
                 kind: Some("wrapper descriptor"),
                 name: Cow::Borrowed(match kind {
                     WrapperDescriptorKind::FunctionTypeDunderGet => "FunctionType.__get__",
@@ -6952,7 +6871,7 @@ impl<'db> CallableDescription<'db> {
                     WrapperDescriptorKind::PropertyDunderDelete => "property.__delete__",
                 }),
             }),
-            (_, _) => None,
+            _ => None,
         }
     }
 }
@@ -7266,13 +7185,10 @@ impl<'db> BindingError<'db> {
         compound_diag: Option<&dyn CompoundDiagnostic>,
         matching_overload: Option<&MatchingOverloadLiteral<'_>>,
     ) {
-        let callable_kind = match {
-            let __ty_view_value = callable_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(_)) => "Function",
-            (_, crate::types::TypeData::BoundMethod(_)) => "Method",
-            (_, _) => "Callable",
+        let callable_kind = match callable_ty.data() {
+            crate::types::TypeData::FunctionLiteral(_) => "Function",
+            crate::types::TypeData::BoundMethod(_) => "Method",
+            _ => "Callable",
         };
 
         match self {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1255,10 +1255,16 @@ impl<'db> Bindings<'db> {
         for binding in self.iter_flat_mut() {
             let binding_type = binding.callable_type;
             for (overload_index, overload) in binding.matching_overloads_mut() {
-                match binding_type {
-                    Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
-                        function,
-                    )) => {
+                match {
+                    let __ty_view_value = binding_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::FunctionTypeDunderGet(function),
+                        ),
+                    ) => {
                         if function.is_classmethod(db) {
                             match overload.parameter_types() {
                                 [_, Some(owner)] => {
@@ -1290,15 +1296,22 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::WrapperDescriptor(WrapperDescriptorKind::FunctionTypeDunderGet) => {
-                        if let [Some(function_ty @ Type::FunctionLiteral(function)), ..] =
-                            overload.parameter_types()
+                    (
+                        _,
+                        crate::types::TypeData::WrapperDescriptor(
+                            WrapperDescriptorKind::FunctionTypeDunderGet,
+                        ),
+                    ) => {
+                        if let Some(function_ty) =
+                            overload.parameter_types().first().copied().flatten()
+                            && let crate::types::TypeData::FunctionLiteral(function) =
+                                function_ty.data()
                         {
                             if function.is_classmethod(db) {
                                 match overload.parameter_types() {
                                     [_, _, Some(owner)] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *owner),
+                                            BoundMethodType::new(db, function, *owner),
                                         ));
                                     }
 
@@ -1306,7 +1319,7 @@ impl<'db> Bindings<'db> {
                                         overload.set_return_type(Type::BoundMethod(
                                             BoundMethodType::new(
                                                 db,
-                                                *function,
+                                                function,
                                                 instance.to_meta_type(db),
                                             ),
                                         ));
@@ -1315,15 +1328,15 @@ impl<'db> Bindings<'db> {
                                     _ => {}
                                 }
                             } else if function.is_staticmethod(db) {
-                                overload.set_return_type(*function_ty);
+                                overload.set_return_type(function_ty);
                             } else {
                                 match overload.parameter_types() {
                                     [_, Some(instance), _] if instance.is_none(db) => {
-                                        overload.set_return_type(*function_ty);
+                                        overload.set_return_type(function_ty);
                                     }
                                     [_, Some(instance), _] => {
                                         overload.set_return_type(Type::BoundMethod(
-                                            BoundMethodType::new(db, *function, *instance),
+                                            BoundMethodType::new(db, function, *instance),
                                         ));
                                     }
 
@@ -1333,22 +1346,37 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::WrapperDescriptor(WrapperDescriptorKind::PropertyDunderGet) => {
-                        match overload.parameter_types() {
-                            [
-                                Some(property @ Type::PropertyInstance(_)),
+                    (
+                        _,
+                        crate::types::TypeData::WrapperDescriptor(
+                            WrapperDescriptorKind::PropertyDunderGet,
+                        ),
+                    ) => {
+                        let parameters = overload.parameter_types();
+                        let property_ty = parameters.first().copied().flatten();
+                        let instance_ty = parameters.get(1).copied().flatten();
+                        match (
+                            property_ty,
+                            property_ty.map(Type::data),
+                            instance_ty,
+                            instance_ty.map(Type::data),
+                        ) {
+                            (
+                                Some(property),
+                                Some(crate::types::TypeData::PropertyInstance(_)),
                                 Some(instance),
-                                ..,
-                            ] if instance.is_none(db) => {
-                                overload.set_return_type(*property);
+                                _,
+                            ) if instance.is_none(db) => {
+                                overload.set_return_type(property);
                             }
-                            [
-                                Some(Type::PropertyInstance(property)),
-                                Some(Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                                    type_alias,
-                                ))),
-                                ..,
-                            ] if property.getter(db).is_some_and(|getter| {
+                            (
+                                _,
+                                Some(crate::types::TypeData::PropertyInstance(property)),
+                                _,
+                                Some(crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::TypeAliasType(type_alias),
+                                )),
+                            ) if property.getter(db).is_some_and(|getter| {
                                 getter
                                     .as_function_literal()
                                     .is_some_and(|f| f.name(db) == "__name__")
@@ -1357,11 +1385,14 @@ impl<'db> Bindings<'db> {
                                 overload
                                     .set_return_type(Type::string_literal(db, type_alias.name(db)));
                             }
-                            [
-                                Some(Type::PropertyInstance(property)),
-                                Some(Type::KnownInstance(KnownInstanceType::TypeVar(typevar))),
-                                ..,
-                            ] => {
+                            (
+                                _,
+                                Some(crate::types::TypeData::PropertyInstance(property)),
+                                _,
+                                Some(crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::TypeVar(typevar),
+                                )),
+                            ) => {
                                 match property
                                     .getter(db)
                                     .and_then(Type::as_function_literal)
@@ -1396,10 +1427,15 @@ impl<'db> Bindings<'db> {
                                     _ => {}
                                 }
                             }
-                            [Some(Type::PropertyInstance(property)), Some(instance), ..] => {
+                            (
+                                _,
+                                Some(crate::types::TypeData::PropertyInstance(property)),
+                                Some(instance),
+                                _,
+                            ) => {
                                 if let Some(getter) = property.getter(db) {
                                     if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
+                                        .try_call(db, &CallArguments::positional([instance]))
                                         .map(|binding| binding.return_type(db))
                                     {
                                         overload.set_return_type(return_ty);
@@ -1412,7 +1448,7 @@ impl<'db> Bindings<'db> {
                                 } else {
                                     overload
                                         .errors
-                                        .push(BindingError::PropertyHasNoSetter(*property));
+                                        .push(BindingError::PropertyHasNoSetter(property));
                                     overload.set_return_type(Type::Never);
                                 }
                             }
@@ -1420,42 +1456,48 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)) => {
-                        match overload.parameter_types() {
-                            [Some(instance), ..] if instance.is_none(db) => {
-                                overload.set_return_type(Type::PropertyInstance(property));
-                            }
-                            [Some(instance), ..] => {
-                                if let Some(getter) = property.getter(db) {
-                                    if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
-                                        .map(|binding| binding.return_type(db))
-                                    {
-                                        overload.set_return_type(return_ty);
-                                    } else {
-                                        overload.errors.push(BindingError::InternalCallError(
-                                            "calling the getter failed",
-                                        ));
-                                        overload.set_return_type(Type::unknown());
-                                    }
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::PropertyDunderGet(property),
+                        ),
+                    ) => match overload.parameter_types() {
+                        [Some(instance), ..] if instance.is_none(db) => {
+                            overload.set_return_type(Type::PropertyInstance(property));
+                        }
+                        [Some(instance), ..] => {
+                            if let Some(getter) = property.getter(db) {
+                                if let Ok(return_ty) = getter
+                                    .try_call(db, &CallArguments::positional([*instance]))
+                                    .map(|binding| binding.return_type(db))
+                                {
+                                    overload.set_return_type(return_ty);
                                 } else {
-                                    overload.set_return_type(Type::Never);
                                     overload.errors.push(BindingError::InternalCallError(
-                                        "property has no getter",
+                                        "calling the getter failed",
                                     ));
+                                    overload.set_return_type(Type::unknown());
                                 }
+                            } else {
+                                overload.set_return_type(Type::Never);
+                                overload.errors.push(BindingError::InternalCallError(
+                                    "property has no getter",
+                                ));
                             }
-                            _ => {}
                         }
-                    }
+                        _ => {}
+                    },
 
-                    Type::WrapperDescriptor(WrapperDescriptorKind::PropertyDunderSet) => {
-                        if let [
-                            Some(Type::PropertyInstance(property)),
-                            Some(instance),
-                            Some(value),
-                            ..,
-                        ] = overload.parameter_types()
+                    (
+                        _,
+                        crate::types::TypeData::WrapperDescriptor(
+                            WrapperDescriptorKind::PropertyDunderSet,
+                        ),
+                    ) => {
+                        if let [Some(property_ty), Some(instance), Some(value), ..] =
+                            overload.parameter_types()
+                            && let crate::types::TypeData::PropertyInstance(property) =
+                                property_ty.data()
                         {
                             if let Some(setter) = property.setter(db) {
                                 if let Ok(return_ty) = setter
@@ -1478,14 +1520,20 @@ impl<'db> Bindings<'db> {
                             } else {
                                 overload
                                     .errors
-                                    .push(BindingError::PropertyHasNoSetter(*property));
+                                    .push(BindingError::PropertyHasNoSetter(property));
                             }
                         }
                     }
 
-                    Type::WrapperDescriptor(WrapperDescriptorKind::PropertyDunderDelete) => {
-                        if let [Some(Type::PropertyInstance(property)), Some(instance), ..] =
-                            overload.parameter_types()
+                    (
+                        _,
+                        crate::types::TypeData::WrapperDescriptor(
+                            WrapperDescriptorKind::PropertyDunderDelete,
+                        ),
+                    ) => {
+                        if let [Some(property_ty), Some(instance), ..] = overload.parameter_types()
+                            && let crate::types::TypeData::PropertyInstance(property) =
+                                property_ty.data()
                         {
                             if let Some(deleter) = property.deleter(db) {
                                 if let Ok(return_ty) = deleter
@@ -1508,12 +1556,17 @@ impl<'db> Bindings<'db> {
                             } else {
                                 overload
                                     .errors
-                                    .push(BindingError::PropertyHasNoDeleter(*property));
+                                    .push(BindingError::PropertyHasNoDeleter(property));
                             }
                         }
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::PropertyDunderSet(property),
+                        ),
+                    ) => {
                         if let [Some(instance), Some(value), ..] = overload.parameter_types() {
                             if let Some(setter) = property.setter(db) {
                                 if let Ok(return_ty) = setter
@@ -1541,9 +1594,12 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(
-                        property,
-                    )) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::PropertyDunderDelete(property),
+                        ),
+                    ) => {
                         if let [Some(instance), ..] = overload.parameter_types() {
                             if let Some(deleter) = property.deleter(db) {
                                 if let Ok(return_ty) = deleter
@@ -1571,7 +1627,12 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::StrStartswith(literal)) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::StrStartswith(literal),
+                        ),
+                    ) => {
                         if let [Some(first), None, None] = overload.parameter_types()
                             && let Some(prefix) = first.as_string_literal()
                         {
@@ -1581,8 +1642,10 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::DataclassTransformer(params) => {
-                        if let [Some(Type::FunctionLiteral(function))] = overload.parameter_types()
+                    (_, crate::types::TypeData::DataclassTransformer(params)) => {
+                        if let [Some(function_ty)] = overload.parameter_types()
+                            && let crate::types::TypeData::FunctionLiteral(function) =
+                                function_ty.data()
                         {
                             overload.set_return_type(Type::FunctionLiteral(
                                 function.with_dataclass_transformer_params(db, params),
@@ -1590,39 +1653,51 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::DataclassDecorator(params) => match overload.parameter_types() {
-                        [Some(Type::ClassLiteral(class_literal))] => {
-                            if let Some(target) = invalid_dataclass_target(db, class_literal) {
-                                overload
-                                    .errors
-                                    .push(BindingError::InvalidDataclassApplication(target));
-                            } else {
-                                overload.set_return_type(Type::from(
-                                    class_literal.with_dataclass_params(db, Some(params)),
-                                ));
-                            }
+                    (_, crate::types::TypeData::DataclassDecorator(params)) => {
+                        match overload.parameter_types() {
+                            [Some(ty)] => match ty.data() {
+                                crate::types::TypeData::ClassLiteral(class_literal) => {
+                                    if let Some(target) =
+                                        invalid_dataclass_target(db, &class_literal)
+                                    {
+                                        overload.errors.push(
+                                            BindingError::InvalidDataclassApplication(target),
+                                        );
+                                    } else {
+                                        overload.set_return_type(Type::from(
+                                            class_literal.with_dataclass_params(db, Some(params)),
+                                        ));
+                                    }
+                                }
+                                crate::types::TypeData::GenericAlias(generic_alias) => {
+                                    let new_origin = generic_alias
+                                        .origin(db)
+                                        .with_dataclass_params(db, Some(params));
+                                    overload.set_return_type(Type::GenericAlias(
+                                        GenericAlias::new(
+                                            db,
+                                            new_origin,
+                                            generic_alias.specialization(db),
+                                        ),
+                                    ));
+                                }
+                                _ => {}
+                            },
+                            _ => {}
                         }
-                        [Some(Type::GenericAlias(generic_alias))] => {
-                            let new_origin = generic_alias
-                                .origin(db)
-                                .with_dataclass_params(db, Some(params));
-                            overload.set_return_type(Type::GenericAlias(GenericAlias::new(
-                                db,
-                                new_origin,
-                                generic_alias.specialization(db),
-                            )));
-                        }
-                        _ => {}
-                    },
+                    }
 
-                    Type::BoundMethod(bound_method)
+                    (_, crate::types::TypeData::BoundMethod(bound_method))
                         if bound_method.self_instance(db).is_property_instance() =>
                     {
                         match bound_method.function(db).name(db).as_str() {
                             "setter" => {
                                 if let [Some(_), Some(setter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
+                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
+                                        let __ty_view_value = ty_property;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -1637,7 +1712,10 @@ impl<'db> Bindings<'db> {
                             "getter" => {
                                 if let [Some(_), Some(getter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
+                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
+                                        let __ty_view_value = ty_property;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -1652,7 +1730,10 @@ impl<'db> Bindings<'db> {
                             "deleter" => {
                                 if let [Some(_), Some(deleter)] = overload.parameter_types() {
                                     let mut ty_property = bound_method.self_instance(db);
-                                    if let Type::PropertyInstance(property) = ty_property {
+                                    if let (_, crate::types::TypeData::PropertyInstance(property)) = {
+                                        let __ty_view_value = ty_property;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
                                         ty_property =
                                             Type::PropertyInstance(property.with_accessors(
                                                 db,
@@ -1671,7 +1752,7 @@ impl<'db> Bindings<'db> {
                     }
 
                     // TODO: This branch can be removed once https://github.com/astral-sh/ty/issues/501 is resolved
-                    Type::BoundMethod(bound_method)
+                    (_, crate::types::TypeData::BoundMethod(bound_method))
                         if bound_method.function(db).name(db) == "__iter__"
                             && is_enum_class(db, bound_method.self_instance(db)) =>
                     {
@@ -1683,7 +1764,7 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    function @ Type::FunctionLiteral(_)
+                    (function, crate::types::TypeData::FunctionLiteral(_))
                         if dataclass_field_specifiers.contains(&function) =>
                     {
                         // Helper to get the type of a keyword argument by name. We first try to get it from
@@ -1847,638 +1928,707 @@ impl<'db> Bindings<'db> {
                         )));
                     }
 
-                    Type::FunctionLiteral(function_type) => match function_type.known(db) {
-                        Some(KnownFunction::IsEquivalentTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_equivalent_to(db, ty_b, constraints)
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
+                    (_, crate::types::TypeData::FunctionLiteral(function_type)) => {
+                        match function_type.known(db) {
+                            Some(KnownFunction::IsEquivalentTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db);
+                                    let ty_b = ty_b.project_type_form(db);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_equivalent_to(db, ty_b, constraints)
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
                             }
-                        }
 
-                        Some(KnownFunction::IsSubtypeOf) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_subtype_of(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsAssignableTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_assignable_to(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsConstraintSetAssignableTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_constraint_set_assignable_to(db, ty_b, constraints)
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsDisjointFrom) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_disjoint_from(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsSingleton) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.project_type_form(db).is_singleton(db),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsSingleValued) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.project_type_form(db).is_single_valued(db),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::GenericContext) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                let wrap_generic_context = |generic_context| {
-                                    Type::KnownInstance(KnownInstanceType::GenericContext(
-                                        generic_context,
-                                    ))
-                                };
-
-                                let signature_generic_context =
-                                    |signature: &CallableSignature<'db>| {
-                                        UnionType::try_from_elements(
+                            Some(KnownFunction::IsSubtypeOf) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db);
+                                    let ty_b = ty_b.project_type_form(db);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_subtype_of(
                                             db,
-                                            signature.overloads.iter().map(|signature| {
-                                                signature.generic_context.map(wrap_generic_context)
-                                            }),
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
                                         )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsAssignableTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db);
+                                    let ty_b = ty_b.project_type_form(db);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_assignable_to(
+                                            db,
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsConstraintSetAssignableTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db);
+                                    let ty_b = ty_b.project_type_form(db);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_constraint_set_assignable_to(
+                                            db,
+                                            ty_b,
+                                            constraints,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsDisjointFrom) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db);
+                                    let ty_b = ty_b.project_type_form(db);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_disjoint_from(
+                                            db,
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsSingleton) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.project_type_form(db).is_singleton(db),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsSingleValued) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.project_type_form(db).is_single_valued(db),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::GenericContext) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    let wrap_generic_context = |generic_context| {
+                                        Type::KnownInstance(KnownInstanceType::GenericContext(
+                                            generic_context,
+                                        ))
                                     };
 
-                                let generic_context_for_simple_type = |ty: Type<'db>| match ty {
-                                    Type::ClassLiteral(class) => {
-                                        class.generic_context(db).map(wrap_generic_context)
-                                    }
-
-                                    Type::FunctionLiteral(function) => {
-                                        signature_generic_context(function.signature(db))
-                                    }
-
-                                    Type::BoundMethod(bound_method) => signature_generic_context(
-                                        bound_method.function(db).signature(db),
-                                    ),
-
-                                    Type::Callable(callable) => {
-                                        signature_generic_context(callable.signatures(db))
-                                    }
-
-                                    Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                                        TypeAliasType::PEP695(alias),
-                                    )) => alias.generic_context(db).map(wrap_generic_context),
-
-                                    _ => None,
-                                };
-
-                                let generic_context = match ty {
-                                    Type::Union(union_type) => UnionType::try_from_elements(
-                                        db,
-                                        union_type
-                                            .elements(db)
-                                            .iter()
-                                            .map(|ty| generic_context_for_simple_type(*ty)),
-                                    ),
-                                    _ => generic_context_for_simple_type(*ty),
-                                };
-
-                                overload.set_return_type(
-                                    generic_context.unwrap_or_else(|| Type::none(db)),
-                                );
-                            }
-                        }
-
-                        Some(
-                            into_callable @ (KnownFunction::IntoCallable
-                            | KnownFunction::IntoRegularCallable),
-                        ) => {
-                            let [Some(ty)] = overload.parameter_types() else {
-                                continue;
-                            };
-                            let Some(callables) = ty.try_upcast_to_callable(db).map(|callables| {
-                                if into_callable == KnownFunction::IntoRegularCallable {
-                                    callables.map(|callable| callable.into_regular(db))
-                                } else {
-                                    callables
-                                }
-                            }) else {
-                                continue;
-                            };
-                            overload.set_return_type(callables.into_type(db));
-                        }
-
-                        Some(KnownFunction::DunderAllNames) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(match ty {
-                                    Type::ModuleLiteral(module_literal) => {
-                                        let all_names = module_literal
-                                            .module(db)
-                                            .file(db)
-                                            .map(|file| dunder_all_names(db, file))
-                                            .unwrap_or_default();
-                                        match all_names {
-                                            Some(names) => {
-                                                let mut names = names.iter().collect::<Vec<_>>();
-                                                names.sort();
-                                                Type::heterogeneous_tuple(
-                                                    db,
-                                                    names.iter().map(|name| {
-                                                        Type::string_literal(db, name.as_str())
-                                                    }),
-                                                )
-                                            }
-                                            None => Type::none(db),
-                                        }
-                                    }
-                                    _ => Type::none(db),
-                                });
-                            }
-                        }
-
-                        Some(KnownFunction::EnumMembers) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                let return_ty = match ty {
-                                    Type::ClassLiteral(class) => {
-                                        if let Some(metadata) = enums::enum_metadata(db, *class) {
-                                            Type::heterogeneous_tuple(
+                                    let signature_generic_context =
+                                        |signature: &CallableSignature<'db>| {
+                                            UnionType::try_from_elements(
                                                 db,
-                                                metadata
-                                                    .members
-                                                    .keys()
-                                                    .map(|member| Type::string_literal(db, member)),
+                                                signature.overloads.iter().map(|signature| {
+                                                    signature
+                                                        .generic_context
+                                                        .map(wrap_generic_context)
+                                                }),
                                             )
-                                        } else {
-                                            Type::unknown()
+                                        };
+
+                                    let generic_context_for_simple_type = |ty: Type<'db>| match {
+                                        let __ty_view_value = ty;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
+                                        (_, crate::types::TypeData::ClassLiteral(class)) => {
+                                            class.generic_context(db).map(wrap_generic_context)
                                         }
-                                    }
-                                    _ => Type::unknown(),
-                                };
 
-                                overload.set_return_type(return_ty);
-                            }
-                        }
+                                        (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                                            signature_generic_context(function.signature(db))
+                                        }
 
-                        Some(KnownFunction::AllMembers) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::heterogeneous_tuple(
-                                    db,
-                                    list_members::all_members(db, *ty)
-                                        .into_iter()
-                                        .sorted()
-                                        .map(|member| Type::string_literal(db, &member.name)),
-                                ));
-                            }
-                        }
+                                        (_, crate::types::TypeData::BoundMethod(bound_method)) => {
+                                            signature_generic_context(
+                                                bound_method.function(db).signature(db),
+                                            )
+                                        }
 
-                        Some(KnownFunction::Len) => {
-                            if let [Some(first_arg)] = overload.parameter_types() {
-                                if let Some(len_ty) = first_arg.len(db) {
-                                    overload.set_return_type(len_ty);
-                                }
-                            }
-                        }
+                                        (_, crate::types::TypeData::Callable(callable)) => {
+                                            signature_generic_context(callable.signatures(db))
+                                        }
 
-                        Some(KnownFunction::Repr) => {
-                            if let [Some(first_arg)] = overload.parameter_types() {
-                                overload.set_return_type(first_arg.repr(db));
-                            }
-                        }
+                                        (
+                                            _,
+                                            crate::types::TypeData::KnownInstance(
+                                                KnownInstanceType::TypeAliasType(
+                                                    TypeAliasType::PEP695(alias),
+                                                ),
+                                            ),
+                                        ) => alias.generic_context(db).map(wrap_generic_context),
 
-                        Some(KnownFunction::Cast) => {
-                            if let [Some(casted_ty), Some(_)] = overload.parameter_types() {
-                                overload.set_return_type(casted_ty.project_type_form(db));
-                            }
-                        }
+                                        (_, _) => None,
+                                    };
 
-                        Some(KnownFunction::IsProtocol) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                // We evaluate this to `Literal[True]` only if the runtime function `typing.is_protocol`
-                                // would return `True` for the given type. Internally we consider `SupportsAbs[int]` to
-                                // be a "(specialised) protocol class", but `typing.is_protocol(SupportsAbs[int])` returns
-                                // `False` at runtime, so we do not set the return type to `Literal[True]` in this case.
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.as_class_literal()
-                                        .is_some_and(|class| class.is_protocol(db)),
-                                ));
-                            }
-                        }
+                                    let generic_context = match {
+                                        let __ty_view_value = ty;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
+                                        (_, crate::types::TypeData::Union(union_type)) => {
+                                            UnionType::try_from_elements(
+                                                db,
+                                                union_type
+                                                    .elements(db)
+                                                    .iter()
+                                                    .map(|ty| generic_context_for_simple_type(*ty)),
+                                            )
+                                        }
+                                        (_, _) => generic_context_for_simple_type(*ty),
+                                    };
 
-                        Some(KnownFunction::GetProtocolMembers) => {
-                            // Similarly to `is_protocol`, we only evaluate to this a frozenset of literal strings if a
-                            // class-literal is passed in, not if a generic alias is passed in, to emulate the behaviour
-                            // of `typing.get_protocol_members` at runtime.
-                            if let [Some(Type::ClassLiteral(class))] = overload.parameter_types() {
-                                if let Some(protocol_class) = class.into_protocol_class(db) {
-                                    let member_names = protocol_class
-                                        .interface(db)
-                                        .members(db)
-                                        .map(|member| Type::string_literal(db, member.name()));
-                                    let specialization = UnionType::from_elements(db, member_names);
                                     overload.set_return_type(
-                                        KnownClass::FrozenSet
-                                            .to_specialized_instance(db, &[specialization]),
+                                        generic_context.unwrap_or_else(|| Type::none(db)),
                                     );
                                 }
                             }
-                        }
 
-                        Some(KnownFunction::GetattrStatic) => {
-                            let [Some(instance_ty), Some(attr_name), default] =
-                                overload.parameter_types()
-                            else {
-                                continue;
-                            };
-
-                            let Some(attr_name) = attr_name.as_string_literal() else {
-                                continue;
-                            };
-
-                            let default = if let Some(default) = default {
-                                *default
-                            } else {
-                                Type::Never
-                            };
-
-                            let union_with_default =
-                                |ty| UnionType::from_two_elements(db, ty, default);
-
-                            // TODO: we could emit a diagnostic here (if default is not set)
-                            overload.set_return_type(
-                                match instance_ty.static_member(db, attr_name.value(db)) {
-                                    Place::Defined(DefinedPlace {
-                                        ty,
-                                        definedness: Definedness::AlwaysDefined,
-                                        ..
-                                    }) => {
-                                        if ty.is_dynamic() {
-                                            // Here, we attempt to model the fact that an attribute lookup on
-                                            // a dynamic type could fail
-
-                                            union_with_default(ty)
+                            Some(
+                                into_callable @ (KnownFunction::IntoCallable
+                                | KnownFunction::IntoRegularCallable),
+                            ) => {
+                                let [Some(ty)] = overload.parameter_types() else {
+                                    continue;
+                                };
+                                let Some(callables) =
+                                    ty.try_upcast_to_callable(db).map(|callables| {
+                                        if into_callable == KnownFunction::IntoRegularCallable {
+                                            callables.map(|callable| callable.into_regular(db))
                                         } else {
-                                            ty
+                                            callables
                                         }
-                                    }
-                                    Place::Defined(DefinedPlace {
-                                        ty,
-                                        definedness: Definedness::PossiblyUndefined,
-                                        ..
-                                    }) => union_with_default(ty),
-                                    Place::Undefined => default,
-                                },
-                            );
-                        }
-
-                        Some(KnownFunction::Dataclass) => {
-                            if let [
-                                init,
-                                repr,
-                                eq,
-                                order,
-                                unsafe_hash,
-                                frozen,
-                                versioned_parameters @ ..,
-                            ] = overload.parameter_types()
-                            {
-                                let mut flags = DataclassFlags::empty();
-
-                                if to_bool(init, true) {
-                                    flags |= DataclassFlags::INIT;
-                                }
-                                if to_bool(repr, true) {
-                                    flags |= DataclassFlags::REPR;
-                                }
-                                if to_bool(eq, true) {
-                                    flags |= DataclassFlags::EQ;
-                                }
-                                if to_bool(order, false) {
-                                    flags |= DataclassFlags::ORDER;
-                                }
-                                if to_bool(unsafe_hash, false) {
-                                    flags |= DataclassFlags::UNSAFE_HASH;
-                                }
-                                if to_bool(frozen, false) {
-                                    flags |= DataclassFlags::FROZEN;
-                                }
-
-                                match versioned_parameters {
-                                    // Python < 3.10.
-                                    [] => {}
-                                    // Python 3.10.
-                                    [match_args, kw_only, slots] => {
-                                        if to_bool(match_args, true) {
-                                            flags |= DataclassFlags::MATCH_ARGS;
-                                        }
-                                        if to_bool(kw_only, false) {
-                                            flags |= DataclassFlags::KW_ONLY;
-                                        }
-                                        if to_bool(slots, false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
-                                    }
-                                    // Python >= 3.11.
-                                    [match_args, kw_only, slots, weakref_slot] => {
-                                        if to_bool(match_args, true) {
-                                            flags |= DataclassFlags::MATCH_ARGS;
-                                        }
-                                        if to_bool(kw_only, false) {
-                                            flags |= DataclassFlags::KW_ONLY;
-                                        }
-                                        if to_bool(slots, false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
-                                        if to_bool(weakref_slot, false) {
-                                            flags |= DataclassFlags::WEAKREF_SLOT;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-
-                                let params = DataclassParams::from_flags(db, flags);
-
-                                overload.set_return_type(Type::DataclassDecorator(params));
+                                    })
+                                else {
+                                    continue;
+                                };
+                                overload.set_return_type(callables.into_type(db));
                             }
 
-                            // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`)
-                            if let [Some(Type::ClassLiteral(class_literal)), ..] =
-                                overload.parameter_types()
-                            {
-                                if let Some(target) = invalid_dataclass_target(db, class_literal) {
-                                    overload
-                                        .errors
-                                        .push(BindingError::InvalidDataclassApplication(target));
+                            Some(KnownFunction::DunderAllNames) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(
+                                        match {
+                                            let __ty_view_value = ty;
+                                            (__ty_view_value, __ty_view_value.data())
+                                        } {
+                                            (
+                                                _,
+                                                crate::types::TypeData::ModuleLiteral(
+                                                    module_literal,
+                                                ),
+                                            ) => {
+                                                let all_names = module_literal
+                                                    .module(db)
+                                                    .file(db)
+                                                    .map(|file| dunder_all_names(db, file))
+                                                    .unwrap_or_default();
+                                                match all_names {
+                                                    Some(names) => {
+                                                        let mut names =
+                                                            names.iter().collect::<Vec<_>>();
+                                                        names.sort();
+                                                        Type::heterogeneous_tuple(
+                                                            db,
+                                                            names.iter().map(|name| {
+                                                                Type::string_literal(
+                                                                    db,
+                                                                    name.as_str(),
+                                                                )
+                                                            }),
+                                                        )
+                                                    }
+                                                    None => Type::none(db),
+                                                }
+                                            }
+                                            (_, _) => Type::none(db),
+                                        },
+                                    );
+                                }
+                            }
+
+                            Some(KnownFunction::EnumMembers) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    let return_ty = match {
+                                        let __ty_view_value = ty;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    } {
+                                        (_, crate::types::TypeData::ClassLiteral(class)) => {
+                                            if let Some(metadata) = enums::enum_metadata(db, class)
+                                            {
+                                                Type::heterogeneous_tuple(
+                                                    db,
+                                                    metadata.members.keys().map(|member| {
+                                                        Type::string_literal(db, member)
+                                                    }),
+                                                )
+                                            } else {
+                                                Type::unknown()
+                                            }
+                                        }
+                                        (_, _) => Type::unknown(),
+                                    };
+
+                                    overload.set_return_type(return_ty);
+                                }
+                            }
+
+                            Some(KnownFunction::AllMembers) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::heterogeneous_tuple(
+                                        db,
+                                        list_members::all_members(db, *ty)
+                                            .into_iter()
+                                            .sorted()
+                                            .map(|member| Type::string_literal(db, &member.name)),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::Len) => {
+                                if let [Some(first_arg)] = overload.parameter_types() {
+                                    if let Some(len_ty) = first_arg.len(db) {
+                                        overload.set_return_type(len_ty);
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::Repr) => {
+                                if let [Some(first_arg)] = overload.parameter_types() {
+                                    overload.set_return_type(first_arg.repr(db));
+                                }
+                            }
+
+                            Some(KnownFunction::Cast) => {
+                                if let [Some(casted_ty), Some(_)] = overload.parameter_types() {
+                                    overload.set_return_type(casted_ty.project_type_form(db));
+                                }
+                            }
+
+                            Some(KnownFunction::IsProtocol) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    // We evaluate this to `Literal[True]` only if the runtime function `typing.is_protocol`
+                                    // would return `True` for the given type. Internally we consider `SupportsAbs[int]` to
+                                    // be a "(specialised) protocol class", but `typing.is_protocol(SupportsAbs[int])` returns
+                                    // `False` at runtime, so we do not set the return type to `Literal[True]` in this case.
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.as_class_literal()
+                                            .is_some_and(|class| class.is_protocol(db)),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::GetProtocolMembers) => {
+                                // Similarly to `is_protocol`, we only evaluate to this a frozenset of literal strings if a
+                                // class-literal is passed in, not if a generic alias is passed in, to emulate the behaviour
+                                // of `typing.get_protocol_members` at runtime.
+                                if let [Some(class_ty)] = overload.parameter_types()
+                                    && let crate::types::TypeData::ClassLiteral(class) =
+                                        class_ty.data()
+                                {
+                                    if let Some(protocol_class) = class.into_protocol_class(db) {
+                                        let member_names = protocol_class
+                                            .interface(db)
+                                            .members(db)
+                                            .map(|member| Type::string_literal(db, member.name()));
+                                        let specialization =
+                                            UnionType::from_elements(db, member_names);
+                                        overload.set_return_type(
+                                            KnownClass::FrozenSet
+                                                .to_specialized_instance(db, &[specialization]),
+                                        );
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::GetattrStatic) => {
+                                let [Some(instance_ty), Some(attr_name), default] =
+                                    overload.parameter_types()
+                                else {
+                                    continue;
+                                };
+
+                                let Some(attr_name) = attr_name.as_string_literal() else {
+                                    continue;
+                                };
+
+                                let default = if let Some(default) = default {
+                                    *default
                                 } else {
-                                    let params = DataclassParams::default_params(db);
-                                    overload.set_return_type(Type::from(
-                                        class_literal.with_dataclass_params(db, Some(params)),
+                                    Type::Never
+                                };
+
+                                let union_with_default =
+                                    |ty| UnionType::from_two_elements(db, ty, default);
+
+                                // TODO: we could emit a diagnostic here (if default is not set)
+                                overload.set_return_type(
+                                    match instance_ty.static_member(db, attr_name.value(db)) {
+                                        Place::Defined(DefinedPlace {
+                                            ty,
+                                            definedness: Definedness::AlwaysDefined,
+                                            ..
+                                        }) => {
+                                            if ty.is_dynamic() {
+                                                // Here, we attempt to model the fact that an attribute lookup on
+                                                // a dynamic type could fail
+
+                                                union_with_default(ty)
+                                            } else {
+                                                ty
+                                            }
+                                        }
+                                        Place::Defined(DefinedPlace {
+                                            ty,
+                                            definedness: Definedness::PossiblyUndefined,
+                                            ..
+                                        }) => union_with_default(ty),
+                                        Place::Undefined => default,
+                                    },
+                                );
+                            }
+
+                            Some(KnownFunction::Dataclass) => {
+                                if let [
+                                    init,
+                                    repr,
+                                    eq,
+                                    order,
+                                    unsafe_hash,
+                                    frozen,
+                                    versioned_parameters @ ..,
+                                ] = overload.parameter_types()
+                                {
+                                    let mut flags = DataclassFlags::empty();
+
+                                    if to_bool(init, true) {
+                                        flags |= DataclassFlags::INIT;
+                                    }
+                                    if to_bool(repr, true) {
+                                        flags |= DataclassFlags::REPR;
+                                    }
+                                    if to_bool(eq, true) {
+                                        flags |= DataclassFlags::EQ;
+                                    }
+                                    if to_bool(order, false) {
+                                        flags |= DataclassFlags::ORDER;
+                                    }
+                                    if to_bool(unsafe_hash, false) {
+                                        flags |= DataclassFlags::UNSAFE_HASH;
+                                    }
+                                    if to_bool(frozen, false) {
+                                        flags |= DataclassFlags::FROZEN;
+                                    }
+
+                                    match versioned_parameters {
+                                        // Python < 3.10.
+                                        [] => {}
+                                        // Python 3.10.
+                                        [match_args, kw_only, slots] => {
+                                            if to_bool(match_args, true) {
+                                                flags |= DataclassFlags::MATCH_ARGS;
+                                            }
+                                            if to_bool(kw_only, false) {
+                                                flags |= DataclassFlags::KW_ONLY;
+                                            }
+                                            if to_bool(slots, false) {
+                                                flags |= DataclassFlags::SLOTS;
+                                            }
+                                        }
+                                        // Python >= 3.11.
+                                        [match_args, kw_only, slots, weakref_slot] => {
+                                            if to_bool(match_args, true) {
+                                                flags |= DataclassFlags::MATCH_ARGS;
+                                            }
+                                            if to_bool(kw_only, false) {
+                                                flags |= DataclassFlags::KW_ONLY;
+                                            }
+                                            if to_bool(slots, false) {
+                                                flags |= DataclassFlags::SLOTS;
+                                            }
+                                            if to_bool(weakref_slot, false) {
+                                                flags |= DataclassFlags::WEAKREF_SLOT;
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+
+                                    let params = DataclassParams::from_flags(db, flags);
+
+                                    overload.set_return_type(Type::DataclassDecorator(params));
+                                }
+
+                                // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`)
+                                if let [Some(class_ty), ..] = overload.parameter_types()
+                                    && let crate::types::TypeData::ClassLiteral(class_literal) =
+                                        class_ty.data()
+                                {
+                                    if let Some(target) =
+                                        invalid_dataclass_target(db, &class_literal)
+                                    {
+                                        overload.errors.push(
+                                            BindingError::InvalidDataclassApplication(target),
+                                        );
+                                    } else {
+                                        let params = DataclassParams::default_params(db);
+                                        overload.set_return_type(Type::from(
+                                            class_literal.with_dataclass_params(db, Some(params)),
+                                        ));
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::DataclassTransform) => {
+                                // Use named parameter lookup to handle custom
+                                // `__dataclass_transform__` functions that follow older versions
+                                // of the spec.
+                                let mut flags = DataclassTransformerFlags::empty();
+
+                                let eq_default = overload
+                                    .parameter_type_by_name("eq_default", false)
+                                    .ok()
+                                    .flatten();
+                                let order_default = overload
+                                    .parameter_type_by_name("order_default", false)
+                                    .ok()
+                                    .flatten();
+                                let kw_only_default = overload
+                                    .parameter_type_by_name("kw_only_default", false)
+                                    .ok()
+                                    .flatten();
+                                let frozen_default = overload
+                                    .parameter_type_by_name("frozen_default", false)
+                                    .ok()
+                                    .flatten();
+
+                                if to_bool(&eq_default, true) {
+                                    flags |= DataclassTransformerFlags::EQ_DEFAULT;
+                                }
+                                if to_bool(&order_default, false) {
+                                    flags |= DataclassTransformerFlags::ORDER_DEFAULT;
+                                }
+                                if to_bool(&kw_only_default, false) {
+                                    flags |= DataclassTransformerFlags::KW_ONLY_DEFAULT;
+                                }
+                                if to_bool(&frozen_default, false) {
+                                    flags |= DataclassTransformerFlags::FROZEN_DEFAULT;
+                                }
+
+                                // Accept both `field_specifiers` (current name) and
+                                // `field_descriptors` (legacy name).
+                                let field_specifiers_param = overload
+                                    .parameter_type_by_name("field_specifiers", false)
+                                    .ok()
+                                    .flatten()
+                                    .or_else(|| {
+                                        overload
+                                            .parameter_type_by_name("field_descriptors", false)
+                                            .ok()
+                                            .flatten()
+                                    });
+
+                                let field_specifiers: Box<[Type<'db>]> = field_specifiers_param
+                                    .map(|tuple_type| {
+                                        tuple_type
+                                            .exact_tuple_instance_spec(db)
+                                            .iter()
+                                            .flat_map(|tuple_spec| tuple_spec.fixed_elements())
+                                            .copied()
+                                            .collect::<Vec<_>>()
+                                            .into_boxed_slice()
+                                    })
+                                    .unwrap_or_default();
+
+                                let params =
+                                    DataclassTransformerParams::new(db, flags, field_specifiers);
+
+                                overload.set_return_type(Type::DataclassTransformer(params));
+                            }
+
+                            Some(KnownFunction::Unpack) => {
+                                let [Some(format), Some(_buffer)] = overload.parameter_types()
+                                else {
+                                    continue;
+                                };
+
+                                let Some(format_literal) = format.as_string_literal() else {
+                                    continue;
+                                };
+
+                                let return_type = parse_struct_format(db, format_literal.value(db))
+                                    .map(|elements| Type::heterogeneous_tuple(db, elements))
+                                    .unwrap_or_else(|| {
+                                        Type::homogeneous_tuple(db, Type::unknown())
+                                    });
+
+                                overload.set_return_type(return_type);
+                            }
+
+                            _ => {
+                                // Ideally, either the implementation, or exactly one of the overloads
+                                // of the function can have the dataclass_transform decorator applied.
+                                // However, we do not yet enforce this, and in the case of multiple
+                                // applications of the decorator, we will only consider the last one.
+                                let transformer_params = function_type
+                                    .iter_overloads_and_implementation(db)
+                                    .rev()
+                                    .find_map(|function_overload| {
+                                        function_overload.dataclass_transformer_params(db)
+                                    });
+
+                                if let Some(params) = transformer_params {
+                                    // If this function was called with a keyword argument like
+                                    // `order=False`, we extract the argument type and overwrite
+                                    // the corresponding flag in `dataclass_params`.
+                                    let dataclass_params =
+                                        DataclassParams::from_transformer_params(db, params);
+                                    let mut flags = dataclass_params.flags(db);
+
+                                    for (param, flag) in DATACLASS_FLAGS {
+                                        if let Some(ty) =
+                                            call_arguments.iter().find_map(|(arg, arg_types)| {
+                                                if let Argument::Keyword(arg_name) = arg
+                                                    && *arg_name == **param
+                                                {
+                                                    arg_types.get_default()
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            && let Some(LiteralValueTypeKind::Bool(value)) =
+                                                ty.as_literal_value_kind()
+                                        {
+                                            flags.set(*flag, value);
+                                        }
+                                    }
+
+                                    let dataclass_params = DataclassParams::new(
+                                        db,
+                                        flags,
+                                        dataclass_params.field_specifiers(db),
+                                    );
+
+                                    // The dataclass_transform spec doesn't clarify how to tell whether
+                                    // a decorated function is a decorator or a decorator factory. We
+                                    // use heuristics based on the number and type of positional arguments:
+                                    //
+                                    // - Zero positional arguments: assume it's a decorator factory.
+                                    // - More than one positional argument: assume it's a decorator factory.
+                                    // - Exactly one positional argument that's a class: ambiguous, so check
+                                    //   the return type to disambiguate (class-like means decorate directly).
+                                    let mut positional_args = overload
+                                        .signature
+                                        .parameters()
+                                        .iter()
+                                        .zip(overload.parameter_types())
+                                        .filter(|(param, ty)| {
+                                            ty.is_some() && !param.is_keyword_only()
+                                        })
+                                        .map(|(_, ty)| ty);
+
+                                    let first_positional =
+                                        positional_args.next().copied().flatten();
+                                    let has_more = positional_args.next().is_some();
+
+                                    // Only attempt direct decoration if exactly one positional argument.
+                                    if !has_more {
+                                        // Helper to check if return type is class-like.
+                                        let returns_class = || {
+                                            matches!(
+                                                {
+                                                    let __ty_view_value = overload.return_type();
+                                                    (__ty_view_value, __ty_view_value.data())
+                                                },
+                                                (
+                                                    _,
+                                                    crate::types::TypeData::ClassLiteral(_)
+                                                        | crate::types::TypeData::GenericAlias(_)
+                                                        | crate::types::TypeData::SubclassOf(_)
+                                                )
+                                            )
+                                        };
+
+                                        match first_positional.map(Type::data) {
+                                            Some(crate::types::TypeData::ClassLiteral(
+                                                class_literal,
+                                            )) if returns_class() => {
+                                                overload.set_return_type(Type::from(
+                                                    class_literal.with_dataclass_params(
+                                                        db,
+                                                        Some(dataclass_params),
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            Some(crate::types::TypeData::GenericAlias(
+                                                generic_alias,
+                                            )) if returns_class() => {
+                                                let new_origin =
+                                                    generic_alias.origin(db).with_dataclass_params(
+                                                        db,
+                                                        Some(dataclass_params),
+                                                    );
+                                                overload.set_return_type(Type::GenericAlias(
+                                                    GenericAlias::new(
+                                                        db,
+                                                        new_origin,
+                                                        generic_alias.specialization(db),
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+
+                                    // Zero or more than one positional argument, or the argument is
+                                    // not a class: assume it's a decorator factory.
+                                    overload.set_return_type(Type::DataclassDecorator(
+                                        dataclass_params,
                                     ));
                                 }
                             }
                         }
+                    }
 
-                        Some(KnownFunction::DataclassTransform) => {
-                            // Use named parameter lookup to handle custom
-                            // `__dataclass_transform__` functions that follow older versions
-                            // of the spec.
-                            let mut flags = DataclassTransformerFlags::empty();
-
-                            let eq_default = overload
-                                .parameter_type_by_name("eq_default", false)
-                                .ok()
-                                .flatten();
-                            let order_default = overload
-                                .parameter_type_by_name("order_default", false)
-                                .ok()
-                                .flatten();
-                            let kw_only_default = overload
-                                .parameter_type_by_name("kw_only_default", false)
-                                .ok()
-                                .flatten();
-                            let frozen_default = overload
-                                .parameter_type_by_name("frozen_default", false)
-                                .ok()
-                                .flatten();
-
-                            if to_bool(&eq_default, true) {
-                                flags |= DataclassTransformerFlags::EQ_DEFAULT;
-                            }
-                            if to_bool(&order_default, false) {
-                                flags |= DataclassTransformerFlags::ORDER_DEFAULT;
-                            }
-                            if to_bool(&kw_only_default, false) {
-                                flags |= DataclassTransformerFlags::KW_ONLY_DEFAULT;
-                            }
-                            if to_bool(&frozen_default, false) {
-                                flags |= DataclassTransformerFlags::FROZEN_DEFAULT;
-                            }
-
-                            // Accept both `field_specifiers` (current name) and
-                            // `field_descriptors` (legacy name).
-                            let field_specifiers_param = overload
-                                .parameter_type_by_name("field_specifiers", false)
-                                .ok()
-                                .flatten()
-                                .or_else(|| {
-                                    overload
-                                        .parameter_type_by_name("field_descriptors", false)
-                                        .ok()
-                                        .flatten()
-                                });
-
-                            let field_specifiers: Box<[Type<'db>]> = field_specifiers_param
-                                .map(|tuple_type| {
-                                    tuple_type
-                                        .exact_tuple_instance_spec(db)
-                                        .iter()
-                                        .flat_map(|tuple_spec| tuple_spec.fixed_elements())
-                                        .copied()
-                                        .collect::<Vec<_>>()
-                                        .into_boxed_slice()
-                                })
-                                .unwrap_or_default();
-
-                            let params =
-                                DataclassTransformerParams::new(db, flags, field_specifiers);
-
-                            overload.set_return_type(Type::DataclassTransformer(params));
-                        }
-
-                        Some(KnownFunction::Unpack) => {
-                            let [Some(format), Some(_buffer)] = overload.parameter_types() else {
-                                continue;
-                            };
-
-                            let Some(format_literal) = format.as_string_literal() else {
-                                continue;
-                            };
-
-                            let return_type = parse_struct_format(db, format_literal.value(db))
-                                .map(|elements| Type::heterogeneous_tuple(db, elements))
-                                .unwrap_or_else(|| Type::homogeneous_tuple(db, Type::unknown()));
-
-                            overload.set_return_type(return_type);
-                        }
-
-                        _ => {
-                            // Ideally, either the implementation, or exactly one of the overloads
-                            // of the function can have the dataclass_transform decorator applied.
-                            // However, we do not yet enforce this, and in the case of multiple
-                            // applications of the decorator, we will only consider the last one.
-                            let transformer_params = function_type
-                                .iter_overloads_and_implementation(db)
-                                .rev()
-                                .find_map(|function_overload| {
-                                    function_overload.dataclass_transformer_params(db)
-                                });
-
-                            if let Some(params) = transformer_params {
-                                // If this function was called with a keyword argument like
-                                // `order=False`, we extract the argument type and overwrite
-                                // the corresponding flag in `dataclass_params`.
-                                let dataclass_params =
-                                    DataclassParams::from_transformer_params(db, params);
-                                let mut flags = dataclass_params.flags(db);
-
-                                for (param, flag) in DATACLASS_FLAGS {
-                                    if let Some(ty) =
-                                        call_arguments.iter().find_map(|(arg, arg_types)| {
-                                            if let Argument::Keyword(arg_name) = arg
-                                                && *arg_name == **param
-                                            {
-                                                arg_types.get_default()
-                                            } else {
-                                                None
-                                            }
-                                        })
-                                        && let Some(LiteralValueTypeKind::Bool(value)) =
-                                            ty.as_literal_value_kind()
-                                    {
-                                        flags.set(*flag, value);
-                                    }
-                                }
-
-                                let dataclass_params = DataclassParams::new(
-                                    db,
-                                    flags,
-                                    dataclass_params.field_specifiers(db),
-                                );
-
-                                // The dataclass_transform spec doesn't clarify how to tell whether
-                                // a decorated function is a decorator or a decorator factory. We
-                                // use heuristics based on the number and type of positional arguments:
-                                //
-                                // - Zero positional arguments: assume it's a decorator factory.
-                                // - More than one positional argument: assume it's a decorator factory.
-                                // - Exactly one positional argument that's a class: ambiguous, so check
-                                //   the return type to disambiguate (class-like means decorate directly).
-                                let mut positional_args = overload
-                                    .signature
-                                    .parameters()
-                                    .iter()
-                                    .zip(overload.parameter_types())
-                                    .filter(|(param, ty)| ty.is_some() && !param.is_keyword_only())
-                                    .map(|(_, ty)| ty);
-
-                                let first_positional = positional_args.next();
-                                let has_more = positional_args.next().is_some();
-
-                                // Only attempt direct decoration if exactly one positional argument.
-                                if !has_more {
-                                    // Helper to check if return type is class-like.
-                                    let returns_class = || {
-                                        matches!(
-                                            overload.return_type(),
-                                            Type::ClassLiteral(_)
-                                                | Type::GenericAlias(_)
-                                                | Type::SubclassOf(_)
-                                        )
-                                    };
-
-                                    match first_positional {
-                                        Some(Some(Type::ClassLiteral(class_literal)))
-                                            if returns_class() =>
-                                        {
-                                            overload.set_return_type(Type::from(
-                                                class_literal.with_dataclass_params(
-                                                    db,
-                                                    Some(dataclass_params),
-                                                ),
-                                            ));
-                                            continue;
-                                        }
-                                        Some(Some(Type::GenericAlias(generic_alias)))
-                                            if returns_class() =>
-                                        {
-                                            let new_origin = generic_alias
-                                                .origin(db)
-                                                .with_dataclass_params(db, Some(dataclass_params));
-                                            overload.set_return_type(Type::GenericAlias(
-                                                GenericAlias::new(
-                                                    db,
-                                                    new_origin,
-                                                    generic_alias.specialization(db),
-                                                ),
-                                            ));
-                                            continue;
-                                        }
-                                        _ => {}
-                                    }
-                                }
-
-                                // Zero or more than one positional argument, or the argument is
-                                // not a class: assume it's a decorator factory.
-                                overload
-                                    .set_return_type(Type::DataclassDecorator(dataclass_params));
-                            }
-                        }
-                    },
-
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetRange,
+                        ),
+                    ) => {
                         let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
                         else {
                             return;
@@ -2486,7 +2636,10 @@ impl<'db> Bindings<'db> {
                         let lower = lower.project_type_form(db);
                         let typevar = typevar.project_type_form(db);
                         let upper = upper.project_type_form(db);
-                        let Type::TypeVar(typevar) = typevar else {
+                        let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                            let __ty_view_value = typevar;
+                            (__ty_view_value, __ty_view_value.data())
+                        }) else {
                             return;
                         };
                         let constraints = ConstraintSetBuilder::new();
@@ -2499,7 +2652,12 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetAlways) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetAlways,
+                        ),
+                    ) => {
                         if !overload.parameter_types().is_empty() {
                             return;
                         }
@@ -2512,7 +2670,12 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetNever) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetNever,
+                        ),
+                    ) => {
                         if !overload.parameter_types().is_empty() {
                             return;
                         }
@@ -2525,8 +2688,11 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(
-                        KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(tracked),
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetImpliesSubtypeOf(tracked),
+                        ),
                     ) => {
                         let [Some(ty_a), Some(ty_b)] = overload.parameter_types() else {
                             continue;
@@ -2564,13 +2730,24 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetSatisfies(
-                        tracked,
-                    )) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetSatisfies(tracked),
+                        ),
+                    ) => {
                         let [Some(other)] = overload.parameter_types() else {
                             continue;
                         };
-                        let Type::KnownInstance(KnownInstanceType::ConstraintSet(other)) = other
+                        let (
+                            _,
+                            crate::types::TypeData::KnownInstance(
+                                KnownInstanceType::ConstraintSet(other),
+                            ),
+                        ) = ({
+                            let __ty_view_value = other;
+                            (__ty_view_value, __ty_view_value.data())
+                        })
                         else {
                             continue;
                         };
@@ -2587,8 +2764,11 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::KnownBoundMethod(
-                        KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(tracked),
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(tracked),
+                        ),
                     ) => {
                         let extract_inferable = |instance: &NominalInstanceType<'db>| {
                             if instance.has_known_class(db, KnownClass::NoneType) {
@@ -2610,8 +2790,10 @@ impl<'db> Bindings<'db> {
                             // Caller did not provide argument, so no typevars are inferable.
                             [None] => InferableTypeVars::None,
                             [Some(ty)] => {
-                                let Type::NominalInstance(instance) = ty.project_type_form(db)
-                                else {
+                                let (_, crate::types::TypeData::NominalInstance(instance)) = ({
+                                    let __ty_view_value = ty.project_type_form(db);
+                                    (__ty_view_value, __ty_view_value.data())
+                                }) else {
                                     continue;
                                 };
                                 match extract_inferable(&instance) {
@@ -2628,8 +2810,11 @@ impl<'db> Bindings<'db> {
                         overload.set_return_type(Type::bool_literal(result));
                     }
 
-                    Type::KnownBoundMethod(
-                        KnownBoundMethodType::ConstraintSetWithDetailedDisplay(tracked),
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::ConstraintSetWithDetailedDisplay(tracked),
+                        ),
                     ) => {
                         let tracked = tracked.with_detailed_display(db);
                         overload.set_return_type(Type::KnownInstance(
@@ -2637,7 +2822,7 @@ impl<'db> Bindings<'db> {
                         ));
                     }
 
-                    Type::ClassLiteral(class) => match class.known(db) {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => match class.known(db) {
                         Some(KnownClass::Bool) => match overload.parameter_types() {
                             [Some(arg)] => {
                                 overload.set_return_type(Type::from_truthiness(db, arg.bool(db)));
@@ -2691,7 +2876,10 @@ impl<'db> Bindings<'db> {
                                 // iterable (it could be a Liskov-uncompliant subtype of the `Iterable` class that sets
                                 // `__iter__ = None`, for example). That would be badly written Python code, but we still
                                 // need to be able to handle it without crashing.
-                                let return_type = if let Type::Union(union) = argument {
+                                let return_type = if let (_, crate::types::TypeData::Union(union)) = {
+                                    let __ty_view_value = argument;
+                                    (__ty_view_value, __ty_view_value.data())
+                                } {
                                     union.map(db, |element| {
                                         Type::tuple(TupleType::new(db, &element.iterate(db)))
                                     })
@@ -2706,7 +2894,7 @@ impl<'db> Bindings<'db> {
                     },
 
                     // Not a special case
-                    _ => {}
+                    (_, _) => {}
                 }
             }
         }
@@ -3872,16 +4060,24 @@ impl<'db> CallableBinding<'db> {
                 // standard function and method calls.
                 //
                 // [1]: https://github.com/astral-sh/ty/issues/274#issuecomment-2881856028
-                let function_type_and_kind = match self.signature_type {
-                    Type::FunctionLiteral(function) => Some((FunctionKind::Function, function)),
-                    Type::BoundMethod(bound_method) => Some((
+                let function_type_and_kind = match {
+                    let __ty_view_value = self.signature_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                        Some((FunctionKind::Function, function))
+                    }
+                    (_, crate::types::TypeData::BoundMethod(bound_method)) => Some((
                         FunctionKind::BoundMethod,
                         bound_method.function(context.db()),
                     )),
-                    Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(
-                        function,
-                    )) => Some((FunctionKind::MethodWrapper, function)),
-                    _ => None,
+                    (
+                        _,
+                        crate::types::TypeData::KnownBoundMethod(
+                            KnownBoundMethodType::FunctionTypeDunderGet(function),
+                        ),
+                    ) => Some((FunctionKind::MethodWrapper, function)),
+                    (_, _) => None,
                 };
 
                 // If only one overload passed arity check, report its errors directly.
@@ -4310,7 +4506,10 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 // P.args` is matched against, for example, `n: int` and correctly type check when
                 // `*args: P.args` is matched against `*args: P.args` (another `ParamSpec`).
                 Some(paramspec) => VariadicArgumentType::ParamSpec(paramspec),
-                None => match argument_type {
+                None => match {
+                    let __ty_view_value = argument_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     // `Type::iterate` unions tuple specs in a way that can invent additional
                     // arities. Iterate each union element individually and compute per-position
                     // union types, length bounds, and variable element so that the rest of the
@@ -4324,7 +4523,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                     // only sound when no later argument can still contribute more positional
                     // slots; otherwise, a later positional argument could shift left differently
                     // for different union members.
-                    Type::Union(union)
+                    (_, crate::types::TypeData::Union(union))
                         if self.parameters.variadic().is_none()
                             && !self.has_later_positional_input(argument_index) =>
                     {
@@ -4382,7 +4581,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             variable_element,
                         }
                     }
-                    _ => VariadicArgumentType::Other(argument_type.iterate(db)),
+                    (_, _) => VariadicArgumentType::Other(argument_type.iterate(db)),
                 },
             },
             None => VariadicArgumentType::None,
@@ -4707,8 +4906,13 @@ fn validate_keyword_unpack_key_type<'db>(
     argument_type: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
 ) -> KeywordUnpackKeyTypeCheck<'db> {
-    if matches!(argument_type, Type::TypedDict(_))
-        || argument_type.as_paramspec_typevar(db).is_some()
+    if matches!(
+        {
+            let __ty_view_value = argument_type;
+            (__ty_view_value, __ty_view_value.data())
+        },
+        (_, crate::types::TypeData::TypedDict(_))
+    ) || argument_type.as_paramspec_typevar(db).is_some()
     {
         return KeywordUnpackKeyTypeCheck::NotApplicable;
     }
@@ -5181,7 +5385,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let parameter = &parameters[parameter_index];
 
         matches!(parameters.kind(), ParametersKind::Gradual)
-            && matches!(parameter.annotated_type(), Type::Dynamic(_))
+            && matches!(
+                {
+                    let __ty_view_value = parameter.annotated_type();
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::Dynamic(_))
+            )
             && (parameter.is_variadic() || parameter.is_keyword_variadic())
     }
 
@@ -5205,9 +5415,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                             return false;
                         };
 
-                        let Type::TypeVar(typevar) =
-                            self.signature.parameters()[parameter_index.index].annotated_type()
-                        else {
+                        let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                            let __ty_view_value =
+                                self.signature.parameters()[parameter_index.index].annotated_type();
+                            (__ty_view_value, __ty_view_value.data())
+                        }) else {
                             return false;
                         };
 
@@ -5308,10 +5520,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         paramspec_arguments: Option<&[(usize, Option<usize>)]>,
         paramspec: BoundTypeVarInstance<'db>,
     ) -> bool {
-        let Some(Type::Callable(callable)) = self
+        let Some(callable_ty) = self
             .specialization
             .and_then(|specialization| specialization.get(self.db, paramspec))
         else {
+            return false;
+        };
+        let crate::types::TypeData::Callable(callable) = callable_ty.data() else {
             return false;
         };
 
@@ -5829,12 +6044,14 @@ impl<'db> Binding<'db> {
             &[],
         );
 
-        let Type::Callable(callable) = specialized_bindings
-            .single_element()
-            .and_then(|binding| binding.matching_overloads().exactly_one().ok())
-            .and_then(|(_, overload)| overload.specialization())
-            .and_then(|specialization| specialization.get(db, paramspec))?
-        else {
+        let (_, crate::types::TypeData::Callable(callable)) = ({
+            let __ty_view_value = specialized_bindings
+                .single_element()
+                .and_then(|binding| binding.matching_overloads().exactly_one().ok())
+                .and_then(|(_, overload)| overload.specialization())
+                .and_then(|specialization| specialization.get(db, paramspec))?;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return None;
         };
 
@@ -5990,8 +6207,10 @@ impl<'db> Binding<'db> {
         // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
         // need to reach generic call specialization below, where earlier arguments can
         // specialize the full `ParamSpec`.
-        if let Type::TypeVar(typevar) = parameter_type
-            && !typevar.is_paramspec(db)
+        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+            let __ty_view_value = parameter_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) && !typevar.is_paramspec(db)
             && let Some(TypeVarBoundOrConstraints::UpperBound(bound)) =
                 typevar.typevar(db).bound_or_constraints(db)
         {
@@ -6004,8 +6223,10 @@ impl<'db> Binding<'db> {
         // If this is a generic call, attempt to specialize the parameter type using the
         // declared type context, propagating the declared types of any type variables.
         if let Some(generic_context) = self.signature.generic_context {
-            let paramspec = if let Type::TypeVar(typevar) = original_parameter_type
-                && typevar.is_paramspec(db)
+            let paramspec = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                let __ty_view_value = original_parameter_type;
+                (__ty_view_value, __ty_view_value.data())
+            }) && typevar.is_paramspec(db)
                 && typevar.paramspec_attr(db).is_some()
             {
                 Some(typevar.without_paramspec_attr(db))
@@ -6667,8 +6888,11 @@ impl<'db> CallableDescription<'db> {
             }
         }
 
-        match callable_type {
-            Type::FunctionLiteral(function) => Some(CallableDescription {
+        match {
+            let __ty_view_value = callable_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => Some(CallableDescription {
                 kind: Some(if function.name(db) == "__new__" {
                     "constructor"
                 } else {
@@ -6676,11 +6900,11 @@ impl<'db> CallableDescription<'db> {
                 }),
                 name: qualified_function_name(db, function),
             }),
-            Type::ClassLiteral(class_type) => Some(CallableDescription {
+            (_, crate::types::TypeData::ClassLiteral(class_type)) => Some(CallableDescription {
                 kind: Some("class"),
                 name: Cow::Borrowed(class_type.name(db)),
             }),
-            Type::BoundMethod(bound_method) => Some({
+            (_, crate::types::TypeData::BoundMethod(bound_method)) => Some({
                 let function = bound_method.function(db);
                 let kind = if function.name(db) == "__init__" {
                     None
@@ -6692,25 +6916,34 @@ impl<'db> CallableDescription<'db> {
                     name: qualified_function_name(db, function),
                 }
             }),
-            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
-                Some(CallableDescription {
-                    kind: Some("method wrapper `__get__` of function"),
-                    name: Cow::Borrowed(function.name(db)),
-                })
-            }
-            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(_)) => {
-                Some(CallableDescription {
-                    kind: Some("method wrapper"),
-                    name: Cow::Borrowed("`__get__` of property"),
-                })
-            }
-            Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(_)) => {
-                Some(CallableDescription {
-                    kind: Some("method wrapper"),
-                    name: Cow::Borrowed("`__delete__` of property"),
-                })
-            }
-            Type::WrapperDescriptor(kind) => Some(CallableDescription {
+            (
+                _,
+                crate::types::TypeData::KnownBoundMethod(
+                    KnownBoundMethodType::FunctionTypeDunderGet(function),
+                ),
+            ) => Some(CallableDescription {
+                kind: Some("method wrapper `__get__` of function"),
+                name: Cow::Borrowed(function.name(db)),
+            }),
+            (
+                _,
+                crate::types::TypeData::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(
+                    _,
+                )),
+            ) => Some(CallableDescription {
+                kind: Some("method wrapper"),
+                name: Cow::Borrowed("`__get__` of property"),
+            }),
+            (
+                _,
+                crate::types::TypeData::KnownBoundMethod(
+                    KnownBoundMethodType::PropertyDunderDelete(_),
+                ),
+            ) => Some(CallableDescription {
+                kind: Some("method wrapper"),
+                name: Cow::Borrowed("`__delete__` of property"),
+            }),
+            (_, crate::types::TypeData::WrapperDescriptor(kind)) => Some(CallableDescription {
                 kind: Some("wrapper descriptor"),
                 name: Cow::Borrowed(match kind {
                     WrapperDescriptorKind::FunctionTypeDunderGet => "FunctionType.__get__",
@@ -6719,7 +6952,7 @@ impl<'db> CallableDescription<'db> {
                     WrapperDescriptorKind::PropertyDunderDelete => "property.__delete__",
                 }),
             }),
-            _ => None,
+            (_, _) => None,
         }
     }
 }
@@ -7033,10 +7266,13 @@ impl<'db> BindingError<'db> {
         compound_diag: Option<&dyn CompoundDiagnostic>,
         matching_overload: Option<&MatchingOverloadLiteral<'_>>,
     ) {
-        let callable_kind = match callable_ty {
-            Type::FunctionLiteral(_) => "Function",
-            Type::BoundMethod(_) => "Method",
-            _ => "Callable",
+        let callable_kind = match {
+            let __ty_view_value = callable_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(_)) => "Function",
+            (_, crate::types::TypeData::BoundMethod(_)) => "Method",
+            (_, _) => "Callable",
         };
 
         match self {

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -555,23 +555,26 @@ fn constructor_returns_instance<'db>(
     class_literal: ClassLiteral<'db>,
     return_ty: Type<'db>,
 ) -> bool {
-    match return_ty.resolve_type_alias(db) {
-        Type::Union(union) => union
+    match {
+        let __ty_view_value = return_ty.resolve_type_alias(db);
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .all(|element| constructor_returns_instance(db, class_literal, *element)),
-        Type::Intersection(intersection) => intersection
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
             .iter_positive(db)
             .any(|element| constructor_returns_instance(db, class_literal, element)),
         // Spec says an explicit `Any` return type should be considered non-instance.
-        Type::Dynamic(DynamicType::Any) => false,
+        (_, crate::types::TypeData::Dynamic(DynamicType::Any)) => false,
         // But a missing return annotation should be considered instance.
         // TODO currently this is also true for explicit annotations that resolve to `Unknown`;
         // should it be? Other type checkers also treat it this way.
-        Type::Dynamic(_) => true,
+        (_, crate::types::TypeData::Dynamic(_)) => true,
         // A `Never` constructor return is terminal and does not run downstream construction.
-        Type::Never => false,
-        Type::NominalInstance(instance) => instance
+        (_, crate::types::TypeData::Never) => false,
+        (_, crate::types::TypeData::NominalInstance(instance)) => instance
             .class(db)
             .is_subtype_of_class_literal(db, class_literal),
         // We don't need to handle `ProtocolInstance` here, since the only way a protocol can be
@@ -580,7 +583,7 @@ fn constructor_returns_instance<'db>(
         // in which case we'll already solve it to the subclass and consider it an instance
         // type, or it will return an explicit annotation of the protocol type itself, in which
         // case we shouldn't (and don't) consider it an instance of the subclass.
-        _ => false,
+        (_, _) => false,
     }
 }
 
@@ -607,7 +610,10 @@ impl<'db> Binding<'db> {
             return false;
         };
 
-        let Type::SubclassOf(subclass_of) = cls_parameter_ty else {
+        let (_, crate::types::TypeData::SubclassOf(subclass_of)) = ({
+            let __ty_view_value = cls_parameter_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return false;
         };
         let Some(cls_typevar) = subclass_of.into_type_var() else {
@@ -662,11 +668,14 @@ impl<'db> Binding<'db> {
 
         match (
             constructor_context.kind(),
-            self.signature.return_ty.resolve_type_alias(db),
+            ({
+                let __ty_view_value = self.signature.return_ty.resolve_type_alias(db);
+                (__ty_view_value, __ty_view_value.data())
+            }),
         ) {
-            (ConstructorCallableKind::Init, _) => Some(instance_type),
-            (_, ty) if ty.is_unknown() => Some(instance_type),
-            (ConstructorCallableKind::New, Type::TypeVar(typevar))
+            (ConstructorCallableKind::Init, (_, _)) => Some(instance_type),
+            (_, (ty, _)) if ty.is_unknown() => Some(instance_type),
+            (ConstructorCallableKind::New, (_, crate::types::TypeData::TypeVar(typevar)))
                 if self.is_self_like_constructor_return_typevar(db, typevar) =>
             {
                 Some(instance_type)

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -555,26 +555,23 @@ fn constructor_returns_instance<'db>(
     class_literal: ClassLiteral<'db>,
     return_ty: Type<'db>,
 ) -> bool {
-    match {
-        let __ty_view_value = return_ty.resolve_type_alias(db);
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::Union(union)) => union
+    match return_ty.resolve_type_alias(db).data() {
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .all(|element| constructor_returns_instance(db, class_literal, *element)),
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+        crate::types::TypeData::Intersection(intersection) => intersection
             .iter_positive(db)
             .any(|element| constructor_returns_instance(db, class_literal, element)),
         // Spec says an explicit `Any` return type should be considered non-instance.
-        (_, crate::types::TypeData::Dynamic(DynamicType::Any)) => false,
+        crate::types::TypeData::Dynamic(DynamicType::Any) => false,
         // But a missing return annotation should be considered instance.
         // TODO currently this is also true for explicit annotations that resolve to `Unknown`;
         // should it be? Other type checkers also treat it this way.
-        (_, crate::types::TypeData::Dynamic(_)) => true,
+        crate::types::TypeData::Dynamic(_) => true,
         // A `Never` constructor return is terminal and does not run downstream construction.
-        (_, crate::types::TypeData::Never) => false,
-        (_, crate::types::TypeData::NominalInstance(instance)) => instance
+        crate::types::TypeData::Never => false,
+        crate::types::TypeData::NominalInstance(instance) => instance
             .class(db)
             .is_subtype_of_class_literal(db, class_literal),
         // We don't need to handle `ProtocolInstance` here, since the only way a protocol can be
@@ -583,7 +580,7 @@ fn constructor_returns_instance<'db>(
         // in which case we'll already solve it to the subclass and consider it an instance
         // type, or it will return an explicit annotation of the protocol type itself, in which
         // case we shouldn't (and don't) consider it an instance of the subclass.
-        (_, _) => false,
+        _ => false,
     }
 }
 
@@ -610,10 +607,7 @@ impl<'db> Binding<'db> {
             return false;
         };
 
-        let (_, crate::types::TypeData::SubclassOf(subclass_of)) = ({
-            let __ty_view_value = cls_parameter_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::SubclassOf(subclass_of) = cls_parameter_ty.data() else {
             return false;
         };
         let Some(cls_typevar) = subclass_of.into_type_var() else {
@@ -668,10 +662,7 @@ impl<'db> Binding<'db> {
 
         match (
             constructor_context.kind(),
-            ({
-                let __ty_view_value = self.signature.return_ty.resolve_type_alias(db);
-                (__ty_view_value, __ty_view_value.data())
-            }),
+            self.signature.return_ty.resolve_type_alias(db).view(),
         ) {
             (ConstructorCallableKind::Init, (_, _)) => Some(instance_type),
             (_, (ty, _)) if ty.is_unknown() => Some(instance_type),

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -81,36 +81,41 @@ impl<'db> Type<'db> {
             return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
         }
 
-        match self {
-            Type::Callable(callable) => Some(CallableTypes::one(callable)),
+        match {
+            let __ty_view_value = self;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Callable(callable)) => Some(CallableTypes::one(callable)),
 
-            Type::Dynamic(_) => Some(CallableTypes::one(CallableType::function_like(
-                db,
-                Signature::dynamic(self),
-            ))),
-            Type::Divergent(_) => Some(CallableTypes::one(CallableType::function_like(
-                db,
-                Signature::dynamic(self),
-            ))),
+            (_, crate::types::TypeData::Dynamic(_)) => Some(CallableTypes::one(
+                CallableType::function_like(db, Signature::dynamic(self)),
+            )),
+            (_, crate::types::TypeData::Divergent(_)) => Some(CallableTypes::one(
+                CallableType::function_like(db, Signature::dynamic(self)),
+            )),
 
-            Type::FunctionLiteral(function_literal)
+            (_, crate::types::TypeData::FunctionLiteral(function_literal))
                 if context.is_recursive_reference(db, function_literal) =>
             {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
-            Type::FunctionLiteral(function_literal) => {
+            (_, crate::types::TypeData::FunctionLiteral(function_literal)) => {
                 Some(CallableTypes::one(function_literal.into_callable_type(db)))
             }
-            Type::BoundMethod(bound_method)
+            (_, crate::types::TypeData::BoundMethod(bound_method))
                 if context.is_recursive_reference(db, bound_method.function(db)) =>
             {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
-            Type::BoundMethod(bound_method) => {
+            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
                 Some(CallableTypes::one(bound_method.into_callable_type(db)))
             }
 
-            Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
+            (
+                _,
+                crate::types::TypeData::NominalInstance(_)
+                | crate::types::TypeData::ProtocolInstance(_),
+            ) => {
                 let call_symbol = self
                     .member_lookup_with_policy(
                         db,
@@ -129,17 +134,21 @@ impl<'db> Type<'db> {
                     None
                 }
             }
-            Type::ClassLiteral(class_literal) => {
+            (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
                 Some(class_literal.identity_specialization(db).into_callable(db))
             }
 
-            Type::GenericAlias(alias) => Some(ClassType::Generic(alias).into_callable(db)),
+            (_, crate::types::TypeData::GenericAlias(alias)) => {
+                Some(ClassType::Generic(alias).into_callable(db))
+            }
 
-            Type::NewTypeInstance(newtype) => newtype
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => newtype
                 .concrete_base_type(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
-            Type::SubclassOf(subclass_of_ty) if policy == UpcastPolicy::Sound => {
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty))
+                if policy == UpcastPolicy::Sound =>
+            {
                 Some(CallableTypes::one(CallableType::function_like(
                     db,
                     Signature::new(Parameters::top(), subclass_of_ty.to_instance(db)),
@@ -147,7 +156,9 @@ impl<'db> Type<'db> {
             }
 
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
-            Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => match subclass_of_ty
+                .subclass_of()
+            {
                 SubclassOfInner::Class(class) => Some(class.into_callable(db)),
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -201,7 +212,7 @@ impl<'db> Type<'db> {
                 ))),
             },
 
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 let mut callables = SmallVec::new();
                 for element in union.elements(db) {
                     let element_callable = element
@@ -211,31 +222,36 @@ impl<'db> Type<'db> {
                 Some(CallableTypes::new(callables))
             }
 
-            Type::LiteralValue(literal) => match literal.kind() {
+            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db)
                     .try_upcast_to_callable_with_policy_and_context(db, policy, context),
                 _ => None,
             },
 
-            Type::TypeAlias(alias) => alias
+            (_, crate::types::TypeData::TypeAlias(alias)) => alias
                 .value_type(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
-            Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function))
-                if context.is_recursive_reference(db, function) =>
-            {
+            (
+                _,
+                crate::types::TypeData::KnownBoundMethod(
+                    KnownBoundMethodType::FunctionTypeDunderCall(function),
+                ),
+            ) if context.is_recursive_reference(db, function) => {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
 
-            Type::KnownBoundMethod(method) => Some(CallableTypes::one(CallableType::new(
-                db,
-                CallableSignature::from_overloads(method.signatures(db)),
-                CallableTypeKind::Regular,
-                CallableFunctionProvenance::None,
-            ))),
+            (_, crate::types::TypeData::KnownBoundMethod(method)) => {
+                Some(CallableTypes::one(CallableType::new(
+                    db,
+                    CallableSignature::from_overloads(method.signatures(db)),
+                    CallableTypeKind::Regular,
+                    CallableFunctionProvenance::None,
+                )))
+            }
 
-            Type::WrapperDescriptor(wrapper_descriptor) => {
+            (_, crate::types::TypeData::WrapperDescriptor(wrapper_descriptor)) => {
                 Some(CallableTypes::one(CallableType::new(
                     db,
                     CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
@@ -244,7 +260,7 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            Type::KnownInstance(KnownInstanceType::NewType(newtype)) => {
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) => {
                 Some(CallableTypes::one(CallableType::single(
                     db,
                     Signature::new(
@@ -258,39 +274,44 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            Type::Never
-            | Type::DataclassTransformer(_)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_) => None,
+            (
+                _,
+                crate::types::TypeData::Never
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_),
+            ) => None,
 
-            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
-                Some(CallableTypes::one(partial.partial(db)))
-            }
+            (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+            ) => Some(CallableTypes::one(partial.partial(db))),
 
-            Type::Intersection(intersection) => {
-                intersection
-                    .finite_alternative_union(db)
-                    .and_then(|alternatives| {
-                        alternatives.try_upcast_to_callable_with_policy(db, policy)
-                    })
-            }
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                .finite_alternative_union(db)
+                .and_then(|alternatives| {
+                    alternatives.try_upcast_to_callable_with_policy(db, policy)
+                }),
 
-            Type::EnumComplement(complement) => complement
+            (_, crate::types::TypeData::EnumComplement(complement)) => complement
                 .remaining_literal_union(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
             // TODO
-            Type::DataclassDecorator(_)
-            | Type::ModuleLiteral(_)
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::TypeVar(_)
-            | Type::BoundSuper(_) => None,
+            (
+                _,
+                crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::TypeVar(_)
+                | crate::types::TypeData::BoundSuper(_),
+            ) => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -81,41 +81,35 @@ impl<'db> Type<'db> {
             return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
         }
 
-        match {
-            let __ty_view_value = self;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Callable(callable)) => Some(CallableTypes::one(callable)),
+        match self.data() {
+            crate::types::TypeData::Callable(callable) => Some(CallableTypes::one(callable)),
 
-            (_, crate::types::TypeData::Dynamic(_)) => Some(CallableTypes::one(
+            crate::types::TypeData::Dynamic(_) => Some(CallableTypes::one(
                 CallableType::function_like(db, Signature::dynamic(self)),
             )),
-            (_, crate::types::TypeData::Divergent(_)) => Some(CallableTypes::one(
+            crate::types::TypeData::Divergent(_) => Some(CallableTypes::one(
                 CallableType::function_like(db, Signature::dynamic(self)),
             )),
 
-            (_, crate::types::TypeData::FunctionLiteral(function_literal))
+            crate::types::TypeData::FunctionLiteral(function_literal)
                 if context.is_recursive_reference(db, function_literal) =>
             {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
-            (_, crate::types::TypeData::FunctionLiteral(function_literal)) => {
+            crate::types::TypeData::FunctionLiteral(function_literal) => {
                 Some(CallableTypes::one(function_literal.into_callable_type(db)))
             }
-            (_, crate::types::TypeData::BoundMethod(bound_method))
+            crate::types::TypeData::BoundMethod(bound_method)
                 if context.is_recursive_reference(db, bound_method.function(db)) =>
             {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
-            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
+            crate::types::TypeData::BoundMethod(bound_method) => {
                 Some(CallableTypes::one(bound_method.into_callable_type(db)))
             }
 
-            (
-                _,
-                crate::types::TypeData::NominalInstance(_)
-                | crate::types::TypeData::ProtocolInstance(_),
-            ) => {
+            crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_) => {
                 let call_symbol = self
                     .member_lookup_with_policy(
                         db,
@@ -134,21 +128,19 @@ impl<'db> Type<'db> {
                     None
                 }
             }
-            (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+            crate::types::TypeData::ClassLiteral(class_literal) => {
                 Some(class_literal.identity_specialization(db).into_callable(db))
             }
 
-            (_, crate::types::TypeData::GenericAlias(alias)) => {
+            crate::types::TypeData::GenericAlias(alias) => {
                 Some(ClassType::Generic(alias).into_callable(db))
             }
 
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => newtype
+            crate::types::TypeData::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
-            (_, crate::types::TypeData::SubclassOf(subclass_of_ty))
-                if policy == UpcastPolicy::Sound =>
-            {
+            crate::types::TypeData::SubclassOf(subclass_of_ty) if policy == UpcastPolicy::Sound => {
                 Some(CallableTypes::one(CallableType::function_like(
                     db,
                     Signature::new(Parameters::top(), subclass_of_ty.to_instance(db)),
@@ -156,63 +148,67 @@ impl<'db> Type<'db> {
             }
 
             // TODO: This is unsound so in future we can consider an opt-in option to disable it.
-            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => match subclass_of_ty
-                .subclass_of()
-            {
-                SubclassOfInner::Class(class) => Some(class.into_callable(db)),
-                SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        let upcast_callables = bound
-                            .to_meta_type(db)
-                            .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
-                        Some(upcast_callables.map(|callable| {
-                            let signatures = callable
-                                .signatures(db)
-                                .into_iter()
-                                .map(|sig| sig.clone().with_return_type(Type::TypeVar(tvar)));
-                            CallableType::new(
-                                db,
-                                CallableSignature::from_overloads(signatures),
-                                callable.kind(db),
-                                callable.provenance(db),
-                            )
-                        }))
-                    }
-                    Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        let mut callables = SmallVec::new();
-                        for constraint in constraints.elements(db) {
-                            let element_upcast = constraint
-                                .to_meta_type(db)
-                                .try_upcast_to_callable_with_policy_and_context(
-                                    db, policy, context,
-                                )?;
-                            for callable in element_upcast.into_inner() {
-                                let signatures = callable
-                                    .signatures(db)
-                                    .into_iter()
-                                    .map(|sig| sig.clone().with_return_type(Type::TypeVar(tvar)));
-                                callables.push(CallableType::new(
-                                    db,
-                                    CallableSignature::from_overloads(signatures),
-                                    callable.kind(db),
-                                    callable.provenance(db),
-                                ));
+            crate::types::TypeData::SubclassOf(subclass_of_ty) => {
+                match subclass_of_ty.subclass_of() {
+                    SubclassOfInner::Class(class) => Some(class.into_callable(db)),
+                    SubclassOfInner::TypeVar(tvar) => {
+                        match tvar.typevar(db).bound_or_constraints(db) {
+                            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                                let upcast_callables = bound
+                                    .to_meta_type(db)
+                                    .try_upcast_to_callable_with_policy_and_context(
+                                        db, policy, context,
+                                    )?;
+                                Some(upcast_callables.map(|callable| {
+                                    let signatures =
+                                        callable.signatures(db).into_iter().map(|sig| {
+                                            sig.clone().with_return_type(Type::TypeVar(tvar))
+                                        });
+                                    CallableType::new(
+                                        db,
+                                        CallableSignature::from_overloads(signatures),
+                                        callable.kind(db),
+                                        callable.provenance(db),
+                                    )
+                                }))
                             }
+                            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
+                                let mut callables = SmallVec::new();
+                                for constraint in constraints.elements(db) {
+                                    let element_upcast = constraint
+                                        .to_meta_type(db)
+                                        .try_upcast_to_callable_with_policy_and_context(
+                                            db, policy, context,
+                                        )?;
+                                    for callable in element_upcast.into_inner() {
+                                        let signatures =
+                                            callable.signatures(db).into_iter().map(|sig| {
+                                                sig.clone().with_return_type(Type::TypeVar(tvar))
+                                            });
+                                        callables.push(CallableType::new(
+                                            db,
+                                            CallableSignature::from_overloads(signatures),
+                                            callable.kind(db),
+                                            callable.provenance(db),
+                                        ));
+                                    }
+                                }
+                                Some(CallableTypes::new(callables))
+                            }
+                            None => Some(CallableTypes::one(CallableType::single(
+                                db,
+                                Signature::new(Parameters::gradual_form(), Type::TypeVar(tvar)),
+                            ))),
                         }
-                        Some(CallableTypes::new(callables))
                     }
-                    None => Some(CallableTypes::one(CallableType::single(
+                    SubclassOfInner::Dynamic(_) => Some(CallableTypes::one(CallableType::single(
                         db,
-                        Signature::new(Parameters::gradual_form(), Type::TypeVar(tvar)),
+                        Signature::new(Parameters::unknown(), Type::from(subclass_of_ty)),
                     ))),
-                },
-                SubclassOfInner::Dynamic(_) => Some(CallableTypes::one(CallableType::single(
-                    db,
-                    Signature::new(Parameters::unknown(), Type::from(subclass_of_ty)),
-                ))),
-            },
+                }
+            }
 
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 let mut callables = SmallVec::new();
                 for element in union.elements(db) {
                     let element_callable = element
@@ -222,27 +218,24 @@ impl<'db> Type<'db> {
                 Some(CallableTypes::new(callables))
             }
 
-            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
+            crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db)
                     .try_upcast_to_callable_with_policy_and_context(db, policy, context),
                 _ => None,
             },
 
-            (_, crate::types::TypeData::TypeAlias(alias)) => alias
+            crate::types::TypeData::TypeAlias(alias) => alias
                 .value_type(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
-            (
-                _,
-                crate::types::TypeData::KnownBoundMethod(
-                    KnownBoundMethodType::FunctionTypeDunderCall(function),
-                ),
+            crate::types::TypeData::KnownBoundMethod(
+                KnownBoundMethodType::FunctionTypeDunderCall(function),
             ) if context.is_recursive_reference(db, function) => {
                 Some(CallableTypes::one(CallableType::bottom(db)))
             }
 
-            (_, crate::types::TypeData::KnownBoundMethod(method)) => {
+            crate::types::TypeData::KnownBoundMethod(method) => {
                 Some(CallableTypes::one(CallableType::new(
                     db,
                     CallableSignature::from_overloads(method.signatures(db)),
@@ -251,7 +244,7 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            (_, crate::types::TypeData::WrapperDescriptor(wrapper_descriptor)) => {
+            crate::types::TypeData::WrapperDescriptor(wrapper_descriptor) => {
                 Some(CallableTypes::one(CallableType::new(
                     db,
                     CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
@@ -260,7 +253,7 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype)) => {
                 Some(CallableTypes::one(CallableType::single(
                     db,
                     Signature::new(
@@ -274,44 +267,37 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            (
-                _,
-                crate::types::TypeData::Never
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::TypedDict(_),
-            ) => None,
+            crate::types::TypeData::Never
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::TypedDict(_) => None,
 
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
-            ) => Some(CallableTypes::one(partial.partial(db))),
+            crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Some(CallableTypes::one(partial.partial(db)))
+            }
 
-            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            crate::types::TypeData::Intersection(intersection) => intersection
                 .finite_alternative_union(db)
                 .and_then(|alternatives| {
                     alternatives.try_upcast_to_callable_with_policy(db, policy)
                 }),
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => complement
+            crate::types::TypeData::EnumComplement(complement) => complement
                 .remaining_literal_union(db)
                 .try_upcast_to_callable_with_policy_and_context(db, policy, context),
 
             // TODO
-            (
-                _,
-                crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::ModuleLiteral(_)
-                | crate::types::TypeData::SpecialForm(_)
-                | crate::types::TypeData::KnownInstance(_)
-                | crate::types::TypeData::PropertyInstance(_)
-                | crate::types::TypeData::TypeVar(_)
-                | crate::types::TypeData::BoundSuper(_),
-            ) => None,
+            crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::TypeVar(_)
+            | crate::types::TypeData::BoundSuper(_) => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1097,12 +1097,17 @@ impl<'db> ClassType<'db> {
             ty: Type<'db>,
             defining_class: ClassType<'db>,
         ) -> Option<AbstractMethodKind> {
-            match ty {
-                Type::FunctionLiteral(function) => function.as_abstract_method(db, defining_class),
-                Type::BoundMethod(method) => {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                    function.as_abstract_method(db, defining_class)
+                }
+                (_, crate::types::TypeData::BoundMethod(method)) => {
                     method.function(db).as_abstract_method(db, defining_class)
                 }
-                Type::PropertyInstance(property) => {
+                (_, crate::types::TypeData::PropertyInstance(property)) => {
                     // A property is abstract if any of its accessors is abstract.
                     property
                         .getter(db)
@@ -1118,7 +1123,7 @@ impl<'db> ClassType<'db> {
                             })
                         })
                 }
-                _ => None,
+                (_, _) => None,
             }
         }
 
@@ -1904,10 +1909,8 @@ impl<'db> ClassType<'db> {
             )
             .place;
 
-        if let Place::Defined(DefinedPlace {
-            ty: Type::BoundMethod(metaclass_dunder_call_function),
-            ..
-        }) = metaclass_dunder_call_function_symbol
+        if let Place::Defined(DefinedPlace { ty, .. }) = metaclass_dunder_call_function_symbol
+            && let crate::types::TypeData::BoundMethod(metaclass_dunder_call_function) = ty.data()
         {
             // TODO: this intentionally diverges from step 1 in
             // https://typing.python.org/en/latest/spec/constructors.html#converting-a-constructor-to-callable
@@ -1929,10 +1932,19 @@ impl<'db> ClassType<'db> {
 
         let dunder_new_signature = dunder_new_function_symbol
             .and_then(|place_and_quals| place_and_quals.ignore_possibly_undefined())
-            .and_then(|ty| match ty {
-                Type::FunctionLiteral(function) => Some(function.signature(db)),
-                Type::Callable(callable) => Some(callable.signatures(db)),
-                _ => None,
+            .and_then(|ty| {
+                match {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                        Some(function.signature(db))
+                    }
+                    (_, crate::types::TypeData::Callable(callable)) => {
+                        Some(callable.signatures(db))
+                    }
+                    (_, _) => None,
+                }
             });
 
         let dunder_new_function = if let Some(dunder_new_signature) = dunder_new_signature {
@@ -1980,12 +1992,15 @@ impl<'db> ClassType<'db> {
         let synthesized_dunder_init_callable = if let Place::Defined(DefinedPlace { ty, .. }) =
             dunder_init_function_symbol
         {
-            let signature = match ty {
-                Type::FunctionLiteral(dunder_init_function) => {
+            let signature = match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::FunctionLiteral(dunder_init_function)) => {
                     Some(dunder_init_function.signature(db))
                 }
-                Type::Callable(callable) => Some(callable.signatures(db)),
-                _ => None,
+                (_, crate::types::TypeData::Callable(callable)) => Some(callable.signatures(db)),
+                (_, _) => None,
             };
 
             if let Some(signature) = signature {
@@ -2053,10 +2068,8 @@ impl<'db> ClassType<'db> {
                     )
                     .place;
 
-                if let Place::Defined(DefinedPlace {
-                    ty: Type::FunctionLiteral(mut new_function),
-                    ..
-                }) = new_function_symbol
+                if let Place::Defined(DefinedPlace { ty, .. }) = new_function_symbol
+                    && let crate::types::TypeData::FunctionLiteral(mut new_function) = ty.data()
                 {
                     if let Some(class_generic_context) = class_generic_context {
                         new_function =
@@ -2791,9 +2804,12 @@ impl SlotsKind {
             return Self::Dynamic;
         }
 
-        match slots_ty {
+        match {
+            let __ty_view_value = slots_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // __slots__ = ("a", "b")
-            Type::NominalInstance(nominal) => match nominal
+            (_, crate::types::TypeData::NominalInstance(nominal)) => match nominal
                 .tuple_spec(db)
                 .and_then(|spec| spec.len().into_fixed_length())
             {
@@ -2803,9 +2819,11 @@ impl SlotsKind {
             },
 
             // __slots__ = "abc"  # Same as `("abc",)`
-            Type::LiteralValue(literal) if literal.is_string() => Self::NotEmpty,
+            (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
+                Self::NotEmpty
+            }
 
-            _ => Self::Dynamic,
+            (_, _) => Self::Dynamic,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -1097,17 +1097,14 @@ impl<'db> ClassType<'db> {
             ty: Type<'db>,
             defining_class: ClassType<'db>,
         ) -> Option<AbstractMethodKind> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::FunctionLiteral(function)) => {
+            match ty.data() {
+                crate::types::TypeData::FunctionLiteral(function) => {
                     function.as_abstract_method(db, defining_class)
                 }
-                (_, crate::types::TypeData::BoundMethod(method)) => {
+                crate::types::TypeData::BoundMethod(method) => {
                     method.function(db).as_abstract_method(db, defining_class)
                 }
-                (_, crate::types::TypeData::PropertyInstance(property)) => {
+                crate::types::TypeData::PropertyInstance(property) => {
                     // A property is abstract if any of its accessors is abstract.
                     property
                         .getter(db)
@@ -1123,7 +1120,7 @@ impl<'db> ClassType<'db> {
                             })
                         })
                 }
-                (_, _) => None,
+                _ => None,
             }
         }
 
@@ -1932,19 +1929,10 @@ impl<'db> ClassType<'db> {
 
         let dunder_new_signature = dunder_new_function_symbol
             .and_then(|place_and_quals| place_and_quals.ignore_possibly_undefined())
-            .and_then(|ty| {
-                match {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
-                        Some(function.signature(db))
-                    }
-                    (_, crate::types::TypeData::Callable(callable)) => {
-                        Some(callable.signatures(db))
-                    }
-                    (_, _) => None,
-                }
+            .and_then(|ty| match ty.data() {
+                crate::types::TypeData::FunctionLiteral(function) => Some(function.signature(db)),
+                crate::types::TypeData::Callable(callable) => Some(callable.signatures(db)),
+                _ => None,
             });
 
         let dunder_new_function = if let Some(dunder_new_signature) = dunder_new_signature {
@@ -1992,15 +1980,12 @@ impl<'db> ClassType<'db> {
         let synthesized_dunder_init_callable = if let Place::Defined(DefinedPlace { ty, .. }) =
             dunder_init_function_symbol
         {
-            let signature = match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::FunctionLiteral(dunder_init_function)) => {
+            let signature = match ty.data() {
+                crate::types::TypeData::FunctionLiteral(dunder_init_function) => {
                     Some(dunder_init_function.signature(db))
                 }
-                (_, crate::types::TypeData::Callable(callable)) => Some(callable.signatures(db)),
-                (_, _) => None,
+                crate::types::TypeData::Callable(callable) => Some(callable.signatures(db)),
+                _ => None,
             };
 
             if let Some(signature) = signature {
@@ -2804,12 +2789,9 @@ impl SlotsKind {
             return Self::Dynamic;
         }
 
-        match {
-            let __ty_view_value = slots_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match slots_ty.data() {
             // __slots__ = ("a", "b")
-            (_, crate::types::TypeData::NominalInstance(nominal)) => match nominal
+            crate::types::TypeData::NominalInstance(nominal) => match nominal
                 .tuple_spec(db)
                 .and_then(|spec| spec.len().into_fixed_length())
             {
@@ -2819,11 +2801,9 @@ impl SlotsKind {
             },
 
             // __slots__ = "abc"  # Same as `("abc",)`
-            (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
-                Self::NotEmpty
-            }
+            crate::types::TypeData::LiteralValue(literal) if literal.is_string() => Self::NotEmpty,
 
-            (_, _) => Self::Dynamic,
+            _ => Self::Dynamic,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -484,15 +484,22 @@ impl<'db> DynamicClassLiteral<'db> {
         for (name, ty) in self.members(db) {
             if name.as_str() == "__slots__" {
                 // Check if the slots are non-empty
-                let is_non_empty = match ty {
+                let is_non_empty = match {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     // __slots__ = ("a", "b")
-                    Type::NominalInstance(nominal) => nominal.tuple_spec(db).is_some_and(|spec| {
-                        spec.len().into_fixed_length().is_some_and(|len| len > 0)
-                    }),
+                    (_, crate::types::TypeData::NominalInstance(nominal)) => {
+                        nominal.tuple_spec(db).is_some_and(|spec| {
+                            spec.len().into_fixed_length().is_some_and(|len| len > 0)
+                        })
+                    }
                     // __slots__ = "abc"  # Same as ("abc",)
-                    Type::LiteralValue(literal) if literal.is_string() => true,
+                    (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
+                        true
+                    }
                     // Other types are considered dynamic/unknown
-                    _ => false,
+                    (_, _) => false,
                 };
                 if is_non_empty {
                     return Some(DisjointBase::due_to_dunder_slots(ClassLiteral::Dynamic(

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -484,22 +484,17 @@ impl<'db> DynamicClassLiteral<'db> {
         for (name, ty) in self.members(db) {
             if name.as_str() == "__slots__" {
                 // Check if the slots are non-empty
-                let is_non_empty = match {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                let is_non_empty = match ty.data() {
                     // __slots__ = ("a", "b")
-                    (_, crate::types::TypeData::NominalInstance(nominal)) => {
+                    crate::types::TypeData::NominalInstance(nominal) => {
                         nominal.tuple_spec(db).is_some_and(|spec| {
                             spec.len().into_fixed_length().is_some_and(|len| len > 0)
                         })
                     }
                     // __slots__ = "abc"  # Same as ("abc",)
-                    (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
-                        true
-                    }
+                    crate::types::TypeData::LiteralValue(literal) if literal.is_string() => true,
                     // Other types are considered dynamic/unknown
-                    (_, _) => false,
+                    _ => false,
                 };
                 if is_non_empty {
                     return Some(DisjointBase::due_to_dunder_slots(ClassLiteral::Dynamic(

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -1045,18 +1045,18 @@ impl KnownClass {
         let symbol = known_module_symbol(db, self.canonical_module(db), self.name(db)).place;
         match symbol {
             Place::Defined(DefinedPlace {
-                ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),
-                definedness: Definedness::AlwaysDefined,
-                ..
-            }) => Ok(class_literal),
-            Place::Defined(DefinedPlace {
-                ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),
-                definedness: Definedness::PossiblyUndefined,
-                ..
-            }) => Err(KnownClassLookupError::ClassPossiblyUnbound { class_literal }),
-            Place::Defined(DefinedPlace { ty: found_type, .. }) => {
-                Err(KnownClassLookupError::SymbolNotAClass { found_type })
-            }
+                ty, definedness, ..
+            }) => match ty.data() {
+                crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class_literal)) => {
+                    match definedness {
+                        Definedness::AlwaysDefined => Ok(class_literal),
+                        Definedness::PossiblyUndefined => {
+                            Err(KnownClassLookupError::ClassPossiblyUnbound { class_literal })
+                        }
+                    }
+                }
+                _ => Err(KnownClassLookupError::SymbolNotAClass { found_type: ty }),
+            },
             Place::Undefined => Err(KnownClassLookupError::ClassNotFound),
         }
     }

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -449,16 +449,11 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
                 .expect("Expected `NamedTuple` definition to be an assignment")
                 .as_call_expr()
                 .expect("Expected `NamedTuple` definition r.h.s. to be a call expression");
-            match {
-                let __ty_view_value =
-                    definition_expression_type(db, definition, &node.arguments.args[1]);
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::NamedTupleSpec(spec)),
-                ) => spec,
-                (_, _) => NamedTupleSpec::unknown(db),
+            match definition_expression_type(db, definition, &node.arguments.args[1]).data() {
+                crate::types::TypeData::KnownInstance(KnownInstanceType::NamedTupleSpec(spec)) => {
+                    spec
+                }
+                _ => NamedTupleSpec::unknown(db),
             }
         }
 

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -449,9 +449,16 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
                 .expect("Expected `NamedTuple` definition to be an assignment")
                 .as_call_expr()
                 .expect("Expected `NamedTuple` definition r.h.s. to be a call expression");
-            match definition_expression_type(db, definition, &node.arguments.args[1]) {
-                Type::KnownInstance(KnownInstanceType::NamedTupleSpec(spec)) => spec,
-                _ => NamedTupleSpec::unknown(db),
+            match {
+                let __ty_view_value =
+                    definition_expression_type(db, definition, &node.arguments.args[1]);
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::NamedTupleSpec(spec)),
+                ) => spec,
+                (_, _) => NamedTupleSpec::unknown(db),
             }
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -306,21 +306,9 @@ impl<'db> StaticClassLiteral<'db> {
     }
 
     pub(crate) fn legacy_generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        self.explicit_bases(db).iter().find_map(|base| {
-            match {
-                let __ty_view_value = base;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(
-                        KnownInstanceType::SubscriptedGeneric(generic_context)
-                        | KnownInstanceType::SubscriptedProtocol(generic_context),
-                    ),
-                ) => Some(generic_context),
-                (_, _) => None,
-            }
-        })
+        self.explicit_bases(db)
+            .iter()
+            .find_map(|base| base.as_legacy_generic_context())
     }
 
     pub(crate) fn inherited_legacy_generic_context(
@@ -338,15 +326,11 @@ impl<'db> StaticClassLiteral<'db> {
             GenericContext::from_base_classes(
                 db,
                 class.definition(db),
-                class.explicit_bases(db).iter().copied().filter(|ty| {
-                    matches!(
-                        {
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (_, crate::types::TypeData::GenericAlias(_))
-                    )
-                }),
+                class
+                    .explicit_bases(db)
+                    .iter()
+                    .copied()
+                    .filter(|ty| ty.is_generic_alias()),
             )
         }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -122,20 +122,14 @@ impl<'db> StaticClassLiteral<'db> {
     /// When the base namedtuple's fields were determined dynamically (e.g., from a variable),
     /// we can't synthesize precise method signatures and should fall back to `NamedTupleFallback`.
     pub(crate) fn namedtuple_base_has_unknown_fields(self, db: &'db dyn Db) -> bool {
-        self.explicit_bases(db).iter().any(|base| {
-            match {
-                let __ty_view_value = base;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    crate::types::TypeData::ClassLiteral(ClassLiteral::DynamicNamedTuple(
-                        namedtuple,
-                    )),
-                ) => !namedtuple.has_known_fields(db),
-                (_, _) => false,
-            }
-        })
+        self.explicit_bases(db)
+            .iter()
+            .any(|base| match base.data() {
+                crate::types::TypeData::ClassLiteral(ClassLiteral::DynamicNamedTuple(
+                    namedtuple,
+                )) => !namedtuple.has_known_fields(db),
+                _ => false,
+            })
     }
 
     /// Returns `true` if this class is a dataclass-like class.
@@ -330,7 +324,7 @@ impl<'db> StaticClassLiteral<'db> {
                     .explicit_bases(db)
                     .iter()
                     .copied()
-                    .filter(|ty| ty.is_generic_alias()),
+                    .filter(Type::is_generic_alias),
             )
         }
 
@@ -557,17 +551,11 @@ impl<'db> StaticClassLiteral<'db> {
                 //                                and the final base being `object`)
                 self.explicit_bases(db).iter().rev().take(3).any(|base| {
                     matches!(
-                        {
-                            let __ty_view_value = base;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (
-                            _,
-                            crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)
-                                | crate::types::TypeData::KnownInstance(
-                                    KnownInstanceType::SubscriptedProtocol(_)
-                                )
-                        )
+                        base.data(),
+                        crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)
+                            | crate::types::TypeData::KnownInstance(
+                                KnownInstanceType::SubscriptedProtocol(_)
+                            )
                     )
                 })
             })
@@ -1060,24 +1048,19 @@ impl<'db> StaticClassLiteral<'db> {
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::Callable(callable_ty)) => {
-                    Type::Callable(CallableType::new(
-                        db,
-                        callable_ty.signatures(db),
-                        CallableTypeKind::FunctionLike,
-                        callable_ty.provenance(db),
-                    ))
-                }
-                (_, crate::types::TypeData::Union(union)) => {
+            match ty.data() {
+                crate::types::TypeData::Callable(callable_ty) => Type::Callable(CallableType::new(
+                    db,
+                    callable_ty.signatures(db),
+                    CallableTypeKind::FunctionLike,
+                    callable_ty.provenance(db),
+                )),
+                crate::types::TypeData::Union(union) => {
                     union.map(db, |element| into_function_like_callable(db, *element))
                 }
-                (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                crate::types::TypeData::Intersection(intersection) => intersection
                     .map_positive(db, |element| into_function_like_callable(db, *element)),
-                (_, _) => ty,
+                _ => ty,
             }
         }
 
@@ -1197,18 +1180,10 @@ impl<'db> StaticClassLiteral<'db> {
             // to any method with a `@classmethod` decorator. (`__init__` would remain a special
             // case, since it's an _instance_ method where we don't yet know the generic class's
             // specialization.)
-            match (
-                inherited_generic_context,
-                ({
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                }),
-                specialization,
-                name,
-            ) {
+            match (inherited_generic_context, ty.data(), specialization, name) {
                 (
                     Some(generic_context),
-                    (_, crate::types::TypeData::FunctionLiteral(function)),
+                    crate::types::TypeData::FunctionLiteral(function),
                     Some(_),
                     "__new__" | "__init__",
                 ) => Type::FunctionLiteral(
@@ -2246,10 +2221,7 @@ impl<'db> StaticClassLiteral<'db> {
             for decorator in &function_node.decorator_list {
                 let decorator_ty =
                     definition_expression_type(db, definition, &decorator.expression);
-                if let (_, crate::types::TypeData::ClassLiteral(class)) = {
-                    let __ty_view_value = decorator_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::ClassLiteral(class) = decorator_ty.data() {
                     match class.known(db) {
                         Some(KnownClass::Classmethod) => is_classmethod = true,
                         Some(KnownClass::Staticmethod) => is_staticmethod = true,
@@ -2801,17 +2773,14 @@ impl<'db> StaticClassLiteral<'db> {
             ) -> bool {
                 let mut result = false;
                 for explicit_base in class.explicit_bases(db) {
-                    let explicit_base_class_literal = match {
-                        let __ty_view_value = explicit_base;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+                    let explicit_base_class_literal = match explicit_base.data() {
+                        crate::types::TypeData::ClassLiteral(class_literal) => {
                             class_literal.as_static()
                         }
-                        (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                        crate::types::TypeData::GenericAlias(generic_alias) => {
                             Some(generic_alias.origin(db))
                         }
-                        (_, _) => continue,
+                        _ => continue,
                     };
                     let Some(explicit_base_class_literal) = explicit_base_class_literal else {
                         continue;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -122,11 +122,19 @@ impl<'db> StaticClassLiteral<'db> {
     /// When the base namedtuple's fields were determined dynamically (e.g., from a variable),
     /// we can't synthesize precise method signatures and should fall back to `NamedTupleFallback`.
     pub(crate) fn namedtuple_base_has_unknown_fields(self, db: &'db dyn Db) -> bool {
-        self.explicit_bases(db).iter().any(|base| match base {
-            Type::ClassLiteral(ClassLiteral::DynamicNamedTuple(namedtuple)) => {
-                !namedtuple.has_known_fields(db)
+        self.explicit_bases(db).iter().any(|base| {
+            match {
+                let __ty_view_value = base;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(ClassLiteral::DynamicNamedTuple(
+                        namedtuple,
+                    )),
+                ) => !namedtuple.has_known_fields(db),
+                (_, _) => false,
             }
-            _ => false,
         })
     }
 
@@ -298,12 +306,20 @@ impl<'db> StaticClassLiteral<'db> {
     }
 
     pub(crate) fn legacy_generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
-        self.explicit_bases(db).iter().find_map(|base| match base {
-            Type::KnownInstance(
-                KnownInstanceType::SubscriptedGeneric(generic_context)
-                | KnownInstanceType::SubscriptedProtocol(generic_context),
-            ) => Some(*generic_context),
-            _ => None,
+        self.explicit_bases(db).iter().find_map(|base| {
+            match {
+                let __ty_view_value = base;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::SubscriptedGeneric(generic_context)
+                        | KnownInstanceType::SubscriptedProtocol(generic_context),
+                    ),
+                ) => Some(generic_context),
+                (_, _) => None,
+            }
         })
     }
 
@@ -322,11 +338,15 @@ impl<'db> StaticClassLiteral<'db> {
             GenericContext::from_base_classes(
                 db,
                 class.definition(db),
-                class
-                    .explicit_bases(db)
-                    .iter()
-                    .copied()
-                    .filter(|ty| matches!(ty, Type::GenericAlias(_))),
+                class.explicit_bases(db).iter().copied().filter(|ty| {
+                    matches!(
+                        {
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (_, crate::types::TypeData::GenericAlias(_))
+                    )
+                }),
             )
         }
 
@@ -553,9 +573,17 @@ impl<'db> StaticClassLiteral<'db> {
                 //                                and the final base being `object`)
                 self.explicit_bases(db).iter().rev().take(3).any(|base| {
                     matches!(
-                        base,
-                        Type::SpecialForm(SpecialFormType::Protocol)
-                            | Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(_))
+                        {
+                            let __ty_view_value = base;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (
+                            _,
+                            crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)
+                                | crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::SubscriptedProtocol(_)
+                                )
+                        )
                     )
                 })
             })
@@ -914,7 +942,9 @@ impl<'db> StaticClassLiteral<'db> {
             // Generic metaclasses parameterized by type variables are not supported.
             // `metaclass=Meta[int]` is fine, but `metaclass=Meta[T]` is not.
             // See: https://typing.python.org/en/latest/spec/generics.html#generic-metaclasses
-            if let Some(Type::GenericAlias(alias)) = explicit_metaclass {
+            if let Some(crate::types::TypeData::GenericAlias(alias)) =
+                explicit_metaclass.map(Type::data)
+            {
                 let specialization_has_typevars = alias
                     .specialization(db)
                     .types(db)
@@ -1046,19 +1076,24 @@ impl<'db> StaticClassLiteral<'db> {
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
-            match ty {
-                Type::Callable(callable_ty) => Type::Callable(CallableType::new(
-                    db,
-                    callable_ty.signatures(db),
-                    CallableTypeKind::FunctionLike,
-                    callable_ty.provenance(db),
-                )),
-                Type::Union(union) => {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Callable(callable_ty)) => {
+                    Type::Callable(CallableType::new(
+                        db,
+                        callable_ty.signatures(db),
+                        CallableTypeKind::FunctionLike,
+                        callable_ty.provenance(db),
+                    ))
+                }
+                (_, crate::types::TypeData::Union(union)) => {
                     union.map(db, |element| into_function_like_callable(db, *element))
                 }
-                Type::Intersection(intersection) => intersection
+                (_, crate::types::TypeData::Intersection(intersection)) => intersection
                     .map_positive(db, |element| into_function_like_callable(db, *element)),
-                _ => ty,
+                (_, _) => ty,
             }
         }
 
@@ -1178,10 +1213,18 @@ impl<'db> StaticClassLiteral<'db> {
             // to any method with a `@classmethod` decorator. (`__init__` would remain a special
             // case, since it's an _instance_ method where we don't yet know the generic class's
             // specialization.)
-            match (inherited_generic_context, ty, specialization, name) {
+            match (
+                inherited_generic_context,
+                ({
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                }),
+                specialization,
+                name,
+            ) {
                 (
                     Some(generic_context),
-                    Type::FunctionLiteral(function),
+                    (_, crate::types::TypeData::FunctionLiteral(function)),
                     Some(_),
                     "__new__" | "__init__",
                 ) => Type::FunctionLiteral(
@@ -1882,8 +1925,10 @@ impl<'db> StaticClassLiteral<'db> {
             let symbol = table.symbol(symbol_id);
             let name = symbol.name();
 
-            let Some(Type::FunctionLiteral(literal)) = attr.place.ignore_possibly_undefined()
-            else {
+            let Some(ty) = attr.place.ignore_possibly_undefined() else {
+                continue;
+            };
+            let crate::types::TypeData::FunctionLiteral(literal) = ty.data() else {
                 continue;
             };
 
@@ -2033,7 +2078,10 @@ impl<'db> StaticClassLiteral<'db> {
                 let mut kw_only = None;
                 let mut alias = None;
                 let mut converter = None;
-                if let Some(Type::KnownInstance(KnownInstanceType::Field(field))) = default_ty {
+                if let Some(crate::types::TypeData::KnownInstance(KnownInstanceType::Field(
+                    field,
+                ))) = default_ty.map(Type::data)
+                {
                     default_ty = field.default_type(db);
                     init = field.init(db);
                     kw_only = field.kw_only(db);
@@ -2214,7 +2262,10 @@ impl<'db> StaticClassLiteral<'db> {
             for decorator in &function_node.decorator_list {
                 let decorator_ty =
                     definition_expression_type(db, definition, &decorator.expression);
-                if let Type::ClassLiteral(class) = decorator_ty {
+                if let (_, crate::types::TypeData::ClassLiteral(class)) = {
+                    let __ty_view_value = decorator_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     match class.known(db) {
                         Some(KnownClass::Classmethod) => is_classmethod = true,
                         Some(KnownClass::Staticmethod) => is_staticmethod = true,
@@ -2766,10 +2817,17 @@ impl<'db> StaticClassLiteral<'db> {
             ) -> bool {
                 let mut result = false;
                 for explicit_base in class.explicit_bases(db) {
-                    let explicit_base_class_literal = match explicit_base {
-                        Type::ClassLiteral(class_literal) => class_literal.as_static(),
-                        Type::GenericAlias(generic_alias) => Some(generic_alias.origin(db)),
-                        _ => continue,
+                    let explicit_base_class_literal = match {
+                        let __ty_view_value = explicit_base;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+                            class_literal.as_static()
+                        }
+                        (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                            Some(generic_alias.origin(db))
+                        }
+                        (_, _) => continue,
                     };
                     let Some(explicit_base_class_literal) = explicit_base_class_literal else {
                         continue;

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -705,8 +705,10 @@ fn synthesize_typed_dict_merge<'db>(
     let mut overloads: smallvec::SmallVec<[Signature<'db>; 3]>;
 
     let first_overload_value_ty = if name == "__ior__"
-        && let Type::TypedDict(typed_dict) = instance_ty
-    {
+        && let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
+            let __ty_view_value = instance_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) {
         Type::TypedDict(typed_dict.to_update_patch(db))
     } else {
         instance_ty
@@ -724,7 +726,10 @@ fn synthesize_typed_dict_merge<'db>(
     )];
 
     if name != "__ior__" {
-        let partial_ty = if let Type::TypedDict(td) = instance_ty {
+        let partial_ty = if let (_, crate::types::TypeData::TypedDict(td)) = {
+            let __ty_view_value = instance_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             Type::TypedDict(td.to_partial(db))
         } else {
             instance_ty

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -705,10 +705,8 @@ fn synthesize_typed_dict_merge<'db>(
     let mut overloads: smallvec::SmallVec<[Signature<'db>; 3]>;
 
     let first_overload_value_ty = if name == "__ior__"
-        && let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
-            let __ty_view_value = instance_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) {
+        && let crate::types::TypeData::TypedDict(typed_dict) = instance_ty.data()
+    {
         Type::TypedDict(typed_dict.to_update_patch(db))
     } else {
         instance_ty
@@ -726,10 +724,7 @@ fn synthesize_typed_dict_merge<'db>(
     )];
 
     if name != "__ior__" {
-        let partial_ty = if let (_, crate::types::TypeData::TypedDict(td)) = {
-            let __ty_view_value = instance_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        let partial_ty = if let crate::types::TypeData::TypedDict(td) = instance_ty.data() {
             Type::TypedDict(td.to_partial(db))
         } else {
             instance_ty

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -94,21 +94,28 @@ impl<'db> ClassBase<'db> {
         ty: Type<'db>,
         subclass: Option<ClassLiteral<'db>>,
     ) -> Option<Self> {
-        match ty {
-            Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
-            Type::Divergent(divergent) => Some(Self::Divergent(divergent)),
-            Type::ClassLiteral(literal) => Some(Self::Class(literal.default_specialization(db))),
-            Type::GenericAlias(generic) => Some(Self::Class(ClassType::Generic(generic))),
-            Type::NominalInstance(instance)
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Dynamic(dynamic)) => Some(Self::Dynamic(dynamic)),
+            (_, crate::types::TypeData::Divergent(divergent)) => Some(Self::Divergent(divergent)),
+            (_, crate::types::TypeData::ClassLiteral(literal)) => {
+                Some(Self::Class(literal.default_specialization(db)))
+            }
+            (_, crate::types::TypeData::GenericAlias(generic)) => {
+                Some(Self::Class(ClassType::Generic(generic)))
+            }
+            (_, crate::types::TypeData::NominalInstance(instance))
                 if instance.has_known_class(db, KnownClass::GenericAlias) =>
             {
                 Self::try_from_type(db, todo_type!("GenericAlias instance"), subclass)
             }
-            Type::SubclassOf(subclass_of) => subclass_of
+            (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of
                 .subclass_of()
                 .into_dynamic()
                 .map(ClassBase::Dynamic),
-            Type::Intersection(inter) => {
+            (_, crate::types::TypeData::Intersection(inter)) => {
                 let valid_element = inter
                     .positive(db)
                     .iter()
@@ -120,7 +127,7 @@ impl<'db> ClassBase<'db> {
                     Some(valid_element)
                 }
             }
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 // We do not support full unions of MROs (yet). Until we do,
                 // support the cases where one of the types in the union is
                 // a dynamic type such as `Any` or `Unknown`, and all other
@@ -128,11 +135,13 @@ impl<'db> ClassBase<'db> {
                 // "fold" the other potential bases into the dynamic type,
                 // and return `Any`/`Unknown` as the class base to prevent
                 // invalid-base diagnostics and further downstream errors.
-                let Some(Type::Dynamic(dynamic)) = union
-                    .elements(db)
-                    .iter()
-                    .find(|elem| matches!(elem, Type::Dynamic(_)))
-                else {
+                let Some(dynamic) = union.elements(db).iter().find_map(|elem| {
+                    if let crate::types::TypeData::Dynamic(dynamic) = elem.data() {
+                        Some(dynamic)
+                    } else {
+                        None
+                    }
+                }) else {
                     return None;
                 };
 
@@ -141,45 +150,50 @@ impl<'db> ClassBase<'db> {
                     .iter()
                     .all(|elem| ClassBase::try_from_type(db, *elem, subclass).is_some())
                 {
-                    Some(ClassBase::Dynamic(*dynamic))
+                    Some(ClassBase::Dynamic(dynamic))
                 } else {
                     None
                 }
             }
-            Type::NominalInstance(_) => None, // TODO -- handle `__mro_entries__`?
+            (_, crate::types::TypeData::NominalInstance(_)) => None, // TODO -- handle `__mro_entries__`?
 
             // This likely means that we're in unreachable code,
             // in which case we want to treat `Never` in a forgiving way and silence diagnostics
-            Type::Never => Some(ClassBase::unknown()),
+            (_, crate::types::TypeData::Never) => Some(ClassBase::unknown()),
 
-            Type::TypeAlias(alias) => Self::try_from_type(db, alias.value_type(db), subclass),
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
+                Self::try_from_type(db, alias.value_type(db), subclass)
+            }
 
-            Type::NewTypeInstance(newtype) => {
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                 ClassBase::try_from_type(db, newtype.concrete_base_type(db), subclass)
             }
 
-            Type::PropertyInstance(_)
-            | Type::EnumComplement(_)
-            | Type::LiteralValue(_)
-            | Type::FunctionLiteral(_)
-            | Type::Callable(..)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(_)
-            | Type::TypeVar(_)
-            | Type::BoundSuper(_)
-            | Type::ProtocolInstance(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_) => None,
+            (
+                _,
+                crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::EnumComplement(_)
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::Callable(..)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::TypeVar(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_),
+            ) => None,
 
-            Type::KnownInstance(known_instance) => match known_instance {
+            (_, crate::types::TypeData::KnownInstance(known_instance)) => match known_instance {
                 KnownInstanceType::SubscriptedGeneric(_) => Some(Self::Generic),
                 KnownInstanceType::SubscriptedProtocol(_) => Some(Self::Protocol),
                 KnownInstanceType::TypeAliasType(_)
@@ -215,7 +229,7 @@ impl<'db> ClassBase<'db> {
                 }
             },
 
-            Type::SpecialForm(special_form) => match special_form {
+            (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
                 SpecialFormType::TypeQualifier(_) => None,
 
                 SpecialFormType::Annotated

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -94,28 +94,25 @@ impl<'db> ClassBase<'db> {
         ty: Type<'db>,
         subclass: Option<ClassLiteral<'db>>,
     ) -> Option<Self> {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Dynamic(dynamic)) => Some(Self::Dynamic(dynamic)),
-            (_, crate::types::TypeData::Divergent(divergent)) => Some(Self::Divergent(divergent)),
-            (_, crate::types::TypeData::ClassLiteral(literal)) => {
+        match ty.data() {
+            crate::types::TypeData::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
+            crate::types::TypeData::Divergent(divergent) => Some(Self::Divergent(divergent)),
+            crate::types::TypeData::ClassLiteral(literal) => {
                 Some(Self::Class(literal.default_specialization(db)))
             }
-            (_, crate::types::TypeData::GenericAlias(generic)) => {
+            crate::types::TypeData::GenericAlias(generic) => {
                 Some(Self::Class(ClassType::Generic(generic)))
             }
-            (_, crate::types::TypeData::NominalInstance(instance))
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::GenericAlias) =>
             {
                 Self::try_from_type(db, todo_type!("GenericAlias instance"), subclass)
             }
-            (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of
+            crate::types::TypeData::SubclassOf(subclass_of) => subclass_of
                 .subclass_of()
                 .into_dynamic()
                 .map(ClassBase::Dynamic),
-            (_, crate::types::TypeData::Intersection(inter)) => {
+            crate::types::TypeData::Intersection(inter) => {
                 let valid_element = inter
                     .positive(db)
                     .iter()
@@ -127,7 +124,7 @@ impl<'db> ClassBase<'db> {
                     Some(valid_element)
                 }
             }
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 // We do not support full unions of MROs (yet). Until we do,
                 // support the cases where one of the types in the union is
                 // a dynamic type such as `Any` or `Unknown`, and all other
@@ -135,15 +132,13 @@ impl<'db> ClassBase<'db> {
                 // "fold" the other potential bases into the dynamic type,
                 // and return `Any`/`Unknown` as the class base to prevent
                 // invalid-base diagnostics and further downstream errors.
-                let Some(dynamic) = union.elements(db).iter().find_map(|elem| {
+                let dynamic = union.elements(db).iter().find_map(|elem| {
                     if let crate::types::TypeData::Dynamic(dynamic) = elem.data() {
                         Some(dynamic)
                     } else {
                         None
                     }
-                }) else {
-                    return None;
-                };
+                })?;
 
                 if union
                     .elements(db)
@@ -155,45 +150,42 @@ impl<'db> ClassBase<'db> {
                     None
                 }
             }
-            (_, crate::types::TypeData::NominalInstance(_)) => None, // TODO -- handle `__mro_entries__`?
+            crate::types::TypeData::NominalInstance(_) => None, // TODO -- handle `__mro_entries__`?
 
             // This likely means that we're in unreachable code,
             // in which case we want to treat `Never` in a forgiving way and silence diagnostics
-            (_, crate::types::TypeData::Never) => Some(ClassBase::unknown()),
+            crate::types::TypeData::Never => Some(ClassBase::unknown()),
 
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+            crate::types::TypeData::TypeAlias(alias) => {
                 Self::try_from_type(db, alias.value_type(db), subclass)
             }
 
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+            crate::types::TypeData::NewTypeInstance(newtype) => {
                 ClassBase::try_from_type(db, newtype.concrete_base_type(db), subclass)
             }
 
-            (
-                _,
-                crate::types::TypeData::PropertyInstance(_)
-                | crate::types::TypeData::EnumComplement(_)
-                | crate::types::TypeData::LiteralValue(_)
-                | crate::types::TypeData::FunctionLiteral(_)
-                | crate::types::TypeData::Callable(..)
-                | crate::types::TypeData::BoundMethod(_)
-                | crate::types::TypeData::KnownBoundMethod(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::ModuleLiteral(_)
-                | crate::types::TypeData::TypeVar(_)
-                | crate::types::TypeData::BoundSuper(_)
-                | crate::types::TypeData::ProtocolInstance(_)
-                | crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::TypedDict(_),
-            ) => None,
+            crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::Callable(..)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::TypeVar(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::TypedDict(_) => None,
 
-            (_, crate::types::TypeData::KnownInstance(known_instance)) => match known_instance {
+            crate::types::TypeData::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::SubscriptedGeneric(_) => Some(Self::Generic),
                 KnownInstanceType::SubscriptedProtocol(_) => Some(Self::Protocol),
                 KnownInstanceType::TypeAliasType(_)
@@ -229,7 +221,7 @@ impl<'db> ClassBase<'db> {
                 }
             },
 
-            (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
+            crate::types::TypeData::SpecialForm(special_form) => match special_form {
                 SpecialFormType::TypeQualifier(_) => None,
 
                 SpecialFormType::Annotated

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1180,7 +1180,7 @@ impl<'db> Constraint<'db> {
         //   T ≤ (α & β)   ⇔ (T ≤ α) ∧ (T ≤ β)
         //   T ≤ (¬α & ¬β) ⇔ (T ≤ ¬α) ∧ (T ≤ ¬β)
         //   (α | β) ≤ T   ⇔ (α ≤ T) ∧ (β ≤ T)
-        if let Some(Type::Union(lower_union)) = lower {
+        if let Some(crate::types::TypeData::Union(lower_union)) = lower.map(Type::data) {
             let mut result = ALWAYS_TRUE;
             for lower_element in lower_union.elements(db) {
                 result = result.and_with_offset(
@@ -1199,7 +1199,8 @@ impl<'db> Constraint<'db> {
         // A negated type ¬α is represented as an intersection with no positive elements, and a
         // single negative element. We _don't_ want to treat that an "intersection" for the
         // purposes of simplifying upper bounds.
-        if let Some(Type::Intersection(upper_intersection)) = upper
+        if let Some(crate::types::TypeData::Intersection(upper_intersection)) =
+            upper.map(Type::data)
             && !upper_intersection.is_simple_negation(db)
         {
             let mut result = ALWAYS_TRUE;
@@ -1232,13 +1233,13 @@ impl<'db> Constraint<'db> {
 
         // Two identical typevars must always solve to the same type, so it is not useful to have
         // an upper or lower bound that is the typevar being constrained.
-        match lower {
-            Some(Type::TypeVar(lower_bound_typevar))
+        match lower.map(Type::data) {
+            Some(crate::types::TypeData::TypeVar(lower_bound_typevar))
                 if typevar.is_same_typevar_as(db, lower_bound_typevar) =>
             {
                 lower = None;
             }
-            Some(Type::Intersection(intersection))
+            Some(crate::types::TypeData::Intersection(intersection))
                 if intersection.positive(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
@@ -1247,7 +1248,7 @@ impl<'db> Constraint<'db> {
             {
                 lower = None;
             }
-            Some(Type::Intersection(intersection))
+            Some(crate::types::TypeData::Intersection(intersection))
                 if intersection.negative(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
@@ -1263,13 +1264,13 @@ impl<'db> Constraint<'db> {
             }
             _ => {}
         }
-        match upper {
-            Some(Type::TypeVar(upper_bound_typevar))
+        match upper.map(Type::data) {
+            Some(crate::types::TypeData::TypeVar(upper_bound_typevar))
                 if typevar.is_same_typevar_as(db, upper_bound_typevar) =>
             {
                 upper = None;
             }
-            Some(Type::Union(union))
+            Some(crate::types::TypeData::Union(union))
                 if union.elements(db).iter().any(|element| {
                     element.as_typevar().is_some_and(|element_bound_typevar| {
                         typevar.is_same_typevar_as(db, element_bound_typevar)
@@ -1302,9 +1303,21 @@ impl<'db> Constraint<'db> {
         //
         // In the comments below, we use brackets to indicate which typevar is "earlier", and
         // therefore the typevar that the constraint applies to.
-        match (effective_lower, effective_upper) {
+        match (
+            ({
+                let __ty_view_value = effective_lower;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = effective_upper;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
             // L ≤ T ≤ L == (T ≤ [L] ≤ T)
-            (Type::TypeVar(lower), Type::TypeVar(upper)) if lower.is_same_typevar_as(db, upper) => {
+            (
+                (_, crate::types::TypeData::TypeVar(lower)),
+                (_, crate::types::TypeData::TypeVar(upper)),
+            ) if lower.is_same_typevar_as(db, upper) => {
                 let (bound, typevar) = if lower.can_be_bound_for(db, builder, typevar) {
                     (lower, typevar)
                 } else {
@@ -1324,9 +1337,11 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
-            (Type::TypeVar(lower), Type::TypeVar(upper))
-                if typevar.can_be_bound_for(db, builder, lower)
-                    && typevar.can_be_bound_for(db, builder, upper) =>
+            (
+                (_, crate::types::TypeData::TypeVar(lower)),
+                (_, crate::types::TypeData::TypeVar(upper)),
+            ) if typevar.can_be_bound_for(db, builder, lower)
+                && typevar.can_be_bound_for(db, builder, upper) =>
             {
                 let lower = Node::new_constraint(
                     builder,
@@ -1354,7 +1369,9 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
-            (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
+            ((_, crate::types::TypeData::TypeVar(lower)), (_, _))
+                if typevar.can_be_bound_for(db, builder, lower) =>
+            {
                 let lower = Node::new_constraint(
                     builder,
                     ConstraintId::new_with_bounds(
@@ -1375,7 +1392,9 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
-            (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, builder, upper) => {
+            ((_, _), (_, crate::types::TypeData::TypeVar(upper)))
+                if typevar.can_be_bound_for(db, builder, upper) =>
+            {
                 let lower = if lower.is_none() {
                     ALWAYS_TRUE
                 } else {
@@ -2389,21 +2408,34 @@ impl NodeId {
         // these types are coming in from arbitrary subtyping checks that the caller might want to
         // perform. So we have to take the appropriate materialization when translating the check
         // into a constraint.
-        let constraint = match (lhs, rhs) {
-            (Type::TypeVar(bound_typevar), _) => Constraint::new_node_with_bounds(
-                db,
-                builder,
-                bound_typevar,
-                None,
-                Some(rhs.bottom_materialization(db)),
-            ),
-            (_, Type::TypeVar(bound_typevar)) => Constraint::new_node_with_bounds(
-                db,
-                builder,
-                bound_typevar,
-                Some(lhs.top_materialization(db)),
-                None,
-            ),
+        let constraint = match (
+            ({
+                let __ty_view_value = lhs;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = rhs;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
+            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _)) => {
+                Constraint::new_node_with_bounds(
+                    db,
+                    builder,
+                    bound_typevar,
+                    None,
+                    Some(rhs.bottom_materialization(db)),
+                )
+            }
+            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar))) => {
+                Constraint::new_node_with_bounds(
+                    db,
+                    builder,
+                    bound_typevar,
+                    Some(lhs.top_materialization(db)),
+                    None,
+                )
+            }
             _ => panic!("at least one type should be a typevar"),
         };
 
@@ -3142,7 +3174,10 @@ impl<'db> PathBounds<'db> {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_lower(db, lower);
 
-                    if let Type::TypeVar(lower_bound_typevar) = lower {
+                    if let (_, crate::types::TypeData::TypeVar(lower_bound_typevar)) = {
+                        let __ty_view_value = lower;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
                         let bounds = mappings.entry(lower_bound_typevar).or_default();
                         bounds.add_upper(db, Type::TypeVar(typevar));
                     }
@@ -3152,7 +3187,10 @@ impl<'db> PathBounds<'db> {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_upper(db, upper);
 
-                    if let Type::TypeVar(upper_bound_typevar) = upper {
+                    if let (_, crate::types::TypeData::TypeVar(upper_bound_typevar)) = {
+                        let __ty_view_value = upper;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
                         let bounds = mappings.entry(upper_bound_typevar).or_default();
                         bounds.add_lower(db, Type::TypeVar(typevar));
                     }
@@ -3517,9 +3555,14 @@ impl InteriorNode {
         drop(storage);
 
         let mut path = self.path_assignments(builder);
-        let mentions_typevar = |ty: Type<'db>| match ty {
-            Type::TypeVar(haystack) => haystack.identity(db) == bound_typevar,
-            _ => false,
+        let mentions_typevar = |ty: Type<'db>| match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeVar(haystack)) => {
+                haystack.identity(db) == bound_typevar
+            }
+            (_, _) => false,
         };
         let result = self.abstract_one_inner(
             db,
@@ -3949,16 +3992,16 @@ impl InteriorNode {
                 // bound matches the "bound" typevar. If so, we're going to add an implication to
                 // the constraint set that replaces the upper/lower bound that matched with the
                 // bound constraint's corresponding bound.
+                let constrained_lower = constrained_constraint_data.bounds.lower;
+                let constrained_upper = constrained_constraint_data.bounds.upper;
                 let (new_lower, new_upper) = match (
-                    constrained_constraint_data.bounds.lower,
-                    constrained_constraint_data.bounds.upper,
+                    constrained_lower.and_then(Type::as_typevar),
+                    constrained_upper.and_then(Type::as_typevar),
                 ) {
                     // (B ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ BU)
-                    (
-                        Some(Type::TypeVar(constrained_lower)),
-                        Some(Type::TypeVar(constrained_upper)),
-                    ) if constrained_lower.is_same_typevar_as(db, bound_typevar)
-                        && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
+                    (Some(constrained_lower), Some(constrained_upper))
+                        if constrained_lower.is_same_typevar_as(db, bound_typevar)
+                            && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
                     {
                         (
                             bound_constraint_data.bounds.lower,
@@ -3967,14 +4010,14 @@ impl InteriorNode {
                     }
 
                     // (CL ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (CL ≤ C ≤ BU)
-                    (constrained_lower, Some(Type::TypeVar(constrained_upper)))
+                    (_, Some(constrained_upper))
                         if constrained_upper.is_same_typevar_as(db, bound_typevar) =>
                     {
                         (constrained_lower, bound_constraint_data.bounds.upper)
                     }
 
                     // (B ≤ C ≤ CU) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ CU)
-                    (Some(Type::TypeVar(constrained_lower)), constrained_upper)
+                    (Some(constrained_lower), _)
                         if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
                     {
                         (bound_constraint_data.bounds.lower, constrained_upper)
@@ -4475,7 +4518,10 @@ impl ConstraintAssignment {
                     // If this typevar is equivalent to another, output the constraint in a
                     // consistent alphabetical order, regardless of the salsa ordering that we are
                     // using the in BDD.
-                    if let Type::TypeVar(bound) = lower {
+                    if let (_, crate::types::TypeData::TypeVar(bound)) = {
+                        let __ty_view_value = lower;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
                         let bound = bound.identity(self.db).display(self.db).to_string();
                         let typevar = typevar.identity(self.db).display(self.db).to_string();
                         let (smaller, larger) = if bound < typevar {
@@ -5020,20 +5066,22 @@ impl SequentMap {
 
         // Transitive pivots require subtyping; classes with dynamic bases can be assignable to
         // unrelated types without being subtypes.
+        let constrained_lower = constrained_constraint_data.bounds.lower;
+        let constrained_upper = constrained_constraint_data.bounds.upper;
+        let bound_lower = bound_constraint_data.bounds.lower;
+        let bound_upper = bound_constraint_data.bounds.upper;
         let (new_lower, new_upper) = match (
-            constrained_constraint_data.bounds.lower,
-            constrained_constraint_data.bounds.upper,
-            bound_constraint_data.bounds.lower,
-            bound_constraint_data.bounds.upper,
+            constrained_lower,
+            constrained_upper,
+            bound_lower,
+            bound_upper,
+            constrained_lower.and_then(Type::as_typevar),
+            constrained_upper.and_then(Type::as_typevar),
         ) {
             // (B ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ BU)
-            (
-                Some(Type::TypeVar(constrained_lower)),
-                Some(Type::TypeVar(constrained_upper)),
-                _,
-                _,
-            ) if constrained_lower.is_same_typevar_as(db, bound_typevar)
-                && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
+            (_, _, _, _, Some(constrained_lower), Some(constrained_upper))
+                if constrained_lower.is_same_typevar_as(db, bound_typevar)
+                    && constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
                 (
                     bound_constraint_data.bounds.lower,
@@ -5042,21 +5090,21 @@ impl SequentMap {
             }
 
             // (CL ≤ C ≤ B) ∧ (BL ≤ B ≤ BU) → (CL ≤ C ≤ BU)
-            (constrained_lower, Some(Type::TypeVar(constrained_upper)), _, _)
+            (constrained_lower, _, _, _, _, Some(constrained_upper))
                 if constrained_upper.is_same_typevar_as(db, bound_typevar) =>
             {
                 (constrained_lower, bound_constraint_data.bounds.upper)
             }
 
             // (B ≤ C ≤ CU) ∧ (BL ≤ B ≤ BU) → (BL ≤ C ≤ CU)
-            (Some(Type::TypeVar(constrained_lower)), constrained_upper, _, _)
+            (_, constrained_upper, _, _, Some(constrained_lower), _)
                 if constrained_lower.is_same_typevar_as(db, bound_typevar) =>
             {
                 (bound_constraint_data.bounds.lower, constrained_upper)
             }
 
             // (CL ≤ C ≤ pivot) ∧ (pivot ≤ B ≤ BU) → (CL ≤ C ≤ B)
-            (constrained_lower, Some(constrained_upper), Some(bound_lower), _)
+            (constrained_lower, Some(constrained_upper), Some(bound_lower), _, _, _)
                 if !constrained_upper.is_never()
                     && !constrained_upper.is_object()
                     && builder.cached_is_constraint_set_subtype_of(
@@ -5069,7 +5117,7 @@ impl SequentMap {
             }
 
             // (pivot ≤ C ≤ CU) ∧ (BL ≤ B ≤ pivot) → (B ≤ C ≤ CU)
-            (Some(constrained_lower), constrained_upper, _, Some(bound_upper))
+            (Some(constrained_lower), constrained_upper, _, Some(bound_upper), _, _)
                 if !constrained_lower.is_never()
                     && !constrained_lower.is_object()
                     && builder.cached_is_constraint_set_subtype_of(
@@ -5107,7 +5155,7 @@ impl SequentMap {
         // `T` in this ordering, we emit two pair implications:
         //   `(Never ≤ [A] ≤ T)` and `(T ≤ [B] ≤ object)`.
         // This preserves the relationship while keeping all derived constraints canonical.
-        if let Some(Type::TypeVar(lower_bound_typevar)) = new_lower
+        if let Some(lower_bound_typevar) = new_lower.and_then(Type::as_typevar)
             && !lower_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5120,7 +5168,7 @@ impl SequentMap {
             constrained_lower = None;
         }
 
-        if let Some(Type::TypeVar(upper_bound_typevar)) = new_upper
+        if let Some(upper_bound_typevar) = new_upper.and_then(Type::as_typevar)
             && !upper_bound_typevar.can_be_bound_for(db, builder, constrained_typevar)
         {
             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5538,12 +5586,12 @@ impl SequentMap {
                     |bound_typevar: BoundTypeVarInstance<'db>,
                      mut right_lower: Option<Type<'db>>,
                      mut right_upper: Option<Type<'db>>| {
-                        if let Some(Type::TypeVar(other_bound_typevar)) = right_lower
+                        if let Some(other_bound_typevar) = right_lower.and_then(Type::as_typevar)
                             && bound_typevar.is_same_typevar_as(db, other_bound_typevar)
                         {
                             right_lower = None;
                         }
-                        if let Some(Type::TypeVar(other_bound_typevar)) = right_upper
+                        if let Some(other_bound_typevar) = right_upper.and_then(Type::as_typevar)
                             && bound_typevar.is_same_typevar_as(db, other_bound_typevar)
                         {
                             right_upper = None;
@@ -5561,7 +5609,7 @@ impl SequentMap {
                         let mut constrained_lower = right_lower.filter(|lower| !lower.is_never());
                         let mut constrained_upper = right_upper.filter(|upper| !upper.is_object());
 
-                        if let Some(Type::TypeVar(lower_bound_typevar)) = right_lower
+                        if let Some(lower_bound_typevar) = right_lower.and_then(Type::as_typevar)
                             && !lower_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5574,7 +5622,7 @@ impl SequentMap {
                             constrained_lower = None;
                         }
 
-                        if let Some(Type::TypeVar(upper_bound_typevar)) = right_upper
+                        if let Some(upper_bound_typevar) = right_upper.and_then(Type::as_typevar)
                             && !upper_bound_typevar.can_be_bound_for(db, builder, bound_typevar)
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
@@ -5601,19 +5649,17 @@ impl SequentMap {
 
                         post_constraints
                     };
-                let post_constraints = match (left_lower, left_upper) {
-                    (
-                        Some(Type::TypeVar(bound_typevar)),
-                        Some(Type::TypeVar(other_bound_typevar)),
-                    ) if bound_typevar.is_same_typevar_as(db, other_bound_typevar) => {
+                let post_constraints = match (
+                    left_lower.and_then(Type::as_typevar),
+                    left_upper.and_then(Type::as_typevar),
+                ) {
+                    (Some(bound_typevar), Some(other_bound_typevar))
+                        if bound_typevar.is_same_typevar_as(db, other_bound_typevar) =>
+                    {
                         new_constraints(bound_typevar, right_lower, right_upper)
                     }
-                    (Some(Type::TypeVar(bound_typevar)), _) => {
-                        new_constraints(bound_typevar, None, right_upper)
-                    }
-                    (_, Some(Type::TypeVar(bound_typevar))) => {
-                        new_constraints(bound_typevar, right_lower, None)
-                    }
+                    (Some(bound_typevar), _) => new_constraints(bound_typevar, None, right_upper),
+                    (_, Some(bound_typevar)) => new_constraints(bound_typevar, right_lower, None),
                     _ => return,
                 };
                 for post_constraint in post_constraints {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -1303,21 +1303,11 @@ impl<'db> Constraint<'db> {
         //
         // In the comments below, we use brackets to indicate which typevar is "earlier", and
         // therefore the typevar that the constraint applies to.
-        match (
-            ({
-                let __ty_view_value = effective_lower;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = effective_upper;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (effective_lower.data(), effective_upper.data()) {
             // L ≤ T ≤ L == (T ≤ [L] ≤ T)
-            (
-                (_, crate::types::TypeData::TypeVar(lower)),
-                (_, crate::types::TypeData::TypeVar(upper)),
-            ) if lower.is_same_typevar_as(db, upper) => {
+            (crate::types::TypeData::TypeVar(lower), crate::types::TypeData::TypeVar(upper))
+                if lower.is_same_typevar_as(db, upper) =>
+            {
                 let (bound, typevar) = if lower.can_be_bound_for(db, builder, typevar) {
                     (lower, typevar)
                 } else {
@@ -1337,11 +1327,9 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
-            (
-                (_, crate::types::TypeData::TypeVar(lower)),
-                (_, crate::types::TypeData::TypeVar(upper)),
-            ) if typevar.can_be_bound_for(db, builder, lower)
-                && typevar.can_be_bound_for(db, builder, upper) =>
+            (crate::types::TypeData::TypeVar(lower), crate::types::TypeData::TypeVar(upper))
+                if typevar.can_be_bound_for(db, builder, lower)
+                    && typevar.can_be_bound_for(db, builder, upper) =>
             {
                 let lower = Node::new_constraint(
                     builder,
@@ -1369,7 +1357,7 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
-            ((_, crate::types::TypeData::TypeVar(lower)), (_, _))
+            (crate::types::TypeData::TypeVar(lower), _)
                 if typevar.can_be_bound_for(db, builder, lower) =>
             {
                 let lower = Node::new_constraint(
@@ -1392,7 +1380,7 @@ impl<'db> Constraint<'db> {
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
-            ((_, _), (_, crate::types::TypeData::TypeVar(upper)))
+            (_, crate::types::TypeData::TypeVar(upper))
                 if typevar.can_be_bound_for(db, builder, upper) =>
             {
                 let lower = if lower.is_none() {
@@ -2408,17 +2396,8 @@ impl NodeId {
         // these types are coming in from arbitrary subtyping checks that the caller might want to
         // perform. So we have to take the appropriate materialization when translating the check
         // into a constraint.
-        let constraint = match (
-            ({
-                let __ty_view_value = lhs;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = rhs;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
-            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _)) => {
+        let constraint = match (lhs.data(), rhs.data()) {
+            (crate::types::TypeData::TypeVar(bound_typevar), _) => {
                 Constraint::new_node_with_bounds(
                     db,
                     builder,
@@ -2427,7 +2406,7 @@ impl NodeId {
                     Some(rhs.bottom_materialization(db)),
                 )
             }
-            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar))) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 Constraint::new_node_with_bounds(
                     db,
                     builder,
@@ -3174,10 +3153,7 @@ impl<'db> PathBounds<'db> {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_lower(db, lower);
 
-                    if let (_, crate::types::TypeData::TypeVar(lower_bound_typevar)) = {
-                        let __ty_view_value = lower;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    if let crate::types::TypeData::TypeVar(lower_bound_typevar) = lower.data() {
                         let bounds = mappings.entry(lower_bound_typevar).or_default();
                         bounds.add_upper(db, Type::TypeVar(typevar));
                     }
@@ -3187,10 +3163,7 @@ impl<'db> PathBounds<'db> {
                     let bounds = mappings.entry(typevar).or_default();
                     bounds.add_upper(db, upper);
 
-                    if let (_, crate::types::TypeData::TypeVar(upper_bound_typevar)) = {
-                        let __ty_view_value = upper;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    if let crate::types::TypeData::TypeVar(upper_bound_typevar) = upper.data() {
                         let bounds = mappings.entry(upper_bound_typevar).or_default();
                         bounds.add_lower(db, Type::TypeVar(typevar));
                     }
@@ -3555,14 +3528,9 @@ impl InteriorNode {
         drop(storage);
 
         let mut path = self.path_assignments(builder);
-        let mentions_typevar = |ty: Type<'db>| match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeVar(haystack)) => {
-                haystack.identity(db) == bound_typevar
-            }
-            (_, _) => false,
+        let mentions_typevar = |ty: Type<'db>| match ty.data() {
+            crate::types::TypeData::TypeVar(haystack) => haystack.identity(db) == bound_typevar,
+            _ => false,
         };
         let result = self.abstract_one_inner(
             db,
@@ -4518,10 +4486,7 @@ impl ConstraintAssignment {
                     // If this typevar is equivalent to another, output the constraint in a
                     // consistent alphabetical order, regardless of the salsa ordering that we are
                     // using the in BDD.
-                    if let (_, crate::types::TypeData::TypeVar(bound)) = {
-                        let __ty_view_value = lower;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    if let crate::types::TypeData::TypeVar(bound) = lower.data() {
                         let bound = bound.identity(self.db).display(self.db).to_string();
                         let typevar = typevar.identity(self.db).display(self.db).to_string();
                         let (smaller, larger) = if bound < typevar {

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -123,26 +123,17 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
             return true;
         }
 
-        match (
-            ({
-                let __ty_view_value = left;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = right;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (left.data(), right.data()) {
             // We can create a self-referential function type: e.g. `def f(x: "TypeOf[f]"): reveal_type(x)`
             // To avoid the difficulty of equality checking for function types containing this, we simply use `literal` for equality checking.
             (
-                (_, crate::types::TypeData::FunctionLiteral(left)),
-                (_, crate::types::TypeData::FunctionLiteral(right)),
+                crate::types::TypeData::FunctionLiteral(left),
+                crate::types::TypeData::FunctionLiteral(right),
             ) => left.literal(db) == right.literal(db),
             // Similarly, we can create a self-referential NewType: e.g. `T = NewType("T", list["T"])`
             (
-                (_, crate::types::TypeData::NewTypeInstance(left)),
-                (_, crate::types::TypeData::NewTypeInstance(right)),
+                crate::types::TypeData::NewTypeInstance(left),
+                crate::types::TypeData::NewTypeInstance(right),
             ) => left.definition(db) == right.definition(db),
             _ => false,
         }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -123,16 +123,27 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
             return true;
         }
 
-        match (left, right) {
+        match (
+            ({
+                let __ty_view_value = left;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = right;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
             // We can create a self-referential function type: e.g. `def f(x: "TypeOf[f]"): reveal_type(x)`
             // To avoid the difficulty of equality checking for function types containing this, we simply use `literal` for equality checking.
-            (Type::FunctionLiteral(left), Type::FunctionLiteral(right)) => {
-                left.literal(db) == right.literal(db)
-            }
+            (
+                (_, crate::types::TypeData::FunctionLiteral(left)),
+                (_, crate::types::TypeData::FunctionLiteral(right)),
+            ) => left.literal(db) == right.literal(db),
             // Similarly, we can create a self-referential NewType: e.g. `T = NewType("T", list["T"])`
-            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
-                left.definition(db) == right.definition(db)
-            }
+            (
+                (_, crate::types::TypeData::NewTypeInstance(left)),
+                (_, crate::types::TypeData::NewTypeInstance(right)),
+            ) => left.definition(db) == right.definition(db),
             _ => false,
         }
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2037,11 +2037,8 @@ pub(super) fn report_missing_type_arguments<'db>(
     ty: Type<'db>,
     annotation: &ast::Expr,
 ) {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class)) => {
+    match ty.data() {
+        crate::types::TypeData::ClassLiteral(class) => {
             let db = context.db();
 
             let Some(generic_context) = class.generic_context(db) else {
@@ -2076,11 +2073,8 @@ pub(super) fn report_missing_type_arguments<'db>(
                 }
             }
         }
-        (
-            _,
-            crate::types::TypeData::SpecialForm(
-                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable,
-            ),
+        crate::types::TypeData::SpecialForm(
+            SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable,
         ) => {
             if let Some(builder) = context.report_lint(&MISSING_TYPE_ARGUMENT, annotation) {
                 builder.into_diagnostic(format_args!(
@@ -2089,7 +2083,7 @@ pub(super) fn report_missing_type_arguments<'db>(
                 ));
             }
         }
-        (_, _) => {}
+        _ => {}
     }
 }
 
@@ -3755,23 +3749,20 @@ fn report_invalid_assignment_with_message<'db, 'ctx: 'db, T: Ranged>(
 
     let mut diag = builder.into_diagnostic(message);
 
-    match {
-        let __ty_view_value = target_ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class)) => {
+    match target_ty.data() {
+        crate::types::TypeData::ClassLiteral(class) => {
             diag.info(format_args!(
                 "Implicit shadowing of class `{}`. Add an annotation to make it explicit if this is intentional",
                 class.name(context.db()),
             ));
         }
-        (_, crate::types::TypeData::FunctionLiteral(function)) => {
+        crate::types::TypeData::FunctionLiteral(function) => {
             diag.info(format_args!(
                 "Implicit shadowing of function `{}`. Add an annotation to make it explicit if this is intentional",
                 function.name(context.db()),
             ));
         }
-        (_, _) => {}
+        _ => {}
     }
     Some(diag)
 }
@@ -3785,10 +3776,7 @@ pub(super) fn note_numbers_module_not_supported<'db>(
     const BUILTIN_NUMBERS: [KnownClass; 3] =
         [KnownClass::Int, KnownClass::Float, KnownClass::Complex];
 
-    if let (_, crate::types::TypeData::NominalInstance(target_instance)) = {
-        let __ty_view_value = target_ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    if let crate::types::TypeData::NominalInstance(target_instance) = target_ty.data() {
         let file = target_instance.class(db).class_literal(db).file(db);
         if let Some(module) = file_to_module(db, file)
             && module.is_known(db, KnownModule::Numbers)
@@ -4361,25 +4349,20 @@ pub(super) fn report_possibly_missing_attribute(
         return;
     };
     let db = context.db();
-    match {
-        let __ty_view_value = object_ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ModuleLiteral(module)) => {
-            builder.into_diagnostic(format_args!(
-                "Member `{attribute}` may be missing on module `{}`",
-                module.module(db).name(db),
-            ))
-        }
-        (_, crate::types::TypeData::ClassLiteral(class)) => builder.into_diagnostic(format_args!(
+    match object_ty.data() {
+        crate::types::TypeData::ModuleLiteral(module) => builder.into_diagnostic(format_args!(
+            "Member `{attribute}` may be missing on module `{}`",
+            module.module(db).name(db),
+        )),
+        crate::types::TypeData::ClassLiteral(class) => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on class `{}`",
             class.name(db),
         )),
-        (_, crate::types::TypeData::GenericAlias(alias)) => builder.into_diagnostic(format_args!(
+        crate::types::TypeData::GenericAlias(alias) => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on class `{}`",
             alias.display(db),
         )),
-        (_, _) => builder.into_diagnostic(format_args!(
+        _ => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on object of type `{}`",
             object_ty.display(db),
         )),
@@ -5112,31 +5095,24 @@ pub(crate) fn report_undeclared_protocol_member(
     /// because the user almost certainly doesn't want to write `x: None = None`.
     /// We also want to avoid suggesting invalid syntax such as `x: <class 'int'> = int`.
     fn should_give_hint<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        let class = match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
-                    inner: Protocol::FromClass(_),
-                    ..
-                }),
-            ) => return true,
-            (_, crate::types::TypeData::SubclassOf(subclass_of)) => match subclass_of.subclass_of()
-            {
+        let class = match ty.data() {
+            crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::FromClass(_),
+                ..
+            }) => return true,
+            crate::types::TypeData::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Class(class) => class,
                 SubclassOfInner::Dynamic(DynamicType::Any) => return true,
                 SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => return false,
             },
-            (_, crate::types::TypeData::NominalInstance(instance)) => instance.class(db),
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::NominalInstance(instance) => instance.class(db),
+            crate::types::TypeData::Union(union) => {
                 return union
                     .elements(db)
                     .iter()
                     .all(|elem| should_give_hint(db, *elem));
             }
-            (_, _) => return false,
+            _ => return false,
         };
 
         !matches!(
@@ -5263,10 +5239,9 @@ pub(crate) fn report_invalid_or_unsupported_base(
         return;
     }
 
-    if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) = {
-        let __ty_view_value = base_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    if let crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype)) =
+        base_type.data()
+    {
         let Some(builder) = context.report_lint(&INVALID_BASE, base_node) else {
             return;
         };
@@ -5713,16 +5688,10 @@ pub(crate) fn report_invalid_type_param_order<'db>(
         .iter()
         .position(|base| {
             matches!(
-                {
-                    let __ty_view_value = base;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(
-                        KnownInstanceType::SubscriptedProtocol(_)
-                            | KnownInstanceType::SubscriptedGeneric(_)
-                    )
+                base.data(),
+                crate::types::TypeData::KnownInstance(
+                    KnownInstanceType::SubscriptedProtocol(_)
+                        | KnownInstanceType::SubscriptedGeneric(_)
                 )
             )
         })
@@ -5861,17 +5830,12 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
         FxHashMap::<StaticClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
 
     'outer: for (i, base) in explicit_bases.iter().enumerate() {
-        let base_class = match {
-            let __ty_view_value = base;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::GenericAlias(alias)) => ClassType::Generic(alias),
-            (_, crate::types::TypeData::ClassLiteral(class))
-                if class.generic_context(db).is_none() =>
-            {
+        let base_class = match base.data() {
+            crate::types::TypeData::GenericAlias(alias) => ClassType::Generic(alias),
+            crate::types::TypeData::ClassLiteral(class) if class.generic_context(db).is_none() => {
                 ClassType::NonGeneric(class)
             }
-            (_, _) => continue,
+            _ => continue,
         };
 
         for supercls in base_class.iter_mro(db) {
@@ -5898,8 +5862,8 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                         origin.name(db)
                     ));
                     let later_is_direct = matches!(
-                        { let __ty_view_value = base; (__ty_view_value, __ty_view_value.data()) } ,
-                        (_, crate::types::TypeData::GenericAlias(alias)) if alias.origin(db) == origin
+                        base.data() ,
+                        crate::types::TypeData::GenericAlias(alias) if alias.origin(db) == origin
                     );
 
                     if let (Some(earlier_base), Some(later_base)) = (
@@ -5982,13 +5946,10 @@ pub(crate) fn report_shadowed_type_variable<'db>(
     let Some(other_definition) = other_typevar.binding_context(db).definition() else {
         return;
     };
-    let span = match {
-        let __ty_view_value = binding_type(db, other_definition);
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class)) => class.header_span(db),
-        (_, crate::types::TypeData::FunctionLiteral(function)) => function.spans(db).signature,
-        (_, _) => return,
+    let span = match binding_type(db, other_definition).data() {
+        crate::types::TypeData::ClassLiteral(class) => class.header_span(db),
+        crate::types::TypeData::FunctionLiteral(function) => function.spans(db).signature,
+        _ => return,
     };
     diagnostic.annotate(Annotation::secondary(span).message(format_args!(
         "Type variable `{typevar_name}` is bound in this enclosing scope",
@@ -6109,17 +6070,14 @@ pub(super) fn report_invalid_method_override<'db>(
                         .full_range(db, &parsed_module(db, superclass_scope.file(db)).load(db)),
                 );
 
-                let superclass_function_span = match {
-                    let __ty_view_value = superclass_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                let superclass_function_span = match superclass_type.data() {
+                    crate::types::TypeData::FunctionLiteral(function) => {
                         Some(signature_span(function))
                     }
-                    (_, crate::types::TypeData::BoundMethod(method)) => {
+                    crate::types::TypeData::BoundMethod(method) => {
                         Some(signature_span(method.function(db)))
                     }
-                    (_, _) => None,
+                    _ => None,
                 };
 
                 let superclass_definition_kind = definition.kind(db);
@@ -6209,10 +6167,7 @@ pub(super) fn report_overridden_final_method<'db>(
 
     // Some hijinks so that we emit a diagnostic on the property getter rather than the property setter
     let property_getter_definition = if subclass_definition.kind(db).is_function_def()
-        && let (_, crate::types::TypeData::PropertyInstance(property)) = ({
-            let __ty_view_value = subclass_type;
-            (__ty_view_value, __ty_view_value.data())
-        })
+        && let crate::types::TypeData::PropertyInstance(property) = subclass_type.data()
         && let Some(getter) = property.getter(db).and_then(Type::as_function_literal)
     {
         let getter_definition = getter.definition(db);
@@ -6294,10 +6249,8 @@ pub(super) fn report_overridden_final_method<'db>(
     // We also only provide autofixes if the subclass member is a function definition (not an
     // assignment like `method = some_function`). If it's an assignment, the function type
     // might be from a different file, and the autofix should delete the assignment instead, which we don't handle today.
-    if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-        let __ty_view_value = subclass_type;
-        (__ty_view_value, __ty_view_value.data())
-    }) && subclass_definition.kind(db).is_function_def()
+    if let crate::types::TypeData::FunctionLiteral(function) = subclass_type.data()
+        && subclass_definition.kind(db).is_function_def()
     {
         let Some((subclass_literal, _)) = subclass.static_class_literal(db) else {
             return;
@@ -6378,10 +6331,8 @@ pub(super) fn report_overridden_final_method<'db>(
                 );
             }
         }
-    } else if let (_, crate::types::TypeData::PropertyInstance(property)) = ({
-        let __ty_view_value = subclass_type;
-        (__ty_view_value, __ty_view_value.data())
-    }) && property.setter(db).is_some()
+    } else if let crate::types::TypeData::PropertyInstance(property) = subclass_type.data()
+        && property.setter(db).is_some()
     {
         diagnostic.help(format_args!("Remove the getter and setter for `{member}`"));
     } else {
@@ -6851,10 +6802,7 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // Currently we limit this analysis to attributes of stdlib modules,
     // as this covers the most important cases while not being too noisy
     // about basic typos or special types like `super(C, self)`
-    let (_, crate::types::TypeData::ModuleLiteral(module_ty)) = ({
-        let __ty_view_value = value_type;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::ModuleLiteral(module_ty) = value_type.data() else {
         return;
     };
     let module = module_ty.module(db);

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2037,8 +2037,11 @@ pub(super) fn report_missing_type_arguments<'db>(
     ty: Type<'db>,
     annotation: &ast::Expr,
 ) {
-    match ty {
-        Type::ClassLiteral(class) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class)) => {
             let db = context.db();
 
             let Some(generic_context) = class.generic_context(db) else {
@@ -2073,8 +2076,11 @@ pub(super) fn report_missing_type_arguments<'db>(
                 }
             }
         }
-        Type::SpecialForm(
-            SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable,
+        (
+            _,
+            crate::types::TypeData::SpecialForm(
+                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable,
+            ),
         ) => {
             if let Some(builder) = context.report_lint(&MISSING_TYPE_ARGUMENT, annotation) {
                 builder.into_diagnostic(format_args!(
@@ -2083,7 +2089,7 @@ pub(super) fn report_missing_type_arguments<'db>(
                 ));
             }
         }
-        _ => {}
+        (_, _) => {}
     }
 }
 
@@ -3749,20 +3755,23 @@ fn report_invalid_assignment_with_message<'db, 'ctx: 'db, T: Ranged>(
 
     let mut diag = builder.into_diagnostic(message);
 
-    match target_ty {
-        Type::ClassLiteral(class) => {
+    match {
+        let __ty_view_value = target_ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class)) => {
             diag.info(format_args!(
                 "Implicit shadowing of class `{}`. Add an annotation to make it explicit if this is intentional",
                 class.name(context.db()),
             ));
         }
-        Type::FunctionLiteral(function) => {
+        (_, crate::types::TypeData::FunctionLiteral(function)) => {
             diag.info(format_args!(
                 "Implicit shadowing of function `{}`. Add an annotation to make it explicit if this is intentional",
                 function.name(context.db()),
             ));
         }
-        _ => {}
+        (_, _) => {}
     }
     Some(diag)
 }
@@ -3776,7 +3785,10 @@ pub(super) fn note_numbers_module_not_supported<'db>(
     const BUILTIN_NUMBERS: [KnownClass; 3] =
         [KnownClass::Int, KnownClass::Float, KnownClass::Complex];
 
-    if let Type::NominalInstance(target_instance) = target_ty {
+    if let (_, crate::types::TypeData::NominalInstance(target_instance)) = {
+        let __ty_view_value = target_ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
         let file = target_instance.class(db).class_literal(db).file(db);
         if let Some(module) = file_to_module(db, file)
             && module.is_known(db, KnownModule::Numbers)
@@ -4349,20 +4361,25 @@ pub(super) fn report_possibly_missing_attribute(
         return;
     };
     let db = context.db();
-    match object_ty {
-        Type::ModuleLiteral(module) => builder.into_diagnostic(format_args!(
-            "Member `{attribute}` may be missing on module `{}`",
-            module.module(db).name(db),
-        )),
-        Type::ClassLiteral(class) => builder.into_diagnostic(format_args!(
+    match {
+        let __ty_view_value = object_ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ModuleLiteral(module)) => {
+            builder.into_diagnostic(format_args!(
+                "Member `{attribute}` may be missing on module `{}`",
+                module.module(db).name(db),
+            ))
+        }
+        (_, crate::types::TypeData::ClassLiteral(class)) => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on class `{}`",
             class.name(db),
         )),
-        Type::GenericAlias(alias) => builder.into_diagnostic(format_args!(
+        (_, crate::types::TypeData::GenericAlias(alias)) => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on class `{}`",
             alias.display(db),
         )),
-        _ => builder.into_diagnostic(format_args!(
+        (_, _) => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on object of type `{}`",
             object_ty.display(db),
         )),
@@ -5095,24 +5112,31 @@ pub(crate) fn report_undeclared_protocol_member(
     /// because the user almost certainly doesn't want to write `x: None = None`.
     /// We also want to avoid suggesting invalid syntax such as `x: <class 'int'> = int`.
     fn should_give_hint<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        let class = match ty {
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(_),
-                ..
-            }) => return true,
-            Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
+        let class = match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
+                    inner: Protocol::FromClass(_),
+                    ..
+                }),
+            ) => return true,
+            (_, crate::types::TypeData::SubclassOf(subclass_of)) => match subclass_of.subclass_of()
+            {
                 SubclassOfInner::Class(class) => class,
                 SubclassOfInner::Dynamic(DynamicType::Any) => return true,
                 SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => return false,
             },
-            Type::NominalInstance(instance) => instance.class(db),
-            Type::Union(union) => {
+            (_, crate::types::TypeData::NominalInstance(instance)) => instance.class(db),
+            (_, crate::types::TypeData::Union(union)) => {
                 return union
                     .elements(db)
                     .iter()
                     .all(|elem| should_give_hint(db, *elem));
             }
-            _ => return false,
+            (_, _) => return false,
         };
 
         !matches!(
@@ -5239,7 +5263,10 @@ pub(crate) fn report_invalid_or_unsupported_base(
         return;
     }
 
-    if let Type::KnownInstance(KnownInstanceType::NewType(newtype)) = base_type {
+    if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) = {
+        let __ty_view_value = base_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
         let Some(builder) = context.report_lint(&INVALID_BASE, base_node) else {
             return;
         };
@@ -5422,8 +5449,12 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
 
                 let existing_keys = items.keys().map(Name::as_str);
 
-                if !matches!(full_object_ty, Some(Type::Union(_) | Type::Intersection(_)))
-                    && let Some(suggestion) = did_you_mean(existing_keys, key)
+                if !full_object_ty.is_some_and(|ty| {
+                    matches!(
+                        ty.data(),
+                        crate::types::TypeData::Union(_) | crate::types::TypeData::Intersection(_)
+                    )
+                }) && let Some(suggestion) = did_you_mean(existing_keys, key)
                 {
                     if let AnyNodeRef::ExprStringLiteral(literal) = key_node {
                         let quoted_suggestion = format!(
@@ -5682,10 +5713,16 @@ pub(crate) fn report_invalid_type_param_order<'db>(
         .iter()
         .position(|base| {
             matches!(
-                base,
-                Type::KnownInstance(
-                    KnownInstanceType::SubscriptedProtocol(_)
-                        | KnownInstanceType::SubscriptedGeneric(_)
+                {
+                    let __ty_view_value = base;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::SubscriptedProtocol(_)
+                            | KnownInstanceType::SubscriptedGeneric(_)
+                    )
                 )
             )
         })
@@ -5824,12 +5861,17 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
         FxHashMap::<StaticClassLiteral<'db>, (GenericAlias<'db>, usize)>::default();
 
     'outer: for (i, base) in explicit_bases.iter().enumerate() {
-        let base_class = match base {
-            Type::GenericAlias(alias) => ClassType::Generic(*alias),
-            Type::ClassLiteral(class) if class.generic_context(db).is_none() => {
-                ClassType::NonGeneric(*class)
+        let base_class = match {
+            let __ty_view_value = base;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::GenericAlias(alias)) => ClassType::Generic(alias),
+            (_, crate::types::TypeData::ClassLiteral(class))
+                if class.generic_context(db).is_none() =>
+            {
+                ClassType::NonGeneric(class)
             }
-            _ => continue,
+            (_, _) => continue,
         };
 
         for supercls in base_class.iter_mro(db) {
@@ -5856,8 +5898,8 @@ pub(crate) fn report_inconsistent_generic_bases<'db>(
                         origin.name(db)
                     ));
                     let later_is_direct = matches!(
-                        base,
-                        Type::GenericAlias(alias) if alias.origin(db) == origin
+                        { let __ty_view_value = base; (__ty_view_value, __ty_view_value.data()) } ,
+                        (_, crate::types::TypeData::GenericAlias(alias)) if alias.origin(db) == origin
                     );
 
                     if let (Some(earlier_base), Some(later_base)) = (
@@ -5940,10 +5982,13 @@ pub(crate) fn report_shadowed_type_variable<'db>(
     let Some(other_definition) = other_typevar.binding_context(db).definition() else {
         return;
     };
-    let span = match binding_type(db, other_definition) {
-        Type::ClassLiteral(class) => class.header_span(db),
-        Type::FunctionLiteral(function) => function.spans(db).signature,
-        _ => return,
+    let span = match {
+        let __ty_view_value = binding_type(db, other_definition);
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class)) => class.header_span(db),
+        (_, crate::types::TypeData::FunctionLiteral(function)) => function.spans(db).signature,
+        (_, _) => return,
     };
     diagnostic.annotate(Annotation::secondary(span).message(format_args!(
         "Type variable `{typevar_name}` is bound in this enclosing scope",
@@ -6013,13 +6058,14 @@ pub(super) fn report_invalid_method_override<'db>(
     };
 
     if let Place::Defined(DefinedPlace {
-        ty: Type::FunctionLiteral(subclass_function),
-        ..
+        ty: subclass_type, ..
     }) = class_member(subclass)
+        && let crate::types::TypeData::FunctionLiteral(subclass_function) = subclass_type.data()
         && let Place::Defined(DefinedPlace {
-            ty: Type::FunctionLiteral(superclass_function),
+            ty: superclass_type,
             ..
         }) = class_member(superclass)
+        && let crate::types::TypeData::FunctionLiteral(superclass_function) = superclass_type.data()
         && let Some(superclass_function_kind) =
             MethodDecorator::try_from_fn_type(db, superclass_function)
         && let Some(subclass_function_kind) =
@@ -6063,10 +6109,17 @@ pub(super) fn report_invalid_method_override<'db>(
                         .full_range(db, &parsed_module(db, superclass_scope.file(db)).load(db)),
                 );
 
-                let superclass_function_span = match superclass_type {
-                    Type::FunctionLiteral(function) => Some(signature_span(function)),
-                    Type::BoundMethod(method) => Some(signature_span(method.function(db))),
-                    _ => None,
+                let superclass_function_span = match {
+                    let __ty_view_value = superclass_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                        Some(signature_span(function))
+                    }
+                    (_, crate::types::TypeData::BoundMethod(method)) => {
+                        Some(signature_span(method.function(db)))
+                    }
+                    (_, _) => None,
                 };
 
                 let superclass_definition_kind = definition.kind(db);
@@ -6156,8 +6209,11 @@ pub(super) fn report_overridden_final_method<'db>(
 
     // Some hijinks so that we emit a diagnostic on the property getter rather than the property setter
     let property_getter_definition = if subclass_definition.kind(db).is_function_def()
-        && let Type::PropertyInstance(property) = subclass_type
-        && let Some(Type::FunctionLiteral(getter)) = property.getter(db)
+        && let (_, crate::types::TypeData::PropertyInstance(property)) = ({
+            let __ty_view_value = subclass_type;
+            (__ty_view_value, __ty_view_value.data())
+        })
+        && let Some(getter) = property.getter(db).and_then(Type::as_function_literal)
     {
         let getter_definition = getter.definition(db);
         if getter_definition.scope(db) == subclass_definition.scope(db) {
@@ -6238,8 +6294,10 @@ pub(super) fn report_overridden_final_method<'db>(
     // We also only provide autofixes if the subclass member is a function definition (not an
     // assignment like `method = some_function`). If it's an assignment, the function type
     // might be from a different file, and the autofix should delete the assignment instead, which we don't handle today.
-    if let Type::FunctionLiteral(function) = subclass_type
-        && subclass_definition.kind(db).is_function_def()
+    if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+        let __ty_view_value = subclass_type;
+        (__ty_view_value, __ty_view_value.data())
+    }) && subclass_definition.kind(db).is_function_def()
     {
         let Some((subclass_literal, _)) = subclass.static_class_literal(db) else {
             return;
@@ -6320,8 +6378,10 @@ pub(super) fn report_overridden_final_method<'db>(
                 );
             }
         }
-    } else if let Type::PropertyInstance(property) = subclass_type
-        && property.setter(db).is_some()
+    } else if let (_, crate::types::TypeData::PropertyInstance(property)) = ({
+        let __ty_view_value = subclass_type;
+        (__ty_view_value, __ty_view_value.data())
+    }) && property.setter(db).is_some()
     {
         diagnostic.help(format_args!("Remove the getter and setter for `{member}`"));
     } else {
@@ -6791,7 +6851,10 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // Currently we limit this analysis to attributes of stdlib modules,
     // as this covers the most important cases while not being too noisy
     // about basic typos or special types like `super(C, self)`
-    let Type::ModuleLiteral(module_ty) = value_type else {
+    let (_, crate::types::TypeData::ModuleLiteral(module_ty)) = ({
+        let __ty_view_value = value_type;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return;
     };
     let module = module_ty.module(db);

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -567,35 +567,27 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
     }
 
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class)) => self.record_class(db, class),
-            (_, crate::types::TypeData::LiteralValue(literal)) => {
+        match ty.data() {
+            crate::types::TypeData::ClassLiteral(class) => self.record_class(db, class),
+            crate::types::TypeData::LiteralValue(literal) => {
                 if let LiteralValueTypeKind::Enum(literal) = literal.kind() {
                     self.record_class(db, literal.enum_class(db));
                 }
             }
-            (_, crate::types::TypeData::GenericAlias(alias)) => {
+            crate::types::TypeData::GenericAlias(alias) => {
                 self.record_class(db, ClassLiteral::Static(alias.origin(db)));
             }
-            (_, crate::types::TypeData::TypeAlias(type_alias)) => {
-                self.record_type_alias(db, type_alias)
-            }
+            crate::types::TypeData::TypeAlias(type_alias) => self.record_type_alias(db, type_alias),
             // Visit the class (as if it were a nominal-instance type)
             // rather than the protocol members, if it is a class-based protocol.
             // (For the purposes of displaying the type, we'll use the class name.)
-            (
-                _,
-                crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
-                    inner: Protocol::FromClass(class),
-                    ..
-                }),
-            ) => return self.visit_type(db, Type::from(class)),
+            crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::FromClass(class),
+                ..
+            }) => return self.visit_type(db, Type::from(class)),
             // no need to recurse into TypeVar bounds/constraints
-            (_, crate::types::TypeData::TypeVar(_)) => return,
-            (_, _) => {}
+            crate::types::TypeData::TypeVar(_) => return,
+            _ => {}
         }
 
         if let visitor::TypeKind::NonAtomic(t) = visitor::TypeKind::from(ty) {
@@ -956,21 +948,16 @@ impl Display for DisplayRepresentation<'_> {
 
 impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        match {
-            let __ty_view_value = self.ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Dynamic(dynamic)) => {
+        match self.ty.data() {
+            crate::types::TypeData::Dynamic(dynamic) => {
                 if dynamic.is_todo() {
                     f.set_invalid_type_annotation();
                 }
                 write!(f.with_type(self.ty), "{dynamic}")
             }
-            (_, crate::types::TypeData::Divergent(_)) => {
-                f.with_type(self.ty).write_str("Divergent")
-            }
-            (_, crate::types::TypeData::Never) => f.with_type(self.ty).write_str("Never"),
-            (_, crate::types::TypeData::NominalInstance(instance)) => {
+            crate::types::TypeData::Divergent(_) => f.with_type(self.ty).write_str("Divergent"),
+            crate::types::TypeData::Never => f.with_type(self.ty).write_str("Never"),
+            crate::types::TypeData::NominalInstance(instance) => {
                 let class = instance.class(self.db);
 
                 match (class, class.known(self.db)) {
@@ -988,7 +975,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     (ClassType::Generic(alias), _) => alias.display_with(self.db, self.settings.clone()).fmt_detailed(f),
                 }
             }
-            (_, crate::types::TypeData::ProtocolInstance(protocol)) => match protocol.inner {
+            crate::types::TypeData::ProtocolInstance(protocol) => match protocol.inner {
                 Protocol::FromClass(class) => match *class {
                     ClassType::NonGeneric(class) => class
                         .display_with(self.db, self.settings.clone())
@@ -1016,10 +1003,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_char('>')
                 }
             },
-            (_, crate::types::TypeData::PropertyInstance(property)) => f
+            crate::types::TypeData::PropertyInstance(property) => f
                 .with_type(self.ty)
                 .write_str(property_display_name(self.db, property)),
-            (_, crate::types::TypeData::ModuleLiteral(module)) => {
+            crate::types::TypeData::ModuleLiteral(module) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(KnownClass::ModuleType.to_class_literal(self.db))
@@ -1029,7 +1016,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .write_str(module.module(self.db).name(self.db))?;
                 f.write_str("'>")
             }
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
+            crate::types::TypeData::ClassLiteral(class) => {
                 f.set_invalid_type_annotation();
                 let mut f = f.with_type(self.ty);
                 f.write_str("<class '")?;
@@ -1038,7 +1025,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(&mut f)?;
                 f.write_str("'>")
             }
-            (_, crate::types::TypeData::GenericAlias(generic)) => {
+            crate::types::TypeData::GenericAlias(generic) => {
                 f.set_invalid_type_annotation();
                 let mut f = f.with_type(self.ty);
                 f.write_str("<class '")?;
@@ -1047,7 +1034,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(&mut f)?;
                 f.write_str("'>")
             }
-            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
+            crate::types::TypeData::SubclassOf(subclass_of_ty) => {
                 match subclass_of_ty.subclass_of() {
                     SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
                         f.with_type(KnownClass::Type.to_class_literal(self.db))
@@ -1090,20 +1077,20 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                 }
             }
-            (_, crate::types::TypeData::SpecialForm(special_form)) => {
+            crate::types::TypeData::SpecialForm(special_form) => {
                 f.set_invalid_type_annotation();
                 write!(f.with_type(self.ty), "<special-form '{special_form}'>")
             }
-            (_, crate::types::TypeData::KnownInstance(known_instance)) => known_instance
+            crate::types::TypeData::KnownInstance(known_instance) => known_instance
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            (_, crate::types::TypeData::FunctionLiteral(function)) => function
+            crate::types::TypeData::FunctionLiteral(function) => function
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            (_, crate::types::TypeData::Callable(callable)) => callable
+            crate::types::TypeData::Callable(callable) => callable
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
+            crate::types::TypeData::BoundMethod(bound_method) => {
                 let function = bound_method.function(self.db);
                 let self_ty = bound_method.self_instance(self.db);
                 let bound_signatures = bound_method.bound_signatures(self.db);
@@ -1153,7 +1140,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                 }
             }
-            (_, crate::types::TypeData::KnownBoundMethod(method_type)) => {
+            crate::types::TypeData::KnownBoundMethod(method_type) => {
                 f.set_invalid_type_annotation();
                 let (cls, member_name, cls_name, ty, ty_name) = match method_type {
                     KnownBoundMethodType::FunctionTypeDunderGet(function) => (
@@ -1255,7 +1242,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_str("' object>")
                 }
             }
-            (_, crate::types::TypeData::WrapperDescriptor(kind)) => {
+            crate::types::TypeData::WrapperDescriptor(kind) => {
                 f.set_invalid_type_annotation();
                 let (method, object, cls) = match kind {
                     WrapperDescriptorKind::FunctionTypeDunderGet => {
@@ -1281,21 +1268,21 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .write_str(object)?;
                 f.write_str("' objects>")
             }
-            (_, crate::types::TypeData::DataclassDecorator(_)) => {
+            crate::types::TypeData::DataclassDecorator(_) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<decorator produced by dataclass-like function>")
             }
-            (_, crate::types::TypeData::DataclassTransformer(_)) => {
+            crate::types::TypeData::DataclassTransformer(_) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<decorator produced by typing.dataclass_transform>")
             }
-            (_, crate::types::TypeData::Union(union)) => union
+            crate::types::TypeData::Union(union) => union
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            crate::types::TypeData::Intersection(intersection) => intersection
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            (_, crate::types::TypeData::EnumComplement(complement)) => {
+            crate::types::TypeData::EnumComplement(complement) => {
                 if let Some(literals) =
                     complement.remaining_literal_types_for_display(self.db, LITERAL_POLICY.max)
                 {
@@ -1312,7 +1299,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .fmt_detailed(f)
                 }
             }
-            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
+            crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(n) => write!(f.with_type(self.ty), "{n}"),
                 LiteralValueTypeKind::Bool(boolean) => {
                     f.with_type(self.ty)
@@ -1355,7 +1342,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     )
                 }
             },
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+            crate::types::TypeData::TypeVar(bound_typevar) => {
                 f.set_invalid_type_annotation();
                 write!(
                     f,
@@ -1365,13 +1352,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .display_with(self.db, self.settings.clone())
                 )
             }
-            (_, crate::types::TypeData::AlwaysTruthy) => {
-                f.with_type(self.ty).write_str("AlwaysTruthy")
-            }
-            (_, crate::types::TypeData::AlwaysFalsy) => {
-                f.with_type(self.ty).write_str("AlwaysFalsy")
-            }
-            (_, crate::types::TypeData::BoundSuper(bound_super)) => {
+            crate::types::TypeData::AlwaysTruthy => f.with_type(self.ty).write_str("AlwaysTruthy"),
+            crate::types::TypeData::AlwaysFalsy => f.with_type(self.ty).write_str("AlwaysFalsy"),
+            crate::types::TypeData::BoundSuper(bound_super) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<super: ")?;
                 Type::from(bound_super.pivot_class(self.db))
@@ -1385,13 +1368,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_str(">")
             }
-            (_, crate::types::TypeData::TypeIs(type_is)) => {
+            crate::types::TypeData::TypeIs(type_is) => {
                 fmt_type_guard_like(self.db, type_is, &self.settings, f)
             }
-            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
+            crate::types::TypeData::TypeGuard(type_guard) => {
                 fmt_type_guard_like(self.db, type_guard, &self.settings, f)
             }
-            (_, crate::types::TypeData::TypeForm(typeform)) => {
+            crate::types::TypeData::TypeForm(typeform) => {
                 f.with_type(Type::SpecialForm(SpecialFormType::TypeForm))
                     .write_str("TypeForm")?;
                 f.write_char('[')?;
@@ -1401,7 +1384,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
-            (_, crate::types::TypeData::TypedDict(TypedDictType::Class(defining_class))) => {
+            crate::types::TypeData::TypedDict(TypedDictType::Class(defining_class)) => {
                 match defining_class {
                     ClassType::NonGeneric(class) => class
                         .display_with(self.db, self.settings.clone())
@@ -1411,7 +1394,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .fmt_detailed(f),
                 }
             }
-            (_, crate::types::TypeData::TypedDict(TypedDictType::Synthesized(synthesized))) => {
+            crate::types::TypeData::TypedDict(TypedDictType::Synthesized(synthesized)) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(Type::SpecialForm(SpecialFormType::TypedDict))
@@ -1427,7 +1410,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 }
                 f.write_char('>')
             }
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+            crate::types::TypeData::TypeAlias(alias) => {
                 alias
                     .display_with(self.db, self.settings.clone())
                     .fmt_detailed(f)?;
@@ -1438,7 +1421,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .fmt_detailed(f),
                 }
             }
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+            crate::types::TypeData::NewTypeInstance(newtype) => {
                 f.with_type(self.ty).write_str(newtype.name(self.db))
             }
         }
@@ -2461,11 +2444,8 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                 } else {
                     f.write_str("=")?;
                 }
-                match {
-                    let __ty_view_value = default_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::LiteralValue(literal))
+                match default_type.data() {
+                    crate::types::TypeData::LiteralValue(literal)
                         if matches!(
                             literal.kind(),
                             LiteralValueTypeKind::Int(_)
@@ -2480,7 +2460,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                             default_type.representation(self.db, self.settings.clone());
                         representation.fmt_detailed(f)?;
                     }
-                    (_, crate::types::TypeData::NominalInstance(instance)) => {
+                    crate::types::TypeData::NominalInstance(instance) => {
                         // Some key default types like `None` are worth showing
                         let class = instance.class(self.db);
 
@@ -2494,7 +2474,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                             _ => f.write_str("...")?,
                         }
                     }
-                    (_, _) => f.write_str("...")?,
+                    _ => f.write_str("...")?,
                 }
             }
         } else {
@@ -2605,11 +2585,8 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         /// # Color excluding RED displays through the literal-group path for BLUE.
         /// ```
         fn condensable_literals<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::LiteralValue(literal))
+            match ty.data() {
+                crate::types::TypeData::LiteralValue(literal)
                     if matches!(
                         literal.kind(),
                         LiteralValueTypeKind::Int(_)
@@ -2621,13 +2598,13 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                 {
                     Some(vec![ty])
                 }
-                (_, crate::types::TypeData::EnumComplement(complement)) => {
+                crate::types::TypeData::EnumComplement(complement) => {
                     complement.remaining_literal_types_for_display(db, LITERAL_POLICY.max)
                 }
-                (_, crate::types::TypeData::Intersection(intersection)) => {
+                crate::types::TypeData::Intersection(intersection) => {
                     intersection.finite_alternatives_for_display(db, LITERAL_POLICY.max)
                 }
-                (_, _) => None,
+                _ => None,
             }
         }
 
@@ -2674,10 +2651,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                         condensed_types.push(literal);
                     }
                 }
-            } else if let (_, crate::types::TypeData::SubclassOf(subclass_of)) = {
-                let __ty_view_value = element;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            } else if let crate::types::TypeData::SubclassOf(subclass_of) = element.data() {
                 subclass_of_types.push(subclass_of);
             }
         }
@@ -2966,10 +2940,7 @@ impl Display for DisplayMaybeNegatedType<'_> {
 /// - Overloaded callables, which display as `Overload[...]` (already unambiguous)
 /// - Callables with top-materialization parameters, which display as `Top[...]` (already unambiguous)
 fn should_parenthesize_callable_type(ty: Type<'_>, db: &dyn Db) -> bool {
-    if let (_, crate::types::TypeData::Callable(callable)) = {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    if let crate::types::TypeData::Callable(callable) = ty.data() {
         let overloads = &callable.signatures(db).overloads;
         overloads.len() == 1 && !overloads[0].parameters().is_top()
     } else {
@@ -2993,10 +2964,7 @@ impl<'db> FmtDetailed<'db> for DisplayMaybeParenthesizedType<'db> {
                 .fmt_detailed(f)?;
             f.write_char(')')
         };
-        match {
-            let __ty_view_value = self.ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match self.ty.view() {
             (ty, _) if should_parenthesize_callable_type(ty, self.db) => write_parentheses(f),
             (
                 _,

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -567,27 +567,35 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
     }
 
     fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-        match ty {
-            Type::ClassLiteral(class) => self.record_class(db, class),
-            Type::LiteralValue(literal) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class)) => self.record_class(db, class),
+            (_, crate::types::TypeData::LiteralValue(literal)) => {
                 if let LiteralValueTypeKind::Enum(literal) = literal.kind() {
                     self.record_class(db, literal.enum_class(db));
                 }
             }
-            Type::GenericAlias(alias) => {
+            (_, crate::types::TypeData::GenericAlias(alias)) => {
                 self.record_class(db, ClassLiteral::Static(alias.origin(db)));
             }
-            Type::TypeAlias(type_alias) => self.record_type_alias(db, type_alias),
+            (_, crate::types::TypeData::TypeAlias(type_alias)) => {
+                self.record_type_alias(db, type_alias)
+            }
             // Visit the class (as if it were a nominal-instance type)
             // rather than the protocol members, if it is a class-based protocol.
             // (For the purposes of displaying the type, we'll use the class name.)
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::FromClass(class),
-                ..
-            }) => return self.visit_type(db, Type::from(class)),
+            (
+                _,
+                crate::types::TypeData::ProtocolInstance(ProtocolInstanceType {
+                    inner: Protocol::FromClass(class),
+                    ..
+                }),
+            ) => return self.visit_type(db, Type::from(class)),
             // no need to recurse into TypeVar bounds/constraints
-            Type::TypeVar(_) => return,
-            _ => {}
+            (_, crate::types::TypeData::TypeVar(_)) => return,
+            (_, _) => {}
         }
 
         if let visitor::TypeKind::NonAtomic(t) = visitor::TypeKind::from(ty) {
@@ -948,16 +956,21 @@ impl Display for DisplayRepresentation<'_> {
 
 impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        match self.ty {
-            Type::Dynamic(dynamic) => {
+        match {
+            let __ty_view_value = self.ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Dynamic(dynamic)) => {
                 if dynamic.is_todo() {
                     f.set_invalid_type_annotation();
                 }
                 write!(f.with_type(self.ty), "{dynamic}")
             }
-            Type::Divergent(_) => f.with_type(self.ty).write_str("Divergent"),
-            Type::Never => f.with_type(self.ty).write_str("Never"),
-            Type::NominalInstance(instance) => {
+            (_, crate::types::TypeData::Divergent(_)) => {
+                f.with_type(self.ty).write_str("Divergent")
+            }
+            (_, crate::types::TypeData::Never) => f.with_type(self.ty).write_str("Never"),
+            (_, crate::types::TypeData::NominalInstance(instance)) => {
                 let class = instance.class(self.db);
 
                 match (class, class.known(self.db)) {
@@ -975,7 +988,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     (ClassType::Generic(alias), _) => alias.display_with(self.db, self.settings.clone()).fmt_detailed(f),
                 }
             }
-            Type::ProtocolInstance(protocol) => match protocol.inner {
+            (_, crate::types::TypeData::ProtocolInstance(protocol)) => match protocol.inner {
                 Protocol::FromClass(class) => match *class {
                     ClassType::NonGeneric(class) => class
                         .display_with(self.db, self.settings.clone())
@@ -1003,10 +1016,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_char('>')
                 }
             },
-            Type::PropertyInstance(property) => f
+            (_, crate::types::TypeData::PropertyInstance(property)) => f
                 .with_type(self.ty)
                 .write_str(property_display_name(self.db, property)),
-            Type::ModuleLiteral(module) => {
+            (_, crate::types::TypeData::ModuleLiteral(module)) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(KnownClass::ModuleType.to_class_literal(self.db))
@@ -1016,7 +1029,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .write_str(module.module(self.db).name(self.db))?;
                 f.write_str("'>")
             }
-            Type::ClassLiteral(class) => {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
                 f.set_invalid_type_annotation();
                 let mut f = f.with_type(self.ty);
                 f.write_str("<class '")?;
@@ -1025,7 +1038,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(&mut f)?;
                 f.write_str("'>")
             }
-            Type::GenericAlias(generic) => {
+            (_, crate::types::TypeData::GenericAlias(generic)) => {
                 f.set_invalid_type_annotation();
                 let mut f = f.with_type(self.ty);
                 f.write_str("<class '")?;
@@ -1034,61 +1047,63 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(&mut f)?;
                 f.write_str("'>")
             }
-            Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
-                SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
-                        .write_str("type")?;
-                    f.write_char('[')?;
-                    class
-                        .display_with(self.db, self.settings.clone())
-                        .fmt_detailed(f)?;
-                    f.write_char(']')
-                }
-                SubclassOfInner::Class(ClassType::Generic(alias)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
-                        .write_str("type")?;
-                    f.write_char('[')?;
-                    alias
-                        .display_with(self.db, self.settings.clone())
-                        .fmt_detailed(f)?;
-                    f.write_char(']')
-                }
-                SubclassOfInner::Dynamic(dynamic) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
-                        .write_str("type")?;
-                    f.write_char('[')?;
-                    write!(f.with_type(Type::Dynamic(dynamic)), "{dynamic}")?;
-                    f.write_char(']')
-                }
-                SubclassOfInner::TypeVar(bound_typevar) => {
-                    f.set_invalid_type_annotation();
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
-                        .write_str("type")?;
-                    f.write_char('[')?;
-                    write!(
-                        f.with_type(Type::TypeVar(bound_typevar)),
-                        "{}",
-                        bound_typevar
-                            .identity(self.db)
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
+                match subclass_of_ty.subclass_of() {
+                    SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
+                        f.with_type(KnownClass::Type.to_class_literal(self.db))
+                            .write_str("type")?;
+                        f.write_char('[')?;
+                        class
                             .display_with(self.db, self.settings.clone())
-                    )?;
-                    f.write_char(']')
+                            .fmt_detailed(f)?;
+                        f.write_char(']')
+                    }
+                    SubclassOfInner::Class(ClassType::Generic(alias)) => {
+                        f.with_type(KnownClass::Type.to_class_literal(self.db))
+                            .write_str("type")?;
+                        f.write_char('[')?;
+                        alias
+                            .display_with(self.db, self.settings.clone())
+                            .fmt_detailed(f)?;
+                        f.write_char(']')
+                    }
+                    SubclassOfInner::Dynamic(dynamic) => {
+                        f.with_type(KnownClass::Type.to_class_literal(self.db))
+                            .write_str("type")?;
+                        f.write_char('[')?;
+                        write!(f.with_type(Type::Dynamic(dynamic)), "{dynamic}")?;
+                        f.write_char(']')
+                    }
+                    SubclassOfInner::TypeVar(bound_typevar) => {
+                        f.set_invalid_type_annotation();
+                        f.with_type(KnownClass::Type.to_class_literal(self.db))
+                            .write_str("type")?;
+                        f.write_char('[')?;
+                        write!(
+                            f.with_type(Type::TypeVar(bound_typevar)),
+                            "{}",
+                            bound_typevar
+                                .identity(self.db)
+                                .display_with(self.db, self.settings.clone())
+                        )?;
+                        f.write_char(']')
+                    }
                 }
-            },
-            Type::SpecialForm(special_form) => {
+            }
+            (_, crate::types::TypeData::SpecialForm(special_form)) => {
                 f.set_invalid_type_annotation();
                 write!(f.with_type(self.ty), "<special-form '{special_form}'>")
             }
-            Type::KnownInstance(known_instance) => known_instance
+            (_, crate::types::TypeData::KnownInstance(known_instance)) => known_instance
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            Type::FunctionLiteral(function) => function
+            (_, crate::types::TypeData::FunctionLiteral(function)) => function
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            Type::Callable(callable) => callable
+            (_, crate::types::TypeData::Callable(callable)) => callable
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            Type::BoundMethod(bound_method) => {
+            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
                 let function = bound_method.function(self.db);
                 let self_ty = bound_method.self_instance(self.db);
                 let bound_signatures = bound_method.bound_signatures(self.db);
@@ -1138,7 +1153,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                 }
             }
-            Type::KnownBoundMethod(method_type) => {
+            (_, crate::types::TypeData::KnownBoundMethod(method_type)) => {
                 f.set_invalid_type_annotation();
                 let (cls, member_name, cls_name, ty, ty_name) = match method_type {
                     KnownBoundMethodType::FunctionTypeDunderGet(function) => (
@@ -1240,7 +1255,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_str("' object>")
                 }
             }
-            Type::WrapperDescriptor(kind) => {
+            (_, crate::types::TypeData::WrapperDescriptor(kind)) => {
                 f.set_invalid_type_annotation();
                 let (method, object, cls) = match kind {
                     WrapperDescriptorKind::FunctionTypeDunderGet => {
@@ -1266,21 +1281,21 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .write_str(object)?;
                 f.write_str("' objects>")
             }
-            Type::DataclassDecorator(_) => {
+            (_, crate::types::TypeData::DataclassDecorator(_)) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<decorator produced by dataclass-like function>")
             }
-            Type::DataclassTransformer(_) => {
+            (_, crate::types::TypeData::DataclassTransformer(_)) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<decorator produced by typing.dataclass_transform>")
             }
-            Type::Union(union) => union
+            (_, crate::types::TypeData::Union(union)) => union
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            Type::Intersection(intersection) => intersection
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 if let Some(literals) =
                     complement.remaining_literal_types_for_display(self.db, LITERAL_POLICY.max)
                 {
@@ -1297,7 +1312,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .fmt_detailed(f)
                 }
             }
-            Type::LiteralValue(literal) => match literal.kind() {
+            (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
                 LiteralValueTypeKind::Int(n) => write!(f.with_type(self.ty), "{n}"),
                 LiteralValueTypeKind::Bool(boolean) => {
                     f.with_type(self.ty)
@@ -1340,7 +1355,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     )
                 }
             },
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 f.set_invalid_type_annotation();
                 write!(
                     f,
@@ -1350,9 +1365,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .display_with(self.db, self.settings.clone())
                 )
             }
-            Type::AlwaysTruthy => f.with_type(self.ty).write_str("AlwaysTruthy"),
-            Type::AlwaysFalsy => f.with_type(self.ty).write_str("AlwaysFalsy"),
-            Type::BoundSuper(bound_super) => {
+            (_, crate::types::TypeData::AlwaysTruthy) => {
+                f.with_type(self.ty).write_str("AlwaysTruthy")
+            }
+            (_, crate::types::TypeData::AlwaysFalsy) => {
+                f.with_type(self.ty).write_str("AlwaysFalsy")
+            }
+            (_, crate::types::TypeData::BoundSuper(bound_super)) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<super: ")?;
                 Type::from(bound_super.pivot_class(self.db))
@@ -1366,11 +1385,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_str(">")
             }
-            Type::TypeIs(type_is) => fmt_type_guard_like(self.db, type_is, &self.settings, f),
-            Type::TypeGuard(type_guard) => {
+            (_, crate::types::TypeData::TypeIs(type_is)) => {
+                fmt_type_guard_like(self.db, type_is, &self.settings, f)
+            }
+            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
                 fmt_type_guard_like(self.db, type_guard, &self.settings, f)
             }
-            Type::TypeForm(typeform) => {
+            (_, crate::types::TypeData::TypeForm(typeform)) => {
                 f.with_type(Type::SpecialForm(SpecialFormType::TypeForm))
                     .write_str("TypeForm")?;
                 f.write_char('[')?;
@@ -1380,15 +1401,17 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
-            Type::TypedDict(TypedDictType::Class(defining_class)) => match defining_class {
-                ClassType::NonGeneric(class) => class
-                    .display_with(self.db, self.settings.clone())
-                    .fmt_detailed(f),
-                ClassType::Generic(alias) => alias
-                    .display_with(self.db, self.settings.clone())
-                    .fmt_detailed(f),
-            },
-            Type::TypedDict(TypedDictType::Synthesized(synthesized)) => {
+            (_, crate::types::TypeData::TypedDict(TypedDictType::Class(defining_class))) => {
+                match defining_class {
+                    ClassType::NonGeneric(class) => class
+                        .display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f),
+                    ClassType::Generic(alias) => alias
+                        .display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f),
+                }
+            }
+            (_, crate::types::TypeData::TypedDict(TypedDictType::Synthesized(synthesized))) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
                 f.with_type(Type::SpecialForm(SpecialFormType::TypedDict))
@@ -1404,7 +1427,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 }
                 f.write_char('>')
             }
-            Type::TypeAlias(alias) => {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 alias
                     .display_with(self.db, self.settings.clone())
                     .fmt_detailed(f)?;
@@ -1415,7 +1438,9 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .fmt_detailed(f),
                 }
             }
-            Type::NewTypeInstance(newtype) => f.with_type(self.ty).write_str(newtype.name(self.db)),
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+                f.with_type(self.ty).write_str(newtype.name(self.db))
+            }
         }
     }
 }
@@ -2436,8 +2461,11 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                 } else {
                     f.write_str("=")?;
                 }
-                match default_type {
-                    Type::LiteralValue(literal)
+                match {
+                    let __ty_view_value = default_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::LiteralValue(literal))
                         if matches!(
                             literal.kind(),
                             LiteralValueTypeKind::Int(_)
@@ -2452,7 +2480,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                             default_type.representation(self.db, self.settings.clone());
                         representation.fmt_detailed(f)?;
                     }
-                    Type::NominalInstance(instance) => {
+                    (_, crate::types::TypeData::NominalInstance(instance)) => {
                         // Some key default types like `None` are worth showing
                         let class = instance.class(self.db);
 
@@ -2466,7 +2494,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                             _ => f.write_str("...")?,
                         }
                     }
-                    _ => f.write_str("...")?,
+                    (_, _) => f.write_str("...")?,
                 }
             }
         } else {
@@ -2577,8 +2605,11 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         /// # Color excluding RED displays through the literal-group path for BLUE.
         /// ```
         fn condensable_literals<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
-            match ty {
-                Type::LiteralValue(literal)
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::LiteralValue(literal))
                     if matches!(
                         literal.kind(),
                         LiteralValueTypeKind::Int(_)
@@ -2590,13 +2621,13 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                 {
                     Some(vec![ty])
                 }
-                Type::EnumComplement(complement) => {
+                (_, crate::types::TypeData::EnumComplement(complement)) => {
                     complement.remaining_literal_types_for_display(db, LITERAL_POLICY.max)
                 }
-                Type::Intersection(intersection) => {
+                (_, crate::types::TypeData::Intersection(intersection)) => {
                     intersection.finite_alternatives_for_display(db, LITERAL_POLICY.max)
                 }
-                _ => None,
+                (_, _) => None,
             }
         }
 
@@ -2643,7 +2674,10 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                         condensed_types.push(literal);
                     }
                 }
-            } else if let Type::SubclassOf(subclass_of) = element {
+            } else if let (_, crate::types::TypeData::SubclassOf(subclass_of)) = {
+                let __ty_view_value = element;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 subclass_of_types.push(subclass_of);
             }
         }
@@ -2932,7 +2966,10 @@ impl Display for DisplayMaybeNegatedType<'_> {
 /// - Overloaded callables, which display as `Overload[...]` (already unambiguous)
 /// - Callables with top-materialization parameters, which display as `Top[...]` (already unambiguous)
 fn should_parenthesize_callable_type(ty: Type<'_>, db: &dyn Db) -> bool {
-    if let Type::Callable(callable) = ty {
+    if let (_, crate::types::TypeData::Callable(callable)) = {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
         let overloads = &callable.signatures(db).overloads;
         overloads.len() == 1 && !overloads[0].parameters().is_top()
     } else {
@@ -2956,16 +2993,24 @@ impl<'db> FmtDetailed<'db> for DisplayMaybeParenthesizedType<'db> {
                 .fmt_detailed(f)?;
             f.write_char(')')
         };
-        match self.ty {
-            ty if should_parenthesize_callable_type(ty, self.db) => write_parentheses(f),
-            Type::KnownBoundMethod(_)
-            | Type::FunctionLiteral(_)
-            | Type::BoundMethod(_)
-            | Type::Union(_) => write_parentheses(f),
-            Type::Intersection(intersection) if !intersection.has_one_element(self.db) => {
+        match {
+            let __ty_view_value = self.ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (ty, _) if should_parenthesize_callable_type(ty, self.db) => write_parentheses(f),
+            (
+                _,
+                crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::Union(_),
+            ) => write_parentheses(f),
+            (_, crate::types::TypeData::Intersection(intersection))
+                if !intersection.has_one_element(self.db) =>
+            {
                 write_parentheses(f)
             }
-            _ => self
+            (_, _) => self
                 .ty
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -300,10 +300,7 @@ impl<'db> EnumComplementType<'db> {
         let mut enum_class = None;
         let mut rest = SmallVec::<[Type<'db>; 1]>::default();
         for positive in positive {
-            let (_, crate::types::TypeData::NominalInstance(instance)) = ({
-                let __ty_view_value = positive;
-                (__ty_view_value, __ty_view_value.data())
-            }) else {
+            let crate::types::TypeData::NominalInstance(instance) = positive.data() else {
                 rest.push(*positive);
                 continue;
             };
@@ -706,19 +703,13 @@ pub(crate) fn enum_metadata<'db>(
                     return None;
                 }
                 Place::Defined(DefinedPlace { ty, .. }) => {
-                    let special_case = match {
-                        let __ty_view_value = ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (
-                            _,
-                            crate::types::TypeData::Callable(_)
-                            | crate::types::TypeData::FunctionLiteral(_),
-                        ) => {
+                    let special_case = match ty.data() {
+                        crate::types::TypeData::Callable(_)
+                        | crate::types::TypeData::FunctionLiteral(_) => {
                             // Some types are specifically disallowed for enum members.
                             return None;
                         }
-                        (_, crate::types::TypeData::NominalInstance(instance)) => match instance
+                        crate::types::TypeData::NominalInstance(instance) => match instance
                             .known_class(db)
                         {
                             // enum.nonmember
@@ -792,7 +783,7 @@ pub(crate) fn enum_metadata<'db>(
                             _ => None,
                         },
 
-                        (_, _) => None,
+                        _ => None,
                     };
 
                     if let Some(special_case) = special_case {
@@ -1009,12 +1000,9 @@ fn custom_init<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined()?;
 
-    match {
-        let __ty_view_value = init_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
-        (_, _) => None,
+    match init_type.data() {
+        crate::types::TypeData::FunctionLiteral(f) => Some(f),
+        _ => None,
     }
 }
 
@@ -1028,12 +1016,9 @@ fn custom_new<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType<
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined()?;
 
-    match {
-        let __ty_view_value = new_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
-        (_, _) => None,
+    match new_type.data() {
+        crate::types::TypeData::FunctionLiteral(f) => Some(f),
+        _ => None,
     }
 }
 
@@ -1051,12 +1036,9 @@ fn custom_generate_next_value<'db>(
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined();
     let new_type = new_type?;
-    match {
-        let __ty_view_value = new_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
-        (_, _) => None,
+    match new_type.data() {
+        crate::types::TypeData::FunctionLiteral(f) => Some(f),
+        _ => None,
     }
 }
 
@@ -1079,14 +1061,11 @@ pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'d
 }
 
 pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+    match ty.data() {
+        crate::types::TypeData::ClassLiteral(class_literal) => {
             enum_metadata(db, class_literal).is_some()
         }
-        (_, _) => false,
+        _ => false,
     }
 }
 
@@ -1113,11 +1092,8 @@ pub(crate) fn is_enum_class_by_inheritance<'db>(
 ///
 /// Returns `Some(value_type)` if the type is a `nonmember[T]`, otherwise `None`.
 pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::NominalInstance(instance))
+    match ty.data() {
+        crate::types::TypeData::NominalInstance(instance)
             if instance.has_known_class(db, KnownClass::Nonmember) =>
         {
             Some(
@@ -1127,6 +1103,6 @@ pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) ->
                     .unwrap_or(Type::unknown()),
             )
         }
-        (_, _) => None,
+        _ => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -300,7 +300,10 @@ impl<'db> EnumComplementType<'db> {
         let mut enum_class = None;
         let mut rest = SmallVec::<[Type<'db>; 1]>::default();
         for positive in positive {
-            let Type::NominalInstance(instance) = positive else {
+            let (_, crate::types::TypeData::NominalInstance(instance)) = ({
+                let __ty_view_value = positive;
+                (__ty_view_value, __ty_view_value.data())
+            }) else {
                 rest.push(*positive);
                 continue;
             };
@@ -703,12 +706,21 @@ pub(crate) fn enum_metadata<'db>(
                     return None;
                 }
                 Place::Defined(DefinedPlace { ty, .. }) => {
-                    let special_case = match ty {
-                        Type::Callable(_) | Type::FunctionLiteral(_) => {
+                    let special_case = match {
+                        let __ty_view_value = ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (
+                            _,
+                            crate::types::TypeData::Callable(_)
+                            | crate::types::TypeData::FunctionLiteral(_),
+                        ) => {
                             // Some types are specifically disallowed for enum members.
                             return None;
                         }
-                        Type::NominalInstance(instance) => match instance.known_class(db) {
+                        (_, crate::types::TypeData::NominalInstance(instance)) => match instance
+                            .known_class(db)
+                        {
                             // enum.nonmember
                             Some(KnownClass::Nonmember) => return None,
 
@@ -780,7 +792,7 @@ pub(crate) fn enum_metadata<'db>(
                             _ => None,
                         },
 
-                        _ => None,
+                        (_, _) => None,
                     };
 
                     if let Some(special_case) = special_case {
@@ -795,12 +807,8 @@ pub(crate) fn enum_metadata<'db>(
                             .place;
 
                         match dunder_get {
-                            Place::Undefined
-                            | Place::Defined(DefinedPlace {
-                                ty: Type::Dynamic(_),
-                                ..
-                            }) => ty,
-
+                            Place::Undefined => ty,
+                            Place::Defined(defined) if defined.ty.is_dynamic() => ty,
                             Place::Defined(_) => {
                                 // Descriptors are not considered members.
                                 return None;
@@ -1001,9 +1009,12 @@ fn custom_init<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined()?;
 
-    match init_type {
-        Type::FunctionLiteral(f) => Some(f),
-        _ => None,
+    match {
+        let __ty_view_value = init_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
+        (_, _) => None,
     }
 }
 
@@ -1017,9 +1028,12 @@ fn custom_new<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<FunctionType<
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined()?;
 
-    match new_type {
-        Type::FunctionLiteral(f) => Some(f),
-        _ => None,
+    match {
+        let __ty_view_value = new_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
+        (_, _) => None,
     }
 }
 
@@ -1037,9 +1051,12 @@ fn custom_generate_next_value<'db>(
     .ignore_conflicting_declarations()
     .ignore_possibly_undefined();
     let new_type = new_type?;
-    match new_type {
-        Type::FunctionLiteral(f) => Some(f),
-        _ => None,
+    match {
+        let __ty_view_value = new_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::FunctionLiteral(f)) => Some(f),
+        (_, _) => None,
     }
 }
 
@@ -1062,9 +1079,14 @@ pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'d
 }
 
 pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty {
-        Type::ClassLiteral(class_literal) => enum_metadata(db, class_literal).is_some(),
-        _ => false,
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+            enum_metadata(db, class_literal).is_some()
+        }
+        (_, _) => false,
     }
 }
 
@@ -1091,8 +1113,13 @@ pub(crate) fn is_enum_class_by_inheritance<'db>(
 ///
 /// Returns `Some(value_type)` if the type is a `nonmember[T]`, otherwise `None`.
 pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-    match ty {
-        Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Nonmember) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::NominalInstance(instance))
+            if instance.has_known_class(db, KnownClass::Nonmember) =>
+        {
             Some(
                 ty.member(db, "value")
                     .place
@@ -1100,6 +1127,6 @@ pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) ->
                     .unwrap_or(Type::unknown()),
             )
         }
-        _ => None,
+        (_, _) => None,
     }
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -186,8 +186,11 @@ impl get_size2::GetSize for FunctionDecorators {}
 
 impl FunctionDecorators {
     pub(super) fn from_decorator_type(db: &dyn Db, decorator_type: Type) -> Self {
-        match decorator_type {
-            Type::FunctionLiteral(function) => match function.known(db) {
+        match {
+            let __ty_view_value = decorator_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => match function.known(db) {
                 Some(KnownFunction::NoTypeCheck) => FunctionDecorators::NO_TYPE_CHECK,
                 Some(KnownFunction::Overload) => FunctionDecorators::OVERLOAD,
                 Some(KnownFunction::AbstractMethod) => FunctionDecorators::ABSTRACT_METHOD,
@@ -196,12 +199,12 @@ impl FunctionDecorators {
                 Some(KnownFunction::TypeCheckOnly) => FunctionDecorators::TYPE_CHECK_ONLY,
                 _ => FunctionDecorators::empty(),
             },
-            Type::ClassLiteral(class) => match class.known(db) {
+            (_, crate::types::TypeData::ClassLiteral(class)) => match class.known(db) {
                 Some(KnownClass::Classmethod) => FunctionDecorators::CLASSMETHOD,
                 Some(KnownClass::Staticmethod) => FunctionDecorators::STATICMETHOD,
                 _ => FunctionDecorators::empty(),
             },
-            _ => FunctionDecorators::empty(),
+            (_, _) => FunctionDecorators::empty(),
         }
     }
 }
@@ -444,11 +447,14 @@ impl<'db> OverloadLiteral<'db> {
             .scoped_use_id(db, self.file(db));
 
         let Place::Defined(DefinedPlace {
-            ty: Type::FunctionLiteral(previous_type),
+            ty,
             definedness: Definedness::AlwaysDefined,
             ..
         }) = place_from_bindings(db, use_def.bindings_at_use(use_id)).place
         else {
+            return None;
+        };
+        let crate::types::TypeData::FunctionLiteral(previous_type) = ty.data() else {
             return None;
         };
 
@@ -1571,8 +1577,11 @@ fn check_classinfo_in_isinstance<'db>(
     classinfo: Type<'db>,
     classinfo_expr: Option<&ast::Expr>,
 ) {
-    match classinfo {
-        Type::ClassLiteral(class) => {
+    match {
+        let __ty_view_value = classinfo;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class)) => {
             if class.is_typed_dict(db) {
                 report_runtime_check_against_typed_dict(context, call_expression, class, function);
             } else if let Some(protocol_class) = class.into_protocol_class(db) {
@@ -1596,7 +1605,9 @@ fn check_classinfo_in_isinstance<'db>(
                 }
             }
         }
-        Type::SpecialForm(SpecialFormType::Any) if function == KnownFunction::IsInstance => {
+        (_, crate::types::TypeData::SpecialForm(SpecialFormType::Any))
+            if function == KnownFunction::IsInstance =>
+        {
             let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, call_expression) else {
                 return;
             };
@@ -1605,7 +1616,7 @@ fn check_classinfo_in_isinstance<'db>(
             ));
             diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
         }
-        Type::KnownInstance(KnownInstanceType::UnionType(_)) => {
+        (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(_))) => {
             report_invalid_union_type_elements(
                 db,
                 context,
@@ -1615,7 +1626,7 @@ fn check_classinfo_in_isinstance<'db>(
                 classinfo_expr,
             );
         }
-        Type::NominalInstance(nominal) => {
+        (_, crate::types::TypeData::NominalInstance(nominal)) => {
             if let Some(tuple_spec) = nominal.tuple_spec(db) {
                 let element_exprs = match classinfo_expr {
                     Some(ast::Expr::Tuple(tuple_expr)) => Some(&tuple_expr.elts),
@@ -1634,7 +1645,7 @@ fn check_classinfo_in_isinstance<'db>(
                 }
             }
         }
-        _ => {}
+        (_, _) => {}
     }
 }
 
@@ -1654,14 +1665,19 @@ fn report_invalid_union_type_elements<'db>(
         ty: Type<'db>,
         invalid_elements: &mut Vec<Type<'db>>,
     ) {
-        match ty {
-            Type::ClassLiteral(_) => {}
-            Type::NominalInstance(instance)
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(_)) => {}
+            (_, crate::types::TypeData::NominalInstance(instance))
                 if instance.has_known_class(db, KnownClass::NoneType) => {}
-            Type::SpecialForm(special_form) if special_form.is_valid_isinstance_target() => {}
+            (_, crate::types::TypeData::SpecialForm(special_form))
+                if special_form.is_valid_isinstance_target() => {}
             // `Any` can be used in `issubclass()` calls but not `isinstance()` calls
-            Type::SpecialForm(SpecialFormType::Any) if function == KnownFunction::IsSubclass => {}
-            Type::KnownInstance(KnownInstanceType::UnionType(instance)) => {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Any))
+                if function == KnownFunction::IsSubclass => {}
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))) => {
                 match instance.value_expression_types(db) {
                     Ok(value_expression_types) => {
                         for element in value_expression_types {
@@ -1673,7 +1689,7 @@ fn report_invalid_union_type_elements<'db>(
                     }
                 }
             }
-            _ => invalid_elements.push(ty),
+            (_, _) => invalid_elements.push(ty),
         }
     }
 
@@ -1706,13 +1722,20 @@ fn report_invalid_union_type_elements<'db>(
 
     // When we have a secondary annotation pointing at the UnionType expression,
     // "the union" is unambiguous. Otherwise, spell out the union type in the message.
-    let union_suffix = match (&union_type_expr, union_type) {
-        (None, Type::KnownInstance(KnownInstanceType::UnionType(instance))) => {
-            match instance.union_type(db) {
-                Ok(ty) => format!(" `{}`", ty.display(db)),
-                Err(_) => String::new(),
-            }
-        }
+    let union_suffix = match (
+        &union_type_expr,
+        ({
+            let __ty_view_value = union_type;
+            (__ty_view_value, __ty_view_value.data())
+        }),
+    ) {
+        (
+            None,
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))),
+        ) => match instance.union_type(db) {
+            Ok(ty) => format!(" `{}`", ty.display(db)),
+            Err(_) => String::new(),
+        },
         _ => String::new(),
     };
 
@@ -1756,8 +1779,11 @@ fn is_instance_truthiness<'db>(
         }
     };
 
-    match ty {
-        Type::Union(..) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::Union(..)) => {
             // We do not handle unions specifically here, because something like `A | SubclassOfA` would
             // have been simplified to `A` anyway
             Truthiness::Ambiguous
@@ -1767,14 +1793,17 @@ fn is_instance_truthiness<'db>(
         // and evaluate the truthiness of the `isinstance()` check with that type.
         // Along the way, short-circuit to `AlwaysTrue` if we find any positive element
         // that is always true.
-        Type::Intersection(intersection) => {
+        (_, crate::types::TypeData::Intersection(intersection)) => {
             let mut effective = IntersectionBuilder::new(db);
             let mut found_tvars_or_newtypes = false;
 
             for &positive in intersection.positive(db) {
                 if is_instance_truthiness(db, positive, class).is_always_true() {
                     return Truthiness::AlwaysTrue;
-                } else if let Type::TypeVar(tvar) = positive {
+                } else if let (_, crate::types::TypeData::TypeVar(tvar)) = {
+                    let __ty_view_value = positive;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     match tvar.typevar(db).bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                             effective = effective.add_positive(bound);
@@ -1787,7 +1816,10 @@ fn is_instance_truthiness<'db>(
                         None => {}
                     }
                     found_tvars_or_newtypes = true;
-                } else if let Type::NewTypeInstance(newtype) = positive {
+                } else if let (_, crate::types::TypeData::NewTypeInstance(newtype)) = {
+                    let __ty_view_value = positive;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     found_tvars_or_newtypes = true;
                     effective = effective.add_positive(newtype.concrete_base_type(db));
                 } else {
@@ -1815,63 +1847,75 @@ fn is_instance_truthiness<'db>(
             }
         }
 
-        Type::EnumComplement(complement) => {
+        (_, crate::types::TypeData::EnumComplement(complement)) => {
             is_instance_truthiness(db, complement.to_intersection(db), class)
         }
 
-        Type::NominalInstance(..) => always_true_if(is_instance(&ty)),
+        (_, crate::types::TypeData::NominalInstance(..)) => always_true_if(is_instance(&ty)),
 
-        Type::NewTypeInstance(newtype) => {
+        (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
             always_true_if(is_instance(&newtype.concrete_base_type(db)))
         }
 
-        Type::LiteralValue(..) | Type::ModuleLiteral(..) | Type::FunctionLiteral(..) => {
-            always_true_if(
-                ty.literal_fallback_instance(db)
-                    .as_ref()
-                    .is_some_and(is_instance),
-            )
+        (
+            _,
+            crate::types::TypeData::LiteralValue(..)
+            | crate::types::TypeData::ModuleLiteral(..)
+            | crate::types::TypeData::FunctionLiteral(..),
+        ) => always_true_if(
+            ty.literal_fallback_instance(db)
+                .as_ref()
+                .is_some_and(is_instance),
+        ),
+
+        (_, crate::types::TypeData::ClassLiteral(..)) => {
+            always_true_if(is_instance(&KnownClass::Type.to_instance(db)))
         }
 
-        Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
+            is_instance_truthiness(db, alias.value_type(db), class)
+        }
 
-        Type::TypeAlias(alias) => is_instance_truthiness(db, alias.value_type(db), class),
-
-        Type::TypeVar(bound_typevar) => match bound_typevar.typevar(db).bound_or_constraints(db) {
-            None => is_instance_truthiness(db, Type::object(), class),
-            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                is_instance_truthiness(db, bound, class)
+        (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+            match bound_typevar.typevar(db).bound_or_constraints(db) {
+                None => is_instance_truthiness(db, Type::object(), class),
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    is_instance_truthiness(db, bound, class)
+                }
+                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => always_true_if(
+                    constraints
+                        .elements(db)
+                        .iter()
+                        .all(|c| is_instance_truthiness(db, *c, class).is_always_true()),
+                ),
             }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => always_true_if(
-                constraints
-                    .elements(db)
-                    .iter()
-                    .all(|c| is_instance_truthiness(db, *c, class).is_always_true()),
-            ),
-        },
+        }
 
-        Type::BoundMethod(..)
-        | Type::KnownBoundMethod(..)
-        | Type::WrapperDescriptor(..)
-        | Type::DataclassDecorator(..)
-        | Type::DataclassTransformer(..)
-        | Type::GenericAlias(..)
-        | Type::SubclassOf(..)
-        | Type::ProtocolInstance(..)
-        | Type::SpecialForm(..)
-        | Type::KnownInstance(..)
-        | Type::PropertyInstance(..)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::BoundSuper(..)
-        | Type::TypeIs(..)
-        | Type::TypeGuard(..)
-        | Type::TypeForm(..)
-        | Type::Callable(..)
-        | Type::Dynamic(..)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::TypedDict(_) => {
+        (
+            _,
+            crate::types::TypeData::BoundMethod(..)
+            | crate::types::TypeData::KnownBoundMethod(..)
+            | crate::types::TypeData::WrapperDescriptor(..)
+            | crate::types::TypeData::DataclassDecorator(..)
+            | crate::types::TypeData::DataclassTransformer(..)
+            | crate::types::TypeData::GenericAlias(..)
+            | crate::types::TypeData::SubclassOf(..)
+            | crate::types::TypeData::ProtocolInstance(..)
+            | crate::types::TypeData::SpecialForm(..)
+            | crate::types::TypeData::KnownInstance(..)
+            | crate::types::TypeData::PropertyInstance(..)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::BoundSuper(..)
+            | crate::types::TypeData::TypeIs(..)
+            | crate::types::TypeData::TypeGuard(..)
+            | crate::types::TypeData::TypeForm(..)
+            | crate::types::TypeData::Callable(..)
+            | crate::types::TypeData::Dynamic(..)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::TypedDict(_),
+        ) => {
             // We could probably try to infer more precise types in some of these cases, but it's unclear
             // if it's worth the effort.
             Truthiness::Ambiguous
@@ -2199,7 +2243,10 @@ impl KnownFunction {
             }
 
             KnownFunction::HasMember => {
-                let [Some(ty), Some(Type::LiteralValue(literal))] = parameter_types else {
+                let [Some(ty), Some(literal_ty)] = parameter_types else {
+                    return;
+                };
+                let crate::types::TypeData::LiteralValue(literal) = literal_ty.data() else {
                     return;
                 };
                 let Some(member) = literal.as_string() else {
@@ -2358,7 +2405,14 @@ impl KnownFunction {
                 };
                 let casted_type = casted_type.project_type_form(db);
                 let contains_unknown_or_todo = |ty: Type<'_>| {
-                    ty.is_dynamic() && !matches!(ty, Type::Dynamic(DynamicType::Any))
+                    ty.is_dynamic()
+                        && !matches!(
+                            {
+                                let __ty_view_value = ty;
+                                (__ty_view_value, __ty_view_value.data())
+                            },
+                            (_, crate::types::TypeData::Dynamic(DynamicType::Any))
+                        )
                 };
                 if source_type.is_equivalent_to(db, casted_type)
                     && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
@@ -2405,13 +2459,16 @@ impl KnownFunction {
             }
 
             KnownFunction::GetProtocolMembers => {
-                let [Some(Type::ClassLiteral(class))] = parameter_types else {
+                let [Some(class_ty)] = parameter_types else {
+                    return;
+                };
+                let crate::types::TypeData::ClassLiteral(class) = class_ty.data() else {
                     return;
                 };
                 if class.is_protocol(db) {
                     return;
                 }
-                report_bad_argument_to_get_protocol_members(context, call_expression, *class);
+                report_bad_argument_to_get_protocol_members(context, call_expression, class);
             }
 
             KnownFunction::RevealProtocolInterface => {
@@ -2449,21 +2506,31 @@ impl KnownFunction {
                     return;
                 };
                 let mut good_argument = true;
-                let classes = match param_type {
-                    Type::ClassLiteral(class) => vec![ClassType::NonGeneric(*class)],
-                    Type::GenericAlias(generic_alias) => vec![ClassType::Generic(*generic_alias)],
-                    Type::Union(union) => {
+                let classes = match {
+                    let __ty_view_value = param_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                        vec![ClassType::NonGeneric(class)]
+                    }
+                    (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                        vec![ClassType::Generic(generic_alias)]
+                    }
+                    (_, crate::types::TypeData::Union(union)) => {
                         let elements = union.elements(db);
                         let mut classes = Vec::with_capacity(elements.len());
                         for element in elements {
-                            match element {
-                                Type::ClassLiteral(class) => {
-                                    classes.push(ClassType::NonGeneric(*class));
+                            match {
+                                let __ty_view_value = element;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
+                                (_, crate::types::TypeData::ClassLiteral(class)) => {
+                                    classes.push(ClassType::NonGeneric(class));
                                 }
-                                Type::GenericAlias(generic_alias) => {
-                                    classes.push(ClassType::Generic(*generic_alias));
+                                (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                                    classes.push(ClassType::Generic(generic_alias));
                                 }
-                                _ => {
+                                (_, _) => {
                                     good_argument = false;
                                     break;
                                 }
@@ -2471,7 +2538,7 @@ impl KnownFunction {
                         }
                         classes
                     }
-                    _ => {
+                    (_, _) => {
                         good_argument = false;
                         vec![]
                     }
@@ -2549,12 +2616,14 @@ impl KnownFunction {
                     call_expression.arguments.args.get(1),
                 );
 
-                if let Type::ClassLiteral(class) = second_argument
-                    && self == KnownFunction::IsInstance
+                if let (_, crate::types::TypeData::ClassLiteral(class)) = ({
+                    let __ty_view_value = second_argument;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && self == KnownFunction::IsInstance
                 {
                     overload.set_return_type(Type::from_truthiness(
                         db,
-                        is_instance_truthiness(db, *first_arg, *class),
+                        is_instance_truthiness(db, *first_arg, class),
                     ));
                 }
             }
@@ -2598,10 +2667,17 @@ impl KnownFunction {
                     return;
                 };
 
-                let class = match class_type {
-                    Type::ClassLiteral(class) => ClassType::NonGeneric(*class),
-                    Type::GenericAlias(generic) => ClassType::Generic(*generic),
-                    _ => return,
+                let class = match {
+                    let __ty_view_value = class_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                        ClassType::NonGeneric(class)
+                    }
+                    (_, crate::types::TypeData::GenericAlias(generic)) => {
+                        ClassType::Generic(generic)
+                    }
+                    (_, _) => return,
                 };
 
                 if !class.has_ordering_method_in_mro(db) {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -186,11 +186,8 @@ impl get_size2::GetSize for FunctionDecorators {}
 
 impl FunctionDecorators {
     pub(super) fn from_decorator_type(db: &dyn Db, decorator_type: Type) -> Self {
-        match {
-            let __ty_view_value = decorator_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(function)) => match function.known(db) {
+        match decorator_type.data() {
+            crate::types::TypeData::FunctionLiteral(function) => match function.known(db) {
                 Some(KnownFunction::NoTypeCheck) => FunctionDecorators::NO_TYPE_CHECK,
                 Some(KnownFunction::Overload) => FunctionDecorators::OVERLOAD,
                 Some(KnownFunction::AbstractMethod) => FunctionDecorators::ABSTRACT_METHOD,
@@ -199,12 +196,12 @@ impl FunctionDecorators {
                 Some(KnownFunction::TypeCheckOnly) => FunctionDecorators::TYPE_CHECK_ONLY,
                 _ => FunctionDecorators::empty(),
             },
-            (_, crate::types::TypeData::ClassLiteral(class)) => match class.known(db) {
+            crate::types::TypeData::ClassLiteral(class) => match class.known(db) {
                 Some(KnownClass::Classmethod) => FunctionDecorators::CLASSMETHOD,
                 Some(KnownClass::Staticmethod) => FunctionDecorators::STATICMETHOD,
                 _ => FunctionDecorators::empty(),
             },
-            (_, _) => FunctionDecorators::empty(),
+            _ => FunctionDecorators::empty(),
         }
     }
 }
@@ -1577,11 +1574,8 @@ fn check_classinfo_in_isinstance<'db>(
     classinfo: Type<'db>,
     classinfo_expr: Option<&ast::Expr>,
 ) {
-    match {
-        let __ty_view_value = classinfo;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class)) => {
+    match classinfo.data() {
+        crate::types::TypeData::ClassLiteral(class) => {
             if class.is_typed_dict(db) {
                 report_runtime_check_against_typed_dict(context, call_expression, class, function);
             } else if let Some(protocol_class) = class.into_protocol_class(db) {
@@ -1605,7 +1599,7 @@ fn check_classinfo_in_isinstance<'db>(
                 }
             }
         }
-        (_, crate::types::TypeData::SpecialForm(SpecialFormType::Any))
+        crate::types::TypeData::SpecialForm(SpecialFormType::Any)
             if function == KnownFunction::IsInstance =>
         {
             let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, call_expression) else {
@@ -1616,7 +1610,7 @@ fn check_classinfo_in_isinstance<'db>(
             ));
             diagnostic.set_primary_message("This call will raise `TypeError` at runtime");
         }
-        (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(_))) => {
+        crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(_)) => {
             report_invalid_union_type_elements(
                 db,
                 context,
@@ -1626,7 +1620,7 @@ fn check_classinfo_in_isinstance<'db>(
                 classinfo_expr,
             );
         }
-        (_, crate::types::TypeData::NominalInstance(nominal)) => {
+        crate::types::TypeData::NominalInstance(nominal) => {
             if let Some(tuple_spec) = nominal.tuple_spec(db) {
                 let element_exprs = match classinfo_expr {
                     Some(ast::Expr::Tuple(tuple_expr)) => Some(&tuple_expr.elts),
@@ -1645,7 +1639,7 @@ fn check_classinfo_in_isinstance<'db>(
                 }
             }
         }
-        (_, _) => {}
+        _ => {}
     }
 }
 
@@ -1665,19 +1659,16 @@ fn report_invalid_union_type_elements<'db>(
         ty: Type<'db>,
         invalid_elements: &mut Vec<Type<'db>>,
     ) {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(_)) => {}
-            (_, crate::types::TypeData::NominalInstance(instance))
+        match ty.data() {
+            crate::types::TypeData::ClassLiteral(_) => {}
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::NoneType) => {}
-            (_, crate::types::TypeData::SpecialForm(special_form))
+            crate::types::TypeData::SpecialForm(special_form)
                 if special_form.is_valid_isinstance_target() => {}
             // `Any` can be used in `issubclass()` calls but not `isinstance()` calls
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Any))
+            crate::types::TypeData::SpecialForm(SpecialFormType::Any)
                 if function == KnownFunction::IsSubclass => {}
-            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance)) => {
                 match instance.value_expression_types(db) {
                     Ok(value_expression_types) => {
                         for element in value_expression_types {
@@ -1689,7 +1680,7 @@ fn report_invalid_union_type_elements<'db>(
                     }
                 }
             }
-            (_, _) => invalid_elements.push(ty),
+            _ => invalid_elements.push(ty),
         }
     }
 
@@ -1722,20 +1713,13 @@ fn report_invalid_union_type_elements<'db>(
 
     // When we have a secondary annotation pointing at the UnionType expression,
     // "the union" is unambiguous. Otherwise, spell out the union type in the message.
-    let union_suffix = match (
-        &union_type_expr,
-        ({
-            let __ty_view_value = union_type;
-            (__ty_view_value, __ty_view_value.data())
-        }),
-    ) {
-        (
-            None,
-            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))),
-        ) => match instance.union_type(db) {
-            Ok(ty) => format!(" `{}`", ty.display(db)),
-            Err(_) => String::new(),
-        },
+    let union_suffix = match (&union_type_expr, union_type.data()) {
+        (None, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))) => {
+            match instance.union_type(db) {
+                Ok(ty) => format!(" `{}`", ty.display(db)),
+                Err(_) => String::new(),
+            }
+        }
         _ => String::new(),
     };
 
@@ -1779,11 +1763,8 @@ fn is_instance_truthiness<'db>(
         }
     };
 
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::Union(..)) => {
+    match ty.data() {
+        crate::types::TypeData::Union(..) => {
             // We do not handle unions specifically here, because something like `A | SubclassOfA` would
             // have been simplified to `A` anyway
             Truthiness::Ambiguous
@@ -1793,17 +1774,14 @@ fn is_instance_truthiness<'db>(
         // and evaluate the truthiness of the `isinstance()` check with that type.
         // Along the way, short-circuit to `AlwaysTrue` if we find any positive element
         // that is always true.
-        (_, crate::types::TypeData::Intersection(intersection)) => {
+        crate::types::TypeData::Intersection(intersection) => {
             let mut effective = IntersectionBuilder::new(db);
             let mut found_tvars_or_newtypes = false;
 
             for &positive in intersection.positive(db) {
                 if is_instance_truthiness(db, positive, class).is_always_true() {
                     return Truthiness::AlwaysTrue;
-                } else if let (_, crate::types::TypeData::TypeVar(tvar)) = {
-                    let __ty_view_value = positive;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                } else if let crate::types::TypeData::TypeVar(tvar) = positive.data() {
                     match tvar.typevar(db).bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                             effective = effective.add_positive(bound);
@@ -1816,10 +1794,7 @@ fn is_instance_truthiness<'db>(
                         None => {}
                     }
                     found_tvars_or_newtypes = true;
-                } else if let (_, crate::types::TypeData::NewTypeInstance(newtype)) = {
-                    let __ty_view_value = positive;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                } else if let crate::types::TypeData::NewTypeInstance(newtype) = positive.data() {
                     found_tvars_or_newtypes = true;
                     effective = effective.add_positive(newtype.concrete_base_type(db));
                 } else {
@@ -1847,36 +1822,33 @@ fn is_instance_truthiness<'db>(
             }
         }
 
-        (_, crate::types::TypeData::EnumComplement(complement)) => {
+        crate::types::TypeData::EnumComplement(complement) => {
             is_instance_truthiness(db, complement.to_intersection(db), class)
         }
 
-        (_, crate::types::TypeData::NominalInstance(..)) => always_true_if(is_instance(&ty)),
+        crate::types::TypeData::NominalInstance(..) => always_true_if(is_instance(&ty)),
 
-        (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+        crate::types::TypeData::NewTypeInstance(newtype) => {
             always_true_if(is_instance(&newtype.concrete_base_type(db)))
         }
 
-        (
-            _,
-            crate::types::TypeData::LiteralValue(..)
-            | crate::types::TypeData::ModuleLiteral(..)
-            | crate::types::TypeData::FunctionLiteral(..),
-        ) => always_true_if(
+        crate::types::TypeData::LiteralValue(..)
+        | crate::types::TypeData::ModuleLiteral(..)
+        | crate::types::TypeData::FunctionLiteral(..) => always_true_if(
             ty.literal_fallback_instance(db)
                 .as_ref()
                 .is_some_and(is_instance),
         ),
 
-        (_, crate::types::TypeData::ClassLiteral(..)) => {
+        crate::types::TypeData::ClassLiteral(..) => {
             always_true_if(is_instance(&KnownClass::Type.to_instance(db)))
         }
 
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             is_instance_truthiness(db, alias.value_type(db), class)
         }
 
-        (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+        crate::types::TypeData::TypeVar(bound_typevar) => {
             match bound_typevar.typevar(db).bound_or_constraints(db) {
                 None => is_instance_truthiness(db, Type::object(), class),
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
@@ -1891,31 +1863,28 @@ fn is_instance_truthiness<'db>(
             }
         }
 
-        (
-            _,
-            crate::types::TypeData::BoundMethod(..)
-            | crate::types::TypeData::KnownBoundMethod(..)
-            | crate::types::TypeData::WrapperDescriptor(..)
-            | crate::types::TypeData::DataclassDecorator(..)
-            | crate::types::TypeData::DataclassTransformer(..)
-            | crate::types::TypeData::GenericAlias(..)
-            | crate::types::TypeData::SubclassOf(..)
-            | crate::types::TypeData::ProtocolInstance(..)
-            | crate::types::TypeData::SpecialForm(..)
-            | crate::types::TypeData::KnownInstance(..)
-            | crate::types::TypeData::PropertyInstance(..)
-            | crate::types::TypeData::AlwaysTruthy
-            | crate::types::TypeData::AlwaysFalsy
-            | crate::types::TypeData::BoundSuper(..)
-            | crate::types::TypeData::TypeIs(..)
-            | crate::types::TypeData::TypeGuard(..)
-            | crate::types::TypeData::TypeForm(..)
-            | crate::types::TypeData::Callable(..)
-            | crate::types::TypeData::Dynamic(..)
-            | crate::types::TypeData::Divergent(_)
-            | crate::types::TypeData::Never
-            | crate::types::TypeData::TypedDict(_),
-        ) => {
+        crate::types::TypeData::BoundMethod(..)
+        | crate::types::TypeData::KnownBoundMethod(..)
+        | crate::types::TypeData::WrapperDescriptor(..)
+        | crate::types::TypeData::DataclassDecorator(..)
+        | crate::types::TypeData::DataclassTransformer(..)
+        | crate::types::TypeData::GenericAlias(..)
+        | crate::types::TypeData::SubclassOf(..)
+        | crate::types::TypeData::ProtocolInstance(..)
+        | crate::types::TypeData::SpecialForm(..)
+        | crate::types::TypeData::KnownInstance(..)
+        | crate::types::TypeData::PropertyInstance(..)
+        | crate::types::TypeData::AlwaysTruthy
+        | crate::types::TypeData::AlwaysFalsy
+        | crate::types::TypeData::BoundSuper(..)
+        | crate::types::TypeData::TypeIs(..)
+        | crate::types::TypeData::TypeGuard(..)
+        | crate::types::TypeData::TypeForm(..)
+        | crate::types::TypeData::Callable(..)
+        | crate::types::TypeData::Dynamic(..)
+        | crate::types::TypeData::Divergent(_)
+        | crate::types::TypeData::Never
+        | crate::types::TypeData::TypedDict(_) => {
             // We could probably try to infer more precise types in some of these cases, but it's unclear
             // if it's worth the effort.
             Truthiness::Ambiguous
@@ -2406,13 +2375,7 @@ impl KnownFunction {
                 let casted_type = casted_type.project_type_form(db);
                 let contains_unknown_or_todo = |ty: Type<'_>| {
                     ty.is_dynamic()
-                        && !matches!(
-                            {
-                                let __ty_view_value = ty;
-                                (__ty_view_value, __ty_view_value.data())
-                            },
-                            (_, crate::types::TypeData::Dynamic(DynamicType::Any))
-                        )
+                        && !matches!(ty.data(), crate::types::TypeData::Dynamic(DynamicType::Any))
                 };
                 if source_type.is_equivalent_to(db, casted_type)
                     && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
@@ -2506,31 +2469,25 @@ impl KnownFunction {
                     return;
                 };
                 let mut good_argument = true;
-                let classes = match {
-                    let __ty_view_value = param_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                let classes = match param_type.data() {
+                    crate::types::TypeData::ClassLiteral(class) => {
                         vec![ClassType::NonGeneric(class)]
                     }
-                    (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                    crate::types::TypeData::GenericAlias(generic_alias) => {
                         vec![ClassType::Generic(generic_alias)]
                     }
-                    (_, crate::types::TypeData::Union(union)) => {
+                    crate::types::TypeData::Union(union) => {
                         let elements = union.elements(db);
                         let mut classes = Vec::with_capacity(elements.len());
                         for element in elements {
-                            match {
-                                let __ty_view_value = element;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
-                                (_, crate::types::TypeData::ClassLiteral(class)) => {
+                            match element.data() {
+                                crate::types::TypeData::ClassLiteral(class) => {
                                     classes.push(ClassType::NonGeneric(class));
                                 }
-                                (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                                crate::types::TypeData::GenericAlias(generic_alias) => {
                                     classes.push(ClassType::Generic(generic_alias));
                                 }
-                                (_, _) => {
+                                _ => {
                                     good_argument = false;
                                     break;
                                 }
@@ -2538,7 +2495,7 @@ impl KnownFunction {
                         }
                         classes
                     }
-                    (_, _) => {
+                    _ => {
                         good_argument = false;
                         vec![]
                     }
@@ -2616,10 +2573,8 @@ impl KnownFunction {
                     call_expression.arguments.args.get(1),
                 );
 
-                if let (_, crate::types::TypeData::ClassLiteral(class)) = ({
-                    let __ty_view_value = second_argument;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && self == KnownFunction::IsInstance
+                if let crate::types::TypeData::ClassLiteral(class) = second_argument.data()
+                    && self == KnownFunction::IsInstance
                 {
                     overload.set_return_type(Type::from_truthiness(
                         db,
@@ -2667,17 +2622,10 @@ impl KnownFunction {
                     return;
                 };
 
-                let class = match {
-                    let __ty_view_value = class_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
-                        ClassType::NonGeneric(class)
-                    }
-                    (_, crate::types::TypeData::GenericAlias(generic)) => {
-                        ClassType::Generic(generic)
-                    }
-                    (_, _) => return,
+                let class = match class_type.data() {
+                    crate::types::TypeData::ClassLiteral(class) => ClassType::NonGeneric(class),
+                    crate::types::TypeData::GenericAlias(generic) => ClassType::Generic(generic),
+                    _ => return,
                 };
 
                 if !class.has_ordering_method_in_mro(db) {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -551,11 +551,8 @@ impl<'db> GenericContext<'db> {
             ast::TypeParam::TypeVar(node) => {
                 let definition = index.expect_single_definition(node);
                 let declared = inferred_declaration(db, definition).declared()?;
-                let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
-                    ({
-                        let __ty_view_value = declared.inner_type();
-                        (__ty_view_value, __ty_view_value.data())
-                    })
+                let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                    declared.inner_type().data()
                 else {
                     return None;
                 };
@@ -564,11 +561,8 @@ impl<'db> GenericContext<'db> {
             ast::TypeParam::ParamSpec(node) => {
                 let definition = index.expect_single_definition(node);
                 let declared = inferred_declaration(db, definition).declared()?;
-                let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
-                    ({
-                        let __ty_view_value = declared.inner_type();
-                        (__ty_view_value, __ty_view_value.data())
-                    })
+                let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                    declared.inner_type().data()
                 else {
                     return None;
                 };
@@ -1639,19 +1633,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // return `self.always()` from that branch, as that leads to union
             // simplification, which means that we lose track of type variables
             // without recording the constraints under which the relation holds.
-            if matches!(
-                {
-                    let __ty_view_value = target;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::TypeVar(_))
-            ) || matches!(
-                {
-                    let __ty_view_value = source;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::TypeVar(_))
-            ) {
+            if matches!(target.data(), crate::types::TypeData::TypeVar(_))
+                || matches!(source.data(), crate::types::TypeData::TypeVar(_))
+            {
                 return self.always();
             }
 
@@ -2044,27 +2028,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         identity: BoundTypeVarIdentity<'db>,
         ty: Type<'db>,
     ) -> bool {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match ty.data() {
             // A bare `T = U` edge only replaces one typevar with another; it does not wrap the
             // replacement in additional structure and therefore cannot grow during repeated
             // specialization.
-            (_, crate::types::TypeData::TypeVar(_)) => false,
+            crate::types::TypeData::TypeVar(_) => false,
             // Unions and intersections are flattened and deduplicated as they are constructed.
             // A cyclic reference directly inside one can add elements but cannot create
             // unbounded nesting. Keep looking inside its elements for a genuinely embedded edge.
-            (_, crate::types::TypeData::Union(union)) => {
-                union.elements(self.db).iter().any(|element| {
-                    self.has_expanding_cycle(generic_context, types, identity, *element)
-                })
-            }
-            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            crate::types::TypeData::Union(union) => union.elements(self.db).iter().any(|element| {
+                self.has_expanding_cycle(generic_context, types, identity, *element)
+            }),
+            crate::types::TypeData::Intersection(intersection) => intersection
                 .iter_positive(self.db)
                 .chain(intersection.iter_negative(self.db))
                 .any(|element| self.has_expanding_cycle(generic_context, types, identity, element)),
-            (_, _) => any_over_type(self.db, ty, false, |nested| {
+            _ => any_over_type(self.db, ty, false, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(self.db);
                     dependency != identity
@@ -2156,11 +2135,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union))
+        match ty.data() {
+            crate::types::TypeData::Union(union)
                 if union.elements(self.db).iter().any(|element| {
                     !self.is_inferable_typevar_artifact(generic_context, *element)
                 }) =>
@@ -2169,7 +2145,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     !self.is_inferable_typevar_artifact(generic_context, *element)
                 })
             }
-            (_, _) => ty,
+            _ => ty,
         }
     }
 
@@ -2178,11 +2154,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Intersection(intersection))
+        match ty.data() {
+            crate::types::TypeData::Intersection(intersection)
                 if intersection.iter_positive(self.db).any(|element| {
                     !self.is_inferable_typevar_artifact(generic_context, element)
                 }) =>
@@ -2195,7 +2168,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     }
                 })
             }
-            (_, _) => ty,
+            _ => ty,
         }
     }
 
@@ -2351,15 +2324,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return *result;
             }
 
-            let result = match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypedDict(_)) => {
+            let result = match ty.data() {
+                crate::types::TypeData::TypedDict(_) => {
                     typed_dicts.insert(ty);
                     true
                 }
-                (_, crate::types::TypeData::Union(union)) => {
+                crate::types::TypeData::Union(union) => {
                     if !resolving.insert(ty) {
                         return false;
                     }
@@ -2369,7 +2339,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     resolving.remove(&ty);
                     result
                 }
-                (_, _) => false,
+                _ => false,
             };
             completed.insert(ty, result);
             result
@@ -2503,16 +2473,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
         let formal = formal.filter_disjoint_elements(self.db, actual, self.inferable);
 
-        match (
-            ({
-                let __ty_view_value = formal;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = actual;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (formal.view(), actual.view()) {
             // Expand PEP 695 type aliases in the formal type.
             // This is necessary for solving generics like `def head[T](my_list: MyList[T]) -> T`.
             ((_, crate::types::TypeData::TypeAlias(alias)), (_, _)) => {
@@ -2644,10 +2605,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // partial mappings from non-matching elements. For example, while comparing
                 // `ClassSelector[T]` with `ClassSelector[CT | None]`, descending into `None`
                 // would map `T` to `None` before `CT` is solved from another argument.
-                if let (_, crate::types::TypeData::TypeVar(actual_typevar)) = ({
-                    let __ty_view_value = actual;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && actual_typevar.is_inferable(self.db, self.inferable)
+                if let crate::types::TypeData::TypeVar(actual_typevar) = actual.data()
+                    && actual_typevar.is_inferable(self.db, self.inferable)
                     && matches!(polarity, TypeVarVariance::Invariant)
                 {
                     self.add_type_mapping(actual_typevar, formal, polarity);
@@ -2774,11 +2733,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // that is a strict subtype (e.g. `bool` vs `int`) would allow
                         // the callee to return a widened type that violates the caller's
                         // constraint.
-                        if let (_, crate::types::TypeData::TypeVar(actual_typevar)) = ({
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        }) && let Some(actual_constraints) =
-                            actual_typevar.typevar(self.db).constraints(self.db)
+                        if let crate::types::TypeData::TypeVar(actual_typevar) = ty.data()
+                            && let Some(actual_constraints) =
+                                actual_typevar.typevar(self.db).constraints(self.db)
                         {
                             let all_satisfied =
                                 actual_constraints.iter().all(|actual_constraint| {
@@ -2949,15 +2906,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
 
                 // Extract formal_alias if this is a generic class
-                let formal_alias = match {
-                    let __ty_view_value = formal;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::NominalInstance(formal_nominal)) => {
+                let formal_alias = match formal.data() {
+                    crate::types::TypeData::NominalInstance(formal_nominal) => {
                         formal_nominal.class(self.db).into_generic_alias()
                     }
 
-                    (_, crate::types::TypeData::ProtocolInstance(_)) => {
+                    crate::types::TypeData::ProtocolInstance(_) => {
                         // TODO: For protocols, we use the new constraint set implementation, which
                         // will handle implicitly implemented protocols and generic protocols. We
                         // eventually want this logic to be used for _all_ nominal instances
@@ -2976,7 +2930,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         return Ok(());
                     }
 
-                    (_, _) => None,
+                    _ => None,
                 };
 
                 if let Some(formal_alias) = formal_alias {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -551,8 +551,11 @@ impl<'db> GenericContext<'db> {
             ast::TypeParam::TypeVar(node) => {
                 let definition = index.expect_single_definition(node);
                 let declared = inferred_declaration(db, definition).declared()?;
-                let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
-                    declared.inner_type()
+                let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
+                    ({
+                        let __ty_view_value = declared.inner_type();
+                        (__ty_view_value, __ty_view_value.data())
+                    })
                 else {
                     return None;
                 };
@@ -561,8 +564,11 @@ impl<'db> GenericContext<'db> {
             ast::TypeParam::ParamSpec(node) => {
                 let definition = index.expect_single_definition(node);
                 let declared = inferred_declaration(db, definition).declared()?;
-                let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
-                    declared.inner_type()
+                let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
+                    ({
+                        let __ty_view_value = declared.inner_type();
+                        (__ty_view_value, __ty_view_value.data())
+                    })
                 else {
                     return None;
                 };
@@ -1633,7 +1639,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // return `self.always()` from that branch, as that leads to union
             // simplification, which means that we lose track of type variables
             // without recording the constraints under which the relation holds.
-            if matches!(target, Type::TypeVar(_)) || matches!(source, Type::TypeVar(_)) {
+            if matches!(
+                {
+                    let __ty_view_value = target;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::TypeVar(_))
+            ) || matches!(
+                {
+                    let __ty_view_value = source;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::TypeVar(_))
+            ) {
                 return self.always();
             }
 
@@ -2026,22 +2044,27 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         identity: BoundTypeVarIdentity<'db>,
         ty: Type<'db>,
     ) -> bool {
-        match ty {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // A bare `T = U` edge only replaces one typevar with another; it does not wrap the
             // replacement in additional structure and therefore cannot grow during repeated
             // specialization.
-            Type::TypeVar(_) => false,
+            (_, crate::types::TypeData::TypeVar(_)) => false,
             // Unions and intersections are flattened and deduplicated as they are constructed.
             // A cyclic reference directly inside one can add elements but cannot create
             // unbounded nesting. Keep looking inside its elements for a genuinely embedded edge.
-            Type::Union(union) => union.elements(self.db).iter().any(|element| {
-                self.has_expanding_cycle(generic_context, types, identity, *element)
-            }),
-            Type::Intersection(intersection) => intersection
+            (_, crate::types::TypeData::Union(union)) => {
+                union.elements(self.db).iter().any(|element| {
+                    self.has_expanding_cycle(generic_context, types, identity, *element)
+                })
+            }
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
                 .iter_positive(self.db)
                 .chain(intersection.iter_negative(self.db))
                 .any(|element| self.has_expanding_cycle(generic_context, types, identity, element)),
-            _ => any_over_type(self.db, ty, false, |nested| {
+            (_, _) => any_over_type(self.db, ty, false, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(self.db);
                     dependency != identity
@@ -2133,8 +2156,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        match ty {
-            Type::Union(union)
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union))
                 if union.elements(self.db).iter().any(|element| {
                     !self.is_inferable_typevar_artifact(generic_context, *element)
                 }) =>
@@ -2143,7 +2169,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     !self.is_inferable_typevar_artifact(generic_context, *element)
                 })
             }
-            _ => ty,
+            (_, _) => ty,
         }
     }
 
@@ -2152,8 +2178,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        match ty {
-            Type::Intersection(intersection)
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Intersection(intersection))
                 if intersection.iter_positive(self.db).any(|element| {
                     !self.is_inferable_typevar_artifact(generic_context, element)
                 }) =>
@@ -2166,7 +2195,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     }
                 })
             }
-            _ => ty,
+            (_, _) => ty,
         }
     }
 
@@ -2322,12 +2351,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return *result;
             }
 
-            let result = match ty {
-                Type::TypedDict(_) => {
+            let result = match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypedDict(_)) => {
                     typed_dicts.insert(ty);
                     true
                 }
-                Type::Union(union) => {
+                (_, crate::types::TypeData::Union(union)) => {
                     if !resolving.insert(ty) {
                         return false;
                     }
@@ -2337,7 +2369,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     resolving.remove(&ty);
                     result
                 }
-                _ => false,
+                (_, _) => false,
             };
             completed.insert(ty, result);
             result
@@ -2471,14 +2503,26 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
         let formal = formal.filter_disjoint_elements(self.db, actual, self.inferable);
 
-        match (formal, actual) {
+        match (
+            ({
+                let __ty_view_value = formal;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = actual;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
             // Expand PEP 695 type aliases in the formal type.
             // This is necessary for solving generics like `def head[T](my_list: MyList[T]) -> T`.
-            (Type::TypeAlias(alias), _) => {
+            ((_, crate::types::TypeData::TypeAlias(alias)), (_, _)) => {
                 return self.infer_map_impl(alias.value_type(self.db), actual, polarity, seen);
             }
 
-            (Type::TypeForm(formal_typeform), Type::TypeForm(actual_typeform)) => {
+            (
+                (_, crate::types::TypeData::TypeForm(formal_typeform)),
+                (_, crate::types::TypeData::TypeForm(actual_typeform)),
+            ) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
                 return self.infer_map_impl(
                     formal_typeform.type_argument(self.db),
@@ -2489,8 +2533,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (
-                Type::TypeForm(formal_typeform),
-                actual @ (Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)),
+                (_, crate::types::TypeData::TypeForm(formal_typeform)),
+                (
+                    actual,
+                    crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_),
+                ),
             ) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
                 if let Some(actual_instance) = actual.to_instance(self.db) {
@@ -2503,9 +2552,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (Type::TypeForm(formal_typeform), Type::KnownInstance(actual_instance))
-                if actual_instance.is_type_form_value() =>
-            {
+            (
+                (_, crate::types::TypeData::TypeForm(formal_typeform)),
+                (_, crate::types::TypeData::KnownInstance(actual_instance)),
+            ) if actual_instance.is_type_form_value() => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
                 if let Some(actual_argument) = actual_instance.type_form_argument(self.db) {
                     return self.infer_map_impl(
@@ -2517,7 +2567,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (Type::TypeForm(formal_typeform), Type::SpecialForm(actual_form)) => {
+            (
+                (_, crate::types::TypeData::TypeForm(formal_typeform)),
+                (_, crate::types::TypeData::SpecialForm(actual_form)),
+            ) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
                 if let Some(actual_argument) = actual_form.type_form_argument(self.db) {
                     return self.infer_map_impl(
@@ -2535,7 +2588,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             //
             // For now, we punt on fully handling multiple typevar elements. Instead, we handle two
             // common cases specially:
-            (Type::Union(formal_union), Type::Union(actual_union)) => {
+            (
+                (_, crate::types::TypeData::Union(formal_union)),
+                (_, crate::types::TypeData::Union(actual_union)),
+            ) => {
                 // First, if both formal and actual are unions, and precisely one formal union
                 // element _is_ a typevar (not _contains_ a typevar), then we remove any actual
                 // union elements that are a subtype of the formal (as a whole), and map the formal
@@ -2560,7 +2616,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .elements(self.db)
                     .iter()
                     .filter(|ty| ty.has_typevar(self.db));
-                let Ok(Type::TypeVar(formal_bound_typevar)) = types_have_typevars.exactly_one()
+                let Ok(formal_typevar) = types_have_typevars.exactly_one() else {
+                    return Ok(());
+                };
+                let crate::types::TypeData::TypeVar(formal_bound_typevar) = formal_typevar.data()
                 else {
                     return Ok(());
                 };
@@ -2576,17 +2635,19 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if remaining_actual.is_never() {
                     return Ok(());
                 }
-                self.add_type_mapping(*formal_bound_typevar, remaining_actual, polarity);
+                self.add_type_mapping(formal_bound_typevar, remaining_actual, polarity);
             }
-            (Type::Union(union_formal), _) => {
+            ((_, crate::types::TypeData::Union(union_formal)), (_, _)) => {
                 // If the formal is a union and the actual is a bare inferable TypeVar in an
                 // invariant position, record the whole union as the mapping. Invariant matching is
                 // equality-like; probing individual union elements below can leave spurious
                 // partial mappings from non-matching elements. For example, while comparing
                 // `ClassSelector[T]` with `ClassSelector[CT | None]`, descending into `None`
                 // would map `T` to `None` before `CT` is solved from another argument.
-                if let Type::TypeVar(actual_typevar) = actual
-                    && actual_typevar.is_inferable(self.db, self.inferable)
+                if let (_, crate::types::TypeData::TypeVar(actual_typevar)) = ({
+                    let __ty_view_value = actual;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && actual_typevar.is_inferable(self.db, self.inferable)
                     && matches!(polarity, TypeVarVariance::Invariant)
                 {
                     self.add_type_mapping(actual_typevar, formal, polarity);
@@ -2661,7 +2722,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (Type::TypeVar(bound_typevar), ty) | (ty, Type::TypeVar(bound_typevar))
+            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (ty, _))
+            | ((ty, _), (_, crate::types::TypeData::TypeVar(bound_typevar)))
                 if bound_typevar.is_inferable(self.db, self.inferable) =>
             {
                 match bound_typevar.typevar(self.db).bound_or_constraints(self.db) {
@@ -2712,9 +2774,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // that is a strict subtype (e.g. `bool` vs `int`) would allow
                         // the callee to return a widened type that violates the caller's
                         // constraint.
-                        if let Type::TypeVar(actual_typevar) = ty
-                            && let Some(actual_constraints) =
-                                actual_typevar.typevar(self.db).constraints(self.db)
+                        if let (_, crate::types::TypeData::TypeVar(actual_typevar)) = ({
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        }) && let Some(actual_constraints) =
+                            actual_typevar.typevar(self.db).constraints(self.db)
                         {
                             let all_satisfied =
                                 actual_constraints.iter().all(|actual_constraint| {
@@ -2765,7 +2829,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (Type::Intersection(formal_intersection), _) => {
+            ((_, crate::types::TypeData::Intersection(formal_intersection)), (_, _)) => {
                 // The actual type must be assignable to every (positive) element of the
                 // formal intersection, so we must infer type mappings for each of them. (The
                 // actual type must also be disjoint from every negative element of the
@@ -2774,7 +2838,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     self.infer_map_impl(positive, actual, polarity, seen)?;
                 }
             }
-            (_, Type::Intersection(actual_intersection)) => {
+            ((_, _), (_, crate::types::TypeData::Intersection(actual_intersection))) => {
                 // Try to infer type mappings by checking against each intersection element. This
                 // is the dual of the `union_formal` arm above, and it handles cases like:
                 //
@@ -2816,7 +2880,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (Type::SubclassOf(subclass_of), ty) | (ty, Type::SubclassOf(subclass_of))
+            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (ty, _))
+            | ((ty, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
                 if subclass_of.is_type_var() =>
             {
                 let formal_instance = Type::TypeVar(subclass_of.into_type_var().unwrap());
@@ -2826,8 +2891,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (
-                formal @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
-                Type::LiteralValue(literal),
+                (
+                    formal,
+                    crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::ProtocolInstance(_),
+                ),
+                (_, crate::types::TypeData::LiteralValue(literal)),
             ) => {
                 // Retry specialization with the literal's fallback instance so literals can
                 // contribute to generic inference for nominal and protocol formals.
@@ -2835,7 +2904,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return self.infer_map_impl(formal, actual_instance, polarity, seen);
             }
 
-            (formal, Type::ProtocolInstance(actual_protocol)) => {
+            ((formal, _), (_, crate::types::TypeData::ProtocolInstance(actual_protocol))) => {
                 // TODO: This will only handle protocol classes that explicit inherit
                 // from other generic protocol classes by listing it as a base class.
                 // To handle classes that implicitly implement a generic protocol, we
@@ -2851,7 +2920,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (formal, Type::NominalInstance(actual_nominal)) => {
+            ((formal, _), (_, crate::types::TypeData::NominalInstance(actual_nominal))) => {
                 // Special case: `formal` and `actual` are both tuples.
                 if let (Some(formal_tuple), Some(actual_tuple)) = (
                     formal.tuple_instance_spec(self.db),
@@ -2880,12 +2949,15 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
 
                 // Extract formal_alias if this is a generic class
-                let formal_alias = match formal {
-                    Type::NominalInstance(formal_nominal) => {
+                let formal_alias = match {
+                    let __ty_view_value = formal;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::NominalInstance(formal_nominal)) => {
                         formal_nominal.class(self.db).into_generic_alias()
                     }
 
-                    Type::ProtocolInstance(_) => {
+                    (_, crate::types::TypeData::ProtocolInstance(_)) => {
                         // TODO: For protocols, we use the new constraint set implementation, which
                         // will handle implicitly implemented protocols and generic protocols. We
                         // eventually want this logic to be used for _all_ nominal instances
@@ -2904,7 +2976,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         return Ok(());
                     }
 
-                    _ => None,
+                    (_, _) => None,
                 };
 
                 if let Some(formal_alias) = formal_alias {
@@ -2939,7 +3011,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // TODO: in principle this could be a generalized Union-actual arm that maps over the
             // union, but the old solver isn't well-equipped to handle that (due to side effects
             // from even failed matches), so for now we handle this particular case.
-            (formal @ Type::ProtocolInstance(_), actual @ Type::Union(actual_union)) => {
+            (
+                (formal, crate::types::TypeData::ProtocolInstance(_)),
+                (actual, crate::types::TypeData::Union(actual_union)),
+            ) => {
                 let when = self
                     .common_typed_dict_protocol_constraints(formal, actual_union)
                     .unwrap_or_else(|| {
@@ -2954,7 +3029,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 return Ok(());
             }
 
-            (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
+            (
+                (formal, crate::types::TypeData::ProtocolInstance(_)),
+                (actual, crate::types::TypeData::TypedDict(_)),
+            ) => {
                 let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
                 let when = self.constraints.load(self.db, &when);
                 // For protocol inference via constraint sets, keep unsatisfiable results non-fatal
@@ -2969,7 +3047,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // When the formal type is a protocol with a `__call__` method, infer the specialization
             // from matching the actual type's callable signature against the protocol's `__call__`
             // method signature.
-            (Type::ProtocolInstance(formal_protocol), _) => {
+            ((_, crate::types::TypeData::ProtocolInstance(formal_protocol)), (_, _)) => {
                 let Some(call_method) = formal_protocol.interface(self.db).call_method(self.db)
                 else {
                     return Ok(());
@@ -2989,7 +3067,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let _ = self.infer_from_callable_signature(formal_signature, &actual_callables);
             }
 
-            (Type::Callable(formal_callable), _) => {
+            ((_, crate::types::TypeData::Callable(formal_callable)), (_, _)) => {
                 let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
                     return Ok(());
                 };
@@ -3007,7 +3085,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // This is placed at the end of the match block to avoid expanding the type alias
             // when it can be matched directly against a type variable in the formal type,
             // e.g., `reveal_type(alias)` should reveal the type alias, not its value type.
-            (formal, Type::TypeAlias(alias)) => {
+            ((formal, _), (_, crate::types::TypeData::TypeAlias(alias))) => {
                 return self.infer_map_impl(formal, alias.value_type(self.db), polarity, seen);
             }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -230,23 +230,36 @@ pub fn definitions_for_attribute<'db>(
         return resolved;
     };
 
-    let tys = match lhs_ty {
-        Type::Union(union) => union.elements(model.db()),
-        _ => std::slice::from_ref(&lhs_ty),
+    let tys = match {
+        let __ty_view_value = lhs_ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::Union(union)) => union.elements(model.db()),
+        (_, _) => std::slice::from_ref(&lhs_ty),
     };
 
     // Expand intersections for each subtype into their components
     let expanded_tys = tys
         .iter()
-        .flat_map(|ty| match ty {
-            Type::Intersection(intersection) => Either::Left(intersection.positive(db).iter()),
-            _ => Either::Right(std::iter::once(ty)),
+        .flat_map(|ty| {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Intersection(intersection)) => {
+                    Either::Left(intersection.positive(db).iter())
+                }
+                (_, _) => Either::Right(std::iter::once(ty)),
+            }
         })
         .copied();
 
     for ty in expanded_tys {
         // Handle modules
-        if let Type::ModuleLiteral(module_literal) = ty {
+        if let (_, crate::types::TypeData::ModuleLiteral(module_literal)) = {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             if let Some(module_file) = module_literal.module(db).file(db) {
                 let module_scope = global_scope(db, module_file);
                 for def in find_symbol_in_scope(db, module_scope, name_str) {
@@ -262,28 +275,47 @@ pub fn definitions_for_attribute<'db>(
         }
 
         // Prevent lookup on BoundSuper proxy object
-        if matches!(ty, Type::BoundSuper(_)) {
+        if matches!(
+            {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::BoundSuper(_))
+        ) {
             continue;
         }
 
         let meta_type = ty.to_meta_type(db);
 
         // Look up the attribute first on the meta-type, unless it's already a class-like type.
-        let lookup_type = match ty {
-            Type::ClassLiteral(_) | Type::SubclassOf(_) | Type::GenericAlias(_) => ty,
-            _ => meta_type,
+        let lookup_type = match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::SubclassOf(_)
+                | crate::types::TypeData::GenericAlias(_),
+            ) => ty,
+            (_, _) => meta_type,
         };
 
-        let class_literal = match lookup_type {
-            Type::ClassLiteral(class_literal) => class_literal,
-            Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                Some(cls) => match cls.static_class_literal(db) {
-                    Some((lit, _)) => ClassLiteral::Static(lit),
+        let class_literal = match {
+            let __ty_view_value = lookup_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class_literal)) => class_literal,
+            (_, crate::types::TypeData::SubclassOf(subclass)) => {
+                match subclass.subclass_of().into_class(db) {
+                    Some(cls) => match cls.static_class_literal(db) {
+                        Some((lit, _)) => ClassLiteral::Static(lit),
+                        None => continue,
+                    },
                     None => continue,
-                },
-                None => continue,
-            },
-            _ => continue,
+                }
+            }
+            (_, _) => continue,
         };
 
         resolved.extend(definitions_for_attribute_in_class_hierarchy(
@@ -298,16 +330,21 @@ pub fn definitions_for_attribute<'db>(
         // Only look up definitions on the metaclass if the type is a class object to begin with in
         // order to prevent looking up instance members on the class metaclass
         if resolved.is_empty() && meta_type != lookup_type {
-            let class_literal = match meta_type {
-                Type::ClassLiteral(class_literal) => class_literal,
-                Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                    Some(cls) => match cls.static_class_literal(db) {
-                        Some((lit, _)) => ClassLiteral::Static(lit),
+            let class_literal = match {
+                let __ty_view_value = meta_type;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::ClassLiteral(class_literal)) => class_literal,
+                (_, crate::types::TypeData::SubclassOf(subclass)) => {
+                    match subclass.subclass_of().into_class(db) {
+                        Some(cls) => match cls.static_class_literal(db) {
+                            Some((lit, _)) => ClassLiteral::Static(lit),
+                            None => continue,
+                        },
                         None => continue,
-                    },
-                    None => continue,
-                },
-                _ => continue,
+                    }
+                }
+                (_, _) => continue,
             };
 
             resolved.extend(definitions_for_attribute_in_class_hierarchy(
@@ -872,14 +909,21 @@ fn full_type_bindings_for_call<'db>(
 // values, while aliases, unions, intersections, and specialized generics require more context.
 // `TypeForm(...)` also bypasses callable bindings and needs separate handling.
 fn known_type_form_parameter_index(db: &dyn Db, callable_type: Type<'_>) -> Option<usize> {
-    match callable_type {
-        Type::FunctionLiteral(function) => match function.known(db) {
+    match {
+        let __ty_view_value = callable_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::FunctionLiteral(function)) => match function.known(db) {
             Some(KnownFunction::Cast) => Some(0),
             Some(KnownFunction::AssertType) => Some(1),
             _ => None,
         },
-        Type::ClassLiteral(class) if class.is_known(db, KnownClass::TypeAliasType) => Some(1),
-        _ => None,
+        (_, crate::types::TypeData::ClassLiteral(class))
+            if class.is_known(db, KnownClass::TypeAliasType) =>
+        {
+            Some(1)
+        }
+        (_, _) => None,
     }
 }
 
@@ -1102,17 +1146,29 @@ pub fn definitions_for_unary_op<'db>(
 ///
 /// This is so that we show e.g. `int.__add__` instead of `Literal[4].__add__`.
 fn promote_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    match ty {
-        Type::BoundMethod(method) => Type::BoundMethod(method.map_self_type(db, |self_ty| {
-            self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
-        })),
-        Type::Union(elements) => elements.map(db, |ty| match ty {
-            Type::BoundMethod(method) => Type::BoundMethod(method.map_self_type(db, |self_ty| {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::BoundMethod(method)) => {
+            Type::BoundMethod(method.map_self_type(db, |self_ty| {
                 self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
-            })),
-            _ => *ty,
+            }))
+        }
+        (_, crate::types::TypeData::Union(elements)) => elements.map(db, |ty| {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::BoundMethod(method)) => {
+                    Type::BoundMethod(method.map_self_type(db, |self_ty| {
+                        self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
+                    }))
+                }
+                (_, _) => *ty,
+            }
         }),
-        ty => ty,
+        (ty, _) => ty,
     }
 }
 
@@ -2061,9 +2117,12 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
 
 /// Extract a `ClassLiteral` from a `Type`, handling various type forms.
 fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
-    match ty {
-        Type::ClassLiteral(class_literal) => Some(class_literal),
-        Type::SubclassOf(subclass_of) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(class_literal)) => Some(class_literal),
+        (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
             let inner = subclass_of.subclass_of();
             match inner {
                 crate::types::SubclassOfInner::Class(class_type) => {
@@ -2073,14 +2132,18 @@ fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLit
                 | crate::types::SubclassOfInner::TypeVar(_) => None,
             }
         }
-        Type::GenericAlias(generic_alias) => Some(ClassLiteral::Static(generic_alias.origin(db))),
-        Type::NominalInstance(instance) => Some(instance.class(db).class_literal(db)),
-        Type::Union(union) => union
+        (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+            Some(ClassLiteral::Static(generic_alias.origin(db)))
+        }
+        (_, crate::types::TypeData::NominalInstance(instance)) => {
+            Some(instance.class(db).class_literal(db))
+        }
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .find_map(|elem| extract_class_literal(db, *elem)),
 
-        _ => None,
+        (_, _) => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -230,36 +230,25 @@ pub fn definitions_for_attribute<'db>(
         return resolved;
     };
 
-    let tys = match {
-        let __ty_view_value = lhs_ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::Union(union)) => union.elements(model.db()),
-        (_, _) => std::slice::from_ref(&lhs_ty),
+    let tys = match lhs_ty.data() {
+        crate::types::TypeData::Union(union) => union.elements(model.db()),
+        _ => std::slice::from_ref(&lhs_ty),
     };
 
     // Expand intersections for each subtype into their components
     let expanded_tys = tys
         .iter()
-        .flat_map(|ty| {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::Intersection(intersection)) => {
-                    Either::Left(intersection.positive(db).iter())
-                }
-                (_, _) => Either::Right(std::iter::once(ty)),
+        .flat_map(|ty| match ty.data() {
+            crate::types::TypeData::Intersection(intersection) => {
+                Either::Left(intersection.positive(db).iter())
             }
+            _ => Either::Right(std::iter::once(ty)),
         })
         .copied();
 
     for ty in expanded_tys {
         // Handle modules
-        if let (_, crate::types::TypeData::ModuleLiteral(module_literal)) = {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::ModuleLiteral(module_literal) = ty.data() {
             if let Some(module_file) = module_literal.module(db).file(db) {
                 let module_scope = global_scope(db, module_file);
                 for def in find_symbol_in_scope(db, module_scope, name_str) {
@@ -275,38 +264,23 @@ pub fn definitions_for_attribute<'db>(
         }
 
         // Prevent lookup on BoundSuper proxy object
-        if matches!(
-            {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::BoundSuper(_))
-        ) {
+        if matches!(ty.data(), crate::types::TypeData::BoundSuper(_)) {
             continue;
         }
 
         let meta_type = ty.to_meta_type(db);
 
         // Look up the attribute first on the meta-type, unless it's already a class-like type.
-        let lookup_type = match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                crate::types::TypeData::ClassLiteral(_)
-                | crate::types::TypeData::SubclassOf(_)
-                | crate::types::TypeData::GenericAlias(_),
-            ) => ty,
-            (_, _) => meta_type,
+        let lookup_type = match ty.data() {
+            crate::types::TypeData::ClassLiteral(_)
+            | crate::types::TypeData::SubclassOf(_)
+            | crate::types::TypeData::GenericAlias(_) => ty,
+            _ => meta_type,
         };
 
-        let class_literal = match {
-            let __ty_view_value = lookup_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class_literal)) => class_literal,
-            (_, crate::types::TypeData::SubclassOf(subclass)) => {
+        let class_literal = match lookup_type.data() {
+            crate::types::TypeData::ClassLiteral(class_literal) => class_literal,
+            crate::types::TypeData::SubclassOf(subclass) => {
                 match subclass.subclass_of().into_class(db) {
                     Some(cls) => match cls.static_class_literal(db) {
                         Some((lit, _)) => ClassLiteral::Static(lit),
@@ -315,7 +289,7 @@ pub fn definitions_for_attribute<'db>(
                     None => continue,
                 }
             }
-            (_, _) => continue,
+            _ => continue,
         };
 
         resolved.extend(definitions_for_attribute_in_class_hierarchy(
@@ -330,12 +304,9 @@ pub fn definitions_for_attribute<'db>(
         // Only look up definitions on the metaclass if the type is a class object to begin with in
         // order to prevent looking up instance members on the class metaclass
         if resolved.is_empty() && meta_type != lookup_type {
-            let class_literal = match {
-                let __ty_view_value = meta_type;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::ClassLiteral(class_literal)) => class_literal,
-                (_, crate::types::TypeData::SubclassOf(subclass)) => {
+            let class_literal = match meta_type.data() {
+                crate::types::TypeData::ClassLiteral(class_literal) => class_literal,
+                crate::types::TypeData::SubclassOf(subclass) => {
                     match subclass.subclass_of().into_class(db) {
                         Some(cls) => match cls.static_class_literal(db) {
                             Some((lit, _)) => ClassLiteral::Static(lit),
@@ -344,7 +315,7 @@ pub fn definitions_for_attribute<'db>(
                         None => continue,
                     }
                 }
-                (_, _) => continue,
+                _ => continue,
             };
 
             resolved.extend(definitions_for_attribute_in_class_hierarchy(
@@ -909,21 +880,18 @@ fn full_type_bindings_for_call<'db>(
 // values, while aliases, unions, intersections, and specialized generics require more context.
 // `TypeForm(...)` also bypasses callable bindings and needs separate handling.
 fn known_type_form_parameter_index(db: &dyn Db, callable_type: Type<'_>) -> Option<usize> {
-    match {
-        let __ty_view_value = callable_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::FunctionLiteral(function)) => match function.known(db) {
+    match callable_type.data() {
+        crate::types::TypeData::FunctionLiteral(function) => match function.known(db) {
             Some(KnownFunction::Cast) => Some(0),
             Some(KnownFunction::AssertType) => Some(1),
             _ => None,
         },
-        (_, crate::types::TypeData::ClassLiteral(class))
+        crate::types::TypeData::ClassLiteral(class)
             if class.is_known(db, KnownClass::TypeAliasType) =>
         {
             Some(1)
         }
-        (_, _) => None,
+        _ => None,
     }
 }
 
@@ -1146,27 +1114,19 @@ pub fn definitions_for_unary_op<'db>(
 ///
 /// This is so that we show e.g. `int.__add__` instead of `Literal[4].__add__`.
 fn promote_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    match ty.view() {
         (_, crate::types::TypeData::BoundMethod(method)) => {
             Type::BoundMethod(method.map_self_type(db, |self_ty| {
                 self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
             }))
         }
-        (_, crate::types::TypeData::Union(elements)) => elements.map(db, |ty| {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::BoundMethod(method)) => {
-                    Type::BoundMethod(method.map_self_type(db, |self_ty| {
-                        self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
-                    }))
-                }
-                (_, _) => *ty,
+        (_, crate::types::TypeData::Union(elements)) => elements.map(db, |ty| match ty.data() {
+            crate::types::TypeData::BoundMethod(method) => {
+                Type::BoundMethod(method.map_self_type(db, |self_ty| {
+                    self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
+                }))
             }
+            _ => *ty,
         }),
         (ty, _) => ty,
     }
@@ -2117,12 +2077,9 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
 
 /// Extract a `ClassLiteral` from a `Type`, handling various type forms.
 fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(class_literal)) => Some(class_literal),
-        (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
+    match ty.data() {
+        crate::types::TypeData::ClassLiteral(class_literal) => Some(class_literal),
+        crate::types::TypeData::SubclassOf(subclass_of) => {
             let inner = subclass_of.subclass_of();
             match inner {
                 crate::types::SubclassOfInner::Class(class_type) => {
@@ -2132,18 +2089,18 @@ fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLit
                 | crate::types::SubclassOfInner::TypeVar(_) => None,
             }
         }
-        (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+        crate::types::TypeData::GenericAlias(generic_alias) => {
             Some(ClassLiteral::Static(generic_alias.origin(db)))
         }
-        (_, crate::types::TypeData::NominalInstance(instance)) => {
+        crate::types::TypeData::NominalInstance(instance) => {
             Some(instance.class(db).class_literal(db))
         }
-        (_, crate::types::TypeData::Union(union)) => union
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .find_map(|elem| extract_class_literal(db, *elem)),
 
-        (_, _) => None,
+        _ => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -174,14 +174,8 @@ fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
     // Dataclass field specifiers carry metadata in the inferred RHS type; replacing it with the
     // declared field type would lose settings like `init=False`.
     matches!(
-        {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        },
-        (
-            _,
-            crate::types::TypeData::KnownInstance(KnownInstanceType::Field(_))
-        )
+        ty.data(),
+        crate::types::TypeData::KnownInstance(KnownInstanceType::Field(_))
     )
 }
 
@@ -748,8 +742,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return false;
         };
         matches!(
-            { let __ty_view_value = self.expression_type(&call.func); (__ty_view_value, __ty_view_value.data()) } ,
-            (_, crate::types::TypeData::FunctionLiteral(f))
+            self.expression_type(&call.func).data() ,
+            crate::types::TypeData::FunctionLiteral(f)
                 if matches!(
                     f.known(self.db()),
                     Some(KnownFunction::RevealType | KnownFunction::AssertType)
@@ -1167,10 +1161,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         for decorator in &function.node(self.module()).decorator_list {
             let decorator_type = self.infer_decorator(decorator);
-            if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-                let __ty_view_value = decorator_type;
-                (__ty_view_value, __ty_view_value.data())
-            }) && let Some(KnownFunction::NoTypeCheck) = function.known(self.db())
+            if let crate::types::TypeData::FunctionLiteral(function) = decorator_type.data()
+                && let Some(KnownFunction::NoTypeCheck) = function.known(self.db())
             {
                 // Match `infer_function_definition`: suppress diagnostics that follow
                 // `@no_type_check`, including later decorators.
@@ -1558,7 +1550,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // "declared types is `Unknown` (e.g. due to a bad annotation, missing
                         // import, etc.)". Ideally we would still prefer `Unknown` declared type,
                         // but use inferred type if there is no declared type.
-                        && !matches!( { let __ty_view_value = declared_type; (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)))
+                        && !matches!( declared_type.data() , crate::types::TypeData::Dynamic(DynamicType::Unknown))
                         && declared_type.is_assignable_to(self.db(), inferred_ty)
                     {
                         (declared_ty, declared_type)
@@ -1730,22 +1722,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.function_decorator_types(function)
             .any(|decorator_type| {
-                match {
-                    let __ty_view_value = decorator_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::FunctionLiteral(function)) => matches!(
+                match decorator_type.data() {
+                    crate::types::TypeData::FunctionLiteral(function) => matches!(
                         function.known(self.db()),
                         Some(KnownFunction::Overload | KnownFunction::AbstractMethod)
                     ),
-                    (_, crate::types::TypeData::Never) => {
+                    crate::types::TypeData::Never => {
                         // In unreachable code, we infer `Never` for decorators like `typing.overload`.
                         // Return `true` here to avoid false positive `invalid-return-type` lints for
                         // `@overload`ed functions without a body in unreachable code.
                         true
                     }
-                    (_, crate::types::TypeData::Divergent(_)) => true,
-                    (_, _) => false,
+                    crate::types::TypeData::Divergent(_) => true,
+                    _ => false,
                 }
             })
     }
@@ -2164,10 +2153,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     })
                     .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db())),
             )
-        } else if let (_, crate::types::TypeData::Union(union)) = {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        } else if let crate::types::TypeData::Union(union) = ty.data() {
             // `except exception_types as e:`, where
             // `exception_types: type[ValueError] | tuple[type[ValueError], ...]`
             union.try_map(self.db(), |element| {
@@ -2392,10 +2378,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn validate_class_pattern(&mut self, pattern: &ast::PatternMatchClass, cls_ty: Type<'db>) {
-        if let (_, crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable)) = {
-            let __ty_view_value = cls_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable) =
+            cls_ty.data()
+        {
             if let Some(first_excess_pattern) = pattern.arguments.patterns.first() {
                 report_too_many_positional_patterns_for_callable_class_pattern(
                     &self.context,
@@ -2406,10 +2391,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        if let (_, crate::types::TypeData::ClassLiteral(class)) = {
-            let __ty_view_value = cls_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::ClassLiteral(class) = cls_ty.data() {
             if class.is_typed_dict(self.db()) {
                 report_match_pattern_against_typed_dict(&self.context, &*pattern.cls, class);
             } else if let Some(protocol_class) = class.into_protocol_class(self.db())
@@ -2644,10 +2626,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // input type (the type of the first positional parameter), not the field's
         // declared type.
         let effective_write_type = |attr_ty: Type<'db>| -> Type<'db> {
-            if let (_, crate::types::TypeData::NominalInstance(instance)) = {
-                let __ty_view_value = object_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::NominalInstance(instance) = object_ty.data() {
                 if let Some(converter_ty) = instance
                     .class(db)
                     .converter_input_type_for_field(db, attribute)
@@ -2658,11 +2637,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             attr_ty
         };
 
-        match {
-            let __ty_view_value = object_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match object_ty.data() {
+            crate::types::TypeData::Union(union) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // Perform loud inference without type context, as there may be multiple
@@ -2700,7 +2676,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // TODO: Handle negative intersection elements
@@ -2740,7 +2716,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => self
+            crate::types::TypeData::EnumComplement(complement) => self
                 .validate_attribute_assignment(
                     target,
                     complement.remaining_literal_union(db),
@@ -2749,7 +2725,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     emit_diagnostics,
                 ),
 
-            (_, crate::types::TypeData::TypeAlias(alias)) => self.validate_attribute_assignment(
+            crate::types::TypeData::TypeAlias(alias) => self.validate_attribute_assignment(
                 target,
                 alias.value_type(self.db()),
                 attribute,
@@ -2758,7 +2734,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ),
 
             // Super instances do not allow attribute assignment
-            (_, crate::types::TypeData::NominalInstance(instance))
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::Super) =>
             {
                 infer_value_ty(self, TypeContext::default());
@@ -2774,7 +2750,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 false
             }
-            (_, crate::types::TypeData::BoundSuper(_)) => {
+            crate::types::TypeData::BoundSuper(_) => {
                 infer_value_ty(self, TypeContext::default());
 
                 if emit_diagnostics
@@ -2788,40 +2764,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 false
             }
 
-            (
-                _,
-                crate::types::TypeData::Dynamic(..)
-                | crate::types::TypeData::Divergent(_)
-                | crate::types::TypeData::Never,
-            ) => {
+            crate::types::TypeData::Dynamic(..)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never => {
                 infer_value_ty(self, TypeContext::default());
                 true
             }
 
-            (
-                _,
-                crate::types::TypeData::NominalInstance(..)
-                | crate::types::TypeData::ProtocolInstance(_)
-                | crate::types::TypeData::LiteralValue(..)
-                | crate::types::TypeData::SpecialForm(..)
-                | crate::types::TypeData::KnownInstance(..)
-                | crate::types::TypeData::PropertyInstance(..)
-                | crate::types::TypeData::FunctionLiteral(..)
-                | crate::types::TypeData::Callable(..)
-                | crate::types::TypeData::BoundMethod(_)
-                | crate::types::TypeData::KnownBoundMethod(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::TypeVar(..)
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::TypedDict(_)
-                | crate::types::TypeData::NewTypeInstance(_),
-            ) => {
+            crate::types::TypeData::NominalInstance(..)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::LiteralValue(..)
+            | crate::types::TypeData::SpecialForm(..)
+            | crate::types::TypeData::KnownInstance(..)
+            | crate::types::TypeData::PropertyInstance(..)
+            | crate::types::TypeData::FunctionLiteral(..)
+            | crate::types::TypeData::Callable(..)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::TypeVar(..)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::TypedDict(_)
+            | crate::types::TypeData::NewTypeInstance(_) => {
                 // We may infer the value type multiple times with distinct type context during
                 // attribute resolution.
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
@@ -3113,12 +3083,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (
-                _,
-                crate::types::TypeData::ClassLiteral(..)
-                | crate::types::TypeData::GenericAlias(..)
-                | crate::types::TypeData::SubclassOf(..),
-            ) => {
+            crate::types::TypeData::ClassLiteral(..)
+            | crate::types::TypeData::GenericAlias(..)
+            | crate::types::TypeData::SubclassOf(..) => {
                 let Some((meta_attr, fallback_attr)) =
                     self.assignment_attribute_members(object_ty, attribute)
                 else {
@@ -3319,7 +3286,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::ModuleLiteral(module)) => {
+            crate::types::TypeData::ModuleLiteral(module) => {
                 let sym = if module
                     .module(db)
                     .known(db)
@@ -3376,11 +3343,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
-        match {
-            let __ty_view_value = object_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match object_ty.data() {
+            crate::types::TypeData::Union(union) => {
                 for element_ty in union.elements(db) {
                     if !self.validate_attribute_deletion(
                         target,
@@ -3394,7 +3358,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 true
             }
 
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 if intersection.positive(db).iter().any(|element_ty| {
                     self.validate_attribute_deletion(target, *element_ty, attribute, false)
                 }) {
@@ -3408,51 +3372,47 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => self
-                .validate_attribute_deletion(
-                    target,
-                    complement.remaining_literal_union(db),
-                    attribute,
-                    emit_diagnostics,
-                ),
+            crate::types::TypeData::EnumComplement(complement) => self.validate_attribute_deletion(
+                target,
+                complement.remaining_literal_union(db),
+                attribute,
+                emit_diagnostics,
+            ),
 
             // Type aliases need their own arm so aliased unions and intersections reuse the
             // specialized handling above. `NewType` instances don't: dunder lookup and attribute
             // fallback already delegate through the concrete base type when needed.
-            (_, crate::types::TypeData::TypeAlias(alias)) => self.validate_attribute_deletion(
+            crate::types::TypeData::TypeAlias(alias) => self.validate_attribute_deletion(
                 target,
                 alias.value_type(db),
                 attribute,
                 emit_diagnostics,
             ),
 
-            (
-                _,
-                crate::types::TypeData::NominalInstance(..)
-                | crate::types::TypeData::ProtocolInstance(_)
-                | crate::types::TypeData::LiteralValue(..)
-                | crate::types::TypeData::SpecialForm(..)
-                | crate::types::TypeData::ClassLiteral(..)
-                | crate::types::TypeData::GenericAlias(..)
-                | crate::types::TypeData::SubclassOf(..)
-                | crate::types::TypeData::KnownInstance(..)
-                | crate::types::TypeData::PropertyInstance(..)
-                | crate::types::TypeData::FunctionLiteral(..)
-                | crate::types::TypeData::Callable(..)
-                | crate::types::TypeData::BoundMethod(_)
-                | crate::types::TypeData::KnownBoundMethod(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::TypeVar(..)
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::TypedDict(_)
-                | crate::types::TypeData::NewTypeInstance(_),
-            ) => {
+            crate::types::TypeData::NominalInstance(..)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::LiteralValue(..)
+            | crate::types::TypeData::SpecialForm(..)
+            | crate::types::TypeData::ClassLiteral(..)
+            | crate::types::TypeData::GenericAlias(..)
+            | crate::types::TypeData::SubclassOf(..)
+            | crate::types::TypeData::KnownInstance(..)
+            | crate::types::TypeData::PropertyInstance(..)
+            | crate::types::TypeData::FunctionLiteral(..)
+            | crate::types::TypeData::Callable(..)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::TypeVar(..)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::TypedDict(_)
+            | crate::types::TypeData::NewTypeInstance(_) => {
                 let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
                     db,
                     "__delattr__",
@@ -3570,14 +3530,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 true
             }
 
-            (
-                _,
-                crate::types::TypeData::Dynamic(..)
-                | crate::types::TypeData::Divergent(_)
-                | crate::types::TypeData::Never
-                | crate::types::TypeData::ModuleLiteral(..)
-                | crate::types::TypeData::BoundSuper(..),
-            ) => true,
+            crate::types::TypeData::Dynamic(..)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::ModuleLiteral(..)
+            | crate::types::TypeData::BoundSuper(..) => true,
         }
     }
 
@@ -3596,57 +3553,45 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }) | Place::Undefined
         );
         let fallback_attr = if needs_fallback {
-            Some(
-                match {
-                    let __ty_view_value = object_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (
-                        _,
-                        crate::types::TypeData::NominalInstance(..)
-                        | crate::types::TypeData::ProtocolInstance(_)
-                        | crate::types::TypeData::LiteralValue(..)
-                        | crate::types::TypeData::SpecialForm(..)
-                        | crate::types::TypeData::KnownInstance(..)
-                        | crate::types::TypeData::PropertyInstance(..)
-                        | crate::types::TypeData::FunctionLiteral(..)
-                        | crate::types::TypeData::Callable(..)
-                        | crate::types::TypeData::BoundMethod(_)
-                        | crate::types::TypeData::KnownBoundMethod(_)
-                        | crate::types::TypeData::WrapperDescriptor(_)
-                        | crate::types::TypeData::DataclassDecorator(_)
-                        | crate::types::TypeData::DataclassTransformer(_)
-                        | crate::types::TypeData::EnumComplement(_)
-                        | crate::types::TypeData::TypeVar(..)
-                        | crate::types::TypeData::AlwaysTruthy
-                        | crate::types::TypeData::AlwaysFalsy
-                        | crate::types::TypeData::TypeIs(_)
-                        | crate::types::TypeData::TypeGuard(_)
-                        | crate::types::TypeData::TypeForm(_)
-                        | crate::types::TypeData::TypedDict(_)
-                        | crate::types::TypeData::NewTypeInstance(_),
-                    ) => object_ty.instance_member(db, attribute),
-                    (
-                        _,
-                        crate::types::TypeData::ClassLiteral(..)
-                        | crate::types::TypeData::GenericAlias(..)
-                        | crate::types::TypeData::SubclassOf(..),
-                    ) => {
-                        object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
-                    }
-                    (
-                        _,
-                        crate::types::TypeData::Union(..)
-                        | crate::types::TypeData::Intersection(..)
-                        | crate::types::TypeData::TypeAlias(..)
-                        | crate::types::TypeData::Dynamic(..)
-                        | crate::types::TypeData::Divergent(_)
-                        | crate::types::TypeData::Never
-                        | crate::types::TypeData::ModuleLiteral(..)
-                        | crate::types::TypeData::BoundSuper(..),
-                    ) => return None,
-                },
-            )
+            Some(match object_ty.data() {
+                crate::types::TypeData::NominalInstance(..)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::LiteralValue(..)
+                | crate::types::TypeData::SpecialForm(..)
+                | crate::types::TypeData::KnownInstance(..)
+                | crate::types::TypeData::PropertyInstance(..)
+                | crate::types::TypeData::FunctionLiteral(..)
+                | crate::types::TypeData::Callable(..)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::EnumComplement(_)
+                | crate::types::TypeData::TypeVar(..)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_) => {
+                    object_ty.instance_member(db, attribute)
+                }
+                crate::types::TypeData::ClassLiteral(..)
+                | crate::types::TypeData::GenericAlias(..)
+                | crate::types::TypeData::SubclassOf(..) => {
+                    object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
+                }
+                crate::types::TypeData::Union(..)
+                | crate::types::TypeData::Intersection(..)
+                | crate::types::TypeData::TypeAlias(..)
+                | crate::types::TypeData::Dynamic(..)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::ModuleLiteral(..)
+                | crate::types::TypeData::BoundSuper(..) => return None,
+            })
         } else {
             None
         };
@@ -4214,28 +4159,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        match {
-            let __ty_view_value = inferred;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                crate::types::TypeData::NewTypeInstance(_)
-                | crate::types::TypeData::NominalInstance(_),
-            ) => return,
+        match inferred.data() {
+            crate::types::TypeData::NewTypeInstance(_)
+            | crate::types::TypeData::NominalInstance(_) => return,
             // There are exactly two union types allowed as bases for NewType: `int | float` and
             // `int | float | complex`. These are allowed because that's what `float` and `complex`
             // expand into in type position. We don't currently ask whether the union was implicit
             // or explicit, so the explicit version is also allowed.
-            (_, crate::types::TypeData::Union(union_ty)) => {
+            crate::types::TypeData::Union(union_ty) => {
                 if let Some(KnownUnion::Float | KnownUnion::Complex) = union_ty.known(self.db()) {
                     return;
                 }
             }
             // `Unknown` is likely to be the result of an unresolved import or a typo, which will
             // already get a diagnostic, so don't pile on an extra diagnostic here.
-            (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => return,
-            (_, _) => {}
+            crate::types::TypeData::Dynamic(DynamicType::Unknown) => return,
+            _ => {}
         }
         if let Some(builder) = self
             .context
@@ -4243,21 +4182,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
             diag.set_primary_message(format!("type `{}`", inferred.display(self.db())));
-            if matches!(
-                {
-                    let __ty_view_value = inferred;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::ProtocolInstance(_))
-            ) {
+            if matches!(inferred.data(), crate::types::TypeData::ProtocolInstance(_)) {
                 diag.info("The base of a `NewType` is not allowed to be a protocol class.");
-            } else if matches!(
-                {
-                    let __ty_view_value = inferred;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::TypedDict(_))
-            ) {
+            } else if matches!(inferred.data(), crate::types::TypeData::TypedDict(_)) {
                 diag.info("The base of a `NewType` is not allowed to be a `TypedDict`.");
             } else {
                 diag.info("The base of a `NewType` must be a class type or another `NewType`.");
@@ -4415,10 +4342,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             // P.args and P.kwargs are only valid as annotations on *args and **kwargs.
-            if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                let __ty_view_value = annotated.inner_type();
-                (__ty_view_value, __ty_view_value.data())
-            }) && typevar.is_paramspec(self.db())
+            if let crate::types::TypeData::TypeVar(typevar) = annotated.inner_type().data()
+                && typevar.is_paramspec(self.db())
                 && let Some(attr) = typevar.paramspec_attr(self.db())
             {
                 let name = typevar.name(self.db());
@@ -4438,13 +4363,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 && matches!(attr_expr.attr.as_str(), "args" | "kwargs")
             {
                 let value_ty = self.expression_type(&attr_expr.value);
-                if let (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
-                ) = ({
-                    let __ty_view_value = value_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && typevar.is_paramspec(self.db())
+                if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                    value_ty.data()
+                    && typevar.is_paramspec(self.db())
                 {
                     let name = typevar.name(self.db());
                     let attr_name = &attr_expr.attr;
@@ -4623,10 +4544,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
         // not as variable annotations. Check both resolved type and AST form.
-        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-            let __ty_view_value = declared.inner_type();
-            (__ty_view_value, __ty_view_value.data())
-        }) && typevar.is_paramspec(self.db())
+        if let crate::types::TypeData::TypeVar(typevar) = declared.inner_type().data()
+            && typevar.is_paramspec(self.db())
             && let Some(attr) = typevar.paramspec_attr(self.db())
         {
             let name = typevar.name(self.db());
@@ -4645,11 +4564,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Also check the AST form for cases where P isn't bound (e.g., class body
             // annotations). In this case, the type might not resolve to a TypeVar.
             let value_ty = self.expression_type(&attr_expr.value);
-            if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
-                ({
-                    let __ty_view_value = value_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                })
+            if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+                value_ty.data()
                 && typevar.is_paramspec(self.db())
             {
                 let name = typevar.name(self.db());
@@ -4846,25 +4762,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferred_ty = if is_pep_613_type_alias && target.is_name_expr() {
                 // The post-inference pass emits the diagnostic, but this first-pass value is
                 // retained as the alias binding.
-                match {
-                    let __ty_view_value = inferred_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypingSelf)) => {
+                match inferred_ty.data() {
+                    crate::types::TypeData::SpecialForm(SpecialFormType::TypingSelf) => {
                         self.expressions.insert(value.into(), Type::unknown());
                         Type::unknown()
                     }
-                    (
-                        _,
-                        crate::types::TypeData::KnownInstance(
-                            KnownInstanceType::LiteralStringAlias(ty),
-                        ),
+                    crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::LiteralStringAlias(ty),
                     ) if ty.inner(self.db()).contains_self(self.db()) => {
                         Type::KnownInstance(KnownInstanceType::LiteralStringAlias(
                             InternedType::new(self.db(), Type::unknown()),
                         ))
                     }
-                    (_, _) => inferred_ty,
+                    _ => inferred_ty,
                 }
             } else {
                 inferred_ty
@@ -4889,13 +4799,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if is_pep_613_type_alias {
-                let inferred_ty = if let (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
-                ) = {
-                    let __ty_view_value = inferred_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                let inferred_ty = if let crate::types::TypeData::KnownInstance(
+                    KnownInstanceType::TypeVar(typevar),
+                ) = inferred_ty.data()
+                {
                     let identity = TypeVarIdentity::new(
                         self.db(),
                         typevar.identity(self.db()).name(self.db()),
@@ -4921,7 +4828,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !matches!(name_expr.id.as_str(), "_ignore_" | "_value_" | "_name_")
                     // Not bare Final (bare Final is allowed on enum members)
                     && !(declared.qualifiers.contains(TypeQualifiers::FINAL)
-                        && matches!( { let __ty_view_value = declared.inner_type(); (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::Dynamic(DynamicType::Unknown))))
+                        && matches!( declared.inner_type().data() , crate::types::TypeData::Dynamic(DynamicType::Unknown)))
                     // Value type would be an enum member at runtime (exclude callables,
                     // which are never members)
                     && !inferred_ty.is_subtype_of(
@@ -5026,11 +4933,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
         };
 
-        match {
-            let __ty_view_value = target_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match target_type.data() {
+            crate::types::TypeData::Union(union) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // Perform loud inference without type context, as there may be multiple
@@ -5047,7 +4951,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             }
 
-            (_, _) => {
+            _ => {
                 if let Some(typed_dict_update_ty) = self
                     .try_infer_typed_dict_pep_584_augmented_assignment(
                         assignment,
@@ -5437,58 +5341,49 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             kind: CallableTypeKind,
             provenance: CallableFunctionProvenance,
         ) -> Option<Type<'d>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::Callable(callable)) => Some(Type::Callable(
+            match ty.data() {
+                crate::types::TypeData::Callable(callable) => Some(Type::Callable(
                     CallableType::new(db, callable.signatures(db), kind, provenance),
                 )),
-                (_, crate::types::TypeData::Union(union)) => union.try_map(db, |element| {
+                crate::types::TypeData::Union(union) => union.try_map(db, |element| {
                     propagate_callable_kind(db, *element, kind, provenance)
                 }),
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                crate::types::TypeData::TypeAlias(alias) => {
                     propagate_callable_kind(db, alias.value_type(db), kind, provenance)
                 }
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
-                (
-                    _,
-                    crate::types::TypeData::Intersection(_)
-                    | crate::types::TypeData::EnumComplement(_),
-                ) => None,
+                crate::types::TypeData::Intersection(_)
+                | crate::types::TypeData::EnumComplement(_) => None,
                 // All other types cannot have a callable kind propagated to them.
-                (
-                    _,
-                    crate::types::TypeData::Dynamic(_)
-                    | crate::types::TypeData::Divergent(_)
-                    | crate::types::TypeData::Never
-                    | crate::types::TypeData::FunctionLiteral(_)
-                    | crate::types::TypeData::BoundMethod(_)
-                    | crate::types::TypeData::KnownBoundMethod(_)
-                    | crate::types::TypeData::WrapperDescriptor(_)
-                    | crate::types::TypeData::DataclassDecorator(_)
-                    | crate::types::TypeData::DataclassTransformer(_)
-                    | crate::types::TypeData::ModuleLiteral(_)
-                    | crate::types::TypeData::ClassLiteral(_)
-                    | crate::types::TypeData::GenericAlias(_)
-                    | crate::types::TypeData::SubclassOf(_)
-                    | crate::types::TypeData::NominalInstance(_)
-                    | crate::types::TypeData::ProtocolInstance(_)
-                    | crate::types::TypeData::SpecialForm(_)
-                    | crate::types::TypeData::KnownInstance(_)
-                    | crate::types::TypeData::PropertyInstance(_)
-                    | crate::types::TypeData::AlwaysTruthy
-                    | crate::types::TypeData::AlwaysFalsy
-                    | crate::types::TypeData::LiteralValue(_)
-                    | crate::types::TypeData::TypeVar(_)
-                    | crate::types::TypeData::BoundSuper(_)
-                    | crate::types::TypeData::TypeIs(_)
-                    | crate::types::TypeData::TypeGuard(_)
-                    | crate::types::TypeData::TypeForm(_)
-                    | crate::types::TypeData::TypedDict(_)
-                    | crate::types::TypeData::NewTypeInstance(_),
-                ) => None,
+                crate::types::TypeData::Dynamic(_)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::GenericAlias(_)
+                | crate::types::TypeData::SubclassOf(_)
+                | crate::types::TypeData::NominalInstance(_)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::TypeVar(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_) => None,
             }
         }
 
@@ -5513,15 +5408,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             decorated_ty: Type<'d>,
         ) -> bool {
             if !matches!(
-                {
-                    let __ty_view_value = decorated_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::FunctionLiteral(_)
-                        | crate::types::TypeData::Callable(_)
-                )
+                decorated_ty.data(),
+                crate::types::TypeData::FunctionLiteral(_) | crate::types::TypeData::Callable(_)
             ) {
                 return false;
             }
@@ -5557,17 +5445,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // This avoids a query cycle when the function has default parameter values, since
         // computing the signature requires evaluating those defaults which may trigger
         // deferred inference.
-        let propagatable_kind = match {
-            let __ty_view_value = decorated_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(func)) => Some((
+        let propagatable_kind = match decorated_ty.data() {
+            crate::types::TypeData::FunctionLiteral(func) => Some((
                 func.callable_type_kind(self.db()),
                 CallableFunctionProvenance::from_function_return_annotation(
                     func.has_explicit_return_annotation(self.db()),
                 ),
             )),
-            (_, _) => decorated_ty
+            _ => decorated_ty
                 .try_upcast_to_callable(self.db())
                 .and_then(CallableTypes::exactly_one)
                 .and_then(|callable| match callable.kind(self.db()) {
@@ -6231,19 +6116,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         // Avoid promoting explicitly annotated literal values.
-        if let (_, crate::types::TypeData::LiteralValue(literal)) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) && let Some(tcx) = tcx.annotation
+        if let crate::types::TypeData::LiteralValue(literal) = ty.data()
+            && let Some(tcx) = tcx.annotation
             && let (
                 literal_tcx,
                 crate::types::TypeData::Union(_) | crate::types::TypeData::LiteralValue(_),
-            ) = ({
-                let __ty_view_value = tcx
-                    .resolve_type_alias(self.db())
-                    .filter_union(self.db(), |ty| ty.as_literal_value().is_some());
-                (__ty_view_value, __ty_view_value.data())
-            })
+            ) = tcx
+                .resolve_type_alias(self.db())
+                .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
+                .view()
             && ty.is_assignable_to(self.db(), literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
@@ -6284,10 +6165,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // the information we need to choose an appropriate specialization of
         // `list` given the type context, and we wouldn't have to duplicate all
         // of the logic below.
-        let (_, crate::types::TypeData::ClassLiteral(class)) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::ClassLiteral(class) = ty.data() else {
             return ty;
         };
         let db = self.db();
@@ -6299,19 +6177,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .exactly_one()
                 .ok()
         };
-        let Some(target_callable) = (match {
-            let __ty_view_value = target;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        let Some(target_callable) = (match target.view() {
             (_, crate::types::TypeData::Callable(callable)) => Some(callable),
             (_, crate::types::TypeData::Union(union)) => exactly_one_callable(union),
-            (_, crate::types::TypeData::TypeAlias(_)) => match {
-                let __ty_view_value = target.resolve_type_alias(db);
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::Callable(callable)) => Some(callable),
-                (_, crate::types::TypeData::Union(union)) => exactly_one_callable(union),
-                (_, _) => None,
+            (_, crate::types::TypeData::TypeAlias(_)) => match target.resolve_type_alias(db).data()
+            {
+                crate::types::TypeData::Callable(callable) => Some(callable),
+                crate::types::TypeData::Union(union) => exactly_one_callable(union),
+                _ => None,
             },
             (_, _) => None,
         }) else {
@@ -6328,14 +6201,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .all(|parameter| parameter.annotated_type().is_dynamic()))
                 || (parameters.is_empty()
                     && matches!(
-                        {
-                            let __ty_view_value = signature.return_ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (
-                            _,
-                            crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
-                        )
+                        signature.return_ty.data(),
+                        crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
                     ))
         }) {
             return ty;
@@ -6448,20 +6315,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn has_string_literal_completion_candidates(&self, ty: Type<'db>) -> bool {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::LiteralValue(literal)) => literal.as_string().is_some(),
-            (_, crate::types::TypeData::Union(union)) => union
+        match ty.data() {
+            crate::types::TypeData::LiteralValue(literal) => literal.as_string().is_some(),
+            crate::types::TypeData::Union(union) => union
                 .elements(self.db())
                 .iter()
                 .any(|ty| self.has_string_literal_completion_candidates(*ty)),
-            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            crate::types::TypeData::Intersection(intersection) => intersection
                 .iter_positive(self.db())
                 .any(|ty| self.has_string_literal_completion_candidates(ty)),
-            (_, crate::types::TypeData::TypeAlias(_)) => true,
-            (_, _) => false,
+            crate::types::TypeData::TypeAlias(_) => true,
+            _ => false,
         }
     }
 
@@ -6891,10 +6755,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     return ty;
                 }
-            } else if let (_, crate::types::TypeData::Union(union)) = {
-                let __ty_view_value = annotation;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            } else if let crate::types::TypeData::Union(union) = annotation.data() {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
@@ -7114,13 +6975,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 FxHashMap::default();
 
             if let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
-                && matches!(
-                    {
-                        let __ty_view_value = tcx;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (_, crate::types::TypeData::NominalInstance(_))
-                )
+                && matches!(tcx.data(), crate::types::TypeData::NominalInstance(_))
                 && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
                 && specialization.generic_context(self.db()) == generic_context
                 && generic_context.variables(self.db()).all(|typevar| {
@@ -8208,14 +8063,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If we have a direct `Callable` type context, we can infer the body with the annotated
         // return type as type context.
         let return_tcx = if let Some(signature) = callable_tcx {
-            match {
-                let __ty_view_value = signature.return_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => {
-                    TypeContext::new(None)
-                }
-                (_, _) => TypeContext::new(Some(signature.return_ty)),
+            match signature.return_ty.data() {
+                crate::types::TypeData::Dynamic(DynamicType::Unknown) => TypeContext::new(None),
+                _ => TypeContext::new(Some(signature.return_ty)),
             }
         } else {
             // TODO: Useful inference of a lambda's return type will require a different approach,
@@ -8487,10 +8337,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Handle 3-argument `type(name, bases, dict)`.
-        if let (_, crate::types::TypeData::ClassLiteral(class)) = ({
-            let __ty_view_value = callable_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) && class.is_known(self.db(), KnownClass::Type)
+        if let crate::types::TypeData::ClassLiteral(class) = callable_type.data()
+            && class.is_known(self.db(), KnownClass::Type)
         {
             return self.infer_builtins_type_call(call_expression, None);
         }
@@ -8540,16 +8388,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         }
 
-        let class = match {
-            let __ty_view_value = callable_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class)) => Some(ClassType::NonGeneric(class)),
-            (_, crate::types::TypeData::GenericAlias(generic)) => Some(ClassType::Generic(generic)),
-            (_, crate::types::TypeData::SubclassOf(subclass)) => {
+        let class = match callable_type.data() {
+            crate::types::TypeData::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
+            crate::types::TypeData::GenericAlias(generic) => Some(ClassType::Generic(generic)),
+            crate::types::TypeData::SubclassOf(subclass) => {
                 subclass.subclass_of().into_class(self.db())
             }
-            (_, _) => None,
+            _ => None,
         };
 
         // Prepare `TypedDict` constructor calls before variadic argument setup so field-directed
@@ -8578,7 +8423,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let value_type = self.expression_type(value);
             let method_name = attr.id.as_str();
 
-            if let (_, crate::types::TypeData::TypedDict(typed_dict_ty)) = ({ let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) })
+            if let crate::types::TypeData::TypedDict(typed_dict_ty) = value_type.data()
                 && matches!(method_name, "get" | "pop" | "setdefault")
                 && !arguments.args.is_empty()
 
@@ -8725,10 +8570,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        if let (_, crate::types::TypeData::FunctionLiteral(function)) = {
-            let __ty_view_value = callable_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::FunctionLiteral(function) = callable_type.data() {
             // Make sure that the `function.definition` is only called when the function is defined
             // in the same file as the one we're currently inferring the types for. This is because
             // the `definition` method accesses the semantic index, which could create a
@@ -8755,11 +8597,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Check for unsound calls to abstract classmethods/staticmethods on class objects
-        match {
-            let __ty_view_value = callable_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
+        match callable_type.data() {
+            crate::types::TypeData::BoundMethod(bound_method) => {
                 let function = bound_method.function(self.db());
                 if let Some(class) = bound_method
                     .self_instance(self.db())
@@ -8778,7 +8617,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-            (_, crate::types::TypeData::FunctionLiteral(function))
+            crate::types::TypeData::FunctionLiteral(function)
                 if function.is_staticmethod(self.db()) =>
             {
                 if let ast::Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() {
@@ -8797,7 +8636,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-            (_, _) => {}
+            _ => {}
         }
 
         if let Some(class) = class {
@@ -8901,11 +8740,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for binding in bindings.iter_flat_mut() {
             let binding_type = binding.callable_type;
             for (_, overload) in binding.matching_overloads_mut() {
-                match {
-                    let __ty_view_value = binding_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::FunctionLiteral(function_literal)) => {
+                match binding_type.data() {
+                    crate::types::TypeData::FunctionLiteral(function_literal) => {
                         if let Some(known_function) = function_literal.known(self.db()) {
                             known_function.check_call(
                                 &self.context,
@@ -8916,7 +8752,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             );
                         }
                     }
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                    crate::types::TypeData::ClassLiteral(class) => {
                         if let Some(known_class) = class.known(self.db()) {
                             known_class.check_call(
                                 &self.context,
@@ -8926,7 +8762,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             );
                         }
                     }
-                    (_, crate::types::TypeData::Never) => {
+                    crate::types::TypeData::Never => {
                         // In unreachable sections of code, we infer `Never` for symbols that were
                         // defined outside the unreachable part. We still want to emit revealed-type
                         // diagnostics in these sections, so check on the name of the callable here
@@ -8943,7 +8779,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             report_revealed_type(&self.context, revealed_ty, first_arg);
                         }
                     }
-                    (_, _) => {}
+                    _ => {}
                 }
             }
         }
@@ -9055,23 +8891,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .unwrap_or(0)
         };
 
-        match {
-            let __ty_view_value = return_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeIs(type_is)) => {
+        match return_ty.data() {
+            crate::types::TypeData::TypeIs(type_is) => {
                 match find_narrowed_place(narrowed_argument_index()) {
                     Some(place) => type_is.bind(db, scope, place),
                     None => return_ty,
                 }
             }
-            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
+            crate::types::TypeData::TypeGuard(type_guard) => {
                 match find_narrowed_place(narrowed_argument_index()) {
                     Some(place) => type_guard.bind(db, scope, place),
                     None => return_ty,
                 }
             }
-            (_, _) => return_ty,
+            _ => return_ty,
         }
     }
 
@@ -9326,10 +9159,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Check if the given ty is `@deprecated` or not
     fn check_deprecated<T: Ranged>(&self, ranged: T, ty: Type) {
         // First handle classes
-        if let (_, crate::types::TypeData::ClassLiteral(class_literal)) = {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::ClassLiteral(class_literal) = ty.data() {
             let Some(deprecated) = class_literal.deprecated(self.db()) else {
                 return;
             };
@@ -9349,13 +9179,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Next handle functions
-        let function = match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(function)) => function,
-            (_, crate::types::TypeData::BoundMethod(bound)) => bound.function(self.db()),
-            (_, _) => return,
+        let function = match ty.data() {
+            crate::types::TypeData::FunctionLiteral(function) => function,
+            crate::types::TypeData::BoundMethod(bound) => bound.function(self.db()),
+            _ => return,
         };
 
         // Currently we only check the final implementation for deprecation, as
@@ -10039,10 +9866,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let mut constraint_keys = vec![];
 
-        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
-            let __ty_view_value = value_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) && typevar.is_paramspec(db)
+        if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+            value_type.data()
+            && typevar.is_paramspec(db)
             && let Some(bound_typevar) = bind_typevar(
                 db,
                 self.index,
@@ -10086,11 +9912,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         )
                     };
 
-                    let bound_on_instance = match { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
-                        (_, crate::types::TypeData::ClassLiteral(class)) => {
+                    let bound_on_instance = match value_type.data()  {
+                        crate::types::TypeData::ClassLiteral(class) => {
                             !class.instance_member(db, None, attr).is_undefined()
                         }
-                        (_, crate::types::TypeData::SubclassOf(subclass_of @ SubclassOfType { .. })) => {
+                        crate::types::TypeData::SubclassOf(subclass_of @ SubclassOfType { .. }) => {
                             match subclass_of.subclass_of() {
                                 SubclassOfInner::Class(class) => {
                                     !class.instance_member(db, attr).is_undefined()
@@ -10102,10 +9928,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 SubclassOfInner::TypeVar(_) => false,
                             }
                         }
-                        (_, _) => false,
+                        _ => false,
                     };
 
-                    if let (_, crate::types::TypeData::ModuleLiteral(module)) = { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
+                    if let crate::types::TypeData::ModuleLiteral(module) = value_type.data()  {
                         let module = module.module(db);
                         let module_name = module.name(db);
                         if module.kind(db).is_package()
@@ -10130,7 +9956,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     }
 
-                    if let (_, crate::types::TypeData::SpecialForm(special_form)) = { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
+                    if let crate::types::TypeData::SpecialForm(special_form) = value_type.data()  {
                         if let Some(builder) =
                             self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute)
                         {
@@ -10183,24 +10009,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return fallback();
                     }
 
-                    let mut diagnostic = match { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
-                        (_, crate::types::TypeData::ModuleLiteral(module)) => builder.into_diagnostic(format_args!(
+                    let mut diagnostic = match value_type.data()  {
+                        crate::types::TypeData::ModuleLiteral(module) => builder.into_diagnostic(format_args!(
                             "Module `{module_name}` has no member `{attr_name}`",
                             module_name = module.module(db).name(db),
                         )),
-                        (_, crate::types::TypeData::ClassLiteral(class)) => builder.into_diagnostic(format_args!(
+                        crate::types::TypeData::ClassLiteral(class) => builder.into_diagnostic(format_args!(
                             "Class `{}` has no attribute `{attr_name}`",
                             class.name(db),
                         )),
-                        (_, crate::types::TypeData::GenericAlias(alias)) => builder.into_diagnostic(format_args!(
+                        crate::types::TypeData::GenericAlias(alias) => builder.into_diagnostic(format_args!(
                             "Class `{}` has no attribute `{attr_name}`",
                             alias.display(db),
                         )),
-                        (_, crate::types::TypeData::FunctionLiteral(function)) => builder.into_diagnostic(format_args!(
+                        crate::types::TypeData::FunctionLiteral(function) => builder.into_diagnostic(format_args!(
                             "Function `{}` has no attribute `{attr_name}`",
                             function.name(db),
                         )),
-                        (_, _) => builder.into_diagnostic(format_args!(
+                        _ => builder.into_diagnostic(format_args!(
                             "Object of type `{}` has no attribute `{attr_name}`",
                             value_type.display(db),
                         )),
@@ -10265,7 +10091,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Attribute lookup on a bounded type variable delegates to its upper bound, so
                     // use that bound here too when determining whether the lookup was on a union.
-                    let union_like_type = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({ let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) })
+                    let union_like_type = if let crate::types::TypeData::TypeVar(typevar) = value_type.data()
                         && let Some(bound) = typevar.typevar(db).upper_bound(db)
                     {
                         bound
@@ -10436,13 +10262,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match (
-            op,
-            ({
-                let __ty_view_value = operand_type;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (op, operand_type.view()) {
             (
                 ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub,
                 (_, crate::types::TypeData::Dynamic(_)),

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -173,7 +173,16 @@ impl<'db> DeclaredAndInferredType<'db> {
 fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
     // Dataclass field specifiers carry metadata in the inferred RHS type; replacing it with the
     // declared field type would lose settings like `init=False`.
-    matches!(ty, Type::KnownInstance(KnownInstanceType::Field(_)))
+    matches!(
+        {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        },
+        (
+            _,
+            crate::types::TypeData::KnownInstance(KnownInstanceType::Field(_))
+        )
+    )
 }
 
 /// We currently store one dataclass field-specifiers inline, because that covers standard
@@ -739,8 +748,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return false;
         };
         matches!(
-            self.expression_type(&call.func),
-            Type::FunctionLiteral(f)
+            { let __ty_view_value = self.expression_type(&call.func); (__ty_view_value, __ty_view_value.data()) } ,
+            (_, crate::types::TypeData::FunctionLiteral(f))
                 if matches!(
                     f.known(self.db()),
                     Some(KnownFunction::RevealType | KnownFunction::AssertType)
@@ -1158,8 +1167,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         for decorator in &function.node(self.module()).decorator_list {
             let decorator_type = self.infer_decorator(decorator);
-            if let Type::FunctionLiteral(function) = decorator_type
-                && let Some(KnownFunction::NoTypeCheck) = function.known(self.db())
+            if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+                let __ty_view_value = decorator_type;
+                (__ty_view_value, __ty_view_value.data())
+            }) && let Some(KnownFunction::NoTypeCheck) = function.known(self.db())
             {
                 // Match `infer_function_definition`: suppress diagnostics that follow
                 // `@no_type_check`, including later decorators.
@@ -1547,7 +1558,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // "declared types is `Unknown` (e.g. due to a bad annotation, missing
                         // import, etc.)". Ideally we would still prefer `Unknown` declared type,
                         // but use inferred type if there is no declared type.
-                        && !matches!(declared_type, Type::Dynamic(DynamicType::Unknown))
+                        && !matches!( { let __ty_view_value = declared_type; (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)))
                         && declared_type.is_assignable_to(self.db(), inferred_ty)
                     {
                         (declared_ty, declared_type)
@@ -1719,19 +1730,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.function_decorator_types(function)
             .any(|decorator_type| {
-                match decorator_type {
-                    Type::FunctionLiteral(function) => matches!(
+                match {
+                    let __ty_view_value = decorator_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::FunctionLiteral(function)) => matches!(
                         function.known(self.db()),
                         Some(KnownFunction::Overload | KnownFunction::AbstractMethod)
                     ),
-                    Type::Never => {
+                    (_, crate::types::TypeData::Never) => {
                         // In unreachable code, we infer `Never` for decorators like `typing.overload`.
                         // Return `true` here to avoid false positive `invalid-return-type` lints for
                         // `@overload`ed functions without a body in unreachable code.
                         true
                     }
-                    Type::Divergent(_) => true,
-                    _ => false,
+                    (_, crate::types::TypeData::Divergent(_)) => true,
+                    (_, _) => false,
                 }
             })
     }
@@ -2150,7 +2164,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     })
                     .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db())),
             )
-        } else if let Type::Union(union) = ty {
+        } else if let (_, crate::types::TypeData::Union(union)) = {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // `except exception_types as e:`, where
             // `exception_types: type[ValueError] | tuple[type[ValueError], ...]`
             union.try_map(self.db(), |element| {
@@ -2375,7 +2392,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn validate_class_pattern(&mut self, pattern: &ast::PatternMatchClass, cls_ty: Type<'db>) {
-        if let Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) = cls_ty {
+        if let (_, crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable)) = {
+            let __ty_view_value = cls_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             if let Some(first_excess_pattern) = pattern.arguments.patterns.first() {
                 report_too_many_positional_patterns_for_callable_class_pattern(
                     &self.context,
@@ -2386,7 +2406,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        if let Type::ClassLiteral(class) = cls_ty {
+        if let (_, crate::types::TypeData::ClassLiteral(class)) = {
+            let __ty_view_value = cls_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             if class.is_typed_dict(self.db()) {
                 report_match_pattern_against_typed_dict(&self.context, &*pattern.cls, class);
             } else if let Some(protocol_class) = class.into_protocol_class(self.db())
@@ -2621,7 +2644,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // input type (the type of the first positional parameter), not the field's
         // declared type.
         let effective_write_type = |attr_ty: Type<'db>| -> Type<'db> {
-            if let Type::NominalInstance(instance) = object_ty {
+            if let (_, crate::types::TypeData::NominalInstance(instance)) = {
+                let __ty_view_value = object_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 if let Some(converter_ty) = instance
                     .class(db)
                     .converter_input_type_for_field(db, attribute)
@@ -2632,8 +2658,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             attr_ty
         };
 
-        match object_ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = object_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // Perform loud inference without type context, as there may be multiple
@@ -2671,7 +2700,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // TODO: Handle negative intersection elements
@@ -2711,15 +2740,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::EnumComplement(complement) => self.validate_attribute_assignment(
-                target,
-                complement.remaining_literal_union(db),
-                attribute,
-                infer_value_ty,
-                emit_diagnostics,
-            ),
+            (_, crate::types::TypeData::EnumComplement(complement)) => self
+                .validate_attribute_assignment(
+                    target,
+                    complement.remaining_literal_union(db),
+                    attribute,
+                    infer_value_ty,
+                    emit_diagnostics,
+                ),
 
-            Type::TypeAlias(alias) => self.validate_attribute_assignment(
+            (_, crate::types::TypeData::TypeAlias(alias)) => self.validate_attribute_assignment(
                 target,
                 alias.value_type(self.db()),
                 attribute,
@@ -2728,7 +2758,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ),
 
             // Super instances do not allow attribute assignment
-            Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Super) => {
+            (_, crate::types::TypeData::NominalInstance(instance))
+                if instance.has_known_class(db, KnownClass::Super) =>
+            {
                 infer_value_ty(self, TypeContext::default());
 
                 if emit_diagnostics
@@ -2742,7 +2774,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 false
             }
-            Type::BoundSuper(_) => {
+            (_, crate::types::TypeData::BoundSuper(_)) => {
                 infer_value_ty(self, TypeContext::default());
 
                 if emit_diagnostics
@@ -2756,32 +2788,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 false
             }
 
-            Type::Dynamic(..) | Type::Divergent(_) | Type::Never => {
+            (
+                _,
+                crate::types::TypeData::Dynamic(..)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never,
+            ) => {
                 infer_value_ty(self, TypeContext::default());
                 true
             }
 
-            Type::NominalInstance(..)
-            | Type::ProtocolInstance(_)
-            | Type::LiteralValue(..)
-            | Type::SpecialForm(..)
-            | Type::KnownInstance(..)
-            | Type::PropertyInstance(..)
-            | Type::FunctionLiteral(..)
-            | Type::Callable(..)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeVar(..)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_) => {
+            (
+                _,
+                crate::types::TypeData::NominalInstance(..)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::LiteralValue(..)
+                | crate::types::TypeData::SpecialForm(..)
+                | crate::types::TypeData::KnownInstance(..)
+                | crate::types::TypeData::PropertyInstance(..)
+                | crate::types::TypeData::FunctionLiteral(..)
+                | crate::types::TypeData::Callable(..)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::TypeVar(..)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_),
+            ) => {
                 // We may infer the value type multiple times with distinct type context during
                 // attribute resolution.
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
@@ -3073,7 +3113,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+            (
+                _,
+                crate::types::TypeData::ClassLiteral(..)
+                | crate::types::TypeData::GenericAlias(..)
+                | crate::types::TypeData::SubclassOf(..),
+            ) => {
                 let Some((meta_attr, fallback_attr)) =
                     self.assignment_attribute_members(object_ty, attribute)
                 else {
@@ -3274,7 +3319,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::ModuleLiteral(module) => {
+            (_, crate::types::TypeData::ModuleLiteral(module)) => {
                 let sym = if module
                     .module(db)
                     .known(db)
@@ -3331,8 +3376,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
-        match object_ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = object_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 for element_ty in union.elements(db) {
                     if !self.validate_attribute_deletion(
                         target,
@@ -3346,7 +3394,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 true
             }
 
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 if intersection.positive(db).iter().any(|element_ty| {
                     self.validate_attribute_deletion(target, *element_ty, attribute, false)
                 }) {
@@ -3360,47 +3408,51 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::EnumComplement(complement) => self.validate_attribute_deletion(
-                target,
-                complement.remaining_literal_union(db),
-                attribute,
-                emit_diagnostics,
-            ),
+            (_, crate::types::TypeData::EnumComplement(complement)) => self
+                .validate_attribute_deletion(
+                    target,
+                    complement.remaining_literal_union(db),
+                    attribute,
+                    emit_diagnostics,
+                ),
 
             // Type aliases need their own arm so aliased unions and intersections reuse the
             // specialized handling above. `NewType` instances don't: dunder lookup and attribute
             // fallback already delegate through the concrete base type when needed.
-            Type::TypeAlias(alias) => self.validate_attribute_deletion(
+            (_, crate::types::TypeData::TypeAlias(alias)) => self.validate_attribute_deletion(
                 target,
                 alias.value_type(db),
                 attribute,
                 emit_diagnostics,
             ),
 
-            Type::NominalInstance(..)
-            | Type::ProtocolInstance(_)
-            | Type::LiteralValue(..)
-            | Type::SpecialForm(..)
-            | Type::ClassLiteral(..)
-            | Type::GenericAlias(..)
-            | Type::SubclassOf(..)
-            | Type::KnownInstance(..)
-            | Type::PropertyInstance(..)
-            | Type::FunctionLiteral(..)
-            | Type::Callable(..)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypeVar(..)
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_) => {
+            (
+                _,
+                crate::types::TypeData::NominalInstance(..)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::LiteralValue(..)
+                | crate::types::TypeData::SpecialForm(..)
+                | crate::types::TypeData::ClassLiteral(..)
+                | crate::types::TypeData::GenericAlias(..)
+                | crate::types::TypeData::SubclassOf(..)
+                | crate::types::TypeData::KnownInstance(..)
+                | crate::types::TypeData::PropertyInstance(..)
+                | crate::types::TypeData::FunctionLiteral(..)
+                | crate::types::TypeData::Callable(..)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::TypeVar(..)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_),
+            ) => {
                 let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
                     db,
                     "__delattr__",
@@ -3518,11 +3570,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 true
             }
 
-            Type::Dynamic(..)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::ModuleLiteral(..)
-            | Type::BoundSuper(..) => true,
+            (
+                _,
+                crate::types::TypeData::Dynamic(..)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::ModuleLiteral(..)
+                | crate::types::TypeData::BoundSuper(..),
+            ) => true,
         }
     }
 
@@ -3541,41 +3596,57 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }) | Place::Undefined
         );
         let fallback_attr = if needs_fallback {
-            Some(match object_ty {
-                Type::NominalInstance(..)
-                | Type::ProtocolInstance(_)
-                | Type::LiteralValue(..)
-                | Type::SpecialForm(..)
-                | Type::KnownInstance(..)
-                | Type::PropertyInstance(..)
-                | Type::FunctionLiteral(..)
-                | Type::Callable(..)
-                | Type::BoundMethod(_)
-                | Type::KnownBoundMethod(_)
-                | Type::WrapperDescriptor(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::EnumComplement(_)
-                | Type::TypeVar(..)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_)
-                | Type::NewTypeInstance(_) => object_ty.instance_member(db, attribute),
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                    object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
-                }
-                Type::Union(..)
-                | Type::Intersection(..)
-                | Type::TypeAlias(..)
-                | Type::Dynamic(..)
-                | Type::Divergent(_)
-                | Type::Never
-                | Type::ModuleLiteral(..)
-                | Type::BoundSuper(..) => return None,
-            })
+            Some(
+                match {
+                    let __ty_view_value = object_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (
+                        _,
+                        crate::types::TypeData::NominalInstance(..)
+                        | crate::types::TypeData::ProtocolInstance(_)
+                        | crate::types::TypeData::LiteralValue(..)
+                        | crate::types::TypeData::SpecialForm(..)
+                        | crate::types::TypeData::KnownInstance(..)
+                        | crate::types::TypeData::PropertyInstance(..)
+                        | crate::types::TypeData::FunctionLiteral(..)
+                        | crate::types::TypeData::Callable(..)
+                        | crate::types::TypeData::BoundMethod(_)
+                        | crate::types::TypeData::KnownBoundMethod(_)
+                        | crate::types::TypeData::WrapperDescriptor(_)
+                        | crate::types::TypeData::DataclassDecorator(_)
+                        | crate::types::TypeData::DataclassTransformer(_)
+                        | crate::types::TypeData::EnumComplement(_)
+                        | crate::types::TypeData::TypeVar(..)
+                        | crate::types::TypeData::AlwaysTruthy
+                        | crate::types::TypeData::AlwaysFalsy
+                        | crate::types::TypeData::TypeIs(_)
+                        | crate::types::TypeData::TypeGuard(_)
+                        | crate::types::TypeData::TypeForm(_)
+                        | crate::types::TypeData::TypedDict(_)
+                        | crate::types::TypeData::NewTypeInstance(_),
+                    ) => object_ty.instance_member(db, attribute),
+                    (
+                        _,
+                        crate::types::TypeData::ClassLiteral(..)
+                        | crate::types::TypeData::GenericAlias(..)
+                        | crate::types::TypeData::SubclassOf(..),
+                    ) => {
+                        object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
+                    }
+                    (
+                        _,
+                        crate::types::TypeData::Union(..)
+                        | crate::types::TypeData::Intersection(..)
+                        | crate::types::TypeData::TypeAlias(..)
+                        | crate::types::TypeData::Dynamic(..)
+                        | crate::types::TypeData::Divergent(_)
+                        | crate::types::TypeData::Never
+                        | crate::types::TypeData::ModuleLiteral(..)
+                        | crate::types::TypeData::BoundSuper(..),
+                    ) => return None,
+                },
+            )
         } else {
             None
         };
@@ -4143,21 +4214,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        match inferred {
-            Type::NewTypeInstance(_) | Type::NominalInstance(_) => return,
+        match {
+            let __ty_view_value = inferred;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                crate::types::TypeData::NewTypeInstance(_)
+                | crate::types::TypeData::NominalInstance(_),
+            ) => return,
             // There are exactly two union types allowed as bases for NewType: `int | float` and
             // `int | float | complex`. These are allowed because that's what `float` and `complex`
             // expand into in type position. We don't currently ask whether the union was implicit
             // or explicit, so the explicit version is also allowed.
-            Type::Union(union_ty) => {
+            (_, crate::types::TypeData::Union(union_ty)) => {
                 if let Some(KnownUnion::Float | KnownUnion::Complex) = union_ty.known(self.db()) {
                     return;
                 }
             }
             // `Unknown` is likely to be the result of an unresolved import or a typo, which will
             // already get a diagnostic, so don't pile on an extra diagnostic here.
-            Type::Dynamic(DynamicType::Unknown) => return,
-            _ => {}
+            (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => return,
+            (_, _) => {}
         }
         if let Some(builder) = self
             .context
@@ -4165,9 +4243,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
             diag.set_primary_message(format!("type `{}`", inferred.display(self.db())));
-            if matches!(inferred, Type::ProtocolInstance(_)) {
+            if matches!(
+                {
+                    let __ty_view_value = inferred;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::ProtocolInstance(_))
+            ) {
                 diag.info("The base of a `NewType` is not allowed to be a protocol class.");
-            } else if matches!(inferred, Type::TypedDict(_)) {
+            } else if matches!(
+                {
+                    let __ty_view_value = inferred;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::TypedDict(_))
+            ) {
                 diag.info("The base of a `NewType` is not allowed to be a `TypedDict`.");
             } else {
                 diag.info("The base of a `NewType` must be a class type or another `NewType`.");
@@ -4325,8 +4415,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             // P.args and P.kwargs are only valid as annotations on *args and **kwargs.
-            if let Type::TypeVar(typevar) = annotated.inner_type()
-                && typevar.is_paramspec(self.db())
+            if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                let __ty_view_value = annotated.inner_type();
+                (__ty_view_value, __ty_view_value.data())
+            }) && typevar.is_paramspec(self.db())
                 && let Some(attr) = typevar.paramspec_attr(self.db())
             {
                 let name = typevar.name(self.db());
@@ -4346,8 +4438,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 && matches!(attr_expr.attr.as_str(), "args" | "kwargs")
             {
                 let value_ty = self.expression_type(&attr_expr.value);
-                if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_ty
-                    && typevar.is_paramspec(self.db())
+                if let (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                ) = ({
+                    let __ty_view_value = value_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && typevar.is_paramspec(self.db())
                 {
                     let name = typevar.name(self.db());
                     let attr_name = &attr_expr.attr;
@@ -4526,8 +4623,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
         // not as variable annotations. Check both resolved type and AST form.
-        if let Type::TypeVar(typevar) = declared.inner_type()
-            && typevar.is_paramspec(self.db())
+        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+            let __ty_view_value = declared.inner_type();
+            (__ty_view_value, __ty_view_value.data())
+        }) && typevar.is_paramspec(self.db())
             && let Some(attr) = typevar.paramspec_attr(self.db())
         {
             let name = typevar.name(self.db());
@@ -4546,7 +4645,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Also check the AST form for cases where P isn't bound (e.g., class body
             // annotations). In this case, the type might not resolve to a TypeVar.
             let value_ty = self.expression_type(&attr_expr.value);
-            if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_ty
+            if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) =
+                ({
+                    let __ty_view_value = value_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                })
                 && typevar.is_paramspec(self.db())
             {
                 let name = typevar.name(self.db());
@@ -4743,19 +4846,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let inferred_ty = if is_pep_613_type_alias && target.is_name_expr() {
                 // The post-inference pass emits the diagnostic, but this first-pass value is
                 // retained as the alias binding.
-                match inferred_ty {
-                    Type::SpecialForm(SpecialFormType::TypingSelf) => {
+                match {
+                    let __ty_view_value = inferred_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypingSelf)) => {
                         self.expressions.insert(value.into(), Type::unknown());
                         Type::unknown()
                     }
-                    Type::KnownInstance(KnownInstanceType::LiteralStringAlias(ty))
-                        if ty.inner(self.db()).contains_self(self.db()) =>
-                    {
+                    (
+                        _,
+                        crate::types::TypeData::KnownInstance(
+                            KnownInstanceType::LiteralStringAlias(ty),
+                        ),
+                    ) if ty.inner(self.db()).contains_self(self.db()) => {
                         Type::KnownInstance(KnownInstanceType::LiteralStringAlias(
                             InternedType::new(self.db(), Type::unknown()),
                         ))
                     }
-                    _ => inferred_ty,
+                    (_, _) => inferred_ty,
                 }
             } else {
                 inferred_ty
@@ -4780,20 +4889,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if is_pep_613_type_alias {
-                let inferred_ty =
-                    if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = inferred_ty {
-                        let identity = TypeVarIdentity::new(
-                            self.db(),
-                            typevar.identity(self.db()).name(self.db()),
-                            typevar.identity(self.db()).definition(self.db()),
-                            TypeVarKind::Pep613Alias,
-                        );
-                        Type::KnownInstance(KnownInstanceType::TypeVar(
-                            typevar.with_identity(self.db(), identity),
-                        ))
-                    } else {
-                        inferred_ty
-                    };
+                let inferred_ty = if let (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                ) = {
+                    let __ty_view_value = inferred_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    let identity = TypeVarIdentity::new(
+                        self.db(),
+                        typevar.identity(self.db()).name(self.db()),
+                        typevar.identity(self.db()).definition(self.db()),
+                        TypeVarKind::Pep613Alias,
+                    );
+                    Type::KnownInstance(KnownInstanceType::TypeVar(
+                        typevar.with_identity(self.db(), identity),
+                    ))
+                } else {
+                    inferred_ty
+                };
                 self.add_declaration_with_binding(
                     target.into(),
                     definition,
@@ -4807,7 +4921,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !matches!(name_expr.id.as_str(), "_ignore_" | "_value_" | "_name_")
                     // Not bare Final (bare Final is allowed on enum members)
                     && !(declared.qualifiers.contains(TypeQualifiers::FINAL)
-                        && matches!(declared.inner_type(), Type::Dynamic(DynamicType::Unknown)))
+                        && matches!( { let __ty_view_value = declared.inner_type(); (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::Dynamic(DynamicType::Unknown))))
                     // Value type would be an enum member at runtime (exclude callables,
                     // which are never members)
                     && !inferred_ty.is_subtype_of(
@@ -4912,8 +5026,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
         };
 
-        match target_type {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = target_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
 
                 // Perform loud inference without type context, as there may be multiple
@@ -4930,7 +5047,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             }
 
-            _ => {
+            (_, _) => {
                 if let Some(typed_dict_update_ty) = self
                     .try_infer_typed_dict_pep_584_augmented_assignment(
                         assignment,
@@ -5320,51 +5437,58 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             kind: CallableTypeKind,
             provenance: CallableFunctionProvenance,
         ) -> Option<Type<'d>> {
-            match ty {
-                Type::Callable(callable) => Some(Type::Callable(CallableType::new(
-                    db,
-                    callable.signatures(db),
-                    kind,
-                    provenance,
-                ))),
-                Type::Union(union) => union.try_map(db, |element| {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Callable(callable)) => Some(Type::Callable(
+                    CallableType::new(db, callable.signatures(db), kind, provenance),
+                )),
+                (_, crate::types::TypeData::Union(union)) => union.try_map(db, |element| {
                     propagate_callable_kind(db, *element, kind, provenance)
                 }),
-                Type::TypeAlias(alias) => {
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
                     propagate_callable_kind(db, alias.value_type(db), kind, provenance)
                 }
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
-                Type::Intersection(_) | Type::EnumComplement(_) => None,
+                (
+                    _,
+                    crate::types::TypeData::Intersection(_)
+                    | crate::types::TypeData::EnumComplement(_),
+                ) => None,
                 // All other types cannot have a callable kind propagated to them.
-                Type::Dynamic(_)
-                | Type::Divergent(_)
-                | Type::Never
-                | Type::FunctionLiteral(_)
-                | Type::BoundMethod(_)
-                | Type::KnownBoundMethod(_)
-                | Type::WrapperDescriptor(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::NominalInstance(_)
-                | Type::ProtocolInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::LiteralValue(_)
-                | Type::TypeVar(_)
-                | Type::BoundSuper(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_)
-                | Type::NewTypeInstance(_) => None,
+                (
+                    _,
+                    crate::types::TypeData::Dynamic(_)
+                    | crate::types::TypeData::Divergent(_)
+                    | crate::types::TypeData::Never
+                    | crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::BoundMethod(_)
+                    | crate::types::TypeData::KnownBoundMethod(_)
+                    | crate::types::TypeData::WrapperDescriptor(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_)
+                    | crate::types::TypeData::ModuleLiteral(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_)
+                    | crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::ProtocolInstance(_)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(_)
+                    | crate::types::TypeData::PropertyInstance(_)
+                    | crate::types::TypeData::AlwaysTruthy
+                    | crate::types::TypeData::AlwaysFalsy
+                    | crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::TypeVar(_)
+                    | crate::types::TypeData::BoundSuper(_)
+                    | crate::types::TypeData::TypeIs(_)
+                    | crate::types::TypeData::TypeGuard(_)
+                    | crate::types::TypeData::TypeForm(_)
+                    | crate::types::TypeData::TypedDict(_)
+                    | crate::types::TypeData::NewTypeInstance(_),
+                ) => None,
             }
         }
 
@@ -5388,7 +5512,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             decorator_ty: Type<'d>,
             decorated_ty: Type<'d>,
         ) -> bool {
-            if !matches!(decorated_ty, Type::FunctionLiteral(_) | Type::Callable(_)) {
+            if !matches!(
+                {
+                    let __ty_view_value = decorated_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::FunctionLiteral(_)
+                        | crate::types::TypeData::Callable(_)
+                )
+            ) {
                 return false;
             }
             let Some(decorator_callable) = decorator_ty
@@ -5423,14 +5557,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // This avoids a query cycle when the function has default parameter values, since
         // computing the signature requires evaluating those defaults which may trigger
         // deferred inference.
-        let propagatable_kind = match decorated_ty {
-            Type::FunctionLiteral(func) => Some((
+        let propagatable_kind = match {
+            let __ty_view_value = decorated_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(func)) => Some((
                 func.callable_type_kind(self.db()),
                 CallableFunctionProvenance::from_function_return_annotation(
                     func.has_explicit_return_annotation(self.db()),
                 ),
             )),
-            _ => decorated_ty
+            (_, _) => decorated_ty
                 .try_upcast_to_callable(self.db())
                 .and_then(CallableTypes::exactly_one)
                 .and_then(|callable| match callable.kind(self.db()) {
@@ -6094,11 +6231,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         // Avoid promoting explicitly annotated literal values.
-        if let Type::LiteralValue(literal) = ty
-            && let Some(tcx) = tcx.annotation
-            && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
-                .resolve_type_alias(self.db())
-                .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
+        if let (_, crate::types::TypeData::LiteralValue(literal)) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) && let Some(tcx) = tcx.annotation
+            && let (
+                literal_tcx,
+                crate::types::TypeData::Union(_) | crate::types::TypeData::LiteralValue(_),
+            ) = ({
+                let __ty_view_value = tcx
+                    .resolve_type_alias(self.db())
+                    .filter_union(self.db(), |ty| ty.as_literal_value().is_some());
+                (__ty_view_value, __ty_view_value.data())
+            })
             && ty.is_assignable_to(self.db(), literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
@@ -6139,7 +6284,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // the information we need to choose an appropriate specialization of
         // `list` given the type context, and we wouldn't have to duplicate all
         // of the logic below.
-        let Type::ClassLiteral(class) = ty else {
+        let (_, crate::types::TypeData::ClassLiteral(class)) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return ty;
         };
         let db = self.db();
@@ -6151,15 +6299,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .exactly_one()
                 .ok()
         };
-        let Some(target_callable) = (match target {
-            Type::Callable(callable) => Some(callable),
-            Type::Union(union) => exactly_one_callable(union),
-            Type::TypeAlias(_) => match target.resolve_type_alias(db) {
-                Type::Callable(callable) => Some(callable),
-                Type::Union(union) => exactly_one_callable(union),
-                _ => None,
+        let Some(target_callable) = (match {
+            let __ty_view_value = target;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Callable(callable)) => Some(callable),
+            (_, crate::types::TypeData::Union(union)) => exactly_one_callable(union),
+            (_, crate::types::TypeData::TypeAlias(_)) => match {
+                let __ty_view_value = target.resolve_type_alias(db);
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Callable(callable)) => Some(callable),
+                (_, crate::types::TypeData::Union(union)) => exactly_one_callable(union),
+                (_, _) => None,
             },
-            _ => None,
+            (_, _) => None,
         }) else {
             return ty;
         };
@@ -6174,8 +6328,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .all(|parameter| parameter.annotated_type().is_dynamic()))
                 || (parameters.is_empty()
                     && matches!(
-                        signature.return_ty,
-                        Type::Dynamic(DynamicType::UnspecializedTypeVar)
+                        {
+                            let __ty_view_value = signature.return_ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (
+                            _,
+                            crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
+                        )
                     ))
         }) {
             return ty;
@@ -6288,17 +6448,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn has_string_literal_completion_candidates(&self, ty: Type<'db>) -> bool {
-        match ty {
-            Type::LiteralValue(literal) => literal.as_string().is_some(),
-            Type::Union(union) => union
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::LiteralValue(literal)) => literal.as_string().is_some(),
+            (_, crate::types::TypeData::Union(union)) => union
                 .elements(self.db())
                 .iter()
                 .any(|ty| self.has_string_literal_completion_candidates(*ty)),
-            Type::Intersection(intersection) => intersection
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
                 .iter_positive(self.db())
                 .any(|ty| self.has_string_literal_completion_candidates(ty)),
-            Type::TypeAlias(_) => true,
-            _ => false,
+            (_, crate::types::TypeData::TypeAlias(_)) => true,
+            (_, _) => false,
         }
     }
 
@@ -6728,7 +6891,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     return ty;
                 }
-            } else if let Type::Union(union) = annotation {
+            } else if let (_, crate::types::TypeData::Union(union)) = {
+                let __ty_view_value = annotation;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 let union_elements = union.elements(self.db());
                 let mut typed_dicts = Vec::new();
                 let mut has_dict_compatible_fallback = false;
@@ -6948,7 +7114,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 FxHashMap::default();
 
             if let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
-                && matches!(tcx, Type::NominalInstance(_))
+                && matches!(
+                    {
+                        let __ty_view_value = tcx;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (_, crate::types::TypeData::NominalInstance(_))
+                )
                 && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
                 && specialization.generic_context(self.db()) == generic_context
                 && generic_context.variables(self.db()).all(|typevar| {
@@ -8036,9 +8208,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // If we have a direct `Callable` type context, we can infer the body with the annotated
         // return type as type context.
         let return_tcx = if let Some(signature) = callable_tcx {
-            match signature.return_ty {
-                Type::Dynamic(DynamicType::Unknown) => TypeContext::new(None),
-                _ => TypeContext::new(Some(signature.return_ty)),
+            match {
+                let __ty_view_value = signature.return_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => {
+                    TypeContext::new(None)
+                }
+                (_, _) => TypeContext::new(Some(signature.return_ty)),
             }
         } else {
             // TODO: Useful inference of a lambda's return type will require a different approach,
@@ -8310,8 +8487,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Handle 3-argument `type(name, bases, dict)`.
-        if let Type::ClassLiteral(class) = callable_type
-            && class.is_known(self.db(), KnownClass::Type)
+        if let (_, crate::types::TypeData::ClassLiteral(class)) = ({
+            let __ty_view_value = callable_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) && class.is_known(self.db(), KnownClass::Type)
         {
             return self.infer_builtins_type_call(call_expression, None);
         }
@@ -8361,11 +8540,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         }
 
-        let class = match callable_type {
-            Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
-            Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
-            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
-            _ => None,
+        let class = match {
+            let __ty_view_value = callable_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class)) => Some(ClassType::NonGeneric(class)),
+            (_, crate::types::TypeData::GenericAlias(generic)) => Some(ClassType::Generic(generic)),
+            (_, crate::types::TypeData::SubclassOf(subclass)) => {
+                subclass.subclass_of().into_class(self.db())
+            }
+            (_, _) => None,
         };
 
         // Prepare `TypedDict` constructor calls before variadic argument setup so field-directed
@@ -8394,7 +8578,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let value_type = self.expression_type(value);
             let method_name = attr.id.as_str();
 
-            if let Type::TypedDict(typed_dict_ty) = value_type
+            if let (_, crate::types::TypeData::TypedDict(typed_dict_ty)) = ({ let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) })
                 && matches!(method_name, "get" | "pop" | "setdefault")
                 && !arguments.args.is_empty()
 
@@ -8541,7 +8725,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        if let Type::FunctionLiteral(function) = callable_type {
+        if let (_, crate::types::TypeData::FunctionLiteral(function)) = {
+            let __ty_view_value = callable_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // Make sure that the `function.definition` is only called when the function is defined
             // in the same file as the one we're currently inferring the types for. This is because
             // the `definition` method accesses the semantic index, which could create a
@@ -8568,8 +8755,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Check for unsound calls to abstract classmethods/staticmethods on class objects
-        match callable_type {
-            Type::BoundMethod(bound_method) => {
+        match {
+            let __ty_view_value = callable_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::BoundMethod(bound_method)) => {
                 let function = bound_method.function(self.db());
                 if let Some(class) = bound_method
                     .self_instance(self.db())
@@ -8588,7 +8778,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-            Type::FunctionLiteral(function) if function.is_staticmethod(self.db()) => {
+            (_, crate::types::TypeData::FunctionLiteral(function))
+                if function.is_staticmethod(self.db()) =>
+            {
                 if let ast::Expr::Attribute(ast::ExprAttribute { value, .. }) = func.as_ref() {
                     let value_type = self.expression_type(value);
                     if let Some(class) = value_type.to_class_type(self.db()) {
@@ -8605,7 +8797,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-            _ => {}
+            (_, _) => {}
         }
 
         if let Some(class) = class {
@@ -8709,8 +8901,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for binding in bindings.iter_flat_mut() {
             let binding_type = binding.callable_type;
             for (_, overload) in binding.matching_overloads_mut() {
-                match binding_type {
-                    Type::FunctionLiteral(function_literal) => {
+                match {
+                    let __ty_view_value = binding_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::FunctionLiteral(function_literal)) => {
                         if let Some(known_function) = function_literal.known(self.db()) {
                             known_function.check_call(
                                 &self.context,
@@ -8721,7 +8916,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             );
                         }
                     }
-                    Type::ClassLiteral(class) => {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
                         if let Some(known_class) = class.known(self.db()) {
                             known_class.check_call(
                                 &self.context,
@@ -8731,7 +8926,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             );
                         }
                     }
-                    Type::Never => {
+                    (_, crate::types::TypeData::Never) => {
                         // In unreachable sections of code, we infer `Never` for symbols that were
                         // defined outside the unreachable part. We still want to emit revealed-type
                         // diagnostics in these sections, so check on the name of the callable here
@@ -8748,7 +8943,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             report_revealed_type(&self.context, revealed_ty, first_arg);
                         }
                     }
-                    _ => {}
+                    (_, _) => {}
                 }
             }
         }
@@ -8860,16 +9055,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .unwrap_or(0)
         };
 
-        match return_ty {
-            Type::TypeIs(type_is) => match find_narrowed_place(narrowed_argument_index()) {
-                Some(place) => type_is.bind(db, scope, place),
-                None => return_ty,
-            },
-            Type::TypeGuard(type_guard) => match find_narrowed_place(narrowed_argument_index()) {
-                Some(place) => type_guard.bind(db, scope, place),
-                None => return_ty,
-            },
-            _ => return_ty,
+        match {
+            let __ty_view_value = return_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeIs(type_is)) => {
+                match find_narrowed_place(narrowed_argument_index()) {
+                    Some(place) => type_is.bind(db, scope, place),
+                    None => return_ty,
+                }
+            }
+            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
+                match find_narrowed_place(narrowed_argument_index()) {
+                    Some(place) => type_guard.bind(db, scope, place),
+                    None => return_ty,
+                }
+            }
+            (_, _) => return_ty,
         }
     }
 
@@ -9124,7 +9326,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Check if the given ty is `@deprecated` or not
     fn check_deprecated<T: Ranged>(&self, ranged: T, ty: Type) {
         // First handle classes
-        if let Type::ClassLiteral(class_literal) = ty {
+        if let (_, crate::types::TypeData::ClassLiteral(class_literal)) = {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             let Some(deprecated) = class_literal.deprecated(self.db()) else {
                 return;
             };
@@ -9144,10 +9349,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         // Next handle functions
-        let function = match ty {
-            Type::FunctionLiteral(function) => function,
-            Type::BoundMethod(bound) => bound.function(self.db()),
-            _ => return,
+        let function = match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => function,
+            (_, crate::types::TypeData::BoundMethod(bound)) => bound.function(self.db()),
+            (_, _) => return,
         };
 
         // Currently we only check the final implementation for deprecation, as
@@ -9831,8 +10039,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let mut constraint_keys = vec![];
 
-        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_type
-            && typevar.is_paramspec(db)
+        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
+            let __ty_view_value = value_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) && typevar.is_paramspec(db)
             && let Some(bound_typevar) = bind_typevar(
                 db,
                 self.index,
@@ -9876,11 +10086,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         )
                     };
 
-                    let bound_on_instance = match value_type {
-                        Type::ClassLiteral(class) => {
+                    let bound_on_instance = match { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
+                        (_, crate::types::TypeData::ClassLiteral(class)) => {
                             !class.instance_member(db, None, attr).is_undefined()
                         }
-                        Type::SubclassOf(subclass_of @ SubclassOfType { .. }) => {
+                        (_, crate::types::TypeData::SubclassOf(subclass_of @ SubclassOfType { .. })) => {
                             match subclass_of.subclass_of() {
                                 SubclassOfInner::Class(class) => {
                                     !class.instance_member(db, attr).is_undefined()
@@ -9892,10 +10102,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 SubclassOfInner::TypeVar(_) => false,
                             }
                         }
-                        _ => false,
+                        (_, _) => false,
                     };
 
-                    if let Type::ModuleLiteral(module) = value_type {
+                    if let (_, crate::types::TypeData::ModuleLiteral(module)) = { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
                         let module = module.module(db);
                         let module_name = module.name(db);
                         if module.kind(db).is_package()
@@ -9920,7 +10130,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     }
 
-                    if let Type::SpecialForm(special_form) = value_type {
+                    if let (_, crate::types::TypeData::SpecialForm(special_form)) = { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
                         if let Some(builder) =
                             self.context.report_lint(&UNRESOLVED_ATTRIBUTE, attribute)
                         {
@@ -9973,24 +10183,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return fallback();
                     }
 
-                    let mut diagnostic = match value_type {
-                        Type::ModuleLiteral(module) => builder.into_diagnostic(format_args!(
+                    let mut diagnostic = match { let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) }  {
+                        (_, crate::types::TypeData::ModuleLiteral(module)) => builder.into_diagnostic(format_args!(
                             "Module `{module_name}` has no member `{attr_name}`",
                             module_name = module.module(db).name(db),
                         )),
-                        Type::ClassLiteral(class) => builder.into_diagnostic(format_args!(
+                        (_, crate::types::TypeData::ClassLiteral(class)) => builder.into_diagnostic(format_args!(
                             "Class `{}` has no attribute `{attr_name}`",
                             class.name(db),
                         )),
-                        Type::GenericAlias(alias) => builder.into_diagnostic(format_args!(
+                        (_, crate::types::TypeData::GenericAlias(alias)) => builder.into_diagnostic(format_args!(
                             "Class `{}` has no attribute `{attr_name}`",
                             alias.display(db),
                         )),
-                        Type::FunctionLiteral(function) => builder.into_diagnostic(format_args!(
+                        (_, crate::types::TypeData::FunctionLiteral(function)) => builder.into_diagnostic(format_args!(
                             "Function `{}` has no attribute `{attr_name}`",
                             function.name(db),
                         )),
-                        _ => builder.into_diagnostic(format_args!(
+                        (_, _) => builder.into_diagnostic(format_args!(
                             "Object of type `{}` has no attribute `{attr_name}`",
                             value_type.display(db),
                         )),
@@ -10055,7 +10265,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Attribute lookup on a bounded type variable delegates to its upper bound, so
                     // use that bound here too when determining whether the lookup was on a union.
-                    let union_like_type = if let Type::TypeVar(typevar) = value_type
+                    let union_like_type = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({ let __ty_view_value = value_type; (__ty_view_value, __ty_view_value.data()) })
                         && let Some(bound) = typevar.typevar(db).upper_bound(db)
                     {
                         bound
@@ -10226,38 +10436,56 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match (op, operand_type) {
-            (ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub, Type::Dynamic(_))
-            | (_, Type::Divergent(_)) => operand_type,
-            (_, Type::Never) => Type::Never,
+        match (
+            op,
+            ({
+                let __ty_view_value = operand_type;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
+            (
+                ast::UnaryOp::Invert | ast::UnaryOp::UAdd | ast::UnaryOp::USub,
+                (_, crate::types::TypeData::Dynamic(_)),
+            )
+            | (_, (_, crate::types::TypeData::Divergent(_))) => operand_type,
+            (_, (_, crate::types::TypeData::Never)) => Type::Never,
 
-            (_, Type::TypeAlias(alias)) => {
+            (_, (_, crate::types::TypeData::TypeAlias(alias))) => {
                 self.infer_unary_expression_type(op, alias.value_type(self.db()), unary)
             }
 
-            (ast::UnaryOp::UAdd, Type::LiteralValue(literal)) => match literal.kind() {
-                LiteralValueTypeKind::Int(value) => Type::int_literal(value.as_i64()),
-                LiteralValueTypeKind::Bool(value) => Type::int_literal(i64::from(value)),
-                _ => fallback_unary_expression_type(),
-            },
+            (ast::UnaryOp::UAdd, (_, crate::types::TypeData::LiteralValue(literal))) => {
+                match literal.kind() {
+                    LiteralValueTypeKind::Int(value) => Type::int_literal(value.as_i64()),
+                    LiteralValueTypeKind::Bool(value) => Type::int_literal(i64::from(value)),
+                    _ => fallback_unary_expression_type(),
+                }
+            }
 
-            (ast::UnaryOp::USub, Type::LiteralValue(literal)) => match literal.kind() {
-                LiteralValueTypeKind::Int(value) => value
-                    .as_i64()
-                    .checked_neg()
-                    .map(Type::int_literal)
-                    .unwrap_or_else(|| KnownClass::Int.to_instance(self.db())),
-                LiteralValueTypeKind::Bool(value) => Type::int_literal(-i64::from(value)),
-                _ => fallback_unary_expression_type(),
-            },
+            (ast::UnaryOp::USub, (_, crate::types::TypeData::LiteralValue(literal))) => {
+                match literal.kind() {
+                    LiteralValueTypeKind::Int(value) => value
+                        .as_i64()
+                        .checked_neg()
+                        .map(Type::int_literal)
+                        .unwrap_or_else(|| KnownClass::Int.to_instance(self.db())),
+                    LiteralValueTypeKind::Bool(value) => Type::int_literal(-i64::from(value)),
+                    _ => fallback_unary_expression_type(),
+                }
+            }
 
-            (ast::UnaryOp::Invert, Type::LiteralValue(literal)) => match literal.kind() {
-                LiteralValueTypeKind::Int(value) => Type::int_literal(!value.as_i64()),
-                LiteralValueTypeKind::Bool(value) => Type::int_literal(!i64::from(value)),
-                _ => fallback_unary_expression_type(),
-            },
+            (ast::UnaryOp::Invert, (_, crate::types::TypeData::LiteralValue(literal))) => {
+                match literal.kind() {
+                    LiteralValueTypeKind::Int(value) => Type::int_literal(!value.as_i64()),
+                    LiteralValueTypeKind::Bool(value) => Type::int_literal(!i64::from(value)),
+                    _ => fallback_unary_expression_type(),
+                }
+            }
 
-            (ast::UnaryOp::Invert, Type::KnownInstance(KnownInstanceType::ConstraintSet(set))) => {
+            (
+                ast::UnaryOp::Invert,
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(set))),
+            ) => {
                 let constraints = ConstraintSetBuilder::new();
                 let result = constraints.into_owned(|constraints| {
                     let set = constraints.load(self.db(), set.constraints(self.db()));
@@ -10268,7 +10496,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ))
             }
 
-            (ast::UnaryOp::Not, ty) => Type::from_truthiness(
+            (ast::UnaryOp::Not, (ty, _)) => Type::from_truthiness(
                 self.db(),
                 ty.try_bool(self.db())
                     .unwrap_or_else(|err| {
@@ -10283,7 +10511,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // solver.
             (
                 op @ (ast::UnaryOp::UAdd | ast::UnaryOp::USub | ast::UnaryOp::Invert),
-                Type::TypeVar(tvar),
+                (_, crate::types::TypeData::TypeVar(tvar)),
             ) => {
                 let unary_dunder_method = match op {
                     ast::UnaryOp::Invert => "__invert__",
@@ -10364,33 +10592,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             (
                 ast::UnaryOp::UAdd | ast::UnaryOp::USub | ast::UnaryOp::Invert,
-                Type::FunctionLiteral(_)
-                | Type::Callable(..)
-                | Type::WrapperDescriptor(_)
-                | Type::KnownBoundMethod(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::BoundMethod(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::NominalInstance(_)
-                | Type::ProtocolInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::Union(_)
-                | Type::Intersection(_)
-                | Type::EnumComplement(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::BoundSuper(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_)
-                | Type::NewTypeInstance(_),
+                (
+                    _,
+                    crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::Callable(..)
+                    | crate::types::TypeData::WrapperDescriptor(_)
+                    | crate::types::TypeData::KnownBoundMethod(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_)
+                    | crate::types::TypeData::BoundMethod(_)
+                    | crate::types::TypeData::ModuleLiteral(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_)
+                    | crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::ProtocolInstance(_)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(_)
+                    | crate::types::TypeData::PropertyInstance(_)
+                    | crate::types::TypeData::Union(_)
+                    | crate::types::TypeData::Intersection(_)
+                    | crate::types::TypeData::EnumComplement(_)
+                    | crate::types::TypeData::AlwaysTruthy
+                    | crate::types::TypeData::AlwaysFalsy
+                    | crate::types::TypeData::BoundSuper(_)
+                    | crate::types::TypeData::TypeIs(_)
+                    | crate::types::TypeData::TypeGuard(_)
+                    | crate::types::TypeData::TypeForm(_)
+                    | crate::types::TypeData::TypedDict(_)
+                    | crate::types::TypeData::NewTypeInstance(_),
+                ),
             ) => fallback_unary_expression_type(),
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -84,11 +84,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             builder: &TypeInferenceBuilder<'db, '_>,
             pep_613_policy: PEP613Policy,
         ) -> TypeAndQualifiers<'db> {
-            let special_case = match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
+            let special_case = match ty.data() {
+                crate::types::TypeData::SpecialForm(special_form) => match special_form {
                     SpecialFormType::TypeQualifier(qualifier) => {
                         match qualifier {
                             TypeQualifier::InitVar
@@ -120,19 +117,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 },
                 // Conditional import of `typing.TypeAlias` or `typing_extensions.TypeAlias` on a
                 // Python version where the former doesn't exist.
-                (_, crate::types::TypeData::Union(union))
+                crate::types::TypeData::Union(union)
                     if pep_613_policy == PEP613Policy::Allowed
                         && union.elements(builder.db()).iter().all(|ty| {
                             matches!(
-                                {
-                                    let __ty_view_value = ty;
-                                    (__ty_view_value, __ty_view_value.data())
-                                },
-                                (
-                                    _,
-                                    crate::types::TypeData::SpecialForm(SpecialFormType::TypeAlias)
-                                        | crate::types::TypeData::Dynamic(_)
-                                )
+                                ty.data(),
+                                crate::types::TypeData::SpecialForm(SpecialFormType::TypeAlias)
+                                    | crate::types::TypeData::Dynamic(_)
                             )
                         }) =>
                 {
@@ -140,7 +131,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         SpecialFormType::TypeAlias,
                     )))
                 }
-                (_, _) => None,
+                _ => None,
             };
 
             special_case.unwrap_or_else(|| {
@@ -194,11 +185,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let slice = &**slice;
                 let value_ty = self.infer_expression(value, TypeContext::default());
 
-                match {
-                    let __ty_view_value = value_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
+                match value_ty.data() {
+                    crate::types::TypeData::SpecialForm(special_form) => match special_form {
                         SpecialFormType::Annotated => {
                             let inferred = self.parse_subscription_of_annotated_special_form(
                                 subscript,
@@ -315,7 +303,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             ),
                         ),
                     },
-                    (_, _) => TypeAndQualifiers::declared(
+                    _ => TypeAndQualifiers::declared(
                         self.infer_subscript_type_expression_no_store(subscript, slice, value_ty),
                     ),
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -84,8 +84,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             builder: &TypeInferenceBuilder<'db, '_>,
             pep_613_policy: PEP613Policy,
         ) -> TypeAndQualifiers<'db> {
-            let special_case = match ty {
-                Type::SpecialForm(special_form) => match special_form {
+            let special_case = match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
                     SpecialFormType::TypeQualifier(qualifier) => {
                         match qualifier {
                             TypeQualifier::InitVar
@@ -117,12 +120,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 },
                 // Conditional import of `typing.TypeAlias` or `typing_extensions.TypeAlias` on a
                 // Python version where the former doesn't exist.
-                Type::Union(union)
+                (_, crate::types::TypeData::Union(union))
                     if pep_613_policy == PEP613Policy::Allowed
                         && union.elements(builder.db()).iter().all(|ty| {
                             matches!(
-                                ty,
-                                Type::SpecialForm(SpecialFormType::TypeAlias) | Type::Dynamic(_)
+                                {
+                                    let __ty_view_value = ty;
+                                    (__ty_view_value, __ty_view_value.data())
+                                },
+                                (
+                                    _,
+                                    crate::types::TypeData::SpecialForm(SpecialFormType::TypeAlias)
+                                        | crate::types::TypeData::Dynamic(_)
+                                )
                             )
                         }) =>
                 {
@@ -130,7 +140,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         SpecialFormType::TypeAlias,
                     )))
                 }
-                _ => None,
+                (_, _) => None,
             };
 
             special_case.unwrap_or_else(|| {
@@ -184,8 +194,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let slice = &**slice;
                 let value_ty = self.infer_expression(value, TypeContext::default());
 
-                match value_ty {
-                    Type::SpecialForm(special_form) => match special_form {
+                match {
+                    let __ty_view_value = value_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
                         SpecialFormType::Annotated => {
                             let inferred = self.parse_subscription_of_annotated_special_form(
                                 subscript,
@@ -302,7 +315,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             ),
                         ),
                     },
-                    _ => TypeAndQualifiers::declared(
+                    (_, _) => TypeAndQualifiers::declared(
                         self.infer_subscript_type_expression_no_store(subscript, slice, value_ty),
                     ),
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -134,15 +134,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // `__or__`/`__ror__` method on the TypedDict side.
         if op == ast::Operator::BitOr && matches!(left, ast::Expr::Dict(_)) {
             let right_ty = self.infer_expression(right, operand_tcx(right));
-            if let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
-                let __ty_view_value = right_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) && let Some(ty) = self.try_typed_dict_pep_584_dunder(
-                left,
-                typed_dict.to_partial(self.db()),
-                typed_dict,
-                "__ror__",
-            ) {
+            if let crate::types::TypeData::TypedDict(typed_dict) = right_ty.data()
+                && let Some(ty) = self.try_typed_dict_pep_584_dunder(
+                    left,
+                    typed_dict.to_partial(self.db()),
+                    typed_dict,
+                    "__ror__",
+                )
+            {
                 return BinaryExpressionOperandTypes::TypedDictResult(ty);
             }
 
@@ -156,10 +155,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let left_ty = self.infer_expression(left, operand_tcx(left));
         if op == ast::Operator::BitOr
-            && let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
-                let __ty_view_value = left_ty;
-                (__ty_view_value, __ty_view_value.data())
-            })
+            && let crate::types::TypeData::TypedDict(typed_dict) = left_ty.data()
             && matches!(right, ast::Expr::Dict(_))
             && let Some(ty) = self.try_typed_dict_pep_584_dunder(
                 right,
@@ -220,10 +216,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         }
 
-        let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
-            let __ty_view_value = target_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::TypedDict(typed_dict) = target_type.data() else {
             return None;
         };
 
@@ -327,17 +320,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             emitted_division_by_zero_diagnostic = self.check_division_by_zero(node, op, left_ty);
         }
 
-        match (
-            ({
-                let __ty_view_value = left_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = right_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            op,
-        ) {
+        match (left_ty.view(), right_ty.view(), op) {
             ((_, crate::types::TypeData::Union(lhs_union)), (rhs, _), _) => {
                 lhs_union.try_map(db, |lhs_element| {
                     self.infer_binary_expression_type_impl(
@@ -914,16 +897,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
                 };
 
-                result.map(|result| {
-                    match {
-                        let __ty_view_value = result;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::LiteralValue(literal)) => Type::LiteralValue(
-                            literal.with_recursively_defined(recursively_defined),
-                        ),
-                        (_, _) => result,
+                result.map(|result| match result.data() {
+                    crate::types::TypeData::LiteralValue(literal) => {
+                        Type::LiteralValue(literal.with_recursively_defined(recursively_defined))
                     }
+                    _ => result,
                 })
             }
 
@@ -1156,21 +1134,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         left: Type<'db>,
     ) -> bool {
         let db = self.db();
-        match {
-            let __ty_view_value = left;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::LiteralValue(literal))
+        match left.data() {
+            crate::types::TypeData::LiteralValue(literal)
                 if matches!(
                     literal.kind(),
                     LiteralValueTypeKind::Bool(_) | LiteralValueTypeKind::Int(_)
                 ) => {}
-            (_, crate::types::TypeData::NominalInstance(instance))
+            crate::types::TypeData::NominalInstance(instance)
                 if matches!(
                     instance.known_class(db),
                     Some(KnownClass::Float | KnownClass::Int | KnownClass::Bool)
                 ) => {}
-            (_, _) => return false,
+            _ => return false,
         }
 
         let (op, by_zero) = match op {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -134,14 +134,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // `__or__`/`__ror__` method on the TypedDict side.
         if op == ast::Operator::BitOr && matches!(left, ast::Expr::Dict(_)) {
             let right_ty = self.infer_expression(right, operand_tcx(right));
-            if let Type::TypedDict(typed_dict) = right_ty
-                && let Some(ty) = self.try_typed_dict_pep_584_dunder(
-                    left,
-                    typed_dict.to_partial(self.db()),
-                    typed_dict,
-                    "__ror__",
-                )
-            {
+            if let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
+                let __ty_view_value = right_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) && let Some(ty) = self.try_typed_dict_pep_584_dunder(
+                left,
+                typed_dict.to_partial(self.db()),
+                typed_dict,
+                "__ror__",
+            ) {
                 return BinaryExpressionOperandTypes::TypedDictResult(ty);
             }
 
@@ -155,7 +156,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let left_ty = self.infer_expression(left, operand_tcx(left));
         if op == ast::Operator::BitOr
-            && let Type::TypedDict(typed_dict) = left_ty
+            && let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
+                let __ty_view_value = left_ty;
+                (__ty_view_value, __ty_view_value.data())
+            })
             && matches!(right, ast::Expr::Dict(_))
             && let Some(ty) = self.try_typed_dict_pep_584_dunder(
                 right,
@@ -216,7 +220,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return None;
         }
 
-        let Type::TypedDict(typed_dict) = target_type else {
+        let (_, crate::types::TypeData::TypedDict(typed_dict)) = ({
+            let __ty_view_value = target_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return None;
         };
 
@@ -320,85 +327,140 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             emitted_division_by_zero_diagnostic = self.check_division_by_zero(node, op, left_ty);
         }
 
-        match (left_ty, right_ty, op) {
-            (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, |lhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    *lhs_element,
-                    rhs,
-                    op,
-                    visitor,
-                )
+        match (
+            ({
+                let __ty_view_value = left_ty;
+                (__ty_view_value, __ty_view_value.data())
             }),
-            (lhs, Type::Union(rhs_union), _) => rhs_union.try_map(db, |rhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    lhs,
-                    *rhs_element,
-                    op,
-                    visitor,
-                )
+            ({
+                let __ty_view_value = right_ty;
+                (__ty_view_value, __ty_view_value.data())
             }),
+            op,
+        ) {
+            ((_, crate::types::TypeData::Union(lhs_union)), (rhs, _), _) => {
+                lhs_union.try_map(db, |lhs_element| {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        *lhs_element,
+                        rhs,
+                        op,
+                        visitor,
+                    )
+                })
+            }
+            ((lhs, _), (_, crate::types::TypeData::Union(rhs_union)), _) => {
+                rhs_union.try_map(db, |rhs_element| {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        lhs,
+                        *rhs_element,
+                        op,
+                        visitor,
+                    )
+                })
+            }
 
-            (Type::TypeAlias(alias), rhs, _) => visitor.visit((left_ty, op, right_ty), || {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    alias.value_type(db),
-                    rhs,
-                    op,
-                    visitor,
-                )
-            }),
+            ((_, crate::types::TypeData::TypeAlias(alias)), (rhs, _), _) => {
+                visitor.visit((left_ty, op, right_ty), || {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        alias.value_type(db),
+                        rhs,
+                        op,
+                        visitor,
+                    )
+                })
+            }
 
-            (lhs, Type::TypeAlias(alias), _) => visitor.visit((left_ty, op, right_ty), || {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    lhs,
-                    alias.value_type(db),
-                    op,
-                    visitor,
-                )
-            }),
+            ((lhs, _), (_, crate::types::TypeData::TypeAlias(alias)), _) => {
+                visitor.visit((left_ty, op, right_ty), || {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        lhs,
+                        alias.value_type(db),
+                        op,
+                        visitor,
+                    )
+                })
+            }
 
-            (Type::TypedDict(left_typed_dict), rhs, ast::Operator::BitOr)
-                if rhs.is_assignable_to(db, Type::TypedDict(left_typed_dict)) =>
-            {
+            (
+                (_, crate::types::TypeData::TypedDict(left_typed_dict)),
+                (rhs, _),
+                ast::Operator::BitOr,
+            ) if rhs.is_assignable_to(db, Type::TypedDict(left_typed_dict)) => {
                 Some(Type::TypedDict(left_typed_dict))
             }
 
-            (lhs, Type::TypedDict(right_typed_dict), ast::Operator::BitOr)
-                if lhs.is_assignable_to(db, Type::TypedDict(right_typed_dict)) =>
-            {
+            (
+                (lhs, _),
+                (_, crate::types::TypeData::TypedDict(right_typed_dict)),
+                ast::Operator::BitOr,
+            ) if lhs.is_assignable_to(db, Type::TypedDict(right_typed_dict)) => {
                 Some(Type::TypedDict(right_typed_dict))
             }
 
             // Non-todo Anys take precedence over Todos (as if we fix this `Todo` in the future,
             // the result would then become Any or Unknown, respectively).
-            (div @ Type::Divergent(_), _, _) | (_, div @ Type::Divergent(_), _) => Some(div),
+            ((div, crate::types::TypeData::Divergent(_)), (_, _), _)
+            | ((_, _), (div, crate::types::TypeData::Divergent(_)), _) => Some(div),
 
-            (unknown @ Type::Dynamic(DynamicType::AmbiguousOverload), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::AmbiguousOverload), _) => Some(unknown),
+            (
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::AmbiguousOverload)),
+                (_, _),
+                _,
+            )
+            | (
+                (_, _),
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::AmbiguousOverload)),
+                _,
+            ) => Some(unknown),
 
-            (any @ Type::Dynamic(DynamicType::Any), _, _)
-            | (_, any @ Type::Dynamic(DynamicType::Any), _) => Some(any),
+            ((any, crate::types::TypeData::Dynamic(DynamicType::Any)), (_, _), _)
+            | ((_, _), (any, crate::types::TypeData::Dynamic(DynamicType::Any)), _) => Some(any),
 
-            (unknown @ Type::Dynamic(DynamicType::Unknown), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::Unknown), _) => Some(unknown),
-
-            (unknown @ Type::Dynamic(DynamicType::InvalidConcatenateUnknown), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::InvalidConcatenateUnknown), _) => {
+            ((unknown, crate::types::TypeData::Dynamic(DynamicType::Unknown)), (_, _), _)
+            | ((_, _), (unknown, crate::types::TypeData::Dynamic(DynamicType::Unknown)), _) => {
                 Some(unknown)
             }
 
-            (unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _, _)
-            | (_, unknown @ Type::Dynamic(DynamicType::UnknownGeneric(_)), _) => Some(unknown),
+            (
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::InvalidConcatenateUnknown)),
+                (_, _),
+                _,
+            )
+            | (
+                (_, _),
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::InvalidConcatenateUnknown)),
+                _,
+            ) => Some(unknown),
 
-            (typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _, _)
-            | (_, typevar @ Type::Dynamic(DynamicType::UnspecializedTypeVar), _) => Some(typevar),
+            (
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::UnknownGeneric(_))),
+                (_, _),
+                _,
+            )
+            | (
+                (_, _),
+                (unknown, crate::types::TypeData::Dynamic(DynamicType::UnknownGeneric(_))),
+                _,
+            ) => Some(unknown),
+
+            (
+                (typevar, crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)),
+                (_, _),
+                _,
+            )
+            | (
+                (_, _),
+                (typevar, crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)),
+                _,
+            ) => Some(typevar),
 
             // When both operands are the same constrained TypeVar (e.g., `T: (int, str)`),
             // we check if the operation is valid for each constraint paired with itself.
@@ -412,9 +474,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             //
             // TODO: We expect to replace this with more general support for handling constrained TypeVars
             // in arbitrary method/function calls.
-            (Type::TypeVar(left_tvar), Type::TypeVar(right_tvar), _)
-                if left_tvar.identity(db) == right_tvar.identity(db) =>
-            {
+            (
+                (_, crate::types::TypeData::TypeVar(left_tvar)),
+                (_, crate::types::TypeData::TypeVar(right_tvar)),
+                _,
+            ) if left_tvar.identity(db) == right_tvar.identity(db) => {
                 match left_tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
@@ -444,7 +508,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             //
             // TODO: We expect to replace this with more general support once we migrate to the new
             // solver.
-            (Type::TypeVar(left_tvar), rhs, _) if !rhs.is_type_var() => {
+            ((_, crate::types::TypeData::TypeVar(left_tvar)), (rhs, _), _)
+                if !rhs.is_type_var() =>
+            {
                 match left_tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
@@ -470,7 +536,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             // When the right operand is a constrained TypeVar and the left operand is not a TypeVar,
             // we check if each constraint supports the operation with the left operand.
-            (lhs, Type::TypeVar(right_tvar), _) if !lhs.is_type_var() => {
+            ((lhs, _), (_, crate::types::TypeData::TypeVar(right_tvar)), _)
+                if !lhs.is_type_var() =>
+            {
                 match right_tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
@@ -500,7 +568,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // get the same `int | float` and `int | float | complex` special treatment that the
             // positional arguments get. In those cases we need to explicitly delegate to the base
             // type, so that it hits the `Type::Union` branches above.
-            (Type::NewTypeInstance(newtype), rhs, _) => {
+            ((_, crate::types::TypeData::NewTypeInstance(newtype)), (rhs, _), _) => {
                 Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
@@ -512,7 +580,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     )
                 })
             }
-            (lhs, Type::NewTypeInstance(newtype), _) => {
+            ((lhs, _), (_, crate::types::TypeData::NewTypeInstance(newtype)), _) => {
                 Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
                     self.infer_binary_expression_type_impl(
                         node,
@@ -526,29 +594,40 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
 
             (
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
+                (
+                    todo,
+                    crate::types::TypeData::Dynamic(
+                        DynamicType::Todo(_)
+                        | DynamicType::TodoUnpack
+                        | DynamicType::TodoStarredExpression
+                        | DynamicType::TodoTypeVarTuple,
+                    ),
                 ),
-                _,
+                (_, _),
                 _,
             )
             | (
-                _,
-                todo @ Type::Dynamic(
-                    DynamicType::Todo(_)
-                    | DynamicType::TodoUnpack
-                    | DynamicType::TodoStarredExpression
-                    | DynamicType::TodoTypeVarTuple,
+                (_, _),
+                (
+                    todo,
+                    crate::types::TypeData::Dynamic(
+                        DynamicType::Todo(_)
+                        | DynamicType::TodoUnpack
+                        | DynamicType::TodoStarredExpression
+                        | DynamicType::TodoTypeVarTuple,
+                    ),
                 ),
                 _,
             ) => Some(todo),
 
-            (Type::Never, _, _) | (_, Type::Never, _) => Some(Type::Never),
+            ((_, crate::types::TypeData::Never), (_, _), _)
+            | ((_, _), (_, crate::types::TypeData::Never), _) => Some(Type::Never),
 
-            (Type::LiteralValue(left), Type::LiteralValue(right), _) => {
+            (
+                (_, crate::types::TypeData::LiteralValue(left)),
+                (_, crate::types::TypeData::LiteralValue(right)),
+                _,
+            ) => {
                 let recursively_defined = if left.recursively_defined().is_yes()
                     || right.recursively_defined().is_yes()
                 {
@@ -835,17 +914,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
                 };
 
-                result.map(|result| match result {
-                    Type::LiteralValue(literal) => {
-                        Type::LiteralValue(literal.with_recursively_defined(recursively_defined))
+                result.map(|result| {
+                    match {
+                        let __ty_view_value = result;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::LiteralValue(literal)) => Type::LiteralValue(
+                            literal.with_recursively_defined(recursively_defined),
+                        ),
+                        (_, _) => result,
                     }
-                    _ => result,
                 })
             }
 
             (
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(left))),
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(right))),
                 ast::Operator::BitAnd,
             ) => {
                 let constraints = ConstraintSetBuilder::new();
@@ -860,8 +944,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
 
             (
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
-                Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(left))),
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(right))),
                 ast::Operator::BitOr,
             ) => {
                 let constraints = ConstraintSetBuilder::new();
@@ -877,33 +961,39 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             // PEP 604-style union types using the `|` operator.
             (
-                Type::ClassLiteral(..)
-                | Type::SubclassOf(..)
-                | Type::GenericAlias(..)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(
-                    KnownInstanceType::UnionType(_)
-                    | KnownInstanceType::Literal(_)
-                    | KnownInstanceType::Annotated(_)
-                    | KnownInstanceType::TypeGenericAlias(_)
-                    | KnownInstanceType::Callable(_)
-                    | KnownInstanceType::TypeVar(_)
-                    | KnownInstanceType::TypeAliasType(_)
-                    | KnownInstanceType::NewType(_),
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SubclassOf(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::UnionType(_)
+                        | KnownInstanceType::Literal(_)
+                        | KnownInstanceType::Annotated(_)
+                        | KnownInstanceType::TypeGenericAlias(_)
+                        | KnownInstanceType::Callable(_)
+                        | KnownInstanceType::TypeVar(_)
+                        | KnownInstanceType::TypeAliasType(_)
+                        | KnownInstanceType::NewType(_),
+                    ),
                 ),
-                Type::ClassLiteral(..)
-                | Type::SubclassOf(..)
-                | Type::GenericAlias(..)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(
-                    KnownInstanceType::UnionType(_)
-                    | KnownInstanceType::Literal(_)
-                    | KnownInstanceType::Annotated(_)
-                    | KnownInstanceType::TypeGenericAlias(_)
-                    | KnownInstanceType::Callable(_)
-                    | KnownInstanceType::TypeVar(_)
-                    | KnownInstanceType::TypeAliasType(_)
-                    | KnownInstanceType::NewType(_),
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SubclassOf(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::UnionType(_)
+                        | KnownInstanceType::Literal(_)
+                        | KnownInstanceType::Annotated(_)
+                        | KnownInstanceType::TypeGenericAlias(_)
+                        | KnownInstanceType::Callable(_)
+                        | KnownInstanceType::TypeVar(_)
+                        | KnownInstanceType::TypeAliasType(_)
+                        | KnownInstanceType::NewType(_),
+                    ),
                 ),
                 ast::Operator::BitOr,
             ) => {
@@ -920,21 +1010,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
             }
             (
-                Type::ClassLiteral(..)
-                | Type::SubclassOf(..)
-                | Type::GenericAlias(..)
-                | Type::KnownInstance(..)
-                | Type::SpecialForm(..),
-                Type::NominalInstance(instance),
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SubclassOf(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::KnownInstance(..)
+                    | crate::types::TypeData::SpecialForm(..),
+                ),
+                (_, crate::types::TypeData::NominalInstance(instance)),
                 ast::Operator::BitOr,
             )
             | (
-                Type::NominalInstance(instance),
-                Type::ClassLiteral(..)
-                | Type::SubclassOf(..)
-                | Type::GenericAlias(..)
-                | Type::KnownInstance(..)
-                | Type::SpecialForm(..),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SubclassOf(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::KnownInstance(..)
+                    | crate::types::TypeData::SpecialForm(..),
+                ),
                 ast::Operator::BitOr,
             ) if instance.has_known_class(db, KnownClass::NoneType) => {
                 Some(UnionTypeInstance::from_value_expression_types(
@@ -954,13 +1050,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // that custom method as we'd take one of the earlier branches.
             // This seems like it's probably rare enough that it's acceptable, however.
             (
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..),
-                _,
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::SubclassOf(..),
+                ),
+                (_, _),
                 ast::Operator::BitOr,
             )
             | (
-                _,
-                Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..),
+                (_, _),
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::GenericAlias(..)
+                    | crate::types::TypeData::SubclassOf(..),
+                ),
                 ast::Operator::BitOr,
             ) => Type::try_call_bin_op_with_policy(
                 db,
@@ -975,60 +1081,66 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.
             (
-                Type::FunctionLiteral(_)
-                | Type::Callable(..)
-                | Type::BoundMethod(_)
-                | Type::WrapperDescriptor(_)
-                | Type::KnownBoundMethod(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::NominalInstance(_)
-                | Type::ProtocolInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::Intersection(_)
-                | Type::EnumComplement(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::LiteralValue(_)
-                | Type::BoundSuper(_)
-                | Type::TypeVar(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_),
-                Type::FunctionLiteral(_)
-                | Type::Callable(..)
-                | Type::BoundMethod(_)
-                | Type::WrapperDescriptor(_)
-                | Type::KnownBoundMethod(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::NominalInstance(_)
-                | Type::ProtocolInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::Intersection(_)
-                | Type::EnumComplement(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::LiteralValue(_)
-                | Type::BoundSuper(_)
-                | Type::TypeVar(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_),
+                (
+                    _,
+                    crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::Callable(..)
+                    | crate::types::TypeData::BoundMethod(_)
+                    | crate::types::TypeData::WrapperDescriptor(_)
+                    | crate::types::TypeData::KnownBoundMethod(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_)
+                    | crate::types::TypeData::ModuleLiteral(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_)
+                    | crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::ProtocolInstance(_)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(_)
+                    | crate::types::TypeData::PropertyInstance(_)
+                    | crate::types::TypeData::Intersection(_)
+                    | crate::types::TypeData::EnumComplement(_)
+                    | crate::types::TypeData::AlwaysTruthy
+                    | crate::types::TypeData::AlwaysFalsy
+                    | crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::BoundSuper(_)
+                    | crate::types::TypeData::TypeVar(_)
+                    | crate::types::TypeData::TypeIs(_)
+                    | crate::types::TypeData::TypeGuard(_)
+                    | crate::types::TypeData::TypeForm(_)
+                    | crate::types::TypeData::TypedDict(_),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::Callable(..)
+                    | crate::types::TypeData::BoundMethod(_)
+                    | crate::types::TypeData::WrapperDescriptor(_)
+                    | crate::types::TypeData::KnownBoundMethod(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_)
+                    | crate::types::TypeData::ModuleLiteral(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_)
+                    | crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::ProtocolInstance(_)
+                    | crate::types::TypeData::SpecialForm(_)
+                    | crate::types::TypeData::KnownInstance(_)
+                    | crate::types::TypeData::PropertyInstance(_)
+                    | crate::types::TypeData::Intersection(_)
+                    | crate::types::TypeData::EnumComplement(_)
+                    | crate::types::TypeData::AlwaysTruthy
+                    | crate::types::TypeData::AlwaysFalsy
+                    | crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::BoundSuper(_)
+                    | crate::types::TypeData::TypeVar(_)
+                    | crate::types::TypeData::TypeIs(_)
+                    | crate::types::TypeData::TypeGuard(_)
+                    | crate::types::TypeData::TypeForm(_)
+                    | crate::types::TypeData::TypedDict(_),
+                ),
                 op,
             ) => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
         }
@@ -1044,18 +1156,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         left: Type<'db>,
     ) -> bool {
         let db = self.db();
-        match left {
-            Type::LiteralValue(literal)
+        match {
+            let __ty_view_value = left;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if matches!(
                     literal.kind(),
                     LiteralValueTypeKind::Bool(_) | LiteralValueTypeKind::Int(_)
                 ) => {}
-            Type::NominalInstance(instance)
+            (_, crate::types::TypeData::NominalInstance(instance))
                 if matches!(
                     instance.known_class(db),
                     Some(KnownClass::Float | KnownClass::Int | KnownClass::Bool)
                 ) => {}
-            _ => return false,
+            (_, _) => return false,
         }
 
         let (op, by_zero) = match op {

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -53,11 +53,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 } else {
                     self.infer_expression(base, TypeContext::default())
                 };
-                is_typed_dict |= match ty {
-                    Type::SpecialForm(SpecialFormType::TypedDict) => true,
-                    Type::ClassLiteral(class) => class.is_typed_dict(self.db()),
-                    Type::GenericAlias(alias) => alias.is_typed_dict(self.db()),
-                    _ => false,
+                is_typed_dict |= match {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict)) => true,
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                        class.is_typed_dict(self.db())
+                    }
+                    (_, crate::types::TypeData::GenericAlias(alias)) => {
+                        alias.is_typed_dict(self.db())
+                    }
+                    (_, _) => false,
                 };
             }
 
@@ -194,7 +201,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let Type::DataclassDecorator(params) = decorator_ty {
+            if let (_, crate::types::TypeData::DataclassDecorator(params)) = {
+                let __ty_view_value = decorator_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 dataclass_params = Some(params);
                 continue;
             }
@@ -209,9 +219,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated_inst)) =
-                decorator_ty
-            {
+            if let (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::Deprecated(
+                    deprecated_inst,
+                )),
+            ) = {
+                let __ty_view_value = decorator_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 deprecated = Some(deprecated_inst);
                 continue;
             }
@@ -238,7 +254,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let Type::FunctionLiteral(f) = decorator_ty {
+            if let (_, crate::types::TypeData::FunctionLiteral(f)) = {
+                let __ty_view_value = decorator_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 // We do not yet detect or flag `@dataclass_transform` applied to more than one
                 // overload, or an overload and the implementation both. Nevertheless, this is not
                 // allowed. We do not try to treat the offenders intelligently -- just use the
@@ -262,7 +281,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
             }
 
-            if let Type::DataclassTransformer(params) = decorator_ty {
+            if let (_, crate::types::TypeData::DataclassTransformer(params)) = {
+                let __ty_view_value = decorator_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 dataclass_transformer_params = Some(params);
                 continue;
             }
@@ -331,9 +353,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     bindings.return_type(db)
                 }
             };
-            let decorated_ty = match decorated_ty {
-                Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
-                decorated_ty => decorated_ty,
+            let decorated_ty = match {
+                let __ty_view_value = decorated_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ) => Type::unknown(),
+                (decorated_ty, _) => decorated_ty,
             };
             // If a class decorator application loses all precision, preserve the original class
             // binding for decorators known to preserve unknown results.
@@ -477,32 +506,40 @@ fn class_decorator_preserves_class_binding<'db>(
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
-    let Type::ClassLiteral(original_literal) = original_class else {
+    let (_, crate::types::TypeData::ClassLiteral(original_literal)) = ({
+        let __ty_view_value = original_class;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return false;
     };
 
-    match decorated_class {
-        Type::ClassLiteral(decorated_literal) => {
+    match {
+        let __ty_view_value = decorated_class;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::ClassLiteral(decorated_literal)) => {
             let decorated_definition = decorated_literal.definition(db);
             decorated_literal == original_literal
                 || decorated_definition.is_some()
                     && decorated_definition == original_literal.definition(db)
         }
-        Type::SubclassOf(subclass_of) => subclass_of
+        (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of
             .subclass_of()
             .into_class(db)
             .is_some_and(|class| class == original_literal.default_specialization(db)),
-        Type::Divergent(_) => true,
-        Type::Union(union) => union
+        (_, crate::types::TypeData::Divergent(_)) => true,
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
-        Type::TypeAlias(alias) => {
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
             class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
         }
-        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
-            decorated_class.is_equivalent_to(db, original_meta_type)
-        }),
+        (_, _) => {
+            SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
+                decorated_class.is_equivalent_to(db, original_meta_type)
+            })
+        }
     }
 }
 
@@ -513,19 +550,22 @@ fn type_retains_original_class<'db>(
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
-    match decorated_class {
-        Type::Intersection(intersection) => intersection
+    match {
+        let __ty_view_value = decorated_class;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
             .positive(db)
             .iter()
             .any(|element| type_retains_original_class(db, original_class, *element)),
-        Type::Union(union) => union
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .all(|element| type_retains_original_class(db, original_class, *element)),
-        Type::TypeAlias(alias) => {
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
             type_retains_original_class(db, original_class, alias.value_type(db))
         }
-        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+        (_, _) => class_decorator_preserves_class_binding(db, original_class, decorated_class),
     }
 }
 
@@ -580,7 +620,10 @@ fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bo
 /// class C: ...
 /// ```
 fn is_unknown_class_object_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
-    let Type::SubclassOf(subclass_of) = ty.resolve_type_alias(db) else {
+    let (_, crate::types::TypeData::SubclassOf(subclass_of)) = ({
+        let __ty_view_value = ty.resolve_type_alias(db);
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return false;
     };
 
@@ -645,22 +688,29 @@ impl ClassDecoratorUnknownResultPolicy {
         decorator_ty: Type<'db>,
         decorator_result_ty: Type<'db>,
     ) -> Option<Self> {
-        match decorator_ty {
-            Type::FunctionLiteral(function) => {
+        match {
+            let __ty_view_value = decorator_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => {
                 Some(if function.has_explicit_return_annotation(db) {
                     Self::ReplaceBinding
                 } else {
                     Self::PreserveBinding
                 })
             }
-            Type::BoundMethod(method) => {
+            (_, crate::types::TypeData::BoundMethod(method)) => {
                 Some(if method.function(db).has_explicit_return_annotation(db) {
                     Self::ReplaceBinding
                 } else {
                     Self::PreserveBinding
                 })
             }
-            Type::NominalInstance(_) | Type::ProtocolInstance(_) => {
+            (
+                _,
+                crate::types::TypeData::NominalInstance(_)
+                | crate::types::TypeData::ProtocolInstance(_),
+            ) => {
                 let call_symbol = decorator_ty
                     .member_lookup_with_policy(
                         db,
@@ -680,7 +730,7 @@ impl ClassDecoratorUnknownResultPolicy {
                     Some(Self::ReplaceBinding)
                 }
             }
-            Type::Union(union) => Some(
+            (_, crate::types::TypeData::Union(union)) => Some(
                 if union.elements(db).iter().all(|element| {
                     Self::known_from_decorator(db, *element, decorator_result_ty)
                         == Some(Self::PreserveBinding)
@@ -690,52 +740,54 @@ impl ClassDecoratorUnknownResultPolicy {
                     Self::ReplaceBinding
                 },
             ),
-            Type::TypeAlias(alias) => Some(
+            (_, crate::types::TypeData::TypeAlias(alias)) => Some(
                 Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
-            Type::Callable(callable) => Some(match callable.provenance(db) {
-                // An unannotated function preserves the class binding when applying it loses the
-                // concrete return type:
-                // ```python
-                // decorator = lambda cls: cls
-                //
-                // @decorator
-                // class C: ...
-                // ```
-                CallableFunctionProvenance::ImplicitReturn => Self::PreserveBinding,
-                // An explicit return annotation can intentionally replace the class binding:
-                // ```python
-                // def decorator[T](cls) -> T: ...
-                //
-                // @decorator
-                // class C: ...
-                // ```
-                CallableFunctionProvenance::ExplicitReturn => Self::ReplaceBinding,
-                // Generic class-preserving decorator factories can lose the concrete class in
-                // their returned `Callable`, while still producing an unknown class-object result:
-                // ```python
-                // def identity_factory[T]() -> Callable[[type[T]], type[T]]: ...
-                //
-                // @identity_factory()
-                // class C: ...
-                // ```
-                CallableFunctionProvenance::None
-                    if is_unknown_class_object_decorator_result(db, decorator_result_ty) =>
-                {
-                    Self::PreserveBinding
-                }
-                // An ordinary `Callable` replacement result has no function provenance to justify
-                // the unannotated-function preservation fallback:
-                // ```python
-                // def replacement_factory[T]() -> Callable[[type[object]], T]: ...
-                //
-                // @replacement_factory()
-                // class C: ...
-                // ```
-                CallableFunctionProvenance::None => Self::ReplaceBinding,
-            }),
-            _ => None,
+            (_, crate::types::TypeData::Callable(callable)) => {
+                Some(match callable.provenance(db) {
+                    // An unannotated function preserves the class binding when applying it loses the
+                    // concrete return type:
+                    // ```python
+                    // decorator = lambda cls: cls
+                    //
+                    // @decorator
+                    // class C: ...
+                    // ```
+                    CallableFunctionProvenance::ImplicitReturn => Self::PreserveBinding,
+                    // An explicit return annotation can intentionally replace the class binding:
+                    // ```python
+                    // def decorator[T](cls) -> T: ...
+                    //
+                    // @decorator
+                    // class C: ...
+                    // ```
+                    CallableFunctionProvenance::ExplicitReturn => Self::ReplaceBinding,
+                    // Generic class-preserving decorator factories can lose the concrete class in
+                    // their returned `Callable`, while still producing an unknown class-object result:
+                    // ```python
+                    // def identity_factory[T]() -> Callable[[type[T]], type[T]]: ...
+                    //
+                    // @identity_factory()
+                    // class C: ...
+                    // ```
+                    CallableFunctionProvenance::None
+                        if is_unknown_class_object_decorator_result(db, decorator_result_ty) =>
+                    {
+                        Self::PreserveBinding
+                    }
+                    // An ordinary `Callable` replacement result has no function provenance to justify
+                    // the unannotated-function preservation fallback:
+                    // ```python
+                    // def replacement_factory[T]() -> Callable[[type[object]], T]: ...
+                    //
+                    // @replacement_factory()
+                    // class C: ...
+                    // ```
+                    CallableFunctionProvenance::None => Self::ReplaceBinding,
+                })
+            }
+            (_, _) => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -53,18 +53,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 } else {
                     self.infer_expression(base, TypeContext::default())
                 };
-                is_typed_dict |= match {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict)) => true,
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
-                        class.is_typed_dict(self.db())
-                    }
-                    (_, crate::types::TypeData::GenericAlias(alias)) => {
-                        alias.is_typed_dict(self.db())
-                    }
-                    (_, _) => false,
+                is_typed_dict |= match ty.data() {
+                    crate::types::TypeData::SpecialForm(SpecialFormType::TypedDict) => true,
+                    crate::types::TypeData::ClassLiteral(class) => class.is_typed_dict(self.db()),
+                    crate::types::TypeData::GenericAlias(alias) => alias.is_typed_dict(self.db()),
+                    _ => false,
                 };
             }
 
@@ -201,10 +194,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let (_, crate::types::TypeData::DataclassDecorator(params)) = {
-                let __ty_view_value = decorator_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::DataclassDecorator(params) = decorator_ty.data() {
                 dataclass_params = Some(params);
                 continue;
             }
@@ -219,15 +209,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::Deprecated(
-                    deprecated_inst,
-                )),
-            ) = {
-                let __ty_view_value = decorator_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::KnownInstance(KnownInstanceType::Deprecated(
+                deprecated_inst,
+            )) = decorator_ty.data()
+            {
                 deprecated = Some(deprecated_inst);
                 continue;
             }
@@ -254,10 +239,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 continue;
             }
 
-            if let (_, crate::types::TypeData::FunctionLiteral(f)) = {
-                let __ty_view_value = decorator_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::FunctionLiteral(f) = decorator_ty.data() {
                 // We do not yet detect or flag `@dataclass_transform` applied to more than one
                 // overload, or an overload and the implementation both. Nevertheless, this is not
                 // allowed. We do not try to treat the offenders intelligently -- just use the
@@ -281,10 +263,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
             }
 
-            if let (_, crate::types::TypeData::DataclassTransformer(params)) = {
-                let __ty_view_value = decorator_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::DataclassTransformer(params) = decorator_ty.data() {
                 dataclass_transformer_params = Some(params);
                 continue;
             }
@@ -353,10 +332,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     bindings.return_type(db)
                 }
             };
-            let decorated_ty = match {
-                let __ty_view_value = decorated_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            let decorated_ty = match decorated_ty.view() {
                 (
                     _,
                     crate::types::TypeData::DataclassDecorator(_)
@@ -506,40 +482,32 @@ fn class_decorator_preserves_class_binding<'db>(
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
-    let (_, crate::types::TypeData::ClassLiteral(original_literal)) = ({
-        let __ty_view_value = original_class;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::ClassLiteral(original_literal) = original_class.data() else {
         return false;
     };
 
-    match {
-        let __ty_view_value = decorated_class;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::ClassLiteral(decorated_literal)) => {
+    match decorated_class.data() {
+        crate::types::TypeData::ClassLiteral(decorated_literal) => {
             let decorated_definition = decorated_literal.definition(db);
             decorated_literal == original_literal
                 || decorated_definition.is_some()
                     && decorated_definition == original_literal.definition(db)
         }
-        (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of
+        crate::types::TypeData::SubclassOf(subclass_of) => subclass_of
             .subclass_of()
             .into_class(db)
             .is_some_and(|class| class == original_literal.default_specialization(db)),
-        (_, crate::types::TypeData::Divergent(_)) => true,
-        (_, crate::types::TypeData::Union(union)) => union
+        crate::types::TypeData::Divergent(_) => true,
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
         }
-        (_, _) => {
-            SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
-                decorated_class.is_equivalent_to(db, original_meta_type)
-            })
-        }
+        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
+            decorated_class.is_equivalent_to(db, original_meta_type)
+        }),
     }
 }
 
@@ -550,22 +518,19 @@ fn type_retains_original_class<'db>(
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
-    match {
-        let __ty_view_value = decorated_class;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+    match decorated_class.data() {
+        crate::types::TypeData::Intersection(intersection) => intersection
             .positive(db)
             .iter()
             .any(|element| type_retains_original_class(db, original_class, *element)),
-        (_, crate::types::TypeData::Union(union)) => union
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .all(|element| type_retains_original_class(db, original_class, *element)),
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             type_retains_original_class(db, original_class, alias.value_type(db))
         }
-        (_, _) => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
     }
 }
 
@@ -620,10 +585,7 @@ fn is_unknown_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bo
 /// class C: ...
 /// ```
 fn is_unknown_class_object_decorator_result<'db>(db: &'db dyn crate::Db, ty: Type<'db>) -> bool {
-    let (_, crate::types::TypeData::SubclassOf(subclass_of)) = ({
-        let __ty_view_value = ty.resolve_type_alias(db);
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::SubclassOf(subclass_of) = ty.resolve_type_alias(db).data() else {
         return false;
     };
 
@@ -688,29 +650,23 @@ impl ClassDecoratorUnknownResultPolicy {
         decorator_ty: Type<'db>,
         decorator_result_ty: Type<'db>,
     ) -> Option<Self> {
-        match {
-            let __ty_view_value = decorator_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::FunctionLiteral(function)) => {
+        match decorator_ty.data() {
+            crate::types::TypeData::FunctionLiteral(function) => {
                 Some(if function.has_explicit_return_annotation(db) {
                     Self::ReplaceBinding
                 } else {
                     Self::PreserveBinding
                 })
             }
-            (_, crate::types::TypeData::BoundMethod(method)) => {
+            crate::types::TypeData::BoundMethod(method) => {
                 Some(if method.function(db).has_explicit_return_annotation(db) {
                     Self::ReplaceBinding
                 } else {
                     Self::PreserveBinding
                 })
             }
-            (
-                _,
-                crate::types::TypeData::NominalInstance(_)
-                | crate::types::TypeData::ProtocolInstance(_),
-            ) => {
+            crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_) => {
                 let call_symbol = decorator_ty
                     .member_lookup_with_policy(
                         db,
@@ -730,7 +686,7 @@ impl ClassDecoratorUnknownResultPolicy {
                     Some(Self::ReplaceBinding)
                 }
             }
-            (_, crate::types::TypeData::Union(union)) => Some(
+            crate::types::TypeData::Union(union) => Some(
                 if union.elements(db).iter().all(|element| {
                     Self::known_from_decorator(db, *element, decorator_result_ty)
                         == Some(Self::PreserveBinding)
@@ -740,11 +696,11 @@ impl ClassDecoratorUnknownResultPolicy {
                     Self::ReplaceBinding
                 },
             ),
-            (_, crate::types::TypeData::TypeAlias(alias)) => Some(
+            crate::types::TypeData::TypeAlias(alias) => Some(
                 Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
-            (_, crate::types::TypeData::Callable(callable)) => {
+            crate::types::TypeData::Callable(callable) => {
                 Some(match callable.provenance(db) {
                     // An unannotated function preserves the class binding when applying it loses the
                     // concrete return type:
@@ -787,7 +743,7 @@ impl ClassDecoratorUnknownResultPolicy {
                     CallableFunctionProvenance::None => Self::ReplaceBinding,
                 })
             }
-            (_, _) => None,
+            _ => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -71,15 +71,20 @@ impl TypeMixinMemberBehavior {
     fn from_mixin(db: &dyn Db, mixin_type: Type<'_>, value_form: EnumMemberValueForm) -> Self {
         match value_form {
             EnumMemberValueForm::Explicit => Self::UnknownMembers,
-            EnumMemberValueForm::Generated => match mixin_type {
-                Type::ClassLiteral(ClassLiteral::Static(class)) => match class.known(db) {
-                    Some(KnownClass::Int) => Self::Precise,
-                    Some(KnownClass::Str | KnownClass::Bytes | KnownClass::Float) => {
-                        Self::ConvertedValues
+            EnumMemberValueForm::Generated => match {
+                let __ty_view_value = mixin_type;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) => {
+                    match class.known(db) {
+                        Some(KnownClass::Int) => Self::Precise,
+                        Some(KnownClass::Str | KnownClass::Bytes | KnownClass::Float) => {
+                            Self::ConvertedValues
+                        }
+                        _ => Self::UnknownMembers,
                     }
-                    _ => Self::UnknownMembers,
-                },
-                _ => Self::UnknownMembers,
+                }
+                (_, _) => Self::UnknownMembers,
             },
         }
     }
@@ -250,7 +255,10 @@ fn apply_generated_type_mixin_member_values<'db>(
     mixin_type: Type<'_>,
     members: Vec<(Name, Type<'db>)>,
 ) -> Option<Vec<(Name, Type<'db>)>> {
-    let Type::ClassLiteral(ClassLiteral::Static(class)) = mixin_type else {
+    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = ({
+        let __ty_view_value = mixin_type;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return None;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -71,11 +71,8 @@ impl TypeMixinMemberBehavior {
     fn from_mixin(db: &dyn Db, mixin_type: Type<'_>, value_form: EnumMemberValueForm) -> Self {
         match value_form {
             EnumMemberValueForm::Explicit => Self::UnknownMembers,
-            EnumMemberValueForm::Generated => match {
-                let __ty_view_value = mixin_type;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) => {
+            EnumMemberValueForm::Generated => match mixin_type.data() {
+                crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class)) => {
                     match class.known(db) {
                         Some(KnownClass::Int) => Self::Precise,
                         Some(KnownClass::Str | KnownClass::Bytes | KnownClass::Float) => {
@@ -84,7 +81,7 @@ impl TypeMixinMemberBehavior {
                         _ => Self::UnknownMembers,
                     }
                 }
-                (_, _) => Self::UnknownMembers,
+                _ => Self::UnknownMembers,
             },
         }
     }
@@ -255,10 +252,8 @@ fn apply_generated_type_mixin_member_values<'db>(
     mixin_type: Type<'_>,
     members: Vec<(Name, Type<'db>)>,
 ) -> Option<Vec<(Name, Type<'db>)>> {
-    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = ({
-        let __ty_view_value = mixin_type;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class)) = mixin_type.data()
+    else {
         return None;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -73,10 +73,7 @@ impl<'db> ExpectedReturnType<'db> {
     ) -> Self {
         /// Normalizes special return annotations to the type actually returned by expressions.
         fn normalize<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            match ty.view() {
                 (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)) => {
                     KnownClass::Bool.to_instance(db)
                 }
@@ -256,10 +253,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .iter()
                 .copied()
                 .filter_map(|ty_range| {
-                    match {
-                        let __ty_view_value = ty_range.ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    match ty_range.ty.view() {
                         // We skip `is_assignable_to` checks for `NotImplemented`,
                         // so we remove it beforehand.
                         (_, crate::types::TypeData::Union(union)) => Some(TypeAndRange {
@@ -347,11 +341,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 FunctionDecorators::from_decorator_type(db, decorator_type);
             function_decorators |= decorator_function_decorator;
 
-            match {
-                let __ty_view_value = decorator_type;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::FunctionLiteral(function)) => {
+            match decorator_type.data() {
+                crate::types::TypeData::FunctionLiteral(function) => {
                     match function.known(db) {
                         Some(KnownFunction::NoTypeCheck) => {
                             // If the function is decorated with the `no_type_check` decorator,
@@ -366,10 +357,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         _ => {}
                     }
                 }
-                (_, crate::types::TypeData::DataclassTransformer(params)) => {
+                crate::types::TypeData::DataclassTransformer(params) => {
                     dataclass_transformer_params = Some(params);
                 }
-                (_, _) => {}
+                _ => {}
             }
             if !decorator_function_decorator.is_empty() {
                 continue;
@@ -463,16 +454,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            inferred_ty = if let (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::Deprecated(deprecated)),
-            ) = ({
-                let __ty_view_value = decorator_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) && let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-                let __ty_view_value = inferred_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) {
+            inferred_ty = if let crate::types::TypeData::KnownInstance(
+                KnownInstanceType::Deprecated(deprecated),
+            ) = decorator_ty.data()
+                && let crate::types::TypeData::FunctionLiteral(function) = inferred_ty.data()
+            {
                 Type::FunctionLiteral(function.with_deprecated(db, deprecated))
             } else {
                 self.apply_decorator(*decorator_ty, inferred_ty, decorator_node)
@@ -529,10 +515,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .replace(InferenceFlags::IN_NO_TYPE_CHECK, true);
         for decorator in &function.decorator_list {
             let decorator_type = self.infer_decorator(decorator);
-            if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-                let __ty_view_value = decorator_type;
-                (__ty_view_value, __ty_view_value.data())
-            }) && let Some(KnownFunction::NoTypeCheck) = function.known(db)
+            if let crate::types::TypeData::FunctionLiteral(function) = decorator_type.data()
+                && let Some(KnownFunction::NoTypeCheck) = function.known(db)
             {
                 // If the function is decorated with the `no_type_check` decorator,
                 // we need to suppress any errors that come after the decorators.
@@ -823,10 +807,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
             // not on regular parameters.
-            if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                let __ty_view_value = declared_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) && typevar.is_paramspec(db)
+            if let crate::types::TypeData::TypeVar(typevar) = declared_ty.data()
+                && typevar.is_paramspec(db)
                 && let Some(attr) = typevar.paramspec_attr(db)
             {
                 let name = typevar.name(db);
@@ -916,10 +898,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 todo_type!("PEP 646")
             } else {
                 let annotated_type = self.file_expression_type(annotation);
-                if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                    let __ty_view_value = annotated_type;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && typevar.is_paramspec(db)
+                if let crate::types::TypeData::TypeVar(typevar) = annotated_type.data()
+                    && typevar.is_paramspec(db)
                 {
                     match typevar.paramspec_attr(db) {
                         // `*args: P.args`
@@ -1052,10 +1032,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(annotation) = parameter.annotation() {
             let annotated_type = self.file_expression_type(annotation);
-            let ty = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                let __ty_view_value = annotated_type;
-                (__ty_view_value, __ty_view_value.data())
-            }) && typevar.is_paramspec(db)
+            let ty = if let crate::types::TypeData::TypeVar(typevar) = annotated_type.data()
+                && typevar.is_paramspec(db)
             {
                 match typevar.paramspec_attr(db) {
                     // `**kwargs: P.args`

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -73,9 +73,14 @@ impl<'db> ExpectedReturnType<'db> {
     ) -> Self {
         /// Normalizes special return annotations to the type actually returned by expressions.
         fn normalize<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-            match ty {
-                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_instance(db),
-                ty => ty,
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)) => {
+                    KnownClass::Bool.to_instance(db)
+                }
+                (ty, _) => ty,
             }
         }
 
@@ -250,15 +255,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .return_types_and_ranges
                 .iter()
                 .copied()
-                .filter_map(|ty_range| match ty_range.ty {
-                    // We skip `is_assignable_to` checks for `NotImplemented`,
-                    // so we remove it beforehand.
-                    Type::Union(union) => Some(TypeAndRange {
-                        ty: union.filter(db, |ty| !ty.is_notimplemented(db)),
-                        range: ty_range.range,
-                    }),
-                    ty if ty.is_notimplemented(db) => None,
-                    _ => Some(ty_range),
+                .filter_map(|ty_range| {
+                    match {
+                        let __ty_view_value = ty_range.ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        // We skip `is_assignable_to` checks for `NotImplemented`,
+                        // so we remove it beforehand.
+                        (_, crate::types::TypeData::Union(union)) => Some(TypeAndRange {
+                            ty: union.filter(db, |ty| !ty.is_notimplemented(db)),
+                            range: ty_range.range,
+                        }),
+                        (ty, _) if ty.is_notimplemented(db) => None,
+                        (_, _) => Some(ty_range),
+                    }
                 })
                 .filter(|ty_range| !expected_return.accepts(db, ty_range.ty))
             {
@@ -337,24 +347,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 FunctionDecorators::from_decorator_type(db, decorator_type);
             function_decorators |= decorator_function_decorator;
 
-            match decorator_type {
-                Type::FunctionLiteral(function) => match function.known(db) {
-                    Some(KnownFunction::NoTypeCheck) => {
-                        // If the function is decorated with the `no_type_check` decorator,
-                        // we need to suppress any errors that come after the decorators.
-                        self.context.inference_flags |= InferenceFlags::IN_NO_TYPE_CHECK;
-                        continue;
+            match {
+                let __ty_view_value = decorator_type;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::FunctionLiteral(function)) => {
+                    match function.known(db) {
+                        Some(KnownFunction::NoTypeCheck) => {
+                            // If the function is decorated with the `no_type_check` decorator,
+                            // we need to suppress any errors that come after the decorators.
+                            self.context.inference_flags |= InferenceFlags::IN_NO_TYPE_CHECK;
+                            continue;
+                        }
+                        Some(KnownFunction::Final) => {
+                            final_decorator = Some(decorator);
+                            continue;
+                        }
+                        _ => {}
                     }
-                    Some(KnownFunction::Final) => {
-                        final_decorator = Some(decorator);
-                        continue;
-                    }
-                    _ => {}
-                },
-                Type::DataclassTransformer(params) => {
+                }
+                (_, crate::types::TypeData::DataclassTransformer(params)) => {
                     dataclass_transformer_params = Some(params);
                 }
-                _ => {}
+                (_, _) => {}
             }
             if !decorator_function_decorator.is_empty() {
                 continue;
@@ -448,11 +463,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         for (decorator_ty, decorator_node) in decorator_types_and_nodes.iter().rev() {
-            inferred_ty = if let Type::KnownInstance(KnownInstanceType::Deprecated(deprecated)) =
-                decorator_ty
-                && let Type::FunctionLiteral(function) = inferred_ty
-            {
-                Type::FunctionLiteral(function.with_deprecated(db, *deprecated))
+            inferred_ty = if let (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::Deprecated(deprecated)),
+            ) = ({
+                let __ty_view_value = decorator_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) && let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+                let __ty_view_value = inferred_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) {
+                Type::FunctionLiteral(function.with_deprecated(db, deprecated))
             } else {
                 self.apply_decorator(*decorator_ty, inferred_ty, decorator_node)
             };
@@ -508,8 +529,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .replace(InferenceFlags::IN_NO_TYPE_CHECK, true);
         for decorator in &function.decorator_list {
             let decorator_type = self.infer_decorator(decorator);
-            if let Type::FunctionLiteral(function) = decorator_type
-                && let Some(KnownFunction::NoTypeCheck) = function.known(db)
+            if let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+                let __ty_view_value = decorator_type;
+                (__ty_view_value, __ty_view_value.data())
+            }) && let Some(KnownFunction::NoTypeCheck) = function.known(db)
             {
                 // If the function is decorated with the `no_type_check` decorator,
                 // we need to suppress any errors that come after the decorators.
@@ -800,8 +823,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // P.args and P.kwargs are only valid as annotations on *args and **kwargs,
             // not on regular parameters.
-            if let Type::TypeVar(typevar) = declared_ty
-                && typevar.is_paramspec(db)
+            if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                let __ty_view_value = declared_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) && typevar.is_paramspec(db)
                 && let Some(attr) = typevar.paramspec_attr(db)
             {
                 let name = typevar.name(db);
@@ -891,8 +916,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 todo_type!("PEP 646")
             } else {
                 let annotated_type = self.file_expression_type(annotation);
-                if let Type::TypeVar(typevar) = annotated_type
-                    && typevar.is_paramspec(db)
+                if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                    let __ty_view_value = annotated_type;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && typevar.is_paramspec(db)
                 {
                     match typevar.paramspec_attr(db) {
                         // `*args: P.args`
@@ -1025,8 +1052,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(annotation) = parameter.annotation() {
             let annotated_type = self.file_expression_type(annotation);
-            let ty = if let Type::TypeVar(typevar) = annotated_type
-                && typevar.is_paramspec(db)
+            let ty = if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                let __ty_view_value = annotated_type;
+                (__ty_view_value, __ty_view_value.data())
+            }) && typevar.is_paramspec(db)
             {
                 match typevar.paramspec_attr(db) {
                     // `**kwargs: P.args`

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -753,12 +753,17 @@ impl NamedTupleKind {
     }
 
     pub(super) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
-        match ty {
-            Type::SpecialForm(SpecialFormType::NamedTuple) => Some(NamedTupleKind::Typing),
-            Type::FunctionLiteral(function) => function
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple)) => {
+                Some(NamedTupleKind::Typing)
+            }
+            (_, crate::types::TypeData::FunctionLiteral(function)) => function
                 .is_known(db, KnownFunction::NamedTuple)
                 .then_some(NamedTupleKind::Collections),
-            _ => None,
+            (_, _) => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -753,17 +753,14 @@ impl NamedTupleKind {
     }
 
     pub(super) fn from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple)) => {
+        match ty.data() {
+            crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple) => {
                 Some(NamedTupleKind::Typing)
             }
-            (_, crate::types::TypeData::FunctionLiteral(function)) => function
+            crate::types::TypeData::FunctionLiteral(function) => function
                 .is_known(db, KnownFunction::NamedTuple)
                 .then_some(NamedTupleKind::Collections),
-            (_, _) => None,
+            _ => None,
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -216,7 +216,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Get the already-inferred class type from the initial pass.
         let inferred_type = definition_expression_type(db, definition, call_expr);
-        let Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) = inferred_type else {
+        let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
+            let __ty_view_value = inferred_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -216,10 +216,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Get the already-inferred class type from the initial pass.
         let inferred_type = definition_expression_type(db, definition, call_expr);
-        let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
-            let __ty_view_value = inferred_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) =
+            inferred_type.data()
+        else {
             return;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/paramspec_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/paramspec_validation.rs
@@ -20,8 +20,10 @@ pub(super) fn validate_paramspec_components<'db>(
     let args_paramspec = parameters.vararg.as_deref().and_then(|vararg| {
         let annotation = vararg.annotation()?;
         let ty = infer_type(annotation);
-        if let Type::TypeVar(typevar) = ty
-            && typevar.is_paramspec(db)
+        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) && typevar.is_paramspec(db)
             && typevar.paramspec_attr(db) == Some(ParamSpecAttrKind::Args)
         {
             Some((typevar.without_paramspec_attr(db), annotation))
@@ -34,8 +36,10 @@ pub(super) fn validate_paramspec_components<'db>(
     let kwargs_paramspec = parameters.kwarg.as_deref().and_then(|kwarg| {
         let annotation = kwarg.annotation()?;
         let ty = infer_type(annotation);
-        if let Type::TypeVar(typevar) = ty
-            && typevar.is_paramspec(db)
+        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) && typevar.is_paramspec(db)
             && typevar.paramspec_attr(db) == Some(ParamSpecAttrKind::Kwargs)
         {
             Some((typevar.without_paramspec_attr(db), annotation))

--- a/crates/ty_python_semantic/src/types/infer/builder/paramspec_validation.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/paramspec_validation.rs
@@ -20,10 +20,8 @@ pub(super) fn validate_paramspec_components<'db>(
     let args_paramspec = parameters.vararg.as_deref().and_then(|vararg| {
         let annotation = vararg.annotation()?;
         let ty = infer_type(annotation);
-        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) && typevar.is_paramspec(db)
+        if let crate::types::TypeData::TypeVar(typevar) = ty.data()
+            && typevar.is_paramspec(db)
             && typevar.paramspec_attr(db) == Some(ParamSpecAttrKind::Args)
         {
             Some((typevar.without_paramspec_attr(db), annotation))
@@ -36,10 +34,8 @@ pub(super) fn validate_paramspec_components<'db>(
     let kwargs_paramspec = parameters.kwarg.as_deref().and_then(|kwarg| {
         let annotation = kwarg.annotation()?;
         let ty = infer_type(annotation);
-        if let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) && typevar.is_paramspec(db)
+        if let crate::types::TypeData::TypeVar(typevar) = ty.data()
+            && typevar.is_paramspec(db)
             && typevar.paramspec_attr(db) == Some(ParamSpecAttrKind::Kwargs)
         {
             Some((typevar.without_paramspec_attr(db), annotation))

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -1,5 +1,5 @@
 use crate::types::{
-    ClassLiteral, Type, binding_type,
+    ClassLiteral, binding_type,
     class::{DynamicClassAnchor, DynamicMetaclassConflict, dynamic_class_bases_argument},
     context::InferContext,
     diagnostic::{
@@ -27,7 +27,10 @@ pub(crate) fn check_dynamic_class_definition<'db>(
     let ty = binding_type(db, definition);
 
     // Check if it's a dynamic class with a Definition anchor.
-    let Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) = ty else {
+    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -27,10 +27,8 @@ pub(crate) fn check_dynamic_class_definition<'db>(
     let ty = binding_type(db, definition);
 
     // Check if it's a dynamic class with a Definition anchor.
-    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) = ty.data()
+    else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -135,15 +135,10 @@ fn check_legacy_typevar_defaults<'db>(
         };
 
         let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
-            let tvar = match {
-                let __ty_view_value = t;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypeVar(tvar)) => tvar.typevar(db),
-                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar))) => {
-                    tvar
-                }
-                (_, _) => return None,
+            let tvar = match t.data() {
+                crate::types::TypeData::TypeVar(tvar) => tvar.typevar(db),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
+                _ => return None,
             };
             if !typevars.clone().take(i).contains(&tvar) {
                 Some(tvar)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -135,10 +135,15 @@ fn check_legacy_typevar_defaults<'db>(
         };
 
         let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
-            let tvar = match t {
-                Type::TypeVar(tvar) => tvar.typevar(db),
-                Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
-                _ => return None,
+            let tvar = match {
+                let __ty_view_value = t;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeVar(tvar)) => tvar.typevar(db),
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar))) => {
+                    tvar
+                }
+                (_, _) => return None,
             };
             if !typevars.clone().take(i).contains(&tvar) {
                 Some(tvar)

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -41,7 +41,10 @@ pub(crate) fn check_overloaded_function<'db>(
     // Collect all the unique overloaded function places in this scope. This requires a set
     // because an overloaded function uses the same place for each of the overloads and the
     // implementation.
-    let Type::FunctionLiteral(function) = ty else {
+    let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return;
     };
 
@@ -62,7 +65,7 @@ pub(crate) fn check_overloaded_function<'db>(
     let use_def = index.use_def_map(context.scope().file_scope_id(db));
 
     let Place::Defined(DefinedPlace {
-        ty: Type::FunctionLiteral(function),
+        ty,
         definedness: Definedness::AlwaysDefined,
         ..
     }) = place_from_bindings(
@@ -71,6 +74,9 @@ pub(crate) fn check_overloaded_function<'db>(
     )
     .place
     else {
+        return;
+    };
+    let crate::types::TypeData::FunctionLiteral(function) = ty.data() else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -41,10 +41,7 @@ pub(crate) fn check_overloaded_function<'db>(
     // Collect all the unique overloaded function places in this scope. This requires a set
     // because an overloaded function uses the same place for each of the overloads and the
     // implementation.
-    let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::FunctionLiteral(function) = ty.data() else {
         return;
     };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -81,10 +81,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 ) {
     let db = context.db();
 
-    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = ({
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class)) = ty.data() else {
         return;
     };
 
@@ -236,17 +233,11 @@ pub(crate) fn check_static_class_definitions<'db>(
 
         if class_kind == Some(CodeGeneratorKind::NamedTuple)
             && !matches!(
-                {
-                    let __ty_view_value = base_class;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple)
-                        | crate::types::TypeData::KnownInstance(
-                            KnownInstanceType::SubscriptedGeneric(_)
-                        )
-                )
+                base_class.data(),
+                crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple)
+                    | crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(
+                        _
+                    ))
             )
             && let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, source_node)
         {
@@ -256,11 +247,8 @@ pub(crate) fn check_static_class_definitions<'db>(
             ));
         }
 
-        let base_class = match {
-            let __ty_view_value = base_class;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
+        let base_class = match base_class.data() {
+            crate::types::TypeData::SpecialForm(SpecialFormType::Generic) => {
                 if let Some(builder) = context.report_lint(&INVALID_BASE, source_node) {
                     // Unsubscripted `Generic` can appear in the MRO of many classes,
                     // but it is never valid as an explicit base class in user code.
@@ -268,12 +256,9 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
                 continue;
             }
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(
-                    new_context,
-                )),
-            ) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(
+                new_context,
+            )) => {
                 let Some((previous_node, previous_context)) = protocol_base_with_generic_context
                 else {
                     continue;
@@ -300,12 +285,9 @@ pub(crate) fn check_static_class_definitions<'db>(
             // Note that unlike several of the other errors caught in this function,
             // this does not lead to the class creation failing at runtime,
             // but it is semantically invalid.
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(
-                    generic_context,
-                )),
-            ) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(
+                generic_context,
+            )) => {
                 if let Some(type_params) = class_node.type_params.as_deref() {
                     let node = source_node;
                     let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, node) else {
@@ -333,8 +315,8 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
                 continue;
             }
-            (_, crate::types::TypeData::ClassLiteral(class)) => ClassType::NonGeneric(class),
-            (_, crate::types::TypeData::GenericAlias(base_alias)) => {
+            crate::types::TypeData::ClassLiteral(class) => ClassType::NonGeneric(class),
+            crate::types::TypeData::GenericAlias(base_alias) => {
                 if check_explicit_base_variance
                     && let Some(generic_context) = class.generic_context(db)
                     && let Some((typevar, declared_variance, required_variance)) =
@@ -368,7 +350,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
                 ClassType::Generic(base_alias)
             }
-            (_, _) => continue,
+            _ => continue,
         };
 
         if let Some(disjoint_base) = base_class.nearest_disjoint_base(db) {
@@ -833,16 +815,12 @@ pub(crate) fn check_static_class_definitions<'db>(
                 };
 
                 let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
-                    let tvar = match {
-                        let __ty_view_value = t;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::TypeVar(tvar)) => tvar.typevar(db),
-                        (
-                            _,
-                            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar)),
-                        ) => tvar,
-                        (_, _) => return None,
+                    let tvar = match t.data() {
+                        crate::types::TypeData::TypeVar(tvar) => tvar.typevar(db),
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar)) => {
+                            tvar
+                        }
+                        _ => return None,
                     };
                     if !typevars.clone().take(i).contains(&tvar) {
                         Some(tvar)
@@ -1303,10 +1281,8 @@ fn check_final_class_abstract_methods<'db>(
 
     let defining_class_name = defining_class.name(db);
 
-    if let (_, crate::types::TypeData::FunctionLiteral(function)) = {
-        let __ty_view_value = binding_type(db, *definition);
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    if let crate::types::TypeData::FunctionLiteral(function) = binding_type(db, *definition).data()
+    {
         let policy = if kind.is_explicit() {
             AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -81,7 +81,10 @@ pub(crate) fn check_static_class_definitions<'db>(
 ) {
     let db = context.db();
 
-    let Type::ClassLiteral(ClassLiteral::Static(class)) = ty else {
+    let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = ({
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return;
     };
 
@@ -233,9 +236,17 @@ pub(crate) fn check_static_class_definitions<'db>(
 
         if class_kind == Some(CodeGeneratorKind::NamedTuple)
             && !matches!(
-                base_class,
-                Type::SpecialForm(SpecialFormType::NamedTuple)
-                    | Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
+                {
+                    let __ty_view_value = base_class;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::SpecialForm(SpecialFormType::NamedTuple)
+                        | crate::types::TypeData::KnownInstance(
+                            KnownInstanceType::SubscriptedGeneric(_)
+                        )
+                )
             )
             && let Some(builder) = context.report_lint(&INVALID_NAMED_TUPLE, source_node)
         {
@@ -245,8 +256,11 @@ pub(crate) fn check_static_class_definitions<'db>(
             ));
         }
 
-        let base_class = match base_class {
-            Type::SpecialForm(SpecialFormType::Generic) => {
+        let base_class = match {
+            let __ty_view_value = base_class;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
                 if let Some(builder) = context.report_lint(&INVALID_BASE, source_node) {
                     // Unsubscripted `Generic` can appear in the MRO of many classes,
                     // but it is never valid as an explicit base class in user code.
@@ -254,7 +268,12 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
                 continue;
             }
-            Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(new_context)) => {
+            (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(
+                    new_context,
+                )),
+            ) => {
                 let Some((previous_node, previous_context)) = protocol_base_with_generic_context
                 else {
                     continue;
@@ -281,7 +300,12 @@ pub(crate) fn check_static_class_definitions<'db>(
             // Note that unlike several of the other errors caught in this function,
             // this does not lead to the class creation failing at runtime,
             // but it is semantically invalid.
-            Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(generic_context)) => {
+            (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(
+                    generic_context,
+                )),
+            ) => {
                 if let Some(type_params) = class_node.type_params.as_deref() {
                     let node = source_node;
                     let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, node) else {
@@ -309,8 +333,8 @@ pub(crate) fn check_static_class_definitions<'db>(
                 }
                 continue;
             }
-            Type::ClassLiteral(class) => ClassType::NonGeneric(class),
-            Type::GenericAlias(base_alias) => {
+            (_, crate::types::TypeData::ClassLiteral(class)) => ClassType::NonGeneric(class),
+            (_, crate::types::TypeData::GenericAlias(base_alias)) => {
                 if check_explicit_base_variance
                     && let Some(generic_context) = class.generic_context(db)
                     && let Some((typevar, declared_variance, required_variance)) =
@@ -344,7 +368,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
                 ClassType::Generic(base_alias)
             }
-            _ => continue,
+            (_, _) => continue,
         };
 
         if let Some(disjoint_base) = base_class.nearest_disjoint_base(db) {
@@ -809,10 +833,16 @@ pub(crate) fn check_static_class_definitions<'db>(
                 };
 
                 let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
-                    let tvar = match t {
-                        Type::TypeVar(tvar) => tvar.typevar(db),
-                        Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
-                        _ => return None,
+                    let tvar = match {
+                        let __ty_view_value = t;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::TypeVar(tvar)) => tvar.typevar(db),
+                        (
+                            _,
+                            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(tvar)),
+                        ) => tvar,
+                        (_, _) => return None,
                     };
                     if !typevars.clone().take(i).contains(&tvar) {
                         Some(tvar)
@@ -1273,7 +1303,10 @@ fn check_final_class_abstract_methods<'db>(
 
     let defining_class_name = defining_class.name(db);
 
-    if let Type::FunctionLiteral(function) = binding_type(db, *definition) {
+    if let (_, crate::types::TypeData::FunctionLiteral(function)) = {
+        let __ty_view_value = binding_type(db, *definition);
+        (__ty_view_value, __ty_view_value.data())
+    } {
         let policy = if kind.is_explicit() {
             AbstractMethodAnnotationPolicy::ExcludeVerboseBody
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
@@ -10,10 +10,7 @@ pub(crate) fn check_type_guard_definition<'db>(
     ty: Type<'db>,
     node: &ast::StmtFunctionDef,
 ) {
-    let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::FunctionLiteral(function) = ty.data() else {
         return;
     };
 
@@ -24,15 +21,10 @@ pub(crate) fn check_type_guard_definition<'db>(
         let return_ty = signature.return_ty;
 
         // Check if this is a `TypeIs` or `TypeGuard` return type.
-        let (type_guard_form_name, narrowed_type) = match {
-            let __ty_view_value = return_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeIs(type_is)) => {
-                ("TypeIs", Some(type_is.return_type(db)))
-            }
-            (_, crate::types::TypeData::TypeGuard(_)) => ("TypeGuard", None),
-            (_, _) => continue,
+        let (type_guard_form_name, narrowed_type) = match return_ty.data() {
+            crate::types::TypeData::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db))),
+            crate::types::TypeData::TypeGuard(_) => ("TypeGuard", None),
+            _ => continue,
         };
 
         // The return type annotation must exist since we matched `TypeIs`/`TypeGuard`.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
@@ -10,7 +10,10 @@ pub(crate) fn check_type_guard_definition<'db>(
     ty: Type<'db>,
     node: &ast::StmtFunctionDef,
 ) {
-    let Type::FunctionLiteral(function) = ty else {
+    let (_, crate::types::TypeData::FunctionLiteral(function)) = ({
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return;
     };
 
@@ -21,10 +24,15 @@ pub(crate) fn check_type_guard_definition<'db>(
         let return_ty = signature.return_ty;
 
         // Check if this is a `TypeIs` or `TypeGuard` return type.
-        let (type_guard_form_name, narrowed_type) = match return_ty {
-            Type::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db))),
-            Type::TypeGuard(_) => ("TypeGuard", None),
-            _ => continue,
+        let (type_guard_form_name, narrowed_type) = match {
+            let __ty_view_value = return_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeIs(type_is)) => {
+                ("TypeIs", Some(type_is.return_type(db)))
+            }
+            (_, crate::types::TypeData::TypeGuard(_)) => ("TypeGuard", None),
+            (_, _) => continue,
         };
 
         // The return type annotation must exist since we matched `TypeIs`/`TypeGuard`.

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -71,8 +71,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ty: Type<'db>,
             visitor: &TypedDictKeyExpectedTypeVisitor<'db>,
         ) -> Option<Type<'db>> {
-            match ty {
-                Type::TypedDict(typed_dict) => {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypedDict(typed_dict)) => {
                     if typed_dict.explicit_extra_items(db).is_some() {
                         return Some(KnownClass::Str.to_instance(db));
                     }
@@ -83,7 +86,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                Type::Union(union) => {
+                (_, crate::types::TypeData::Union(union)) => {
                     let keys = union
                         .elements(db)
                         .iter()
@@ -91,7 +94,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                Type::Intersection(intersection) => {
+                (_, crate::types::TypeData::Intersection(intersection)) => {
                     let keys = intersection
                         .positive(db)
                         .iter()
@@ -99,10 +102,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                Type::TypeAlias(alias) => {
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
                     visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
                 }
-                _ => None,
+                (_, _) => None,
             }
         }
 
@@ -212,8 +215,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Type::from(tuple.to_class_type(db))
         };
 
-        match value_ty {
-            Type::ClassLiteral(class) => {
+        match {
+            let __ty_view_value = value_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
                 // HACK ALERT: If we are subscripting a generic class, short-circuit the rest of the
                 // subscript inference logic and treat this as an explicit specialization.
                 // TODO: Move this logic into a custom callable, and update `find_name_in_mro` to return
@@ -240,9 +246,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::ManualPEP695(
+            (
                 _,
-            ))) => {
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                    TypeAliasType::ManualPEP695(_),
+                )),
+            ) => {
                 let slice_ty = self.infer_expression(slice, TypeContext::default());
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -253,7 +262,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
-            Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
+            (
+                _,
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)),
+            ) => {
                 if let Some(generic_context) = type_alias.generic_context(db) {
                     return self.infer_explicit_type_alias_type_specialization(
                         subscript,
@@ -263,7 +275,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            Type::SpecialForm(special_form) => match special_form {
+            (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
                 SpecialFormType::Tuple => {
                     return tuple_generic_alias(db, self.infer_tuple_type_expression(subscript));
                 }
@@ -404,15 +416,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 _ => {}
             },
 
-            Type::KnownInstance(
-                KnownInstanceType::UnionType(_)
-                | KnownInstanceType::Annotated(_)
-                | KnownInstanceType::Callable(_)
-                | KnownInstanceType::TypeGenericAlias(_),
+            (
+                _,
+                crate::types::TypeData::KnownInstance(
+                    KnownInstanceType::UnionType(_)
+                    | KnownInstanceType::Annotated(_)
+                    | KnownInstanceType::Callable(_)
+                    | KnownInstanceType::TypeGenericAlias(_),
+                ),
             ) => {
                 return self.infer_explicit_type_alias_specialization(subscript, value_ty, false);
             }
-            Type::Dynamic(DynamicType::Unknown) => {
+            (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => {
                 let slice_ty = self.infer_expression(slice, TypeContext::default());
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -423,7 +438,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
-            _ => {}
+            (_, _) => {}
         }
 
         let slice_ty = self.infer_expression(slice, TypeContext::default());
@@ -629,8 +644,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .inference_flags()
                         .contains(InferenceFlags::IN_KWARG_ANNOTATION)
                     && !matches!(
-                        value_ty,
-                        Type::GenericAlias(alias)
+                        { let __ty_view_value = value_ty; (__ty_view_value, __ty_view_value.data()) } ,
+                        (_, crate::types::TypeData::GenericAlias(alias))
                             if alias
                                 .specialization(db)
                                 .types(db)
@@ -701,7 +716,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // A ParamSpec cannot be used to specialize a regular TypeVar.
                     if !typevar.is_paramspec(db)
-                        && let Type::TypeVar(tv) = provided_type
+                        && let (_, crate::types::TypeData::TypeVar(tv)) = ({
+                            let __ty_view_value = provided_type;
+                            (__ty_view_value, __ty_view_value.data())
+                        })
                         && tv.is_paramspec(db)
                     {
                         if let Some(builder) = self
@@ -845,11 +863,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(first_excess_type_argument_index) = first_excess_type_argument_index {
-            if let Type::GenericAlias(alias) = value_ty
-                && alias
-                    .specialization(db)
-                    .types(db)
-                    .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
+            if let (_, crate::types::TypeData::GenericAlias(alias)) = ({
+                let __ty_view_value = value_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) && alias
+                .specialization(db)
+                .types(db)
+                .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
             {
                 // Avoid false-positive errors when specializing a class
                 // that's generic over a legacy TypeVarTuple
@@ -860,12 +880,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         "Cannot subscript non-generic type `{}`",
                         value_ty.display(db)
                     ));
-                    let already_specialized = match value_ty {
-                        Type::GenericAlias(_) => true,
-                        Type::KnownInstance(KnownInstanceType::UnionType(union)) => union
+                    let already_specialized = match {
+                        let __ty_view_value = value_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::GenericAlias(_)) => true,
+                        (
+                            _,
+                            crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(
+                                union,
+                            )),
+                        ) => union
                             .value_expression_types(db)
                             .is_ok_and(|mut tys| tys.any(|ty| ty.is_generic_alias())),
-                        _ => false,
+                        (_, _) => false,
                     };
                     if already_specialized {
                         diagnostic.annotate(
@@ -1007,7 +1035,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Expr::Subscript(subscript) => {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
 
-                if matches!(value_ty, Type::SpecialForm(SpecialFormType::Concatenate)) {
+                if matches!(
+                    {
+                        let __ty_view_value = value_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
+                    )
+                ) {
                     return Ok(Type::paramspec_value_callable(
                         db,
                         self.infer_concatenate_special_form(subscript),
@@ -1033,14 +1070,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     previous_concatenate_context,
                 );
 
-                match param_type {
-                    Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
+                match {
+                    let __ty_view_value = param_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
                         return Ok(param_type);
                     }
 
-                    Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
-                        if typevar.is_paramspec(db) =>
-                    {
+                    (
+                        _,
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                    ) if typevar.is_paramspec(db) => {
                         if let Some(diagnostic_builder) =
                             self.context.report_lint(&INVALID_TYPE_ARGUMENTS, expr)
                         {
@@ -1061,7 +1102,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Foo[ParamSpec]  # P: (ParamSpec, /)
                     // ```
-                    Type::NominalInstance(nominal)
+                    (_, crate::types::TypeData::NominalInstance(nominal))
                         if nominal.has_known_class(db, KnownClass::ParamSpec) =>
                     {
                         return Ok(Type::paramspec_value_callable(
@@ -1076,7 +1117,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ));
                     }
 
-                    _ if exactly_one_paramspec => {
+                    (_, _) if exactly_one_paramspec => {
                         // Square brackets are optional when `ParamSpec` is the only type variable
                         // being specialized. This means that a single name expression represents a
                         // parameter list with a single parameter. For example,
@@ -1115,7 +1156,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Foo[Any, int]  # P: (Any, /), T: int
                     // ```
-                    Type::Dynamic(DynamicType::Any) => {
+                    (_, crate::types::TypeData::Dynamic(DynamicType::Any)) => {
                         return Ok(Type::paramspec_value_callable(
                             db,
                             Parameters::gradual_form(),
@@ -1124,11 +1165,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // If we ended up with an `Unknown` type here, it almost certainly means
                     // that we already emitted an error elsewhere
-                    Type::Dynamic(_) => {
+                    (_, crate::types::TypeData::Dynamic(_)) => {
                         return Ok(Type::paramspec_value_callable(db, Parameters::unknown()));
                     }
 
-                    _ => {}
+                    (_, _) => {}
                 }
             }
 
@@ -1157,26 +1198,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Special typing forms for which subscriptions are context-dependent are parsed here,
         // outside of `Type::subscript`, which is a pure function that doesn't depend on the
         // semantic index or any context-dependent state.
-        let subscript_result = match value_ty {
-            Type::SpecialForm(SpecialFormType::Generic) => infer_legacy_generic_subscript(
-                db,
-                self.index,
-                self.scope().file_scope_id(db),
-                self.typevar_binding_context,
-                slice_ty,
-                LegacyGenericOrigin::Generic,
-                KnownInstanceType::SubscriptedGeneric,
-            ),
-            Type::SpecialForm(SpecialFormType::Protocol) => infer_legacy_generic_subscript(
-                db,
-                self.index,
-                self.scope().file_scope_id(db),
-                self.typevar_binding_context,
-                slice_ty,
-                LegacyGenericOrigin::Protocol,
-                KnownInstanceType::SubscriptedProtocol,
-            ),
-            Type::SpecialForm(SpecialFormType::Concatenate) => {
+        let subscript_result = match {
+            let __ty_view_value = value_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
+                infer_legacy_generic_subscript(
+                    db,
+                    self.index,
+                    self.scope().file_scope_id(db),
+                    self.typevar_binding_context,
+                    slice_ty,
+                    LegacyGenericOrigin::Generic,
+                    KnownInstanceType::SubscriptedGeneric,
+                )
+            }
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)) => {
+                infer_legacy_generic_subscript(
+                    db,
+                    self.index,
+                    self.scope().file_scope_id(db),
+                    self.typevar_binding_context,
+                    slice_ty,
+                    LegacyGenericOrigin::Protocol,
+                    KnownInstanceType::SubscriptedProtocol,
+                )
+            }
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)) => {
                 // TODO: Add proper support for `Concatenate`
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -1187,7 +1235,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 Ok(Type::Dynamic(DynamicType::UnknownGeneric(generic_context)))
             }
-            _ => value_ty.subscript(db, slice_ty, expr_context),
+            (_, _) => value_ty.subscript(db, slice_ty, expr_context),
         };
 
         subscript_result.unwrap_or_else(|e| {
@@ -1352,8 +1400,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match object_ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = object_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
                 let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
@@ -1380,7 +1431,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
                 let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
@@ -1420,17 +1471,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            Type::EnumComplement(complement) => self.validate_subscript_assignment_impl(
-                target,
-                full_object_ty,
-                complement.remaining_literal_union(db),
-                infer_slice_ty,
-                rhs_value_node,
-                infer_rhs_value,
-                emit_diagnostic,
-            ),
+            (_, crate::types::TypeData::EnumComplement(complement)) => self
+                .validate_subscript_assignment_impl(
+                    target,
+                    full_object_ty,
+                    complement.remaining_literal_union(db),
+                    infer_slice_ty,
+                    rhs_value_node,
+                    infer_rhs_value,
+                    emit_diagnostic,
+                ),
 
-            Type::TypedDict(typed_dict) => {
+            (_, crate::types::TypeData::TypedDict(typed_dict)) => {
                 // As an optimization, prevent calling `__setitem__` on (unions of) large `TypedDict`s, and
                 // validate the assignment ourselves. This also allows us to emit better diagnostics.
 
@@ -1549,7 +1601,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            _ => {
+            (_, _) => {
                 let ast_arguments = [
                     ArgOrKeyword::Arg(&target.slice),
                     ArgOrKeyword::Arg(rhs_value_node),
@@ -1767,8 +1819,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match object_ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = object_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 for element_ty in union.elements(db) {
                     self.validate_subscript_deletion_impl(
                         target,
@@ -1779,7 +1834,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 // Check if any positive element supports deletion
                 let mut any_valid = false;
                 for element_ty in intersection.positive(db) {
@@ -1800,15 +1855,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            Type::EnumComplement(complement) => self.validate_subscript_deletion_impl(
-                target,
-                full_object_ty,
-                complement.remaining_literal_union(db),
-                slice_ty,
-            ),
+            (_, crate::types::TypeData::EnumComplement(complement)) => self
+                .validate_subscript_deletion_impl(
+                    target,
+                    full_object_ty,
+                    complement.remaining_literal_union(db),
+                    slice_ty,
+                ),
 
-            _ => {
-                if let Type::TypedDict(typed_dict) = object_ty {
+            (_, _) => {
+                if let (_, crate::types::TypeData::TypedDict(typed_dict)) = {
+                    let __ty_view_value = object_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     // Known undeclared keys can only refer to explicit extra items, so they can be
                     // deleted whenever those items are mutable. An arbitrary string key could
                     // instead refer to any declared field, so deletion is only safe when all
@@ -2034,7 +2093,7 @@ enum LegacyGenericContextError<'db> {
 }
 
 impl<'db> LegacyGenericContextError<'db> {
-    const fn into_type(self) -> Type<'db> {
+    fn into_type(self) -> Type<'db> {
         match self {
             LegacyGenericContextError::InvalidArgument(_)
             | LegacyGenericContextError::VariadicTupleArguments
@@ -2111,7 +2170,10 @@ fn legacy_generic_class_context<'db>(
     let mut validated_typevars = FxOrderSet::default();
     for ty in typevars {
         let argument_ty = *ty;
-        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = argument_ty {
+        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = {
+            let __ty_view_value = argument_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             let bound = bind_typevar(db, index, file_scope_id, typevar_binding_context, typevar)
                 .ok_or(LegacyGenericContextError::InvalidArgument(argument_ty))?;
             if !validated_typevars.insert(bound) {
@@ -2119,14 +2181,28 @@ fn legacy_generic_class_context<'db>(
                     typevar.name(db),
                 ));
             }
-        } else if let Type::NominalInstance(instance) = argument_ty
-            && instance.has_known_class(db, KnownClass::TypeVarTuple)
+        } else if let (_, crate::types::TypeData::NominalInstance(instance)) = ({
+            let __ty_view_value = argument_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) && instance.has_known_class(db, KnownClass::TypeVarTuple)
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
-        } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty {
-            Type::Dynamic(DynamicType::TodoUnpack | DynamicType::TodoStarredExpression) => true,
-            Type::NominalInstance(nominal) => nominal.has_known_class(db, KnownClass::TypeVarTuple),
-            _ => false,
+        } else if any_over_type(db, argument_ty, true, |inner_ty| {
+            match {
+                let __ty_view_value = inner_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::Dynamic(
+                        DynamicType::TodoUnpack | DynamicType::TodoStarredExpression,
+                    ),
+                ) => true,
+                (_, crate::types::TypeData::NominalInstance(nominal)) => {
+                    nominal.has_known_class(db, KnownClass::TypeVarTuple)
+                }
+                (_, _) => false,
+            }
         }) {
             return Err(LegacyGenericContextError::NotYetSupported);
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -71,11 +71,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ty: Type<'db>,
             visitor: &TypedDictKeyExpectedTypeVisitor<'db>,
         ) -> Option<Type<'db>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypedDict(typed_dict)) => {
+            match ty.data() {
+                crate::types::TypeData::TypedDict(typed_dict) => {
                     if typed_dict.explicit_extra_items(db).is_some() {
                         return Some(KnownClass::Str.to_instance(db));
                     }
@@ -86,7 +83,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                (_, crate::types::TypeData::Union(union)) => {
+                crate::types::TypeData::Union(union) => {
                     let keys = union
                         .elements(db)
                         .iter()
@@ -94,7 +91,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                (_, crate::types::TypeData::Intersection(intersection)) => {
+                crate::types::TypeData::Intersection(intersection) => {
                     let keys = intersection
                         .positive(db)
                         .iter()
@@ -102,10 +99,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect_vec();
                     (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
                 }
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                crate::types::TypeData::TypeAlias(alias) => {
                     visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
                 }
-                (_, _) => None,
+                _ => None,
             }
         }
 
@@ -215,11 +212,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Type::from(tuple.to_class_type(db))
         };
 
-        match {
-            let __ty_view_value = value_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
+        match value_ty.data() {
+            crate::types::TypeData::ClassLiteral(class) => {
                 // HACK ALERT: If we are subscripting a generic class, short-circuit the rest of the
                 // subscript inference logic and treat this as an explicit specialization.
                 // TODO: Move this logic into a custom callable, and update `find_name_in_mro` to return
@@ -246,12 +240,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                    TypeAliasType::ManualPEP695(_),
-                )),
-            ) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                TypeAliasType::ManualPEP695(_),
+            )) => {
                 let slice_ty = self.infer_expression(slice, TypeContext::default());
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -262,10 +253,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
-            (
-                _,
-                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)),
-            ) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
                 if let Some(generic_context) = type_alias.generic_context(db) {
                     return self.infer_explicit_type_alias_type_specialization(
                         subscript,
@@ -275,7 +263,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
             }
-            (_, crate::types::TypeData::SpecialForm(special_form)) => match special_form {
+            crate::types::TypeData::SpecialForm(special_form) => match special_form {
                 SpecialFormType::Tuple => {
                     return tuple_generic_alias(db, self.infer_tuple_type_expression(subscript));
                 }
@@ -416,18 +404,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 _ => {}
             },
 
-            (
-                _,
-                crate::types::TypeData::KnownInstance(
-                    KnownInstanceType::UnionType(_)
-                    | KnownInstanceType::Annotated(_)
-                    | KnownInstanceType::Callable(_)
-                    | KnownInstanceType::TypeGenericAlias(_),
-                ),
+            crate::types::TypeData::KnownInstance(
+                KnownInstanceType::UnionType(_)
+                | KnownInstanceType::Annotated(_)
+                | KnownInstanceType::Callable(_)
+                | KnownInstanceType::TypeGenericAlias(_),
             ) => {
                 return self.infer_explicit_type_alias_specialization(subscript, value_ty, false);
             }
-            (_, crate::types::TypeData::Dynamic(DynamicType::Unknown)) => {
+            crate::types::TypeData::Dynamic(DynamicType::Unknown) => {
                 let slice_ty = self.infer_expression(slice, TypeContext::default());
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -438,7 +423,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
-            (_, _) => {}
+            _ => {}
         }
 
         let slice_ty = self.infer_expression(slice, TypeContext::default());
@@ -644,8 +629,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .inference_flags()
                         .contains(InferenceFlags::IN_KWARG_ANNOTATION)
                     && !matches!(
-                        { let __ty_view_value = value_ty; (__ty_view_value, __ty_view_value.data()) } ,
-                        (_, crate::types::TypeData::GenericAlias(alias))
+                        value_ty.data() ,
+                        crate::types::TypeData::GenericAlias(alias)
                             if alias
                                 .specialization(db)
                                 .types(db)
@@ -716,10 +701,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // A ParamSpec cannot be used to specialize a regular TypeVar.
                     if !typevar.is_paramspec(db)
-                        && let (_, crate::types::TypeData::TypeVar(tv)) = ({
-                            let __ty_view_value = provided_type;
-                            (__ty_view_value, __ty_view_value.data())
-                        })
+                        && let crate::types::TypeData::TypeVar(tv) = provided_type.data()
                         && tv.is_paramspec(db)
                     {
                         if let Some(builder) = self
@@ -863,13 +845,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if let Some(first_excess_type_argument_index) = first_excess_type_argument_index {
-            if let (_, crate::types::TypeData::GenericAlias(alias)) = ({
-                let __ty_view_value = value_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) && alias
-                .specialization(db)
-                .types(db)
-                .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
+            if let crate::types::TypeData::GenericAlias(alias) = value_ty.data()
+                && alias
+                    .specialization(db)
+                    .types(db)
+                    .contains(&Type::Dynamic(DynamicType::TodoTypeVarTuple))
             {
                 // Avoid false-positive errors when specializing a class
                 // that's generic over a legacy TypeVarTuple
@@ -880,20 +860,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         "Cannot subscript non-generic type `{}`",
                         value_ty.display(db)
                     ));
-                    let already_specialized = match {
-                        let __ty_view_value = value_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::GenericAlias(_)) => true,
-                        (
-                            _,
-                            crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(
-                                union,
-                            )),
-                        ) => union
+                    let already_specialized = match value_ty.data() {
+                        crate::types::TypeData::GenericAlias(_) => true,
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(
+                            union,
+                        )) => union
                             .value_expression_types(db)
                             .is_ok_and(|mut tys| tys.any(|ty| ty.is_generic_alias())),
-                        (_, _) => false,
+                        _ => false,
                     };
                     if already_specialized {
                         diagnostic.annotate(
@@ -1036,14 +1010,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
 
                 if matches!(
-                    {
-                        let __ty_view_value = value_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (
-                        _,
-                        crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
-                    )
+                    value_ty.data(),
+                    crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
                 ) {
                     return Ok(Type::paramspec_value_callable(
                         db,
@@ -1070,18 +1038,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     previous_concatenate_context,
                 );
 
-                match {
-                    let __ty_view_value = param_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
+                match param_type.data() {
+                    crate::types::TypeData::TypeVar(typevar) if typevar.is_paramspec(db) => {
                         return Ok(param_type);
                     }
 
-                    (
-                        _,
-                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
-                    ) if typevar.is_paramspec(db) => {
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))
+                        if typevar.is_paramspec(db) =>
+                    {
                         if let Some(diagnostic_builder) =
                             self.context.report_lint(&INVALID_TYPE_ARGUMENTS, expr)
                         {
@@ -1102,7 +1066,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Foo[ParamSpec]  # P: (ParamSpec, /)
                     // ```
-                    (_, crate::types::TypeData::NominalInstance(nominal))
+                    crate::types::TypeData::NominalInstance(nominal)
                         if nominal.has_known_class(db, KnownClass::ParamSpec) =>
                     {
                         return Ok(Type::paramspec_value_callable(
@@ -1117,7 +1081,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ));
                     }
 
-                    (_, _) if exactly_one_paramspec => {
+                    _ if exactly_one_paramspec => {
                         // Square brackets are optional when `ParamSpec` is the only type variable
                         // being specialized. This means that a single name expression represents a
                         // parameter list with a single parameter. For example,
@@ -1156,7 +1120,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //
                     // Foo[Any, int]  # P: (Any, /), T: int
                     // ```
-                    (_, crate::types::TypeData::Dynamic(DynamicType::Any)) => {
+                    crate::types::TypeData::Dynamic(DynamicType::Any) => {
                         return Ok(Type::paramspec_value_callable(
                             db,
                             Parameters::gradual_form(),
@@ -1165,11 +1129,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // If we ended up with an `Unknown` type here, it almost certainly means
                     // that we already emitted an error elsewhere
-                    (_, crate::types::TypeData::Dynamic(_)) => {
+                    crate::types::TypeData::Dynamic(_) => {
                         return Ok(Type::paramspec_value_callable(db, Parameters::unknown()));
                     }
 
-                    (_, _) => {}
+                    _ => {}
                 }
             }
 
@@ -1198,11 +1162,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Special typing forms for which subscriptions are context-dependent are parsed here,
         // outside of `Type::subscript`, which is a pure function that doesn't depend on the
         // semantic index or any context-dependent state.
-        let subscript_result = match {
-            let __ty_view_value = value_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Generic)) => {
+        let subscript_result = match value_ty.data() {
+            crate::types::TypeData::SpecialForm(SpecialFormType::Generic) => {
                 infer_legacy_generic_subscript(
                     db,
                     self.index,
@@ -1213,7 +1174,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     KnownInstanceType::SubscriptedGeneric,
                 )
             }
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Protocol)) => {
+            crate::types::TypeData::SpecialForm(SpecialFormType::Protocol) => {
                 infer_legacy_generic_subscript(
                     db,
                     self.index,
@@ -1224,7 +1185,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     KnownInstanceType::SubscriptedProtocol,
                 )
             }
-            (_, crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)) => {
+            crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate) => {
                 // TODO: Add proper support for `Concatenate`
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
@@ -1235,7 +1196,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let generic_context = GenericContext::from_typevar_instances(db, variables);
                 Ok(Type::Dynamic(DynamicType::UnknownGeneric(generic_context)))
             }
-            (_, _) => value_ty.subscript(db, slice_ty, expr_context),
+            _ => value_ty.subscript(db, slice_ty, expr_context),
         };
 
         subscript_result.unwrap_or_else(|e| {
@@ -1400,11 +1361,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match {
-            let __ty_view_value = object_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match object_ty.data() {
+            crate::types::TypeData::Union(union) => {
                 let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
                 let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
@@ -1431,7 +1389,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 let mut infer_slice_ty = MultiInferenceGuard::new(infer_slice_ty);
                 let mut infer_rhs_value = MultiInferenceGuard::new(infer_rhs_value);
 
@@ -1471,7 +1429,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => self
+            crate::types::TypeData::EnumComplement(complement) => self
                 .validate_subscript_assignment_impl(
                     target,
                     full_object_ty,
@@ -1482,7 +1440,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     emit_diagnostic,
                 ),
 
-            (_, crate::types::TypeData::TypedDict(typed_dict)) => {
+            crate::types::TypeData::TypedDict(typed_dict) => {
                 // As an optimization, prevent calling `__setitem__` on (unions of) large `TypedDict`s, and
                 // validate the assignment ourselves. This also allows us to emit better diagnostics.
 
@@ -1601,7 +1559,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 valid
             }
 
-            (_, _) => {
+            _ => {
                 let ast_arguments = [
                     ArgOrKeyword::Arg(&target.slice),
                     ArgOrKeyword::Arg(rhs_value_node),
@@ -1819,11 +1777,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        match {
-            let __ty_view_value = object_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match object_ty.data() {
+            crate::types::TypeData::Union(union) => {
                 for element_ty in union.elements(db) {
                     self.validate_subscript_deletion_impl(
                         target,
@@ -1834,7 +1789,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 // Check if any positive element supports deletion
                 let mut any_valid = false;
                 for element_ty in intersection.positive(db) {
@@ -1855,7 +1810,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
 
-            (_, crate::types::TypeData::EnumComplement(complement)) => self
+            crate::types::TypeData::EnumComplement(complement) => self
                 .validate_subscript_deletion_impl(
                     target,
                     full_object_ty,
@@ -1863,11 +1818,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     slice_ty,
                 ),
 
-            (_, _) => {
-                if let (_, crate::types::TypeData::TypedDict(typed_dict)) = {
-                    let __ty_view_value = object_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+            _ => {
+                if let crate::types::TypeData::TypedDict(typed_dict) = object_ty.data() {
                     // Known undeclared keys can only refer to explicit extra items, so they can be
                     // deleted whenever those items are mutable. An arbitrary string key could
                     // instead refer to any declared field, so deletion is only safe when all
@@ -2170,10 +2122,9 @@ fn legacy_generic_class_context<'db>(
     let mut validated_typevars = FxOrderSet::default();
     for ty in typevars {
         let argument_ty = *ty;
-        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = {
-            let __ty_view_value = argument_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+            argument_ty.data()
+        {
             let bound = bind_typevar(db, index, file_scope_id, typevar_binding_context, typevar)
                 .ok_or(LegacyGenericContextError::InvalidArgument(argument_ty))?;
             if !validated_typevars.insert(bound) {
@@ -2181,28 +2132,18 @@ fn legacy_generic_class_context<'db>(
                     typevar.name(db),
                 ));
             }
-        } else if let (_, crate::types::TypeData::NominalInstance(instance)) = ({
-            let __ty_view_value = argument_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) && instance.has_known_class(db, KnownClass::TypeVarTuple)
+        } else if let crate::types::TypeData::NominalInstance(instance) = argument_ty.data()
+            && instance.has_known_class(db, KnownClass::TypeVarTuple)
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
-        } else if any_over_type(db, argument_ty, true, |inner_ty| {
-            match {
-                let __ty_view_value = inner_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    crate::types::TypeData::Dynamic(
-                        DynamicType::TodoUnpack | DynamicType::TodoStarredExpression,
-                    ),
-                ) => true,
-                (_, crate::types::TypeData::NominalInstance(nominal)) => {
-                    nominal.has_known_class(db, KnownClass::TypeVarTuple)
-                }
-                (_, _) => false,
+        } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty.data() {
+            crate::types::TypeData::Dynamic(
+                DynamicType::TodoUnpack | DynamicType::TodoStarredExpression,
+            ) => true,
+            crate::types::TypeData::NominalInstance(nominal) => {
+                nominal.has_known_class(db, KnownClass::TypeVarTuple)
             }
+            _ => false,
         }) {
             return Err(LegacyGenericContextError::NotYetSupported);
         } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -158,7 +158,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     })
                     .collect();
                 (members, !all_keys_are_string_literals)
-            } else if let Type::TypedDict(typed_dict) = namespace_type {
+            } else if let (_, crate::types::TypeData::TypedDict(typed_dict)) = {
+                let __ty_view_value = namespace_type;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 // `namespace` is a TypedDict instance. Extract known keys as members.
                 // TypedDicts are "open" (can have additional string keys), so this
                 // is still a dynamic namespace for unknown attributes.
@@ -173,15 +176,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !matches!(namespace_type, Type::TypedDict(_))
-            && !namespace_type.is_assignable_to(
-                db,
-                KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
-            )
-            && let Some(builder) = self
-                .context
-                .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)
+        if !matches!(
+            {
+                let __ty_view_value = namespace_type;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::TypedDict(_))
+        ) && !namespace_type.is_assignable_to(
+            db,
+            KnownClass::Dict
+                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
+        ) && let Some(builder) = self
+            .context
+            .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)
         {
             let mut diagnostic = builder
                 .into_diagnostic("Invalid argument to parameter 3 (`namespace`) of `type()`");
@@ -329,7 +336,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Get the already-inferred class type from the initial pass.
         let inferred_type = definition_expression_type(db, definition, call_expr);
-        let Type::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) = inferred_type else {
+        let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
+            let __ty_view_value = inferred_type;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -158,10 +158,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     })
                     .collect();
                 (members, !all_keys_are_string_literals)
-            } else if let (_, crate::types::TypeData::TypedDict(typed_dict)) = {
-                let __ty_view_value = namespace_type;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            } else if let crate::types::TypeData::TypedDict(typed_dict) = namespace_type.data() {
                 // `namespace` is a TypedDict instance. Extract known keys as members.
                 // TypedDicts are "open" (can have additional string keys), so this
                 // is still a dynamic namespace for unknown attributes.
@@ -176,19 +173,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 (Box::new([]), true)
             };
 
-        if !matches!(
-            {
-                let __ty_view_value = namespace_type;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::TypedDict(_))
-        ) && !namespace_type.is_assignable_to(
-            db,
-            KnownClass::Dict
-                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
-        ) && let Some(builder) = self
-            .context
-            .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)
+        if !matches!(namespace_type.data(), crate::types::TypeData::TypedDict(_))
+            && !namespace_type.is_assignable_to(
+                db,
+                KnownClass::Dict
+                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
+            )
+            && let Some(builder) = self
+                .context
+                .report_lint(&INVALID_ARGUMENT_TYPE, namespace_arg)
         {
             let mut diagnostic = builder
                 .into_diagnostic("Invalid argument to parameter 3 (`namespace`) of `type()`");
@@ -336,10 +329,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Get the already-inferred class type from the initial pass.
         let inferred_type = definition_expression_type(db, definition, call_expr);
-        let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class))) = ({
-            let __ty_view_value = inferred_type;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::ClassLiteral(ClassLiteral::Dynamic(dynamic_class)) =
+            inferred_type.data()
+        else {
             return;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -107,10 +107,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         annotation: &ast::Expr,
     ) -> Type<'db> {
         if annotation.is_attribute_expr()
-            && let (_, crate::types::TypeData::TypeVar(tvar)) = ({
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            })
+            && let crate::types::TypeData::TypeVar(tvar) = ty.data()
             && tvar.paramspec_attr(self.db()).is_some()
         {
             return ty;
@@ -246,38 +243,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             let should_emit_error = if dunder_fails {
                                 true
                             } else {
-                                let literal = match (
-                                    ({
-                                        let __ty_view_value = left_type_value;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    }),
-                                    ({
-                                        let __ty_view_value = right_type_value;
-                                        (__ty_view_value, __ty_view_value.data())
-                                    }),
-                                ) {
-                                    (
-                                        (_, crate::types::TypeData::ClassLiteral(class)),
-                                        (_, crate::types::TypeData::LiteralValue(literal)),
-                                    )
-                                    | (
-                                        (_, crate::types::TypeData::LiteralValue(literal)),
-                                        (_, crate::types::TypeData::ClassLiteral(class)),
-                                    ) if class.metaclass(self.db())
-                                        == KnownClass::Type.to_class_literal(self.db()) =>
-                                    {
-                                        Some(literal)
-                                    }
-                                    (
-                                        (_, crate::types::TypeData::GenericAlias(_)),
-                                        (_, crate::types::TypeData::LiteralValue(literal)),
-                                    )
-                                    | (
-                                        (_, crate::types::TypeData::LiteralValue(literal)),
-                                        (_, crate::types::TypeData::GenericAlias(_)),
-                                    ) => Some(literal),
-                                    _ => None,
-                                };
+                                let literal =
+                                    match (left_type_value.data(), right_type_value.data()) {
+                                        (
+                                            crate::types::TypeData::ClassLiteral(class),
+                                            crate::types::TypeData::LiteralValue(literal),
+                                        )
+                                        | (
+                                            crate::types::TypeData::LiteralValue(literal),
+                                            crate::types::TypeData::ClassLiteral(class),
+                                        ) if class.metaclass(self.db())
+                                            == KnownClass::Type.to_class_literal(self.db()) =>
+                                        {
+                                            Some(literal)
+                                        }
+                                        (
+                                            crate::types::TypeData::GenericAlias(_),
+                                            crate::types::TypeData::LiteralValue(literal),
+                                        )
+                                        | (
+                                            crate::types::TypeData::LiteralValue(literal),
+                                            crate::types::TypeData::GenericAlias(_),
+                                        ) => Some(literal),
+                                        _ => None,
+                                    };
                                 literal.is_some_and(|literal| !literal.is_enum())
                             };
 
@@ -885,18 +874,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         slice: &ast::Expr,
         value_ty: Type<'db>,
     ) -> Type<'db> {
-        match {
-            let __ty_view_value = value_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::ClassLiteral(class_literal)) => match class_literal
+        match value_ty.data() {
+            crate::types::TypeData::ClassLiteral(class_literal) => match class_literal
                 .known(self.db())
             {
                 Some(KnownClass::Tuple) => Type::tuple(self.infer_tuple_type_expression(subscript)),
                 Some(KnownClass::Type) => self.infer_subclass_of_type_expression(slice),
                 _ => self.infer_subscript_type_expression(subscript, value_ty),
             },
-            (_, _) => self.infer_subscript_type_expression(subscript, value_ty),
+            _ => self.infer_subscript_type_expression(subscript, value_ty),
         }
     }
 
@@ -1169,31 +1155,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SubclassOfType::subclass_of_unknown()
         };
 
-        let infer_type_argument =
-            |builder: &mut Self, slice: &ast::Expr| {
-                let slice_ty = builder.infer_type_expression(slice);
-                if matches!(
-                    {
-                        let __ty_view_value = slice_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (_, crate::types::TypeData::ProtocolInstance(_))
-                ) {
-                    return SubclassOfType::from(
-                        builder.db(),
-                        todo_type!("type[T] for protocols").expect_dynamic(),
-                    );
+        let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
+            let slice_ty = builder.infer_type_expression(slice);
+            if matches!(slice_ty.data(), crate::types::TypeData::ProtocolInstance(_)) {
+                return SubclassOfType::from(
+                    builder.db(),
+                    todo_type!("type[T] for protocols").expect_dynamic(),
+                );
+            }
+            SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
+                match slice_ty.data() {
+                    crate::types::TypeData::Callable(_) => invalid_type_argument(builder, slice),
+                    _ => todo_type!("unsupported type[X] special form"),
                 }
-                SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| match {
-                    let __ty_view_value = slice_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::Callable(_)) => {
-                        invalid_type_argument(builder, slice)
-                    }
-                    (_, _) => todo_type!("unsupported type[X] special form"),
-                })
-            };
+            })
+        };
 
         match slice {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::StringLiteral(_) => {
@@ -1222,10 +1198,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ..
                 },
             ) => {
-                let parameters_ty = match {
-                    let __ty_view_value = self.infer_expression(value, TypeContext::default());
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                let parameters_ty = match self
+                    .infer_expression(value, TypeContext::default())
+                    .view()
+                {
                     (_, crate::types::TypeData::SpecialForm(SpecialFormType::Union)) => {
                         match &**parameters {
                             ast::Expr::Tuple(tuple) => {
@@ -1318,10 +1294,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> Type<'db> {
         let db = self.db();
 
-        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
-            let __ty_view_value = value_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) && let Some(definition) = typevar.definition(db)
+        if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+            value_ty.data()
+            && let Some(definition) = typevar.definition(db)
         {
             value_ty = value_ty.apply_type_mapping(
                 db,
@@ -1413,11 +1388,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ctx: _,
         } = subscript;
 
-        match {
-            let __ty_view_value = value_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Never) => {
+        match value_ty.data() {
+            crate::types::TypeData::Never => {
                 // This case can be entered when we use a type annotation like `Literal[1]`
                 // in unreachable code, since we infer `Never` for `Literal`.  We call
                 // `infer_expression` (instead of `infer_type_expression`) here to avoid
@@ -1428,10 +1400,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 Type::unknown()
             }
-            (_, crate::types::TypeData::SpecialForm(special_form)) => {
+            crate::types::TypeData::SpecialForm(special_form) => {
                 self.infer_parameterized_special_form_type_expression(subscript, special_form)
             }
-            (_, crate::types::TypeData::KnownInstance(known_instance)) => match known_instance {
+            crate::types::TypeData::KnownInstance(known_instance) => match known_instance {
                 KnownInstanceType::SubscriptedProtocol(_) => {
                     if !self.in_string_annotation() {
                         self.infer_expression(slice, TypeContext::default());
@@ -1683,10 +1655,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Type::unknown()
                 }
             },
-            (_, crate::types::TypeData::Dynamic(DynamicType::UnknownGeneric(_))) => {
+            crate::types::TypeData::Dynamic(DynamicType::UnknownGeneric(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
-            (_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_)) => {
+            crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_) => {
                 // Infer slice as a value expression to avoid false-positive
                 // `invalid-type-form` diagnostics, when we have e.g.
                 // `MyCallable[[int, str], None]` but `MyCallable` is dynamic.
@@ -1695,7 +1667,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 value_ty
             }
-            (_, crate::types::TypeData::ClassLiteral(class)) => {
+            crate::types::TypeData::ClassLiteral(class) => {
                 match (class.generic_context(self.db()), class.as_static()) {
                     (Some(generic_context), Some(static_class)) => {
                         let specialized_class = self.infer_explicit_class_specialization(
@@ -1721,15 +1693,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
             }
-            (_, crate::types::TypeData::GenericAlias(_)) => {
+            crate::types::TypeData::GenericAlias(_) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
-            (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
+            crate::types::TypeData::LiteralValue(literal) if literal.is_string() => {
                 self.infer_expression(slice, TypeContext::default());
                 // For stringified TypeAlias; remove once properly supported
                 todo_type!("string literal subscripted in type expression")
             }
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 let db = self.db();
                 let mut union_builder =
                     UnionBuilder::new(db).recursively_defined(union.recursively_defined(db));
@@ -1748,7 +1720,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 union_builder.build()
             }
-            (_, _) => {
+            _ => {
                 if !self.in_string_annotation() {
                     self.infer_expression(slice, TypeContext::default());
                 }
@@ -2456,27 +2428,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         .iter()
                         .copied();
 
-                    let probably_meant_literal = argument_elements.all(|ty| {
-                        match {
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        } {
-                            (_, crate::types::TypeData::LiteralValue(literal))
-                                if matches!(
-                                    literal.kind(),
-                                    LiteralValueTypeKind::String(_)
-                                        | LiteralValueTypeKind::Bytes(_)
-                                        | LiteralValueTypeKind::Enum(_)
-                                        | LiteralValueTypeKind::Bool(_)
-                                ) =>
-                            {
-                                true
-                            }
-                            (_, crate::types::TypeData::NominalInstance(instance)) => {
-                                instance.has_known_class(db, KnownClass::NoneType)
-                            }
-                            (_, _) => false,
+                    let probably_meant_literal = argument_elements.all(|ty| match ty.data() {
+                        crate::types::TypeData::LiteralValue(literal)
+                            if matches!(
+                                literal.kind(),
+                                LiteralValueTypeKind::String(_)
+                                    | LiteralValueTypeKind::Bytes(_)
+                                    | LiteralValueTypeKind::Enum(_)
+                                    | LiteralValueTypeKind::Bool(_)
+                            ) =>
+                        {
+                            true
                         }
+                        crate::types::TypeData::NominalInstance(instance) => {
+                            instance.has_known_class(db, KnownClass::NoneType)
+                        }
+                        _ => false,
                     });
 
                     if probably_meant_literal {
@@ -2517,14 +2484,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let value_ty = self.infer_expression(value, TypeContext::default());
                 if matches!(
-                    {
-                        let __ty_view_value = value_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (
-                        _,
-                        crate::types::TypeData::SpecialForm(SpecialFormType::Literal)
-                    )
+                    value_ty.data(),
+                    crate::types::TypeData::SpecialForm(SpecialFormType::Literal)
                 ) {
                     let ty = self.infer_literal_parameter_type(slice)?;
 
@@ -2593,42 +2554,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // enum members and aliases to literal types
             ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
                 let subscript_ty = self.infer_expression(parameters, TypeContext::default());
-                match {
-                    let __ty_view_value = subscript_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                match subscript_ty.data() {
                     // type aliases to literal types
-                    (
-                        _,
-                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                            type_alias,
-                        )),
-                    ) => {
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                        type_alias,
+                    )) => {
                         let value_ty = type_alias.value_type(self.db());
                         if value_ty.is_literal_or_union_of_literals(self.db()) {
                             return Ok(value_ty);
                         }
                     }
-                    (_, crate::types::TypeData::KnownInstance(KnownInstanceType::Literal(ty))) => {
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::Literal(ty)) => {
                         return Ok(ty.inner(self.db()));
                     }
                     // `Literal[SomeEnum.Member]`
-                    (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_enum() => {
+                    crate::types::TypeData::LiteralValue(literal) if literal.is_enum() => {
                         // Avoid promoting values originating from an explicitly annotated literal type.
                         return Ok(Type::LiteralValue(literal.to_unpromotable()));
                     }
                     // `Literal[SingletonEnum.Member]`, where `SingletonEnum.Member` simplifies to
                     // just `SingletonEnum`.
-                    (_, crate::types::TypeData::NominalInstance(_))
+                    crate::types::TypeData::NominalInstance(_)
                         if subscript_ty.is_enum(self.db()) =>
                     {
                         return Ok(subscript_ty);
                     }
                     // suppress false positives for e.g. members of functional-syntax enums
-                    (_, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => {
+                    crate::types::TypeData::Dynamic(DynamicType::Todo(_)) => {
                         return Ok(subscript_ty);
                     }
-                    (_, _) => {}
+                    _ => {}
                 }
                 return Err(vec![parameters]);
             }
@@ -2641,10 +2596,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         };
 
         Ok(
-            if let (_, crate::types::TypeData::LiteralValue(literal)) = {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::LiteralValue(literal) = ty.data() {
                 // Avoid promoting values originating from an explicitly annotated literal type.
                 Type::LiteralValue(literal.to_unpromotable())
             } else {
@@ -2712,14 +2664,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
 
                 if matches!(
-                    {
-                        let __ty_view_value = value_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (
-                        _,
-                        crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
-                    )
+                    value_ty.data(),
+                    crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
                 ) {
                     return Some(self.infer_concatenate_special_form(subscript));
                 }
@@ -2748,10 +2694,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
-                if let (_, crate::types::TypeData::TypeVar(tvar)) = ({
-                    let __ty_view_value = parameters_type;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && tvar.is_paramspec(self.db())
+                if let crate::types::TypeData::TypeVar(tvar) = parameters_type.data()
+                    && tvar.is_paramspec(self.db())
                 {
                     return Some(Parameters::paramspec(self.db(), tvar));
                 }
@@ -2892,10 +2836,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
-                let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                    let __ty_view_value = expr_type;
-                    (__ty_view_value, __ty_view_value.data())
-                }) else {
+                let crate::types::TypeData::TypeVar(typevar) = expr_type.data() else {
                     // `Concatenate` *is* allowed inside `Concatenate`, so avoid emitting here a diagnostic
                     // saying that the argument is invalid if the inner type is an invalid use of the
                     // `Concatenate` special form (we'll already have complained about the invalid use
@@ -2965,10 +2906,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         {
             return ty;
         }
-        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        if let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+            ty.data()
+        {
             if let Some(builder) = self.context.report_lint(&UNBOUND_TYPE_VARIABLE, expression) {
                 builder.into_diagnostic(format_args!(
                     "Type variable `{name}` is not bound to any outer generic context",

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -107,7 +107,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         annotation: &ast::Expr,
     ) -> Type<'db> {
         if annotation.is_attribute_expr()
-            && let Type::TypeVar(tvar) = ty
+            && let (_, crate::types::TypeData::TypeVar(tvar)) = ({
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            })
             && tvar.paramspec_attr(self.db()).is_some()
         {
             return ty;
@@ -243,18 +246,36 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             let should_emit_error = if dunder_fails {
                                 true
                             } else {
-                                let literal = match (left_type_value, right_type_value) {
-                                    (Type::ClassLiteral(class), Type::LiteralValue(literal))
-                                    | (Type::LiteralValue(literal), Type::ClassLiteral(class))
-                                        if class.metaclass(self.db())
-                                            == KnownClass::Type.to_class_literal(self.db()) =>
+                                let literal = match (
+                                    ({
+                                        let __ty_view_value = left_type_value;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    }),
+                                    ({
+                                        let __ty_view_value = right_type_value;
+                                        (__ty_view_value, __ty_view_value.data())
+                                    }),
+                                ) {
+                                    (
+                                        (_, crate::types::TypeData::ClassLiteral(class)),
+                                        (_, crate::types::TypeData::LiteralValue(literal)),
+                                    )
+                                    | (
+                                        (_, crate::types::TypeData::LiteralValue(literal)),
+                                        (_, crate::types::TypeData::ClassLiteral(class)),
+                                    ) if class.metaclass(self.db())
+                                        == KnownClass::Type.to_class_literal(self.db()) =>
                                     {
                                         Some(literal)
                                     }
-                                    (Type::GenericAlias(_), Type::LiteralValue(literal))
-                                    | (Type::LiteralValue(literal), Type::GenericAlias(_)) => {
-                                        Some(literal)
-                                    }
+                                    (
+                                        (_, crate::types::TypeData::GenericAlias(_)),
+                                        (_, crate::types::TypeData::LiteralValue(literal)),
+                                    )
+                                    | (
+                                        (_, crate::types::TypeData::LiteralValue(literal)),
+                                        (_, crate::types::TypeData::GenericAlias(_)),
+                                    ) => Some(literal),
                                     _ => None,
                                 };
                                 literal.is_some_and(|literal| !literal.is_enum())
@@ -864,13 +885,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         slice: &ast::Expr,
         value_ty: Type<'db>,
     ) -> Type<'db> {
-        match value_ty {
-            Type::ClassLiteral(class_literal) => match class_literal.known(self.db()) {
+        match {
+            let __ty_view_value = value_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class_literal)) => match class_literal
+                .known(self.db())
+            {
                 Some(KnownClass::Tuple) => Type::tuple(self.infer_tuple_type_expression(subscript)),
                 Some(KnownClass::Type) => self.infer_subclass_of_type_expression(slice),
                 _ => self.infer_subscript_type_expression(subscript, value_ty),
             },
-            _ => self.infer_subscript_type_expression(subscript, value_ty),
+            (_, _) => self.infer_subscript_type_expression(subscript, value_ty),
         }
     }
 
@@ -1143,21 +1169,31 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             SubclassOfType::subclass_of_unknown()
         };
 
-        let infer_type_argument = |builder: &mut Self, slice: &ast::Expr| {
-            let slice_ty = builder.infer_type_expression(slice);
-            if matches!(slice_ty, Type::ProtocolInstance(_)) {
-                return SubclassOfType::from(
-                    builder.db(),
-                    todo_type!("type[T] for protocols").expect_dynamic(),
-                );
-            }
-            SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
-                match slice_ty {
-                    Type::Callable(_) => invalid_type_argument(builder, slice),
-                    _ => todo_type!("unsupported type[X] special form"),
+        let infer_type_argument =
+            |builder: &mut Self, slice: &ast::Expr| {
+                let slice_ty = builder.infer_type_expression(slice);
+                if matches!(
+                    {
+                        let __ty_view_value = slice_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (_, crate::types::TypeData::ProtocolInstance(_))
+                ) {
+                    return SubclassOfType::from(
+                        builder.db(),
+                        todo_type!("type[T] for protocols").expect_dynamic(),
+                    );
                 }
-            })
-        };
+                SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| match {
+                    let __ty_view_value = slice_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::Callable(_)) => {
+                        invalid_type_argument(builder, slice)
+                    }
+                    (_, _) => todo_type!("unsupported type[X] special form"),
+                })
+            };
 
         match slice {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::StringLiteral(_) => {
@@ -1186,21 +1222,26 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ..
                 },
             ) => {
-                let parameters_ty = match self.infer_expression(value, TypeContext::default()) {
-                    Type::SpecialForm(SpecialFormType::Union) => match &**parameters {
-                        ast::Expr::Tuple(tuple) => {
-                            let ty = UnionType::from_elements_leave_aliases(
-                                self.db(),
-                                tuple
-                                    .iter()
-                                    .map(|element| self.infer_subclass_of_type_expression(element)),
-                            );
-                            self.store_expression_type(parameters, ty);
-                            ty
+                let parameters_ty = match {
+                    let __ty_view_value = self.infer_expression(value, TypeContext::default());
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::SpecialForm(SpecialFormType::Union)) => {
+                        match &**parameters {
+                            ast::Expr::Tuple(tuple) => {
+                                let ty = UnionType::from_elements_leave_aliases(
+                                    self.db(),
+                                    tuple.iter().map(|element| {
+                                        self.infer_subclass_of_type_expression(element)
+                                    }),
+                                );
+                                self.store_expression_type(parameters, ty);
+                                ty
+                            }
+                            _ => self.infer_subclass_of_type_expression(parameters),
                         }
-                        _ => self.infer_subclass_of_type_expression(parameters),
-                    },
-                    value_ty @ Type::ClassLiteral(class_literal) => {
+                    }
+                    (value_ty, crate::types::TypeData::ClassLiteral(class_literal)) => {
                         if class_literal.is_protocol(self.db()) {
                             SubclassOfType::from(
                                 self.db(),
@@ -1240,9 +1281,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             }
                         }
                     }
-                    Type::SpecialForm(
-                        special_form @ (SpecialFormType::TypingCallable
-                        | SpecialFormType::CollectionsAbcCallable),
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(
+                            special_form @ (SpecialFormType::TypingCallable
+                            | SpecialFormType::CollectionsAbcCallable),
+                        ),
                     ) => {
                         self.infer_parameterized_special_form_type_expression(
                             subscript,
@@ -1250,7 +1294,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         );
                         invalid_type_argument(self, slice)
                     }
-                    _ => {
+                    (_, _) => {
                         self.infer_expression(parameters, TypeContext::default());
                         todo_type!("unsupported nested subscript in type[X]")
                     }
@@ -1274,8 +1318,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> Type<'db> {
         let db = self.db();
 
-        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_ty
-            && let Some(definition) = typevar.definition(db)
+        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
+            let __ty_view_value = value_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) && let Some(definition) = typevar.definition(db)
         {
             value_ty = value_ty.apply_type_mapping(
                 db,
@@ -1367,8 +1413,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ctx: _,
         } = subscript;
 
-        match value_ty {
-            Type::Never => {
+        match {
+            let __ty_view_value = value_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Never) => {
                 // This case can be entered when we use a type annotation like `Literal[1]`
                 // in unreachable code, since we infer `Never` for `Literal`.  We call
                 // `infer_expression` (instead of `infer_type_expression`) here to avoid
@@ -1379,10 +1428,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 Type::unknown()
             }
-            Type::SpecialForm(special_form) => {
+            (_, crate::types::TypeData::SpecialForm(special_form)) => {
                 self.infer_parameterized_special_form_type_expression(subscript, special_form)
             }
-            Type::KnownInstance(known_instance) => match known_instance {
+            (_, crate::types::TypeData::KnownInstance(known_instance)) => match known_instance {
                 KnownInstanceType::SubscriptedProtocol(_) => {
                     if !self.in_string_annotation() {
                         self.infer_expression(slice, TypeContext::default());
@@ -1634,10 +1683,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Type::unknown()
                 }
             },
-            Type::Dynamic(DynamicType::UnknownGeneric(_)) => {
+            (_, crate::types::TypeData::Dynamic(DynamicType::UnknownGeneric(_))) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
-            Type::Dynamic(_) | Type::Divergent(_) => {
+            (_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_)) => {
                 // Infer slice as a value expression to avoid false-positive
                 // `invalid-type-form` diagnostics, when we have e.g.
                 // `MyCallable[[int, str], None]` but `MyCallable` is dynamic.
@@ -1646,7 +1695,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 value_ty
             }
-            Type::ClassLiteral(class) => {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
                 match (class.generic_context(self.db()), class.as_static()) {
                     (Some(generic_context), Some(static_class)) => {
                         let specialized_class = self.infer_explicit_class_specialization(
@@ -1672,15 +1721,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
             }
-            Type::GenericAlias(_) => {
+            (_, crate::types::TypeData::GenericAlias(_)) => {
                 self.infer_explicit_type_alias_specialization(subscript, value_ty, true)
             }
-            Type::LiteralValue(literal) if literal.is_string() => {
+            (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_string() => {
                 self.infer_expression(slice, TypeContext::default());
                 // For stringified TypeAlias; remove once properly supported
                 todo_type!("string literal subscripted in type expression")
             }
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 let db = self.db();
                 let mut union_builder =
                     UnionBuilder::new(db).recursively_defined(union.recursively_defined(db));
@@ -1699,7 +1748,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 union_builder.build()
             }
-            _ => {
+            (_, _) => {
                 if !self.in_string_annotation() {
                     self.infer_expression(slice, TypeContext::default());
                 }
@@ -2407,22 +2456,27 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         .iter()
                         .copied();
 
-                    let probably_meant_literal = argument_elements.all(|ty| match ty {
-                        Type::LiteralValue(literal)
-                            if matches!(
-                                literal.kind(),
-                                LiteralValueTypeKind::String(_)
-                                    | LiteralValueTypeKind::Bytes(_)
-                                    | LiteralValueTypeKind::Enum(_)
-                                    | LiteralValueTypeKind::Bool(_)
-                            ) =>
-                        {
-                            true
+                    let probably_meant_literal = argument_elements.all(|ty| {
+                        match {
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        } {
+                            (_, crate::types::TypeData::LiteralValue(literal))
+                                if matches!(
+                                    literal.kind(),
+                                    LiteralValueTypeKind::String(_)
+                                        | LiteralValueTypeKind::Bytes(_)
+                                        | LiteralValueTypeKind::Enum(_)
+                                        | LiteralValueTypeKind::Bool(_)
+                                ) =>
+                            {
+                                true
+                            }
+                            (_, crate::types::TypeData::NominalInstance(instance)) => {
+                                instance.has_known_class(db, KnownClass::NoneType)
+                            }
+                            (_, _) => false,
                         }
-                        Type::NominalInstance(instance) => {
-                            instance.has_known_class(db, KnownClass::NoneType)
-                        }
-                        _ => false,
                     });
 
                     if probably_meant_literal {
@@ -2462,7 +2516,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let ty = match parameters {
             ast::Expr::Subscript(ast::ExprSubscript { value, slice, .. }) => {
                 let value_ty = self.infer_expression(value, TypeContext::default());
-                if matches!(value_ty, Type::SpecialForm(SpecialFormType::Literal)) {
+                if matches!(
+                    {
+                        let __ty_view_value = value_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(SpecialFormType::Literal)
+                    )
+                ) {
                     let ty = self.infer_literal_parameter_type(slice)?;
 
                     // This branch deals with annotations such as `Literal[Literal[1]]`.
@@ -2530,32 +2593,42 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // enum members and aliases to literal types
             ast::Expr::Name(_) | ast::Expr::Attribute(_) => {
                 let subscript_ty = self.infer_expression(parameters, TypeContext::default());
-                match subscript_ty {
+                match {
+                    let __ty_view_value = subscript_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     // type aliases to literal types
-                    Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
+                    (
+                        _,
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                            type_alias,
+                        )),
+                    ) => {
                         let value_ty = type_alias.value_type(self.db());
                         if value_ty.is_literal_or_union_of_literals(self.db()) {
                             return Ok(value_ty);
                         }
                     }
-                    Type::KnownInstance(KnownInstanceType::Literal(ty)) => {
+                    (_, crate::types::TypeData::KnownInstance(KnownInstanceType::Literal(ty))) => {
                         return Ok(ty.inner(self.db()));
                     }
                     // `Literal[SomeEnum.Member]`
-                    Type::LiteralValue(literal) if literal.is_enum() => {
+                    (_, crate::types::TypeData::LiteralValue(literal)) if literal.is_enum() => {
                         // Avoid promoting values originating from an explicitly annotated literal type.
                         return Ok(Type::LiteralValue(literal.to_unpromotable()));
                     }
                     // `Literal[SingletonEnum.Member]`, where `SingletonEnum.Member` simplifies to
                     // just `SingletonEnum`.
-                    Type::NominalInstance(_) if subscript_ty.is_enum(self.db()) => {
+                    (_, crate::types::TypeData::NominalInstance(_))
+                        if subscript_ty.is_enum(self.db()) =>
+                    {
                         return Ok(subscript_ty);
                     }
                     // suppress false positives for e.g. members of functional-syntax enums
-                    Type::Dynamic(DynamicType::Todo(_)) => {
+                    (_, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => {
                         return Ok(subscript_ty);
                     }
-                    _ => {}
+                    (_, _) => {}
                 }
                 return Err(vec![parameters]);
             }
@@ -2567,12 +2640,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        Ok(if let Type::LiteralValue(literal) = ty {
-            // Avoid promoting values originating from an explicitly annotated literal type.
-            Type::LiteralValue(literal.to_unpromotable())
-        } else {
-            ty
-        })
+        Ok(
+            if let (_, crate::types::TypeData::LiteralValue(literal)) = {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                // Avoid promoting values originating from an explicitly annotated literal type.
+                Type::LiteralValue(literal.to_unpromotable())
+            } else {
+                ty
+            },
+        )
     }
 
     /// Infer the first argument to a `typing.Callable` type expression and returns the
@@ -2633,7 +2711,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Subscript(subscript) => {
                 let value_ty = self.infer_expression(&subscript.value, TypeContext::default());
 
-                if matches!(value_ty, Type::SpecialForm(SpecialFormType::Concatenate)) {
+                if matches!(
+                    {
+                        let __ty_view_value = value_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(SpecialFormType::Concatenate)
+                    )
+                ) {
                     return Some(self.infer_concatenate_special_form(subscript));
                 }
 
@@ -2661,8 +2748,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
-                if let Type::TypeVar(tvar) = parameters_type
-                    && tvar.is_paramspec(self.db())
+                if let (_, crate::types::TypeData::TypeVar(tvar)) = ({
+                    let __ty_view_value = parameters_type;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && tvar.is_paramspec(self.db())
                 {
                     return Some(Parameters::paramspec(self.db(), tvar));
                 }
@@ -2803,7 +2892,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     InferenceFlags::ALLOW_PARAMSPEC_TYPE_EXPR,
                     previously_allowed_paramspec,
                 );
-                let Type::TypeVar(typevar) = expr_type else {
+                let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                    let __ty_view_value = expr_type;
+                    (__ty_view_value, __ty_view_value.data())
+                }) else {
                     // `Concatenate` *is* allowed inside `Concatenate`, so avoid emitting here a diagnostic
                     // saying that the argument is invalid if the inner type is an invalid use of the
                     // `Concatenate` special form (we'll already have complained about the invalid use
@@ -2873,7 +2965,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         {
             return ty;
         }
-        if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty {
+        if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             if let Some(builder) = self.context.report_lint(&UNBOUND_TYPE_VARIABLE, expression) {
                 builder.into_diagnostic(format_args!(
                     "Type variable `{name}` is not bound to any outer generic context",

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -18,33 +18,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         expression: &ast::Expr,
         target: Type<'db>,
     ) -> Option<Type<'db>> {
-        let non_type_form_fallback = match {
-            let __ty_view_value = target.resolve_type_alias(self.db());
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeForm(_)) => None,
-            (_, crate::types::TypeData::Union(union))
+        let non_type_form_fallback = match target.resolve_type_alias(self.db()).data() {
+            crate::types::TypeData::TypeForm(_) => None,
+            crate::types::TypeData::Union(union)
                 if union.elements(self.db()).iter().any(|element| {
                     matches!(
-                        {
-                            let __ty_view_value = element.resolve_type_alias(self.db());
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (_, crate::types::TypeData::TypeForm(_))
+                        element.resolve_type_alias(self.db()).data(),
+                        crate::types::TypeData::TypeForm(_)
                     )
                 }) =>
             {
                 Some(target.filter_union(self.db(), |element| {
                     !matches!(
-                        {
-                            let __ty_view_value = element.resolve_type_alias(self.db());
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (_, crate::types::TypeData::TypeForm(_))
+                        element.resolve_type_alias(self.db()).data(),
+                        crate::types::TypeData::TypeForm(_)
                     )
                 }))
             }
-            (_, _) => return None,
+            _ => return None,
         };
 
         // Suppress contextual `TypeForm` evaluation only if ordinary inference already
@@ -53,11 +44,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .speculate()
             .infer_maybe_standalone_expression(expression, TypeContext::default());
         if matches!(
-            {
-                let __ty_view_value = value_ty.resolve_type_alias(self.db());
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::Never)
+            value_ty.resolve_type_alias(self.db()).data(),
+            crate::types::TypeData::Never
         ) || self.contains_type_form_value(expression, value_ty)
             || non_type_form_fallback
                 .is_some_and(|alternative| value_ty.is_assignable_to(self.db(), alternative))
@@ -102,37 +90,31 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ty: Type<'db>,
             visitor: &ContainsTypeFormValueVisitor<'db>,
         ) -> bool {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (
-                    _,
-                    crate::types::TypeData::TypeForm(_) | crate::types::TypeData::SubclassOf(_),
-                ) => true,
+            match ty.data() {
+                crate::types::TypeData::TypeForm(_) | crate::types::TypeData::SubclassOf(_) => true,
                 // A bare class object is valid type-expression syntax and should still be
                 // interpreted as a `TypeForm`. Preserve its ordinary value type only when
                 // it was produced by an expression that is not itself a type expression.
-                (_, crate::types::TypeData::ClassLiteral(_)) => builder
+                crate::types::TypeData::ClassLiteral(_) => builder
                     .speculate()
                     .infer_type_expression_no_store(expression)
                     .is_unknown(),
-                (_, crate::types::TypeData::NominalInstance(instance))
+                crate::types::TypeData::NominalInstance(instance)
                     if instance.has_known_class(builder.db(), KnownClass::Type) =>
                 {
                     true
                 }
-                (_, crate::types::TypeData::Union(union)) => union
+                crate::types::TypeData::Union(union) => union
                     .elements(builder.db())
                     .iter()
                     .any(|element| imp(builder, expression, *element, visitor)),
-                (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                crate::types::TypeData::Intersection(intersection) => intersection
                     .iter_positive(builder.db())
                     .any(|element| imp(builder, expression, element, visitor)),
-                (_, crate::types::TypeData::TypeAlias(alias)) => visitor.visit(ty, || {
+                crate::types::TypeData::TypeAlias(alias) => visitor.visit(ty, || {
                     imp(builder, expression, alias.value_type(builder.db()), visitor)
                 }),
-                (_, crate::types::TypeData::TypeVar(typevar)) => visitor.visit(ty, || {
+                crate::types::TypeData::TypeVar(typevar) => visitor.visit(ty, || {
                     typevar
                         .typevar(builder.db())
                         .bound_or_constraints(builder.db())
@@ -145,7 +127,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             )
                         })
                 }),
-                (_, _) => false,
+                _ => false,
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -18,18 +18,33 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         expression: &ast::Expr,
         target: Type<'db>,
     ) -> Option<Type<'db>> {
-        let non_type_form_fallback = match target.resolve_type_alias(self.db()) {
-            Type::TypeForm(_) => None,
-            Type::Union(union)
+        let non_type_form_fallback = match {
+            let __ty_view_value = target.resolve_type_alias(self.db());
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeForm(_)) => None,
+            (_, crate::types::TypeData::Union(union))
                 if union.elements(self.db()).iter().any(|element| {
-                    matches!(element.resolve_type_alias(self.db()), Type::TypeForm(_))
+                    matches!(
+                        {
+                            let __ty_view_value = element.resolve_type_alias(self.db());
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (_, crate::types::TypeData::TypeForm(_))
+                    )
                 }) =>
             {
                 Some(target.filter_union(self.db(), |element| {
-                    !matches!(element.resolve_type_alias(self.db()), Type::TypeForm(_))
+                    !matches!(
+                        {
+                            let __ty_view_value = element.resolve_type_alias(self.db());
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (_, crate::types::TypeData::TypeForm(_))
+                    )
                 }))
             }
-            _ => return None,
+            (_, _) => return None,
         };
 
         // Suppress contextual `TypeForm` evaluation only if ordinary inference already
@@ -37,8 +52,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let value_ty = self
             .speculate()
             .infer_maybe_standalone_expression(expression, TypeContext::default());
-        if matches!(value_ty.resolve_type_alias(self.db()), Type::Never)
-            || self.contains_type_form_value(expression, value_ty)
+        if matches!(
+            {
+                let __ty_view_value = value_ty.resolve_type_alias(self.db());
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::Never)
+        ) || self.contains_type_form_value(expression, value_ty)
             || non_type_form_fallback
                 .is_some_and(|alternative| value_ty.is_assignable_to(self.db(), alternative))
         {
@@ -82,31 +102,37 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ty: Type<'db>,
             visitor: &ContainsTypeFormValueVisitor<'db>,
         ) -> bool {
-            match ty {
-                Type::TypeForm(_) | Type::SubclassOf(_) => true,
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (
+                    _,
+                    crate::types::TypeData::TypeForm(_) | crate::types::TypeData::SubclassOf(_),
+                ) => true,
                 // A bare class object is valid type-expression syntax and should still be
                 // interpreted as a `TypeForm`. Preserve its ordinary value type only when
                 // it was produced by an expression that is not itself a type expression.
-                Type::ClassLiteral(_) => builder
+                (_, crate::types::TypeData::ClassLiteral(_)) => builder
                     .speculate()
                     .infer_type_expression_no_store(expression)
                     .is_unknown(),
-                Type::NominalInstance(instance)
+                (_, crate::types::TypeData::NominalInstance(instance))
                     if instance.has_known_class(builder.db(), KnownClass::Type) =>
                 {
                     true
                 }
-                Type::Union(union) => union
+                (_, crate::types::TypeData::Union(union)) => union
                     .elements(builder.db())
                     .iter()
                     .any(|element| imp(builder, expression, *element, visitor)),
-                Type::Intersection(intersection) => intersection
+                (_, crate::types::TypeData::Intersection(intersection)) => intersection
                     .iter_positive(builder.db())
                     .any(|element| imp(builder, expression, element, visitor)),
-                Type::TypeAlias(alias) => visitor.visit(ty, || {
+                (_, crate::types::TypeData::TypeAlias(alias)) => visitor.visit(ty, || {
                     imp(builder, expression, alias.value_type(builder.db()), visitor)
                 }),
-                Type::TypeVar(typevar) => visitor.visit(ty, || {
+                (_, crate::types::TypeData::TypeVar(typevar)) => visitor.visit(ty, || {
                     typevar
                         .typevar(builder.db())
                         .bound_or_constraints(builder.db())
@@ -119,7 +145,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             )
                         })
                 }),
-                _ => false,
+                (_, _) => false,
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -181,10 +181,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // follow the same compatibility rules:
         // - `Type::KnownInstance(TypeVar(..))` for legacy `typing.TypeVar(...)` values
         // - `Type::TypeVar(..)` for bound in-scope type parameters (for example, PEP 695)
-        let default_typevar = match default_ty {
-            Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => Some(typevar),
-            Type::TypeVar(bound_typevar) => Some(bound_typevar.typevar(db)),
-            _ => None,
+        let default_typevar = match {
+            let __ty_view_value = default_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) => {
+                Some(typevar)
+            }
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => Some(bound_typevar.typevar(db)),
+            (_, _) => None,
         };
 
         let not_assignable_message =
@@ -487,8 +492,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let expected_binding = BindingContext::Definition(expected_binding_def);
 
         let outer_tv = find_over_type(db, default_ty, false, |ty| {
-            if let Type::TypeVar(bound_tv) = ty
-                && bound_tv.binding_context(db) != expected_binding
+            if let (_, crate::types::TypeData::TypeVar(bound_tv)) = ({
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) && bound_tv.binding_context(db) != expected_binding
             {
                 Some(bound_tv)
             } else {
@@ -634,12 +641,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     return;
                 }
-                let is_paramspec = match ty {
-                    Type::TypeVar(typevar) => typevar.is_paramspec(db),
-                    Type::KnownInstance(known_instance) => {
+                let is_paramspec = match {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::TypeVar(typevar)) => typevar.is_paramspec(db),
+                    (_, crate::types::TypeData::KnownInstance(known_instance)) => {
                         known_instance.class(db) == KnownClass::ParamSpec
                     }
-                    _ => false,
+                    (_, _) => false,
                 };
                 if is_paramspec {
                     return;

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -181,15 +181,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // follow the same compatibility rules:
         // - `Type::KnownInstance(TypeVar(..))` for legacy `typing.TypeVar(...)` values
         // - `Type::TypeVar(..)` for bound in-scope type parameters (for example, PEP 695)
-        let default_typevar = match {
-            let __ty_view_value = default_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) => {
+        let default_typevar = match default_ty.data() {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
                 Some(typevar)
             }
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => Some(bound_typevar.typevar(db)),
-            (_, _) => None,
+            crate::types::TypeData::TypeVar(bound_typevar) => Some(bound_typevar.typevar(db)),
+            _ => None,
         };
 
         let not_assignable_message =
@@ -492,10 +489,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let expected_binding = BindingContext::Definition(expected_binding_def);
 
         let outer_tv = find_over_type(db, default_ty, false, |ty| {
-            if let (_, crate::types::TypeData::TypeVar(bound_tv)) = ({
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) && bound_tv.binding_context(db) != expected_binding
+            if let crate::types::TypeData::TypeVar(bound_tv) = ty.data()
+                && bound_tv.binding_context(db) != expected_binding
             {
                 Some(bound_tv)
             } else {
@@ -641,15 +636,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     return;
                 }
-                let is_paramspec = match {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::TypeVar(typevar)) => typevar.is_paramspec(db),
-                    (_, crate::types::TypeData::KnownInstance(known_instance)) => {
+                let is_paramspec = match ty.data() {
+                    crate::types::TypeData::TypeVar(typevar) => typevar.is_paramspec(db),
+                    crate::types::TypeData::KnownInstance(known_instance) => {
                         known_instance.class(db) == KnownClass::ParamSpec
                     }
-                    (_, _) => false,
+                    _ => false,
                 };
                 if is_paramspec {
                     return;

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -169,7 +169,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let comparison_result = match (({ let __ty_view_value = left; (__ty_view_value, __ty_view_value.data()) }), ({ let __ty_view_value = right; (__ty_view_value, __ty_view_value.data()) })) {
+    let comparison_result = match (left.view(), right.view()) {
         ((_, crate::types::TypeData::EnumComplement(complement)), (right, _)) => Some(infer_binary_type_comparison(
             context,
             complement.remaining_literal_union(db),
@@ -619,7 +619,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                             )
                             .expect("infer_binary_type_comparison should never return None for `CmpOp::Eq`");
 
-                            match { let __ty_view_value = eq_result; (__ty_view_value, __ty_view_value.data()) }  {
+                            match eq_result.view()  {
                                 (todo, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => return Ok(todo),
                                 // It's okay to ignore errors here because Python doesn't call `__bool__`
                                 // for different union variants. Instead, this is just for us to
@@ -648,7 +648,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                                 "infer_binary_type_comparison should never return None for `CmpOp::Eq`",
                             );
 
-                        Ok(match { let __ty_view_value = eq_result; (__ty_view_value, __ty_view_value.data()) }  {
+                        Ok(match eq_result.view()  {
                             (todo, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => todo,
                             // It's okay to ignore errors here because Python doesn't call `__bool__`
                             // for `is` and `is not` comparisons. This is an implementation detail
@@ -933,11 +933,8 @@ fn infer_membership_test_comparison<'db>(
     compare_result_opt
         .map(|ty| {
             if matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::Dynamic(DynamicType::Todo(_)))
+                ty.data(),
+                crate::types::TypeData::Dynamic(DynamicType::Todo(_))
             ) {
                 return ty;
             }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -169,8 +169,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let comparison_result = match (left, right) {
-        (Type::EnumComplement(complement), right) => Some(infer_binary_type_comparison(
+    let comparison_result = match (({ let __ty_view_value = left; (__ty_view_value, __ty_view_value.data()) }), ({ let __ty_view_value = right; (__ty_view_value, __ty_view_value.data()) })) {
+        ((_, crate::types::TypeData::EnumComplement(complement)), (right, _)) => Some(infer_binary_type_comparison(
             context,
             complement.remaining_literal_union(db),
             op,
@@ -178,7 +178,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             range,
             visitor,
         )),
-        (left, Type::EnumComplement(complement)) => Some(infer_binary_type_comparison(
+        ((left, _), (_, crate::types::TypeData::EnumComplement(complement))) => Some(infer_binary_type_comparison(
             context,
             left,
             op,
@@ -187,7 +187,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             visitor,
         )),
 
-        (Type::Union(union), other) => {
+        ((_, crate::types::TypeData::Union(union)), (other, _)) => {
             let mut builder = UnionBuilder::new(db);
             for element in union.elements(db) {
                 builder = builder.add(infer_binary_type_comparison(
@@ -196,7 +196,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
             Some(Ok(builder.build()))
         }
-        (other, Type::Union(union)) => {
+        ((other, _), (_, crate::types::TypeData::Union(union))) => {
             let mut builder = UnionBuilder::new(db);
             for element in union.elements(db) {
                 builder = builder.add(infer_binary_type_comparison(
@@ -206,7 +206,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             Some(Ok(builder.build()))
         }
 
-        (Type::Intersection(intersection), right)
+        ((_, crate::types::TypeData::Intersection(intersection)), (right, _))
             if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
         {
             Some(infer_binary_type_comparison(
@@ -218,7 +218,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 visitor
             ))
         }
-        (left, Type::Intersection(intersection))
+        ((left, _), (_, crate::types::TypeData::Intersection(intersection)))
             if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
         {
             Some(infer_binary_type_comparison(
@@ -231,7 +231,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             ))
         }
 
-        (Type::Intersection(intersection), right) => {
+        ((_, crate::types::TypeData::Intersection(intersection)), (right, _)) => {
             Some(
                 infer_binary_intersection_type_comparison(
                     context,
@@ -249,7 +249,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 }),
             )
         }
-        (left, Type::Intersection(intersection)) => {
+        ((left, _), (_, crate::types::TypeData::Intersection(intersection))) => {
             Some(
                 infer_binary_intersection_type_comparison(
                     context,
@@ -268,11 +268,11 @@ pub(super) fn infer_binary_type_comparison<'db>(
             )
         }
 
-        (Type::TypeAlias(alias), right) => Some(visitor.visit((left, op, right), || {
+        ((_, crate::types::TypeData::TypeAlias(alias)), (right, _)) => Some(visitor.visit((left, op, right), || {
             infer_binary_type_comparison(context, alias.value_type(db), op, right, range, visitor)
         })),
 
-        (left, Type::TypeAlias(alias)) => Some(visitor.visit((left, op, right), || {
+        ((left, _), (_, crate::types::TypeData::TypeAlias(alias))) => Some(visitor.visit((left, op, right), || {
             infer_binary_type_comparison(context, left, op, alias.value_type(db), range, visitor)
         })),
 
@@ -282,7 +282,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         // the same `int | float` and `int | float | complex` special treatment that the
         // positional arguments get. In those cases we need to explicitly delegate to the base
         // type, so that it hits the `Type::Union` branches above.
-        (Type::NewTypeInstance(newtype), right) => Some(
+        ((_, crate::types::TypeData::NewTypeInstance(newtype)), (right, _)) => Some(
             try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                 visitor.visit((left, op, right), || {
                     infer_binary_type_comparison(
@@ -296,7 +296,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 })
             }),
         ),
-        (left, Type::NewTypeInstance(newtype)) => Some(
+        ((left, _), (_, crate::types::TypeData::NewTypeInstance(newtype))) => Some(
             try_dunder(MemberLookupPolicy::default()).or_else(|_| {
                 visitor.visit((left, op, right), || {
                     infer_binary_type_comparison(
@@ -316,7 +316,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         //
         // When both operands are the same bounded TypeVar, we check the comparison on the bound
         // type paired with itself.
-        (Type::TypeVar(left_tvar), Type::TypeVar(right_tvar))
+        ((_, crate::types::TypeData::TypeVar(left_tvar)), (_, crate::types::TypeData::TypeVar(right_tvar)))
             if left_tvar.identity(db) == right_tvar.identity(db) =>
         {
             match left_tvar.typevar(db).bound_or_constraints(db) {
@@ -344,7 +344,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
         // When the left operand is a bounded TypeVar and the right is not a TypeVar,
         // delegate to the bound type.
-        (Type::TypeVar(left_tvar), right) if !right.is_type_var() => {
+        ((_, crate::types::TypeData::TypeVar(left_tvar)), (right, _)) if !right.is_type_var() => {
             match left_tvar.typevar(db).bound_or_constraints(db) {
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Some(
                     try_dunder(MemberLookupPolicy::default()).or_else(|_| {
@@ -369,7 +369,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
         // When the right operand is a bounded TypeVar and the left is not a TypeVar,
         // delegate to the bound type.
-        (left, Type::TypeVar(right_tvar)) if !left.is_type_var() => {
+        ((left, _), (_, crate::types::TypeData::TypeVar(right_tvar))) if !left.is_type_var() => {
             match right_tvar.typevar(db).bound_or_constraints(db) {
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => Some(
                     try_dunder(MemberLookupPolicy::default()).or_else(|_| {
@@ -393,7 +393,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
         }
 
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
+        ((_, crate::types::TypeData::LiteralValue(left_literal)), (_, crate::types::TypeData::LiteralValue(right_literal))) => {
             match (left_literal.kind(), right_literal.kind()) {
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
                     Some(match op {
@@ -570,8 +570,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
 
         (
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(left))),
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::ConstraintSet(right))),
         ) => {
             let constraints = ConstraintSetBuilder::new();
             let left = constraints.load(db, left.constraints(db));
@@ -585,7 +585,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
         }
 
-        (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2)) => nominal1
+        ((_, crate::types::TypeData::NominalInstance(nominal1)), (_, crate::types::TypeData::NominalInstance(nominal2))) => nominal1
             .tuple_spec(db)
             .and_then(|lhs_tuple| Some((lhs_tuple, nominal2.tuple_spec(db)?)))
             .map(|(lhs_tuple, rhs_tuple)| {
@@ -619,12 +619,12 @@ pub(super) fn infer_binary_type_comparison<'db>(
                             )
                             .expect("infer_binary_type_comparison should never return None for `CmpOp::Eq`");
 
-                            match eq_result {
-                                todo @ Type::Dynamic(DynamicType::Todo(_)) => return Ok(todo),
+                            match { let __ty_view_value = eq_result; (__ty_view_value, __ty_view_value.data()) }  {
+                                (todo, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => return Ok(todo),
                                 // It's okay to ignore errors here because Python doesn't call `__bool__`
                                 // for different union variants. Instead, this is just for us to
                                 // evaluate a possibly truthy value to `false` or `true`.
-                                ty => match ty.bool(db) {
+                                (ty, _) => match ty.bool(db) {
                                     Truthiness::AlwaysTrue => any_eq = true,
                                     Truthiness::AlwaysFalse => (),
                                     Truthiness::Ambiguous => any_ambiguous = true,
@@ -648,12 +648,12 @@ pub(super) fn infer_binary_type_comparison<'db>(
                                 "infer_binary_type_comparison should never return None for `CmpOp::Eq`",
                             );
 
-                        Ok(match eq_result {
-                            todo @ Type::Dynamic(DynamicType::Todo(_)) => todo,
+                        Ok(match { let __ty_view_value = eq_result; (__ty_view_value, __ty_view_value.data()) }  {
+                            (todo, crate::types::TypeData::Dynamic(DynamicType::Todo(_))) => todo,
                             // It's okay to ignore errors here because Python doesn't call `__bool__`
                             // for `is` and `is not` comparisons. This is an implementation detail
                             // for how we determine the truthiness of a type.
-                            ty => match ty.bool(db) {
+                            (ty, _) => match ty.bool(db) {
                                 Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
                                 _ => KnownClass::Bool.to_instance(db),
                             },
@@ -932,7 +932,13 @@ fn infer_membership_test_comparison<'db>(
 
     compare_result_opt
         .map(|ty| {
-            if matches!(ty, Type::Dynamic(DynamicType::Todo(_))) {
+            if matches!(
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::Dynamic(DynamicType::Todo(_)))
+            ) {
                 return ty;
             }
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -237,7 +237,10 @@ fn pep695_type_params() {
         let name_ty = var_ty.member(&db, "__name__").place.expect_type();
         assert_eq!(name_ty.display(&db).to_string(), expected_name_ty);
 
-        let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = var_ty else {
+        let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
+            let __ty_view_value = var_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             panic!("expected TypeVar");
         };
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -237,10 +237,9 @@ fn pep695_type_params() {
         let name_ty = var_ty.member(&db, "__name__").place.expect_type();
         assert_eq!(name_ty.display(&db).to_string(), expected_name_ty);
 
-        let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) = ({
-            let __ty_view_value = var_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) =
+            var_ty.data()
+        else {
             panic!("expected TypeVar");
         };
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -9,7 +9,7 @@ use ty_module_resolver::{ModuleName, file_to_module};
 use super::protocol_class::ProtocolInterface;
 use super::{
     BoundTypeVarInstance, ClassType, DivergentType, KnownClass, MaterializationKind,
-    SubclassOfType, Type, TypeVarVariance,
+    SubclassOfType, Type, TypeTag, TypeVarVariance,
 };
 use crate::place::PlaceAndQualifiers;
 use crate::types::constraints::{
@@ -128,24 +128,17 @@ impl<'db> Type<'db> {
     }
 
     pub(crate) fn is_nominal_instance(self) -> bool {
-        matches!((self).data(), crate::types::TypeData::NominalInstance(_))
+        self.tag == TypeTag::NominalInstance
     }
 
     pub(crate) fn as_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
-        match (self).data() {
-            crate::types::TypeData::NominalInstance(instance_type) => Some(instance_type),
-            _ => None,
-        }
+        (self.tag == TypeTag::NominalInstance).then(|| self.nominal_instance())
     }
 
     /// Return `true` if `self` is a nominal instance of the given known class.
     pub(crate) fn is_instance_of(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
-        match (self).data() {
-            crate::types::TypeData::NominalInstance(instance) => {
-                instance.class(db).is_known(db, known_class)
-            }
-            _ => false,
-        }
+        self.as_nominal_instance()
+            .is_some_and(|instance| instance.class(db).is_known(db, known_class))
     }
 
     /// Synthesize a protocol instance type with a given set of read-only property members.

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -34,18 +34,19 @@ pub(super) use synthesized_protocol::SynthesizedProtocolType;
 use ty_python_core::definition::Definition;
 
 impl<'db> Type<'db> {
-    pub(crate) const fn object() -> Self {
+    pub(crate) fn object() -> Self {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::Object))
     }
 
-    pub(crate) const fn is_object(&self) -> bool {
+    pub(crate) fn is_object(&self) -> bool {
         matches!(
-            self,
-            Type::NominalInstance(NominalInstanceType(NominalInstanceInner::Object))
-                | Type::Divergent(DivergentType {
-                    materialization: Some(MaterializationKind::Top),
-                    ..
-                })
+            (self).data(),
+            crate::types::TypeData::NominalInstance(NominalInstanceType(
+                NominalInstanceInner::Object
+            )) | crate::types::TypeData::Divergent(DivergentType {
+                materialization: Some(MaterializationKind::Top),
+                ..
+            })
         )
     }
 
@@ -119,28 +120,30 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
-    pub(crate) const fn sys_version_info() -> Self {
+    pub(crate) fn sys_version_info() -> Self {
         // Keep construction query-free: resolving the backing typeshed class here is on the hot
         // path for projects with many version guards. Resolve it lazily when class behavior is
         // actually needed instead.
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo))
     }
 
-    pub(crate) const fn is_nominal_instance(self) -> bool {
-        matches!(self, Type::NominalInstance(_))
+    pub(crate) fn is_nominal_instance(self) -> bool {
+        matches!((self).data(), crate::types::TypeData::NominalInstance(_))
     }
 
-    pub(crate) const fn as_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
-        match self {
-            Type::NominalInstance(instance_type) => Some(instance_type),
+    pub(crate) fn as_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
+        match (self).data() {
+            crate::types::TypeData::NominalInstance(instance_type) => Some(instance_type),
             _ => None,
         }
     }
 
     /// Return `true` if `self` is a nominal instance of the given known class.
     pub(crate) fn is_instance_of(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
-        match self {
-            Type::NominalInstance(instance) => instance.class(db).is_known(db, known_class),
+        match (self).data() {
+            crate::types::TypeData::NominalInstance(instance) => {
+                instance.class(db).is_known(db, known_class)
+            }
             _ => false,
         }
     }
@@ -171,7 +174,7 @@ impl<'db> Type<'db> {
 pub struct NominalInstanceType<'db>(
     // Keep this field private, so that the only way of constructing `NominalInstanceType` instances
     // is through the `Type::instance` constructor function.
-    NominalInstanceInner<'db>,
+    pub(super) NominalInstanceInner<'db>,
 );
 
 pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
@@ -346,13 +349,13 @@ impl<'db> NominalInstanceType<'db> {
             return None;
         };
 
-        let to_u32 = |ty: &Type<'db>| match ty {
-            Type::LiteralValue(literal) => match literal.kind() {
+        let to_u32 = |ty: &Type<'db>| match (ty).data() {
+            crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(n) => i32::try_from(n.as_i64()).map(Some).ok(),
                 LiteralValueTypeKind::Bool(b) => Some(Some(i32::from(b))),
                 _ => None,
             },
-            Type::NominalInstance(instance)
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::NoneType) =>
             {
                 Some(None)
@@ -526,22 +529,23 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return result;
         }
 
-        let structurally_satisfied = if let Type::ProtocolInstance(source_protocol) = ty {
-            self.check_protocol_interface_pair(
-                db,
-                ty,
-                source_protocol.interface(db),
-                protocol.interface(db),
-            )
-        } else {
-            protocol
-                .inner
-                .interface(db)
-                .members(db)
-                .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member)
-                })
-        };
+        let structurally_satisfied =
+            if let crate::types::TypeData::ProtocolInstance(source_protocol) = (ty).data() {
+                self.check_protocol_interface_pair(
+                    db,
+                    ty,
+                    source_protocol.interface(db),
+                    protocol.interface(db),
+                )
+            } else {
+                protocol
+                    .inner
+                    .interface(db)
+                    .members(db)
+                    .when_all(db, self.constraints, |member| {
+                        self.type_satisfies_protocol_member(db, ty, &member)
+                    })
+            };
         if structurally_satisfied.is_never_satisfied(db) {
             self.provide_context(|| ErrorContext::TypeNotCompatibleWithProtocol {
                 ty,
@@ -619,7 +623,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 /// optimization to avoid having to materialize the [`ClassType`] for tuple
 /// instances where it would be unnecessary (this is somewhat expensive!).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
-enum NominalInstanceInner<'db> {
+pub(super) enum NominalInstanceInner<'db> {
     /// An instance of `object`.
     ///
     /// We model it with a dedicated enum variant since its use as "the type of all values" is so
@@ -693,6 +697,17 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
 }
 
 impl<'db> ProtocolInstanceType<'db> {
+    pub(super) const fn packed_inner(self) -> Protocol<'db> {
+        self.inner
+    }
+
+    pub(super) const fn from_packed_inner(inner: Protocol<'db>) -> Self {
+        Self {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
     // instances is through the `Type::instance` constructor function.
     fn from_class(class: ProtocolClass<'db>) -> Self {

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -104,15 +104,15 @@ impl<'db> Type<'db> {
             // or bytes literals, and creating long heterogeneous tuple specs has a performance cost.
             const MAX_TUPLE_LENGTH: usize = 128;
 
-            match ty {
-                Type::NominalInstance(nominal) => nominal.tuple_spec(db),
-                Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
-                Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
+            match { let __ty_view_value = ty; (__ty_view_value, __ty_view_value.data()) }  {
+                (_, crate::types::TypeData::NominalInstance(nominal)) => nominal.tuple_spec(db),
+                (_, crate::types::TypeData::NewTypeInstance(newtype)) => non_async_special_case(db, newtype.concrete_base_type(db)),
+                (_, crate::types::TypeData::GenericAlias(alias)) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
                         "*tuple[] annotations"
                     ))))
                 }
-                Type::LiteralValue(literal) => match literal.kind() {
+                (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
                     LiteralValueTypeKind::Bytes(bytes) => {
                         let bytes_literal = bytes.value(db);
                         let spec = if bytes_literal.len() < MAX_TUPLE_LENGTH {
@@ -145,7 +145,7 @@ impl<'db> Type<'db> {
                     }
                     _ => None
                 }
-                Type::Never => {
+                (_, crate::types::TypeData::Never) => {
                     // The dunder logic below would have us return `tuple[Never, ...]`, which eagerly
                     // simplifies to `tuple[()]`. That will will cause us to emit false positives if we
                     // index into the tuple. Using `tuple[Unknown, ...]` avoids these false positives.
@@ -153,16 +153,16 @@ impl<'db> Type<'db> {
                     // diagnostic in unreachable code.
                     Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
                 }
-                Type::TypeAlias(alias) => {
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
                     non_async_special_case(db, alias.value_type(db))
                 }
-                Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db)? {
+                (_, crate::types::TypeData::TypeVar(tvar)) => match tvar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
                         non_async_special_case(db, bound)
                     }
                     TypeVarBoundOrConstraints::Constraints(constraints) => non_async_special_case(db, constraints.as_type(db)),
                 },
-                Type::Union(union) => {
+                (_, crate::types::TypeData::Union(union)) => {
                     let elements = union.elements(db);
                     if elements.len() < MAX_TUPLE_LENGTH {
                         let mut elements_iter = elements.iter();
@@ -176,7 +176,7 @@ impl<'db> Type<'db> {
                         None
                     }
                 }
-                Type::Intersection(intersection) => {
+                (_, crate::types::TypeData::Intersection(intersection)) => {
                     // For intersections containing TypeVars with union bounds, we need to
                     // flatten the TypeVars first. This distributes the intersection over
                     // the union and simplifies, e.g.:
@@ -214,44 +214,47 @@ impl<'db> Type<'db> {
                     // Flattening changed the type; recursively iterate the flattened result.
                     flattened.try_iterate(db).ok()
                 }
-                Type::EnumComplement(complement) => {
+                (_, crate::types::TypeData::EnumComplement(complement)) => {
                     non_async_special_case(db, complement.remaining_literal_union(db))
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
-                Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
-                Type::Divergent(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
+                (_, crate::types::TypeData::Dynamic(_)) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
+                (_, crate::types::TypeData::Divergent(_)) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
 
-                Type::FunctionLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::BoundMethod(_)
-                | Type::KnownBoundMethod(_)
-                | Type::WrapperDescriptor(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::Callable(_)
-                | Type::ModuleLiteral(_)
+                (_, crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::GenericAlias(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::ModuleLiteral(_)
                 // We could infer a precise tuple spec for enum classes with members,
                 // but it's not clear whether that's worth the added complexity:
                 // you'd have to check that `EnumMeta.__iter__` is not overridden for it to be sound
                 // (enums can have `EnumMeta` subclasses as their metaclasses).
-                | Type::ClassLiteral(_)
-                | Type::SubclassOf(_)
-                | Type::ProtocolInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::AlwaysTruthy
-                | Type::AlwaysFalsy
-                | Type::BoundSuper(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_) => None
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::SubclassOf(_)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)) => None
             }
         }
 
         if mode.is_async() {
-            if let Type::Intersection(_) = self {
+            if let (_, crate::types::TypeData::Intersection(_)) = {
+                let __ty_view_value = self;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 let flattened = self.flatten_typevars(db);
                 if flattened != self {
                     return flattened.try_iterate_with_mode(db, mode);

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -104,15 +104,15 @@ impl<'db> Type<'db> {
             // or bytes literals, and creating long heterogeneous tuple specs has a performance cost.
             const MAX_TUPLE_LENGTH: usize = 128;
 
-            match { let __ty_view_value = ty; (__ty_view_value, __ty_view_value.data()) }  {
-                (_, crate::types::TypeData::NominalInstance(nominal)) => nominal.tuple_spec(db),
-                (_, crate::types::TypeData::NewTypeInstance(newtype)) => non_async_special_case(db, newtype.concrete_base_type(db)),
-                (_, crate::types::TypeData::GenericAlias(alias)) if alias.origin(db).is_tuple(db) => {
+            match ty.data()  {
+                crate::types::TypeData::NominalInstance(nominal) => nominal.tuple_spec(db),
+                crate::types::TypeData::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
+                crate::types::TypeData::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
                         "*tuple[] annotations"
                     ))))
                 }
-                (_, crate::types::TypeData::LiteralValue(literal)) => match literal.kind() {
+                crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
                     LiteralValueTypeKind::Bytes(bytes) => {
                         let bytes_literal = bytes.value(db);
                         let spec = if bytes_literal.len() < MAX_TUPLE_LENGTH {
@@ -145,7 +145,7 @@ impl<'db> Type<'db> {
                     }
                     _ => None
                 }
-                (_, crate::types::TypeData::Never) => {
+                crate::types::TypeData::Never => {
                     // The dunder logic below would have us return `tuple[Never, ...]`, which eagerly
                     // simplifies to `tuple[()]`. That will will cause us to emit false positives if we
                     // index into the tuple. Using `tuple[Unknown, ...]` avoids these false positives.
@@ -153,16 +153,16 @@ impl<'db> Type<'db> {
                     // diagnostic in unreachable code.
                     Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
                 }
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                crate::types::TypeData::TypeAlias(alias) => {
                     non_async_special_case(db, alias.value_type(db))
                 }
-                (_, crate::types::TypeData::TypeVar(tvar)) => match tvar.typevar(db).bound_or_constraints(db)? {
+                crate::types::TypeData::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
                         non_async_special_case(db, bound)
                     }
                     TypeVarBoundOrConstraints::Constraints(constraints) => non_async_special_case(db, constraints.as_type(db)),
                 },
-                (_, crate::types::TypeData::Union(union)) => {
+                crate::types::TypeData::Union(union) => {
                     let elements = union.elements(db);
                     if elements.len() < MAX_TUPLE_LENGTH {
                         let mut elements_iter = elements.iter();
@@ -176,7 +176,7 @@ impl<'db> Type<'db> {
                         None
                     }
                 }
-                (_, crate::types::TypeData::Intersection(intersection)) => {
+                crate::types::TypeData::Intersection(intersection) => {
                     // For intersections containing TypeVars with union bounds, we need to
                     // flatten the TypeVars first. This distributes the intersection over
                     // the union and simplifies, e.g.:
@@ -214,14 +214,14 @@ impl<'db> Type<'db> {
                     // Flattening changed the type; recursively iterate the flattened result.
                     flattened.try_iterate(db).ok()
                 }
-                (_, crate::types::TypeData::EnumComplement(complement)) => {
+                crate::types::TypeData::EnumComplement(complement) => {
                     non_async_special_case(db, complement.remaining_literal_union(db))
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
-                (_, crate::types::TypeData::Dynamic(_)) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
-                (_, crate::types::TypeData::Divergent(_)) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
+                crate::types::TypeData::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
+                crate::types::TypeData::Divergent(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
 
-                (_, crate::types::TypeData::FunctionLiteral(_)
+                crate::types::TypeData::FunctionLiteral(_)
                 | crate::types::TypeData::GenericAlias(_)
                 | crate::types::TypeData::BoundMethod(_)
                 | crate::types::TypeData::KnownBoundMethod(_)
@@ -246,15 +246,12 @@ impl<'db> Type<'db> {
                 | crate::types::TypeData::TypeIs(_)
                 | crate::types::TypeData::TypeGuard(_)
                 | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::TypedDict(_)) => None
+                | crate::types::TypeData::TypedDict(_) => None
             }
         }
 
         if mode.is_async() {
-            if let (_, crate::types::TypeData::Intersection(_)) = {
-                let __ty_view_value = self;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::Intersection(_) = self.data() {
                 let flattened = self.flatten_typevars(db);
                 if flattened != self {
                     return flattened.try_iterate_with_mode(db, mode);

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -578,7 +578,11 @@ impl<'db> UnionTypeInstance<'db> {
         // instance when its semantic union already contains the new operand, rather than storing
         // an ever-deeper value-expression tree like `((A | B) | B) | B`.
         for ty in &value_expr_types {
-            if let Type::KnownInstance(KnownInstanceType::UnionType(union)) = ty
+            if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(union))) =
+                ({
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                })
                 && let Ok(&existing_union) = union.union_type(db).as_ref()
                 && existing_union == union_type
             {
@@ -635,11 +639,14 @@ impl<'db> UnionTypeInstance<'db> {
         if let Some(value_expr_types) = self._value_expr_types(db) {
             Ok(Either::Left(value_expr_types.iter().copied()))
         } else {
-            match self.union_type(db).clone()? {
-                Type::Union(union) => Ok(Either::Right(Either::Left(
+            match {
+                let __ty_view_value = self.union_type(db).clone()?;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::Union(union)) => Ok(Either::Right(Either::Left(
                     union.elements(db).iter().copied().map(to_class_literal),
                 ))),
-                ty => Ok(Either::Right(Either::Right(std::iter::once(
+                (ty, _) => Ok(Either::Right(Either::Right(std::iter::once(
                     to_class_literal(ty),
                 )))),
             }

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -578,11 +578,8 @@ impl<'db> UnionTypeInstance<'db> {
         // instance when its semantic union already contains the new operand, rather than storing
         // an ever-deeper value-expression tree like `((A | B) | B) | B`.
         for ty in &value_expr_types {
-            if let (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(union))) =
-                ({
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                })
+            if let crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(union)) =
+                ty.data()
                 && let Ok(&existing_union) = union.union_type(db).as_ref()
                 && existing_union == union_type
             {
@@ -639,10 +636,7 @@ impl<'db> UnionTypeInstance<'db> {
         if let Some(value_expr_types) = self._value_expr_types(db) {
             Ok(Either::Left(value_expr_types.iter().copied()))
         } else {
-            match {
-                let __ty_view_value = self.union_type(db).clone()?;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            match self.union_type(db).clone()?.view() {
                 (_, crate::types::TypeData::Union(union)) => Ok(Either::Right(Either::Left(
                     union.elements(db).iter().copied().map(to_class_literal),
                 ))),

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -162,24 +162,33 @@ impl<'db> AllMembers<'db> {
     }
 
     fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
-        match ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
                     // We don't need to use recursion here because
                     // `Type` guarantees that unions/intersections
                     // are kept in DNF (i.e., they are flattened).
                     ty.is_dynamic()
-                        || match ty {
-                            Type::Intersection(intersection) => {
+                        || match {
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        } {
+                            (_, crate::types::TypeData::Intersection(intersection)) => {
                                 intersection.positive(db).iter().any(Type::is_dynamic)
                             }
-                            _ => false,
+                            (_, _) => false,
                         }
                 }
 
-                let union = match union.filter(db, |&ty| !is_dynamic(db, ty)) {
-                    Type::Union(union) => union,
-                    ty => return self.extend_with_type(db, ty),
+                let union = match {
+                    let __ty_view_value = union.filter(db, |&ty| !is_dynamic(db, ty));
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::Union(union)) => union,
+                    (ty, _) => return self.extend_with_type(db, ty),
                 };
                 self.members.extend(
                     union
@@ -191,7 +200,7 @@ impl<'db> AllMembers<'db> {
                 );
             }
 
-            Type::Intersection(intersection) => self.members.extend(
+            (_, crate::types::TypeData::Intersection(intersection)) => self.members.extend(
                 intersection
                     .positive(db)
                     .iter()
@@ -200,11 +209,11 @@ impl<'db> AllMembers<'db> {
                     .unwrap_or_default(),
             ),
 
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 self.extend_with_type(db, complement.to_intersection(db));
             }
 
-            Type::NominalInstance(instance) => {
+            (_, crate::types::TypeData::NominalInstance(instance)) => {
                 let class = instance.class(db);
                 if let Some((class_literal, _)) = class.static_class_literal(db) {
                     self.extend_with_instance_members(db, ty, class_literal);
@@ -216,36 +225,44 @@ impl<'db> AllMembers<'db> {
                 }
             }
 
-            Type::NewTypeInstance(newtype) => {
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                 self.extend_with_type(db, newtype.concrete_base_type(db));
             }
 
-            Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => {
+            (_, crate::types::TypeData::ClassLiteral(class_literal))
+                if class_literal.is_typed_dict(db) =>
+            {
                 self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
-            Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
+            (_, crate::types::TypeData::GenericAlias(generic_alias))
+                if generic_alias.is_typed_dict(db) =>
+            {
                 self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
-            Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
+            (_, crate::types::TypeData::SubclassOf(subclass_of_type))
+                if subclass_of_type.is_typed_dict(db) =>
+            {
                 self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
             }
 
-            Type::ClassLiteral(class_literal) => {
+            (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
                 self.extend_with_class_members(db, ty, class_literal);
                 self.extend_with_synthetic_members(db, ty, class_literal);
                 self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
-            Type::GenericAlias(generic_alias) => {
+            (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
                 let class_literal = generic_alias.origin(db);
                 self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
                 self.extend_with_synthetic_members(db, ty, ClassLiteral::Static(class_literal));
                 self.extend_with_metaclass_members(db, ty, class_literal.metaclass(db));
             }
 
-            Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
+            (_, crate::types::TypeData::SubclassOf(subclass_of_type)) => match subclass_of_type
+                .subclass_of()
+            {
                 SubclassOfInner::Dynamic(_) => {
                     self.extend_with_type(db, KnownClass::Type.to_instance(db));
                 }
@@ -268,18 +285,23 @@ impl<'db> AllMembers<'db> {
                 }
             },
 
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::Never
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy
-            | Type::TypeForm(_) => {
+            (
+                _,
+                crate::types::TypeData::Dynamic(_)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::TypeForm(_),
+            ) => {
                 self.extend_with_type(db, Type::object());
             }
 
-            Type::TypeAlias(alias) => self.extend_with_type(db, alias.value_type(db)),
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
+                self.extend_with_type(db, alias.value_type(db))
+            }
 
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => {
                         self.extend_with_type(db, Type::object());
@@ -302,51 +324,61 @@ impl<'db> AllMembers<'db> {
                 }
             }
 
-            Type::LiteralValue(_)
-            | Type::PropertyInstance(_)
-            | Type::FunctionLiteral(_)
-            | Type::BoundMethod(_)
-            | Type::KnownBoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::Callable(_)
-            | Type::ProtocolInstance(_)
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::BoundSuper(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_) => match ty.to_meta_type(db) {
-                Type::ClassLiteral(class_literal) => {
+            (
+                _,
+                crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_),
+            ) => match {
+                let __ty_view_value = ty.to_meta_type(db);
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
-                Type::SubclassOf(subclass_of) => {
+                (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
                     if let Some(class) = subclass_of.subclass_of().into_class(db)
                         && let Some((class_literal, _)) = class.static_class_literal(db)
                     {
                         self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
                     }
                 }
-                Type::GenericAlias(generic_alias) => {
+                (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
                     let class_literal = generic_alias.origin(db);
                     self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
                 }
-                _ => {}
+                (_, _) => {}
             },
 
-            Type::TypedDict(_) => {
-                if let Type::ClassLiteral(class_literal) = ty.to_meta_type(db) {
+            (_, crate::types::TypeData::TypedDict(_)) => {
+                if let (_, crate::types::TypeData::ClassLiteral(class_literal)) = {
+                    let __ty_view_value = ty.to_meta_type(db);
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
 
-                if let Type::ClassLiteral(ClassLiteral::Static(class)) =
-                    KnownClass::TypedDictFallback.to_class_literal(db)
-                {
+                if let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = {
+                    let __ty_view_value = KnownClass::TypedDictFallback.to_class_literal(db);
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     self.extend_with_instance_members(db, ty, class);
                 }
             }
 
-            Type::ModuleLiteral(literal) => {
+            (_, crate::types::TypeData::ModuleLiteral(literal)) => {
                 // Looking up `__file__` on `types.ModuleType` will not give as precise a type
                 // as we infer in type inference, but it's confuisng if autocomplete etc.
                 // shows a different type in the tooltip to the one inferred by the type checker.
@@ -386,8 +418,11 @@ impl<'db> AllMembers<'db> {
                         NameKind::Sunder => true,
                     };
                     if is_private_symbol && is_stub_file {
-                        match ty {
-                            Type::NominalInstance(instance)
+                        match {
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        } {
+                            (_, crate::types::TypeData::NominalInstance(instance))
                                 if matches!(
                                     instance.known_class(db),
                                     Some(
@@ -400,15 +435,22 @@ impl<'db> AllMembers<'db> {
                             {
                                 continue;
                             }
-                            Type::ClassLiteral(class) if class.is_protocol(db) => continue,
-                            Type::KnownInstance(
-                                KnownInstanceType::TypeVar(_)
-                                | KnownInstanceType::TypeAliasType(_)
-                                | KnownInstanceType::UnionType(_)
-                                | KnownInstanceType::Literal(_)
-                                | KnownInstanceType::Annotated(_),
+                            (_, crate::types::TypeData::ClassLiteral(class))
+                                if class.is_protocol(db) =>
+                            {
+                                continue;
+                            }
+                            (
+                                _,
+                                crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::TypeVar(_)
+                                    | KnownInstanceType::TypeAliasType(_)
+                                    | KnownInstanceType::UnionType(_)
+                                    | KnownInstanceType::Literal(_)
+                                    | KnownInstanceType::Annotated(_),
+                                ),
                             ) => continue,
-                            _ => {}
+                            (_, _) => {}
                         }
                     }
 

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -162,31 +162,22 @@ impl<'db> AllMembers<'db> {
     }
 
     fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match ty.view() {
             (_, crate::types::TypeData::Union(union)) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
                     // We don't need to use recursion here because
                     // `Type` guarantees that unions/intersections
                     // are kept in DNF (i.e., they are flattened).
                     ty.is_dynamic()
-                        || match {
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        } {
-                            (_, crate::types::TypeData::Intersection(intersection)) => {
+                        || match ty.data() {
+                            crate::types::TypeData::Intersection(intersection) => {
                                 intersection.positive(db).iter().any(Type::is_dynamic)
                             }
-                            (_, _) => false,
+                            _ => false,
                         }
                 }
 
-                let union = match {
-                    let __ty_view_value = union.filter(db, |&ty| !is_dynamic(db, ty));
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                let union = match union.filter(db, |&ty| !is_dynamic(db, ty)).view() {
                     (_, crate::types::TypeData::Union(union)) => union,
                     (ty, _) => return self.extend_with_type(db, ty),
                 };
@@ -298,7 +289,7 @@ impl<'db> AllMembers<'db> {
             }
 
             (_, crate::types::TypeData::TypeAlias(alias)) => {
-                self.extend_with_type(db, alias.value_type(db))
+                self.extend_with_type(db, alias.value_type(db));
             }
 
             (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
@@ -341,39 +332,34 @@ impl<'db> AllMembers<'db> {
                 | crate::types::TypeData::BoundSuper(_)
                 | crate::types::TypeData::TypeIs(_)
                 | crate::types::TypeData::TypeGuard(_),
-            ) => match {
-                let __ty_view_value = ty.to_meta_type(db);
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+            ) => match ty.to_meta_type(db).data() {
+                crate::types::TypeData::ClassLiteral(class_literal) => {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
-                (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
+                crate::types::TypeData::SubclassOf(subclass_of) => {
                     if let Some(class) = subclass_of.subclass_of().into_class(db)
                         && let Some((class_literal, _)) = class.static_class_literal(db)
                     {
                         self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
                     }
                 }
-                (_, crate::types::TypeData::GenericAlias(generic_alias)) => {
+                crate::types::TypeData::GenericAlias(generic_alias) => {
                     let class_literal = generic_alias.origin(db);
                     self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
                 }
-                (_, _) => {}
+                _ => {}
             },
 
             (_, crate::types::TypeData::TypedDict(_)) => {
-                if let (_, crate::types::TypeData::ClassLiteral(class_literal)) = {
-                    let __ty_view_value = ty.to_meta_type(db);
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::ClassLiteral(class_literal) =
+                    ty.to_meta_type(db).data()
+                {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
 
-                if let (_, crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class))) = {
-                    let __ty_view_value = KnownClass::TypedDictFallback.to_class_literal(db);
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::ClassLiteral(ClassLiteral::Static(class)) =
+                    KnownClass::TypedDictFallback.to_class_literal(db).data()
+                {
                     self.extend_with_instance_members(db, ty, class);
                 }
             }
@@ -418,11 +404,8 @@ impl<'db> AllMembers<'db> {
                         NameKind::Sunder => true,
                     };
                     if is_private_symbol && is_stub_file {
-                        match {
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        } {
-                            (_, crate::types::TypeData::NominalInstance(instance))
+                        match ty.data() {
+                            crate::types::TypeData::NominalInstance(instance)
                                 if matches!(
                                     instance.known_class(db),
                                     Some(
@@ -435,22 +418,19 @@ impl<'db> AllMembers<'db> {
                             {
                                 continue;
                             }
-                            (_, crate::types::TypeData::ClassLiteral(class))
+                            crate::types::TypeData::ClassLiteral(class)
                                 if class.is_protocol(db) =>
                             {
                                 continue;
                             }
-                            (
-                                _,
-                                crate::types::TypeData::KnownInstance(
-                                    KnownInstanceType::TypeVar(_)
-                                    | KnownInstanceType::TypeAliasType(_)
-                                    | KnownInstanceType::UnionType(_)
-                                    | KnownInstanceType::Literal(_)
-                                    | KnownInstanceType::Annotated(_),
-                                ),
+                            crate::types::TypeData::KnownInstance(
+                                KnownInstanceType::TypeVar(_)
+                                | KnownInstanceType::TypeAliasType(_)
+                                | KnownInstanceType::UnionType(_)
+                                | KnownInstanceType::Literal(_)
+                                | KnownInstanceType::Annotated(_),
                             ) => continue,
-                            (_, _) => {}
+                            _ => {}
                         }
                     }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -184,12 +184,21 @@ pub(crate) fn definite_match_pattern_type<'db>(
         }
         PatternPredicateKind::Class(class_expr, kind) => {
             if kind.is_irrefutable() {
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(db)
+                match {
+                    let __ty_view_value =
+                        infer_same_file_expression_type(db, *class_expr, TypeContext::default());
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                        Type::instance(db, class.top_materialization(db))
                     }
-                    _ => Type::Never,
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(
+                            SpecialFormType::CollectionsAbcCallable,
+                        ),
+                    ) => callable_pattern_type(db),
+                    (_, _) => Type::Never,
                 }
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -184,21 +184,16 @@ pub(crate) fn definite_match_pattern_type<'db>(
         }
         PatternPredicateKind::Class(class_expr, kind) => {
             if kind.is_irrefutable() {
-                match {
-                    let __ty_view_value =
-                        infer_same_file_expression_type(db, *class_expr, TypeContext::default());
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                match infer_same_file_expression_type(db, *class_expr, TypeContext::default())
+                    .data()
+                {
+                    crate::types::TypeData::ClassLiteral(class) => {
                         Type::instance(db, class.top_materialization(db))
                     }
-                    (
-                        _,
-                        crate::types::TypeData::SpecialForm(
-                            SpecialFormType::CollectionsAbcCallable,
-                        ),
+                    crate::types::TypeData::SpecialForm(
+                        SpecialFormType::CollectionsAbcCallable,
                     ) => callable_pattern_type(db),
-                    (_, _) => Type::Never,
+                    _ => Type::Never,
                 }
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -133,18 +133,12 @@ impl<'db> Mro<'db> {
             [single_base]
                 if !class.has_pep_695_type_params(db)
                     && !matches!(
-                        {
-                            let __ty_view_value = single_base;
-                            (__ty_view_value, __ty_view_value.data())
-                        },
-                        (
-                            _,
-                            crate::types::TypeData::GenericAlias(_)
-                                | crate::types::TypeData::KnownInstance(
-                                    KnownInstanceType::SubscriptedGeneric(_)
-                                        | KnownInstanceType::SubscriptedProtocol(_)
-                                )
-                        )
+                        single_base.data(),
+                        crate::types::TypeData::GenericAlias(_)
+                            | crate::types::TypeData::KnownInstance(
+                                KnownInstanceType::SubscriptedGeneric(_)
+                                    | KnownInstanceType::SubscriptedProtocol(_)
+                            )
                     ) =>
             {
                 ClassBase::try_from_type(
@@ -186,15 +180,10 @@ impl<'db> Mro<'db> {
                     // (see `infer::TypeInferenceBuilder::check_class_definitions`),
                     // which is why we only care about `KnownInstanceType::Generic(Some(_))`,
                     // not `KnownInstanceType::Generic(None)`.
-                    if let (
-                        _,
-                        crate::types::TypeData::KnownInstance(
-                            KnownInstanceType::SubscriptedGeneric(_),
-                        ),
-                    ) = {
-                        let __ty_view_value = base;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    if let crate::types::TypeData::KnownInstance(
+                        KnownInstanceType::SubscriptedGeneric(_),
+                    ) = base.data()
+                    {
                         maybe_add_generic(
                             &mut resolved_bases,
                             original_bases,
@@ -250,16 +239,10 @@ impl<'db> Mro<'db> {
                 if class.has_pep_695_type_params(db)
                     && original_bases.iter().any(|base| {
                         matches!(
-                            {
-                                let __ty_view_value = base;
-                                (__ty_view_value, __ty_view_value.data())
-                            },
-                            (
-                                _,
-                                crate::types::TypeData::KnownInstance(
-                                    KnownInstanceType::SubscriptedGeneric(_)
-                                ) | crate::types::TypeData::SpecialForm(SpecialFormType::Generic)
-                            )
+                            base.data(),
+                            crate::types::TypeData::KnownInstance(
+                                KnownInstanceType::SubscriptedGeneric(_)
+                            ) | crate::types::TypeData::SpecialForm(SpecialFormType::Generic)
                         )
                     })
                 {
@@ -859,14 +842,8 @@ fn check_generic_reorder_fixes_mro<'db>(
         .enumerate()
         .filter_map(|(i, base)| {
             matches!(
-                {
-                    let __ty_view_value = base;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
-                )
+                base.data(),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
             )
             .then_some(i)
         })

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -133,12 +133,18 @@ impl<'db> Mro<'db> {
             [single_base]
                 if !class.has_pep_695_type_params(db)
                     && !matches!(
-                        single_base,
-                        Type::GenericAlias(_)
-                            | Type::KnownInstance(
-                                KnownInstanceType::SubscriptedGeneric(_)
-                                    | KnownInstanceType::SubscriptedProtocol(_)
-                            )
+                        {
+                            let __ty_view_value = single_base;
+                            (__ty_view_value, __ty_view_value.data())
+                        },
+                        (
+                            _,
+                            crate::types::TypeData::GenericAlias(_)
+                                | crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::SubscriptedGeneric(_)
+                                        | KnownInstanceType::SubscriptedProtocol(_)
+                                )
+                        )
                     ) =>
             {
                 ClassBase::try_from_type(
@@ -180,7 +186,15 @@ impl<'db> Mro<'db> {
                     // (see `infer::TypeInferenceBuilder::check_class_definitions`),
                     // which is why we only care about `KnownInstanceType::Generic(Some(_))`,
                     // not `KnownInstanceType::Generic(None)`.
-                    if let Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_)) = base {
+                    if let (
+                        _,
+                        crate::types::TypeData::KnownInstance(
+                            KnownInstanceType::SubscriptedGeneric(_),
+                        ),
+                    ) = {
+                        let __ty_view_value = base;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
                         maybe_add_generic(
                             &mut resolved_bases,
                             original_bases,
@@ -236,9 +250,16 @@ impl<'db> Mro<'db> {
                 if class.has_pep_695_type_params(db)
                     && original_bases.iter().any(|base| {
                         matches!(
-                            base,
-                            Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
-                                | Type::SpecialForm(SpecialFormType::Generic)
+                            {
+                                let __ty_view_value = base;
+                                (__ty_view_value, __ty_view_value.data())
+                            },
+                            (
+                                _,
+                                crate::types::TypeData::KnownInstance(
+                                    KnownInstanceType::SubscriptedGeneric(_)
+                                ) | crate::types::TypeData::SpecialForm(SpecialFormType::Generic)
+                            )
                         )
                     })
                 {
@@ -838,8 +859,14 @@ fn check_generic_reorder_fixes_mro<'db>(
         .enumerate()
         .filter_map(|(i, base)| {
             matches!(
-                base,
-                Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
+                {
+                    let __ty_view_value = base;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))
+                )
             )
             .then_some(i)
         })

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -96,25 +96,22 @@ fn finite_single_valued_union_alternatives<'db>(
 ) -> Option<Vec<Type<'db>>> {
     let ty = ty.resolve_type_alias(db);
 
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::EnumComplement(complement)) => complement
+    match ty.data() {
+        crate::types::TypeData::EnumComplement(complement) => complement
             .has_finite_single_valued_alternatives(db)
             .then(|| complement.remaining_literal_types(db)),
-        (_, crate::types::TypeData::Intersection(intersection)) => {
+        crate::types::TypeData::Intersection(intersection) => {
             let complement = intersection.enum_complement(db)?;
             complement
                 .has_finite_single_valued_alternatives(db)
                 .then(|| complement.remaining_literal_types(db))
         }
-        (_, crate::types::TypeData::NominalInstance(instance))
+        crate::types::TypeData::NominalInstance(instance)
             if instance.has_known_class(db, KnownClass::Bool) =>
         {
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
         }
-        (_, crate::types::TypeData::NominalInstance(instance))
+        crate::types::TypeData::NominalInstance(instance)
             if enum_metadata(db, instance.class_literal(db)).is_some()
                 && !ty.overrides_equality(db) =>
         {
@@ -124,7 +121,7 @@ fn finite_single_valued_union_alternatives<'db>(
                     .collect(),
             )
         }
-        (_, _) => None,
+        _ => None,
     }
 }
 
@@ -135,29 +132,26 @@ fn finite_single_valued_union_alternatives<'db>(
 fn has_finite_single_valued_union_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
 
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::EnumComplement(complement)) => {
+    match ty.data() {
+        crate::types::TypeData::EnumComplement(complement) => {
             complement.has_finite_single_valued_alternatives(db)
         }
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+        crate::types::TypeData::Intersection(intersection) => intersection
             .enum_complement(db)
             .is_some_and(|complement| complement.has_finite_single_valued_alternatives(db)),
-        (_, crate::types::TypeData::NominalInstance(instance))
+        crate::types::TypeData::NominalInstance(instance)
             if instance.has_known_class(db, KnownClass::Bool) =>
         {
             true
         }
-        (_, crate::types::TypeData::NominalInstance(instance))
+        crate::types::TypeData::NominalInstance(instance)
             if enum_metadata(db, instance.class_literal(db))
                 .is_some_and(|metadata| !metadata.members.is_empty())
                 && !ty.overrides_equality(db) =>
         {
             true
         }
-        (_, _) => false,
+        _ => false,
     }
 }
 
@@ -304,17 +298,14 @@ impl ClassInfoConstraintFunction {
             }
         };
 
-        match {
-            let __ty_view_value = classinfo;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+        match classinfo.data() {
+            crate::types::TypeData::TypeAlias(alias) => {
                 self.generate_constraint(db, alias.value_type(db), is_positive)
             }
-            (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+            crate::types::TypeData::ClassLiteral(class_literal) => {
                 Some(constraint_from_class_literal(class_literal))
             }
-            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
+            crate::types::TypeData::SubclassOf(subclass_of_ty) => {
                 // We can't narrow negatively from a `SubclassOf` type. `if !isinstance(x, y)`
                 // where `y: type[A]` doesn't ensure that `x` is not an instance of `A`, because
                 // `y` could be some subclass of `A`.
@@ -338,10 +329,10 @@ impl ClassInfoConstraintFunction {
                     },
                 }
             }
-            (_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_)) => {
+            crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_) => {
                 Some(classinfo)
             }
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 if intersection.negative(db).is_empty() {
                     let mut builder = IntersectionBuilder::new(db);
                     for element in intersection.positive(db) {
@@ -357,10 +348,10 @@ impl ClassInfoConstraintFunction {
                     None
                 }
             }
-            (_, crate::types::TypeData::Union(union)) => union.try_map(db, |element| {
+            crate::types::TypeData::Union(union) => union.try_map(db, |element| {
                 self.generate_constraint(db, *element, is_positive)
             }),
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+            crate::types::TypeData::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
                         self.generate_constraint(db, bound, is_positive)
@@ -373,9 +364,9 @@ impl ClassInfoConstraintFunction {
 
             // It's not valid to use a generic alias as the second argument to `isinstance()` or `issubclass()`,
             // e.g. `isinstance(x, list[int])` fails at runtime.
-            (_, crate::types::TypeData::GenericAlias(_)) => None,
+            crate::types::TypeData::GenericAlias(_) => None,
 
-            (_, crate::types::TypeData::NominalInstance(nominal)) => {
+            crate::types::TypeData::NominalInstance(nominal) => {
                 nominal.tuple_spec(db).and_then(|tuple| {
                     UnionType::try_from_elements(
                         db,
@@ -386,7 +377,7 @@ impl ClassInfoConstraintFunction {
                 })
             }
 
-            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))) => {
+            crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance)) => {
                 UnionType::try_from_elements(
                     db,
                     instance.value_expression_types(db).ok()?.map(|element| {
@@ -407,7 +398,7 @@ impl ClassInfoConstraintFunction {
                 )
             }
 
-            (_, crate::types::TypeData::SpecialForm(form)) => match form {
+            crate::types::TypeData::SpecialForm(form) => match form {
                 SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
                     alias.aliased_class().to_class_literal(db),
@@ -436,31 +427,28 @@ impl ClassInfoConstraintFunction {
                 _ => None,
             },
 
-            (
-                _,
-                crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::EnumComplement(_)
-                | crate::types::TypeData::LiteralValue(_)
-                | crate::types::TypeData::BoundMethod(_)
-                | crate::types::TypeData::BoundSuper(_)
-                | crate::types::TypeData::Callable(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::Never
-                | crate::types::TypeData::KnownBoundMethod(_)
-                | crate::types::TypeData::ModuleLiteral(_)
-                | crate::types::TypeData::FunctionLiteral(_)
-                | crate::types::TypeData::ProtocolInstance(_)
-                | crate::types::TypeData::PropertyInstance(_)
-                | crate::types::TypeData::KnownInstance(_)
-                | crate::types::TypeData::TypeIs(_)
-                | crate::types::TypeData::TypeGuard(_)
-                | crate::types::TypeData::TypeForm(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::TypedDict(_)
-                | crate::types::TypeData::NewTypeInstance(_),
-            ) => None,
+            crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::TypedDict(_)
+            | crate::types::TypeData::NewTypeInstance(_) => None,
         }
     }
 }
@@ -790,29 +778,20 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
             .any(|ty| could_compare_equal(db, left_ty, ty));
     }
 
-    match (
-        ({
-            let __ty_view_value = left_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }),
-        ({
-            let __ty_view_value = right_ty;
-            (__ty_view_value, __ty_view_value.data())
-        }),
-    ) {
+    match (left_ty.data(), right_ty.data()) {
         // In order to be sure a union type cannot compare equal to another type, it
         // must be true that no element of the union can compare equal to that type.
-        ((_, crate::types::TypeData::Union(union)), (_, _)) => union
+        (crate::types::TypeData::Union(union), _) => union
             .elements(db)
             .iter()
             .any(|ty| could_compare_equal(db, *ty, right_ty)),
-        ((_, _), (_, crate::types::TypeData::Union(union))) => union
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .any(|ty| could_compare_equal(db, left_ty, *ty)),
         (
-            (_, crate::types::TypeData::LiteralValue(left)),
-            (_, crate::types::TypeData::LiteralValue(right)),
+            crate::types::TypeData::LiteralValue(left),
+            crate::types::TypeData::LiteralValue(right),
         ) => {
             match (left.kind(), right.kind()) {
                 // Boolean literals and int literals are disjoint, and single valued, and yet
@@ -826,12 +805,12 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
         }
         // We assume that tuples use `tuple.__eq__` which only returns True
         // for other tuples, so they cannot compare equal to non-tuple types.
-        ((_, crate::types::TypeData::NominalInstance(instance)), (_, _))
+        (crate::types::TypeData::NominalInstance(instance), _)
             if instance.tuple_spec(db).is_some() =>
         {
             false
         }
-        ((_, _), (_, crate::types::TypeData::NominalInstance(instance)))
+        (_, crate::types::TypeData::NominalInstance(instance))
             if instance.tuple_spec(db).is_some() =>
         {
             false
@@ -1106,16 +1085,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     /// - Arbitrary user types that return `Literal` types from both `__len__` and `__bool__`,
     ///   where the returned `Literal` types are mutually consistent in their truthiness.
     fn is_base_type_narrowable_by_len(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::NominalInstance(instance))
+        match ty.data() {
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.tuple_spec(db).is_some() =>
             {
                 true
             }
-            (_, crate::types::TypeData::LiteralValue(literal))
+            crate::types::TypeData::LiteralValue(literal)
                 if matches!(
                     literal.kind(),
                     LiteralValueTypeKind::String(_)
@@ -1125,7 +1101,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             {
                 true
             }
-            (_, _) => ty.len(db).is_some_and(|len_ty| {
+            _ => ty.len(db).is_some_and(|len_ty| {
                 let len_ty_bool = len_ty.bool(db);
                 len_ty_bool != Truthiness::Ambiguous && len_ty_bool == ty.bool(db)
             }),
@@ -1139,11 +1115,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ///
     /// Returns `None` if no part of the type is narrowable.
     fn narrow_type_by_len(db: &'db dyn Db, ty: Type<'db>, is_positive: bool) -> Option<Type<'db>> {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match ty.data() {
+            crate::types::TypeData::Union(union) => {
                 let mut has_narrowable = false;
                 let narrowed_elements: Vec<_> = union
                     .elements(db)
@@ -1166,7 +1139,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 // For intersections, check if any positive element is narrowable.
                 let positive = intersection.positive(db);
                 let has_narrowable = positive
@@ -1186,7 +1159,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            (_, _) if Self::is_base_type_narrowable_by_len(db, ty) => {
+            _ if Self::is_base_type_narrowable_by_len(db, ty) => {
                 let mut builder = IntersectionBuilder::new(db).add_positive(ty);
                 if is_positive {
                     builder = builder.add_negative(Type::AlwaysFalsy);
@@ -1195,7 +1168,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
                 Some(builder.build())
             }
-            (_, _) => None,
+            _ => None,
         }
     }
 
@@ -1212,18 +1185,15 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Type<'db> {
         let resolved = ty.resolve_type_alias(db);
 
-        let narrowed = match {
-            let __ty_view_value = resolved;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => union.map(db, |element| {
+        let narrowed = match resolved.data() {
+            crate::types::TypeData::Union(union) => union.map(db, |element| {
                 Self::narrow_type_by_exact_len(db, *element, length, is_equality)
             }),
-            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            crate::types::TypeData::Intersection(intersection) => intersection
                 .map_positive(db, |element| {
                     Self::narrow_type_by_exact_len(db, *element, length, is_equality)
                 }),
-            (_, _) => {
+            _ => {
                 if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
                     match tuple.resize(db, TupleLength::Fixed(length)) {
                         Ok(tuple) => Type::tuple(TupleType::new(db, &tuple)),
@@ -1242,17 +1212,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     };
                     let comparison_possible = resolved
                         .len(db)
-                        .map(|length_type| {
-                            match {
-                                let __ty_view_value = length_type;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
-                                (_, crate::types::TypeData::Union(union)) => union
-                                    .elements(db)
-                                    .iter()
-                                    .any(|element| satisfies_comparison(*element)),
-                                (_, _) => satisfies_comparison(length_type),
-                            }
+                        .map(|length_type| match length_type.data() {
+                            crate::types::TypeData::Union(union) => union
+                                .elements(db)
+                                .iter()
+                                .any(|element| satisfies_comparison(*element)),
+                            _ => satisfies_comparison(length_type),
                         })
                         .or_else(|| {
                             tuple_length
@@ -1336,10 +1301,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 lhs_ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> bool {
-                if let (_, crate::types::TypeData::Union(union)) = {
-                    let __ty_view_value = lhs_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::Union(union) = lhs_ty.data() {
                     return union
                         .elements(db)
                         .iter()
@@ -1368,10 +1330,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> Type<'db> {
-                if let (_, crate::types::TypeData::Union(union)) = {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::Union(union) = ty.data() {
                     return union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty));
                 }
 
@@ -1402,15 +1361,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 
     fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        match (
-            ({
-                let __ty_view_value = lhs_ty;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            rhs_ty.as_literal_value_kind(),
-        ) {
+        match (lhs_ty.data(), rhs_ty.as_literal_value_kind()) {
             (
-                (_, crate::types::TypeData::NominalInstance(instance)),
+                crate::types::TypeData::NominalInstance(instance),
                 Some(LiteralValueTypeKind::Int(i)),
             ) if instance.has_known_class(self.db, KnownClass::Bool) => {
                 if i.as_i64() == 0 {
@@ -1421,7 +1374,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            ((_, _), Some(LiteralValueTypeKind::Bool(b))) => Some(
+            (_, Some(LiteralValueTypeKind::Bool(b))) => Some(
                 UnionType::from_two_elements(self.db, rhs_ty, Type::int_literal(i64::from(b)))
                     .negate(self.db),
             ),
@@ -1589,12 +1542,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         /// bound to `type[Y[int]]`, and type aliases where the underlying value is a
         /// generic class.
         fn find_underlying_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::ClassLiteral(class)) => Some(class),
-                (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
+            match ty.data() {
+                crate::types::TypeData::ClassLiteral(class) => Some(class),
+                crate::types::TypeData::SubclassOf(subclass_of) => {
                     match subclass_of.subclass_of().with_transposed_type_var(db) {
                         SubclassOfInner::Class(ClassType::NonGeneric(class)) => Some(class),
                         SubclassOfInner::Class(ClassType::Generic(_))
@@ -1604,13 +1554,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                         }
                     }
                 }
-                (_, crate::types::TypeData::TypeVar(tvar)) => {
+                crate::types::TypeData::TypeVar(tvar) => {
                     find_underlying_class(db, tvar.typevar(db).upper_bound(db)?)
                 }
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                crate::types::TypeData::TypeAlias(alias) => {
                     find_underlying_class(db, alias.value_type(db))
                 }
-                (_, _) => None,
+                _ => None,
             }
         }
 
@@ -1631,10 +1581,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }) => {
                     if keywords.is_empty()
                         && let [single_argument] = &**args
-                        && let (_, crate::types::TypeData::ClassLiteral(called_class)) = ({
-                            let __ty_view_value = inference.expression_type(func);
-                            (__ty_view_value, __ty_view_value.data())
-                        })
+                        && let crate::types::TypeData::ClassLiteral(called_class) =
+                            inference.expression_type(func).data()
                         && called_class.is_known(db, KnownClass::Type)
                     {
                         Some(single_argument)
@@ -1690,12 +1638,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
             && let ast::Expr::Subscript(subscript) = left.expression_value()
-            && let (_, crate::types::TypeData::Union(union)) = ({
-                let __ty_view_value = inference
-                    .expression_type(&*subscript.value)
-                    .resolve_type_alias(self.db);
-                (__ty_view_value, __ty_view_value.data())
-            })
+            && let crate::types::TypeData::Union(union) = inference
+                .expression_type(&*subscript.value)
+                .resolve_type_alias(self.db)
+                .data()
             && let Some(subscript_place_expr) = PlaceExpr::try_from_expr(&subscript.value)
             && let Some(index) = inference
                 .expression_type(&*subscript.slice)
@@ -1743,10 +1689,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
 
             let mut narrow_len_call = |call: &ast::ExprCall, length_type: Type<'db>| {
-                let (_, crate::types::TypeData::FunctionLiteral(function_type)) = ({
-                    let __ty_view_value = inference.expression_type(&*call.func);
-                    (__ty_view_value, __ty_view_value.data())
-                }) else {
+                let crate::types::TypeData::FunctionLiteral(function_type) =
+                    inference.expression_type(&*call.func).data()
+                else {
                     return;
                 };
                 if function_type.known(self.db) != Some(KnownFunction::Len)
@@ -1897,18 +1842,15 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
                 let resolved_rhs_type = rhs_type.resolve_type_alias(self.db);
 
-                let narrowed = match {
-                    let __ty_view_value = resolved_rhs_type;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::TypedDict(td)) => {
+                let narrowed = match resolved_rhs_type.data() {
+                    crate::types::TypeData::TypedDict(td) => {
                         if requires_key(td) {
                             Type::Never
                         } else {
                             resolved_rhs_type
                         }
                     }
-                    (_, crate::types::TypeData::Intersection(intersection)) => {
+                    crate::types::TypeData::Intersection(intersection) => {
                         if intersection
                             .positive(self.db)
                             .iter()
@@ -1921,27 +1863,20 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                             resolved_rhs_type
                         }
                     }
-                    (_, crate::types::TypeData::Union(union)) => {
+                    crate::types::TypeData::Union(union) => {
                         // remove all members of the union that would require the key
-                        union.filter(self.db, |ty| {
-                            match {
-                                let __ty_view_value = ty;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
-                                (_, crate::types::TypeData::TypedDict(td)) => !requires_key(td),
-                                (_, crate::types::TypeData::Intersection(intersection)) => {
-                                    !intersection
-                                        .positive(self.db)
-                                        .iter()
-                                        .copied()
-                                        .filter_map(Type::as_typed_dict)
-                                        .any(requires_key)
-                                }
-                                (_, _) => true,
-                            }
+                        union.filter(self.db, |ty| match ty.data() {
+                            crate::types::TypeData::TypedDict(td) => !requires_key(td),
+                            crate::types::TypeData::Intersection(intersection) => !intersection
+                                .positive(self.db)
+                                .iter()
+                                .copied()
+                                .filter_map(Type::as_typed_dict)
+                                .any(requires_key),
+                            _ => true,
                         })
                     }
-                    (_, _) => resolved_rhs_type,
+                    _ => resolved_rhs_type,
                 };
 
                 if narrowed != resolved_rhs_type {
@@ -2075,15 +2010,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let callable_ty = inference.expression_type(&*expr_call.func);
 
-        match {
-            let __ty_view_value = callable_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match callable_ty.data() {
             // For the expression `len(E)`, we narrow the type based on whether len(E) is truthy
             // (i.e., whether E is non-empty). We only narrow the parts of the type where we know
             // `__bool__` and `__len__` are consistent (literals, tuples). Non-narrowable parts
             // (str, list, etc.) are kept unchanged.
-            (_, crate::types::TypeData::FunctionLiteral(function_type))
+            crate::types::TypeData::FunctionLiteral(function_type)
                 if expr_call.arguments.args.len() == 1
                     && expr_call.arguments.keywords.is_empty()
                     && function_type.known(self.db) == Some(KnownFunction::Len) =>
@@ -2103,7 +2035,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            (_, crate::types::TypeData::FunctionLiteral(function_type))
+            crate::types::TypeData::FunctionLiteral(function_type)
                 if expr_call.arguments.keywords.is_empty() =>
             {
                 let [first_arg, second_arg] = &*expr_call.arguments.args else {
@@ -2152,7 +2084,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     })
             }
             // for the expression `bool(E)`, we further narrow the type based on `E`
-            (_, crate::types::TypeData::ClassLiteral(class_type))
+            crate::types::TypeData::ClassLiteral(class_type)
                 if expr_call.arguments.args.len() == 1
                     && expr_call.arguments.keywords.is_empty()
                     && class_type.is_known(self.db, KnownClass::Bool) =>
@@ -2163,7 +2095,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     is_positive,
                 )
             }
-            (_, _) => None,
+            _ => None,
         }
     }
 
@@ -2177,11 +2109,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         let return_ty = inference.expression_type(expr_call);
 
-        let place_and_constraint = match {
-            let __ty_view_value = return_ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeIs(type_is)) => {
+        let place_and_constraint = match return_ty.data() {
+            crate::types::TypeData::TypeIs(type_is) => {
                 let (_, place) = type_is.place_info(self.db)?;
                 Some((
                     place,
@@ -2193,14 +2122,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 ))
             }
             // TypeGuard only narrows in the positive case
-            (_, crate::types::TypeData::TypeGuard(type_guard)) if is_positive => {
+            crate::types::TypeData::TypeGuard(type_guard) if is_positive => {
                 let (_, place) = type_guard.place_info(self.db)?;
                 Some((
                     place,
                     NarrowingConstraint::replacement(type_guard.return_type(self.db)),
                 ))
             }
-            (_, _) => None,
+            _ => None,
         }?;
 
         Some(NarrowingConstraints::from_iter([place_and_constraint]))
@@ -2242,10 +2171,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
 
-        let narrowed_type = match {
-            let __ty_view_value = class_type;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        let narrowed_type = match class_type.view() {
             (_, crate::types::TypeData::ClassLiteral(class)) => {
                 Type::instance(self.db, class.top_materialization(self.db))
                     .negate_if(self.db, !is_positive)
@@ -2313,21 +2239,15 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 singleton_pattern_type(self.db, *singleton)
             }
             PatternPredicateKind::Class(cls, _) => {
-                match {
-                    let __ty_view_value =
-                        infer_same_file_expression_type(self.db, *cls, TypeContext::default());
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::ClassLiteral(class)) => {
+                match infer_same_file_expression_type(self.db, *cls, TypeContext::default()).data()
+                {
+                    crate::types::TypeData::ClassLiteral(class) => {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }
-                    (
-                        _,
-                        crate::types::TypeData::SpecialForm(
-                            SpecialFormType::CollectionsAbcCallable,
-                        ),
+                    crate::types::TypeData::SpecialForm(
+                        SpecialFormType::CollectionsAbcCallable,
                     ) => callable_pattern_type(self.db),
-                    (_, _) => Type::object(),
+                    _ => Type::object(),
                 }
             }
             PatternPredicateKind::Mapping(_) => mapping_pattern_type(self.db),
@@ -2730,10 +2650,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             IntersectionType::from_two_elements(db, ty, key_presence_constraint)
         };
 
-        match {
-            let __ty_view_value = ty.resolve_type_alias(self.db);
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match ty.resolve_type_alias(self.db).view() {
             (_, crate::types::TypeData::Union(union)) => union.map(self.db, |element| {
                 self.narrow_with_present_key(*element, key)
             }),
@@ -2771,10 +2688,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         // We need a union type for narrowing to be useful.
-        let (_, crate::types::TypeData::Union(union)) = ({
-            let __ty_view_value = subscript_value_type.resolve_type_alias(self.db);
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::Union(union) =
+            subscript_value_type.resolve_type_alias(self.db).data()
+        else {
             return None;
         };
 
@@ -2834,10 +2750,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         rhs_type: Type<'db>,
         is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
-        let (_, crate::types::TypeData::Union(union)) = ({
-            let __ty_view_value = attribute_value_type.resolve_type_alias(self.db);
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::Union(union) =
+            attribute_value_type.resolve_type_alias(self.db).data()
+        else {
             return None;
         };
         if !is_supported_tag_literal(rhs_type) {
@@ -2868,78 +2783,67 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 // Return true if the given type is a `TypedDict` or a union or intersection that includes at least
 // one `TypedDict` (even if other types are also present), or a type alias to such a type.
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::TypedDict(_)) => true,
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+    match ty.data() {
+        crate::types::TypeData::TypedDict(_) => true,
+        crate::types::TypeData::Intersection(intersection) => intersection
             .positive(db)
             .iter()
             .any(|intersection_element_ty| is_or_contains_typeddict(db, *intersection_element_ty)),
-        (_, crate::types::TypeData::Union(union)) => union
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .any(|union_member_ty| is_or_contains_typeddict(db, *union_member_ty)),
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             is_or_contains_typeddict(db, alias.value_type(db))
         }
 
-        (
-            _,
-            crate::types::TypeData::Dynamic(_)
-            | crate::types::TypeData::Divergent(_)
-            | crate::types::TypeData::Never
-            | crate::types::TypeData::EnumComplement(_)
-            | crate::types::TypeData::FunctionLiteral(_)
-            | crate::types::TypeData::BoundMethod(_)
-            | crate::types::TypeData::KnownBoundMethod(_)
-            | crate::types::TypeData::WrapperDescriptor(_)
-            | crate::types::TypeData::DataclassDecorator(_)
-            | crate::types::TypeData::DataclassTransformer(_)
-            | crate::types::TypeData::Callable(_)
-            | crate::types::TypeData::ModuleLiteral(_)
-            | crate::types::TypeData::ClassLiteral(_)
-            | crate::types::TypeData::GenericAlias(_)
-            | crate::types::TypeData::SubclassOf(_)
-            | crate::types::TypeData::NominalInstance(_)
-            | crate::types::TypeData::ProtocolInstance(_)
-            | crate::types::TypeData::SpecialForm(_)
-            | crate::types::TypeData::KnownInstance(_)
-            | crate::types::TypeData::PropertyInstance(_)
-            | crate::types::TypeData::AlwaysTruthy
-            | crate::types::TypeData::AlwaysFalsy
-            | crate::types::TypeData::LiteralValue(_)
-            | crate::types::TypeData::TypeVar(_)
-            | crate::types::TypeData::BoundSuper(_)
-            | crate::types::TypeData::TypeIs(_)
-            | crate::types::TypeData::TypeGuard(_)
-            | crate::types::TypeData::TypeForm(_)
-            | crate::types::TypeData::NewTypeInstance(_),
-        ) => false,
+        crate::types::TypeData::Dynamic(_)
+        | crate::types::TypeData::Divergent(_)
+        | crate::types::TypeData::Never
+        | crate::types::TypeData::EnumComplement(_)
+        | crate::types::TypeData::FunctionLiteral(_)
+        | crate::types::TypeData::BoundMethod(_)
+        | crate::types::TypeData::KnownBoundMethod(_)
+        | crate::types::TypeData::WrapperDescriptor(_)
+        | crate::types::TypeData::DataclassDecorator(_)
+        | crate::types::TypeData::DataclassTransformer(_)
+        | crate::types::TypeData::Callable(_)
+        | crate::types::TypeData::ModuleLiteral(_)
+        | crate::types::TypeData::ClassLiteral(_)
+        | crate::types::TypeData::GenericAlias(_)
+        | crate::types::TypeData::SubclassOf(_)
+        | crate::types::TypeData::NominalInstance(_)
+        | crate::types::TypeData::ProtocolInstance(_)
+        | crate::types::TypeData::SpecialForm(_)
+        | crate::types::TypeData::KnownInstance(_)
+        | crate::types::TypeData::PropertyInstance(_)
+        | crate::types::TypeData::AlwaysTruthy
+        | crate::types::TypeData::AlwaysFalsy
+        | crate::types::TypeData::LiteralValue(_)
+        | crate::types::TypeData::TypeVar(_)
+        | crate::types::TypeData::BoundSuper(_)
+        | crate::types::TypeData::TypeIs(_)
+        | crate::types::TypeData::TypeGuard(_)
+        | crate::types::TypeData::TypeForm(_)
+        | crate::types::TypeData::NewTypeInstance(_) => false,
     }
 }
 
 fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::TypedDict(typed_dict)) => {
-            typed_dict.items(db).contains_key(key)
-        }
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+    match ty.data() {
+        crate::types::TypeData::TypedDict(typed_dict) => typed_dict.items(db).contains_key(key),
+        crate::types::TypeData::Intersection(intersection) => intersection
             .positive(db)
             .iter()
             .any(|element| typeddict_declares_key(db, *element, key)),
-        (_, crate::types::TypeData::Union(union)) => union
+        crate::types::TypeData::Union(union) => union
             .elements(db)
             .iter()
             .any(|element| typeddict_declares_key(db, *element, key)),
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             typeddict_declares_key(db, alias.value_type(db), key)
         }
-        (_, _) => false,
+        _ => false,
     }
 }
 
@@ -3053,70 +2957,64 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
             .is_none_or(|field| is_supported_tag_literal(field.declared_ty))
     };
 
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::TypedDict(td)) => matching_field_is_literal(&td),
-        (_, crate::types::TypeData::Union(union)) => {
-            union.elements(db).iter().all(|union_member_ty| {
-                !is_or_contains_typeddict(db, *union_member_ty)
-                    || all_matching_typeddict_fields_have_literal_types(
-                        db,
-                        *union_member_ty,
-                        field_name,
-                    )
-            })
-        }
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+    match ty.data() {
+        crate::types::TypeData::TypedDict(td) => matching_field_is_literal(&td),
+        crate::types::TypeData::Union(union) => union.elements(db).iter().all(|union_member_ty| {
+            !is_or_contains_typeddict(db, *union_member_ty)
+                || all_matching_typeddict_fields_have_literal_types(
+                    db,
+                    *union_member_ty,
+                    field_name,
+                )
+        }),
+        crate::types::TypeData::TypeAlias(alias) => {
             all_matching_typeddict_fields_have_literal_types(db, alias.value_type(db), field_name)
         }
-        (_, crate::types::TypeData::Intersection(intersection)) => intersection
-            .positive(db)
-            .iter()
-            .all(|intersection_member_ty| {
-                !is_or_contains_typeddict(db, *intersection_member_ty)
-                    || all_matching_typeddict_fields_have_literal_types(
-                        db,
-                        *intersection_member_ty,
-                        field_name,
-                    )
-            }),
+        crate::types::TypeData::Intersection(intersection) => {
+            intersection
+                .positive(db)
+                .iter()
+                .all(|intersection_member_ty| {
+                    !is_or_contains_typeddict(db, *intersection_member_ty)
+                        || all_matching_typeddict_fields_have_literal_types(
+                            db,
+                            *intersection_member_ty,
+                            field_name,
+                        )
+                })
+        }
 
         // Only the four variants above can pass `is_or_contains_typeddict`, and this function is
         // always guarded by that check.
-        (
-            _,
-            crate::types::TypeData::Dynamic(_)
-            | crate::types::TypeData::Divergent(_)
-            | crate::types::TypeData::Never
-            | crate::types::TypeData::EnumComplement(_)
-            | crate::types::TypeData::FunctionLiteral(_)
-            | crate::types::TypeData::BoundMethod(_)
-            | crate::types::TypeData::KnownBoundMethod(_)
-            | crate::types::TypeData::WrapperDescriptor(_)
-            | crate::types::TypeData::DataclassDecorator(_)
-            | crate::types::TypeData::DataclassTransformer(_)
-            | crate::types::TypeData::Callable(_)
-            | crate::types::TypeData::ModuleLiteral(_)
-            | crate::types::TypeData::ClassLiteral(_)
-            | crate::types::TypeData::GenericAlias(_)
-            | crate::types::TypeData::SubclassOf(_)
-            | crate::types::TypeData::NominalInstance(_)
-            | crate::types::TypeData::ProtocolInstance(_)
-            | crate::types::TypeData::SpecialForm(_)
-            | crate::types::TypeData::KnownInstance(_)
-            | crate::types::TypeData::PropertyInstance(_)
-            | crate::types::TypeData::AlwaysTruthy
-            | crate::types::TypeData::AlwaysFalsy
-            | crate::types::TypeData::LiteralValue(_)
-            | crate::types::TypeData::TypeVar(_)
-            | crate::types::TypeData::BoundSuper(_)
-            | crate::types::TypeData::TypeIs(_)
-            | crate::types::TypeData::TypeGuard(_)
-            | crate::types::TypeData::TypeForm(_)
-            | crate::types::TypeData::NewTypeInstance(_),
-        ) => {
+        crate::types::TypeData::Dynamic(_)
+        | crate::types::TypeData::Divergent(_)
+        | crate::types::TypeData::Never
+        | crate::types::TypeData::EnumComplement(_)
+        | crate::types::TypeData::FunctionLiteral(_)
+        | crate::types::TypeData::BoundMethod(_)
+        | crate::types::TypeData::KnownBoundMethod(_)
+        | crate::types::TypeData::WrapperDescriptor(_)
+        | crate::types::TypeData::DataclassDecorator(_)
+        | crate::types::TypeData::DataclassTransformer(_)
+        | crate::types::TypeData::Callable(_)
+        | crate::types::TypeData::ModuleLiteral(_)
+        | crate::types::TypeData::ClassLiteral(_)
+        | crate::types::TypeData::GenericAlias(_)
+        | crate::types::TypeData::SubclassOf(_)
+        | crate::types::TypeData::NominalInstance(_)
+        | crate::types::TypeData::ProtocolInstance(_)
+        | crate::types::TypeData::SpecialForm(_)
+        | crate::types::TypeData::KnownInstance(_)
+        | crate::types::TypeData::PropertyInstance(_)
+        | crate::types::TypeData::AlwaysTruthy
+        | crate::types::TypeData::AlwaysFalsy
+        | crate::types::TypeData::LiteralValue(_)
+        | crate::types::TypeData::TypeVar(_)
+        | crate::types::TypeData::BoundSuper(_)
+        | crate::types::TypeData::TypeIs(_)
+        | crate::types::TypeData::TypeGuard(_)
+        | crate::types::TypeData::TypeForm(_)
+        | crate::types::TypeData::NewTypeInstance(_) => {
             unreachable!(
                 "invalid type {} in all_matching_typeddict_fields_have_literal_types",
                 ty.display(db)

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -96,33 +96,31 @@ fn finite_single_valued_union_alternatives<'db>(
 ) -> Option<Vec<Type<'db>>> {
     let ty = ty.resolve_type_alias(db);
 
-    match ty.data() {
-        crate::types::TypeData::EnumComplement(complement) => complement
+    if let Some(complement) = ty.as_enum_complement() {
+        return complement
             .has_finite_single_valued_alternatives(db)
-            .then(|| complement.remaining_literal_types(db)),
-        crate::types::TypeData::Intersection(intersection) => {
-            let complement = intersection.enum_complement(db)?;
-            complement
-                .has_finite_single_valued_alternatives(db)
-                .then(|| complement.remaining_literal_types(db))
-        }
-        crate::types::TypeData::NominalInstance(instance)
-            if instance.has_known_class(db, KnownClass::Bool) =>
-        {
-            Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
-        }
-        crate::types::TypeData::NominalInstance(instance)
-            if enum_metadata(db, instance.class_literal(db)).is_some()
-                && !ty.overrides_equality(db) =>
-        {
-            Some(
-                enum_member_literals(db, instance.class_literal(db), None)
-                    .expect("Calling `enum_member_literals` on an enum class")
-                    .collect(),
-            )
-        }
-        _ => None,
+            .then(|| complement.remaining_literal_types(db));
     }
+
+    if let Some(intersection) = ty.as_intersection() {
+        let complement = intersection.enum_complement(db)?;
+        return complement
+            .has_finite_single_valued_alternatives(db)
+            .then(|| complement.remaining_literal_types(db));
+    }
+
+    let instance = ty.as_nominal_instance()?;
+    if instance.has_known_class(db, KnownClass::Bool) {
+        return Some(vec![Type::bool_literal(true), Type::bool_literal(false)]);
+    }
+    if enum_metadata(db, instance.class_literal(db)).is_some() && !ty.overrides_equality(db) {
+        return Some(
+            enum_member_literals(db, instance.class_literal(db), None)
+                .expect("Calling `enum_member_literals` on an enum class")
+                .collect(),
+        );
+    }
+    None
 }
 
 /// Return `true` if `finite_single_valued_union_alternatives` would produce a non-empty list.
@@ -132,27 +130,22 @@ fn finite_single_valued_union_alternatives<'db>(
 fn has_finite_single_valued_union_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
 
-    match ty.data() {
-        crate::types::TypeData::EnumComplement(complement) => {
-            complement.has_finite_single_valued_alternatives(db)
-        }
-        crate::types::TypeData::Intersection(intersection) => intersection
-            .enum_complement(db)
-            .is_some_and(|complement| complement.has_finite_single_valued_alternatives(db)),
-        crate::types::TypeData::NominalInstance(instance)
-            if instance.has_known_class(db, KnownClass::Bool) =>
-        {
-            true
-        }
-        crate::types::TypeData::NominalInstance(instance)
-            if enum_metadata(db, instance.class_literal(db))
-                .is_some_and(|metadata| !metadata.members.is_empty())
-                && !ty.overrides_equality(db) =>
-        {
-            true
-        }
-        _ => false,
+    if let Some(complement) = ty.as_enum_complement() {
+        return complement.has_finite_single_valued_alternatives(db);
     }
+    if let Some(intersection) = ty.as_intersection() {
+        return intersection
+            .enum_complement(db)
+            .is_some_and(|complement| complement.has_finite_single_valued_alternatives(db));
+    }
+
+    let Some(instance) = ty.as_nominal_instance() else {
+        return false;
+    };
+    instance.has_known_class(db, KnownClass::Bool)
+        || (enum_metadata(db, instance.class_literal(db))
+            .is_some_and(|metadata| !metadata.members.is_empty())
+            && !ty.overrides_equality(db))
 }
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
@@ -778,47 +771,48 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
             .any(|ty| could_compare_equal(db, left_ty, ty));
     }
 
-    match (left_ty.data(), right_ty.data()) {
-        // In order to be sure a union type cannot compare equal to another type, it
-        // must be true that no element of the union can compare equal to that type.
-        (crate::types::TypeData::Union(union), _) => union
+    // In order to be sure a union type cannot compare equal to another type, it
+    // must be true that no element of the union can compare equal to that type.
+    if let Some(union) = left_ty.as_union() {
+        return union
             .elements(db)
             .iter()
-            .any(|ty| could_compare_equal(db, *ty, right_ty)),
-        (_, crate::types::TypeData::Union(union)) => union
-            .elements(db)
-            .iter()
-            .any(|ty| could_compare_equal(db, left_ty, *ty)),
-        (
-            crate::types::TypeData::LiteralValue(left),
-            crate::types::TypeData::LiteralValue(right),
-        ) => {
-            match (left.kind(), right.kind()) {
-                // Boolean literals and int literals are disjoint, and single valued, and yet
-                // `True == 1` and `False == 0`.
-                (LiteralValueTypeKind::Bool(b), LiteralValueTypeKind::Int(i))
-                | (LiteralValueTypeKind::Int(i), LiteralValueTypeKind::Bool(b)) => {
-                    i64::from(b) == i.as_i64()
-                }
-                _ => !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db)),
-            }
-        }
-        // We assume that tuples use `tuple.__eq__` which only returns True
-        // for other tuples, so they cannot compare equal to non-tuple types.
-        (crate::types::TypeData::NominalInstance(instance), _)
-            if instance.tuple_spec(db).is_some() =>
-        {
-            false
-        }
-        (_, crate::types::TypeData::NominalInstance(instance))
-            if instance.tuple_spec(db).is_some() =>
-        {
-            false
-        }
-        // Other than the above cases, two single-valued disjoint types cannot compare
-        // equal.
-        _ => !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db)),
+            .any(|ty| could_compare_equal(db, *ty, right_ty));
     }
+    if let Some(union) = right_ty.as_union() {
+        return union
+            .elements(db)
+            .iter()
+            .any(|ty| could_compare_equal(db, left_ty, *ty));
+    }
+
+    if let (Some(left), Some(right)) = (left_ty.as_literal_value(), right_ty.as_literal_value()) {
+        return match (left.kind(), right.kind()) {
+            // Boolean literals and int literals are disjoint, and single valued, and yet
+            // `True == 1` and `False == 0`.
+            (LiteralValueTypeKind::Bool(b), LiteralValueTypeKind::Int(i))
+            | (LiteralValueTypeKind::Int(i), LiteralValueTypeKind::Bool(b)) => {
+                i64::from(b) == i.as_i64()
+            }
+            _ => !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db)),
+        };
+    }
+
+    // We assume that tuples use `tuple.__eq__` which only returns True
+    // for other tuples, so they cannot compare equal to non-tuple types.
+    if left_ty
+        .as_nominal_instance()
+        .is_some_and(|instance| instance.tuple_spec(db).is_some())
+        || right_ty
+            .as_nominal_instance()
+            .is_some_and(|instance| instance.tuple_spec(db).is_some())
+    {
+        return false;
+    }
+
+    // Other than the above cases, two single-valued disjoint types cannot compare
+    // equal.
+    !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db))
 }
 
 fn is_exact_membership_value_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
@@ -1301,7 +1295,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 lhs_ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> bool {
-                if let crate::types::TypeData::Union(union) = lhs_ty.data() {
+                if let Some(union) = lhs_ty.as_union() {
                     return union
                         .elements(db)
                         .iter()
@@ -1330,7 +1324,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> Type<'db> {
-                if let crate::types::TypeData::Union(union) = ty.data() {
+                if let Some(union) = ty.as_union() {
                     return union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty));
                 }
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -96,20 +96,25 @@ fn finite_single_valued_union_alternatives<'db>(
 ) -> Option<Vec<Type<'db>>> {
     let ty = ty.resolve_type_alias(db);
 
-    match ty {
-        Type::EnumComplement(complement) => complement
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::EnumComplement(complement)) => complement
             .has_finite_single_valued_alternatives(db)
             .then(|| complement.remaining_literal_types(db)),
-        Type::Intersection(intersection) => {
+        (_, crate::types::TypeData::Intersection(intersection)) => {
             let complement = intersection.enum_complement(db)?;
             complement
                 .has_finite_single_valued_alternatives(db)
                 .then(|| complement.remaining_literal_types(db))
         }
-        Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => {
+        (_, crate::types::TypeData::NominalInstance(instance))
+            if instance.has_known_class(db, KnownClass::Bool) =>
+        {
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
         }
-        Type::NominalInstance(instance)
+        (_, crate::types::TypeData::NominalInstance(instance))
             if enum_metadata(db, instance.class_literal(db)).is_some()
                 && !ty.overrides_equality(db) =>
         {
@@ -119,7 +124,7 @@ fn finite_single_valued_union_alternatives<'db>(
                     .collect(),
             )
         }
-        _ => None,
+        (_, _) => None,
     }
 }
 
@@ -130,20 +135,29 @@ fn finite_single_valued_union_alternatives<'db>(
 fn has_finite_single_valued_union_alternatives<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
 
-    match ty {
-        Type::EnumComplement(complement) => complement.has_finite_single_valued_alternatives(db),
-        Type::Intersection(intersection) => intersection
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::EnumComplement(complement)) => {
+            complement.has_finite_single_valued_alternatives(db)
+        }
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
             .enum_complement(db)
             .is_some_and(|complement| complement.has_finite_single_valued_alternatives(db)),
-        Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => true,
-        Type::NominalInstance(instance)
+        (_, crate::types::TypeData::NominalInstance(instance))
+            if instance.has_known_class(db, KnownClass::Bool) =>
+        {
+            true
+        }
+        (_, crate::types::TypeData::NominalInstance(instance))
             if enum_metadata(db, instance.class_literal(db))
                 .is_some_and(|metadata| !metadata.members.is_empty())
                 && !ty.overrides_equality(db) =>
         {
             true
         }
-        _ => false,
+        (_, _) => false,
     }
 }
 
@@ -290,12 +304,17 @@ impl ClassInfoConstraintFunction {
             }
         };
 
-        match classinfo {
-            Type::TypeAlias(alias) => {
+        match {
+            let __ty_view_value = classinfo;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 self.generate_constraint(db, alias.value_type(db), is_positive)
             }
-            Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
-            Type::SubclassOf(subclass_of_ty) => {
+            (_, crate::types::TypeData::ClassLiteral(class_literal)) => {
+                Some(constraint_from_class_literal(class_literal))
+            }
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty)) => {
                 // We can't narrow negatively from a `SubclassOf` type. `if !isinstance(x, y)`
                 // where `y: type[A]` doesn't ensure that `x` is not an instance of `A`, because
                 // `y` could be some subclass of `A`.
@@ -319,8 +338,10 @@ impl ClassInfoConstraintFunction {
                     },
                 }
             }
-            Type::Dynamic(_) | Type::Divergent(_) => Some(classinfo),
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_)) => {
+                Some(classinfo)
+            }
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 if intersection.negative(db).is_empty() {
                     let mut builder = IntersectionBuilder::new(db);
                     for element in intersection.positive(db) {
@@ -336,10 +357,10 @@ impl ClassInfoConstraintFunction {
                     None
                 }
             }
-            Type::Union(union) => union.try_map(db, |element| {
+            (_, crate::types::TypeData::Union(union)) => union.try_map(db, |element| {
                 self.generate_constraint(db, *element, is_positive)
             }),
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
                         self.generate_constraint(db, bound, is_positive)
@@ -352,18 +373,20 @@ impl ClassInfoConstraintFunction {
 
             // It's not valid to use a generic alias as the second argument to `isinstance()` or `issubclass()`,
             // e.g. `isinstance(x, list[int])` fails at runtime.
-            Type::GenericAlias(_) => None,
+            (_, crate::types::TypeData::GenericAlias(_)) => None,
 
-            Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
-                UnionType::try_from_elements(
-                    db,
-                    tuple
-                        .iter_all_elements()
-                        .map(|element| self.generate_constraint(db, element, is_positive)),
-                )
-            }),
+            (_, crate::types::TypeData::NominalInstance(nominal)) => {
+                nominal.tuple_spec(db).and_then(|tuple| {
+                    UnionType::try_from_elements(
+                        db,
+                        tuple
+                            .iter_all_elements()
+                            .map(|element| self.generate_constraint(db, element, is_positive)),
+                    )
+                })
+            }
 
-            Type::KnownInstance(KnownInstanceType::UnionType(instance)) => {
+            (_, crate::types::TypeData::KnownInstance(KnownInstanceType::UnionType(instance))) => {
                 UnionType::try_from_elements(
                     db,
                     instance.value_expression_types(db).ok()?.map(|element| {
@@ -384,7 +407,7 @@ impl ClassInfoConstraintFunction {
                 )
             }
 
-            Type::SpecialForm(form) => match form {
+            (_, crate::types::TypeData::SpecialForm(form)) => match form {
                 SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
                     alias.aliased_class().to_class_literal(db),
@@ -413,28 +436,31 @@ impl ClassInfoConstraintFunction {
                 _ => None,
             },
 
-            Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::EnumComplement(_)
-            | Type::LiteralValue(_)
-            | Type::BoundMethod(_)
-            | Type::BoundSuper(_)
-            | Type::Callable(_)
-            | Type::DataclassDecorator(_)
-            | Type::Never
-            | Type::KnownBoundMethod(_)
-            | Type::ModuleLiteral(_)
-            | Type::FunctionLiteral(_)
-            | Type::ProtocolInstance(_)
-            | Type::PropertyInstance(_)
-            | Type::KnownInstance(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::WrapperDescriptor(_)
-            | Type::DataclassTransformer(_)
-            | Type::TypedDict(_)
-            | Type::NewTypeInstance(_) => None,
+            (
+                _,
+                crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::EnumComplement(_)
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::KnownBoundMethod(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_),
+            ) => None,
         }
     }
 }
@@ -764,18 +790,30 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
             .any(|ty| could_compare_equal(db, left_ty, ty));
     }
 
-    match (left_ty, right_ty) {
+    match (
+        ({
+            let __ty_view_value = left_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }),
+        ({
+            let __ty_view_value = right_ty;
+            (__ty_view_value, __ty_view_value.data())
+        }),
+    ) {
         // In order to be sure a union type cannot compare equal to another type, it
         // must be true that no element of the union can compare equal to that type.
-        (Type::Union(union), _) => union
+        ((_, crate::types::TypeData::Union(union)), (_, _)) => union
             .elements(db)
             .iter()
             .any(|ty| could_compare_equal(db, *ty, right_ty)),
-        (_, Type::Union(union)) => union
+        ((_, _), (_, crate::types::TypeData::Union(union))) => union
             .elements(db)
             .iter()
             .any(|ty| could_compare_equal(db, left_ty, *ty)),
-        (Type::LiteralValue(left), Type::LiteralValue(right)) => {
+        (
+            (_, crate::types::TypeData::LiteralValue(left)),
+            (_, crate::types::TypeData::LiteralValue(right)),
+        ) => {
             match (left.kind(), right.kind()) {
                 // Boolean literals and int literals are disjoint, and single valued, and yet
                 // `True == 1` and `False == 0`.
@@ -788,8 +826,16 @@ fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<
         }
         // We assume that tuples use `tuple.__eq__` which only returns True
         // for other tuples, so they cannot compare equal to non-tuple types.
-        (Type::NominalInstance(instance), _) if instance.tuple_spec(db).is_some() => false,
-        (_, Type::NominalInstance(instance)) if instance.tuple_spec(db).is_some() => false,
+        ((_, crate::types::TypeData::NominalInstance(instance)), (_, _))
+            if instance.tuple_spec(db).is_some() =>
+        {
+            false
+        }
+        ((_, _), (_, crate::types::TypeData::NominalInstance(instance)))
+            if instance.tuple_spec(db).is_some() =>
+        {
+            false
+        }
         // Other than the above cases, two single-valued disjoint types cannot compare
         // equal.
         _ => !(left_ty.is_single_valued(db) && right_ty.is_single_valued(db)),
@@ -1060,9 +1106,16 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     /// - Arbitrary user types that return `Literal` types from both `__len__` and `__bool__`,
     ///   where the returned `Literal` types are mutually consistent in their truthiness.
     fn is_base_type_narrowable_by_len(db: &'db dyn Db, ty: Type<'db>) -> bool {
-        match ty {
-            Type::NominalInstance(instance) if instance.tuple_spec(db).is_some() => true,
-            Type::LiteralValue(literal)
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::NominalInstance(instance))
+                if instance.tuple_spec(db).is_some() =>
+            {
+                true
+            }
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if matches!(
                     literal.kind(),
                     LiteralValueTypeKind::String(_)
@@ -1072,7 +1125,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             {
                 true
             }
-            _ => ty.len(db).is_some_and(|len_ty| {
+            (_, _) => ty.len(db).is_some_and(|len_ty| {
                 let len_ty_bool = len_ty.bool(db);
                 len_ty_bool != Truthiness::Ambiguous && len_ty_bool == ty.bool(db)
             }),
@@ -1086,8 +1139,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ///
     /// Returns `None` if no part of the type is narrowable.
     fn narrow_type_by_len(db: &'db dyn Db, ty: Type<'db>, is_positive: bool) -> Option<Type<'db>> {
-        match ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 let mut has_narrowable = false;
                 let narrowed_elements: Vec<_> = union
                     .elements(db)
@@ -1110,7 +1166,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 // For intersections, check if any positive element is narrowable.
                 let positive = intersection.positive(db);
                 let has_narrowable = positive
@@ -1130,7 +1186,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            _ if Self::is_base_type_narrowable_by_len(db, ty) => {
+            (_, _) if Self::is_base_type_narrowable_by_len(db, ty) => {
                 let mut builder = IntersectionBuilder::new(db).add_positive(ty);
                 if is_positive {
                     builder = builder.add_negative(Type::AlwaysFalsy);
@@ -1139,7 +1195,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }
                 Some(builder.build())
             }
-            _ => None,
+            (_, _) => None,
         }
     }
 
@@ -1156,14 +1212,18 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Type<'db> {
         let resolved = ty.resolve_type_alias(db);
 
-        let narrowed = match resolved {
-            Type::Union(union) => union.map(db, |element| {
+        let narrowed = match {
+            let __ty_view_value = resolved;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => union.map(db, |element| {
                 Self::narrow_type_by_exact_len(db, *element, length, is_equality)
             }),
-            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
-                Self::narrow_type_by_exact_len(db, *element, length, is_equality)
-            }),
-            _ => {
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
+                .map_positive(db, |element| {
+                    Self::narrow_type_by_exact_len(db, *element, length, is_equality)
+                }),
+            (_, _) => {
                 if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
                     match tuple.resize(db, TupleLength::Fixed(length)) {
                         Ok(tuple) => Type::tuple(TupleType::new(db, &tuple)),
@@ -1182,12 +1242,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     };
                     let comparison_possible = resolved
                         .len(db)
-                        .map(|length_type| match length_type {
-                            Type::Union(union) => union
-                                .elements(db)
-                                .iter()
-                                .any(|element| satisfies_comparison(*element)),
-                            _ => satisfies_comparison(length_type),
+                        .map(|length_type| {
+                            match {
+                                let __ty_view_value = length_type;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
+                                (_, crate::types::TypeData::Union(union)) => union
+                                    .elements(db)
+                                    .iter()
+                                    .any(|element| satisfies_comparison(*element)),
+                                (_, _) => satisfies_comparison(length_type),
+                            }
                         })
                         .or_else(|| {
                             tuple_length
@@ -1271,7 +1336,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 lhs_ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> bool {
-                if let Type::Union(union) = lhs_ty {
+                if let (_, crate::types::TypeData::Union(union)) = {
+                    let __ty_view_value = lhs_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     return union
                         .elements(db)
                         .iter()
@@ -1300,7 +1368,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 ty: Type<'db>,
                 rhs_ty: Type<'db>,
             ) -> Type<'db> {
-                if let Type::Union(union) = ty {
+                if let (_, crate::types::TypeData::Union(union)) = {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     return union.map(db, |ty| filter_to_cannot_be_equal(db, *ty, rhs_ty));
                 }
 
@@ -1331,10 +1402,17 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     }
 
     fn evaluate_expr_ne(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        match (lhs_ty, rhs_ty.as_literal_value_kind()) {
-            (Type::NominalInstance(instance), Some(LiteralValueTypeKind::Int(i)))
-                if instance.has_known_class(self.db, KnownClass::Bool) =>
-            {
+        match (
+            ({
+                let __ty_view_value = lhs_ty;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            rhs_ty.as_literal_value_kind(),
+        ) {
+            (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                Some(LiteralValueTypeKind::Int(i)),
+            ) if instance.has_known_class(self.db, KnownClass::Bool) => {
                 if i.as_i64() == 0 {
                     Some(Type::bool_literal(false).negate(self.db))
                 } else if i.as_i64() == 1 {
@@ -1343,7 +1421,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            (_, Some(LiteralValueTypeKind::Bool(b))) => Some(
+            ((_, _), Some(LiteralValueTypeKind::Bool(b))) => Some(
                 UnionType::from_two_elements(self.db, rhs_ty, Type::int_literal(i64::from(b)))
                     .negate(self.db),
             ),
@@ -1511,9 +1589,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         /// bound to `type[Y[int]]`, and type aliases where the underlying value is a
         /// generic class.
         fn find_underlying_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
-            match ty {
-                Type::ClassLiteral(class) => Some(class),
-                Type::SubclassOf(subclass_of) => {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::ClassLiteral(class)) => Some(class),
+                (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
                     match subclass_of.subclass_of().with_transposed_type_var(db) {
                         SubclassOfInner::Class(ClassType::NonGeneric(class)) => Some(class),
                         SubclassOfInner::Class(ClassType::Generic(_))
@@ -1523,9 +1604,13 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                         }
                     }
                 }
-                Type::TypeVar(tvar) => find_underlying_class(db, tvar.typevar(db).upper_bound(db)?),
-                Type::TypeAlias(alias) => find_underlying_class(db, alias.value_type(db)),
-                _ => None,
+                (_, crate::types::TypeData::TypeVar(tvar)) => {
+                    find_underlying_class(db, tvar.typevar(db).upper_bound(db)?)
+                }
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
+                    find_underlying_class(db, alias.value_type(db))
+                }
+                (_, _) => None,
             }
         }
 
@@ -1546,7 +1631,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 }) => {
                     if keywords.is_empty()
                         && let [single_argument] = &**args
-                        && let Type::ClassLiteral(called_class) = inference.expression_type(func)
+                        && let (_, crate::types::TypeData::ClassLiteral(called_class)) = ({
+                            let __ty_view_value = inference.expression_type(func);
+                            (__ty_view_value, __ty_view_value.data())
+                        })
                         && called_class.is_known(db, KnownClass::Type)
                     {
                         Some(single_argument)
@@ -1602,9 +1690,12 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         //             reveal_type(t)  # tuple[int, int]
         if matches!(&**ops, [ast::CmpOp::Is | ast::CmpOp::IsNot])
             && let ast::Expr::Subscript(subscript) = left.expression_value()
-            && let Type::Union(union) = inference
-                .expression_type(&*subscript.value)
-                .resolve_type_alias(self.db)
+            && let (_, crate::types::TypeData::Union(union)) = ({
+                let __ty_view_value = inference
+                    .expression_type(&*subscript.value)
+                    .resolve_type_alias(self.db);
+                (__ty_view_value, __ty_view_value.data())
+            })
             && let Some(subscript_place_expr) = PlaceExpr::try_from_expr(&subscript.value)
             && let Some(index) = inference
                 .expression_type(&*subscript.slice)
@@ -1652,8 +1743,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             let is_equality = is_positive == (ops[0] == ast::CmpOp::Eq);
 
             let mut narrow_len_call = |call: &ast::ExprCall, length_type: Type<'db>| {
-                let Type::FunctionLiteral(function_type) = inference.expression_type(&*call.func)
-                else {
+                let (_, crate::types::TypeData::FunctionLiteral(function_type)) = ({
+                    let __ty_view_value = inference.expression_type(&*call.func);
+                    (__ty_view_value, __ty_view_value.data())
+                }) else {
                     return;
                 };
                 if function_type.known(self.db) != Some(KnownFunction::Len)
@@ -1804,15 +1897,18 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
                 let resolved_rhs_type = rhs_type.resolve_type_alias(self.db);
 
-                let narrowed = match resolved_rhs_type {
-                    Type::TypedDict(td) => {
+                let narrowed = match {
+                    let __ty_view_value = resolved_rhs_type;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::TypedDict(td)) => {
                         if requires_key(td) {
                             Type::Never
                         } else {
                             resolved_rhs_type
                         }
                     }
-                    Type::Intersection(intersection) => {
+                    (_, crate::types::TypeData::Intersection(intersection)) => {
                         if intersection
                             .positive(self.db)
                             .iter()
@@ -1825,20 +1921,27 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                             resolved_rhs_type
                         }
                     }
-                    Type::Union(union) => {
+                    (_, crate::types::TypeData::Union(union)) => {
                         // remove all members of the union that would require the key
-                        union.filter(self.db, |ty| match ty {
-                            Type::TypedDict(td) => !requires_key(*td),
-                            Type::Intersection(intersection) => !intersection
-                                .positive(self.db)
-                                .iter()
-                                .copied()
-                                .filter_map(Type::as_typed_dict)
-                                .any(requires_key),
-                            _ => true,
+                        union.filter(self.db, |ty| {
+                            match {
+                                let __ty_view_value = ty;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
+                                (_, crate::types::TypeData::TypedDict(td)) => !requires_key(td),
+                                (_, crate::types::TypeData::Intersection(intersection)) => {
+                                    !intersection
+                                        .positive(self.db)
+                                        .iter()
+                                        .copied()
+                                        .filter_map(Type::as_typed_dict)
+                                        .any(requires_key)
+                                }
+                                (_, _) => true,
+                            }
                         })
                     }
-                    _ => resolved_rhs_type,
+                    (_, _) => resolved_rhs_type,
                 };
 
                 if narrowed != resolved_rhs_type {
@@ -1972,12 +2075,15 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let callable_ty = inference.expression_type(&*expr_call.func);
 
-        match callable_ty {
+        match {
+            let __ty_view_value = callable_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // For the expression `len(E)`, we narrow the type based on whether len(E) is truthy
             // (i.e., whether E is non-empty). We only narrow the parts of the type where we know
             // `__bool__` and `__len__` are consistent (literals, tuples). Non-narrowable parts
             // (str, list, etc.) are kept unchanged.
-            Type::FunctionLiteral(function_type)
+            (_, crate::types::TypeData::FunctionLiteral(function_type))
                 if expr_call.arguments.args.len() == 1
                     && expr_call.arguments.keywords.is_empty()
                     && function_type.known(self.db) == Some(KnownFunction::Len) =>
@@ -1997,7 +2103,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            Type::FunctionLiteral(function_type) if expr_call.arguments.keywords.is_empty() => {
+            (_, crate::types::TypeData::FunctionLiteral(function_type))
+                if expr_call.arguments.keywords.is_empty() =>
+            {
                 let [first_arg, second_arg] = &*expr_call.arguments.args else {
                     return None;
                 };
@@ -2044,7 +2152,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     })
             }
             // for the expression `bool(E)`, we further narrow the type based on `E`
-            Type::ClassLiteral(class_type)
+            (_, crate::types::TypeData::ClassLiteral(class_type))
                 if expr_call.arguments.args.len() == 1
                     && expr_call.arguments.keywords.is_empty()
                     && class_type.is_known(self.db, KnownClass::Bool) =>
@@ -2055,7 +2163,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     is_positive,
                 )
             }
-            _ => None,
+            (_, _) => None,
         }
     }
 
@@ -2069,8 +2177,11 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         let return_ty = inference.expression_type(expr_call);
 
-        let place_and_constraint = match return_ty {
-            Type::TypeIs(type_is) => {
+        let place_and_constraint = match {
+            let __ty_view_value = return_ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeIs(type_is)) => {
                 let (_, place) = type_is.place_info(self.db)?;
                 Some((
                     place,
@@ -2082,14 +2193,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 ))
             }
             // TypeGuard only narrows in the positive case
-            Type::TypeGuard(type_guard) if is_positive => {
+            (_, crate::types::TypeData::TypeGuard(type_guard)) if is_positive => {
                 let (_, place) = type_guard.place_info(self.db)?;
                 Some((
                     place,
                     NarrowingConstraint::replacement(type_guard.return_type(self.db)),
                 ))
             }
-            _ => None,
+            (_, _) => None,
         }?;
 
         Some(NarrowingConstraints::from_iter([place_and_constraint]))
@@ -2131,16 +2242,19 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
 
-        let narrowed_type = match class_type {
-            Type::ClassLiteral(class) => {
+        let narrowed_type = match {
+            let __ty_view_value = class_type;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::ClassLiteral(class)) => {
                 Type::instance(self.db, class.top_materialization(self.db))
                     .negate_if(self.db, !is_positive)
             }
-            Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
+            (_, crate::types::TypeData::SpecialForm(SpecialFormType::CollectionsAbcCallable)) => {
                 callable_pattern_type(self.db).negate_if(self.db, !is_positive)
             }
-            dynamic @ Type::Dynamic(_) => dynamic,
-            _ => return None,
+            (dynamic, crate::types::TypeData::Dynamic(_)) => dynamic,
+            (_, _) => return None,
         };
 
         Some(NarrowingConstraints::from_iter([(
@@ -2199,14 +2313,21 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 singleton_pattern_type(self.db, *singleton)
             }
             PatternPredicateKind::Class(cls, _) => {
-                match infer_same_file_expression_type(self.db, *cls, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
+                match {
+                    let __ty_view_value =
+                        infer_same_file_expression_type(self.db, *cls, TypeContext::default());
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::ClassLiteral(class)) => {
                         Type::instance(self.db, class.top_materialization(self.db))
                     }
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(self.db)
-                    }
-                    _ => Type::object(),
+                    (
+                        _,
+                        crate::types::TypeData::SpecialForm(
+                            SpecialFormType::CollectionsAbcCallable,
+                        ),
+                    ) => callable_pattern_type(self.db),
+                    (_, _) => Type::object(),
                 }
             }
             PatternPredicateKind::Mapping(_) => mapping_pattern_type(self.db),
@@ -2609,18 +2730,21 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             IntersectionType::from_two_elements(db, ty, key_presence_constraint)
         };
 
-        match ty.resolve_type_alias(self.db) {
-            Type::Union(union) => union.map(self.db, |element| {
+        match {
+            let __ty_view_value = ty.resolve_type_alias(self.db);
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => union.map(self.db, |element| {
                 self.narrow_with_present_key(*element, key)
             }),
-            resolved if typeddict_declares_key(self.db, resolved, key) => resolved,
+            (resolved, _) if typeddict_declares_key(self.db, resolved, key) => resolved,
             // TODO: Extend this to subtypes of `Mapping[str, object]` whose membership and
             // subscript operations obey the `Mapping` contract.
-            resolved if is_or_contains_typeddict(self.db, resolved) => constrain(
+            (resolved, _) if is_or_contains_typeddict(self.db, resolved) => constrain(
                 ty,
                 Type::TypedDict(required_typeddict_key(self.db, key, Type::object())),
             ),
-            _ => constrain(ty, key_membership_contains_protocol(self.db, key)),
+            (_, _) => constrain(ty, key_membership_contains_protocol(self.db, key)),
         }
     }
 
@@ -2647,7 +2771,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
         // We need a union type for narrowing to be useful.
-        let Type::Union(union) = subscript_value_type.resolve_type_alias(self.db) else {
+        let (_, crate::types::TypeData::Union(union)) = ({
+            let __ty_view_value = subscript_value_type.resolve_type_alias(self.db);
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return None;
         };
 
@@ -2707,7 +2834,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         rhs_type: Type<'db>,
         is_equality: bool,
     ) -> Option<(ScopedPlaceId, NarrowingConstraint<'db>)> {
-        let Type::Union(union) = attribute_value_type.resolve_type_alias(self.db) else {
+        let (_, crate::types::TypeData::Union(union)) = ({
+            let __ty_view_value = attribute_value_type.resolve_type_alias(self.db);
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return None;
         };
         if !is_supported_tag_literal(rhs_type) {
@@ -2738,63 +2868,78 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 // Return true if the given type is a `TypedDict` or a union or intersection that includes at least
 // one `TypedDict` (even if other types are also present), or a type alias to such a type.
 fn is_or_contains_typeddict<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty {
-        Type::TypedDict(_) => true,
-        Type::Intersection(intersection) => intersection
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::TypedDict(_)) => true,
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
             .positive(db)
             .iter()
             .any(|intersection_element_ty| is_or_contains_typeddict(db, *intersection_element_ty)),
-        Type::Union(union) => union
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .any(|union_member_ty| is_or_contains_typeddict(db, *union_member_ty)),
-        Type::TypeAlias(alias) => is_or_contains_typeddict(db, alias.value_type(db)),
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
+            is_or_contains_typeddict(db, alias.value_type(db))
+        }
 
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::EnumComplement(_)
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::NominalInstance(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::TypeForm(_)
-        | Type::NewTypeInstance(_) => false,
+        (
+            _,
+            crate::types::TypeData::Dynamic(_)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::ClassLiteral(_)
+            | crate::types::TypeData::GenericAlias(_)
+            | crate::types::TypeData::SubclassOf(_)
+            | crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::TypeVar(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::NewTypeInstance(_),
+        ) => false,
     }
 }
 
 fn typeddict_declares_key<'db>(db: &'db dyn Db, ty: Type<'db>, key: &str) -> bool {
-    match ty {
-        Type::TypedDict(typed_dict) => typed_dict.items(db).contains_key(key),
-        Type::Intersection(intersection) => intersection
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::TypedDict(typed_dict)) => {
+            typed_dict.items(db).contains_key(key)
+        }
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
             .positive(db)
             .iter()
             .any(|element| typeddict_declares_key(db, *element, key)),
-        Type::Union(union) => union
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .any(|element| typeddict_declares_key(db, *element, key)),
-        Type::TypeAlias(alias) => typeddict_declares_key(db, alias.value_type(db), key),
-        _ => false,
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
+            typeddict_declares_key(db, alias.value_type(db), key)
+        }
+        (_, _) => false,
     }
 }
 
@@ -2908,64 +3053,70 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
             .is_none_or(|field| is_supported_tag_literal(field.declared_ty))
     };
 
-    match ty {
-        Type::TypedDict(td) => matching_field_is_literal(&td),
-        Type::Union(union) => union.elements(db).iter().all(|union_member_ty| {
-            !is_or_contains_typeddict(db, *union_member_ty)
-                || all_matching_typeddict_fields_have_literal_types(
-                    db,
-                    *union_member_ty,
-                    field_name,
-                )
-        }),
-        Type::TypeAlias(alias) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::TypedDict(td)) => matching_field_is_literal(&td),
+        (_, crate::types::TypeData::Union(union)) => {
+            union.elements(db).iter().all(|union_member_ty| {
+                !is_or_contains_typeddict(db, *union_member_ty)
+                    || all_matching_typeddict_fields_have_literal_types(
+                        db,
+                        *union_member_ty,
+                        field_name,
+                    )
+            })
+        }
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
             all_matching_typeddict_fields_have_literal_types(db, alias.value_type(db), field_name)
         }
-        Type::Intersection(intersection) => {
-            intersection
-                .positive(db)
-                .iter()
-                .all(|intersection_member_ty| {
-                    !is_or_contains_typeddict(db, *intersection_member_ty)
-                        || all_matching_typeddict_fields_have_literal_types(
-                            db,
-                            *intersection_member_ty,
-                            field_name,
-                        )
-                })
-        }
+        (_, crate::types::TypeData::Intersection(intersection)) => intersection
+            .positive(db)
+            .iter()
+            .all(|intersection_member_ty| {
+                !is_or_contains_typeddict(db, *intersection_member_ty)
+                    || all_matching_typeddict_fields_have_literal_types(
+                        db,
+                        *intersection_member_ty,
+                        field_name,
+                    )
+            }),
 
         // Only the four variants above can pass `is_or_contains_typeddict`, and this function is
         // always guarded by that check.
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::EnumComplement(_)
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::NominalInstance(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::TypeForm(_)
-        | Type::NewTypeInstance(_) => {
+        (
+            _,
+            crate::types::TypeData::Dynamic(_)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::ClassLiteral(_)
+            | crate::types::TypeData::GenericAlias(_)
+            | crate::types::TypeData::SubclassOf(_)
+            | crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::TypeVar(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::NewTypeInstance(_),
+        ) => {
             unreachable!(
                 "invalid type {} in all_matching_typeddict_fields_have_literal_types",
                 ty.display(db)

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -70,24 +70,21 @@ impl<'db> NewType<'db> {
         let Some(second_arg) = call_expr.arguments.args.get(1) else {
             return object_fallback;
         };
-        match {
-            let __ty_view_value = definition_expression_type(db, definition, second_arg);
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::NominalInstance(nominal_instance_type)) => {
+        match definition_expression_type(db, definition, second_arg).data() {
+            crate::types::TypeData::NominalInstance(nominal_instance_type) => {
                 NewTypeBase::ClassType(nominal_instance_type.class(db))
             }
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => NewTypeBase::NewType(newtype),
+            crate::types::TypeData::NewTypeInstance(newtype) => NewTypeBase::NewType(newtype),
             // There are exactly two union types allowed as bases for NewType: `int | float` and
             // `int | float | complex`. These are allowed because that's what `float` and `complex`
             // expand into in type position. We don't currently ask whether the union was implicit
             // or explicit, so the explicit version is also allowed.
-            (_, crate::types::TypeData::Union(union_type)) => match union_type.known(db) {
+            crate::types::TypeData::Union(union_type) => match union_type.known(db) {
                 Some(KnownUnion::Float) => NewTypeBase::Float,
                 Some(KnownUnion::Complex) => NewTypeBase::Complex,
                 _ => object_fallback,
             },
-            (_, _) => object_fallback,
+            _ => object_fallback,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -70,21 +70,24 @@ impl<'db> NewType<'db> {
         let Some(second_arg) = call_expr.arguments.args.get(1) else {
             return object_fallback;
         };
-        match definition_expression_type(db, definition, second_arg) {
-            Type::NominalInstance(nominal_instance_type) => {
+        match {
+            let __ty_view_value = definition_expression_type(db, definition, second_arg);
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::NominalInstance(nominal_instance_type)) => {
                 NewTypeBase::ClassType(nominal_instance_type.class(db))
             }
-            Type::NewTypeInstance(newtype) => NewTypeBase::NewType(newtype),
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => NewTypeBase::NewType(newtype),
             // There are exactly two union types allowed as bases for NewType: `int | float` and
             // `int | float | complex`. These are allowed because that's what `float` and `complex`
             // expand into in type position. We don't currently ask whether the union was implicit
             // or explicit, so the explicit version is also allowed.
-            Type::Union(union_type) => match union_type.known(db) {
+            (_, crate::types::TypeData::Union(union_type)) => match union_type.known(db) {
                 Some(KnownUnion::Float) => NewTypeBase::Float,
                 Some(KnownUnion::Complex) => NewTypeBase::Complex,
                 _ => object_fallback,
             },
-            _ => object_fallback,
+            (_, _) => object_fallback,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -246,8 +246,8 @@ fn check_class_declaration<'db>(
             // in the source, rather than matching on the type. But this would require storing
             // additional information in `EnumMetadata`.
             let is_ellipsis = matches!(
-                { let __ty_view_value = member_value_type; (__ty_view_value, __ty_view_value.data()) },
-                (_, crate::types::TypeData::NominalInstance(nominal_instance))
+                member_value_type.data(),
+                crate::types::TypeData::NominalInstance(nominal_instance)
                     if nominal_instance.has_known_class(db, KnownClass::EllipsisType)
             );
             // `auto()` values are computed at runtime by the enum metaclass,
@@ -533,10 +533,8 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let (_, crate::types::TypeData::FunctionLiteral(subclass_function)) = ({
-                let __ty_view_value = member.ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) else {
+            let crate::types::TypeData::FunctionLiteral(subclass_function) = member.ty.data()
+            else {
                 continue;
             };
 
@@ -1196,11 +1194,8 @@ fn extract_overriding_functions<'db>(
     member_name: &Name,
     subclass_scope: ScopeId<'db>,
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::PropertyInstance(property)) => {
+    match ty.data() {
+        crate::types::TypeData::PropertyInstance(property) => {
             let subclass_file = subclass_scope.file(db);
             let mut functions = smallvec::smallvec![];
 
@@ -1224,7 +1219,7 @@ fn extract_overriding_functions<'db>(
 
             functions
         }
-        (_, crate::types::TypeData::Union(union)) => {
+        crate::types::TypeData::Union(union) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
                 functions.extend(extract_overriding_functions(
@@ -1236,7 +1231,7 @@ fn extract_overriding_functions<'db>(
             }
             functions
         }
-        (_, _) => extract_underlying_functions(db, ty),
+        _ => extract_underlying_functions(db, ty),
     }
 }
 
@@ -1259,28 +1254,25 @@ fn extract_underlying_functions<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::FunctionLiteral(function)) => {
+    match ty.data() {
+        crate::types::TypeData::FunctionLiteral(function) => {
             smallvec::smallvec_inline![function]
         }
-        (_, crate::types::TypeData::BoundMethod(method)) => {
+        crate::types::TypeData::BoundMethod(method) => {
             smallvec::smallvec_inline![method.function(db)]
         }
-        (_, crate::types::TypeData::PropertyInstance(property)) => property.getter(db).map_or_else(
+        crate::types::TypeData::PropertyInstance(property) => property.getter(db).map_or_else(
             || smallvec::smallvec![],
             |getter| extract_underlying_functions(db, getter),
         ),
-        (_, crate::types::TypeData::Union(union)) => {
+        crate::types::TypeData::Union(union) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
                 functions.extend(extract_underlying_functions(db, *member));
             }
             functions
         }
-        (_, _) => smallvec::smallvec![],
+        _ => smallvec::smallvec![],
     }
 }
 
@@ -1390,23 +1382,21 @@ fn check_enum_member_against_constructor_hook<'db>(
     // The enum metaclass unpacks tuple values as positional args:
     //   MEMBER = (a, b, c)  →  __new__(cls, a, b, c) / __init__(self, a, b, c)
     //   MEMBER = x          →  __new__(cls, x) / __init__(self, x)
-    let args: Vec<Type<'db>> = if let (_, crate::types::TypeData::NominalInstance(instance)) = {
-        let __ty_view_value = member_value_type;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        if let Some(spec) = instance.tuple_spec(db) {
-            if let Tuple::Fixed(fixed) = &*spec {
-                fixed.all_elements().to_vec()
+    let args: Vec<Type<'db>> =
+        if let crate::types::TypeData::NominalInstance(instance) = member_value_type.data() {
+            if let Some(spec) = instance.tuple_spec(db) {
+                if let Tuple::Fixed(fixed) = &*spec {
+                    fixed.all_elements().to_vec()
+                } else {
+                    // Variable-length tuples: can't determine exact args, skip validation.
+                    return;
+                }
             } else {
-                // Variable-length tuples: can't determine exact args, skip validation.
-                return;
+                vec![member_value_type]
             }
         } else {
             vec![member_value_type]
-        }
-    } else {
-        vec![member_value_type]
-    };
+        };
 
     let call_args = CallArguments::positional(args);
     let call_args = call_args.with_self(Some(bound_self_type));

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -246,8 +246,8 @@ fn check_class_declaration<'db>(
             // in the source, rather than matching on the type. But this would require storing
             // additional information in `EnumMetadata`.
             let is_ellipsis = matches!(
-                member_value_type,
-                Type::NominalInstance(nominal_instance)
+                { let __ty_view_value = member_value_type; (__ty_view_value, __ty_view_value.data()) },
+                (_, crate::types::TypeData::NominalInstance(nominal_instance))
                     if nominal_instance.has_known_class(db, KnownClass::EllipsisType)
             );
             // `auto()` values are computed at runtime by the enum metaclass,
@@ -533,7 +533,10 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Type::FunctionLiteral(subclass_function) = member.ty else {
+            let (_, crate::types::TypeData::FunctionLiteral(subclass_function)) = ({
+                let __ty_view_value = member.ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) else {
                 continue;
             };
 
@@ -847,10 +850,8 @@ fn variable_kind<'db>(
     // ```
     if matches!(
         class_member.place,
-        Place::Defined(DefinedPlace {
-            ty: Type::FunctionLiteral(_),
-            ..
-        })
+        Place::Defined(defined)
+            if matches!(defined.ty.data(), crate::types::TypeData::FunctionLiteral(_))
     ) {
         return None;
     }
@@ -1195,8 +1196,11 @@ fn extract_overriding_functions<'db>(
     member_name: &Name,
     subclass_scope: ScopeId<'db>,
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
-    match ty {
-        Type::PropertyInstance(property) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::PropertyInstance(property)) => {
             let subclass_file = subclass_scope.file(db);
             let mut functions = smallvec::smallvec![];
 
@@ -1220,7 +1224,7 @@ fn extract_overriding_functions<'db>(
 
             functions
         }
-        Type::Union(union) => {
+        (_, crate::types::TypeData::Union(union)) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
                 functions.extend(extract_overriding_functions(
@@ -1232,7 +1236,7 @@ fn extract_overriding_functions<'db>(
             }
             functions
         }
-        _ => extract_underlying_functions(db, ty),
+        (_, _) => extract_underlying_functions(db, ty),
     }
 }
 
@@ -1255,21 +1259,28 @@ fn extract_underlying_functions<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> smallvec::SmallVec<[FunctionType<'db>; 1]> {
-    match ty {
-        Type::FunctionLiteral(function) => smallvec::smallvec_inline![function],
-        Type::BoundMethod(method) => smallvec::smallvec_inline![method.function(db)],
-        Type::PropertyInstance(property) => property.getter(db).map_or_else(
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::FunctionLiteral(function)) => {
+            smallvec::smallvec_inline![function]
+        }
+        (_, crate::types::TypeData::BoundMethod(method)) => {
+            smallvec::smallvec_inline![method.function(db)]
+        }
+        (_, crate::types::TypeData::PropertyInstance(property)) => property.getter(db).map_or_else(
             || smallvec::smallvec![],
             |getter| extract_underlying_functions(db, getter),
         ),
-        Type::Union(union) => {
+        (_, crate::types::TypeData::Union(union)) => {
             let mut functions = smallvec::smallvec![];
             for member in union.elements(db) {
                 functions.extend(extract_underlying_functions(db, *member));
             }
             functions
         }
-        _ => smallvec::smallvec![],
+        (_, _) => smallvec::smallvec![],
     }
 }
 
@@ -1379,7 +1390,10 @@ fn check_enum_member_against_constructor_hook<'db>(
     // The enum metaclass unpacks tuple values as positional args:
     //   MEMBER = (a, b, c)  →  __new__(cls, a, b, c) / __init__(self, a, b, c)
     //   MEMBER = x          →  __new__(cls, x) / __init__(self, x)
-    let args: Vec<Type<'db>> = if let Type::NominalInstance(instance) = member_value_type {
+    let args: Vec<Type<'db>> = if let (_, crate::types::TypeData::NominalInstance(instance)) = {
+        let __ty_view_value = member_value_type;
+        (__ty_view_value, __ty_view_value.data())
+    } {
         if let Some(spec) = instance.tuple_spec(db) {
             if let Tuple::Fixed(fixed) = &*spec {
                 fixed.all_elements().to_vec()

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -288,14 +288,11 @@ fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
             "Expected a global symbol for `{name}` in the property test module, but it was not found"
         );
     };
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) => {
+    match ty.data() {
+        crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype)) => {
             Type::NewTypeInstance(newtype)
         }
-        (_, _) => panic!("Expected NewType symbol for `{name}`, got {ty:?}"),
+        _ => panic!("Expected NewType symbol for `{name}`, got {ty:?}"),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -173,9 +173,11 @@ impl Ty {
                 let ty = known_module_symbol(db, KnownModule::Dataclasses, "MISSING")
                     .place
                     .expect_type();
-                debug_assert!(
-                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class_literal(db)))
-                );
+                debug_assert!(matches!(
+                    ty.data(),
+                    crate::types::TypeData::NominalInstance(instance)
+                        if is_single_member_enum(db, instance.class_literal(db))
+                ));
                 ty
             }
             Ty::BuiltinInstance(s) => builtins_symbol(db, s)
@@ -286,9 +288,14 @@ fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
             "Expected a global symbol for `{name}` in the property test module, but it was not found"
         );
     };
-    match ty {
-        Type::KnownInstance(KnownInstanceType::NewType(newtype)) => Type::NewTypeInstance(newtype),
-        _ => panic!("Expected NewType symbol for `{name}`, got {ty:?}"),
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::KnownInstance(KnownInstanceType::NewType(newtype))) => {
+            Type::NewTypeInstance(newtype)
+        }
+        (_, _) => panic!("Expected NewType symbol for `{name}`, got {ty:?}"),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -46,7 +46,7 @@ impl<'db> ClassType<'db> {
 
 /// Representation of a single `Protocol` class definition.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-pub(super) struct ProtocolClass<'db>(ClassType<'db>);
+pub(super) struct ProtocolClass<'db>(pub(super) ClassType<'db>);
 
 impl<'db> ProtocolClass<'db> {
     /// Returns the protocol members of this class.
@@ -1065,21 +1065,23 @@ fn cached_protocol_interface<'db>(
 
             let ty = ty.apply_optional_specialization(db, specialization);
 
-            let member = match ty {
-                Type::PropertyInstance(property) => ProtocolMemberKind::Property(property),
-                Type::Callable(callable)
+            let member = match (ty).data() {
+                crate::types::TypeData::PropertyInstance(property) => {
+                    ProtocolMemberKind::Property(property)
+                }
+                crate::types::TypeData::Callable(callable)
                     if bound_on_class.is_yes() && callable.is_function_like(db) =>
                 {
                     ProtocolMemberKind::Method(callable)
                 }
-                Type::FunctionLiteral(function)
+                crate::types::TypeData::FunctionLiteral(function)
                     if function.is_staticmethod(db) || function.is_classmethod(db) =>
                 {
                     ProtocolMemberKind::Other(todo_type!(
                         "classmethod and staticmethod protocol members"
                     ))
                 }
-                Type::FunctionLiteral(function) if bound_on_class.is_yes() => {
+                crate::types::TypeData::FunctionLiteral(function) if bound_on_class.is_yes() => {
                     ProtocolMemberKind::Method(function.into_callable_type(db))
                 }
                 _ => ProtocolMemberKind::Other(ty),
@@ -1154,8 +1156,8 @@ pub(super) fn has_all_protocol_members_defined<'db>(
 ) -> bool {
     let target_interface = protocol.interface(db);
 
-    match ty {
-        Type::ProtocolInstance(source_protocol) => {
+    match (ty).data() {
+        crate::types::TypeData::ProtocolInstance(source_protocol) => {
             let source_interface = source_protocol.interface(db);
 
             source_interface.member_count(db) >= target_interface.member_count(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -227,7 +227,7 @@ impl TypeRelation {
         matches!(self, TypeRelation::Subtyping)
     }
 
-    pub(crate) const fn can_safely_assume_reflexivity(self, ty: Type) -> bool {
+    pub(crate) fn can_safely_assume_reflexivity(self, ty: Type) -> bool {
         match self {
             TypeRelation::Assignability | TypeRelation::Redundancy { .. } => true,
             TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => {
@@ -247,13 +247,13 @@ impl<'db> Type<'db> {
     ///
     /// This method may have false negatives, but it should not have false positives. It should be
     /// a cheap shallow check, not an exhaustive recursive check.
-    const fn subtyping_is_always_reflexive(self) -> bool {
-        match self {
-            Type::Never
-            | Type::FunctionLiteral(..)
-            | Type::BoundMethod(_)
-            | Type::WrapperDescriptor(_)
-            | Type::KnownBoundMethod(
+    fn subtyping_is_always_reflexive(self) -> bool {
+        match { let __ty_view_value = self; (__ty_view_value, __ty_view_value.data()) }  {
+            (_, crate::types::TypeData::Never
+            | crate::types::TypeData::FunctionLiteral(..)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::KnownBoundMethod(
                 KnownBoundMethodType::FunctionTypeDunderGet(_)
                 | KnownBoundMethodType::FunctionTypeDunderCall(_)
                 | KnownBoundMethodType::StrStartswith(_)
@@ -265,43 +265,43 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::ConstraintSetSatisfiedByAllTypeVars(_)
                 | KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_),
             )
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::ModuleLiteral(..)
-            | Type::LiteralValue(_)
-            | Type::SpecialForm(_)
-            | Type::KnownInstance(_)
-            | Type::AlwaysFalsy
-            | Type::AlwaysTruthy
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::ModuleLiteral(..)
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::AlwaysTruthy
             // `T` is always a subtype of itself,
             // and `T` is always a subtype of `T | None`
-            | Type::TypeVar(_)
+            | crate::types::TypeData::TypeVar(_)
             // might inherit `Any`, but subtyping is still reflexive
-            | Type::ClassLiteral(_)
+            | crate::types::TypeData::ClassLiteral(_))
              => true,
-            Type::Dynamic(_)
-            | Type::Divergent(_)
-            | Type::NominalInstance(_)
-            | Type::ProtocolInstance(_)
-            | Type::GenericAlias(_)
-            | Type::SubclassOf(_)
-            | Type::Union(_)
-            | Type::Intersection(_)
-            | Type::EnumComplement(_)
-            | Type::Callable(_)
-            | Type::KnownBoundMethod(
+            (_, crate::types::TypeData::Dynamic(_)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::GenericAlias(_)
+            | crate::types::TypeData::SubclassOf(_)
+            | crate::types::TypeData::Union(_)
+            | crate::types::TypeData::Intersection(_)
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::KnownBoundMethod(
                 KnownBoundMethodType::PropertyDunderGet(_)
                 | KnownBoundMethodType::PropertyDunderSet(_)
                 | KnownBoundMethodType::PropertyDunderDelete(_),
             )
-            | Type::PropertyInstance(_)
-            | Type::BoundSuper(_)
-            | Type::TypeIs(_)
-            | Type::TypeGuard(_)
-            | Type::TypeForm(_)
-            | Type::TypedDict(_)
-            | Type::TypeAlias(_)
-            | Type::NewTypeInstance(_) => false,
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::TypedDict(_)
+            | crate::types::TypeData::TypeAlias(_)
+            | crate::types::TypeData::NewTypeInstance(_)) => false,
         }
     }
 
@@ -436,14 +436,28 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        match (self, target) {
-            (Type::Never | Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => true,
-            (_, Type::NominalInstance(target)) if target.is_object() => true,
-            (_, Type::Union(union)) => {
+        match (
+            ({
+                let __ty_view_value = self;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = target;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
+            ((_, crate::types::TypeData::Never | crate::types::TypeData::Dynamic(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::Dynamic(_))) => true,
+            ((_, _), (_, crate::types::TypeData::NominalInstance(target)))
+                if target.is_object() =>
+            {
+                true
+            }
+            ((_, _), (_, crate::types::TypeData::Union(union))) => {
                 self.materialized_divergent_fallback().is_none()
                     && union.elements(db).contains(&self)
             }
-            (Type::Intersection(intersection), _) => {
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
                 target.materialized_divergent_fallback().is_none()
                     && intersection.positive(db).contains(&target)
             }
@@ -904,11 +918,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         // These displays already expose the signature being compared; wrapping them would
         // duplicate the lower-level callable mismatch context.
         !matches!(
-            source,
-            Type::Callable(_)
-                | Type::FunctionLiteral(_)
-                | Type::BoundMethod(_)
-                | Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
+            {
+                let __ty_view_value = source;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (
+                _,
+                crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::BoundMethod(_)
+                    | crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
+            )
         )
     }
 
@@ -1038,7 +1058,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // constraint set. If the typevar has an upper bound or constraints, then the relation
             // only has to hold when the typevar has a valid specialization (i.e., one that
             // satisfies the upper bound/constraints).
-            if let Type::TypeVar(bound_typevar) = source {
+            if let (_, crate::types::TypeData::TypeVar(bound_typevar)) = {
+                let __ty_view_value = source;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 let upper = if self.relation.is_subtyping() {
                     target.bottom_materialization(db)
                 } else {
@@ -1050,7 +1073,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     bound_typevar,
                     upper,
                 );
-            } else if let Type::TypeVar(bound_typevar) = target {
+            } else if let (_, crate::types::TypeData::TypeVar(bound_typevar)) = {
+                let __ty_view_value = target;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 let lower = if self.relation.is_subtyping() {
                     source.top_materialization(db)
                 } else {
@@ -1066,126 +1092,159 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         }
 
         let should_expand_intersection = |intersection: IntersectionType<'db>| {
-            intersection
-                .positive(db)
-                .iter()
-                .any(|element| match element {
-                    Type::TypeVar(tvar) => !tvar.is_inferable(db, self.inferable),
-                    Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_union(),
-                    _ => false,
-                })
+            intersection.positive(db).iter().any(|element| {
+                match {
+                    let __ty_view_value = element;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::TypeVar(tvar)) => {
+                        !tvar.is_inferable(db, self.inferable)
+                    }
+                    (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+                        newtype.concrete_base_type(db).is_union()
+                    }
+                    (_, _) => false,
+                }
+            })
         };
 
-        match (source, target) {
+        match (
+            ({
+                let __ty_view_value = source;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = target;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
             // Everything is a subtype of `object`.
-            (_, Type::NominalInstance(target)) if target.is_object() => self.always(),
-            (_, Type::ProtocolInstance(target)) if target.is_equivalent_to_object(db) => {
+            ((_, _), (_, crate::types::TypeData::NominalInstance(target)))
+                if target.is_object() =>
+            {
+                self.always()
+            }
+            ((_, _), (_, crate::types::TypeData::ProtocolInstance(target)))
+                if target.is_equivalent_to_object(db) =>
+            {
                 self.always()
             }
 
             // `Never` is the bottom type, the empty set.
             // It is a subtype of all other types.
-            (Type::Never, _) => self.always(),
+            ((_, crate::types::TypeData::Never), (_, _)) => self.always(),
 
-            (Type::TypeVar(source_typevar), Type::TypeVar(target_typevar))
-                if source_typevar.is_same_typevar_as(db, target_typevar) =>
-            {
-                self.always()
-            }
+            (
+                (_, crate::types::TypeData::TypeVar(source_typevar)),
+                (_, crate::types::TypeData::TypeVar(target_typevar)),
+            ) if source_typevar.is_same_typevar_as(db, target_typevar) => self.always(),
 
             // In some specific situations, `Any`/`Unknown`/`@Todo` can be simplified out of unions and intersections,
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
-            (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
+            ((_, crate::types::TypeData::Divergent(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::Divergent(_))) => {
                 ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
             }
 
-            (Type::TypeAlias(source_alias), _) => self.with_recursion_guard(source, target, || {
-                self.check_type_pair(db, source_alias.value_type(db), target)
-            }),
+            ((_, crate::types::TypeData::TypeAlias(source_alias)), (_, _)) => self
+                .with_recursion_guard(source, target, || {
+                    self.check_type_pair(db, source_alias.value_type(db), target)
+                }),
 
-            (_, Type::TypeAlias(target_alias)) => self.with_recursion_guard(source, target, || {
-                self.check_type_pair(db, source, target_alias.value_type(db))
-            }),
+            ((_, _), (_, crate::types::TypeData::TypeAlias(target_alias))) => self
+                .with_recursion_guard(source, target, || {
+                    self.check_type_pair(db, source, target_alias.value_type(db))
+                }),
 
             // Annotation unions retain type aliases so recursive aliases can be represented.
             // Normalize direct alias elements together before checking the union so reductions
             // that depend on multiple elements, such as all members of an enum, are visible.
-            (_, Type::Union(union)) if union.has_aliases(db) => {
-                self.with_recursion_guard(source, target, || {
-                    self.check_type_pair(db, source, union.expand_aliases(db))
-                })
-            }
-
-            (Type::TypeForm(source_typeform), Type::TypeForm(target_typeform)) => self
+            ((_, _), (_, crate::types::TypeData::Union(union))) if union.has_aliases(db) => self
                 .with_recursion_guard(source, target, || {
-                    self.check_type_pair(
-                        db,
-                        source_typeform.type_argument(db),
-                        target_typeform.type_argument(db),
-                    )
+                    self.check_type_pair(db, source, union.expand_aliases(db))
                 }),
 
-            (Type::SubclassOf(source_subclass), Type::TypeForm(target_typeform)) => self
-                .check_type_pair(
+            (
+                (_, crate::types::TypeData::TypeForm(source_typeform)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_type_pair(
                     db,
-                    source_subclass.to_instance(db),
+                    source_typeform.type_argument(db),
                     target_typeform.type_argument(db),
-                ),
+                )
+            }),
 
-            (Type::NominalInstance(source_instance), Type::TypeForm(target_typeform))
-                if source_instance.has_known_class(db, KnownClass::Type) =>
-            {
+            (
+                (_, crate::types::TypeData::SubclassOf(source_subclass)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) => self.check_type_pair(
+                db,
+                source_subclass.to_instance(db),
+                target_typeform.type_argument(db),
+            ),
+
+            (
+                (_, crate::types::TypeData::NominalInstance(source_instance)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) if source_instance.has_known_class(db, KnownClass::Type) => {
                 self.check_type_pair(db, Type::object(), target_typeform.type_argument(db))
             }
 
-            (Type::ClassLiteral(source_class), Type::TypeForm(target_typeform)) => self
-                .check_type_pair(
-                    db,
-                    Type::instance(db, source_class.default_specialization(db)),
-                    target_typeform.type_argument(db),
-                ),
+            (
+                (_, crate::types::TypeData::ClassLiteral(source_class)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) => self.check_type_pair(
+                db,
+                Type::instance(db, source_class.default_specialization(db)),
+                target_typeform.type_argument(db),
+            ),
 
-            (Type::GenericAlias(source_alias), Type::TypeForm(target_typeform)) => self
-                .check_type_pair(
-                    db,
-                    Type::instance(db, ClassType::Generic(source_alias)),
-                    target_typeform.type_argument(db),
-                ),
+            (
+                (_, crate::types::TypeData::GenericAlias(source_alias)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) => self.check_type_pair(
+                db,
+                Type::instance(db, ClassType::Generic(source_alias)),
+                target_typeform.type_argument(db),
+            ),
 
-            (Type::KnownInstance(source_instance), Type::TypeForm(target_typeform))
-                if source_instance.is_type_form_value() =>
-            {
-                source_instance.type_form_argument(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |source_argument| {
-                        self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
-                    },
-                )
-            }
-
-            (Type::SpecialForm(source_form), Type::TypeForm(target_typeform)) => source_form
+            (
+                (_, crate::types::TypeData::KnownInstance(source_instance)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) if source_instance.is_type_form_value() => source_instance
                 .type_form_argument(db)
                 .when_some_and(db, self.constraints, |source_argument| {
                     self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
                 }),
 
-            (Type::GenericAlias(_), Type::NominalInstance(target_instance))
-                if target_instance.has_known_class(db, KnownClass::GenericAlias) =>
-            {
-                self.always()
-            }
+            (
+                (_, crate::types::TypeData::SpecialForm(source_form)),
+                (_, crate::types::TypeData::TypeForm(target_typeform)),
+            ) => source_form.type_form_argument(db).when_some_and(
+                db,
+                self.constraints,
+                |source_argument| {
+                    self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
+                },
+            ),
 
-            (Type::EnumComplement(complement), Type::LiteralValue(_) | Type::Union(_)) => {
-                self.check_type_pair(db, complement.remaining_literal_union(db), target)
-            }
+            (
+                (_, crate::types::TypeData::GenericAlias(_)),
+                (_, crate::types::TypeData::NominalInstance(target_instance)),
+            ) if target_instance.has_known_class(db, KnownClass::GenericAlias) => self.always(),
 
-            (Type::EnumComplement(complement), _) => {
+            (
+                (_, crate::types::TypeData::EnumComplement(complement)),
+                (_, crate::types::TypeData::LiteralValue(_) | crate::types::TypeData::Union(_)),
+            ) => self.check_type_pair(db, complement.remaining_literal_union(db), target),
+
+            ((_, crate::types::TypeData::EnumComplement(complement)), (_, _)) => {
                 self.check_type_pair(db, complement.to_intersection(db), target)
             }
 
-            (_, Type::EnumComplement(complement)) => {
+            ((_, _), (_, crate::types::TypeData::EnumComplement(complement))) => {
                 self.check_type_pair(db, source, complement.to_intersection(db))
             }
 
@@ -1210,34 +1269,53 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //        declared field type.
             //     3. If neither a converter nor a default value is provided, we allow the field to be
             //        considered assignable to any type.
-            (Type::KnownInstance(KnownInstanceType::Field(field)), _)
-                if self.is_eager_assignability() =>
-            {
-                field
-                    .default_type(db)
-                    .when_none_or(db, self.constraints, |default_type| {
-                        self.check_type_pair(db, default_type, target)
-                    })
-                    .and(db, self.constraints, || {
-                        field
-                            .converter(db)
-                            .map(|(_, output_ty)| output_ty)
-                            .when_none_or(db, self.constraints, |converter_output_type| {
-                                self.check_type_pair(db, converter_output_type, target)
-                            })
-                    })
-            }
+            (
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::Field(field))),
+                (_, _),
+            ) if self.is_eager_assignability() => field
+                .default_type(db)
+                .when_none_or(db, self.constraints, |default_type| {
+                    self.check_type_pair(db, default_type, target)
+                })
+                .and(db, self.constraints, || {
+                    field
+                        .converter(db)
+                        .map(|(_, output_ty)| output_ty)
+                        .when_none_or(db, self.constraints, |converter_output_type| {
+                            self.check_type_pair(db, converter_output_type, target)
+                        })
+                }),
 
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(target_partial)),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                        source_partial,
+                    )),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                        target_partial,
+                    )),
+                ),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
             }),
 
             (
-                Type::KnownInstance(KnownInstanceType::Sentinel(source_sentinel)),
-                Type::KnownInstance(KnownInstanceType::Sentinel(target_sentinel)),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
+                        source_sentinel,
+                    )),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
+                        target_sentinel,
+                    )),
+                ),
             ) => ConstraintSet::from_bool(
                 self.constraints,
                 source_sentinel.is_same_sentinel(db, target_sentinel),
@@ -1246,8 +1324,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
             // the nominal instance with the partial's return type so the check is precise.
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
-                Type::NominalInstance(target_instance),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                        partial,
+                    )),
+                ),
+                (_, crate::types::TypeData::NominalInstance(target_instance)),
             ) if target_instance
                 .class(db)
                 .is_known(db, KnownClass::FunctoolsPartial) =>
@@ -1263,33 +1346,41 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `T` is also a dynamic type or a union that contains a dynamic type. Similarly,
             // `T <: Any` only holds true if `T` is a dynamic type or an intersection that
             // contains a dynamic type.
-            (Type::Dynamic(_dynamic), _) => ConstraintSet::from_bool(
+            ((_, crate::types::TypeData::Dynamic(_dynamic)), (_, _)) => ConstraintSet::from_bool(
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
                     TypeRelation::Assignability => true,
-                    TypeRelation::Redundancy { .. } => match target {
-                        Type::Dynamic(_) => true,
-                        Type::Union(union) => union.elements(db).iter().any(Type::is_dynamic),
-                        _ => false,
+                    TypeRelation::Redundancy { .. } => match {
+                        let __ty_view_value = target;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::Dynamic(_)) => true,
+                        (_, crate::types::TypeData::Union(union)) => {
+                            union.elements(db).iter().any(Type::is_dynamic)
+                        }
+                        (_, _) => false,
                     },
                 },
             ),
-            (_, Type::Dynamic(_)) => ConstraintSet::from_bool(
+            ((_, _), (_, crate::types::TypeData::Dynamic(_))) => ConstraintSet::from_bool(
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
                     TypeRelation::Assignability => true,
-                    TypeRelation::Redundancy { .. } => match source {
-                        Type::Dynamic(_) => true,
-                        Type::Intersection(intersection) => {
+                    TypeRelation::Redundancy { .. } => match {
+                        let __ty_view_value = source;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::Dynamic(_)) => true,
+                        (_, crate::types::TypeData::Intersection(intersection)) => {
                             // If a `Divergent` type is involved, it must not be eliminated.
                             intersection
                                 .positive(db)
                                 .iter()
                                 .any(Type::is_non_divergent_dynamic)
                         }
-                        _ => false,
+                        (_, _) => false,
                     },
                 },
             ),
@@ -1301,7 +1392,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //
             // However, there is one exception to this general rule: for any given typevar `T`,
             // `T` will always be a subtype of any union containing `T`.
-            (_, Type::Union(union))
+            ((_, _), (_, crate::types::TypeData::Union(union)))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
             {
@@ -1309,13 +1400,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // A similar rule applies in reverse to intersection types.
-            (Type::Intersection(intersection), _)
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
                 if self.relation.can_safely_assume_reflexivity(target)
                     && intersection.positive(db).contains(&target) =>
             {
                 self.always()
             }
-            (Type::Intersection(intersection), _)
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
                 if self.is_eager_assignability()
                     && intersection.positive(db).iter().any(Type::is_dynamic) =>
             {
@@ -1324,7 +1415,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 // `T` and any `S`, and `Never` is a subtype of all types.
                 self.always()
             }
-            (Type::Intersection(intersection), _)
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
                 if self.relation.can_safely_assume_reflexivity(target)
                     && intersection.negative(db).contains(&target) =>
             {
@@ -1336,7 +1427,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // subclass of `type`), we instead compare in the metaclass-instance domain, since
             // collapsing `A` through `to_instance()` would erase it to `object` (we have no
             // precise representation for "all instances of any classes with a given metaclass").
-            (Type::SubclassOf(subclass_of), _)
+            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (_, _))
                 if subclass_of.is_type_var()
                     && Self::can_check_typevar_subclass_relation_to_target(db, target) =>
             {
@@ -1345,7 +1436,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // And vice versa. (No special metaclass handling is needed in this direction, since
             // "collapse to 'object'" in this case is a sound over-approximation.)
-            (_, Type::SubclassOf(subclass_of))
+            ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
                 if subclass_of.is_type_var() && source.to_instance(db).is_some() =>
             {
                 subclass_of
@@ -1360,22 +1451,29 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // `ParamSpec` value. This only applies to fixed `ParamSpec` values in already-
             // specialized generic aliases; inferable `ParamSpec`s are handled by the inference
             // paths below.
-            (Type::TypeVar(bound_typevar), Type::Callable(other))
-            | (Type::Callable(other), Type::TypeVar(bound_typevar))
-                if self.is_eager_assignability()
-                    && !bound_typevar.is_inferable(db, self.inferable)
-                    && bound_typevar.is_paramspec(db)
-                    && Self::is_gradual_paramspec_value(db, other) =>
+            (
+                (_, crate::types::TypeData::TypeVar(bound_typevar)),
+                (_, crate::types::TypeData::Callable(other)),
+            )
+            | (
+                (_, crate::types::TypeData::Callable(other)),
+                (_, crate::types::TypeData::TypeVar(bound_typevar)),
+            ) if self.is_eager_assignability()
+                && !bound_typevar.is_inferable(db, self.inferable)
+                && bound_typevar.is_paramspec(db)
+                && Self::is_gradual_paramspec_value(db, other) =>
             {
                 self.always()
             }
 
             // Any concrete specialization of a `ParamSpec` is a subtype of the top
             // materialization of a `ParamSpec` value.
-            (Type::TypeVar(bound_typevar), Type::Callable(other))
-                if !bound_typevar.is_inferable(db, self.inferable)
-                    && bound_typevar.is_paramspec(db)
-                    && Self::is_top_paramspec_value(db, other) =>
+            (
+                (_, crate::types::TypeData::TypeVar(bound_typevar)),
+                (_, crate::types::TypeData::Callable(other)),
+            ) if !bound_typevar.is_inferable(db, self.inferable)
+                && bound_typevar.is_paramspec(db)
+                && Self::is_top_paramspec_value(db, other) =>
             {
                 self.always()
             }
@@ -1383,7 +1481,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // A fully static typevar is a subtype of its upper bound, and to something similar to
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
-            (Type::TypeVar(bound_typevar), _)
+            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _))
                 if !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1405,7 +1503,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // If the typevar is constrained, there must be multiple constraints, and the typevar
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
-            (_, Type::TypeVar(bound_typevar))
+            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar)))
                 if !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)
@@ -1432,7 +1530,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 )
             }
 
-            (Type::TypeVar(bound_typevar), _) if bound_typevar.is_inferable(db, self.inferable) => {
+            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _))
+                if bound_typevar.is_inferable(db, self.inferable) =>
+            {
                 // The implicit lower bound of a typevar is `Never`, which means
                 // that it is always assignable to any other type.
 
@@ -1445,45 +1545,48 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // (`object` can be a subtype of some protocols, or of itself, but those cases are
             // handled above).
             (
-                Type::NominalInstance(source),
-                Type::NominalInstance(_)
-                | Type::SubclassOf(_)
-                | Type::Callable(_)
-                | Type::ProtocolInstance(_),
+                (_, crate::types::TypeData::NominalInstance(source)),
+                (
+                    _,
+                    crate::types::TypeData::NominalInstance(_)
+                    | crate::types::TypeData::SubclassOf(_)
+                    | crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::ProtocolInstance(_),
+                ),
             ) if source.is_object() => self.never(),
 
             // Fast path: `object` is not a subtype of any non-inferable type variable, since the
             // type variable could be specialized to a type smaller than `object`.
-            (Type::NominalInstance(source), Type::TypeVar(typevar))
-                if source.is_object() && !typevar.is_inferable(db, self.inferable) =>
-            {
-                self.never()
-            }
+            (
+                (_, crate::types::TypeData::NominalInstance(source)),
+                (_, crate::types::TypeData::TypeVar(typevar)),
+            ) if source.is_object() && !typevar.is_inferable(db, self.inferable) => self.never(),
 
-            (Type::NewTypeInstance(source_newtype), Type::NewTypeInstance(target_newtype)) => {
-                self.check_newtype_pair(db, source_newtype, target_newtype)
-            }
+            (
+                (_, crate::types::TypeData::NewTypeInstance(source_newtype)),
+                (_, crate::types::TypeData::NewTypeInstance(target_newtype)),
+            ) => self.check_newtype_pair(db, source_newtype, target_newtype),
 
-            (Type::Union(union), _) => {
-                union
-                    .elements(db)
-                    .iter()
-                    .when_all(db, self.constraints, |&elem_ty| {
-                        let constraint_set = self.check_type_pair(db, elem_ty, target);
-                        if constraint_set.is_never_satisfied(db) {
-                            self.provide_context(|| ErrorContext::NotAllUnionElementsAssignable {
-                                element: elem_ty,
-                                union: source,
-                                target,
-                            });
-                        }
-                        constraint_set
-                    })
-            }
+            ((_, crate::types::TypeData::Union(union)), (_, _)) => union
+                .elements(db)
+                .iter()
+                .when_all(db, self.constraints, |&elem_ty| {
+                    let constraint_set = self.check_type_pair(db, elem_ty, target);
+                    if constraint_set.is_never_satisfied(db) {
+                        self.provide_context(|| ErrorContext::NotAllUnionElementsAssignable {
+                            element: elem_ty,
+                            union: source,
+                            target,
+                        });
+                    }
+                    constraint_set
+                }),
 
-            (_, Type::Union(union)) => {
-                if let Type::Intersection(intersection) = source
-                    && let Some(alternatives) = intersection.finite_alternative_union(db)
+            ((_, _), (_, crate::types::TypeData::Union(union))) => {
+                if let (_, crate::types::TypeData::Intersection(intersection)) = ({
+                    let __ty_view_value = source;
+                    (__ty_view_value, __ty_view_value.data())
+                }) && let Some(alternatives) = intersection.finite_alternative_union(db)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1494,8 +1597,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     // to be a newtype of a union, for an intersection to contain a newtype of a union, or for
                     // a non-inferable typevar (possibly inside an intersection) to widen to a bound or set of
                     // constraints that exposes a union; this requires special handling.
-                    match source {
-                        Type::Intersection(intersection)
+                    match {
+                        let __ty_view_value = source;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
+                        (_, crate::types::TypeData::Intersection(intersection))
                             if should_expand_intersection(intersection) =>
                         {
                             self.check_type_pair(
@@ -1504,7 +1610,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 target,
                             )
                         }
-                        Type::NewTypeInstance(newtype) => {
+                        (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                             let concrete_base = newtype.concrete_base_type(db);
                             if concrete_base.is_union() {
                                 self.check_type_pair(db, concrete_base, target)
@@ -1512,7 +1618,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 self.never()
                             }
                         }
-                        _ => self.never(),
+                        (_, _) => self.never(),
                     }
                 };
 
@@ -1562,7 +1668,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // If both sides are intersections we need to handle the right side first
             // (A & B & C) is a subtype of (A & B) because the left is a subtype of both A and B,
             // but none of A, B, or C is a subtype of (A & B).
-            (_, Type::Intersection(intersection)) => intersection
+            ((_, _), (_, crate::types::TypeData::Intersection(intersection))) => intersection
                 .positive(db)
                 .iter()
                 .when_all(db, self.constraints, |&pos_ty| {
@@ -1611,9 +1717,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         })
                 }),
 
-            (Type::Intersection(intersection), _) => {
-                if matches!(target, Type::LiteralValue(_))
-                    && let Some(alternatives) = intersection.finite_alternative_union(db)
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
+                if matches!(
+                    {
+                        let __ty_view_value = target;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (_, crate::types::TypeData::LiteralValue(_))
+                ) && let Some(alternatives) = intersection.finite_alternative_union(db)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1667,21 +1778,23 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // `Never` is the bottom type, the empty set.
-            (_, Type::Never) => self.never(),
+            ((_, _), (_, crate::types::TypeData::Never)) => self.never(),
 
             // Other than the special cases checked above, no other types are a subtype of a
             // typevar, since there's no guarantee what type the typevar will be specialized to.
             // (If the typevar is bounded, it might be specialized to a smaller type than the
             // bound. This is true even if the bound is a final class, since the typevar can still
             // be specialized to `Never`.)
-            (_, Type::TypeVar(bound_typevar))
+            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar)))
                 if !bound_typevar.is_inferable(db, self.inferable) =>
             {
                 self.never()
             }
 
             // TODO: Infer specializations here
-            (_, Type::TypeVar(typevar)) if typevar.is_inferable(db, self.inferable) => {
+            ((_, _), (_, crate::types::TypeData::TypeVar(typevar)))
+                if typevar.is_inferable(db, self.inferable) =>
+            {
                 if self.is_eager_assignability() {
                     // TODO: record the unification constraints
                     typevar.typevar(db).upper_bound(db).when_none_or(
@@ -1693,7 +1806,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     self.never()
                 }
             }
-            (Type::TypeVar(bound_typevar), _) => {
+            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _)) => {
                 // All inferable cases should have been handled above
                 assert!(!bound_typevar.is_inferable(db, self.inferable));
                 self.never()
@@ -1703,36 +1816,43 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // This case must come after the TypeVar cases above, so that when checking
             // `NewType <: TypeVar`, we use the TypeVar handling rather than falling back
             // to the NewType's concrete base type.
-            (Type::NewTypeInstance(source_newtype), _) => {
+            ((_, crate::types::TypeData::NewTypeInstance(source_newtype)), (_, _)) => {
                 self.check_type_pair(db, source_newtype.concrete_base_type(db), target)
             }
 
             // Note that the definition of `Type::AlwaysFalsy` depends on the return value of `__bool__`.
             // If `__bool__` always returns True or False, it can be treated as a subtype of `AlwaysTruthy` or `AlwaysFalsy`, respectively.
-            (_, Type::AlwaysFalsy) => {
+            ((_, _), (_, crate::types::TypeData::AlwaysFalsy)) => {
                 ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_false())
             }
-            (_, Type::AlwaysTruthy) => {
+            ((_, _), (_, crate::types::TypeData::AlwaysTruthy)) => {
                 ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_true())
             }
             // Currently, the only supertype of `AlwaysFalsy` and `AlwaysTruthy` is the universal set (object instance).
-            (Type::AlwaysFalsy | Type::AlwaysTruthy, _) => {
-                self.with_recursion_guard(source, target, || {
-                    self.check_type_pair(db, Type::object(), target)
-                })
-            }
+            (
+                (_, crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy),
+                (_, _),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_type_pair(db, Type::object(), target)
+            }),
 
             // These clauses handle type variants that include function literals. A function
             // literal is the subtype of itself, and not of any other function literal. However,
             // our representation of a function literal includes any specialization that should be
             // applied to the signature. Different specializations of the same function literal are
             // only subtypes of each other if they result in the same signature.
-            (Type::FunctionLiteral(source_function), Type::FunctionLiteral(target_function)) => {
-                self.check_function_pair(db, source_function, target_function)
-            }
             (
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartial(source_partial)),
-                Type::FunctionLiteral(target_function),
+                (_, crate::types::TypeData::FunctionLiteral(source_function)),
+                (_, crate::types::TypeData::FunctionLiteral(target_function)),
+            ) => self.check_function_pair(db, source_function, target_function),
+            (
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                        source_partial,
+                    )),
+                ),
+                (_, crate::types::TypeData::FunctionLiteral(target_function)),
             ) if matches!(self.relation, TypeRelation::Assignability) => {
                 self.with_recursion_guard(source, target, || {
                     self.check_callable_signature_pair(
@@ -1742,57 +1862,68 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     )
                 })
             }
-            (Type::BoundMethod(source_method), Type::BoundMethod(target_method)) => {
-                self.check_bound_method_pair(db, source_method, target_method)
-            }
-            (Type::KnownBoundMethod(source_method), Type::KnownBoundMethod(target_method)) => {
-                self.check_known_bound_method_pair(db, source_method, target_method)
-            }
+            (
+                (_, crate::types::TypeData::BoundMethod(source_method)),
+                (_, crate::types::TypeData::BoundMethod(target_method)),
+            ) => self.check_bound_method_pair(db, source_method, target_method),
+            (
+                (_, crate::types::TypeData::KnownBoundMethod(source_method)),
+                (_, crate::types::TypeData::KnownBoundMethod(target_method)),
+            ) => self.check_known_bound_method_pair(db, source_method, target_method),
 
             // All `StringLiteral` types are a subtype of `LiteralString`.
-            (Type::LiteralValue(source), Type::LiteralValue(target))
-                if source.is_string() && target.is_literal_string() =>
-            {
-                self.always()
-            }
+            (
+                (_, crate::types::TypeData::LiteralValue(source)),
+                (_, crate::types::TypeData::LiteralValue(target)),
+            ) if source.is_string() && target.is_literal_string() => self.always(),
 
             // For union simplification, we want to preserve the unpromotable form of a literal value,
             // and so redundancy is not symmetric.
-            (Type::LiteralValue(source), Type::LiteralValue(target))
-                if matches!(self.relation, TypeRelation::Redundancy { pure: false }) =>
-            {
+            (
+                (_, crate::types::TypeData::LiteralValue(source)),
+                (_, crate::types::TypeData::LiteralValue(target)),
+            ) if matches!(self.relation, TypeRelation::Redundancy { pure: false }) => {
                 ConstraintSet::from_bool(
                     self.constraints,
                     source.kind() == target.kind() && source.is_promotable(),
                 )
             }
 
-            (Type::LiteralValue(source), Type::LiteralValue(target)) => {
-                ConstraintSet::from_bool(self.constraints, source.kind() == target.kind())
-            }
+            (
+                (_, crate::types::TypeData::LiteralValue(source)),
+                (_, crate::types::TypeData::LiteralValue(target)),
+            ) => ConstraintSet::from_bool(self.constraints, source.kind() == target.kind()),
 
             // No literal type is a subtype of any other literal type, unless they are the same
             // type (which is handled above). This case is not necessary from a correctness
             // perspective (the fallback cases below will handle it correctly), but it is important
             // for performance of simplifying large unions of literal types.
             (
-                Type::LiteralValue(_)
-                | Type::ClassLiteral(_)
-                | Type::FunctionLiteral(_)
-                | Type::ModuleLiteral(_),
-                Type::LiteralValue(_)
-                | Type::ClassLiteral(_)
-                | Type::FunctionLiteral(_)
-                | Type::ModuleLiteral(_),
+                (
+                    _,
+                    crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::ModuleLiteral(_),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::FunctionLiteral(_)
+                    | crate::types::TypeData::ModuleLiteral(_),
+                ),
             ) => self.never(),
 
-            (Type::Callable(source_callable), Type::Callable(target_callable)) => self
-                .with_recursion_guard(source, target, || {
-                    self.check_callable_pair(db, source_callable, target_callable)
-                }),
+            (
+                (_, crate::types::TypeData::Callable(source_callable)),
+                (_, crate::types::TypeData::Callable(target_callable)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_callable_pair(db, source_callable, target_callable)
+            }),
 
-            (_, Type::Callable(target_callable)) => {
-                self.with_recursion_guard(source, target, || {
+            ((_, _), (_, crate::types::TypeData::Callable(target_callable))) => self
+                .with_recursion_guard(source, target, || {
                     let Some(callables) = source
                         .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                     else {
@@ -1811,8 +1942,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     }
 
                     result
-                })
-            }
+                }),
 
             // `type[Any]` is assignable to arbitrary protocols as it has arbitrary attributes
             // (this is handled by a lower-down branch), but it is only a subtype of a given
@@ -1820,64 +1950,72 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // always be assignable to any protocol if `type[<upper bound of T>]` is assignable
             // to that protocol (handled lower down), but it is only a subtype of that protocol
             // if `type` is a subtype of that protocol.
-            (Type::SubclassOf(source_subclass_ty), Type::ProtocolInstance(_))
-                if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
-                    && !self.is_eager_assignability() =>
+            (
+                (_, crate::types::TypeData::SubclassOf(source_subclass_ty)),
+                (_, crate::types::TypeData::ProtocolInstance(_)),
+            ) if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
+                && !self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
             }
 
-            (_, Type::ProtocolInstance(target_proto)) => {
-                self.with_recursion_guard(source, target, || {
+            ((_, _), (_, crate::types::TypeData::ProtocolInstance(target_proto))) => self
+                .with_recursion_guard(source, target, || {
                     self.check_type_satisfies_protocol(db, source, target_proto)
-                })
-            }
+                }),
 
             // A protocol instance can never be a subtype of a nominal type, with the *sole* exception of `object`.
-            (Type::ProtocolInstance(_), _) => self.never(),
+            ((_, crate::types::TypeData::ProtocolInstance(_)), (_, _)) => self.never(),
 
-            (Type::TypedDict(source_td), Type::TypedDict(target_td)) => {
-                self.with_recursion_guard(source, target, || {
-                    self.check_typeddict_pair(db, source_td, target_td)
-                })
-            }
-
-            (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
-                let dict_value_type = if self.relation.is_assignability() {
-                    typed_dict.assignable_dict_value_type(db)
-                } else {
-                    typed_dict.dict_value_type(db)
-                };
-                let fallback = if let Some(value_ty) = dict_value_type {
-                    KnownClass::Dict
-                        .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
-                } else {
-                    KnownClass::Mapping.to_specialized_instance(
-                        db,
-                        &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
-                    )
-                };
-                let result = self.check_type_pair(db, fallback, target);
-                if result.is_never_satisfied(db) {
-                    if let Type::NominalInstance(instance) = target
-                        && instance.class(db).is_known(db, KnownClass::Dict)
-                    {
-                        self.provide_context(|| {
-                            ErrorContext::TypedDictNotAssignableToDict(typed_dict)
-                        });
-                    }
-                }
-                result
+            (
+                (_, crate::types::TypeData::TypedDict(source_td)),
+                (_, crate::types::TypeData::TypedDict(target_td)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_typeddict_pair(db, source_td, target_td)
             }),
 
+            ((_, crate::types::TypeData::TypedDict(typed_dict)), (_, _)) => self
+                .with_recursion_guard(source, target, || {
+                    let dict_value_type = if self.relation.is_assignability() {
+                        typed_dict.assignable_dict_value_type(db)
+                    } else {
+                        typed_dict.dict_value_type(db)
+                    };
+                    let fallback = if let Some(value_ty) = dict_value_type {
+                        KnownClass::Dict.to_specialized_instance(
+                            db,
+                            &[KnownClass::Str.to_instance(db), value_ty],
+                        )
+                    } else {
+                        KnownClass::Mapping.to_specialized_instance(
+                            db,
+                            &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+                        )
+                    };
+                    let result = self.check_type_pair(db, fallback, target);
+                    if result.is_never_satisfied(db) {
+                        if let (_, crate::types::TypeData::NominalInstance(instance)) = ({
+                            let __ty_view_value = target;
+                            (__ty_view_value, __ty_view_value.data())
+                        }) && instance.class(db).is_known(db, KnownClass::Dict)
+                        {
+                            self.provide_context(|| {
+                                ErrorContext::TypedDictNotAssignableToDict(typed_dict)
+                            });
+                        }
+                    }
+                    result
+                }),
+
             // A non-`TypedDict` cannot subtype a `TypedDict`
-            (_, Type::TypedDict(_)) => self.never(),
+            ((_, _), (_, crate::types::TypeData::TypedDict(_))) => self.never(),
 
             // A string literal `Literal["abc"]` is assignable to `str` *and* to
             // `Sequence[Literal["a", "b", "c"]]` because strings are sequences of their characters.
-            (Type::LiteralValue(literal), Type::NominalInstance(instance))
-                if literal.is_string() =>
-            {
+            (
+                (_, crate::types::TypeData::LiteralValue(literal)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            ) if literal.is_string() => {
                 let value = literal.as_string().unwrap();
                 let target_class = instance.class(db);
 
@@ -1919,13 +2057,16 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
-            (Type::LiteralValue(literal), _) if literal.is_string() => self.never(),
+            ((_, crate::types::TypeData::LiteralValue(literal)), (_, _)) if literal.is_string() => {
+                self.never()
+            }
 
             // A bytes literal `Literal[b"abc"]` is assignable to `bytes` *and* to
             // `Sequence[Literal[97, 98, 99]]` because bytes are sequences of integers.
-            (Type::LiteralValue(literal), Type::NominalInstance(instance))
-                if literal.is_bytes() =>
-            {
+            (
+                (_, crate::types::TypeData::LiteralValue(literal)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            ) if literal.is_bytes() => {
                 let value = literal.as_bytes().unwrap();
                 let target_class = instance.class(db);
 
@@ -1966,11 +2107,16 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
-            (Type::LiteralValue(literal), _) if literal.is_bytes() => self.never(),
+            ((_, crate::types::TypeData::LiteralValue(literal)), (_, _)) if literal.is_bytes() => {
+                self.never()
+            }
 
             // An instance is a subtype of an enum literal, if it is an instance of the enum class
             // and the enum has only one member.
-            (Type::NominalInstance(_), Type::LiteralValue(literal)) if literal.is_enum() => {
+            (
+                (_, crate::types::TypeData::NominalInstance(_)),
+                (_, crate::types::TypeData::LiteralValue(literal)),
+            ) if literal.is_enum() => {
                 let target_enum_literal = literal.as_enum().unwrap();
                 if target_enum_literal.enum_class_instance(db) != source {
                     return self.never();
@@ -1985,34 +2131,50 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Except for the special `BytesLiteral`, `LiteralString`, and string literal cases above,
             // most `Literal` types delegate to their instance fallbacks
             // unless `source` is exactly equivalent to `target` (handled above)
-            (Type::ModuleLiteral(_) | Type::LiteralValue(_) | Type::FunctionLiteral(_), _) => {
-                source.literal_fallback_instance(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |source_instance| self.check_type_pair(db, source_instance, target),
-                )
-            }
+            (
+                (
+                    _,
+                    crate::types::TypeData::ModuleLiteral(_)
+                    | crate::types::TypeData::LiteralValue(_)
+                    | crate::types::TypeData::FunctionLiteral(_),
+                ),
+                (_, _),
+            ) => source.literal_fallback_instance(db).when_some_and(
+                db,
+                self.constraints,
+                |source_instance| self.check_type_pair(db, source_instance, target),
+            ),
 
             // The same reasoning applies for these special callable types:
-            (Type::BoundMethod(_), _) => {
+            ((_, crate::types::TypeData::BoundMethod(_)), (_, _)) => {
                 self.check_type_pair(db, KnownClass::MethodType.to_instance(db), target)
             }
-            (Type::KnownBoundMethod(method), _) => {
+            ((_, crate::types::TypeData::KnownBoundMethod(method)), (_, _)) => {
                 self.check_type_pair(db, method.class().to_instance(db), target)
             }
-            (Type::WrapperDescriptor(_), _) => self.check_type_pair(
+            ((_, crate::types::TypeData::WrapperDescriptor(_)), (_, _)) => self.check_type_pair(
                 db,
                 KnownClass::WrapperDescriptorType.to_instance(db),
                 target,
             ),
 
-            (Type::DataclassDecorator(_) | Type::DataclassTransformer(_), _) => {
+            (
+                (
+                    _,
+                    crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ),
+                (_, _),
+            ) => {
                 // TODO: Implement subtyping using an equivalent `Callable` type.
                 self.never()
             }
 
             // `TypeIs` is invariant.
-            (Type::TypeIs(source), Type::TypeIs(target)) => {
+            (
+                (_, crate::types::TypeData::TypeIs(source)),
+                (_, crate::types::TypeData::TypeIs(target)),
+            ) => {
                 let source_type = source.type_argument(db);
                 let target_type = target.type_argument(db);
                 self.check_type_pair(db, source_type, target_type)
@@ -2022,31 +2184,39 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // `TypeGuard` is covariant.
-            (Type::TypeGuard(source), Type::TypeGuard(target)) => {
-                self.check_type_pair(db, source.return_type(db), target.return_type(db))
-            }
+            (
+                (_, crate::types::TypeData::TypeGuard(source)),
+                (_, crate::types::TypeData::TypeGuard(target)),
+            ) => self.check_type_pair(db, source.return_type(db), target.return_type(db)),
 
             // `TypeIs[T]` and `TypeGuard[T]` are subtypes of `bool`.
-            (Type::TypeIs(_) | Type::TypeGuard(_), _) => {
-                self.check_type_pair(db, KnownClass::Bool.to_instance(db), target)
-            }
+            (
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
+                (_, _),
+            ) => self.check_type_pair(db, KnownClass::Bool.to_instance(db), target),
 
             // Function-like callables are subtypes of `FunctionType`
-            (Type::Callable(callable), _) if callable.is_function_like(db) => {
+            ((_, crate::types::TypeData::Callable(callable)), (_, _))
+                if callable.is_function_like(db) =>
+            {
                 self.check_type_pair(db, KnownClass::FunctionType.to_instance(db), target)
             }
 
-            (Type::Callable(_), _) => self.never(),
+            ((_, crate::types::TypeData::Callable(_)), (_, _)) => self.never(),
 
-            (Type::BoundSuper(source), Type::BoundSuper(target)) => self
+            (
+                (_, crate::types::TypeData::BoundSuper(source)),
+                (_, crate::types::TypeData::BoundSuper(target)),
+            ) => self
                 .as_equivalence_checker()
                 .check_bound_super_pair(db, source, target),
 
-            (Type::BoundSuper(_), _) => {
+            ((_, crate::types::TypeData::BoundSuper(_)), (_, _)) => {
                 self.check_type_pair(db, KnownClass::Super.to_instance(db), target)
             }
 
-            (Type::SubclassOf(subclass_of), _) | (_, Type::SubclassOf(subclass_of))
+            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
                 if subclass_of.is_type_var() =>
             {
                 self.never()
@@ -2054,68 +2224,78 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `Literal[<class 'C'>]` is a subtype of `type[B]` if `C` is a subclass of `B`,
             // since `type[B]` describes all possible runtime subclasses of the class object `B`.
-            (Type::ClassLiteral(source_cls), Type::SubclassOf(target_subclass_ty)) => {
-                target_subclass_ty
-                    .subclass_of()
-                    .into_class(db)
-                    .map(|target_cls| {
-                        self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
-                    })
-                    .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
-                    })
-            }
+            (
+                (_, crate::types::TypeData::ClassLiteral(source_cls)),
+                (_, crate::types::TypeData::SubclassOf(target_subclass_ty)),
+            ) => target_subclass_ty
+                .subclass_of()
+                .into_class(db)
+                .map(|target_cls| {
+                    self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
+                })
+                .unwrap_or_else(|| {
+                    ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+                }),
 
             // Similarly, `<class 'C'>` is assignable to `<class 'C[...]'>` (a generic-alias type)
             // if the default specialization of `C` is assignable to `C[...]`. This scenario occurs
             // with final generic types, where `type[C[...]]` is simplified to the generic-alias
             // type `<class 'C[...]'>`, due to the fact that `C[...]` has no subclasses.
-            (Type::ClassLiteral(source_cls), Type::GenericAlias(target_alias)) => self
-                .check_class_pair(
-                    db,
-                    source_cls.default_specialization(db),
-                    ClassType::Generic(target_alias),
-                ),
+            (
+                (_, crate::types::TypeData::ClassLiteral(source_cls)),
+                (_, crate::types::TypeData::GenericAlias(target_alias)),
+            ) => self.check_class_pair(
+                db,
+                source_cls.default_specialization(db),
+                ClassType::Generic(target_alias),
+            ),
 
             // For generic aliases, we delegate to the underlying class type.
-            (Type::GenericAlias(source_alias), Type::GenericAlias(target_alias)) => self
-                .check_class_pair(
-                    db,
-                    ClassType::Generic(source_alias),
-                    ClassType::Generic(target_alias),
-                ),
+            (
+                (_, crate::types::TypeData::GenericAlias(source_alias)),
+                (_, crate::types::TypeData::GenericAlias(target_alias)),
+            ) => self.check_class_pair(
+                db,
+                ClassType::Generic(source_alias),
+                ClassType::Generic(target_alias),
+            ),
 
-            (Type::GenericAlias(source_alias), Type::SubclassOf(target_subclass_ty)) => {
-                target_subclass_ty
-                    .subclass_of()
-                    .into_class(db)
-                    .map(|target_cls| {
-                        self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
-                    })
-                    .unwrap_or_else(|| {
-                        ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
-                    })
-            }
+            (
+                (_, crate::types::TypeData::GenericAlias(source_alias)),
+                (_, crate::types::TypeData::SubclassOf(target_subclass_ty)),
+            ) => target_subclass_ty
+                .subclass_of()
+                .into_class(db)
+                .map(|target_cls| {
+                    self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
+                })
+                .unwrap_or_else(|| {
+                    ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+                }),
 
             // This branch asks: given two types `type[T]` and `type[S]`, is `type[T]` a subtype of `type[S]`?
-            (Type::SubclassOf(source), Type::SubclassOf(target)) => {
-                self.check_subclassof_pair(db, source, target)
-            }
+            (
+                (_, crate::types::TypeData::SubclassOf(source)),
+                (_, crate::types::TypeData::SubclassOf(target)),
+            ) => self.check_subclassof_pair(db, source, target),
 
             // `Literal[str]` is a subtype of `type` because the `str` class object is an instance of its metaclass `type`.
             // `Literal[abc.ABC]` is a subtype of `abc.ABCMeta` because the `abc.ABC` class object
             // is an instance of its metaclass `abc.ABCMeta`.
-            (Type::ClassLiteral(source_class), _) => {
+            ((_, crate::types::TypeData::ClassLiteral(source_class)), (_, _)) => {
                 self.check_type_pair(db, source_class.metaclass_instance_type(db), target)
             }
-            (Type::GenericAlias(source_alias), _) => self.check_type_pair(
-                db,
-                ClassType::Generic(source_alias).metaclass_instance_type(db),
-                target,
-            ),
+            ((_, crate::types::TypeData::GenericAlias(source_alias)), (_, _)) => self
+                .check_type_pair(
+                    db,
+                    ClassType::Generic(source_alias).metaclass_instance_type(db),
+                    target,
+                ),
 
             // `type[Any]` is a subtype of `type[object]`, and is assignable to any `type[...]`
-            (Type::SubclassOf(subclass_of_ty), _) if subclass_of_ty.is_dynamic() => {
+            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (_, _))
+                if subclass_of_ty.is_dynamic() =>
+            {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
                     .or(db, self.constraints, || {
                         ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
@@ -2126,7 +2306,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // Any `type[...]` type is assignable to `type[Any]`
-            (_, Type::SubclassOf(subclass_of_ty))
+            ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of_ty)))
                 if subclass_of_ty.is_dynamic() && self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, source, KnownClass::Type.to_instance(db))
@@ -2139,50 +2319,57 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Similarly `type[enum.Enum]`  is a subtype of `enum.EnumMeta` because `enum.Enum`
             // is an instance of `enum.EnumMeta`. `type[Any]` and `type[Unknown]` do not participate in subtyping,
             // however, as they are not fully static types.
-            (Type::SubclassOf(subclass_of_ty), _) => self.check_type_pair(
-                db,
-                subclass_of_ty
-                    .subclass_of()
-                    .into_class(db)
-                    .map(|source_class| source_class.metaclass_instance_type(db))
-                    .unwrap_or_else(|| KnownClass::Type.to_instance(db)),
-                target,
-            ),
+            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (_, _)) => self
+                .check_type_pair(
+                    db,
+                    subclass_of_ty
+                        .subclass_of()
+                        .into_class(db)
+                        .map(|source_class| source_class.metaclass_instance_type(db))
+                        .unwrap_or_else(|| KnownClass::Type.to_instance(db)),
+                    target,
+                ),
 
-            (Type::TypeForm(_), _) => self.check_type_pair(db, Type::object(), target),
+            ((_, crate::types::TypeData::TypeForm(_)), (_, _)) => {
+                self.check_type_pair(db, Type::object(), target)
+            }
 
             // For example: `Type::SpecialForm(SpecialFormType::Type)` is a subtype of `Type::NominalInstance(_SpecialForm)`,
             // because `Type::SpecialForm(SpecialFormType::Type)` is a set with exactly one runtime value in it
             // (the symbol `typing.Type`), and that symbol is known to be an instance of `typing._SpecialForm` at runtime.
-            (Type::SpecialForm(source_form), _) => {
+            ((_, crate::types::TypeData::SpecialForm(source_form)), (_, _)) => {
                 self.check_type_pair(db, source_form.instance_fallback(db), target)
             }
 
-            (Type::KnownInstance(source), _) => {
+            ((_, crate::types::TypeData::KnownInstance(source)), (_, _)) => {
                 self.check_type_pair(db, source.instance_fallback(db), target)
             }
 
             // `bool` is a subtype of `int`, because `bool` subclasses `int`,
             // which means that all instances of `bool` are also instances of `int`
-            (Type::NominalInstance(source_i), Type::NominalInstance(target_i)) => self
-                .with_recursion_guard(source, target, || {
-                    self.check_nominal_instance_pair(db, source_i, target_i)
-                }),
+            (
+                (_, crate::types::TypeData::NominalInstance(source_i)),
+                (_, crate::types::TypeData::NominalInstance(target_i)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_nominal_instance_pair(db, source_i, target_i)
+            }),
 
-            (Type::PropertyInstance(source_p), Type::PropertyInstance(target_p)) => self
-                .with_recursion_guard(source, target, || {
-                    self.check_property_instance_pair(db, source_p, target_p)
-                }),
+            (
+                (_, crate::types::TypeData::PropertyInstance(source_p)),
+                (_, crate::types::TypeData::PropertyInstance(target_p)),
+            ) => self.with_recursion_guard(source, target, || {
+                self.check_property_instance_pair(db, source_p, target_p)
+            }),
 
-            (Type::PropertyInstance(property), _) => {
+            ((_, crate::types::TypeData::PropertyInstance(property)), (_, _)) => {
                 self.check_type_pair(db, property.instance_fallback(db), target)
             }
-            (_, Type::PropertyInstance(property)) => {
+            ((_, _), (_, crate::types::TypeData::PropertyInstance(property))) => {
                 self.check_type_pair(db, source, property.instance_fallback(db))
             }
             // Other than the special cases enumerated above, nominal-instance types are never
             // subtypes of any other variants
-            (Type::NominalInstance(_), _) => self.never(),
+            ((_, crate::types::TypeData::NominalInstance(_)), (_, _)) => self.never(),
         }
     }
 
@@ -2483,42 +2670,62 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             return self.check_type_pair(db, left, right);
         }
 
-        match (left, right) {
-            (Type::Never, _) | (_, Type::Never) => self.always(),
+        match (
+            ({
+                let __ty_view_value = left;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            ({
+                let __ty_view_value = right;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+        ) {
+            ((_, crate::types::TypeData::Never), (_, _))
+            | ((_, _), (_, crate::types::TypeData::Never)) => self.always(),
 
-            (Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => self.never(),
-            (Type::Divergent(_), _) | (_, Type::Divergent(_)) => self.never(),
+            ((_, crate::types::TypeData::Dynamic(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::Dynamic(_))) => self.never(),
+            ((_, crate::types::TypeData::Divergent(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::Divergent(_))) => self.never(),
 
-            (Type::TypeAlias(alias), _) => {
+            ((_, crate::types::TypeData::TypeAlias(alias)), (_, _)) => {
                 let left_alias_ty = alias.value_type(db);
                 self.with_recursion_guard(left, right, || {
                     self.check_type_pair(db, left_alias_ty, right)
                 })
             }
 
-            (_, Type::TypeAlias(alias)) => {
+            ((_, _), (_, crate::types::TypeData::TypeAlias(alias))) => {
                 let right_alias_ty = alias.value_type(db);
                 self.with_recursion_guard(left, right, || {
                     self.check_type_pair(db, left, right_alias_ty)
                 })
             }
 
-            (Type::EnumComplement(complement), other) => {
+            ((_, crate::types::TypeData::EnumComplement(complement)), (other, _)) => {
                 self.check_type_pair(db, complement.remaining_literal_union(db), other)
             }
 
-            (other, Type::EnumComplement(complement)) => {
+            ((other, _), (_, crate::types::TypeData::EnumComplement(complement))) => {
                 self.check_type_pair(db, other, complement.remaining_literal_union(db))
             }
 
             // `type[T]` is disjoint from a callable or protocol instance if its upper bound or constraints are.
             (
-                Type::SubclassOf(subclass_of),
-                other @ (Type::Callable(_) | Type::ProtocolInstance(_)),
+                (_, crate::types::TypeData::SubclassOf(subclass_of)),
+                (
+                    other,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::ProtocolInstance(_),
+                ),
             )
             | (
-                other @ (Type::Callable(_) | Type::ProtocolInstance(_)),
-                Type::SubclassOf(subclass_of),
+                (
+                    other,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::ProtocolInstance(_),
+                ),
+                (_, crate::types::TypeData::SubclassOf(subclass_of)),
             ) if subclass_of.is_type_var() => {
                 let type_var = subclass_of
                     .subclass_of()
@@ -2530,7 +2737,8 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             // `type[T]` is disjoint from a class object `A` if every instance of `T` is disjoint from an instance of `A`.
-            (Type::SubclassOf(subclass_of), other) | (other, Type::SubclassOf(subclass_of))
+            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
                 if subclass_of.is_type_var() && other.to_instance(db).is_some() =>
             {
                 subclass_of
@@ -2545,17 +2753,24 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // be specialized to the same type. (This is an important difference between typevars
             // and `Any`!) Different typevars might be disjoint, depending on their bounds and
             // constraints, which are handled below.
-            (Type::TypeVar(left_tvar), Type::TypeVar(right_tvar))
-                if !left_tvar.is_inferable(db, self.inferable)
-                    && left_tvar.is_same_typevar_as(db, right_tvar) =>
+            (
+                (_, crate::types::TypeData::TypeVar(left_tvar)),
+                (_, crate::types::TypeData::TypeVar(right_tvar)),
+            ) if !left_tvar.is_inferable(db, self.inferable)
+                && left_tvar.is_same_typevar_as(db, right_tvar) =>
             {
                 self.never()
             }
 
-            (Type::TypeVar(tvar), Type::Intersection(intersection))
-            | (Type::Intersection(intersection), Type::TypeVar(tvar))
-                if !tvar.is_inferable(db, self.inferable)
-                    && intersection.negative(db).contains(&Type::TypeVar(tvar)) =>
+            (
+                (_, crate::types::TypeData::TypeVar(tvar)),
+                (_, crate::types::TypeData::Intersection(intersection)),
+            )
+            | (
+                (_, crate::types::TypeData::Intersection(intersection)),
+                (_, crate::types::TypeData::TypeVar(tvar)),
+            ) if !tvar.is_inferable(db, self.inferable)
+                && intersection.negative(db).contains(&Type::TypeVar(tvar)) =>
             {
                 self.always()
             }
@@ -2564,7 +2779,8 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // specialized to any type. A bounded typevar is not disjoint from its bound, and is
             // only disjoint from other types if its bound is. A constrained typevar is disjoint
             // from a type if all of its constraints are.
-            (Type::TypeVar(tvar), other) | (other, Type::TypeVar(tvar))
+            ((_, crate::types::TypeData::TypeVar(tvar)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::TypeVar(tvar)))
                 if !tvar.is_inferable(db, self.inferable) =>
             {
                 match tvar.typevar(db).bound_or_constraints(db) {
@@ -2583,9 +2799,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             // TODO: Infer specializations here
-            (Type::TypeVar(_), _) | (_, Type::TypeVar(_)) => self.never(),
+            ((_, crate::types::TypeData::TypeVar(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::TypeVar(_))) => self.never(),
 
-            (Type::Union(union), other) | (other, Type::Union(union)) => union
+            ((_, crate::types::TypeData::Union(union)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::Union(union))) => union
                 .elements(db)
                 .iter()
                 .when_all(db, self.constraints, |e| {
@@ -2595,7 +2813,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // If we have two intersections, we test the positive elements of each one against the other intersection
             // Negative elements need a positive element on the other side in order to be disjoint.
             // This is similar to what would happen if we tried to build a new intersection that combines the two
-            (Type::Intersection(left_intersection), Type::Intersection(right_intersection)) => {
+            (
+                (_, crate::types::TypeData::Intersection(left_intersection)),
+                (_, crate::types::TypeData::Intersection(right_intersection)),
+            ) => {
                 if let Some(alternatives) = left_intersection.finite_alternative_union(db) {
                     self.check_type_pair(db, alternatives, right)
                 } else if let Some(alternatives) = right_intersection.finite_alternative_union(db) {
@@ -2619,7 +2840,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
             }
 
-            (Type::Intersection(intersection), other) => {
+            ((_, crate::types::TypeData::Intersection(intersection)), (other, _)) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     self.check_type_pair(db, alternatives, other)
                 } else {
@@ -2627,7 +2848,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
             }
 
-            (other, Type::Intersection(intersection)) => {
+            ((other, _), (_, crate::types::TypeData::Intersection(intersection))) => {
                 if let Some(alternatives) = intersection.finite_alternative_union(db) {
                     self.check_type_pair(db, other, alternatives)
                 } else {
@@ -2635,38 +2856,82 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
             }
 
-            (Type::LiteralValue(left), Type::LiteralValue(right))
-                if left.is_literal_string() && right.is_literal_string()
-                    || (left.is_string() && right.is_literal_string())
-                    || (left.is_literal_string() && right.is_string()) =>
+            (
+                (_, crate::types::TypeData::LiteralValue(left)),
+                (_, crate::types::TypeData::LiteralValue(right)),
+            ) if left.is_literal_string() && right.is_literal_string()
+                || (left.is_string() && right.is_literal_string())
+                || (left.is_literal_string() && right.is_string()) =>
             {
                 self.never()
             }
 
-            (Type::LiteralValue(left), Type::LiteralValue(right)) => {
-                ConstraintSet::from_bool(self.constraints, left.kind() != right.kind())
-            }
-
-            (Type::PropertyInstance(left), Type::PropertyInstance(right)) => {
-                self.check_property_instance_pair(db, left, right)
-            }
+            (
+                (_, crate::types::TypeData::LiteralValue(left)),
+                (_, crate::types::TypeData::LiteralValue(right)),
+            ) => ConstraintSet::from_bool(self.constraints, left.kind() != right.kind()),
 
             (
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(left)),
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(right)),
-            )
-            | (
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(left)),
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(right)),
-            )
-            | (
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(left)),
-                Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(right)),
+                (_, crate::types::TypeData::PropertyInstance(left)),
+                (_, crate::types::TypeData::PropertyInstance(right)),
             ) => self.check_property_instance_pair(db, left, right),
 
             (
-                Type::KnownInstance(KnownInstanceType::Sentinel(left_sentinel)),
-                Type::KnownInstance(KnownInstanceType::Sentinel(right_sentinel)),
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderGet(left),
+                    ),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderGet(right),
+                    ),
+                ),
+            )
+            | (
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderSet(left),
+                    ),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderSet(right),
+                    ),
+                ),
+            )
+            | (
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderDelete(left),
+                    ),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownBoundMethod(
+                        KnownBoundMethodType::PropertyDunderDelete(right),
+                    ),
+                ),
+            ) => self.check_property_instance_pair(db, left, right),
+
+            (
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
+                        left_sentinel,
+                    )),
+                ),
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
+                        right_sentinel,
+                    )),
+                ),
             ) => ConstraintSet::from_bool(
                 self.constraints,
                 !left_sentinel.is_same_sentinel(db, right_sentinel),
@@ -2676,75 +2941,101 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // iff the two types are nonequal
             (
                 // note `LiteralString` is not single-valued, but we handle the special case above
-                left @ (Type::FunctionLiteral(..)
-                | Type::KnownBoundMethod(..)
-                | Type::WrapperDescriptor(..)
-                | Type::ModuleLiteral(..)
-                | Type::ClassLiteral(..)
-                | Type::SpecialForm(..)
-                | Type::KnownInstance(..)),
-                right @ (Type::FunctionLiteral(..)
-                | Type::KnownBoundMethod(..)
-                | Type::WrapperDescriptor(..)
-                | Type::ModuleLiteral(..)
-                | Type::ClassLiteral(..)
-                | Type::SpecialForm(..)
-                | Type::KnownInstance(..)),
+                (
+                    left,
+                    crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::KnownBoundMethod(..)
+                    | crate::types::TypeData::WrapperDescriptor(..)
+                    | crate::types::TypeData::ModuleLiteral(..)
+                    | crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SpecialForm(..)
+                    | crate::types::TypeData::KnownInstance(..),
+                ),
+                (
+                    right,
+                    crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::KnownBoundMethod(..)
+                    | crate::types::TypeData::WrapperDescriptor(..)
+                    | crate::types::TypeData::ModuleLiteral(..)
+                    | crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::SpecialForm(..)
+                    | crate::types::TypeData::KnownInstance(..),
+                ),
             ) => ConstraintSet::from_bool(self.constraints, left != right),
 
             (
-                Type::SubclassOf(_),
-                Type::LiteralValue(..)
-                | Type::FunctionLiteral(..)
-                | Type::BoundMethod(..)
-                | Type::KnownBoundMethod(..)
-                | Type::WrapperDescriptor(..)
-                | Type::ModuleLiteral(..),
+                (_, crate::types::TypeData::SubclassOf(_)),
+                (
+                    _,
+                    crate::types::TypeData::LiteralValue(..)
+                    | crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::BoundMethod(..)
+                    | crate::types::TypeData::KnownBoundMethod(..)
+                    | crate::types::TypeData::WrapperDescriptor(..)
+                    | crate::types::TypeData::ModuleLiteral(..),
+                ),
             )
             | (
-                Type::LiteralValue(..)
-                | Type::FunctionLiteral(..)
-                | Type::BoundMethod(..)
-                | Type::KnownBoundMethod(..)
-                | Type::WrapperDescriptor(..)
-                | Type::ModuleLiteral(..),
-                Type::SubclassOf(_),
+                (
+                    _,
+                    crate::types::TypeData::LiteralValue(..)
+                    | crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::BoundMethod(..)
+                    | crate::types::TypeData::KnownBoundMethod(..)
+                    | crate::types::TypeData::WrapperDescriptor(..)
+                    | crate::types::TypeData::ModuleLiteral(..),
+                ),
+                (_, crate::types::TypeData::SubclassOf(_)),
             ) => self.always(),
 
-            (Type::AlwaysTruthy, ty) | (ty, Type::AlwaysTruthy) => {
+            ((_, crate::types::TypeData::AlwaysTruthy), (ty, _))
+            | ((ty, _), (_, crate::types::TypeData::AlwaysTruthy)) => {
                 // `Truthiness::Ambiguous` may include `AlwaysTrue` as a subset, so it's not guaranteed to be disjoint.
                 // Thus, they are only disjoint if `ty.bool() == AlwaysFalse`.
                 ConstraintSet::from_bool(self.constraints, ty.bool(db).is_always_false())
             }
-            (Type::AlwaysFalsy, ty) | (ty, Type::AlwaysFalsy) => {
+            ((_, crate::types::TypeData::AlwaysFalsy), (ty, _))
+            | ((ty, _), (_, crate::types::TypeData::AlwaysFalsy)) => {
                 // Similarly, they are only disjoint if `ty.bool() == AlwaysTrue`.
                 ConstraintSet::from_bool(self.constraints, ty.bool(db).is_always_true())
             }
 
-            (Type::ProtocolInstance(left_proto), Type::ProtocolInstance(right_proto)) => self
-                .with_recursion_guard(left, right, || {
-                    self.check_protocol_instance_pair(db, left_proto, right_proto)
-                }),
+            (
+                (_, crate::types::TypeData::ProtocolInstance(left_proto)),
+                (_, crate::types::TypeData::ProtocolInstance(right_proto)),
+            ) => self.with_recursion_guard(left, right, || {
+                self.check_protocol_instance_pair(db, left_proto, right_proto)
+            }),
 
-            (Type::ProtocolInstance(protocol), Type::SpecialForm(special_form))
-            | (Type::SpecialForm(special_form), Type::ProtocolInstance(protocol)) => self
-                .with_recursion_guard(left, right, || {
-                    self.any_protocol_members_absent_or_disjoint(
-                        db,
-                        protocol,
-                        special_form.instance_fallback(db),
-                    )
-                }),
+            (
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+            )
+            | (
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+            ) => self.with_recursion_guard(left, right, || {
+                self.any_protocol_members_absent_or_disjoint(
+                    db,
+                    protocol,
+                    special_form.instance_fallback(db),
+                )
+            }),
 
-            (Type::ProtocolInstance(protocol), Type::KnownInstance(known_instance))
-            | (Type::KnownInstance(known_instance), Type::ProtocolInstance(protocol)) => self
-                .with_recursion_guard(left, right, || {
-                    self.any_protocol_members_absent_or_disjoint(
-                        db,
-                        protocol,
-                        known_instance.instance_fallback(db),
-                    )
-                }),
+            (
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+                (_, crate::types::TypeData::KnownInstance(known_instance)),
+            )
+            | (
+                (_, crate::types::TypeData::KnownInstance(known_instance)),
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+            ) => self.with_recursion_guard(left, right, || {
+                self.any_protocol_members_absent_or_disjoint(
+                    db,
+                    protocol,
+                    known_instance.instance_fallback(db),
+                )
+            }),
 
             // The absence of a protocol member on one of these types guarantees
             // that the type will be disjoint from the protocol,
@@ -2774,20 +3065,26 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             //     print(Foo.X)
             // ```
             (
-                ty @ (Type::LiteralValue(..)
-                | Type::ClassLiteral(..)
-                | Type::FunctionLiteral(..)
-                | Type::ModuleLiteral(..)
-                | Type::GenericAlias(..)),
-                Type::ProtocolInstance(protocol),
+                (
+                    ty,
+                    crate::types::TypeData::LiteralValue(..)
+                    | crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::ModuleLiteral(..)
+                    | crate::types::TypeData::GenericAlias(..),
+                ),
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
             )
             | (
-                Type::ProtocolInstance(protocol),
-                ty @ (Type::LiteralValue(..)
-                | Type::ClassLiteral(..)
-                | Type::FunctionLiteral(..)
-                | Type::ModuleLiteral(..)
-                | Type::GenericAlias(..)),
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+                (
+                    ty,
+                    crate::types::TypeData::LiteralValue(..)
+                    | crate::types::TypeData::ClassLiteral(..)
+                    | crate::types::TypeData::FunctionLiteral(..)
+                    | crate::types::TypeData::ModuleLiteral(..)
+                    | crate::types::TypeData::GenericAlias(..),
+                ),
             ) => self.with_recursion_guard(left, right, || {
                 self.any_protocol_members_absent_or_disjoint(db, protocol, ty)
             }),
@@ -2795,22 +3092,24 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // This is the same as the branch above --
             // once guard patterns are stabilised, it could be unified with that branch
             // (<https://github.com/rust-lang/rust/issues/129967>)
-            (Type::ProtocolInstance(protocol), Type::NominalInstance(nominal))
-            | (Type::NominalInstance(nominal), Type::ProtocolInstance(protocol))
-                if nominal.class(db).is_final(db) =>
-            {
-                self.with_recursion_guard(left, right, || {
-                    self.any_protocol_members_absent_or_disjoint(
-                        db,
-                        protocol,
-                        Type::NominalInstance(nominal),
-                    )
-                })
-            }
+            (
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+                (_, crate::types::TypeData::NominalInstance(nominal)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(nominal)),
+                (_, crate::types::TypeData::ProtocolInstance(protocol)),
+            ) if nominal.class(db).is_final(db) => self.with_recursion_guard(left, right, || {
+                self.any_protocol_members_absent_or_disjoint(
+                    db,
+                    protocol,
+                    Type::NominalInstance(nominal),
+                )
+            }),
 
-            (Type::ProtocolInstance(protocol), other)
-            | (other, Type::ProtocolInstance(protocol)) => {
-                self.with_recursion_guard(left, right, || {
+            ((_, crate::types::TypeData::ProtocolInstance(protocol)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::ProtocolInstance(protocol))) => self
+                .with_recursion_guard(left, right, || {
                     protocol
                         .interface(db)
                         .members(db)
@@ -2826,104 +3125,136 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                                 Place::Undefined => self.never(),
                             }
                         })
-                })
-            }
+                }),
 
-            (Type::SubclassOf(subclass_of_ty), _) | (_, Type::SubclassOf(subclass_of_ty))
+            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of_ty)))
                 if subclass_of_ty.is_type_var() =>
             {
                 self.always()
             }
 
-            (Type::GenericAlias(left_alias), Type::GenericAlias(right_alias)) => {
-                ConstraintSet::from_bool(
-                    self.constraints,
-                    left_alias.origin(db) != right_alias.origin(db),
+            (
+                (_, crate::types::TypeData::GenericAlias(left_alias)),
+                (_, crate::types::TypeData::GenericAlias(right_alias)),
+            ) => ConstraintSet::from_bool(
+                self.constraints,
+                left_alias.origin(db) != right_alias.origin(db),
+            )
+            .or(db, self.constraints, || {
+                self.check_specialization_pair(
+                    db,
+                    left_alias.specialization(db),
+                    right_alias.specialization(db),
                 )
-                .or(db, self.constraints, || {
-                    self.check_specialization_pair(
-                        db,
-                        left_alias.specialization(db),
-                        right_alias.specialization(db),
-                    )
-                })
-            }
+            }),
 
-            (Type::ClassLiteral(class), Type::GenericAlias(alias_b))
-            | (Type::GenericAlias(alias_b), Type::ClassLiteral(class)) => class
+            (
+                (_, crate::types::TypeData::ClassLiteral(class)),
+                (_, crate::types::TypeData::GenericAlias(alias_b)),
+            )
+            | (
+                (_, crate::types::TypeData::GenericAlias(alias_b)),
+                (_, crate::types::TypeData::ClassLiteral(class)),
+            ) => class
                 .default_specialization(db)
                 .into_generic_alias()
                 .when_none_or(db, self.constraints, |alias| {
                     self.check_type_pair(db, Type::GenericAlias(alias_b), Type::GenericAlias(alias))
                 }),
 
-            (Type::SubclassOf(subclass_of_ty), Type::ClassLiteral(class_b))
-            | (Type::ClassLiteral(class_b), Type::SubclassOf(subclass_of_ty)) => {
-                match subclass_of_ty.subclass_of() {
-                    SubclassOfInner::Dynamic(_) => self.never(),
-                    SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
-                        self.constraints,
-                        !class_a.could_exist_in_mro_of_with_disjointness_checker(
-                            db,
-                            ClassType::NonGeneric(class_b),
-                            self,
-                        ),
+            (
+                (_, crate::types::TypeData::SubclassOf(subclass_of_ty)),
+                (_, crate::types::TypeData::ClassLiteral(class_b)),
+            )
+            | (
+                (_, crate::types::TypeData::ClassLiteral(class_b)),
+                (_, crate::types::TypeData::SubclassOf(subclass_of_ty)),
+            ) => match subclass_of_ty.subclass_of() {
+                SubclassOfInner::Dynamic(_) => self.never(),
+                SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
+                    self.constraints,
+                    !class_a.could_exist_in_mro_of_with_disjointness_checker(
+                        db,
+                        ClassType::NonGeneric(class_b),
+                        self,
                     ),
-                    SubclassOfInner::TypeVar(_) => unreachable!(),
-                }
-            }
-
-            (Type::SubclassOf(subclass_of_ty), Type::GenericAlias(alias_b))
-            | (Type::GenericAlias(alias_b), Type::SubclassOf(subclass_of_ty)) => {
-                match subclass_of_ty.subclass_of() {
-                    SubclassOfInner::Dynamic(_) => self.never(),
-                    SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
-                        self.constraints,
-                        !class_a.could_exist_in_mro_of_with_disjointness_checker(
-                            db,
-                            ClassType::Generic(alias_b),
-                            self,
-                        ),
-                    ),
-                    SubclassOfInner::TypeVar(_) => unreachable!(),
-                }
-            }
-
-            (Type::SubclassOf(left), Type::SubclassOf(right)) => {
-                self.check_subclassof_pair(db, left, right)
-            }
-
-            // for `type[Any]`/`type[Unknown]`/`type[Todo]`, we know the type cannot be any larger than `type`,
-            // so although the type is dynamic we can still determine disjointedness in some situations
-            (Type::SubclassOf(subclass_of_ty), other)
-            | (other, Type::SubclassOf(subclass_of_ty)) => match subclass_of_ty.subclass_of() {
-                SubclassOfInner::Dynamic(_) => {
-                    self.check_type_pair(db, KnownClass::Type.to_instance(db), other)
-                }
-                SubclassOfInner::Class(class) => {
-                    self.check_type_pair(db, class.metaclass_instance_type(db), other)
-                }
+                ),
                 SubclassOfInner::TypeVar(_) => unreachable!(),
             },
 
-            (Type::SpecialForm(special_form), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::SpecialForm(special_form)) => {
-                ConstraintSet::from_bool(
+            (
+                (_, crate::types::TypeData::SubclassOf(subclass_of_ty)),
+                (_, crate::types::TypeData::GenericAlias(alias_b)),
+            )
+            | (
+                (_, crate::types::TypeData::GenericAlias(alias_b)),
+                (_, crate::types::TypeData::SubclassOf(subclass_of_ty)),
+            ) => match subclass_of_ty.subclass_of() {
+                SubclassOfInner::Dynamic(_) => self.never(),
+                SubclassOfInner::Class(class_a) => ConstraintSet::from_bool(
                     self.constraints,
-                    !special_form.is_instance_of(db, instance.class(db)),
-                )
+                    !class_a.could_exist_in_mro_of_with_disjointness_checker(
+                        db,
+                        ClassType::Generic(alias_b),
+                        self,
+                    ),
+                ),
+                SubclassOfInner::TypeVar(_) => unreachable!(),
+            },
+
+            (
+                (_, crate::types::TypeData::SubclassOf(left)),
+                (_, crate::types::TypeData::SubclassOf(right)),
+            ) => self.check_subclassof_pair(db, left, right),
+
+            // for `type[Any]`/`type[Unknown]`/`type[Todo]`, we know the type cannot be any larger than `type`,
+            // so although the type is dynamic we can still determine disjointedness in some situations
+            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::SubclassOf(subclass_of_ty))) => {
+                match subclass_of_ty.subclass_of() {
+                    SubclassOfInner::Dynamic(_) => {
+                        self.check_type_pair(db, KnownClass::Type.to_instance(db), other)
+                    }
+                    SubclassOfInner::Class(class) => {
+                        self.check_type_pair(db, class.metaclass_instance_type(db), other)
+                    }
+                    SubclassOfInner::TypeVar(_) => unreachable!(),
+                }
             }
 
-            (Type::KnownInstance(known_instance), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::KnownInstance(known_instance)) => {
-                ConstraintSet::from_bool(
-                    self.constraints,
-                    !known_instance.is_instance_of(db, instance.class(db)),
-                )
-            }
+            (
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+            ) => ConstraintSet::from_bool(
+                self.constraints,
+                !special_form.is_instance_of(db, instance.class(db)),
+            ),
 
-            (Type::LiteralValue(literal), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::LiteralValue(literal)) => {
+            (
+                (_, crate::types::TypeData::KnownInstance(known_instance)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::KnownInstance(known_instance)),
+            ) => ConstraintSet::from_bool(
+                self.constraints,
+                !known_instance.is_instance_of(db, instance.class(db)),
+            ),
+
+            (
+                (_, crate::types::TypeData::LiteralValue(literal)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::LiteralValue(literal)),
+            ) => {
                 let positive_relation_holds = match literal.kind() {
                     LiteralValueTypeKind::Int(_) => {
                         KnownClass::Int.when_subclass_of(db, instance.class(db), self.constraints)
@@ -2948,8 +3279,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 positive_relation_holds.negate(db, self.constraints)
             }
 
-            (Type::TypeIs(_) | Type::TypeGuard(_), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::TypeIs(_) | Type::TypeGuard(_)) => {
+            (
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
+            ) => {
                 // A boolean literal must be an instance of exactly `bool`
                 // (it cannot be an instance of a `bool` subclass)
                 KnownClass::Bool
@@ -2957,16 +3294,29 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     .negate(db, self.constraints)
             }
 
-            (Type::TypeIs(_) | Type::TypeGuard(_), _)
-            | (_, Type::TypeIs(_) | Type::TypeGuard(_)) => self.always(),
+            (
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
+                (_, _),
+            )
+            | (
+                (_, _),
+                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
+            ) => self.always(),
 
-            (Type::LiteralValue(_), _) | (_, Type::LiteralValue(_)) => self.always(),
+            ((_, crate::types::TypeData::LiteralValue(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::LiteralValue(_))) => self.always(),
 
             // A class-literal type `X` is always disjoint from an instance type `Y`,
             // unless the type expressing "all instances of `Z`" is a subtype of of `Y`,
             // where `Z` is `X`'s metaclass.
-            (Type::ClassLiteral(class), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::ClassLiteral(class)) => class
+            (
+                (_, crate::types::TypeData::ClassLiteral(class)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::ClassLiteral(class)),
+            ) => class
                 .metaclass_instance_type(db)
                 .when_subtype_of(
                     db,
@@ -2976,8 +3326,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 )
                 .negate(db, self.constraints),
 
-            (Type::GenericAlias(alias), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::GenericAlias(alias)) => self
+            (
+                (_, crate::types::TypeData::GenericAlias(alias)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::GenericAlias(alias)),
+            ) => self
                 .as_relation_checker(TypeRelation::Subtyping)
                 .check_type_pair(
                     db,
@@ -2986,8 +3342,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 )
                 .negate(db, self.constraints),
 
-            (Type::FunctionLiteral(..), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::FunctionLiteral(..)) => {
+            (
+                (_, crate::types::TypeData::FunctionLiteral(..)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::FunctionLiteral(..)),
+            ) => {
                 // A `Type::FunctionLiteral()` must be an instance of exactly `types.FunctionType`
                 // (it cannot be an instance of a `types.FunctionType` subclass)
                 KnownClass::FunctionType
@@ -2997,7 +3359,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
             // A `BoundMethod` type includes instances of the same method bound to a
             // subtype/subclass of the self type.
-            (Type::BoundMethod(a), Type::BoundMethod(b)) => {
+            (
+                (_, crate::types::TypeData::BoundMethod(a)),
+                (_, crate::types::TypeData::BoundMethod(b)),
+            ) => {
                 if a.function(db).name(db) != b.function(db).name(db) {
                     // We typically ask about `BoundMethod` disjointness when we're looking at a
                     // method call on an intersection type like `A & B`. In that case, the same
@@ -3047,28 +3412,47 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
             }
 
-            (Type::BoundMethod(_), other) | (other, Type::BoundMethod(_)) => {
+            ((_, crate::types::TypeData::BoundMethod(_)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::BoundMethod(_))) => {
                 self.check_type_pair(db, KnownClass::MethodType.to_instance(db), other)
             }
 
-            (Type::KnownBoundMethod(method), other) | (other, Type::KnownBoundMethod(method)) => {
+            ((_, crate::types::TypeData::KnownBoundMethod(method)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::KnownBoundMethod(method))) => {
                 self.check_type_pair(db, method.class().to_instance(db), other)
             }
 
-            (Type::WrapperDescriptor(_), other) | (other, Type::WrapperDescriptor(_)) => {
+            ((_, crate::types::TypeData::WrapperDescriptor(_)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::WrapperDescriptor(_))) => {
                 self.check_type_pair(db, KnownClass::WrapperDescriptorType.to_instance(db), other)
             }
 
-            (Type::Callable(_) | Type::FunctionLiteral(_), Type::Callable(_))
-            | (Type::Callable(_), Type::FunctionLiteral(_)) => {
+            (
+                (
+                    _,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::FunctionLiteral(_),
+                ),
+                (_, crate::types::TypeData::Callable(_)),
+            )
+            | (
+                (_, crate::types::TypeData::Callable(_)),
+                (_, crate::types::TypeData::FunctionLiteral(_)),
+            ) => {
                 // No two callable types are ever disjoint because
                 // `(*args: object, **kwargs: object) -> Never` is a subtype of all fully static
                 // callable types.
                 self.never()
             }
 
-            (Type::Callable(_), Type::SpecialForm(special_form))
-            | (Type::SpecialForm(special_form), Type::Callable(_)) => {
+            (
+                (_, crate::types::TypeData::Callable(_)),
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+            )
+            | (
+                (_, crate::types::TypeData::SpecialForm(special_form)),
+                (_, crate::types::TypeData::Callable(_)),
+            ) => {
                 // A callable type is disjoint from special form types, except for special forms
                 // that are callable (like TypedDict and collection constructors).
                 // Most special forms are type constructors/annotations (like `typing.Literal`,
@@ -3077,12 +3461,22 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (
-                Type::Callable(_) | Type::DataclassDecorator(_) | Type::DataclassTransformer(_),
-                Type::NominalInstance(nominal),
+                (
+                    _,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ),
+                (_, crate::types::TypeData::NominalInstance(nominal)),
             )
             | (
-                Type::NominalInstance(nominal),
-                Type::Callable(_) | Type::DataclassDecorator(_) | Type::DataclassTransformer(_),
+                (_, crate::types::TypeData::NominalInstance(nominal)),
+                (
+                    _,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ),
             ) if nominal.class(db).is_final(db) => Type::NominalInstance(nominal)
                 .member_lookup_with_policy(
                     db,
@@ -3098,19 +3492,35 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }),
 
             (
-                Type::Callable(_) | Type::DataclassDecorator(_) | Type::DataclassTransformer(_),
-                _,
+                (
+                    _,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ),
+                (_, _),
             )
             | (
-                _,
-                Type::Callable(_) | Type::DataclassDecorator(_) | Type::DataclassTransformer(_),
+                (_, _),
+                (
+                    _,
+                    crate::types::TypeData::Callable(_)
+                    | crate::types::TypeData::DataclassDecorator(_)
+                    | crate::types::TypeData::DataclassTransformer(_),
+                ),
             ) => {
                 // TODO: Implement disjointness for general callable type with other types
                 self.never()
             }
 
-            (Type::ModuleLiteral(..), Type::NominalInstance(instance))
-            | (Type::NominalInstance(instance), Type::ModuleLiteral(..)) => {
+            (
+                (_, crate::types::TypeData::ModuleLiteral(..)),
+                (_, crate::types::TypeData::NominalInstance(instance)),
+            )
+            | (
+                (_, crate::types::TypeData::NominalInstance(instance)),
+                (_, crate::types::TypeData::ModuleLiteral(..)),
+            ) => {
                 // Modules *can* actually be instances of `ModuleType` subclasses
                 self.check_type_pair(
                     db,
@@ -3119,47 +3529,59 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 )
             }
 
-            (Type::NominalInstance(left_i), Type::NominalInstance(right_i)) => self
-                .with_recursion_guard(left, right, || {
-                    self.check_nominal_instance_pair(db, left_i, right_i)
-                }),
+            (
+                (_, crate::types::TypeData::NominalInstance(left_i)),
+                (_, crate::types::TypeData::NominalInstance(right_i)),
+            ) => self.with_recursion_guard(left, right, || {
+                self.check_nominal_instance_pair(db, left_i, right_i)
+            }),
 
-            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
-                self.check_newtype_pair(db, left, right)
-            }
-            (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
+            (
+                (_, crate::types::TypeData::NewTypeInstance(left)),
+                (_, crate::types::TypeData::NewTypeInstance(right)),
+            ) => self.check_newtype_pair(db, left, right),
+            ((_, crate::types::TypeData::NewTypeInstance(newtype)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::NewTypeInstance(newtype))) => {
                 self.check_type_pair(db, newtype.concrete_base_type(db), other)
             }
 
-            (Type::PropertyInstance(property), other)
-            | (other, Type::PropertyInstance(property)) => {
+            ((_, crate::types::TypeData::PropertyInstance(property)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::PropertyInstance(property))) => {
                 self.check_type_pair(db, property.instance_fallback(db), other)
             }
 
-            (Type::BoundSuper(left), Type::BoundSuper(right)) => self
+            (
+                (_, crate::types::TypeData::BoundSuper(left)),
+                (_, crate::types::TypeData::BoundSuper(right)),
+            ) => self
                 .as_equivalence_checker()
                 .check_bound_super_pair(db, left, right)
                 .negate(db, self.constraints),
 
-            (Type::BoundSuper(_), other) | (other, Type::BoundSuper(_)) => {
+            ((_, crate::types::TypeData::BoundSuper(_)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::BoundSuper(_))) => {
                 self.check_type_pair(db, KnownClass::Super.to_instance(db), other)
             }
 
-            (Type::TypeForm(_), _) | (_, Type::TypeForm(_)) => self.never(),
+            ((_, crate::types::TypeData::TypeForm(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::TypeForm(_))) => self.never(),
 
-            (Type::GenericAlias(_), _) | (_, Type::GenericAlias(_)) => self.always(),
+            ((_, crate::types::TypeData::GenericAlias(_)), (_, _))
+            | ((_, _), (_, crate::types::TypeData::GenericAlias(_))) => self.always(),
 
-            (Type::TypedDict(left_td), Type::TypedDict(right_td)) => {
-                self.with_recursion_guard(left, right, || {
-                    self.check_typeddict_pair(db, left_td, right_td)
-                })
-            }
+            (
+                (_, crate::types::TypeData::TypedDict(left_td)),
+                (_, crate::types::TypeData::TypedDict(right_td)),
+            ) => self.with_recursion_guard(left, right, || {
+                self.check_typeddict_pair(db, left_td, right_td)
+            }),
 
             // For any type `T`, if `dict[str, Any]` is not assignable to `T`, then all `TypedDict`
             // types will always be disjoint from `T`. This doesn't cover all cases -- in fact
             // `dict` *itself* is almost always disjoint from `TypedDict` -- but it's a good
             // approximation, and some false negatives are acceptable.
-            (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
+            ((_, crate::types::TypeData::TypedDict(_)), (other, _))
+            | ((other, _), (_, crate::types::TypeData::TypedDict(_))) => {
                 let dict_str_any = KnownClass::Dict
                     .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -248,8 +248,8 @@ impl<'db> Type<'db> {
     /// This method may have false negatives, but it should not have false positives. It should be
     /// a cheap shallow check, not an exhaustive recursive check.
     fn subtyping_is_always_reflexive(self) -> bool {
-        match { let __ty_view_value = self; (__ty_view_value, __ty_view_value.data()) }  {
-            (_, crate::types::TypeData::Never
+        match self.data()  {
+            crate::types::TypeData::Never
             | crate::types::TypeData::FunctionLiteral(..)
             | crate::types::TypeData::BoundMethod(_)
             | crate::types::TypeData::WrapperDescriptor(_)
@@ -277,9 +277,9 @@ impl<'db> Type<'db> {
             // and `T` is always a subtype of `T | None`
             | crate::types::TypeData::TypeVar(_)
             // might inherit `Any`, but subtyping is still reflexive
-            | crate::types::TypeData::ClassLiteral(_))
+            | crate::types::TypeData::ClassLiteral(_)
              => true,
-            (_, crate::types::TypeData::Dynamic(_)
+            crate::types::TypeData::Dynamic(_)
             | crate::types::TypeData::Divergent(_)
             | crate::types::TypeData::NominalInstance(_)
             | crate::types::TypeData::ProtocolInstance(_)
@@ -301,7 +301,7 @@ impl<'db> Type<'db> {
             | crate::types::TypeData::TypeForm(_)
             | crate::types::TypeData::TypedDict(_)
             | crate::types::TypeData::TypeAlias(_)
-            | crate::types::TypeData::NewTypeInstance(_)) => false,
+            | crate::types::TypeData::NewTypeInstance(_) => false,
         }
     }
 
@@ -436,28 +436,15 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        match (
-            ({
-                let __ty_view_value = self;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = target;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
-            ((_, crate::types::TypeData::Never | crate::types::TypeData::Dynamic(_)), (_, _))
-            | ((_, _), (_, crate::types::TypeData::Dynamic(_))) => true,
-            ((_, _), (_, crate::types::TypeData::NominalInstance(target)))
-                if target.is_object() =>
-            {
-                true
-            }
-            ((_, _), (_, crate::types::TypeData::Union(union))) => {
+        match (self.data(), target.data()) {
+            (crate::types::TypeData::Never | crate::types::TypeData::Dynamic(_), _)
+            | (_, crate::types::TypeData::Dynamic(_)) => true,
+            (_, crate::types::TypeData::NominalInstance(target)) if target.is_object() => true,
+            (_, crate::types::TypeData::Union(union)) => {
                 self.materialized_divergent_fallback().is_none()
                     && union.elements(db).contains(&self)
             }
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
+            (crate::types::TypeData::Intersection(intersection), _) => {
                 target.materialized_divergent_fallback().is_none()
                     && intersection.positive(db).contains(&target)
             }
@@ -918,17 +905,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         // These displays already expose the signature being compared; wrapping them would
         // duplicate the lower-level callable mismatch context.
         !matches!(
-            {
-                let __ty_view_value = source;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (
-                _,
-                crate::types::TypeData::Callable(_)
-                    | crate::types::TypeData::FunctionLiteral(_)
-                    | crate::types::TypeData::BoundMethod(_)
-                    | crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
-            )
+            source.data(),
+            crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
         )
     }
 
@@ -1122,23 +1103,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
         };
 
-        match (
-            ({
-                let __ty_view_value = source;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = target;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (source.data(), target.data()) {
             // Everything is a subtype of `object`.
-            ((_, _), (_, crate::types::TypeData::NominalInstance(target)))
-                if target.is_object() =>
-            {
+            (_, crate::types::TypeData::NominalInstance(target)) if target.is_object() => {
                 self.always()
             }
-            ((_, _), (_, crate::types::TypeData::ProtocolInstance(target)))
+            (_, crate::types::TypeData::ProtocolInstance(target))
                 if target.is_equivalent_to_object(db) =>
             {
                 self.always()
@@ -1146,42 +1116,44 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `Never` is the bottom type, the empty set.
             // It is a subtype of all other types.
-            ((_, crate::types::TypeData::Never), (_, _)) => self.always(),
+            (crate::types::TypeData::Never, _) => self.always(),
 
             (
-                (_, crate::types::TypeData::TypeVar(source_typevar)),
-                (_, crate::types::TypeData::TypeVar(target_typevar)),
+                crate::types::TypeData::TypeVar(source_typevar),
+                crate::types::TypeData::TypeVar(target_typevar),
             ) if source_typevar.is_same_typevar_as(db, target_typevar) => self.always(),
 
             // In some specific situations, `Any`/`Unknown`/`@Todo` can be simplified out of unions and intersections,
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
-            ((_, crate::types::TypeData::Divergent(_)), (_, _))
-            | ((_, _), (_, crate::types::TypeData::Divergent(_))) => {
+            (crate::types::TypeData::Divergent(_), _)
+            | (_, crate::types::TypeData::Divergent(_)) => {
                 ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
             }
 
-            ((_, crate::types::TypeData::TypeAlias(source_alias)), (_, _)) => self
-                .with_recursion_guard(source, target, || {
+            (crate::types::TypeData::TypeAlias(source_alias), _) => {
+                self.with_recursion_guard(source, target, || {
                     self.check_type_pair(db, source_alias.value_type(db), target)
-                }),
+                })
+            }
 
-            ((_, _), (_, crate::types::TypeData::TypeAlias(target_alias))) => self
-                .with_recursion_guard(source, target, || {
+            (_, crate::types::TypeData::TypeAlias(target_alias)) => {
+                self.with_recursion_guard(source, target, || {
                     self.check_type_pair(db, source, target_alias.value_type(db))
-                }),
+                })
+            }
 
             // Annotation unions retain type aliases so recursive aliases can be represented.
             // Normalize direct alias elements together before checking the union so reductions
             // that depend on multiple elements, such as all members of an enum, are visible.
-            ((_, _), (_, crate::types::TypeData::Union(union))) if union.has_aliases(db) => self
+            (_, crate::types::TypeData::Union(union)) if union.has_aliases(db) => self
                 .with_recursion_guard(source, target, || {
                     self.check_type_pair(db, source, union.expand_aliases(db))
                 }),
 
             (
-                (_, crate::types::TypeData::TypeForm(source_typeform)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::TypeForm(source_typeform),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_type_pair(
                     db,
@@ -1191,8 +1163,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }),
 
             (
-                (_, crate::types::TypeData::SubclassOf(source_subclass)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::SubclassOf(source_subclass),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) => self.check_type_pair(
                 db,
                 source_subclass.to_instance(db),
@@ -1200,15 +1172,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             (
-                (_, crate::types::TypeData::NominalInstance(source_instance)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::NominalInstance(source_instance),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) if source_instance.has_known_class(db, KnownClass::Type) => {
                 self.check_type_pair(db, Type::object(), target_typeform.type_argument(db))
             }
 
             (
-                (_, crate::types::TypeData::ClassLiteral(source_class)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::ClassLiteral(source_class),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) => self.check_type_pair(
                 db,
                 Type::instance(db, source_class.default_specialization(db)),
@@ -1216,8 +1188,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             (
-                (_, crate::types::TypeData::GenericAlias(source_alias)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::GenericAlias(source_alias),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) => self.check_type_pair(
                 db,
                 Type::instance(db, ClassType::Generic(source_alias)),
@@ -1225,8 +1197,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             (
-                (_, crate::types::TypeData::KnownInstance(source_instance)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::KnownInstance(source_instance),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) if source_instance.is_type_form_value() => source_instance
                 .type_form_argument(db)
                 .when_some_and(db, self.constraints, |source_argument| {
@@ -1234,8 +1206,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 }),
 
             (
-                (_, crate::types::TypeData::SpecialForm(source_form)),
-                (_, crate::types::TypeData::TypeForm(target_typeform)),
+                crate::types::TypeData::SpecialForm(source_form),
+                crate::types::TypeData::TypeForm(target_typeform),
             ) => source_form.type_form_argument(db).when_some_and(
                 db,
                 self.constraints,
@@ -1245,20 +1217,20 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             (
-                (_, crate::types::TypeData::GenericAlias(_)),
-                (_, crate::types::TypeData::NominalInstance(target_instance)),
+                crate::types::TypeData::GenericAlias(_),
+                crate::types::TypeData::NominalInstance(target_instance),
             ) if target_instance.has_known_class(db, KnownClass::GenericAlias) => self.always(),
 
             (
-                (_, crate::types::TypeData::EnumComplement(complement)),
-                (_, crate::types::TypeData::LiteralValue(_) | crate::types::TypeData::Union(_)),
+                crate::types::TypeData::EnumComplement(complement),
+                crate::types::TypeData::LiteralValue(_) | crate::types::TypeData::Union(_),
             ) => self.check_type_pair(db, complement.remaining_literal_union(db), target),
 
-            ((_, crate::types::TypeData::EnumComplement(complement)), (_, _)) => {
+            (crate::types::TypeData::EnumComplement(complement), _) => {
                 self.check_type_pair(db, complement.to_intersection(db), target)
             }
 
-            ((_, _), (_, crate::types::TypeData::EnumComplement(complement))) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 self.check_type_pair(db, source, complement.to_intersection(db))
             }
 
@@ -1283,53 +1255,38 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //        declared field type.
             //     3. If neither a converter nor a default value is provided, we allow the field to be
             //        considered assignable to any type.
-            (
-                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::Field(field))),
-                (_, _),
-            ) if self.is_eager_assignability() => field
-                .default_type(db)
-                .when_none_or(db, self.constraints, |default_type| {
-                    self.check_type_pair(db, default_type, target)
-                })
-                .and(db, self.constraints, || {
-                    field
-                        .converter(db)
-                        .map(|(_, output_ty)| output_ty)
-                        .when_none_or(db, self.constraints, |converter_output_type| {
-                            self.check_type_pair(db, converter_output_type, target)
-                        })
-                }),
+            (crate::types::TypeData::KnownInstance(KnownInstanceType::Field(field)), _)
+                if self.is_eager_assignability() =>
+            {
+                field
+                    .default_type(db)
+                    .when_none_or(db, self.constraints, |default_type| {
+                        self.check_type_pair(db, default_type, target)
+                    })
+                    .and(db, self.constraints, || {
+                        field
+                            .converter(db)
+                            .map(|(_, output_ty)| output_ty)
+                            .when_none_or(db, self.constraints, |converter_output_type| {
+                                self.check_type_pair(db, converter_output_type, target)
+                            })
+                    })
+            }
 
             (
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                        source_partial,
-                    )),
-                ),
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                        target_partial,
-                    )),
-                ),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    source_partial,
+                )),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    target_partial,
+                )),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_callable_pair(db, source_partial.partial(db), target_partial.partial(db))
             }),
 
             (
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
-                        source_sentinel,
-                    )),
-                ),
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(
-                        target_sentinel,
-                    )),
-                ),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(source_sentinel)),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::Sentinel(target_sentinel)),
             ) => ConstraintSet::from_bool(
                 self.constraints,
                 source_sentinel.is_same_sentinel(db, target_sentinel),
@@ -1338,13 +1295,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // When checking `FunctoolsPartial <: functools.partial[T]`, we need to specialize
             // the nominal instance with the partial's return type so the check is precise.
             (
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                        partial,
-                    )),
-                ),
-                (_, crate::types::TypeData::NominalInstance(target_instance)),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
+                crate::types::TypeData::NominalInstance(target_instance),
             ) if target_instance
                 .class(db)
                 .is_known(db, KnownClass::FunctoolsPartial) =>
@@ -1360,41 +1312,35 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // if `T` is also a dynamic type or a union that contains a dynamic type. Similarly,
             // `T <: Any` only holds true if `T` is a dynamic type or an intersection that
             // contains a dynamic type.
-            ((_, crate::types::TypeData::Dynamic(_dynamic)), (_, _)) => ConstraintSet::from_bool(
+            (crate::types::TypeData::Dynamic(_dynamic), _) => ConstraintSet::from_bool(
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
                     TypeRelation::Assignability => true,
-                    TypeRelation::Redundancy { .. } => match {
-                        let __ty_view_value = target;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::Dynamic(_)) => true,
-                        (_, crate::types::TypeData::Union(union)) => {
+                    TypeRelation::Redundancy { .. } => match target.data() {
+                        crate::types::TypeData::Dynamic(_) => true,
+                        crate::types::TypeData::Union(union) => {
                             union.elements(db).iter().any(Type::is_dynamic)
                         }
-                        (_, _) => false,
+                        _ => false,
                     },
                 },
             ),
-            ((_, _), (_, crate::types::TypeData::Dynamic(_))) => ConstraintSet::from_bool(
+            (_, crate::types::TypeData::Dynamic(_)) => ConstraintSet::from_bool(
                 self.constraints,
                 match self.relation {
                     TypeRelation::Subtyping | TypeRelation::SubtypingAssuming => false,
                     TypeRelation::Assignability => true,
-                    TypeRelation::Redundancy { .. } => match {
-                        let __ty_view_value = source;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::Dynamic(_)) => true,
-                        (_, crate::types::TypeData::Intersection(intersection)) => {
+                    TypeRelation::Redundancy { .. } => match source.data() {
+                        crate::types::TypeData::Dynamic(_) => true,
+                        crate::types::TypeData::Intersection(intersection) => {
                             // If a `Divergent` type is involved, it must not be eliminated.
                             intersection
                                 .positive(db)
                                 .iter()
                                 .any(Type::is_non_divergent_dynamic)
                         }
-                        (_, _) => false,
+                        _ => false,
                     },
                 },
             ),
@@ -1406,7 +1352,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             //
             // However, there is one exception to this general rule: for any given typevar `T`,
             // `T` will always be a subtype of any union containing `T`.
-            ((_, _), (_, crate::types::TypeData::Union(union)))
+            (_, crate::types::TypeData::Union(union))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
             {
@@ -1414,13 +1360,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // A similar rule applies in reverse to intersection types.
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
+            (crate::types::TypeData::Intersection(intersection), _)
                 if self.relation.can_safely_assume_reflexivity(target)
                     && intersection.positive(db).contains(&target) =>
             {
                 self.always()
             }
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
+            (crate::types::TypeData::Intersection(intersection), _)
                 if self.is_eager_assignability()
                     && intersection.positive(db).iter().any(Type::is_dynamic) =>
             {
@@ -1429,7 +1375,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 // `T` and any `S`, and `Never` is a subtype of all types.
                 self.always()
             }
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _))
+            (crate::types::TypeData::Intersection(intersection), _)
                 if self.relation.can_safely_assume_reflexivity(target)
                     && intersection.negative(db).contains(&target) =>
             {
@@ -1441,7 +1387,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // subclass of `type`), we instead compare in the metaclass-instance domain, since
             // collapsing `A` through `to_instance()` would erase it to `object` (we have no
             // precise representation for "all instances of any classes with a given metaclass").
-            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (_, _))
+            (crate::types::TypeData::SubclassOf(subclass_of), _)
                 if subclass_of.is_type_var()
                     && Self::can_check_typevar_subclass_relation_to_target(db, target) =>
             {
@@ -1450,7 +1396,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // And vice versa. (No special metaclass handling is needed in this direction, since
             // "collapse to 'object'" in this case is a sound over-approximation.)
-            ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
+            (_, crate::types::TypeData::SubclassOf(subclass_of))
                 if subclass_of.is_type_var() && source.to_instance(db).is_some() =>
             {
                 subclass_of
@@ -1466,12 +1412,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // specialized generic aliases; inferable `ParamSpec`s are handled by the inference
             // paths below.
             (
-                (_, crate::types::TypeData::TypeVar(bound_typevar)),
-                (_, crate::types::TypeData::Callable(other)),
+                crate::types::TypeData::TypeVar(bound_typevar),
+                crate::types::TypeData::Callable(other),
             )
             | (
-                (_, crate::types::TypeData::Callable(other)),
-                (_, crate::types::TypeData::TypeVar(bound_typevar)),
+                crate::types::TypeData::Callable(other),
+                crate::types::TypeData::TypeVar(bound_typevar),
             ) if self.is_eager_assignability()
                 && !bound_typevar.is_inferable(db, self.inferable)
                 && bound_typevar.is_paramspec(db)
@@ -1483,8 +1429,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Any concrete specialization of a `ParamSpec` is a subtype of the top
             // materialization of a `ParamSpec` value.
             (
-                (_, crate::types::TypeData::TypeVar(bound_typevar)),
-                (_, crate::types::TypeData::Callable(other)),
+                crate::types::TypeData::TypeVar(bound_typevar),
+                crate::types::TypeData::Callable(other),
             ) if !bound_typevar.is_inferable(db, self.inferable)
                 && bound_typevar.is_paramspec(db)
                 && Self::is_top_paramspec_value(db, other) =>
@@ -1495,7 +1441,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // A fully static typevar is a subtype of its upper bound, and to something similar to
             // the union of its constraints. An unbound, unconstrained, fully static typevar has an
             // implicit upper bound of `object` (which is handled above).
-            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _))
+            (crate::types::TypeData::TypeVar(bound_typevar), _)
                 if !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1517,7 +1463,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // If the typevar is constrained, there must be multiple constraints, and the typevar
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
-            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar)))
+            (_, crate::types::TypeData::TypeVar(bound_typevar))
                 if !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)
@@ -1544,7 +1490,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 )
             }
 
-            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _))
+            (crate::types::TypeData::TypeVar(bound_typevar), _)
                 if bound_typevar.is_inferable(db, self.inferable) =>
             {
                 // The implicit lower bound of a typevar is `Never`, which means
@@ -1559,48 +1505,45 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // (`object` can be a subtype of some protocols, or of itself, but those cases are
             // handled above).
             (
-                (_, crate::types::TypeData::NominalInstance(source)),
-                (
-                    _,
-                    crate::types::TypeData::NominalInstance(_)
-                    | crate::types::TypeData::SubclassOf(_)
-                    | crate::types::TypeData::Callable(_)
-                    | crate::types::TypeData::ProtocolInstance(_),
-                ),
+                crate::types::TypeData::NominalInstance(source),
+                crate::types::TypeData::NominalInstance(_)
+                | crate::types::TypeData::SubclassOf(_)
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::ProtocolInstance(_),
             ) if source.is_object() => self.never(),
 
             // Fast path: `object` is not a subtype of any non-inferable type variable, since the
             // type variable could be specialized to a type smaller than `object`.
             (
-                (_, crate::types::TypeData::NominalInstance(source)),
-                (_, crate::types::TypeData::TypeVar(typevar)),
+                crate::types::TypeData::NominalInstance(source),
+                crate::types::TypeData::TypeVar(typevar),
             ) if source.is_object() && !typevar.is_inferable(db, self.inferable) => self.never(),
 
             (
-                (_, crate::types::TypeData::NewTypeInstance(source_newtype)),
-                (_, crate::types::TypeData::NewTypeInstance(target_newtype)),
+                crate::types::TypeData::NewTypeInstance(source_newtype),
+                crate::types::TypeData::NewTypeInstance(target_newtype),
             ) => self.check_newtype_pair(db, source_newtype, target_newtype),
 
-            ((_, crate::types::TypeData::Union(union)), (_, _)) => union
-                .elements(db)
-                .iter()
-                .when_all(db, self.constraints, |&elem_ty| {
-                    let constraint_set = self.check_type_pair(db, elem_ty, target);
-                    if constraint_set.is_never_satisfied(db) {
-                        self.provide_context(|| ErrorContext::NotAllUnionElementsAssignable {
-                            element: elem_ty,
-                            union: source,
-                            target,
-                        });
-                    }
-                    constraint_set
-                }),
+            (crate::types::TypeData::Union(union), _) => {
+                union
+                    .elements(db)
+                    .iter()
+                    .when_all(db, self.constraints, |&elem_ty| {
+                        let constraint_set = self.check_type_pair(db, elem_ty, target);
+                        if constraint_set.is_never_satisfied(db) {
+                            self.provide_context(|| ErrorContext::NotAllUnionElementsAssignable {
+                                element: elem_ty,
+                                union: source,
+                                target,
+                            });
+                        }
+                        constraint_set
+                    })
+            }
 
-            ((_, _), (_, crate::types::TypeData::Union(union))) => {
-                if let (_, crate::types::TypeData::Intersection(intersection)) = ({
-                    let __ty_view_value = source;
-                    (__ty_view_value, __ty_view_value.data())
-                }) && let Some(alternatives) = intersection.finite_alternative_union(db)
+            (_, crate::types::TypeData::Union(union)) => {
+                if let crate::types::TypeData::Intersection(intersection) = source.data()
+                    && let Some(alternatives) = intersection.finite_alternative_union(db)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1611,11 +1554,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     // to be a newtype of a union, for an intersection to contain a newtype of a union, or for
                     // a non-inferable typevar (possibly inside an intersection) to widen to a bound or set of
                     // constraints that exposes a union; this requires special handling.
-                    match {
-                        let __ty_view_value = source;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
-                        (_, crate::types::TypeData::Intersection(intersection))
+                    match source.data() {
+                        crate::types::TypeData::Intersection(intersection)
                             if should_expand_intersection(intersection) =>
                         {
                             self.check_type_pair(
@@ -1624,7 +1564,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 target,
                             )
                         }
-                        (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+                        crate::types::TypeData::NewTypeInstance(newtype) => {
                             let concrete_base = newtype.concrete_base_type(db);
                             if concrete_base.is_union() {
                                 self.check_type_pair(db, concrete_base, target)
@@ -1632,7 +1572,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                                 self.never()
                             }
                         }
-                        (_, _) => self.never(),
+                        _ => self.never(),
                     }
                 };
 
@@ -1682,7 +1622,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // If both sides are intersections we need to handle the right side first
             // (A & B & C) is a subtype of (A & B) because the left is a subtype of both A and B,
             // but none of A, B, or C is a subtype of (A & B).
-            ((_, _), (_, crate::types::TypeData::Intersection(intersection))) => intersection
+            (_, crate::types::TypeData::Intersection(intersection)) => intersection
                 .positive(db)
                 .iter()
                 .when_all(db, self.constraints, |&pos_ty| {
@@ -1731,14 +1671,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         })
                 }),
 
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
-                if matches!(
-                    {
-                        let __ty_view_value = target;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (_, crate::types::TypeData::LiteralValue(_))
-                ) && let Some(alternatives) = intersection.finite_alternative_union(db)
+            (crate::types::TypeData::Intersection(intersection), _) => {
+                if matches!(target.data(), crate::types::TypeData::LiteralValue(_))
+                    && let Some(alternatives) = intersection.finite_alternative_union(db)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1792,21 +1727,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // `Never` is the bottom type, the empty set.
-            ((_, _), (_, crate::types::TypeData::Never)) => self.never(),
+            (_, crate::types::TypeData::Never) => self.never(),
 
             // Other than the special cases checked above, no other types are a subtype of a
             // typevar, since there's no guarantee what type the typevar will be specialized to.
             // (If the typevar is bounded, it might be specialized to a smaller type than the
             // bound. This is true even if the bound is a final class, since the typevar can still
             // be specialized to `Never`.)
-            ((_, _), (_, crate::types::TypeData::TypeVar(bound_typevar)))
+            (_, crate::types::TypeData::TypeVar(bound_typevar))
                 if !bound_typevar.is_inferable(db, self.inferable) =>
             {
                 self.never()
             }
 
             // TODO: Infer specializations here
-            ((_, _), (_, crate::types::TypeData::TypeVar(typevar)))
+            (_, crate::types::TypeData::TypeVar(typevar))
                 if typevar.is_inferable(db, self.inferable) =>
             {
                 if self.is_eager_assignability() {
@@ -1820,7 +1755,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     self.never()
                 }
             }
-            ((_, crate::types::TypeData::TypeVar(bound_typevar)), (_, _)) => {
+            (crate::types::TypeData::TypeVar(bound_typevar), _) => {
                 // All inferable cases should have been handled above
                 assert!(!bound_typevar.is_inferable(db, self.inferable));
                 self.never()
@@ -1830,25 +1765,23 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // This case must come after the TypeVar cases above, so that when checking
             // `NewType <: TypeVar`, we use the TypeVar handling rather than falling back
             // to the NewType's concrete base type.
-            ((_, crate::types::TypeData::NewTypeInstance(source_newtype)), (_, _)) => {
+            (crate::types::TypeData::NewTypeInstance(source_newtype), _) => {
                 self.check_type_pair(db, source_newtype.concrete_base_type(db), target)
             }
 
             // Note that the definition of `Type::AlwaysFalsy` depends on the return value of `__bool__`.
             // If `__bool__` always returns True or False, it can be treated as a subtype of `AlwaysTruthy` or `AlwaysFalsy`, respectively.
-            ((_, _), (_, crate::types::TypeData::AlwaysFalsy)) => {
+            (_, crate::types::TypeData::AlwaysFalsy) => {
                 ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_false())
             }
-            ((_, _), (_, crate::types::TypeData::AlwaysTruthy)) => {
+            (_, crate::types::TypeData::AlwaysTruthy) => {
                 ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_true())
             }
             // Currently, the only supertype of `AlwaysFalsy` and `AlwaysTruthy` is the universal set (object instance).
-            (
-                (_, crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy),
-                (_, _),
-            ) => self.with_recursion_guard(source, target, || {
-                self.check_type_pair(db, Type::object(), target)
-            }),
+            (crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy, _) => self
+                .with_recursion_guard(source, target, || {
+                    self.check_type_pair(db, Type::object(), target)
+                }),
 
             // These clauses handle type variants that include function literals. A function
             // literal is the subtype of itself, and not of any other function literal. However,
@@ -1856,17 +1789,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // applied to the signature. Different specializations of the same function literal are
             // only subtypes of each other if they result in the same signature.
             (
-                (_, crate::types::TypeData::FunctionLiteral(source_function)),
-                (_, crate::types::TypeData::FunctionLiteral(target_function)),
+                crate::types::TypeData::FunctionLiteral(source_function),
+                crate::types::TypeData::FunctionLiteral(target_function),
             ) => self.check_function_pair(db, source_function, target_function),
             (
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                        source_partial,
-                    )),
-                ),
-                (_, crate::types::TypeData::FunctionLiteral(target_function)),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::FunctoolsPartial(
+                    source_partial,
+                )),
+                crate::types::TypeData::FunctionLiteral(target_function),
             ) if matches!(self.relation, TypeRelation::Assignability) => {
                 self.with_recursion_guard(source, target, || {
                     self.check_callable_signature_pair(
@@ -1877,25 +1807,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
             }
             (
-                (_, crate::types::TypeData::BoundMethod(source_method)),
-                (_, crate::types::TypeData::BoundMethod(target_method)),
+                crate::types::TypeData::BoundMethod(source_method),
+                crate::types::TypeData::BoundMethod(target_method),
             ) => self.check_bound_method_pair(db, source_method, target_method),
             (
-                (_, crate::types::TypeData::KnownBoundMethod(source_method)),
-                (_, crate::types::TypeData::KnownBoundMethod(target_method)),
+                crate::types::TypeData::KnownBoundMethod(source_method),
+                crate::types::TypeData::KnownBoundMethod(target_method),
             ) => self.check_known_bound_method_pair(db, source_method, target_method),
 
             // All `StringLiteral` types are a subtype of `LiteralString`.
             (
-                (_, crate::types::TypeData::LiteralValue(source)),
-                (_, crate::types::TypeData::LiteralValue(target)),
+                crate::types::TypeData::LiteralValue(source),
+                crate::types::TypeData::LiteralValue(target),
             ) if source.is_string() && target.is_literal_string() => self.always(),
 
             // For union simplification, we want to preserve the unpromotable form of a literal value,
             // and so redundancy is not symmetric.
             (
-                (_, crate::types::TypeData::LiteralValue(source)),
-                (_, crate::types::TypeData::LiteralValue(target)),
+                crate::types::TypeData::LiteralValue(source),
+                crate::types::TypeData::LiteralValue(target),
             ) if matches!(self.relation, TypeRelation::Redundancy { pure: false }) => {
                 ConstraintSet::from_bool(
                     self.constraints,
@@ -1904,8 +1834,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (
-                (_, crate::types::TypeData::LiteralValue(source)),
-                (_, crate::types::TypeData::LiteralValue(target)),
+                crate::types::TypeData::LiteralValue(source),
+                crate::types::TypeData::LiteralValue(target),
             ) => ConstraintSet::from_bool(self.constraints, source.kind() == target.kind()),
 
             // No literal type is a subtype of any other literal type, unless they are the same
@@ -1913,31 +1843,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // perspective (the fallback cases below will handle it correctly), but it is important
             // for performance of simplifying large unions of literal types.
             (
-                (
-                    _,
-                    crate::types::TypeData::LiteralValue(_)
-                    | crate::types::TypeData::ClassLiteral(_)
-                    | crate::types::TypeData::FunctionLiteral(_)
-                    | crate::types::TypeData::ModuleLiteral(_),
-                ),
-                (
-                    _,
-                    crate::types::TypeData::LiteralValue(_)
-                    | crate::types::TypeData::ClassLiteral(_)
-                    | crate::types::TypeData::FunctionLiteral(_)
-                    | crate::types::TypeData::ModuleLiteral(_),
-                ),
+                crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::ModuleLiteral(_),
+                crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::ModuleLiteral(_),
             ) => self.never(),
 
             (
-                (_, crate::types::TypeData::Callable(source_callable)),
-                (_, crate::types::TypeData::Callable(target_callable)),
+                crate::types::TypeData::Callable(source_callable),
+                crate::types::TypeData::Callable(target_callable),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_callable_pair(db, source_callable, target_callable)
             }),
 
-            ((_, _), (_, crate::types::TypeData::Callable(target_callable))) => self
-                .with_recursion_guard(source, target, || {
+            (_, crate::types::TypeData::Callable(target_callable)) => {
+                self.with_recursion_guard(source, target, || {
                     let Some(callables) = source
                         .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
                     else {
@@ -1956,7 +1880,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     }
 
                     result
-                }),
+                })
+            }
 
             // `type[Any]` is assignable to arbitrary protocols as it has arbitrary attributes
             // (this is handled by a lower-down branch), but it is only a subtype of a given
@@ -1965,31 +1890,31 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // to that protocol (handled lower down), but it is only a subtype of that protocol
             // if `type` is a subtype of that protocol.
             (
-                (_, crate::types::TypeData::SubclassOf(source_subclass_ty)),
-                (_, crate::types::TypeData::ProtocolInstance(_)),
+                crate::types::TypeData::SubclassOf(source_subclass_ty),
+                crate::types::TypeData::ProtocolInstance(_),
             ) if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
                 && !self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
             }
 
-            ((_, _), (_, crate::types::TypeData::ProtocolInstance(target_proto))) => self
+            (_, crate::types::TypeData::ProtocolInstance(target_proto)) => self
                 .with_recursion_guard(source, target, || {
                     self.check_type_satisfies_protocol(db, source, target_proto)
                 }),
 
             // A protocol instance can never be a subtype of a nominal type, with the *sole* exception of `object`.
-            ((_, crate::types::TypeData::ProtocolInstance(_)), (_, _)) => self.never(),
+            (crate::types::TypeData::ProtocolInstance(_), _) => self.never(),
 
             (
-                (_, crate::types::TypeData::TypedDict(source_td)),
-                (_, crate::types::TypeData::TypedDict(target_td)),
+                crate::types::TypeData::TypedDict(source_td),
+                crate::types::TypeData::TypedDict(target_td),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_typeddict_pair(db, source_td, target_td)
             }),
 
-            ((_, crate::types::TypeData::TypedDict(typed_dict)), (_, _)) => self
-                .with_recursion_guard(source, target, || {
+            (crate::types::TypeData::TypedDict(typed_dict), _) => {
+                self.with_recursion_guard(source, target, || {
                     let dict_value_type = if self.relation.is_assignability() {
                         typed_dict.assignable_dict_value_type(db)
                     } else {
@@ -2008,10 +1933,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     };
                     let result = self.check_type_pair(db, fallback, target);
                     if result.is_never_satisfied(db) {
-                        if let (_, crate::types::TypeData::NominalInstance(instance)) = ({
-                            let __ty_view_value = target;
-                            (__ty_view_value, __ty_view_value.data())
-                        }) && instance.class(db).is_known(db, KnownClass::Dict)
+                        if let crate::types::TypeData::NominalInstance(instance) = target.data()
+                            && instance.class(db).is_known(db, KnownClass::Dict)
                         {
                             self.provide_context(|| {
                                 ErrorContext::TypedDictNotAssignableToDict(typed_dict)
@@ -2019,16 +1942,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         }
                     }
                     result
-                }),
+                })
+            }
 
             // A non-`TypedDict` cannot subtype a `TypedDict`
-            ((_, _), (_, crate::types::TypeData::TypedDict(_))) => self.never(),
+            (_, crate::types::TypeData::TypedDict(_)) => self.never(),
 
             // A string literal `Literal["abc"]` is assignable to `str` *and* to
             // `Sequence[Literal["a", "b", "c"]]` because strings are sequences of their characters.
             (
-                (_, crate::types::TypeData::LiteralValue(literal)),
-                (_, crate::types::TypeData::NominalInstance(instance)),
+                crate::types::TypeData::LiteralValue(literal),
+                crate::types::TypeData::NominalInstance(instance),
             ) if literal.is_string() => {
                 let value = literal.as_string().unwrap();
                 let target_class = instance.class(db);
@@ -2071,15 +1995,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
-            ((_, crate::types::TypeData::LiteralValue(literal)), (_, _)) if literal.is_string() => {
+            (crate::types::TypeData::LiteralValue(literal), _) if literal.is_string() => {
                 self.never()
             }
 
             // A bytes literal `Literal[b"abc"]` is assignable to `bytes` *and* to
             // `Sequence[Literal[97, 98, 99]]` because bytes are sequences of integers.
             (
-                (_, crate::types::TypeData::LiteralValue(literal)),
-                (_, crate::types::TypeData::NominalInstance(instance)),
+                crate::types::TypeData::LiteralValue(literal),
+                crate::types::TypeData::NominalInstance(instance),
             ) if literal.is_bytes() => {
                 let value = literal.as_bytes().unwrap();
                 let target_class = instance.class(db);
@@ -2121,15 +2045,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
             }
 
-            ((_, crate::types::TypeData::LiteralValue(literal)), (_, _)) if literal.is_bytes() => {
+            (crate::types::TypeData::LiteralValue(literal), _) if literal.is_bytes() => {
                 self.never()
             }
 
             // An instance is a subtype of an enum literal, if it is an instance of the enum class
             // and the enum has only one member.
             (
-                (_, crate::types::TypeData::NominalInstance(_)),
-                (_, crate::types::TypeData::LiteralValue(literal)),
+                crate::types::TypeData::NominalInstance(_),
+                crate::types::TypeData::LiteralValue(literal),
             ) if literal.is_enum() => {
                 let target_enum_literal = literal.as_enum().unwrap();
                 if target_enum_literal.enum_class_instance(db) != source {
@@ -2146,13 +2070,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // most `Literal` types delegate to their instance fallbacks
             // unless `source` is exactly equivalent to `target` (handled above)
             (
-                (
-                    _,
-                    crate::types::TypeData::ModuleLiteral(_)
-                    | crate::types::TypeData::LiteralValue(_)
-                    | crate::types::TypeData::FunctionLiteral(_),
-                ),
-                (_, _),
+                crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::FunctionLiteral(_),
+                _,
             ) => source.literal_fallback_instance(db).when_some_and(
                 db,
                 self.constraints,
@@ -2160,35 +2081,29 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             // The same reasoning applies for these special callable types:
-            ((_, crate::types::TypeData::BoundMethod(_)), (_, _)) => {
+            (crate::types::TypeData::BoundMethod(_), _) => {
                 self.check_type_pair(db, KnownClass::MethodType.to_instance(db), target)
             }
-            ((_, crate::types::TypeData::KnownBoundMethod(method)), (_, _)) => {
+            (crate::types::TypeData::KnownBoundMethod(method), _) => {
                 self.check_type_pair(db, method.class().to_instance(db), target)
             }
-            ((_, crate::types::TypeData::WrapperDescriptor(_)), (_, _)) => self.check_type_pair(
+            (crate::types::TypeData::WrapperDescriptor(_), _) => self.check_type_pair(
                 db,
                 KnownClass::WrapperDescriptorType.to_instance(db),
                 target,
             ),
 
             (
-                (
-                    _,
-                    crate::types::TypeData::DataclassDecorator(_)
-                    | crate::types::TypeData::DataclassTransformer(_),
-                ),
-                (_, _),
+                crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_),
+                _,
             ) => {
                 // TODO: Implement subtyping using an equivalent `Callable` type.
                 self.never()
             }
 
             // `TypeIs` is invariant.
-            (
-                (_, crate::types::TypeData::TypeIs(source)),
-                (_, crate::types::TypeData::TypeIs(target)),
-            ) => {
+            (crate::types::TypeData::TypeIs(source), crate::types::TypeData::TypeIs(target)) => {
                 let source_type = source.type_argument(db);
                 let target_type = target.type_argument(db);
                 self.check_type_pair(db, source_type, target_type)
@@ -2199,38 +2114,35 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `TypeGuard` is covariant.
             (
-                (_, crate::types::TypeData::TypeGuard(source)),
-                (_, crate::types::TypeData::TypeGuard(target)),
+                crate::types::TypeData::TypeGuard(source),
+                crate::types::TypeData::TypeGuard(target),
             ) => self.check_type_pair(db, source.return_type(db), target.return_type(db)),
 
             // `TypeIs[T]` and `TypeGuard[T]` are subtypes of `bool`.
-            (
-                (_, crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_)),
-                (_, _),
-            ) => self.check_type_pair(db, KnownClass::Bool.to_instance(db), target),
+            (crate::types::TypeData::TypeIs(_) | crate::types::TypeData::TypeGuard(_), _) => {
+                self.check_type_pair(db, KnownClass::Bool.to_instance(db), target)
+            }
 
             // Function-like callables are subtypes of `FunctionType`
-            ((_, crate::types::TypeData::Callable(callable)), (_, _))
-                if callable.is_function_like(db) =>
-            {
+            (crate::types::TypeData::Callable(callable), _) if callable.is_function_like(db) => {
                 self.check_type_pair(db, KnownClass::FunctionType.to_instance(db), target)
             }
 
-            ((_, crate::types::TypeData::Callable(_)), (_, _)) => self.never(),
+            (crate::types::TypeData::Callable(_), _) => self.never(),
 
             (
-                (_, crate::types::TypeData::BoundSuper(source)),
-                (_, crate::types::TypeData::BoundSuper(target)),
+                crate::types::TypeData::BoundSuper(source),
+                crate::types::TypeData::BoundSuper(target),
             ) => self
                 .as_equivalence_checker()
                 .check_bound_super_pair(db, source, target),
 
-            ((_, crate::types::TypeData::BoundSuper(_)), (_, _)) => {
+            (crate::types::TypeData::BoundSuper(_), _) => {
                 self.check_type_pair(db, KnownClass::Super.to_instance(db), target)
             }
 
-            ((_, crate::types::TypeData::SubclassOf(subclass_of)), (_, _))
-            | ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of)))
+            (crate::types::TypeData::SubclassOf(subclass_of), _)
+            | (_, crate::types::TypeData::SubclassOf(subclass_of))
                 if subclass_of.is_type_var() =>
             {
                 self.never()
@@ -2239,8 +2151,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // `Literal[<class 'C'>]` is a subtype of `type[B]` if `C` is a subclass of `B`,
             // since `type[B]` describes all possible runtime subclasses of the class object `B`.
             (
-                (_, crate::types::TypeData::ClassLiteral(source_cls)),
-                (_, crate::types::TypeData::SubclassOf(target_subclass_ty)),
+                crate::types::TypeData::ClassLiteral(source_cls),
+                crate::types::TypeData::SubclassOf(target_subclass_ty),
             ) => target_subclass_ty
                 .subclass_of()
                 .into_class(db)
@@ -2256,8 +2168,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // with final generic types, where `type[C[...]]` is simplified to the generic-alias
             // type `<class 'C[...]'>`, due to the fact that `C[...]` has no subclasses.
             (
-                (_, crate::types::TypeData::ClassLiteral(source_cls)),
-                (_, crate::types::TypeData::GenericAlias(target_alias)),
+                crate::types::TypeData::ClassLiteral(source_cls),
+                crate::types::TypeData::GenericAlias(target_alias),
             ) => self.check_class_pair(
                 db,
                 source_cls.default_specialization(db),
@@ -2266,8 +2178,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // For generic aliases, we delegate to the underlying class type.
             (
-                (_, crate::types::TypeData::GenericAlias(source_alias)),
-                (_, crate::types::TypeData::GenericAlias(target_alias)),
+                crate::types::TypeData::GenericAlias(source_alias),
+                crate::types::TypeData::GenericAlias(target_alias),
             ) => self.check_class_pair(
                 db,
                 ClassType::Generic(source_alias),
@@ -2275,8 +2187,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             ),
 
             (
-                (_, crate::types::TypeData::GenericAlias(source_alias)),
-                (_, crate::types::TypeData::SubclassOf(target_subclass_ty)),
+                crate::types::TypeData::GenericAlias(source_alias),
+                crate::types::TypeData::SubclassOf(target_subclass_ty),
             ) => target_subclass_ty
                 .subclass_of()
                 .into_class(db)
@@ -2289,25 +2201,24 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // This branch asks: given two types `type[T]` and `type[S]`, is `type[T]` a subtype of `type[S]`?
             (
-                (_, crate::types::TypeData::SubclassOf(source)),
-                (_, crate::types::TypeData::SubclassOf(target)),
+                crate::types::TypeData::SubclassOf(source),
+                crate::types::TypeData::SubclassOf(target),
             ) => self.check_subclassof_pair(db, source, target),
 
             // `Literal[str]` is a subtype of `type` because the `str` class object is an instance of its metaclass `type`.
             // `Literal[abc.ABC]` is a subtype of `abc.ABCMeta` because the `abc.ABC` class object
             // is an instance of its metaclass `abc.ABCMeta`.
-            ((_, crate::types::TypeData::ClassLiteral(source_class)), (_, _)) => {
+            (crate::types::TypeData::ClassLiteral(source_class), _) => {
                 self.check_type_pair(db, source_class.metaclass_instance_type(db), target)
             }
-            ((_, crate::types::TypeData::GenericAlias(source_alias)), (_, _)) => self
-                .check_type_pair(
-                    db,
-                    ClassType::Generic(source_alias).metaclass_instance_type(db),
-                    target,
-                ),
+            (crate::types::TypeData::GenericAlias(source_alias), _) => self.check_type_pair(
+                db,
+                ClassType::Generic(source_alias).metaclass_instance_type(db),
+                target,
+            ),
 
             // `type[Any]` is a subtype of `type[object]`, and is assignable to any `type[...]`
-            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (_, _))
+            (crate::types::TypeData::SubclassOf(subclass_of_ty), _)
                 if subclass_of_ty.is_dynamic() =>
             {
                 self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
@@ -2320,7 +2231,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             // Any `type[...]` type is assignable to `type[Any]`
-            ((_, _), (_, crate::types::TypeData::SubclassOf(subclass_of_ty)))
+            (_, crate::types::TypeData::SubclassOf(subclass_of_ty))
                 if subclass_of_ty.is_dynamic() && self.is_eager_assignability() =>
             {
                 self.check_type_pair(db, source, KnownClass::Type.to_instance(db))
@@ -2333,57 +2244,56 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Similarly `type[enum.Enum]`  is a subtype of `enum.EnumMeta` because `enum.Enum`
             // is an instance of `enum.EnumMeta`. `type[Any]` and `type[Unknown]` do not participate in subtyping,
             // however, as they are not fully static types.
-            ((_, crate::types::TypeData::SubclassOf(subclass_of_ty)), (_, _)) => self
-                .check_type_pair(
-                    db,
-                    subclass_of_ty
-                        .subclass_of()
-                        .into_class(db)
-                        .map(|source_class| source_class.metaclass_instance_type(db))
-                        .unwrap_or_else(|| KnownClass::Type.to_instance(db)),
-                    target,
-                ),
+            (crate::types::TypeData::SubclassOf(subclass_of_ty), _) => self.check_type_pair(
+                db,
+                subclass_of_ty
+                    .subclass_of()
+                    .into_class(db)
+                    .map(|source_class| source_class.metaclass_instance_type(db))
+                    .unwrap_or_else(|| KnownClass::Type.to_instance(db)),
+                target,
+            ),
 
-            ((_, crate::types::TypeData::TypeForm(_)), (_, _)) => {
+            (crate::types::TypeData::TypeForm(_), _) => {
                 self.check_type_pair(db, Type::object(), target)
             }
 
             // For example: `Type::SpecialForm(SpecialFormType::Type)` is a subtype of `Type::NominalInstance(_SpecialForm)`,
             // because `Type::SpecialForm(SpecialFormType::Type)` is a set with exactly one runtime value in it
             // (the symbol `typing.Type`), and that symbol is known to be an instance of `typing._SpecialForm` at runtime.
-            ((_, crate::types::TypeData::SpecialForm(source_form)), (_, _)) => {
+            (crate::types::TypeData::SpecialForm(source_form), _) => {
                 self.check_type_pair(db, source_form.instance_fallback(db), target)
             }
 
-            ((_, crate::types::TypeData::KnownInstance(source)), (_, _)) => {
+            (crate::types::TypeData::KnownInstance(source), _) => {
                 self.check_type_pair(db, source.instance_fallback(db), target)
             }
 
             // `bool` is a subtype of `int`, because `bool` subclasses `int`,
             // which means that all instances of `bool` are also instances of `int`
             (
-                (_, crate::types::TypeData::NominalInstance(source_i)),
-                (_, crate::types::TypeData::NominalInstance(target_i)),
+                crate::types::TypeData::NominalInstance(source_i),
+                crate::types::TypeData::NominalInstance(target_i),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_nominal_instance_pair(db, source_i, target_i)
             }),
 
             (
-                (_, crate::types::TypeData::PropertyInstance(source_p)),
-                (_, crate::types::TypeData::PropertyInstance(target_p)),
+                crate::types::TypeData::PropertyInstance(source_p),
+                crate::types::TypeData::PropertyInstance(target_p),
             ) => self.with_recursion_guard(source, target, || {
                 self.check_property_instance_pair(db, source_p, target_p)
             }),
 
-            ((_, crate::types::TypeData::PropertyInstance(property)), (_, _)) => {
+            (crate::types::TypeData::PropertyInstance(property), _) => {
                 self.check_type_pair(db, property.instance_fallback(db), target)
             }
-            ((_, _), (_, crate::types::TypeData::PropertyInstance(property))) => {
+            (_, crate::types::TypeData::PropertyInstance(property)) => {
                 self.check_type_pair(db, source, property.instance_fallback(db))
             }
             // Other than the special cases enumerated above, nominal-instance types are never
             // subtypes of any other variants
-            ((_, crate::types::TypeData::NominalInstance(_)), (_, _)) => self.never(),
+            (crate::types::TypeData::NominalInstance(_), _) => self.never(),
         }
     }
 
@@ -2707,16 +2617,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             });
         }
 
-        match (
-            ({
-                let __ty_view_value = left;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            ({
-                let __ty_view_value = right;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-        ) {
+        match (left.view(), right.view()) {
             ((_, crate::types::TypeData::Never), (_, _))
             | ((_, _), (_, crate::types::TypeData::Never)) => self.always(),
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -19,7 +19,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ClassType, CycleDetector,
     IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
     MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, SubclassOfInner,
-    SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
+    SubclassOfType, TypeTag, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
     Db,
@@ -1058,10 +1058,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // constraint set. If the typevar has an upper bound or constraints, then the relation
             // only has to hold when the typevar has a valid specialization (i.e., one that
             // satisfies the upper bound/constraints).
-            if let (_, crate::types::TypeData::TypeVar(bound_typevar)) = {
-                let __ty_view_value = source;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let Some(bound_typevar) = source.as_typevar() {
                 let upper = if self.relation.is_subtyping() {
                     target.bottom_materialization(db)
                 } else {
@@ -1073,10 +1070,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     bound_typevar,
                     upper,
                 );
-            } else if let (_, crate::types::TypeData::TypeVar(bound_typevar)) = {
-                let __ty_view_value = target;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            } else if let Some(bound_typevar) = target.as_typevar() {
                 let lower = if self.relation.is_subtyping() {
                     source.top_materialization(db)
                 } else {
@@ -1091,21 +1085,41 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
         }
 
+        if source.tag == TypeTag::Never {
+            return self.always();
+        }
+
+        if let Some(source_alias) = source.as_lazy_type_alias() {
+            return self.with_recursion_guard(source, target, || {
+                self.check_type_pair(db, source_alias.value_type(db), target)
+            });
+        }
+        if let Some(target_alias) = target.as_lazy_type_alias() {
+            return self.with_recursion_guard(source, target, || {
+                self.check_type_pair(db, source, target_alias.value_type(db))
+            });
+        }
+
+        if let Some(union) = target.as_union()
+            && union.has_aliases(db)
+        {
+            return self.with_recursion_guard(source, target, || {
+                self.check_type_pair(db, source, union.expand_aliases(db))
+            });
+        }
+
         let should_expand_intersection = |intersection: IntersectionType<'db>| {
-            intersection.positive(db).iter().any(|element| {
-                match {
-                    let __ty_view_value = element;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::TypeVar(tvar)) => {
-                        !tvar.is_inferable(db, self.inferable)
-                    }
-                    (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
-                        newtype.concrete_base_type(db).is_union()
-                    }
-                    (_, _) => false,
-                }
-            })
+            intersection
+                .positive(db)
+                .iter()
+                .any(|element| match element.as_typevar() {
+                    Some(tvar) => !tvar.is_inferable(db, self.inferable),
+                    None if element.tag == TypeTag::NewTypeInstance => element
+                        .payload::<crate::types::NewType<'db>>()
+                        .concrete_base_type(db)
+                        .is_union(),
+                    None => false,
+                })
         };
 
         match (
@@ -2668,6 +2682,29 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
         if let Some(right) = right.materialized_divergent_fallback() {
             return self.check_type_pair(db, left, right);
+        }
+
+        if left.tag == TypeTag::Never || right.tag == TypeTag::Never {
+            return self.always();
+        }
+        if left.tag == TypeTag::Dynamic
+            || right.tag == TypeTag::Dynamic
+            || left.tag == TypeTag::Divergent
+            || right.tag == TypeTag::Divergent
+        {
+            return self.never();
+        }
+        if let Some(alias) = left.as_lazy_type_alias() {
+            let left_alias_ty = alias.value_type(db);
+            return self.with_recursion_guard(left, right, || {
+                self.check_type_pair(db, left_alias_ty, right)
+            });
+        }
+        if let Some(alias) = right.as_lazy_type_alias() {
+            let right_alias_ty = alias.value_type(db);
+            return self.with_recursion_guard(left, right, || {
+                self.check_type_pair(db, left, right_alias_ty)
+            });
         }
 
         match (

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -329,10 +329,7 @@ impl<'db> ErrorContext<'db> {
                 )
             }
             Self::TypeNotCompatibleWithProtocol { ty, protocol } => {
-                if let (_, crate::types::TypeData::ProtocolInstance(_)) = {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
+                if let crate::types::TypeData::ProtocolInstance(_) = ty.data() {
                     format!(
                         "protocol `{}` is not assignable to protocol `{}`",
                         ty.display(db),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -329,7 +329,10 @@ impl<'db> ErrorContext<'db> {
                 )
             }
             Self::TypeNotCompatibleWithProtocol { ty, protocol } => {
-                if let Type::ProtocolInstance(_) = ty {
+                if let (_, crate::types::TypeData::ProtocolInstance(_)) = {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
                     format!(
                         "protocol `{}` is not assignable to protocol `{}`",
                         ty.display(db),

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -95,15 +95,9 @@ impl<'db> UnionType<'db> {
 
     /// Returns `true` if any direct element of this union is a type alias.
     pub(crate) fn has_aliases(self, db: &'db dyn Db) -> bool {
-        self.elements(db).iter().any(|element| {
-            matches!(
-                {
-                    let __ty_view_value = element;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::TypeAlias(_))
-            )
-        })
+        self.elements(db)
+            .iter()
+            .any(|element| element.as_lazy_type_alias().is_some())
     }
 
     /// Recursively expands aliases that expose top-level union elements.

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -204,15 +204,7 @@ impl<'db> UnionType<'db> {
         let mut iter = elements.iter().enumerate();
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty)?;
-            if &new_ty != ty
-                || matches!(
-                    {
-                        let __ty_view_value = new_ty;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (_, crate::types::TypeData::TypeAlias(_))
-                )
-            {
+            if &new_ty != ty || matches!(new_ty.data(), crate::types::TypeData::TypeAlias(_)) {
                 let mut builder = elements[..i]
                     .iter()
                     .copied()
@@ -969,11 +961,8 @@ fn expand_intersection_typevars_and_newtypes<'db>(
 ) -> Type<'db> {
     let mut builder = IntersectionBuilder::new(db);
     for &element in positive {
-        match {
-            let __ty_view_value = element;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeVar(tvar)) => {
+        match element.data() {
+            crate::types::TypeData::TypeVar(tvar) => {
                 match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         builder = builder.add_positive(bound);
@@ -986,10 +975,10 @@ fn expand_intersection_typevars_and_newtypes<'db>(
                     None => {}
                 }
             }
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
+            crate::types::TypeData::NewTypeInstance(newtype) => {
                 builder = builder.add_positive(newtype.concrete_base_type(db));
             }
-            (_, _) => builder = builder.add_positive(element),
+            _ => builder = builder.add_positive(element),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -95,9 +95,15 @@ impl<'db> UnionType<'db> {
 
     /// Returns `true` if any direct element of this union is a type alias.
     pub(crate) fn has_aliases(self, db: &'db dyn Db) -> bool {
-        self.elements(db)
-            .iter()
-            .any(|element| matches!(element, Type::TypeAlias(_)))
+        self.elements(db).iter().any(|element| {
+            matches!(
+                {
+                    let __ty_view_value = element;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::TypeAlias(_))
+            )
+        })
     }
 
     /// Recursively expands aliases that expose top-level union elements.
@@ -204,7 +210,15 @@ impl<'db> UnionType<'db> {
         let mut iter = elements.iter().enumerate();
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty)?;
-            if &new_ty != ty || matches!(new_ty, Type::TypeAlias(_)) {
+            if &new_ty != ty
+                || matches!(
+                    {
+                        let __ty_view_value = new_ty;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (_, crate::types::TypeData::TypeAlias(_))
+                )
+            {
                 let mut builder = elements[..i]
                     .iter()
                     .copied()
@@ -961,8 +975,11 @@ fn expand_intersection_typevars_and_newtypes<'db>(
 ) -> Type<'db> {
     let mut builder = IntersectionBuilder::new(db);
     for &element in positive {
-        match element {
-            Type::TypeVar(tvar) => {
+        match {
+            let __ty_view_value = element;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeVar(tvar)) => {
                 match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         builder = builder.add_positive(bound);
@@ -975,10 +992,10 @@ fn expand_intersection_typevars_and_newtypes<'db>(
                     None => {}
                 }
             }
-            Type::NewTypeInstance(newtype) => {
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                 builder = builder.add_positive(newtype.concrete_base_type(db));
             }
-            _ => builder = builder.add_positive(element),
+            (_, _) => builder = builder.add_positive(element),
         }
     }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -61,7 +61,10 @@ fn split_truthiness_guarded_intersection<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<(Type<'db>, Type<'db>)> {
-    let Type::Intersection(intersection) = ty else {
+    let (_, crate::types::TypeData::Intersection(intersection)) = ({
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    }) else {
         return None;
     };
     let falsy = Type::AlwaysTruthy.negate(db);
@@ -146,7 +149,10 @@ fn merge_truthiness_guarded_pair<'db>(
 /// ```
 fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'db>>) -> bool {
     for complement_index in 0..types.len() {
-        let Type::EnumComplement(complement) = types[complement_index] else {
+        let (_, crate::types::TypeData::EnumComplement(complement)) = ({
+            let __ty_view_value = types[complement_index];
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             continue;
         };
         let enum_class = complement.enum_class(db);
@@ -160,7 +166,10 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
                 continue;
             }
 
-            if let Type::EnumComplement(other_complement) = *ty {
+            if let (_, crate::types::TypeData::EnumComplement(other_complement)) = {
+                let __ty_view_value = *ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 if other_complement.enum_class(db) == enum_class
                     && other_complement.rest(db) == complement.rest(db)
                 {
@@ -230,7 +239,13 @@ enum LiteralKind<'db> {
 impl<'db> Type<'db> {
     /// Return `true` if this type can be a supertype of some literals of `kind` and not others.
     fn splits_literals(self, db: &'db dyn Db, kind: LiteralKind) -> bool {
-        match (self, kind) {
+        match (
+            ({
+                let __ty_view_value = self;
+                (__ty_view_value, __ty_view_value.data())
+            }),
+            kind,
+        ) {
             // Note that as of 2026-01-04, `AlwaysFalsy` and `AlwaysTruthy` never split
             // enum literals, but that could change in the future. `Literal[Foo.X]` could
             // plausibly be understood by ty as a subtype of `AlwaysFalsy` in the following
@@ -242,8 +257,12 @@ impl<'db> Type<'db> {
             //     X = 0
             //     Y = 1
             // ```
-            (Type::AlwaysFalsy | Type::AlwaysTruthy, _) => true,
-            (Type::LiteralValue(literal), _) => match (literal.kind(), kind) {
+            (
+                (_, crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy),
+                _,
+            ) => true,
+            ((_, crate::types::TypeData::LiteralValue(literal)), _) => match (literal.kind(), kind)
+            {
                 (LiteralValueTypeKind::String(_), LiteralKind::String) => true,
                 (LiteralValueTypeKind::Bytes(_), LiteralKind::Bytes) => true,
                 (LiteralValueTypeKind::Int(_), LiteralKind::Int) => true,
@@ -252,7 +271,7 @@ impl<'db> Type<'db> {
                 }
                 _ => false,
             },
-            (Type::Intersection(intersection), _) => {
+            ((_, crate::types::TypeData::Intersection(intersection)), _) => {
                 intersection
                     .positive(db)
                     .iter()
@@ -262,13 +281,14 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|ty| ty.splits_literals(db, kind))
             }
-            (Type::Union(union), _) => union
+            ((_, crate::types::TypeData::Union(union)), _) => union
                 .elements(db)
                 .iter()
                 .any(|ty| ty.splits_literals(db, kind)),
-            (Type::EnumComplement(complement), LiteralKind::Enum { enum_class }) => {
-                complement.enum_class(db) == enum_class
-            }
+            (
+                (_, crate::types::TypeData::EnumComplement(complement)),
+                LiteralKind::Enum { enum_class },
+            ) => complement.enum_class(db) == enum_class,
             _ => false,
         }
     }
@@ -587,8 +607,11 @@ impl<'db> UnionBuilder<'db> {
         let mut ty_negated_cache = None;
         let mut ty_negated = || *ty_negated_cache.get_or_insert_with(|| ty.negate(self.db));
 
-        match ty {
-            Type::Union(union) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Union(union)) => {
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
                 for element in new_elements {
@@ -611,8 +634,8 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             // Adding `Never` to a union is a no-op.
-            Type::Never => {}
-            Type::TypeAlias(alias) if self.unpack_aliases => {
+            (_, crate::types::TypeData::Never) => {}
+            (_, crate::types::TypeData::TypeAlias(alias)) if self.unpack_aliases => {
                 if seen_aliases.contains(&ty) {
                     // Union contains itself recursively via a type alias. This is an error, just
                     // leave out the recursive alias. TODO surface this error.
@@ -621,7 +644,7 @@ impl<'db> UnionBuilder<'db> {
                     self.add_in_place_impl(alias.value_type(self.db), seen_aliases);
                 }
             }
-            Type::LiteralValue(literal) => {
+            (_, crate::types::TypeData::LiteralValue(literal)) => {
                 self.recursively_defined =
                     self.recursively_defined.or(literal.recursively_defined());
                 match literal.kind() {
@@ -878,8 +901,8 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             // Adding `object` to a union results in `object`.
-            ty if ty.is_object() => self.collapse_to_object(),
-            _ => self.push_type(ty, seen_aliases),
+            (ty, _) if ty.is_object() => self.collapse_to_object(),
+            (_, _) => self.push_type(ty, seen_aliases),
         }
     }
 
@@ -896,7 +919,13 @@ impl<'db> UnionBuilder<'db> {
         // If an alias gets here, it means we aren't unpacking aliases, and we also
         // shouldn't try to simplify aliases out of the union, because that will require
         // unpacking them.
-        let should_simplify_full = !matches!(ty, Type::TypeAlias(_)) && !self.cycle_recovery;
+        let should_simplify_full = !matches!(
+            {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::TypeAlias(_))
+        ) && !self.cycle_recovery;
 
         let mut ty_negated: Option<Type> = None;
         let mut to_remove = SmallVec::<[usize; 2]>::new();
@@ -947,7 +976,15 @@ impl<'db> UnionBuilder<'db> {
                 continue;
             }
 
-            if should_simplify_full && !matches!(element_type, Type::TypeAlias(_)) {
+            if should_simplify_full
+                && !matches!(
+                    {
+                        let __ty_view_value = element_type;
+                        (__ty_view_value, __ty_view_value.data())
+                    },
+                    (_, crate::types::TypeData::TypeAlias(_))
+                )
+            {
                 if ty.is_redundant_with(self.db, element_type) {
                     return;
                 }
@@ -1094,8 +1131,11 @@ impl<'db> IntersectionBuilder<'db> {
         ty: Type<'db>,
         seen_aliases: &mut Vec<Type<'db>>,
     ) -> Self {
-        match ty {
-            Type::TypeAlias(alias) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 if seen_aliases.contains(&ty) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
@@ -1107,7 +1147,7 @@ impl<'db> IntersectionBuilder<'db> {
                 let value_type = alias.value_type(self.db);
                 self.add_positive_impl(value_type, seen_aliases)
             }
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
                 // intersect with that union element, then create a new union-of-intersections with all
                 // of those sub-intersections in it. E.g. if `self` is a simple intersection `T1 & T2`
@@ -1126,7 +1166,7 @@ impl<'db> IntersectionBuilder<'db> {
                     })
             }
             // `(A & B & ~C) & (D & E & ~F)` -> `A & B & D & E & ~C & ~F`
-            Type::Intersection(other) => {
+            (_, crate::types::TypeData::Intersection(other)) => {
                 let db = self.db;
                 for pos in other.positive(db) {
                     self = self.add_positive_impl(*pos, seen_aliases);
@@ -1136,11 +1176,11 @@ impl<'db> IntersectionBuilder<'db> {
                 }
                 self
             }
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 let db = self.db;
                 self.add_positive_impl(complement.to_intersection(db), seen_aliases)
             }
-            _ => {
+            (_, _) => {
                 // If we are already a union-of-intersections, distribute the new intersected element
                 // across all of those intersections.
                 for inner in &mut self.intersections {
@@ -1161,8 +1201,11 @@ impl<'db> IntersectionBuilder<'db> {
         seen_aliases: &mut Vec<Type<'db>>,
     ) -> Self {
         // See comments above in `add_positive`; this is just the negated version.
-        match ty {
-            Type::TypeAlias(alias) => {
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 if seen_aliases.contains(&ty) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
@@ -1174,13 +1217,13 @@ impl<'db> IntersectionBuilder<'db> {
                 let value_type = alias.value_type(self.db);
                 self.add_negative_impl(value_type, seen_aliases)
             }
-            Type::Union(union) => {
+            (_, crate::types::TypeData::Union(union)) => {
                 for elem in union.elements(self.db) {
                     self = self.add_negative_impl(*elem, seen_aliases);
                 }
                 self
             }
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 // (A | B) & ~(C & ~D)
                 // -> (A | B) & (~C | D)
                 // -> ((A | B) & ~C) | ((A | B) & D)
@@ -1214,11 +1257,11 @@ impl<'db> IntersectionBuilder<'db> {
                     },
                 )
             }
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 let db = self.db;
                 self.add_negative_impl(complement.to_intersection(db), seen_aliases)
             }
-            _ => {
+            (_, _) => {
                 for inner in &mut self.intersections {
                     inner.add_negative(self.db, ty);
                 }
@@ -1273,7 +1316,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
     /// ```
     fn has_empty_enum_complement(&self, db: &'db dyn Db) -> bool {
         for positive in &self.positive {
-            let Type::NominalInstance(instance) = positive else {
+            let (_, crate::types::TypeData::NominalInstance(instance)) = ({
+                let __ty_view_value = positive;
+                (__ty_view_value, __ty_view_value.data())
+            }) else {
                 continue;
             };
 
@@ -1341,8 +1387,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
         }
 
         // A runtime class value of `TypeForm[T]` has type `type[T]`.
-        match new_positive {
-            Type::TypeForm(typeform) => {
+        match {
+            let __ty_view_value = new_positive;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeForm(typeform)) => {
                 if let Some(narrowed) = SubclassOfType::try_from_instance(
                     db,
                     typeform.type_argument(db).resolve_type_alias(db),
@@ -1351,38 +1400,54 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     new_positive = narrowed;
                 }
             }
-            Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Type) => {
+            (_, crate::types::TypeData::NominalInstance(instance))
+                if instance.has_known_class(db, KnownClass::Type) =>
+            {
                 if let Some((index, narrowed)) =
                     self.positive
                         .iter()
                         .enumerate()
-                        .find_map(|(index, positive)| match positive {
-                            Type::TypeForm(typeform) => SubclassOfType::try_from_instance(
-                                db,
-                                typeform.type_argument(db).resolve_type_alias(db),
-                            )
-                            .map(|narrowed| (index, narrowed)),
-                            _ => None,
+                        .find_map(|(index, positive)| {
+                            match {
+                                let __ty_view_value = positive;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
+                                (_, crate::types::TypeData::TypeForm(typeform)) => {
+                                    SubclassOfType::try_from_instance(
+                                        db,
+                                        typeform.type_argument(db).resolve_type_alias(db),
+                                    )
+                                    .map(|narrowed| (index, narrowed))
+                                }
+                                (_, _) => None,
+                            }
                         })
                 {
                     self.positive.swap_remove_index(index);
                     new_positive = narrowed;
                 }
             }
-            _ => {}
+            (_, _) => {}
         }
 
-        match new_positive {
+        match {
+            let __ty_view_value = new_positive;
+            (__ty_view_value, __ty_view_value.data())
+        } {
             // `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
-            Type::AlwaysTruthy if self.positive.contains(&Type::literal_string()) => {
+            (_, crate::types::TypeData::AlwaysTruthy)
+                if self.positive.contains(&Type::literal_string()) =>
+            {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             // `LiteralString & AlwaysFalsy` -> `Literal[""]`
-            Type::AlwaysFalsy if self.positive.swap_remove(&Type::literal_string()) => {
+            (_, crate::types::TypeData::AlwaysFalsy)
+                if self.positive.swap_remove(&Type::literal_string()) =>
+            {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `AlwaysTruthy & LiteralString` -> `LiteralString & ~Literal[""]`
-            Type::LiteralValue(literal)
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if literal.is_literal_string()
                     && self.positive.swap_remove(&Type::AlwaysTruthy) =>
             {
@@ -1390,27 +1455,27 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             // `AlwaysFalsy & LiteralString` -> `Literal[""]`
-            Type::LiteralValue(literal)
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if literal.is_literal_string() && self.positive.swap_remove(&Type::AlwaysFalsy) =>
             {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysTruthy` -> `LiteralString & AlwaysFalsy` -> `Literal[""]`
-            Type::LiteralValue(literal)
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if literal.is_literal_string()
                     && self.negative.swap_remove(&Type::AlwaysTruthy) =>
             {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
-            Type::LiteralValue(literal)
+            (_, crate::types::TypeData::LiteralValue(literal))
                 if literal.is_literal_string() && self.negative.swap_remove(&Type::AlwaysFalsy) =>
             {
                 self.add_positive(db, Type::literal_string());
                 self.add_negative(db, Type::string_literal(db, ""));
             }
 
-            _ => {
+            (_, _) => {
                 let positive_as_instance = new_positive.as_nominal_instance();
 
                 if let Some(instance) = positive_as_instance
@@ -1424,31 +1489,37 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .is_some_and(|instance| instance.has_known_class(db, KnownClass::Bool));
 
                 for (index, existing_positive) in self.positive.iter().enumerate() {
-                    match existing_positive {
+                    match {
+                        let __ty_view_value = existing_positive;
+                        (__ty_view_value, __ty_view_value.data())
+                    } {
                         // `AlwaysTruthy & bool` -> `Literal[True]`
-                        Type::AlwaysTruthy if addition_is_bool_instance => {
+                        (_, crate::types::TypeData::AlwaysTruthy) if addition_is_bool_instance => {
                             new_positive = Type::bool_literal(true);
                         }
                         // `AlwaysFalsy & bool` -> `Literal[False]`
-                        Type::AlwaysFalsy if addition_is_bool_instance => {
+                        (_, crate::types::TypeData::AlwaysFalsy) if addition_is_bool_instance => {
                             new_positive = Type::bool_literal(false);
                         }
-                        Type::NominalInstance(instance)
+                        (_, crate::types::TypeData::NominalInstance(instance))
                             if instance.has_known_class(db, KnownClass::Bool) =>
                         {
-                            match new_positive {
+                            match {
+                                let __ty_view_value = new_positive;
+                                (__ty_view_value, __ty_view_value.data())
+                            } {
                                 // `bool & AlwaysTruthy` -> `Literal[True]`
-                                Type::AlwaysTruthy => {
+                                (_, crate::types::TypeData::AlwaysTruthy) => {
                                     new_positive = Type::bool_literal(true);
                                 }
                                 // `bool & AlwaysFalsy` -> `Literal[False]`
-                                Type::AlwaysFalsy => {
+                                (_, crate::types::TypeData::AlwaysFalsy) => {
                                     new_positive = Type::bool_literal(false);
                                 }
-                                _ => continue,
+                                (_, _) => continue,
                             }
                         }
-                        _ => continue,
+                        (_, _) => continue,
                     }
                     self.positive.swap_remove_index(index);
                     break;
@@ -1456,24 +1527,29 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
                 if addition_is_bool_instance {
                     for (index, existing_negative) in self.negative.iter().enumerate() {
-                        match existing_negative {
+                        match {
+                            let __ty_view_value = existing_negative;
+                            (__ty_view_value, __ty_view_value.data())
+                        } {
                             // `bool & ~Literal[False]` -> `Literal[True]`
                             // `bool & ~Literal[True]` -> `Literal[False]`
-                            Type::LiteralValue(literal) => match literal.kind() {
-                                LiteralValueTypeKind::Bool(bool_value) => {
-                                    new_positive = Type::bool_literal(!bool_value);
+                            (_, crate::types::TypeData::LiteralValue(literal)) => {
+                                match literal.kind() {
+                                    LiteralValueTypeKind::Bool(bool_value) => {
+                                        new_positive = Type::bool_literal(!bool_value);
+                                    }
+                                    _ => continue,
                                 }
-                                _ => continue,
-                            },
+                            }
                             // `bool & ~AlwaysTruthy` -> `Literal[False]`
-                            Type::AlwaysTruthy => {
+                            (_, crate::types::TypeData::AlwaysTruthy) => {
                                 new_positive = Type::bool_literal(false);
                             }
                             // `bool & ~AlwaysFalsy` -> `Literal[True]`
-                            Type::AlwaysFalsy => {
+                            (_, crate::types::TypeData::AlwaysFalsy) => {
                                 new_positive = Type::bool_literal(true);
                             }
-                            _ => continue,
+                            (_, _) => continue,
                         }
                         self.negative.swap_remove_index(index);
                         break;
@@ -1550,8 +1626,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 .any(KnownClass::is_bool)
         };
 
-        match new_negative {
-            Type::Intersection(inter) => {
+        match {
+            let __ty_view_value = new_negative;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Intersection(inter)) => {
                 for pos in inter.positive(db) {
                     self.add_negative(db, *pos);
                 }
@@ -1559,45 +1638,53 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     self.add_positive(db, *neg);
                 }
             }
-            Type::Never => {
+            (_, crate::types::TypeData::Never) => {
                 // Adding ~Never to an intersection is a no-op.
             }
-            Type::NominalInstance(instance) if instance.is_object() => {
+            (_, crate::types::TypeData::NominalInstance(instance)) if instance.is_object() => {
                 // Adding ~object to an intersection results in Never.
                 *self = Self::default();
                 self.positive.insert(Type::Never);
             }
-            ty @ Type::Dynamic(_) => {
+            (ty, crate::types::TypeData::Dynamic(_)) => {
                 // Adding any of these types to the negative side of an intersection
                 // is equivalent to adding it to the positive side. We do this to
                 // simplify the representation.
                 self.add_positive(db, ty);
             }
             // `bool & ~AlwaysTruthy` -> `bool & Literal[False]`
-            Type::AlwaysTruthy if contains_bool() => {
+            (_, crate::types::TypeData::AlwaysTruthy) if contains_bool() => {
                 self.add_positive(db, Type::bool_literal(false));
             }
             // `bool & ~Literal[True]` -> `bool & Literal[False]`
-            Type::LiteralValue(literal) if literal.as_bool() == Some(true) && contains_bool() => {
+            (_, crate::types::TypeData::LiteralValue(literal))
+                if literal.as_bool() == Some(true) && contains_bool() =>
+            {
                 self.add_positive(db, Type::bool_literal(false));
             }
             // `LiteralString & ~AlwaysTruthy` -> `LiteralString & Literal[""]`
-            Type::AlwaysTruthy if self.positive.contains(&Type::literal_string()) => {
+            (_, crate::types::TypeData::AlwaysTruthy)
+                if self.positive.contains(&Type::literal_string()) =>
+            {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `bool & ~AlwaysFalsy` -> `bool & Literal[True]`
-            Type::AlwaysFalsy if contains_bool() => {
+            (_, crate::types::TypeData::AlwaysFalsy) if contains_bool() => {
                 self.add_positive(db, Type::bool_literal(true));
             }
             // `bool & ~Literal[False]` -> `bool & Literal[True]`
-            Type::LiteralValue(literal) if literal.as_bool() == Some(false) && contains_bool() => {
+            (_, crate::types::TypeData::LiteralValue(literal))
+                if literal.as_bool() == Some(false) && contains_bool() =>
+            {
                 self.add_positive(db, Type::bool_literal(true));
             }
             // `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
-            Type::AlwaysFalsy if self.positive.contains(&Type::literal_string()) => {
+            (_, crate::types::TypeData::AlwaysFalsy)
+                if self.positive.contains(&Type::literal_string()) =>
+            {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
-            _ => {
+            (_, _) => {
                 let new_negative_enum = new_negative.as_enum_literal();
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
@@ -1681,7 +1768,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let mut to_add = SmallVec::<[Type<'db>; 1]>::new();
 
         for ty in &self.positive {
-            let Type::TypeVar(bound_typevar) = ty else {
+            let (_, crate::types::TypeData::TypeVar(bound_typevar)) = ({
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            }) else {
                 continue;
             };
             let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
@@ -1742,11 +1832,18 @@ impl<'db> InnerIntersectionBuilder<'db> {
         // to their upper bound and all constrained type variables to the union of their constraints.
         // If that speculative intersection simplifies to `Never`, this intersection must also simplify
         // to `Never`.
-        if self
-            .positive
-            .iter()
-            .any(|ty| matches!(ty, Type::TypeVar(_) | Type::NewTypeInstance(_)))
-        {
+        if self.positive.iter().any(|ty| {
+            matches!(
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::TypeVar(_) | crate::types::TypeData::NewTypeInstance(_)
+                )
+            )
+        }) {
             let speculative =
                 expand_intersection_typevars_and_newtypes(db, &self.positive, &self.negative);
             if speculative.is_never() {
@@ -1853,8 +1950,15 @@ mod tests {
 
         let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
         let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
-        let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
-            alias_ty
+        let (
+            _,
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                TypeAliasType::PEP695(alias),
+            )),
+        ) = ({
+            let __ty_view_value = alias_ty;
+            (__ty_view_value, __ty_view_value.data())
+        })
         else {
             panic!("Expected `Alias` to be a type alias");
         };

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -42,7 +42,7 @@ use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType,
-    SubclassOfType, Type, TypeVarBoundOrConstraints, UnionType,
+    SubclassOfType, Type, TypeTag, TypeVarBoundOrConstraints, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
@@ -607,11 +607,9 @@ impl<'db> UnionBuilder<'db> {
         let mut ty_negated_cache = None;
         let mut ty_negated = || *ty_negated_cache.get_or_insert_with(|| ty.negate(self.db));
 
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Union(union)) => {
+        match ty.tag {
+            TypeTag::Union => {
+                let union = ty.as_union().unwrap();
                 let new_elements = union.elements(self.db);
                 self.elements.reserve(new_elements.len());
                 for element in new_elements {
@@ -634,8 +632,9 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             // Adding `Never` to a union is a no-op.
-            (_, crate::types::TypeData::Never) => {}
-            (_, crate::types::TypeData::TypeAlias(alias)) if self.unpack_aliases => {
+            TypeTag::Never => {}
+            TypeTag::TypeAlias if self.unpack_aliases => {
+                let alias = ty.as_lazy_type_alias().unwrap();
                 if seen_aliases.contains(&ty) {
                     // Union contains itself recursively via a type alias. This is an error, just
                     // leave out the recursive alias. TODO surface this error.
@@ -644,7 +643,8 @@ impl<'db> UnionBuilder<'db> {
                     self.add_in_place_impl(alias.value_type(self.db), seen_aliases);
                 }
             }
-            (_, crate::types::TypeData::LiteralValue(literal)) => {
+            TypeTag::LiteralValue => {
+                let literal = ty.as_literal_value().unwrap();
                 self.recursively_defined =
                     self.recursively_defined.or(literal.recursively_defined());
                 match literal.kind() {
@@ -901,8 +901,8 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             // Adding `object` to a union results in `object`.
-            (ty, _) if ty.is_object() => self.collapse_to_object(),
-            (_, _) => self.push_type(ty, seen_aliases),
+            _ if ty.is_object() => self.collapse_to_object(),
+            _ => self.push_type(ty, seen_aliases),
         }
     }
 
@@ -919,13 +919,7 @@ impl<'db> UnionBuilder<'db> {
         // If an alias gets here, it means we aren't unpacking aliases, and we also
         // shouldn't try to simplify aliases out of the union, because that will require
         // unpacking them.
-        let should_simplify_full = !matches!(
-            {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::TypeAlias(_))
-        ) && !self.cycle_recovery;
+        let should_simplify_full = ty.as_lazy_type_alias().is_none() && !self.cycle_recovery;
 
         let mut ty_negated: Option<Type> = None;
         let mut to_remove = SmallVec::<[usize; 2]>::new();

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -61,10 +61,7 @@ fn split_truthiness_guarded_intersection<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<(Type<'db>, Type<'db>)> {
-    let (_, crate::types::TypeData::Intersection(intersection)) = ({
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    }) else {
+    let crate::types::TypeData::Intersection(intersection) = ty.data() else {
         return None;
     };
     let falsy = Type::AlwaysTruthy.negate(db);
@@ -149,10 +146,8 @@ fn merge_truthiness_guarded_pair<'db>(
 /// ```
 fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'db>>) -> bool {
     for complement_index in 0..types.len() {
-        let (_, crate::types::TypeData::EnumComplement(complement)) = ({
-            let __ty_view_value = types[complement_index];
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::EnumComplement(complement) = types[complement_index].data()
+        else {
             continue;
         };
         let enum_class = complement.enum_class(db);
@@ -166,10 +161,7 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
                 continue;
             }
 
-            if let (_, crate::types::TypeData::EnumComplement(other_complement)) = {
-                let __ty_view_value = *ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::EnumComplement(other_complement) = (*ty).data() {
                 if other_complement.enum_class(db) == enum_class
                     && other_complement.rest(db) == complement.rest(db)
                 {
@@ -239,13 +231,7 @@ enum LiteralKind<'db> {
 impl<'db> Type<'db> {
     /// Return `true` if this type can be a supertype of some literals of `kind` and not others.
     fn splits_literals(self, db: &'db dyn Db, kind: LiteralKind) -> bool {
-        match (
-            ({
-                let __ty_view_value = self;
-                (__ty_view_value, __ty_view_value.data())
-            }),
-            kind,
-        ) {
+        match (self.data(), kind) {
             // Note that as of 2026-01-04, `AlwaysFalsy` and `AlwaysTruthy` never split
             // enum literals, but that could change in the future. `Literal[Foo.X]` could
             // plausibly be understood by ty as a subtype of `AlwaysFalsy` in the following
@@ -257,12 +243,8 @@ impl<'db> Type<'db> {
             //     X = 0
             //     Y = 1
             // ```
-            (
-                (_, crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy),
-                _,
-            ) => true,
-            ((_, crate::types::TypeData::LiteralValue(literal)), _) => match (literal.kind(), kind)
-            {
+            (crate::types::TypeData::AlwaysFalsy | crate::types::TypeData::AlwaysTruthy, _) => true,
+            (crate::types::TypeData::LiteralValue(literal), _) => match (literal.kind(), kind) {
                 (LiteralValueTypeKind::String(_), LiteralKind::String) => true,
                 (LiteralValueTypeKind::Bytes(_), LiteralKind::Bytes) => true,
                 (LiteralValueTypeKind::Int(_), LiteralKind::Int) => true,
@@ -271,7 +253,7 @@ impl<'db> Type<'db> {
                 }
                 _ => false,
             },
-            ((_, crate::types::TypeData::Intersection(intersection)), _) => {
+            (crate::types::TypeData::Intersection(intersection), _) => {
                 intersection
                     .positive(db)
                     .iter()
@@ -281,12 +263,12 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|ty| ty.splits_literals(db, kind))
             }
-            ((_, crate::types::TypeData::Union(union)), _) => union
+            (crate::types::TypeData::Union(union), _) => union
                 .elements(db)
                 .iter()
                 .any(|ty| ty.splits_literals(db, kind)),
             (
-                (_, crate::types::TypeData::EnumComplement(complement)),
+                crate::types::TypeData::EnumComplement(complement),
                 LiteralKind::Enum { enum_class },
             ) => complement.enum_class(db) == enum_class,
             _ => false,
@@ -971,13 +953,7 @@ impl<'db> UnionBuilder<'db> {
             }
 
             if should_simplify_full
-                && !matches!(
-                    {
-                        let __ty_view_value = element_type;
-                        (__ty_view_value, __ty_view_value.data())
-                    },
-                    (_, crate::types::TypeData::TypeAlias(_))
-                )
+                && !matches!(element_type.data(), crate::types::TypeData::TypeAlias(_))
             {
                 if ty.is_redundant_with(self.db, element_type) {
                     return;
@@ -1125,11 +1101,8 @@ impl<'db> IntersectionBuilder<'db> {
         ty: Type<'db>,
         seen_aliases: &mut Vec<Type<'db>>,
     ) -> Self {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+        match ty.data() {
+            crate::types::TypeData::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
@@ -1141,7 +1114,7 @@ impl<'db> IntersectionBuilder<'db> {
                 let value_type = alias.value_type(self.db);
                 self.add_positive_impl(value_type, seen_aliases)
             }
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 // Distribute ourself over this union: for each union element, clone ourself and
                 // intersect with that union element, then create a new union-of-intersections with all
                 // of those sub-intersections in it. E.g. if `self` is a simple intersection `T1 & T2`
@@ -1160,7 +1133,7 @@ impl<'db> IntersectionBuilder<'db> {
                     })
             }
             // `(A & B & ~C) & (D & E & ~F)` -> `A & B & D & E & ~C & ~F`
-            (_, crate::types::TypeData::Intersection(other)) => {
+            crate::types::TypeData::Intersection(other) => {
                 let db = self.db;
                 for pos in other.positive(db) {
                     self = self.add_positive_impl(*pos, seen_aliases);
@@ -1170,11 +1143,11 @@ impl<'db> IntersectionBuilder<'db> {
                 }
                 self
             }
-            (_, crate::types::TypeData::EnumComplement(complement)) => {
+            crate::types::TypeData::EnumComplement(complement) => {
                 let db = self.db;
                 self.add_positive_impl(complement.to_intersection(db), seen_aliases)
             }
-            (_, _) => {
+            _ => {
                 // If we are already a union-of-intersections, distribute the new intersected element
                 // across all of those intersections.
                 for inner in &mut self.intersections {
@@ -1195,11 +1168,8 @@ impl<'db> IntersectionBuilder<'db> {
         seen_aliases: &mut Vec<Type<'db>>,
     ) -> Self {
         // See comments above in `add_positive`; this is just the negated version.
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
+        match ty.data() {
+            crate::types::TypeData::TypeAlias(alias) => {
                 if seen_aliases.contains(&ty) {
                     // Recursive alias, add it without expanding to avoid infinite recursion.
                     for inner in &mut self.intersections {
@@ -1211,13 +1181,13 @@ impl<'db> IntersectionBuilder<'db> {
                 let value_type = alias.value_type(self.db);
                 self.add_negative_impl(value_type, seen_aliases)
             }
-            (_, crate::types::TypeData::Union(union)) => {
+            crate::types::TypeData::Union(union) => {
                 for elem in union.elements(self.db) {
                     self = self.add_negative_impl(*elem, seen_aliases);
                 }
                 self
             }
-            (_, crate::types::TypeData::Intersection(intersection)) => {
+            crate::types::TypeData::Intersection(intersection) => {
                 // (A | B) & ~(C & ~D)
                 // -> (A | B) & (~C | D)
                 // -> ((A | B) & ~C) | ((A | B) & D)
@@ -1251,11 +1221,11 @@ impl<'db> IntersectionBuilder<'db> {
                     },
                 )
             }
-            (_, crate::types::TypeData::EnumComplement(complement)) => {
+            crate::types::TypeData::EnumComplement(complement) => {
                 let db = self.db;
                 self.add_negative_impl(complement.to_intersection(db), seen_aliases)
             }
-            (_, _) => {
+            _ => {
                 for inner in &mut self.intersections {
                     inner.add_negative(self.db, ty);
                 }
@@ -1310,10 +1280,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
     /// ```
     fn has_empty_enum_complement(&self, db: &'db dyn Db) -> bool {
         for positive in &self.positive {
-            let (_, crate::types::TypeData::NominalInstance(instance)) = ({
-                let __ty_view_value = positive;
-                (__ty_view_value, __ty_view_value.data())
-            }) else {
+            let crate::types::TypeData::NominalInstance(instance) = positive.data() else {
                 continue;
             };
 
@@ -1381,11 +1348,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
         }
 
         // A runtime class value of `TypeForm[T]` has type `type[T]`.
-        match {
-            let __ty_view_value = new_positive;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeForm(typeform)) => {
+        match new_positive.data() {
+            crate::types::TypeData::TypeForm(typeform) => {
                 if let Some(narrowed) = SubclassOfType::try_from_instance(
                     db,
                     typeform.type_argument(db).resolve_type_alias(db),
@@ -1394,54 +1358,46 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     new_positive = narrowed;
                 }
             }
-            (_, crate::types::TypeData::NominalInstance(instance))
+            crate::types::TypeData::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::Type) =>
             {
                 if let Some((index, narrowed)) =
                     self.positive
                         .iter()
                         .enumerate()
-                        .find_map(|(index, positive)| {
-                            match {
-                                let __ty_view_value = positive;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
-                                (_, crate::types::TypeData::TypeForm(typeform)) => {
-                                    SubclassOfType::try_from_instance(
-                                        db,
-                                        typeform.type_argument(db).resolve_type_alias(db),
-                                    )
-                                    .map(|narrowed| (index, narrowed))
-                                }
-                                (_, _) => None,
+                        .find_map(|(index, positive)| match positive.data() {
+                            crate::types::TypeData::TypeForm(typeform) => {
+                                SubclassOfType::try_from_instance(
+                                    db,
+                                    typeform.type_argument(db).resolve_type_alias(db),
+                                )
+                                .map(|narrowed| (index, narrowed))
                             }
+                            _ => None,
                         })
                 {
                     self.positive.swap_remove_index(index);
                     new_positive = narrowed;
                 }
             }
-            (_, _) => {}
+            _ => {}
         }
 
-        match {
-            let __ty_view_value = new_positive;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match new_positive.data() {
             // `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
-            (_, crate::types::TypeData::AlwaysTruthy)
+            crate::types::TypeData::AlwaysTruthy
                 if self.positive.contains(&Type::literal_string()) =>
             {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             // `LiteralString & AlwaysFalsy` -> `Literal[""]`
-            (_, crate::types::TypeData::AlwaysFalsy)
+            crate::types::TypeData::AlwaysFalsy
                 if self.positive.swap_remove(&Type::literal_string()) =>
             {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `AlwaysTruthy & LiteralString` -> `LiteralString & ~Literal[""]`
-            (_, crate::types::TypeData::LiteralValue(literal))
+            crate::types::TypeData::LiteralValue(literal)
                 if literal.is_literal_string()
                     && self.positive.swap_remove(&Type::AlwaysTruthy) =>
             {
@@ -1449,27 +1405,27 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             // `AlwaysFalsy & LiteralString` -> `Literal[""]`
-            (_, crate::types::TypeData::LiteralValue(literal))
+            crate::types::TypeData::LiteralValue(literal)
                 if literal.is_literal_string() && self.positive.swap_remove(&Type::AlwaysFalsy) =>
             {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysTruthy` -> `LiteralString & AlwaysFalsy` -> `Literal[""]`
-            (_, crate::types::TypeData::LiteralValue(literal))
+            crate::types::TypeData::LiteralValue(literal)
                 if literal.is_literal_string()
                     && self.negative.swap_remove(&Type::AlwaysTruthy) =>
             {
                 self.add_positive(db, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
-            (_, crate::types::TypeData::LiteralValue(literal))
+            crate::types::TypeData::LiteralValue(literal)
                 if literal.is_literal_string() && self.negative.swap_remove(&Type::AlwaysFalsy) =>
             {
                 self.add_positive(db, Type::literal_string());
                 self.add_negative(db, Type::string_literal(db, ""));
             }
 
-            (_, _) => {
+            _ => {
                 let positive_as_instance = new_positive.as_nominal_instance();
 
                 if let Some(instance) = positive_as_instance
@@ -1483,37 +1439,31 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     .is_some_and(|instance| instance.has_known_class(db, KnownClass::Bool));
 
                 for (index, existing_positive) in self.positive.iter().enumerate() {
-                    match {
-                        let __ty_view_value = existing_positive;
-                        (__ty_view_value, __ty_view_value.data())
-                    } {
+                    match existing_positive.data() {
                         // `AlwaysTruthy & bool` -> `Literal[True]`
-                        (_, crate::types::TypeData::AlwaysTruthy) if addition_is_bool_instance => {
+                        crate::types::TypeData::AlwaysTruthy if addition_is_bool_instance => {
                             new_positive = Type::bool_literal(true);
                         }
                         // `AlwaysFalsy & bool` -> `Literal[False]`
-                        (_, crate::types::TypeData::AlwaysFalsy) if addition_is_bool_instance => {
+                        crate::types::TypeData::AlwaysFalsy if addition_is_bool_instance => {
                             new_positive = Type::bool_literal(false);
                         }
-                        (_, crate::types::TypeData::NominalInstance(instance))
+                        crate::types::TypeData::NominalInstance(instance)
                             if instance.has_known_class(db, KnownClass::Bool) =>
                         {
-                            match {
-                                let __ty_view_value = new_positive;
-                                (__ty_view_value, __ty_view_value.data())
-                            } {
+                            match new_positive.data() {
                                 // `bool & AlwaysTruthy` -> `Literal[True]`
-                                (_, crate::types::TypeData::AlwaysTruthy) => {
+                                crate::types::TypeData::AlwaysTruthy => {
                                     new_positive = Type::bool_literal(true);
                                 }
                                 // `bool & AlwaysFalsy` -> `Literal[False]`
-                                (_, crate::types::TypeData::AlwaysFalsy) => {
+                                crate::types::TypeData::AlwaysFalsy => {
                                     new_positive = Type::bool_literal(false);
                                 }
-                                (_, _) => continue,
+                                _ => continue,
                             }
                         }
-                        (_, _) => continue,
+                        _ => continue,
                     }
                     self.positive.swap_remove_index(index);
                     break;
@@ -1521,29 +1471,24 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
                 if addition_is_bool_instance {
                     for (index, existing_negative) in self.negative.iter().enumerate() {
-                        match {
-                            let __ty_view_value = existing_negative;
-                            (__ty_view_value, __ty_view_value.data())
-                        } {
+                        match existing_negative.data() {
                             // `bool & ~Literal[False]` -> `Literal[True]`
                             // `bool & ~Literal[True]` -> `Literal[False]`
-                            (_, crate::types::TypeData::LiteralValue(literal)) => {
-                                match literal.kind() {
-                                    LiteralValueTypeKind::Bool(bool_value) => {
-                                        new_positive = Type::bool_literal(!bool_value);
-                                    }
-                                    _ => continue,
+                            crate::types::TypeData::LiteralValue(literal) => match literal.kind() {
+                                LiteralValueTypeKind::Bool(bool_value) => {
+                                    new_positive = Type::bool_literal(!bool_value);
                                 }
-                            }
+                                _ => continue,
+                            },
                             // `bool & ~AlwaysTruthy` -> `Literal[False]`
-                            (_, crate::types::TypeData::AlwaysTruthy) => {
+                            crate::types::TypeData::AlwaysTruthy => {
                                 new_positive = Type::bool_literal(false);
                             }
                             // `bool & ~AlwaysFalsy` -> `Literal[True]`
-                            (_, crate::types::TypeData::AlwaysFalsy) => {
+                            crate::types::TypeData::AlwaysFalsy => {
                                 new_positive = Type::bool_literal(true);
                             }
-                            (_, _) => continue,
+                            _ => continue,
                         }
                         self.negative.swap_remove_index(index);
                         break;
@@ -1620,10 +1565,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 .any(KnownClass::is_bool)
         };
 
-        match {
-            let __ty_view_value = new_negative;
-            (__ty_view_value, __ty_view_value.data())
-        } {
+        match new_negative.view() {
             (_, crate::types::TypeData::Intersection(inter)) => {
                 for pos in inter.positive(db) {
                     self.add_negative(db, *pos);
@@ -1762,10 +1704,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
         let mut to_add = SmallVec::<[Type<'db>; 1]>::new();
 
         for ty in &self.positive {
-            let (_, crate::types::TypeData::TypeVar(bound_typevar)) = ({
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            }) else {
+            let crate::types::TypeData::TypeVar(bound_typevar) = ty.data() else {
                 continue;
             };
             let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
@@ -1828,14 +1767,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
         // to `Never`.
         if self.positive.iter().any(|ty| {
             matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::TypeVar(_) | crate::types::TypeData::NewTypeInstance(_)
-                )
+                ty.data(),
+                crate::types::TypeData::TypeVar(_) | crate::types::TypeData::NewTypeInstance(_)
             )
         }) {
             let speculative =
@@ -1944,15 +1877,9 @@ mod tests {
 
         let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
         let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
-        let (
-            _,
-            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                TypeAliasType::PEP695(alias),
-            )),
-        ) = ({
-            let __ty_view_value = alias_ty;
-            (__ty_view_value, __ty_view_value.data())
-        })
+        let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+            TypeAliasType::PEP695(alias),
+        )) = alias_ty.data()
         else {
             panic!("Expected `Alias` to be a type alias");
         };

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -273,8 +273,11 @@ impl<'db> CallableSignature<'db> {
             tcx: TypeContext<'db>,
             visitor: &ApplyTypeMappingVisitor<'db>,
         ) -> Option<CallableSignature<'db>> {
-            match paramspec_value {
-                Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
+            match {
+                let __ty_view_value = paramspec_value;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
                     Some(CallableSignature::single(Signature {
                         generic_context: self_signature.generic_context.map(|context| {
                             type_mapping.update_signature_generic_context(db, context)
@@ -308,7 +311,7 @@ impl<'db> CallableSignature<'db> {
                         ),
                     }))
                 }
-                Type::Callable(callable)
+                (_, crate::types::TypeData::Callable(callable))
                     if matches!(callable.kind(db), CallableTypeKind::ParamSpecValue) =>
                 {
                     Some(CallableSignature::from_overloads(
@@ -348,7 +351,7 @@ impl<'db> CallableSignature<'db> {
                         }),
                     ))
                 }
-                _ => None,
+                (_, _) => None,
             }
         }
 
@@ -941,10 +944,13 @@ impl<'db> Signature<'db> {
             // signature's generic context, too. (The generic context should include any synthetic
             // typevars created for `typing.Self`, even if the `typing.Self` annotation was added
             // implicitly.)
-            let self_typevar = match self_type {
-                Type::TypeVar(self_typevar) => Some(self_typevar),
-                Type::SubclassOf(subclass_of) => subclass_of.into_type_var(),
-                _ => None,
+            let self_typevar = match {
+                let __ty_view_value = self_type;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeVar(self_typevar)) => Some(self_typevar),
+                (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of.into_type_var(),
+                (_, _) => None,
             };
 
             if let Some(self_typevar) = self_typevar {
@@ -1520,8 +1526,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         //
         // Broader overload-set assignability (non-union unary domains, higher arity,
         // typevars/dynamic interactions) needs dedicated relation logic.
-        if !matches!(other_parameter_type, Type::Union(_))
-            || !is_unary_overload_aggregate_candidate_type(other_parameter_type)
+        if !matches!(
+            {
+                let __ty_view_value = other_parameter_type;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::Union(_))
+        ) || !is_unary_overload_aggregate_candidate_type(other_parameter_type)
             || !is_unary_overload_aggregate_candidate_type(target_signature.return_ty)
         {
             return None;
@@ -1962,22 +1973,33 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                source_ty: Type<'db>,
                                target_name: Option<&Name>,
                                target_index: usize| {
-            match (target_ty, source_ty) {
+            match (
+                ({
+                    let __ty_view_value = target_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                }),
+                ({
+                    let __ty_view_value = source_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                }),
+            ) {
                 // This is a special case where the _same_ components of two different `ParamSpec`
                 // type variables are assignable to each other when they're both in an inferable
                 // position.
                 //
                 // `ParamSpec` type variables can only occur in parameter lists so this special case
                 // is present here instead of in `TypeRelationChecker::check_type_pair`.
-                (Type::TypeVar(typevar1), Type::TypeVar(typevar2))
-                    if typevar1.paramspec_attr(db).is_some()
-                        && typevar1.paramspec_attr(db) == typevar2.paramspec_attr(db)
-                        && typevar1
-                            .without_paramspec_attr(db)
-                            .is_inferable(db, self.inferable)
-                        && typevar2
-                            .without_paramspec_attr(db)
-                            .is_inferable(db, self.inferable) =>
+                (
+                    (_, crate::types::TypeData::TypeVar(typevar1)),
+                    (_, crate::types::TypeData::TypeVar(typevar2)),
+                ) if typevar1.paramspec_attr(db).is_some()
+                    && typevar1.paramspec_attr(db) == typevar2.paramspec_attr(db)
+                    && typevar1
+                        .without_paramspec_attr(db)
+                        .is_inferable(db, self.inferable)
+                    && typevar2
+                        .without_paramspec_attr(db)
+                        .is_inferable(db, self.inferable) =>
                 {
                     return true;
                 }
@@ -3282,7 +3304,16 @@ impl<'db> Parameters<'db> {
                 .get(variadic_index + 1..keyword_variadic_index)
                 .unwrap_or(&[]);
 
-            match (variadic_type, keyword_variadic_type) {
+            match (
+                ({
+                    let __ty_view_value = variadic_type;
+                    (__ty_view_value, __ty_view_value.data())
+                }),
+                ({
+                    let __ty_view_value = keyword_variadic_type;
+                    (__ty_view_value, __ty_view_value.data())
+                }),
+            ) {
                 // > If the input signature in a function definition includes both a `*args` and
                 // > `**kwargs` parameter and both are typed as Any (explicitly or implicitly
                 // > because it has no annotation), a type checker should treat this as the
@@ -3290,7 +3321,10 @@ impl<'db> Parameters<'db> {
                 // > are retained as part of the signature.
                 //
                 // https://typing.python.org/en/latest/spec/callables.html#meaning-of-in-callable
-                (Type::Dynamic(_), Type::Dynamic(_)) => {
+                (
+                    (_, crate::types::TypeData::Dynamic(_)),
+                    (_, crate::types::TypeData::Dynamic(_)),
+                ) => {
                     if keyword_only_params.is_empty()
                         && !prefix_params.is_empty()
                         && prefix_params.iter().all(Parameter::is_positional_only)
@@ -3307,9 +3341,10 @@ impl<'db> Parameters<'db> {
                 // > between the `*args` and `**kwargs` is forbidden.
                 //
                 // https://typing.python.org/en/latest/spec/generics.html#id5
-                (Type::TypeVar(variadic_typevar), Type::TypeVar(keyword_variadic_typevar))
-                    if keyword_only_params.is_empty() =>
-                {
+                (
+                    (_, crate::types::TypeData::TypeVar(variadic_typevar)),
+                    (_, crate::types::TypeData::TypeVar(keyword_variadic_typevar)),
+                ) if keyword_only_params.is_empty() => {
                     if let (Some(ParamSpecAttrKind::Args), Some(ParamSpecAttrKind::Kwargs)) = (
                         variadic_typevar.paramspec_attr(db),
                         keyword_variadic_typevar.paramspec_attr(db),
@@ -3752,7 +3787,10 @@ impl<'db> Parameters<'db> {
                 continue;
             }
 
-            let Type::Callable(callable) = parameter.annotated_type() else {
+            let (_, crate::types::TypeData::Callable(callable)) = ({
+                let __ty_view_value = parameter.annotated_type();
+                (__ty_view_value, __ty_view_value.data())
+            }) else {
                 continue;
             };
             if callable.kind(db) != CallableTypeKind::ParamSpecValue {
@@ -3778,7 +3816,10 @@ impl<'db> Parameters<'db> {
             return self.clone();
         }
 
-        let Type::Callable(keyword_callable) = keyword_variadic.annotated_type() else {
+        let (_, crate::types::TypeData::Callable(keyword_callable)) = ({
+            let __ty_view_value = keyword_variadic.annotated_type();
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return self.clone();
         };
         if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -273,11 +273,8 @@ impl<'db> CallableSignature<'db> {
             tcx: TypeContext<'db>,
             visitor: &ApplyTypeMappingVisitor<'db>,
         ) -> Option<CallableSignature<'db>> {
-            match {
-                let __ty_view_value = paramspec_value;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
+            match paramspec_value.data() {
+                crate::types::TypeData::TypeVar(typevar) if typevar.is_paramspec(db) => {
                     Some(CallableSignature::single(Signature {
                         generic_context: self_signature.generic_context.map(|context| {
                             type_mapping.update_signature_generic_context(db, context)
@@ -311,7 +308,7 @@ impl<'db> CallableSignature<'db> {
                         ),
                     }))
                 }
-                (_, crate::types::TypeData::Callable(callable))
+                crate::types::TypeData::Callable(callable)
                     if matches!(callable.kind(db), CallableTypeKind::ParamSpecValue) =>
                 {
                     Some(CallableSignature::from_overloads(
@@ -351,7 +348,7 @@ impl<'db> CallableSignature<'db> {
                         }),
                     ))
                 }
-                (_, _) => None,
+                _ => None,
             }
         }
 
@@ -944,13 +941,10 @@ impl<'db> Signature<'db> {
             // signature's generic context, too. (The generic context should include any synthetic
             // typevars created for `typing.Self`, even if the `typing.Self` annotation was added
             // implicitly.)
-            let self_typevar = match {
-                let __ty_view_value = self_type;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypeVar(self_typevar)) => Some(self_typevar),
-                (_, crate::types::TypeData::SubclassOf(subclass_of)) => subclass_of.into_type_var(),
-                (_, _) => None,
+            let self_typevar = match self_type.data() {
+                crate::types::TypeData::TypeVar(self_typevar) => Some(self_typevar),
+                crate::types::TypeData::SubclassOf(subclass_of) => subclass_of.into_type_var(),
+                _ => None,
             };
 
             if let Some(self_typevar) = self_typevar {
@@ -1527,11 +1521,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Broader overload-set assignability (non-union unary domains, higher arity,
         // typevars/dynamic interactions) needs dedicated relation logic.
         if !matches!(
-            {
-                let __ty_view_value = other_parameter_type;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::Union(_))
+            other_parameter_type.data(),
+            crate::types::TypeData::Union(_)
         ) || !is_unary_overload_aggregate_candidate_type(other_parameter_type)
             || !is_unary_overload_aggregate_candidate_type(target_signature.return_ty)
         {
@@ -1973,16 +1964,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                source_ty: Type<'db>,
                                target_name: Option<&Name>,
                                target_index: usize| {
-            match (
-                ({
-                    let __ty_view_value = target_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                }),
-                ({
-                    let __ty_view_value = source_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                }),
-            ) {
+            match (target_ty.data(), source_ty.data()) {
                 // This is a special case where the _same_ components of two different `ParamSpec`
                 // type variables are assignable to each other when they're both in an inferable
                 // position.
@@ -1990,8 +1972,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // `ParamSpec` type variables can only occur in parameter lists so this special case
                 // is present here instead of in `TypeRelationChecker::check_type_pair`.
                 (
-                    (_, crate::types::TypeData::TypeVar(typevar1)),
-                    (_, crate::types::TypeData::TypeVar(typevar2)),
+                    crate::types::TypeData::TypeVar(typevar1),
+                    crate::types::TypeData::TypeVar(typevar2),
                 ) if typevar1.paramspec_attr(db).is_some()
                     && typevar1.paramspec_attr(db) == typevar2.paramspec_attr(db)
                     && typevar1
@@ -3304,16 +3286,7 @@ impl<'db> Parameters<'db> {
                 .get(variadic_index + 1..keyword_variadic_index)
                 .unwrap_or(&[]);
 
-            match (
-                ({
-                    let __ty_view_value = variadic_type;
-                    (__ty_view_value, __ty_view_value.data())
-                }),
-                ({
-                    let __ty_view_value = keyword_variadic_type;
-                    (__ty_view_value, __ty_view_value.data())
-                }),
-            ) {
+            match (variadic_type.data(), keyword_variadic_type.data()) {
                 // > If the input signature in a function definition includes both a `*args` and
                 // > `**kwargs` parameter and both are typed as Any (explicitly or implicitly
                 // > because it has no annotation), a type checker should treat this as the
@@ -3321,10 +3294,7 @@ impl<'db> Parameters<'db> {
                 // > are retained as part of the signature.
                 //
                 // https://typing.python.org/en/latest/spec/callables.html#meaning-of-in-callable
-                (
-                    (_, crate::types::TypeData::Dynamic(_)),
-                    (_, crate::types::TypeData::Dynamic(_)),
-                ) => {
+                (crate::types::TypeData::Dynamic(_), crate::types::TypeData::Dynamic(_)) => {
                     if keyword_only_params.is_empty()
                         && !prefix_params.is_empty()
                         && prefix_params.iter().all(Parameter::is_positional_only)
@@ -3342,8 +3312,8 @@ impl<'db> Parameters<'db> {
                 //
                 // https://typing.python.org/en/latest/spec/generics.html#id5
                 (
-                    (_, crate::types::TypeData::TypeVar(variadic_typevar)),
-                    (_, crate::types::TypeData::TypeVar(keyword_variadic_typevar)),
+                    crate::types::TypeData::TypeVar(variadic_typevar),
+                    crate::types::TypeData::TypeVar(keyword_variadic_typevar),
                 ) if keyword_only_params.is_empty() => {
                     if let (Some(ParamSpecAttrKind::Args), Some(ParamSpecAttrKind::Kwargs)) = (
                         variadic_typevar.paramspec_attr(db),
@@ -3787,10 +3757,8 @@ impl<'db> Parameters<'db> {
                 continue;
             }
 
-            let (_, crate::types::TypeData::Callable(callable)) = ({
-                let __ty_view_value = parameter.annotated_type();
-                (__ty_view_value, __ty_view_value.data())
-            }) else {
+            let crate::types::TypeData::Callable(callable) = parameter.annotated_type().data()
+            else {
                 continue;
             };
             if callable.kind(db) != CallableTypeKind::ParamSpecValue {
@@ -3816,10 +3784,9 @@ impl<'db> Parameters<'db> {
             return self.clone();
         }
 
-        let (_, crate::types::TypeData::Callable(keyword_callable)) = ({
-            let __ty_view_value = keyword_variadic.annotated_type();
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::Callable(keyword_callable) =
+            keyword_variadic.annotated_type().data()
+        else {
             return self.clone();
         };
         if keyword_callable.kind(db) != CallableTypeKind::ParamSpecValue

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -29,6 +29,14 @@ pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?
 }
 
 impl<'db> SubclassOfType<'db> {
+    pub(super) const fn packed_inner(self) -> SubclassOfInner<'db> {
+        self.subclass_of
+    }
+
+    pub(super) const fn from_packed_inner(subclass_of: SubclassOfInner<'db>) -> Self {
+        Self { subclass_of }
+    }
+
     /// Construct a new [`Type`] instance representing a given class object (or a given dynamic type)
     /// and all possible subclasses of that class object/dynamic type.
     ///
@@ -60,14 +68,18 @@ impl<'db> SubclassOfType<'db> {
 
     /// Given the class object `T`, returns a [`Type`] instance representing `type[T]`.
     pub(crate) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-        let subclass_of = match ty {
-            Type::Dynamic(dynamic) => SubclassOfInner::Dynamic(dynamic),
-            Type::ClassLiteral(literal) => {
+        let subclass_of = match (ty).data() {
+            crate::types::TypeData::Dynamic(dynamic) => SubclassOfInner::Dynamic(dynamic),
+            crate::types::TypeData::ClassLiteral(literal) => {
                 SubclassOfInner::Class(literal.default_specialization(db))
             }
-            Type::GenericAlias(generic) => SubclassOfInner::Class(ClassType::Generic(generic)),
-            Type::SpecialForm(SpecialFormType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
-            Type::SpecialForm(SpecialFormType::Unknown) => {
+            crate::types::TypeData::GenericAlias(generic) => {
+                SubclassOfInner::Class(ClassType::Generic(generic))
+            }
+            crate::types::TypeData::SpecialForm(SpecialFormType::Any) => {
+                SubclassOfInner::Dynamic(DynamicType::Any)
+            }
+            crate::types::TypeData::SpecialForm(SpecialFormType::Unknown) => {
                 SubclassOfInner::Dynamic(DynamicType::Unknown)
             }
             _ => return None,
@@ -80,22 +92,22 @@ impl<'db> SubclassOfType<'db> {
     pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
         // Handle unions by distributing `type[]` over each element:
         // `type[A | B]` -> `type[A] | type[B]`
-        match ty {
-            Type::Union(union) => UnionType::try_from_elements(
+        match (ty).data() {
+            crate::types::TypeData::Union(union) => UnionType::try_from_elements(
                 db,
                 union
                     .elements(db)
                     .iter()
                     .map(|element| Self::try_from_instance(db, *element)),
             ),
-            Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
+            crate::types::TypeData::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
             _ => SubclassOfInner::try_from_instance(db, ty)
                 .map(|subclass_of| Self::from(db, subclass_of)),
         }
     }
 
     /// Return a [`Type`] instance representing the type `type[Unknown]`.
-    pub(crate) const fn subclass_of_unknown() -> Type<'db> {
+    pub(crate) fn subclass_of_unknown() -> Type<'db> {
         Type::SubclassOf(SubclassOfType {
             subclass_of: SubclassOfInner::unknown(),
         })
@@ -103,7 +115,7 @@ impl<'db> SubclassOfType<'db> {
 
     /// Return a [`Type`] instance representing the type `type[Any]`.
     #[cfg(test)]
-    pub(crate) const fn subclass_of_any() -> Type<'db> {
+    pub(crate) fn subclass_of_any() -> Type<'db> {
         Type::SubclassOf(SubclassOfType {
             subclass_of: SubclassOfInner::Dynamic(DynamicType::Any),
         })
@@ -420,17 +432,25 @@ impl<'db> SubclassOfInner<'db> {
     }
 
     pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
-        Some(match ty {
-            Type::NominalInstance(instance) => SubclassOfInner::Class(instance.class(db)),
-            Type::TypedDict(typed_dict) => match typed_dict {
+        Some(match (ty).data() {
+            crate::types::TypeData::NominalInstance(instance) => {
+                SubclassOfInner::Class(instance.class(db))
+            }
+            crate::types::TypeData::TypedDict(typed_dict) => match typed_dict {
                 TypedDictType::Class(class) => SubclassOfInner::Class(class),
                 TypedDictType::Synthesized(_) => SubclassOfInner::Dynamic(
                     todo_type!("type[T] for synthesized TypedDicts").expect_dynamic(),
                 ),
             },
-            Type::TypeVar(bound_typevar) => SubclassOfInner::TypeVar(bound_typevar),
-            Type::Dynamic(DynamicType::Any) => SubclassOfInner::Dynamic(DynamicType::Any),
-            Type::Dynamic(DynamicType::Unknown) => SubclassOfInner::Dynamic(DynamicType::Unknown),
+            crate::types::TypeData::TypeVar(bound_typevar) => {
+                SubclassOfInner::TypeVar(bound_typevar)
+            }
+            crate::types::TypeData::Dynamic(DynamicType::Any) => {
+                SubclassOfInner::Dynamic(DynamicType::Any)
+            }
+            crate::types::TypeData::Dynamic(DynamicType::Unknown) => {
+                SubclassOfInner::Dynamic(DynamicType::Unknown)
+            }
             _ => return None,
         })
     }

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -539,52 +539,52 @@ impl<'db> Type<'db> {
 
         let value_ty = self;
 
-        let inferred = match (value_ty, slice_ty) {
-            (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
+        let inferred = match (({ let __ty_view_value = value_ty; (__ty_view_value, __ty_view_value.data()) }), ({ let __ty_view_value = slice_ty; (__ty_view_value, __ty_view_value.data()) })) {
+            ((_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_) | crate::types::TypeData::Never), (_, _)) => Some(Ok(value_ty)),
 
-            (Type::TypeAlias(alias), _) => {
+            ((_, crate::types::TypeData::TypeAlias(alias)), (_, _)) => {
                 Some(alias.value_type(db).subscript(db, slice_ty, expr_context))
             }
 
-            (_, Type::TypeAlias(alias)) => {
+            ((_, _), (_, crate::types::TypeData::TypeAlias(alias))) => {
                 Some(value_ty.subscript(db, alias.value_type(db), expr_context))
             }
 
-            (Type::Union(union), _) => Some(map_union_subscript(db, union, |element| {
+            ((_, crate::types::TypeData::Union(union)), (_, _)) => Some(map_union_subscript(db, union, |element| {
                 element.subscript(db, slice_ty, expr_context)
             })),
 
-            (_, Type::Union(union)) => Some(map_union_subscript(db, union, |element| {
+            ((_, _), (_, crate::types::TypeData::Union(union))) => Some(map_union_subscript(db, union, |element| {
                 value_ty.subscript(db, element, expr_context)
             })),
 
-            (Type::EnumComplement(complement), _) => {
+            ((_, crate::types::TypeData::EnumComplement(complement)), (_, _)) => {
                 Some(complement.remaining_literal_union(db).subscript(db, slice_ty, expr_context))
             }
 
-            (_, Type::EnumComplement(complement)) => {
+            ((_, _), (_, crate::types::TypeData::EnumComplement(complement))) => {
                 Some(value_ty.subscript(db, complement.remaining_literal_union(db), expr_context))
             }
 
-            (Type::Intersection(intersection), _) => {
+            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
                     element.subscript(db, slice_ty, expr_context)
                 }))
             }
 
-            (_, Type::Intersection(intersection)) => {
+            ((_, _), (_, crate::types::TypeData::Intersection(intersection))) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
                     value_ty.subscript(db, element, expr_context)
                 }))
             }
 
             // Ex) Given `person["name"]`, return `str`
-            (Type::TypedDict(typed_dict), _) if expr_context != ast::ExprContext::Store => {
+            ((_, crate::types::TypeData::TypedDict(typed_dict)), (_, _)) if expr_context != ast::ExprContext::Store => {
                 Some(typed_dict_subscript(db, typed_dict, slice_ty))
             }
 
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
-            (Type::NominalInstance(nominal), Type::LiteralValue(literal)) if literal.is_int() => {
+            ((_, crate::types::TypeData::NominalInstance(nominal)), (_, crate::types::TypeData::LiteralValue(literal))) if literal.is_int() => {
                 let i64_int = literal.as_int().unwrap();
                 nominal
                     .tuple_spec(db)
@@ -605,8 +605,8 @@ impl<'db> Type<'db> {
 
             // Ex) Given `("a", 1, Null)[0:2]`, return `("a", 1)`
             (
-                Type::NominalInstance(maybe_tuple_nominal),
-                Type::NominalInstance(maybe_slice_nominal),
+                (_, crate::types::TypeData::NominalInstance(maybe_tuple_nominal)),
+                (_, crate::types::TypeData::NominalInstance(maybe_slice_nominal)),
             ) => maybe_tuple_nominal
                 .tuple_spec(db)
                 .as_deref()
@@ -627,7 +627,7 @@ impl<'db> Type<'db> {
                 }),
 
             // Ex) Given `"value"[1]`, return `"a"`
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_string() && rhs_literal.is_int() => {
+            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_string() && rhs_literal.is_int() => {
                 let literal_ty = lhs_literal.as_string().unwrap();
                 let i64_int = rhs_literal.as_int().unwrap();
                 i32::try_from(i64_int).ok().map(|i32_int| {
@@ -648,7 +648,7 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `"value"[1:3]`, return `"al"`
-            (Type::LiteralValue(literal), Type::NominalInstance(nominal)) if literal.is_string() => {
+            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal))) if literal.is_string() => {
                 let literal_ty = literal.as_string().unwrap();
                 nominal
                 .slice_literal(db)
@@ -669,18 +669,18 @@ impl<'db> Type<'db> {
                 })
             },
 
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_literal_string() && (rhs_literal.is_int() || rhs_literal.is_bool()) => {
+            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_literal_string() && (rhs_literal.is_int() || rhs_literal.is_bool()) => {
                 Some(Ok(Type::literal_string()))
             }
 
-            (Type::LiteralValue(literal), Type::NominalInstance(nominal))
+            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal)))
                 if literal.is_literal_string() && nominal.slice_literal(db).is_some() =>
             {
                 Some(Ok(Type::literal_string()))
             }
 
             // Ex) Given `b"value"[1]`, return `97` (i.e., `ord(b"a")`)
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if lhs_literal.is_bytes() && rhs_literal.is_int() => {
+            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_bytes() && rhs_literal.is_int() => {
                 let literal_ty = lhs_literal.as_bytes().unwrap();
                 let i64_int = rhs_literal.as_int().unwrap();
                 i32::try_from(i64_int).ok().map(|i32_int| {
@@ -701,7 +701,7 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `b"value"[1:3]`, return `b"al"`
-            (Type::LiteralValue(literal), Type::NominalInstance(nominal)) if literal.is_bytes() =>
+            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal))) if literal.is_bytes() =>
             {
                 let literal_ty = literal.as_bytes().unwrap();
                 nominal
@@ -723,26 +723,26 @@ impl<'db> Type<'db> {
             },
 
             // Ex) Given `"value"[True]`, return `"a"`
-            (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
+            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
                 let bool = rhs_literal.as_bool().unwrap();
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
-            (Type::NominalInstance(nominal), Type::LiteralValue(literal))
+            ((_, crate::types::TypeData::NominalInstance(nominal)), (_, crate::types::TypeData::LiteralValue(literal)))
                 if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
             {
                 let bool = literal.as_bool().unwrap();
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
-            (Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(_)), _) => {
+            ((_, crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(_))), (_, _)) => {
                 // TODO: emit a diagnostic
                 Some(Ok(todo_type!("doubly-specialized typing.Protocol")))
             }
 
             (
-                Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))),
-                _,
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias)))),
+                (_, _),
             ) if alias.generic_context(db).is_none() => {
                 debug_assert!(alias.specialization(db).is_none());
                 Some(Err(SubscriptError::new(
@@ -753,58 +753,58 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            (Type::KnownInstance(KnownInstanceType::SubscriptedGeneric(_)), _) => {
+            ((_, crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))), (_, _)) => {
                 // TODO: emit a diagnostic
                 Some(Ok(todo_type!("doubly-specialized typing.Generic")))
             }
 
-            (Type::SpecialForm(SpecialFormType::Unpack), _) => {
+            ((_, crate::types::TypeData::SpecialForm(SpecialFormType::Unpack)), (_, _)) => {
                 Some(Ok(Type::Dynamic(DynamicType::TodoUnpack)))
             }
 
-            (Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)), _) => {
+            ((_, crate::types::TypeData::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar))), (_, _)) => {
                 // Subscripting `InitVar` gives you (bizarrely) an instance of `InitVar`,
                 // which isn't representable in our model because we don't recognise there as being
                 // an `InitVar` class at all. This doesn't really matter that much, so just infer `Any` here.
                 Some(Ok(Type::any()))
             }
 
-            (Type::SpecialForm(special_form), _) if special_form.class().is_special_form() => {
+            ((_, crate::types::TypeData::SpecialForm(special_form)), (_, _)) if special_form.class().is_special_form() => {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
-            (Type::KnownInstance(known_instance), _) if known_instance.class(db).is_special_form() => {
+            ((_, crate::types::TypeData::KnownInstance(known_instance)), (_, _)) if known_instance.class(db).is_special_form() => {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
             (
-                Type::FunctionLiteral(_)
-                | Type::WrapperDescriptor(_)
-                | Type::BoundMethod(_)
-                | Type::DataclassDecorator(_)
-                | Type::DataclassTransformer(_)
-                | Type::Callable(_)
-                | Type::ModuleLiteral(_)
-                | Type::ClassLiteral(_)
-                | Type::GenericAlias(_)
-                | Type::SubclassOf(_)
-                | Type::AlwaysFalsy
-                | Type::AlwaysTruthy
-                | Type::ProtocolInstance(_)
-                | Type::PropertyInstance(_)
-                | Type::BoundSuper(_)
-                | Type::TypeIs(_)
-                | Type::TypeGuard(_)
-                | Type::TypeForm(_)
-                | Type::TypedDict(_)
-                | Type::NewTypeInstance(_)
-                | Type::NominalInstance(_)
-                | Type::SpecialForm(_)
-                | Type::KnownInstance(_)
-                | Type::LiteralValue(_)
-                | Type::TypeVar(_)  // TODO: more complex logic required here!
-                | Type::KnownBoundMethod(_),
-                _,
+                (_, crate::types::TypeData::FunctionLiteral(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::BoundMethod(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::Callable(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::GenericAlias(_)
+                | crate::types::TypeData::SubclassOf(_)
+                | crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::ProtocolInstance(_)
+                | crate::types::TypeData::PropertyInstance(_)
+                | crate::types::TypeData::BoundSuper(_)
+                | crate::types::TypeData::TypeIs(_)
+                | crate::types::TypeData::TypeGuard(_)
+                | crate::types::TypeData::TypeForm(_)
+                | crate::types::TypeData::TypedDict(_)
+                | crate::types::TypeData::NewTypeInstance(_)
+                | crate::types::TypeData::NominalInstance(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::KnownInstance(_)
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::TypeVar(_)  // TODO: more complex logic required here!
+                | crate::types::TypeData::KnownBoundMethod(_)),
+                (_, _),
             ) => None,
         };
 
@@ -896,7 +896,10 @@ impl<'db> Type<'db> {
                 }
             }
 
-            if let Type::ClassLiteral(class) = value_ty {
+            if let (_, crate::types::TypeData::ClassLiteral(class)) = {
+                let __ty_view_value = value_ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
                 if class.is_known(db, KnownClass::Type) {
                     return Ok(KnownClass::GenericAlias.to_instance(db));
                 }

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -539,52 +539,52 @@ impl<'db> Type<'db> {
 
         let value_ty = self;
 
-        let inferred = match (({ let __ty_view_value = value_ty; (__ty_view_value, __ty_view_value.data()) }), ({ let __ty_view_value = slice_ty; (__ty_view_value, __ty_view_value.data()) })) {
-            ((_, crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_) | crate::types::TypeData::Never), (_, _)) => Some(Ok(value_ty)),
+        let inferred = match (value_ty.data(), slice_ty.data()) {
+            (crate::types::TypeData::Dynamic(_) | crate::types::TypeData::Divergent(_) | crate::types::TypeData::Never, _) => Some(Ok(value_ty)),
 
-            ((_, crate::types::TypeData::TypeAlias(alias)), (_, _)) => {
+            (crate::types::TypeData::TypeAlias(alias), _) => {
                 Some(alias.value_type(db).subscript(db, slice_ty, expr_context))
             }
 
-            ((_, _), (_, crate::types::TypeData::TypeAlias(alias))) => {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
                 Some(value_ty.subscript(db, alias.value_type(db), expr_context))
             }
 
-            ((_, crate::types::TypeData::Union(union)), (_, _)) => Some(map_union_subscript(db, union, |element| {
+            (crate::types::TypeData::Union(union), _) => Some(map_union_subscript(db, union, |element| {
                 element.subscript(db, slice_ty, expr_context)
             })),
 
-            ((_, _), (_, crate::types::TypeData::Union(union))) => Some(map_union_subscript(db, union, |element| {
+            (_, crate::types::TypeData::Union(union)) => Some(map_union_subscript(db, union, |element| {
                 value_ty.subscript(db, element, expr_context)
             })),
 
-            ((_, crate::types::TypeData::EnumComplement(complement)), (_, _)) => {
+            (crate::types::TypeData::EnumComplement(complement), _) => {
                 Some(complement.remaining_literal_union(db).subscript(db, slice_ty, expr_context))
             }
 
-            ((_, _), (_, crate::types::TypeData::EnumComplement(complement))) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 Some(value_ty.subscript(db, complement.remaining_literal_union(db), expr_context))
             }
 
-            ((_, crate::types::TypeData::Intersection(intersection)), (_, _)) => {
+            (crate::types::TypeData::Intersection(intersection), _) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
                     element.subscript(db, slice_ty, expr_context)
                 }))
             }
 
-            ((_, _), (_, crate::types::TypeData::Intersection(intersection))) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 Some(map_intersection_subscript(db, intersection, |element| {
                     value_ty.subscript(db, element, expr_context)
                 }))
             }
 
             // Ex) Given `person["name"]`, return `str`
-            ((_, crate::types::TypeData::TypedDict(typed_dict)), (_, _)) if expr_context != ast::ExprContext::Store => {
+            (crate::types::TypeData::TypedDict(typed_dict), _) if expr_context != ast::ExprContext::Store => {
                 Some(typed_dict_subscript(db, typed_dict, slice_ty))
             }
 
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
-            ((_, crate::types::TypeData::NominalInstance(nominal)), (_, crate::types::TypeData::LiteralValue(literal))) if literal.is_int() => {
+            (crate::types::TypeData::NominalInstance(nominal), crate::types::TypeData::LiteralValue(literal)) if literal.is_int() => {
                 let i64_int = literal.as_int().unwrap();
                 nominal
                     .tuple_spec(db)
@@ -605,8 +605,8 @@ impl<'db> Type<'db> {
 
             // Ex) Given `("a", 1, Null)[0:2]`, return `("a", 1)`
             (
-                (_, crate::types::TypeData::NominalInstance(maybe_tuple_nominal)),
-                (_, crate::types::TypeData::NominalInstance(maybe_slice_nominal)),
+                crate::types::TypeData::NominalInstance(maybe_tuple_nominal),
+                crate::types::TypeData::NominalInstance(maybe_slice_nominal),
             ) => maybe_tuple_nominal
                 .tuple_spec(db)
                 .as_deref()
@@ -627,7 +627,7 @@ impl<'db> Type<'db> {
                 }),
 
             // Ex) Given `"value"[1]`, return `"a"`
-            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_string() && rhs_literal.is_int() => {
+            (crate::types::TypeData::LiteralValue(lhs_literal), crate::types::TypeData::LiteralValue(rhs_literal)) if lhs_literal.is_string() && rhs_literal.is_int() => {
                 let literal_ty = lhs_literal.as_string().unwrap();
                 let i64_int = rhs_literal.as_int().unwrap();
                 i32::try_from(i64_int).ok().map(|i32_int| {
@@ -648,7 +648,7 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `"value"[1:3]`, return `"al"`
-            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal))) if literal.is_string() => {
+            (crate::types::TypeData::LiteralValue(literal), crate::types::TypeData::NominalInstance(nominal)) if literal.is_string() => {
                 let literal_ty = literal.as_string().unwrap();
                 nominal
                 .slice_literal(db)
@@ -669,18 +669,18 @@ impl<'db> Type<'db> {
                 })
             },
 
-            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_literal_string() && (rhs_literal.is_int() || rhs_literal.is_bool()) => {
+            (crate::types::TypeData::LiteralValue(lhs_literal), crate::types::TypeData::LiteralValue(rhs_literal)) if lhs_literal.is_literal_string() && (rhs_literal.is_int() || rhs_literal.is_bool()) => {
                 Some(Ok(Type::literal_string()))
             }
 
-            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal)))
+            (crate::types::TypeData::LiteralValue(literal), crate::types::TypeData::NominalInstance(nominal))
                 if literal.is_literal_string() && nominal.slice_literal(db).is_some() =>
             {
                 Some(Ok(Type::literal_string()))
             }
 
             // Ex) Given `b"value"[1]`, return `97` (i.e., `ord(b"a")`)
-            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if lhs_literal.is_bytes() && rhs_literal.is_int() => {
+            (crate::types::TypeData::LiteralValue(lhs_literal), crate::types::TypeData::LiteralValue(rhs_literal)) if lhs_literal.is_bytes() && rhs_literal.is_int() => {
                 let literal_ty = lhs_literal.as_bytes().unwrap();
                 let i64_int = rhs_literal.as_int().unwrap();
                 i32::try_from(i64_int).ok().map(|i32_int| {
@@ -701,7 +701,7 @@ impl<'db> Type<'db> {
             }
 
             // Ex) Given `b"value"[1:3]`, return `b"al"`
-            ((_, crate::types::TypeData::LiteralValue(literal)), (_, crate::types::TypeData::NominalInstance(nominal))) if literal.is_bytes() =>
+            (crate::types::TypeData::LiteralValue(literal), crate::types::TypeData::NominalInstance(nominal)) if literal.is_bytes() =>
             {
                 let literal_ty = literal.as_bytes().unwrap();
                 nominal
@@ -723,26 +723,26 @@ impl<'db> Type<'db> {
             },
 
             // Ex) Given `"value"[True]`, return `"a"`
-            ((_, crate::types::TypeData::LiteralValue(lhs_literal)), (_, crate::types::TypeData::LiteralValue(rhs_literal))) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
+            (crate::types::TypeData::LiteralValue(lhs_literal), crate::types::TypeData::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
                 let bool = rhs_literal.as_bool().unwrap();
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
-            ((_, crate::types::TypeData::NominalInstance(nominal)), (_, crate::types::TypeData::LiteralValue(literal)))
+            (crate::types::TypeData::NominalInstance(nominal), crate::types::TypeData::LiteralValue(literal))
                 if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
             {
                 let bool = literal.as_bool().unwrap();
                 Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
             }
 
-            ((_, crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(_))), (_, _)) => {
+            (crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedProtocol(_)), _) => {
                 // TODO: emit a diagnostic
                 Some(Ok(todo_type!("doubly-specialized typing.Protocol")))
             }
 
             (
-                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias)))),
-                (_, _),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))),
+                _,
             ) if alias.generic_context(db).is_none() => {
                 debug_assert!(alias.specialization(db).is_none());
                 Some(Err(SubscriptError::new(
@@ -753,32 +753,32 @@ impl<'db> Type<'db> {
                 )))
             }
 
-            ((_, crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_))), (_, _)) => {
+            (crate::types::TypeData::KnownInstance(KnownInstanceType::SubscriptedGeneric(_)), _) => {
                 // TODO: emit a diagnostic
                 Some(Ok(todo_type!("doubly-specialized typing.Generic")))
             }
 
-            ((_, crate::types::TypeData::SpecialForm(SpecialFormType::Unpack)), (_, _)) => {
+            (crate::types::TypeData::SpecialForm(SpecialFormType::Unpack), _) => {
                 Some(Ok(Type::Dynamic(DynamicType::TodoUnpack)))
             }
 
-            ((_, crate::types::TypeData::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar))), (_, _)) => {
+            (crate::types::TypeData::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::InitVar)), _) => {
                 // Subscripting `InitVar` gives you (bizarrely) an instance of `InitVar`,
                 // which isn't representable in our model because we don't recognise there as being
                 // an `InitVar` class at all. This doesn't really matter that much, so just infer `Any` here.
                 Some(Ok(Type::any()))
             }
 
-            ((_, crate::types::TypeData::SpecialForm(special_form)), (_, _)) if special_form.class().is_special_form() => {
+            (crate::types::TypeData::SpecialForm(special_form), _) if special_form.class().is_special_form() => {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
-            ((_, crate::types::TypeData::KnownInstance(known_instance)), (_, _)) if known_instance.class(db).is_special_form() => {
+            (crate::types::TypeData::KnownInstance(known_instance), _) if known_instance.class(db).is_special_form() => {
                 Some(Ok(todo_type!("Inference of subscript on special form")))
             }
 
             (
-                (_, crate::types::TypeData::FunctionLiteral(_)
+                crate::types::TypeData::FunctionLiteral(_)
                 | crate::types::TypeData::WrapperDescriptor(_)
                 | crate::types::TypeData::BoundMethod(_)
                 | crate::types::TypeData::DataclassDecorator(_)
@@ -803,8 +803,8 @@ impl<'db> Type<'db> {
                 | crate::types::TypeData::KnownInstance(_)
                 | crate::types::TypeData::LiteralValue(_)
                 | crate::types::TypeData::TypeVar(_)  // TODO: more complex logic required here!
-                | crate::types::TypeData::KnownBoundMethod(_)),
-                (_, _),
+                | crate::types::TypeData::KnownBoundMethod(_),
+                _,
             ) => None,
         };
 
@@ -896,10 +896,7 @@ impl<'db> Type<'db> {
                 }
             }
 
-            if let (_, crate::types::TypeData::ClassLiteral(class)) = {
-                let __ty_view_value = value_ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
+            if let crate::types::TypeData::ClassLiteral(class) = value_ty.data() {
                 if class.is_known(db, KnownClass::Type) {
                     return Ok(KnownClass::GenericAlias.to_instance(db));
                 }

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -7,6 +7,88 @@ use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
 use test_case::test_case;
 
+fn repack_type(data: TypeData<'_>) -> Type<'_> {
+    match data {
+        TypeData::Dynamic(value) => Type::Dynamic(value),
+        TypeData::Divergent(value) => Type::Divergent(value),
+        TypeData::Never => Type::Never,
+        TypeData::FunctionLiteral(value) => Type::FunctionLiteral(value),
+        TypeData::BoundMethod(value) => Type::BoundMethod(value),
+        TypeData::KnownBoundMethod(value) => Type::KnownBoundMethod(value),
+        TypeData::WrapperDescriptor(value) => Type::WrapperDescriptor(value),
+        TypeData::DataclassDecorator(value) => Type::DataclassDecorator(value),
+        TypeData::DataclassTransformer(value) => Type::DataclassTransformer(value),
+        TypeData::Callable(value) => Type::Callable(value),
+        TypeData::ModuleLiteral(value) => Type::ModuleLiteral(value),
+        TypeData::ClassLiteral(value) => Type::ClassLiteral(value),
+        TypeData::GenericAlias(value) => Type::GenericAlias(value),
+        TypeData::SubclassOf(value) => Type::SubclassOf(value),
+        TypeData::NominalInstance(value) => Type::NominalInstance(value),
+        TypeData::ProtocolInstance(value) => Type::ProtocolInstance(value),
+        TypeData::SpecialForm(value) => Type::SpecialForm(value),
+        TypeData::KnownInstance(value) => Type::KnownInstance(value),
+        TypeData::PropertyInstance(value) => Type::PropertyInstance(value),
+        TypeData::Union(value) => Type::Union(value),
+        TypeData::Intersection(value) => Type::Intersection(value),
+        TypeData::EnumComplement(value) => Type::EnumComplement(value),
+        TypeData::AlwaysTruthy => Type::AlwaysTruthy,
+        TypeData::AlwaysFalsy => Type::AlwaysFalsy,
+        TypeData::LiteralValue(value) => Type::LiteralValue(value),
+        TypeData::TypeVar(value) => Type::TypeVar(value),
+        TypeData::BoundSuper(value) => Type::BoundSuper(value),
+        TypeData::TypeIs(value) => Type::TypeIs(value),
+        TypeData::TypeGuard(value) => Type::TypeGuard(value),
+        TypeData::TypeForm(value) => Type::TypeForm(value),
+        TypeData::TypedDict(value) => Type::TypedDict(value),
+        TypeData::TypeAlias(value) => Type::TypeAlias(value),
+        TypeData::NewTypeInstance(value) => Type::NewTypeInstance(value),
+    }
+}
+
+#[test]
+fn packed_type_layout_and_representative_round_trips() {
+    #[cfg(not(debug_assertions))]
+    assert_eq!(std::mem::size_of::<Type>(), 12);
+
+    let db = setup_db();
+    let id = salsa::Id::from_bits(1);
+    let pep695_alias = <PEP695TypeAliasType<'_> as salsa::plumbing::FromId>::from_id(id);
+    let recursive_literal = Type::LiteralValue(
+        LiteralValueType::promotable(i64::MIN)
+            .with_recursively_defined(set_theoretic::RecursivelyDefined::Yes),
+    );
+    let types = [
+        Type::any(),
+        Type::unknown(),
+        Type::Divergent(DivergentType::new(id).materialized(MaterializationKind::Top)),
+        Type::Never,
+        Type::AlwaysTruthy,
+        Type::AlwaysFalsy,
+        Type::SpecialForm(SpecialFormType::TypedDict),
+        Type::SpecialForm(SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::Dict)),
+        Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::Final)),
+        Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetAlways),
+        Type::int_literal(i64::MAX),
+        Type::bool_literal(false),
+        Type::string_literal(&db, "packed"),
+        recursive_literal,
+        KnownClass::Int.to_class_literal(&db),
+        KnownClass::Int.to_instance(&db),
+        KnownClass::Int.to_subclass_of(&db),
+        Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
+            pep695_alias,
+        ))),
+        Type::TypeAlias(TypeAliasType::PEP695(pep695_alias)),
+    ];
+
+    for ty in types {
+        let data = ty.data();
+        let repacked = repack_type(data);
+        assert_eq!(repacked, ty);
+        assert_eq!(repacked.data(), data);
+    }
+}
+
 /// Explicitly test for Python version <3.13 and >=3.13, to ensure that
 /// the fallback to `typing_extensions` is working correctly.
 /// See [`KnownClass::canonical_module`] for more information.
@@ -285,9 +367,15 @@ fn type_alias_variance() {
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> PEP695TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
         let ty = global_symbol(db, module, name).place.expect_type();
-        let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
-            type_alias,
-        ))) = ty
+        let (
+            _,
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                TypeAliasType::PEP695(type_alias),
+            )),
+        ) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        })
         else {
             panic!("Expected `{name}` to be a type alias");
         };
@@ -441,9 +529,15 @@ fn eager_expansion() {
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
         let ty = global_symbol(db, module, name).place.expect_type();
-        let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
-            type_alias,
-        ))) = ty
+        let (
+            _,
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                TypeAliasType::PEP695(type_alias),
+            )),
+        ) = ({
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        })
         else {
             panic!("Expected `{name}` to be a type alias");
         };

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -367,15 +367,9 @@ fn type_alias_variance() {
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> PEP695TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
         let ty = global_symbol(db, module, name).place.expect_type();
-        let (
-            _,
-            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                TypeAliasType::PEP695(type_alias),
-            )),
-        ) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        })
+        let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+            TypeAliasType::PEP695(type_alias),
+        )) = ty.data()
         else {
             panic!("Expected `{name}` to be a type alias");
         };
@@ -529,15 +523,9 @@ fn eager_expansion() {
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
         let ty = global_symbol(db, module, name).place.expect_type();
-        let (
-            _,
-            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                TypeAliasType::PEP695(type_alias),
-            )),
-        ) = ({
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        })
+        let crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+            TypeAliasType::PEP695(type_alias),
+        )) = ty.data()
         else {
             panic!("Expected `{name}` to be a type alias");
         };

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -74,6 +74,9 @@ fn packed_type_layout_and_representative_round_trips() {
         recursive_literal,
         KnownClass::Int.to_class_literal(&db),
         KnownClass::Int.to_instance(&db),
+        Type::object(),
+        Type::empty_tuple(&db),
+        Type::sys_version_info(),
         KnownClass::Int.to_subclass_of(&db),
         Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             pep695_alias,
@@ -86,6 +89,9 @@ fn packed_type_layout_and_representative_round_trips() {
         let repacked = repack_type(data);
         assert_eq!(repacked, ty);
         assert_eq!(repacked.data(), data);
+        if let TypeData::NominalInstance(instance) = data {
+            assert_eq!(ty.as_nominal_instance(), Some(instance));
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -192,9 +192,12 @@ impl<'db> TupleType<'db> {
     }
 
     pub(crate) fn homogeneous(db: &'db dyn Db, element: Type<'db>) -> Self {
-        match element {
-            Type::Never => TupleType::empty(db),
-            _ => TupleType::new_internal(db, TupleSpec::homogeneous(element)),
+        match {
+            let __ty_view_value = element;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::Never) => TupleType::empty(db),
+            (_, _) => TupleType::new_internal(db, TupleSpec::homogeneous(element)),
         }
     }
 
@@ -430,13 +433,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Tuple::Variable(target) => {
                 // When prenormalizing below, we assume that a dynamic variable-length portion of
                 // one tuple materializes to the variable-length portion of the other tuple.
-                let source_prenormalize_variable = match source.variable() {
-                    Type::Dynamic(_) => Some(target.variable()),
-                    _ => None,
+                let source_prenormalize_variable = match {
+                    let __ty_view_value = source.variable();
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::Dynamic(_)) => Some(target.variable()),
+                    (_, _) => None,
                 };
-                let target_prenormalize_variable = match target.variable() {
-                    Type::Dynamic(_) => Some(source.variable()),
-                    _ => None,
+                let target_prenormalize_variable = match {
+                    let __ty_view_value = target.variable();
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::Dynamic(_)) => Some(source.variable()),
+                    (_, _) => None,
                 };
 
                 // The overlapping parts of the prefixes and suffixes must satisfy the relation.

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -192,12 +192,9 @@ impl<'db> TupleType<'db> {
     }
 
     pub(crate) fn homogeneous(db: &'db dyn Db, element: Type<'db>) -> Self {
-        match {
-            let __ty_view_value = element;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::Never) => TupleType::empty(db),
-            (_, _) => TupleType::new_internal(db, TupleSpec::homogeneous(element)),
+        match element.data() {
+            crate::types::TypeData::Never => TupleType::empty(db),
+            _ => TupleType::new_internal(db, TupleSpec::homogeneous(element)),
         }
     }
 
@@ -433,19 +430,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             Tuple::Variable(target) => {
                 // When prenormalizing below, we assume that a dynamic variable-length portion of
                 // one tuple materializes to the variable-length portion of the other tuple.
-                let source_prenormalize_variable = match {
-                    let __ty_view_value = source.variable();
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::Dynamic(_)) => Some(target.variable()),
-                    (_, _) => None,
+                let source_prenormalize_variable = match source.variable().data() {
+                    crate::types::TypeData::Dynamic(_) => Some(target.variable()),
+                    _ => None,
                 };
-                let target_prenormalize_variable = match {
-                    let __ty_view_value = target.variable();
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::Dynamic(_)) => Some(source.variable()),
-                    (_, _) => None,
+                let target_prenormalize_variable = match target.variable().data() {
+                    crate::types::TypeData::Dynamic(_) => Some(source.variable()),
+                    _ => None,
                 };
 
                 // The overlapping parts of the prefixes and suffixes must satisfy the relation.

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -176,10 +176,7 @@ impl<'db> Type<'db> {
     /// ```
     ///
     pub(crate) fn promote_tuple_size_in_union(self, db: &'db dyn Db) -> Type<'db> {
-        let (_, crate::types::TypeData::Union(union)) = ({
-            let __ty_view_value = self;
-            (__ty_view_value, __ty_view_value.data())
-        }) else {
+        let crate::types::TypeData::Union(union) = self.data() else {
             return self;
         };
 

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -176,7 +176,10 @@ impl<'db> Type<'db> {
     /// ```
     ///
     pub(crate) fn promote_tuple_size_in_union(self, db: &'db dyn Db) -> Type<'db> {
-        let Type::Union(union) = self else {
+        let (_, crate::types::TypeData::Union(union)) = ({
+            let __ty_view_value = self;
+            (__ty_view_value, __ty_view_value.data())
+        }) else {
             return self;
         };
 

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -45,12 +45,17 @@ impl<'db> Type<'db> {
             ty: Type<'db>,
             visitor: &TypeFormArgumentVisitor<'db>,
         ) -> Option<Type<'db>> {
-            match ty {
-                Type::TypeForm(type_form) => Some(type_form.type_argument(db)),
-                Type::TypeAlias(alias) => {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeForm(type_form)) => {
+                    Some(type_form.type_argument(db))
+                }
+                (_, crate::types::TypeData::TypeAlias(alias)) => {
                     visitor.visit(ty, || project(db, alias.value_type(db), visitor))
                 }
-                Type::Union(union) => {
+                (_, crate::types::TypeData::Union(union)) => {
                     let mut elements = union
                         .elements(db)
                         .iter()
@@ -59,7 +64,7 @@ impl<'db> Type<'db> {
                     elements.peek()?;
                     Some(UnionType::from_elements(db, elements))
                 }
-                Type::Intersection(intersection) => {
+                (_, crate::types::TypeData::Intersection(intersection)) => {
                     let mut elements = intersection
                         .iter_positive(db)
                         .filter_map(|element| project(db, element, visitor))
@@ -67,7 +72,7 @@ impl<'db> Type<'db> {
                     elements.peek()?;
                     Some(IntersectionType::from_elements(db, elements))
                 }
-                Type::TypeVar(typevar) => visitor.visit(ty, || {
+                (_, crate::types::TypeData::TypeVar(typevar)) => visitor.visit(ty, || {
                     typevar
                         .typevar(db)
                         .bound_or_constraints(db)
@@ -75,14 +80,21 @@ impl<'db> Type<'db> {
                             project(db, bound_or_constraints.as_type(db), visitor)
                         })
                 }),
-                Type::SpecialForm(special_form) => special_form.type_form_argument(db),
-                Type::KnownInstance(instance) if instance.is_type_form_value() => {
+                (_, crate::types::TypeData::SpecialForm(special_form)) => {
+                    special_form.type_form_argument(db)
+                }
+                (_, crate::types::TypeData::KnownInstance(instance))
+                    if instance.is_type_form_value() =>
+                {
                     instance.type_form_argument(db)
                 }
-                Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
-                    ty.to_instance(db)
-                }
-                _ => None,
+                (
+                    _,
+                    crate::types::TypeData::ClassLiteral(_)
+                    | crate::types::TypeData::GenericAlias(_)
+                    | crate::types::TypeData::SubclassOf(_),
+                ) => ty.to_instance(db),
+                (_, _) => None,
             }
         }
 

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -45,17 +45,12 @@ impl<'db> Type<'db> {
             ty: Type<'db>,
             visitor: &TypeFormArgumentVisitor<'db>,
         ) -> Option<Type<'db>> {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypeForm(type_form)) => {
-                    Some(type_form.type_argument(db))
-                }
-                (_, crate::types::TypeData::TypeAlias(alias)) => {
+            match ty.data() {
+                crate::types::TypeData::TypeForm(type_form) => Some(type_form.type_argument(db)),
+                crate::types::TypeData::TypeAlias(alias) => {
                     visitor.visit(ty, || project(db, alias.value_type(db), visitor))
                 }
-                (_, crate::types::TypeData::Union(union)) => {
+                crate::types::TypeData::Union(union) => {
                     let mut elements = union
                         .elements(db)
                         .iter()
@@ -64,7 +59,7 @@ impl<'db> Type<'db> {
                     elements.peek()?;
                     Some(UnionType::from_elements(db, elements))
                 }
-                (_, crate::types::TypeData::Intersection(intersection)) => {
+                crate::types::TypeData::Intersection(intersection) => {
                     let mut elements = intersection
                         .iter_positive(db)
                         .filter_map(|element| project(db, element, visitor))
@@ -72,7 +67,7 @@ impl<'db> Type<'db> {
                     elements.peek()?;
                     Some(IntersectionType::from_elements(db, elements))
                 }
-                (_, crate::types::TypeData::TypeVar(typevar)) => visitor.visit(ty, || {
+                crate::types::TypeData::TypeVar(typevar) => visitor.visit(ty, || {
                     typevar
                         .typevar(db)
                         .bound_or_constraints(db)
@@ -80,21 +75,18 @@ impl<'db> Type<'db> {
                             project(db, bound_or_constraints.as_type(db), visitor)
                         })
                 }),
-                (_, crate::types::TypeData::SpecialForm(special_form)) => {
+                crate::types::TypeData::SpecialForm(special_form) => {
                     special_form.type_form_argument(db)
                 }
-                (_, crate::types::TypeData::KnownInstance(instance))
+                crate::types::TypeData::KnownInstance(instance)
                     if instance.is_type_form_value() =>
                 {
                     instance.type_form_argument(db)
                 }
-                (
-                    _,
-                    crate::types::TypeData::ClassLiteral(_)
-                    | crate::types::TypeData::GenericAlias(_)
-                    | crate::types::TypeData::SubclassOf(_),
-                ) => ty.to_instance(db),
-                (_, _) => None,
+                crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::GenericAlias(_)
+                | crate::types::TypeData::SubclassOf(_) => ty.to_instance(db),
+                _ => None,
             }
         }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -285,10 +285,13 @@ impl<'db> TypedDictType<'db> {
 
             for base in static_class.explicit_bases(db) {
                 let base = base.apply_optional_specialization(db, specialization);
-                let base_class = match base {
-                    Type::ClassLiteral(base) => ClassType::NonGeneric(base),
-                    Type::GenericAlias(base) => ClassType::Generic(base),
-                    _ => continue,
+                let base_class = match {
+                    let __ty_view_value = base;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::ClassLiteral(base)) => ClassType::NonGeneric(base),
+                    (_, crate::types::TypeData::GenericAlias(base)) => ClassType::Generic(base),
+                    (_, _) => continue,
                 };
 
                 if base_class.class_literal(db).is_typed_dict(db) {
@@ -1704,8 +1707,11 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<UnpackedTypedDict<'db>> {
-    match ty {
-        Type::TypedDict(td) => {
+    match {
+        let __ty_view_value = ty;
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (_, crate::types::TypeData::TypedDict(td)) => {
             let keys = td
                 .items(db)
                 .iter()
@@ -1725,7 +1731,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness: td.openness(db),
             })
         }
-        Type::Intersection(intersection) => {
+        (_, crate::types::TypeData::Intersection(intersection)) => {
             // Collect TypedDict shapes from all TypedDicts in the intersection.
             let unpacked_elements: Vec<_> = intersection
                 .positive(db)
@@ -1786,7 +1792,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness,
             })
         }
-        Type::Union(union) => {
+        (_, crate::types::TypeData::Union(union)) => {
             let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
@@ -1848,39 +1854,42 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness,
             })
         }
-        Type::TypeAlias(alias) => {
+        (_, crate::types::TypeData::TypeAlias(alias)) => {
             extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }
         // All other types cannot contain a TypedDict
-        Type::Dynamic(_)
-        | Type::Divergent(_)
-        | Type::Never
-        | Type::EnumComplement(_)
-        | Type::FunctionLiteral(_)
-        | Type::BoundMethod(_)
-        | Type::KnownBoundMethod(_)
-        | Type::WrapperDescriptor(_)
-        | Type::DataclassDecorator(_)
-        | Type::DataclassTransformer(_)
-        | Type::Callable(_)
-        | Type::ModuleLiteral(_)
-        | Type::ClassLiteral(_)
-        | Type::GenericAlias(_)
-        | Type::SubclassOf(_)
-        | Type::NominalInstance(_)
-        | Type::ProtocolInstance(_)
-        | Type::SpecialForm(_)
-        | Type::KnownInstance(_)
-        | Type::PropertyInstance(_)
-        | Type::AlwaysTruthy
-        | Type::AlwaysFalsy
-        | Type::LiteralValue(_)
-        | Type::TypeVar(_)
-        | Type::BoundSuper(_)
-        | Type::TypeIs(_)
-        | Type::TypeGuard(_)
-        | Type::TypeForm(_)
-        | Type::NewTypeInstance(_) => None,
+        (
+            _,
+            crate::types::TypeData::Dynamic(_)
+            | crate::types::TypeData::Divergent(_)
+            | crate::types::TypeData::Never
+            | crate::types::TypeData::EnumComplement(_)
+            | crate::types::TypeData::FunctionLiteral(_)
+            | crate::types::TypeData::BoundMethod(_)
+            | crate::types::TypeData::KnownBoundMethod(_)
+            | crate::types::TypeData::WrapperDescriptor(_)
+            | crate::types::TypeData::DataclassDecorator(_)
+            | crate::types::TypeData::DataclassTransformer(_)
+            | crate::types::TypeData::Callable(_)
+            | crate::types::TypeData::ModuleLiteral(_)
+            | crate::types::TypeData::ClassLiteral(_)
+            | crate::types::TypeData::GenericAlias(_)
+            | crate::types::TypeData::SubclassOf(_)
+            | crate::types::TypeData::NominalInstance(_)
+            | crate::types::TypeData::ProtocolInstance(_)
+            | crate::types::TypeData::SpecialForm(_)
+            | crate::types::TypeData::KnownInstance(_)
+            | crate::types::TypeData::PropertyInstance(_)
+            | crate::types::TypeData::AlwaysTruthy
+            | crate::types::TypeData::AlwaysFalsy
+            | crate::types::TypeData::LiteralValue(_)
+            | crate::types::TypeData::TypeVar(_)
+            | crate::types::TypeData::BoundSuper(_)
+            | crate::types::TypeData::TypeIs(_)
+            | crate::types::TypeData::TypeGuard(_)
+            | crate::types::TypeData::TypeForm(_)
+            | crate::types::TypeData::NewTypeInstance(_),
+        ) => None,
     }
 }
 
@@ -1944,13 +1953,16 @@ pub(super) fn infer_unpacked_keyword_types<'db>(
 }
 
 pub(super) fn unpacked_keyword_is_gradual<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty.resolve_type_alias(db) {
-        ty if ty.is_never() || ty.is_dynamic() => true,
-        Type::Union(union) => union
+    match {
+        let __ty_view_value = ty.resolve_type_alias(db);
+        (__ty_view_value, __ty_view_value.data())
+    } {
+        (ty, _) if ty.is_never() || ty.is_dynamic() => true,
+        (_, crate::types::TypeData::Union(union)) => union
             .elements(db)
             .iter()
             .any(|element| element.resolve_type_alias(db).is_dynamic()),
-        _ => false,
+        (_, _) => false,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -285,13 +285,10 @@ impl<'db> TypedDictType<'db> {
 
             for base in static_class.explicit_bases(db) {
                 let base = base.apply_optional_specialization(db, specialization);
-                let base_class = match {
-                    let __ty_view_value = base;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::ClassLiteral(base)) => ClassType::NonGeneric(base),
-                    (_, crate::types::TypeData::GenericAlias(base)) => ClassType::Generic(base),
-                    (_, _) => continue,
+                let base_class = match base.data() {
+                    crate::types::TypeData::ClassLiteral(base) => ClassType::NonGeneric(base),
+                    crate::types::TypeData::GenericAlias(base) => ClassType::Generic(base),
+                    _ => continue,
                 };
 
                 if base_class.class_literal(db).is_typed_dict(db) {
@@ -1707,11 +1704,8 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
 ) -> Option<UnpackedTypedDict<'db>> {
-    match {
-        let __ty_view_value = ty;
-        (__ty_view_value, __ty_view_value.data())
-    } {
-        (_, crate::types::TypeData::TypedDict(td)) => {
+    match ty.data() {
+        crate::types::TypeData::TypedDict(td) => {
             let keys = td
                 .items(db)
                 .iter()
@@ -1731,7 +1725,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness: td.openness(db),
             })
         }
-        (_, crate::types::TypeData::Intersection(intersection)) => {
+        crate::types::TypeData::Intersection(intersection) => {
             // Collect TypedDict shapes from all TypedDicts in the intersection.
             let unpacked_elements: Vec<_> = intersection
                 .positive(db)
@@ -1792,7 +1786,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness,
             })
         }
-        (_, crate::types::TypeData::Union(union)) => {
+        crate::types::TypeData::Union(union) => {
             let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
@@ -1854,42 +1848,39 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                 openness,
             })
         }
-        (_, crate::types::TypeData::TypeAlias(alias)) => {
+        crate::types::TypeData::TypeAlias(alias) => {
             extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
         }
         // All other types cannot contain a TypedDict
-        (
-            _,
-            crate::types::TypeData::Dynamic(_)
-            | crate::types::TypeData::Divergent(_)
-            | crate::types::TypeData::Never
-            | crate::types::TypeData::EnumComplement(_)
-            | crate::types::TypeData::FunctionLiteral(_)
-            | crate::types::TypeData::BoundMethod(_)
-            | crate::types::TypeData::KnownBoundMethod(_)
-            | crate::types::TypeData::WrapperDescriptor(_)
-            | crate::types::TypeData::DataclassDecorator(_)
-            | crate::types::TypeData::DataclassTransformer(_)
-            | crate::types::TypeData::Callable(_)
-            | crate::types::TypeData::ModuleLiteral(_)
-            | crate::types::TypeData::ClassLiteral(_)
-            | crate::types::TypeData::GenericAlias(_)
-            | crate::types::TypeData::SubclassOf(_)
-            | crate::types::TypeData::NominalInstance(_)
-            | crate::types::TypeData::ProtocolInstance(_)
-            | crate::types::TypeData::SpecialForm(_)
-            | crate::types::TypeData::KnownInstance(_)
-            | crate::types::TypeData::PropertyInstance(_)
-            | crate::types::TypeData::AlwaysTruthy
-            | crate::types::TypeData::AlwaysFalsy
-            | crate::types::TypeData::LiteralValue(_)
-            | crate::types::TypeData::TypeVar(_)
-            | crate::types::TypeData::BoundSuper(_)
-            | crate::types::TypeData::TypeIs(_)
-            | crate::types::TypeData::TypeGuard(_)
-            | crate::types::TypeData::TypeForm(_)
-            | crate::types::TypeData::NewTypeInstance(_),
-        ) => None,
+        crate::types::TypeData::Dynamic(_)
+        | crate::types::TypeData::Divergent(_)
+        | crate::types::TypeData::Never
+        | crate::types::TypeData::EnumComplement(_)
+        | crate::types::TypeData::FunctionLiteral(_)
+        | crate::types::TypeData::BoundMethod(_)
+        | crate::types::TypeData::KnownBoundMethod(_)
+        | crate::types::TypeData::WrapperDescriptor(_)
+        | crate::types::TypeData::DataclassDecorator(_)
+        | crate::types::TypeData::DataclassTransformer(_)
+        | crate::types::TypeData::Callable(_)
+        | crate::types::TypeData::ModuleLiteral(_)
+        | crate::types::TypeData::ClassLiteral(_)
+        | crate::types::TypeData::GenericAlias(_)
+        | crate::types::TypeData::SubclassOf(_)
+        | crate::types::TypeData::NominalInstance(_)
+        | crate::types::TypeData::ProtocolInstance(_)
+        | crate::types::TypeData::SpecialForm(_)
+        | crate::types::TypeData::KnownInstance(_)
+        | crate::types::TypeData::PropertyInstance(_)
+        | crate::types::TypeData::AlwaysTruthy
+        | crate::types::TypeData::AlwaysFalsy
+        | crate::types::TypeData::LiteralValue(_)
+        | crate::types::TypeData::TypeVar(_)
+        | crate::types::TypeData::BoundSuper(_)
+        | crate::types::TypeData::TypeIs(_)
+        | crate::types::TypeData::TypeGuard(_)
+        | crate::types::TypeData::TypeForm(_)
+        | crate::types::TypeData::NewTypeInstance(_) => None,
     }
 }
 
@@ -1953,10 +1944,7 @@ pub(super) fn infer_unpacked_keyword_types<'db>(
 }
 
 pub(super) fn unpacked_keyword_is_gradual<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match {
-        let __ty_view_value = ty.resolve_type_alias(db);
-        (__ty_view_value, __ty_view_value.data())
-    } {
+    match ty.resolve_type_alias(db).view() {
         (ty, _) if ty.is_never() || ty.is_dynamic() => true,
         (_, crate::types::TypeData::Union(union)) => union
             .elements(db)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -37,13 +37,7 @@ impl<'db> Type<'db> {
 
     pub(crate) fn has_typevar(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| {
-            matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (_, crate::types::TypeData::TypeVar(_))
-            )
+            matches!(ty.data(), crate::types::TypeData::TypeVar(_))
         })
     }
 
@@ -52,19 +46,14 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         typevar_id: TypeVarIdentity<'db>,
     ) -> bool {
-        any_over_type(db, self, false, |ty| {
-            match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
-                    typevar_id == bound_typevar.typevar(db).identity(db)
-                }
-                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) => {
-                    typevar_id == typevar.identity(db)
-                }
-                (_, _) => false,
+        any_over_type(db, self, false, |ty| match ty.data() {
+            crate::types::TypeData::TypeVar(bound_typevar) => {
+                typevar_id == bound_typevar.typevar(db).identity(db)
             }
+            crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                typevar_id == typevar.identity(db)
+            }
+            _ => false,
         })
     }
 
@@ -73,22 +62,16 @@ impl<'db> Type<'db> {
             db,
             self,
             false,
-            |ty| matches!( { let __ty_view_value = ty; (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::TypeVar(tv)) if !tv.typevar(db).is_self(db)),
+            |ty| matches!( ty.data() , crate::types::TypeData::TypeVar(tv) if !tv.typevar(db).is_self(db)),
         )
     }
 
     pub(crate) fn has_typevar_or_typevar_instance(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| {
             matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(_))
-                        | crate::types::TypeData::TypeVar(_)
-                )
+                ty.data(),
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(_))
+                    | crate::types::TypeData::TypeVar(_)
             )
         })
     }
@@ -96,14 +79,8 @@ impl<'db> Type<'db> {
     pub(crate) fn has_unspecialized_type_var(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| {
             matches!(
-                {
-                    let __ty_view_value = ty;
-                    (__ty_view_value, __ty_view_value.data())
-                },
-                (
-                    _,
-                    crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
-                )
+                ty.data(),
+                crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
             )
         })
     }
@@ -427,33 +404,24 @@ impl<'db> TypeVarInstance<'db> {
             ty: Type<'db>,
             self_identity: TypeVarIdentity<'db>,
         ) -> bool {
-            any_over_type(state.db, ty, false, |inner_ty| {
-                match {
-                    let __ty_view_value = inner_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
-                        typevar_default_is_self_referential(
-                            state,
-                            bound_typevar.typevar(state.db),
-                            self_identity,
-                        )
-                    }
-                    (
-                        _,
-                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
-                    ) => typevar_default_is_self_referential(state, typevar, self_identity),
-                    (_, crate::types::TypeData::TypeAlias(alias)) => {
-                        type_alias_is_self_referential(state, alias, self_identity)
-                    }
-                    (
-                        _,
-                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
-                            alias,
-                        )),
-                    ) => type_alias_is_self_referential(state, alias, self_identity),
-                    (_, _) => false,
+            any_over_type(state.db, ty, false, |inner_ty| match inner_ty.data() {
+                crate::types::TypeData::TypeVar(bound_typevar) => {
+                    typevar_default_is_self_referential(
+                        state,
+                        bound_typevar.typevar(state.db),
+                        self_identity,
+                    )
                 }
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                    typevar_default_is_self_referential(state, typevar, self_identity)
+                }
+                crate::types::TypeData::TypeAlias(alias) => {
+                    type_alias_is_self_referential(state, alias, self_identity)
+                }
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => {
+                    type_alias_is_self_referential(state, alias, self_identity)
+                }
+                _ => false,
             })
         }
 
@@ -572,16 +540,13 @@ impl<'db> TypeVarInstance<'db> {
     #[salsa::tracked(cycle_initial=|_, id, _| Some(Type::divergent(id)), cycle_fn=lazy_default_cycle_recover, heap_size=ruff_memory_usage::heap_size)]
     fn lazy_default_unchecked(self, db: &'db dyn Db) -> Option<Type<'db>> {
         fn convert_type_to_paramspec_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-            let parameters = match {
-                let __ty_view_value = ty;
-                (__ty_view_value, __ty_view_value.data())
-            } {
-                (_, crate::types::TypeData::NominalInstance(nominal_instance))
+            let parameters = match ty.data() {
+                crate::types::TypeData::NominalInstance(nominal_instance)
                     if nominal_instance.has_known_class(db, KnownClass::EllipsisType) =>
                 {
                     Parameters::gradual_form()
                 }
-                (_, crate::types::TypeData::NominalInstance(nominal_instance)) => nominal_instance
+                crate::types::TypeData::NominalInstance(nominal_instance) => nominal_instance
                     .own_tuple_spec(db)
                     .map_or_else(Parameters::unknown, |tuple_spec| {
                         Parameters::new(
@@ -591,7 +556,7 @@ impl<'db> TypeVarInstance<'db> {
                                 .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
                         )
                     }),
-                (_, crate::types::TypeData::Dynamic(dynamic)) => match dynamic {
+                crate::types::TypeData::Dynamic(dynamic) => match dynamic {
                     DynamicType::Todo(_)
                     | DynamicType::TodoUnpack
                     | DynamicType::TodoStarredExpression
@@ -603,16 +568,16 @@ impl<'db> TypeVarInstance<'db> {
                     | DynamicType::InvalidConcatenateUnknown
                     | DynamicType::AmbiguousOverload => Parameters::unknown(),
                 },
-                (_, crate::types::TypeData::Divergent(_)) => Parameters::unknown(),
-                (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
+                crate::types::TypeData::Divergent(_) => Parameters::unknown(),
+                crate::types::TypeData::TypeVar(typevar) if typevar.is_paramspec(db) => {
                     return ty;
                 }
-                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)))
+                crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))
                     if typevar.is_paramspec(db) =>
                 {
                     return ty;
                 }
-                (_, _) => Parameters::unknown(),
+                _ => Parameters::unknown(),
             };
             Type::paramspec_value_callable(db, parameters)
         }
@@ -1088,10 +1053,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 };
                 specialization.get(db, typevar).map(|ty| {
                     if let Some(attr) = self.paramspec_attr(db)
-                        && let (_, crate::types::TypeData::TypeVar(typevar)) = ({
-                            let __ty_view_value = ty;
-                            (__ty_view_value, __ty_view_value.data())
-                        })
+                        && let crate::types::TypeData::TypeVar(typevar) = ty.data()
                         && typevar.is_paramspec(db)
                     {
                         return Type::TypeVar(typevar.with_paramspec_attr(db, attr));

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -27,19 +27,36 @@ use ty_python_core::{
 };
 
 impl<'db> Type<'db> {
-    pub(crate) const fn is_type_var(self) -> bool {
-        matches!(self, Type::TypeVar(_))
+    pub(crate) fn is_type_var(self) -> bool {
+        matches!(
+            {
+                let __ty_view_value = self;
+                (__ty_view_value, __ty_view_value.data())
+            },
+            (_, crate::types::TypeData::TypeVar(_))
+        )
     }
 
-    pub(crate) const fn as_typevar(self) -> Option<BoundTypeVarInstance<'db>> {
-        match self {
-            Type::TypeVar(bound_typevar) => Some(bound_typevar),
-            _ => None,
+    pub(crate) fn as_typevar(self) -> Option<BoundTypeVarInstance<'db>> {
+        match {
+            let __ty_view_value = self;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => Some(bound_typevar),
+            (_, _) => None,
         }
     }
 
     pub(crate) fn has_typevar(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, false, |ty| matches!(ty, Type::TypeVar(_)))
+        any_over_type(db, self, false, |ty| {
+            matches!(
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (_, crate::types::TypeData::TypeVar(_))
+            )
+        })
     }
 
     pub(crate) fn references_typevar(
@@ -47,12 +64,19 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         typevar_id: TypeVarIdentity<'db>,
     ) -> bool {
-        any_over_type(db, self, false, |ty| match ty {
-            Type::TypeVar(bound_typevar) => typevar_id == bound_typevar.typevar(db).identity(db),
-            Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                typevar_id == typevar.identity(db)
+        any_over_type(db, self, false, |ty| {
+            match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+                    typevar_id == bound_typevar.typevar(db).identity(db)
+                }
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar))) => {
+                    typevar_id == typevar.identity(db)
+                }
+                (_, _) => false,
             }
-            _ => false,
         })
     }
 
@@ -61,22 +85,38 @@ impl<'db> Type<'db> {
             db,
             self,
             false,
-            |ty| matches!(ty, Type::TypeVar(tv) if !tv.typevar(db).is_self(db)),
+            |ty| matches!( { let __ty_view_value = ty; (__ty_view_value, __ty_view_value.data()) } , (_, crate::types::TypeData::TypeVar(tv)) if !tv.typevar(db).is_self(db)),
         )
     }
 
     pub(crate) fn has_typevar_or_typevar_instance(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| {
             matches!(
-                ty,
-                Type::KnownInstance(KnownInstanceType::TypeVar(_)) | Type::TypeVar(_)
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(_))
+                        | crate::types::TypeData::TypeVar(_)
+                )
             )
         })
     }
 
     pub(crate) fn has_unspecialized_type_var(self, db: &'db dyn Db) -> bool {
         any_over_type(db, self, false, |ty| {
-            matches!(ty, Type::Dynamic(DynamicType::UnspecializedTypeVar))
+            matches!(
+                {
+                    let __ty_view_value = ty;
+                    (__ty_view_value, __ty_view_value.data())
+                },
+                (
+                    _,
+                    crate::types::TypeData::Dynamic(DynamicType::UnspecializedTypeVar)
+                )
+            )
         })
     }
 }
@@ -399,22 +439,33 @@ impl<'db> TypeVarInstance<'db> {
             ty: Type<'db>,
             self_identity: TypeVarIdentity<'db>,
         ) -> bool {
-            any_over_type(state.db, ty, false, |inner_ty| match inner_ty {
-                Type::TypeVar(bound_typevar) => typevar_default_is_self_referential(
-                    state,
-                    bound_typevar.typevar(state.db),
-                    self_identity,
-                ),
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                    typevar_default_is_self_referential(state, typevar, self_identity)
+            any_over_type(state.db, ty, false, |inner_ty| {
+                match {
+                    let __ty_view_value = inner_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
+                        typevar_default_is_self_referential(
+                            state,
+                            bound_typevar.typevar(state.db),
+                            self_identity,
+                        )
+                    }
+                    (
+                        _,
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)),
+                    ) => typevar_default_is_self_referential(state, typevar, self_identity),
+                    (_, crate::types::TypeData::TypeAlias(alias)) => {
+                        type_alias_is_self_referential(state, alias, self_identity)
+                    }
+                    (
+                        _,
+                        crate::types::TypeData::KnownInstance(KnownInstanceType::TypeAliasType(
+                            alias,
+                        )),
+                    ) => type_alias_is_self_referential(state, alias, self_identity),
+                    (_, _) => false,
                 }
-                Type::TypeAlias(alias) => {
-                    type_alias_is_self_referential(state, alias, self_identity)
-                }
-                Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => {
-                    type_alias_is_self_referential(state, alias, self_identity)
-                }
-                _ => false,
             })
         }
 
@@ -533,13 +584,16 @@ impl<'db> TypeVarInstance<'db> {
     #[salsa::tracked(cycle_initial=|_, id, _| Some(Type::divergent(id)), cycle_fn=lazy_default_cycle_recover, heap_size=ruff_memory_usage::heap_size)]
     fn lazy_default_unchecked(self, db: &'db dyn Db) -> Option<Type<'db>> {
         fn convert_type_to_paramspec_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-            let parameters = match ty {
-                Type::NominalInstance(nominal_instance)
+            let parameters = match {
+                let __ty_view_value = ty;
+                (__ty_view_value, __ty_view_value.data())
+            } {
+                (_, crate::types::TypeData::NominalInstance(nominal_instance))
                     if nominal_instance.has_known_class(db, KnownClass::EllipsisType) =>
                 {
                     Parameters::gradual_form()
                 }
-                Type::NominalInstance(nominal_instance) => nominal_instance
+                (_, crate::types::TypeData::NominalInstance(nominal_instance)) => nominal_instance
                     .own_tuple_spec(db)
                     .map_or_else(Parameters::unknown, |tuple_spec| {
                         Parameters::new(
@@ -549,7 +603,7 @@ impl<'db> TypeVarInstance<'db> {
                                 .map(|ty| Parameter::positional_only(None).with_annotated_type(ty)),
                         )
                     }),
-                Type::Dynamic(dynamic) => match dynamic {
+                (_, crate::types::TypeData::Dynamic(dynamic)) => match dynamic {
                     DynamicType::Todo(_)
                     | DynamicType::TodoUnpack
                     | DynamicType::TodoStarredExpression
@@ -561,16 +615,16 @@ impl<'db> TypeVarInstance<'db> {
                     | DynamicType::InvalidConcatenateUnknown
                     | DynamicType::AmbiguousOverload => Parameters::unknown(),
                 },
-                Type::Divergent(_) => Parameters::unknown(),
-                Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
+                (_, crate::types::TypeData::Divergent(_)) => Parameters::unknown(),
+                (_, crate::types::TypeData::TypeVar(typevar)) if typevar.is_paramspec(db) => {
                     return ty;
                 }
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar))
+                (_, crate::types::TypeData::KnownInstance(KnownInstanceType::TypeVar(typevar)))
                     if typevar.is_paramspec(db) =>
                 {
                     return ty;
                 }
-                _ => Parameters::unknown(),
+                (_, _) => Parameters::unknown(),
             };
             Type::paramspec_value_callable(db, parameters)
         }
@@ -1046,7 +1100,10 @@ impl<'db> BoundTypeVarInstance<'db> {
                 };
                 specialization.get(db, typevar).map(|ty| {
                     if let Some(attr) = self.paramspec_attr(db)
-                        && let Type::TypeVar(typevar) = ty
+                        && let (_, crate::types::TypeData::TypeVar(typevar)) = ({
+                            let __ty_view_value = ty;
+                            (__ty_view_value, __ty_view_value.data())
+                        })
                         && typevar.is_paramspec(db)
                     {
                         return Type::TypeVar(typevar.with_paramspec_attr(db, attr));

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{
         ApplySpecialization, ApplyTypeMappingVisitor, CycleDetector, DynamicType, GenericContext,
         KnownClass, KnownInstanceType, MaterializationKind, Parameter, Parameters, Type,
-        TypeAliasType, TypeContext, TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
+        TypeAliasType, TypeContext, TypeMapping, TypeTag, TypeVarVariance, UnionBuilder, UnionType,
         any_over_type, binding_type, definition_expression_type,
         tuple::Tuple,
         variance::VarianceInferable,
@@ -28,23 +28,11 @@ use ty_python_core::{
 
 impl<'db> Type<'db> {
     pub(crate) fn is_type_var(self) -> bool {
-        matches!(
-            {
-                let __ty_view_value = self;
-                (__ty_view_value, __ty_view_value.data())
-            },
-            (_, crate::types::TypeData::TypeVar(_))
-        )
+        self.tag == TypeTag::TypeVar
     }
 
     pub(crate) fn as_typevar(self) -> Option<BoundTypeVarInstance<'db>> {
-        match {
-            let __ty_view_value = self;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => Some(bound_typevar),
-            (_, _) => None,
-        }
+        (self.tag == TypeTag::TypeVar).then(|| self.payload())
     }
 
     pub(crate) fn has_typevar(self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -209,12 +209,9 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 // if we manually map over the union and call `try_iterate` on each union element.
                 // See <https://github.com/astral-sh/ruff/pull/20377#issuecomment-3401380305>
                 // for more discussion.
-                let unpack_types = match {
-                    let __ty_view_value = value_ty;
-                    (__ty_view_value, __ty_view_value.data())
-                } {
-                    (_, crate::types::TypeData::Union(union_ty)) => union_ty.elements(self.db()),
-                    (_, _) => std::slice::from_ref(&value_ty),
+                let unpack_types = match value_ty.data() {
+                    crate::types::TypeData::Union(union_ty) => union_ty.elements(self.db()),
+                    _ => std::slice::from_ref(&value_ty),
                 };
 
                 for ty in unpack_types.iter().copied() {

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -209,9 +209,12 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 // if we manually map over the union and call `try_iterate` on each union element.
                 // See <https://github.com/astral-sh/ruff/pull/20377#issuecomment-3401380305>
                 // for more discussion.
-                let unpack_types = match value_ty {
-                    Type::Union(union_ty) => union_ty.elements(self.db()),
-                    _ => std::slice::from_ref(&value_ty),
+                let unpack_types = match {
+                    let __ty_view_value = value_ty;
+                    (__ty_view_value, __ty_view_value.data())
+                } {
+                    (_, crate::types::TypeData::Union(union_ty)) => union_ty.elements(self.db()),
+                    (_, _) => std::slice::from_ref(&value_ty),
                 };
 
                 for ty in unpack_types.iter().copied() {

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -165,68 +165,88 @@ pub(super) enum TypeKind<'db> {
 
 impl<'db> From<Type<'db>> for TypeKind<'db> {
     fn from(ty: Type<'db>) -> Self {
-        match ty {
-            Type::AlwaysFalsy
-            | Type::AlwaysTruthy
-            | Type::Never
-            | Type::LiteralValue(_)
-            | Type::DataclassDecorator(_)
-            | Type::DataclassTransformer(_)
-            | Type::WrapperDescriptor(_)
-            | Type::ModuleLiteral(_)
-            | Type::ClassLiteral(_)
-            | Type::SpecialForm(_)
-            | Type::Divergent(_)
-            | Type::Dynamic(_) => TypeKind::Atomic,
+        match {
+            let __ty_view_value = ty;
+            (__ty_view_value, __ty_view_value.data())
+        } {
+            (
+                _,
+                crate::types::TypeData::AlwaysFalsy
+                | crate::types::TypeData::AlwaysTruthy
+                | crate::types::TypeData::Never
+                | crate::types::TypeData::LiteralValue(_)
+                | crate::types::TypeData::DataclassDecorator(_)
+                | crate::types::TypeData::DataclassTransformer(_)
+                | crate::types::TypeData::WrapperDescriptor(_)
+                | crate::types::TypeData::ModuleLiteral(_)
+                | crate::types::TypeData::ClassLiteral(_)
+                | crate::types::TypeData::SpecialForm(_)
+                | crate::types::TypeData::Divergent(_)
+                | crate::types::TypeData::Dynamic(_),
+            ) => TypeKind::Atomic,
 
             // Non-atomic types
-            Type::FunctionLiteral(function) => {
+            (_, crate::types::TypeData::FunctionLiteral(function)) => {
                 TypeKind::NonAtomic(NonAtomicType::FunctionLiteral(function))
             }
-            Type::Intersection(intersection) => {
+            (_, crate::types::TypeData::Intersection(intersection)) => {
                 TypeKind::NonAtomic(NonAtomicType::Intersection(intersection))
             }
-            Type::EnumComplement(complement) => {
+            (_, crate::types::TypeData::EnumComplement(complement)) => {
                 TypeKind::NonAtomic(NonAtomicType::EnumComplement(complement))
             }
-            Type::Union(union) => TypeKind::NonAtomic(NonAtomicType::Union(union)),
-            Type::BoundMethod(method) => TypeKind::NonAtomic(NonAtomicType::BoundMethod(method)),
-            Type::BoundSuper(bound_super) => {
+            (_, crate::types::TypeData::Union(union)) => {
+                TypeKind::NonAtomic(NonAtomicType::Union(union))
+            }
+            (_, crate::types::TypeData::BoundMethod(method)) => {
+                TypeKind::NonAtomic(NonAtomicType::BoundMethod(method))
+            }
+            (_, crate::types::TypeData::BoundSuper(bound_super)) => {
                 TypeKind::NonAtomic(NonAtomicType::BoundSuper(bound_super))
             }
-            Type::KnownBoundMethod(method_wrapper) => {
+            (_, crate::types::TypeData::KnownBoundMethod(method_wrapper)) => {
                 TypeKind::NonAtomic(NonAtomicType::MethodWrapper(method_wrapper))
             }
-            Type::Callable(callable) => TypeKind::NonAtomic(NonAtomicType::Callable(callable)),
-            Type::GenericAlias(alias) => TypeKind::NonAtomic(NonAtomicType::GenericAlias(alias)),
-            Type::KnownInstance(known_instance) => {
+            (_, crate::types::TypeData::Callable(callable)) => {
+                TypeKind::NonAtomic(NonAtomicType::Callable(callable))
+            }
+            (_, crate::types::TypeData::GenericAlias(alias)) => {
+                TypeKind::NonAtomic(NonAtomicType::GenericAlias(alias))
+            }
+            (_, crate::types::TypeData::KnownInstance(known_instance)) => {
                 TypeKind::NonAtomic(NonAtomicType::KnownInstance(known_instance))
             }
-            Type::SubclassOf(subclass_of) => {
+            (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
                 TypeKind::NonAtomic(NonAtomicType::SubclassOf(subclass_of))
             }
-            Type::NominalInstance(nominal) => {
+            (_, crate::types::TypeData::NominalInstance(nominal)) => {
                 TypeKind::NonAtomic(NonAtomicType::NominalInstance(nominal))
             }
-            Type::ProtocolInstance(protocol) => {
+            (_, crate::types::TypeData::ProtocolInstance(protocol)) => {
                 TypeKind::NonAtomic(NonAtomicType::ProtocolInstance(protocol))
             }
-            Type::PropertyInstance(property) => {
+            (_, crate::types::TypeData::PropertyInstance(property)) => {
                 TypeKind::NonAtomic(NonAtomicType::PropertyInstance(property))
             }
-            Type::TypeVar(bound_typevar) => {
+            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
                 TypeKind::NonAtomic(NonAtomicType::TypeVar(bound_typevar))
             }
-            Type::TypeIs(type_is) => TypeKind::NonAtomic(NonAtomicType::TypeIs(type_is)),
-            Type::TypeGuard(type_guard) => {
+            (_, crate::types::TypeData::TypeIs(type_is)) => {
+                TypeKind::NonAtomic(NonAtomicType::TypeIs(type_is))
+            }
+            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
                 TypeKind::NonAtomic(NonAtomicType::TypeGuard(type_guard))
             }
-            Type::TypeForm(typeform) => TypeKind::NonAtomic(NonAtomicType::TypeForm(typeform)),
-            Type::TypedDict(typed_dict) => {
+            (_, crate::types::TypeData::TypeForm(typeform)) => {
+                TypeKind::NonAtomic(NonAtomicType::TypeForm(typeform))
+            }
+            (_, crate::types::TypeData::TypedDict(typed_dict)) => {
                 TypeKind::NonAtomic(NonAtomicType::TypedDict(typed_dict))
             }
-            Type::TypeAlias(alias) => TypeKind::NonAtomic(NonAtomicType::TypeAlias(alias)),
-            Type::NewTypeInstance(newtype) => {
+            (_, crate::types::TypeData::TypeAlias(alias)) => {
+                TypeKind::NonAtomic(NonAtomicType::TypeAlias(alias))
+            }
+            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
                 TypeKind::NonAtomic(NonAtomicType::NewTypeInstance(newtype))
             }
         }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -6,7 +6,7 @@ use crate::{
         BoundMethodType, BoundSuperType, BoundTypeVarInstance, CallableType, EnumComplementType,
         GenericAlias, IntersectionType, KnownBoundMethodType, KnownInstanceType,
         NominalInstanceType, PropertyInstanceType, ProtocolInstanceType, SubclassOfType, Type,
-        TypeAliasType, TypeFormType, TypeGuardType, TypeIsType, TypedDictType, UnionType,
+        TypeAliasType, TypeFormType, TypeGuardType, TypeIsType, TypeTag, TypedDictType, UnionType,
         bound_super::walk_bound_super_type,
         callable::walk_callable_type,
         class::walk_generic_alias,
@@ -165,90 +165,82 @@ pub(super) enum TypeKind<'db> {
 
 impl<'db> From<Type<'db>> for TypeKind<'db> {
     fn from(ty: Type<'db>) -> Self {
-        match {
-            let __ty_view_value = ty;
-            (__ty_view_value, __ty_view_value.data())
-        } {
-            (
-                _,
-                crate::types::TypeData::AlwaysFalsy
-                | crate::types::TypeData::AlwaysTruthy
-                | crate::types::TypeData::Never
-                | crate::types::TypeData::LiteralValue(_)
-                | crate::types::TypeData::DataclassDecorator(_)
-                | crate::types::TypeData::DataclassTransformer(_)
-                | crate::types::TypeData::WrapperDescriptor(_)
-                | crate::types::TypeData::ModuleLiteral(_)
-                | crate::types::TypeData::ClassLiteral(_)
-                | crate::types::TypeData::SpecialForm(_)
-                | crate::types::TypeData::Divergent(_)
-                | crate::types::TypeData::Dynamic(_),
-            ) => TypeKind::Atomic,
+        match ty.tag {
+            TypeTag::AlwaysFalsy
+            | TypeTag::AlwaysTruthy
+            | TypeTag::Never
+            | TypeTag::LiteralValue
+            | TypeTag::DataclassDecorator
+            | TypeTag::DataclassTransformer
+            | TypeTag::WrapperDescriptor
+            | TypeTag::ModuleLiteral
+            | TypeTag::ClassLiteral
+            | TypeTag::SpecialForm
+            | TypeTag::Divergent
+            | TypeTag::Dynamic => TypeKind::Atomic,
 
             // Non-atomic types
-            (_, crate::types::TypeData::FunctionLiteral(function)) => {
-                TypeKind::NonAtomic(NonAtomicType::FunctionLiteral(function))
+            TypeTag::FunctionLiteral => {
+                TypeKind::NonAtomic(NonAtomicType::FunctionLiteral(ty.payload()))
             }
-            (_, crate::types::TypeData::Intersection(intersection)) => {
-                TypeKind::NonAtomic(NonAtomicType::Intersection(intersection))
+            TypeTag::Intersection => TypeKind::NonAtomic(NonAtomicType::Intersection(ty.payload())),
+            TypeTag::EnumComplement => {
+                TypeKind::NonAtomic(NonAtomicType::EnumComplement(ty.payload()))
             }
-            (_, crate::types::TypeData::EnumComplement(complement)) => {
-                TypeKind::NonAtomic(NonAtomicType::EnumComplement(complement))
+            TypeTag::Union => TypeKind::NonAtomic(NonAtomicType::Union(ty.payload())),
+            TypeTag::BoundMethod => TypeKind::NonAtomic(NonAtomicType::BoundMethod(ty.payload())),
+            TypeTag::BoundSuper => TypeKind::NonAtomic(NonAtomicType::BoundSuper(ty.payload())),
+            TypeTag::Callable => TypeKind::NonAtomic(NonAtomicType::Callable(ty.payload())),
+            TypeTag::GenericAlias => TypeKind::NonAtomic(NonAtomicType::GenericAlias(ty.payload())),
+            TypeTag::PropertyInstance => {
+                TypeKind::NonAtomic(NonAtomicType::PropertyInstance(ty.payload()))
             }
-            (_, crate::types::TypeData::Union(union)) => {
-                TypeKind::NonAtomic(NonAtomicType::Union(union))
+            TypeTag::TypeVar => TypeKind::NonAtomic(NonAtomicType::TypeVar(ty.payload())),
+            TypeTag::TypeIs => TypeKind::NonAtomic(NonAtomicType::TypeIs(ty.payload())),
+            TypeTag::TypeGuard => TypeKind::NonAtomic(NonAtomicType::TypeGuard(ty.payload())),
+            TypeTag::TypeForm => TypeKind::NonAtomic(NonAtomicType::TypeForm(ty.payload())),
+            TypeTag::TypeAlias => {
+                TypeKind::NonAtomic(NonAtomicType::TypeAlias(ty.as_lazy_type_alias().unwrap()))
             }
-            (_, crate::types::TypeData::BoundMethod(method)) => {
-                TypeKind::NonAtomic(NonAtomicType::BoundMethod(method))
+            TypeTag::NewTypeInstance => {
+                TypeKind::NonAtomic(NonAtomicType::NewTypeInstance(ty.payload()))
             }
-            (_, crate::types::TypeData::BoundSuper(bound_super)) => {
-                TypeKind::NonAtomic(NonAtomicType::BoundSuper(bound_super))
-            }
-            (_, crate::types::TypeData::KnownBoundMethod(method_wrapper)) => {
-                TypeKind::NonAtomic(NonAtomicType::MethodWrapper(method_wrapper))
-            }
-            (_, crate::types::TypeData::Callable(callable)) => {
-                TypeKind::NonAtomic(NonAtomicType::Callable(callable))
-            }
-            (_, crate::types::TypeData::GenericAlias(alias)) => {
-                TypeKind::NonAtomic(NonAtomicType::GenericAlias(alias))
-            }
-            (_, crate::types::TypeData::KnownInstance(known_instance)) => {
-                TypeKind::NonAtomic(NonAtomicType::KnownInstance(known_instance))
-            }
-            (_, crate::types::TypeData::SubclassOf(subclass_of)) => {
-                TypeKind::NonAtomic(NonAtomicType::SubclassOf(subclass_of))
-            }
-            (_, crate::types::TypeData::NominalInstance(nominal)) => {
-                TypeKind::NonAtomic(NonAtomicType::NominalInstance(nominal))
-            }
-            (_, crate::types::TypeData::ProtocolInstance(protocol)) => {
-                TypeKind::NonAtomic(NonAtomicType::ProtocolInstance(protocol))
-            }
-            (_, crate::types::TypeData::PropertyInstance(property)) => {
-                TypeKind::NonAtomic(NonAtomicType::PropertyInstance(property))
-            }
-            (_, crate::types::TypeData::TypeVar(bound_typevar)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypeVar(bound_typevar))
-            }
-            (_, crate::types::TypeData::TypeIs(type_is)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypeIs(type_is))
-            }
-            (_, crate::types::TypeData::TypeGuard(type_guard)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypeGuard(type_guard))
-            }
-            (_, crate::types::TypeData::TypeForm(typeform)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypeForm(typeform))
-            }
-            (_, crate::types::TypeData::TypedDict(typed_dict)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypedDict(typed_dict))
-            }
-            (_, crate::types::TypeData::TypeAlias(alias)) => {
-                TypeKind::NonAtomic(NonAtomicType::TypeAlias(alias))
-            }
-            (_, crate::types::TypeData::NewTypeInstance(newtype)) => {
-                TypeKind::NonAtomic(NonAtomicType::NewTypeInstance(newtype))
-            }
+            TypeTag::KnownBoundMethod => match ty.data() {
+                crate::types::TypeData::KnownBoundMethod(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::MethodWrapper(value))
+                }
+                _ => unreachable!(),
+            },
+            TypeTag::KnownInstance => match ty.data() {
+                crate::types::TypeData::KnownInstance(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::KnownInstance(value))
+                }
+                _ => unreachable!(),
+            },
+            TypeTag::SubclassOf => match ty.data() {
+                crate::types::TypeData::SubclassOf(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::SubclassOf(value))
+                }
+                _ => unreachable!(),
+            },
+            TypeTag::NominalInstance => match ty.data() {
+                crate::types::TypeData::NominalInstance(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::NominalInstance(value))
+                }
+                _ => unreachable!(),
+            },
+            TypeTag::ProtocolInstance => match ty.data() {
+                crate::types::TypeData::ProtocolInstance(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::ProtocolInstance(value))
+                }
+                _ => unreachable!(),
+            },
+            TypeTag::TypedDict => match ty.data() {
+                crate::types::TypeData::TypedDict(value) => {
+                    TypeKind::NonAtomic(NonAtomicType::TypedDict(value))
+                }
+                _ => unreachable!(),
+            },
         }
     }
 }


### PR DESCRIPTION
This draft tests reducing the release representation of `Type` from 16 bytes to 12 bytes. `Type` values are pervasive across inference results, signatures, collections, and Salsa query values, so the smaller representation may improve cache density and retained memory.

The prototype replaces the public enum representation with an eight-byte payload, an outer tag, and three bytes for nested discriminants and flags. Payloads retain the full 64-bit Salsa ID or scalar value. Nested families such as dynamic types, class literals, nominal instances, literal values, and special forms are flattened into the tag/detail bytes, while `TypeData` provides the logical enum used for destructuring. This accounts for the broad mechanical migration from direct enum patterns to logical views.

The final representation canonicalizes nested payloads so raw equality, hashing, and Salsa updates remain correct without reconstructing `TypeData` on those hot paths. Release layout and representative round trips are asserted, and the full `ty_python_semantic` and `ty_ide` suites pass.

This is intentionally a draft so CodSpeed can measure whether the cache-density improvement outweighs the cost of unpacking logical variants.
