### PR TITLE
[ty] Recognize standard IntEnum equality

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,245 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+`IntEnum` members use integer equality. The standard `IntEnum` constructor preserves integer literal
+values, so these comparisons can narrow both operands:
+
+```py
+from enum import IntEnum, auto
+from typing import Literal
+from typing_extensions import assert_never
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+def narrow_int_enum(number: Number):
+    if number == 1:
+        reveal_type(number)  # revealed: Literal[Number.ONE]
+    else:
+        reveal_type(number)  # revealed: Literal[Number.TWO]
+
+def int_enum_on_left(number: Literal[Number.ONE]):
+    if number == 1:
+        reveal_type(number)  # revealed: Literal[Number.ONE]
+    else:
+        assert_never(number)
+
+def int_enum_on_right(number: Literal[Number.ONE]):
+    if 1 == number:
+        reveal_type(number)  # revealed: Literal[Number.ONE]
+    else:
+        assert_never(number)
+
+class AutoNumber(IntEnum):
+    ONE = auto()
+    TWO = auto()
+
+def narrow_auto_int_enum(number: AutoNumber):
+    if number == 1:
+        reveal_type(number)  # revealed: Literal[AutoNumber.ONE]
+    else:
+        reveal_type(number)  # revealed: Literal[AutoNumber.TWO]
+```
+
+A custom constructor can replace an `IntEnum` member's runtime value, so these comparisons remain
+ambiguous:
+
+```py
+from enum import IntEnum
+
+class ShiftedNumber(IntEnum):
+    def __new__(cls, value: int) -> "ShiftedNumber":
+        member = int.__new__(cls, value + 1)
+        member._value_ = value + 1
+        return member
+
+    ONE = 1
+    TWO = 2
+
+def _(number: ShiftedNumber):
+    if number == 1:
+        reveal_type(number)  # revealed: ShiftedNumber
+    else:
+        reveal_type(number)  # revealed: ShiftedNumber
+```
+
+This also applies when the custom constructor is assigned through `staticmethod`:
+
+```py
+from enum import IntEnum, auto
+from typing import Literal
+
+def shifted_new(cls: type["AssignedShiftedNumber"], value: int) -> "AssignedShiftedNumber":
+    member = int.__new__(cls, value + 10)
+    member._value_ = value + 10
+    return member
+
+class AssignedShiftedNumber(IntEnum):
+    __new__ = staticmethod(shifted_new)
+    ONE = 1
+
+def shifted_auto_new(cls: type["AssignedAutoShiftedNumber"], value: int) -> "AssignedAutoShiftedNumber":
+    member = int.__new__(cls, value + 10)
+    member._value_ = value + 10
+    return member
+
+class AssignedAutoShiftedNumber(IntEnum):
+    __new__ = staticmethod(shifted_auto_new)
+    ONE = 1
+    ANSWER = auto()
+
+def _(number: Literal[AssignedShiftedNumber.ONE]):
+    if number == 1:
+        reveal_type(number)  # revealed: AssignedShiftedNumber
+    else:
+        reveal_type(number)  # revealed: AssignedShiftedNumber
+
+    if number == 11:
+        reveal_type(number)  # revealed: AssignedShiftedNumber
+    else:
+        reveal_type(number)  # revealed: AssignedShiftedNumber
+
+def _(number: Literal[AssignedAutoShiftedNumber.ANSWER]):
+    reveal_type(number)  # revealed: Literal[AssignedAutoShiftedNumber.ANSWER]
+```
+
+A custom `_generate_next_value_` means the placeholder for an `auto()` member is not its runtime
+value. Comparisons against either value therefore remain ambiguous:
+
+```py
+from enum import IntEnum, auto
+from typing import Literal
+
+class GeneratedNumber(IntEnum):
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return 42
+
+    ANSWER = auto()
+
+def _(number: Literal[GeneratedNumber.ANSWER]):
+    if number == 1:
+        reveal_type(number)  # revealed: GeneratedNumber
+    else:
+        reveal_type(number)  # revealed: GeneratedNumber
+
+    if number == 42:
+        reveal_type(number)  # revealed: GeneratedNumber
+    else:
+        reveal_type(number)  # revealed: GeneratedNumber
+```
+
+Assigned custom generators are likewise treated conservatively:
+
+```py
+from enum import IntEnum, auto
+from typing import Literal
+
+def generated(name: str, start: int, count: int, last_values: list[int]) -> int:
+    return 42
+
+class AssignedGeneratedNumber(IntEnum):
+    _generate_next_value_ = staticmethod(generated)
+    ONE = 1
+    ANSWER = auto()
+
+def _(number: Literal[AssignedGeneratedNumber.ANSWER]):
+    if number == 1:
+        reveal_type(number)  # revealed: Literal[AssignedGeneratedNumber.ANSWER]
+    else:
+        reveal_type(number)  # revealed: Literal[AssignedGeneratedNumber.ANSWER]
+
+    if number == 42:
+        reveal_type(number)  # revealed: Literal[AssignedGeneratedNumber.ANSWER]
+    else:
+        reveal_type(number)  # revealed: Literal[AssignedGeneratedNumber.ANSWER]
+```
+
+A custom metaclass can also rewrite values through the namespace returned by `__prepare__`:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from enum import EnumDict, EnumType, IntEnum
+from typing import Any, Literal
+
+class ShiftedEnumDict(EnumDict):
+    def __setitem__(self, key: str, value: object) -> None:
+        if key.isupper() and isinstance(value, int):
+            value += 10
+        super().__setitem__(key, value)
+
+class ShiftedEnumType(EnumType):
+    @classmethod
+    def __prepare__(metacls, cls: str, bases: tuple[type, ...], **kwds: Any) -> ShiftedEnumDict:
+        return ShiftedEnumDict(cls)
+
+class PreparedNumber(IntEnum, metaclass=ShiftedEnumType):
+    ONE = 1
+
+def _(number: Literal[PreparedNumber.ONE]):
+    if number == 1:
+        reveal_type(number)  # revealed: PreparedNumber
+    else:
+        reveal_type(number)  # revealed: PreparedNumber
+
+    if number == 11:
+        reveal_type(number)  # revealed: PreparedNumber
+    else:
+        reveal_type(number)  # revealed: PreparedNumber
+```
+
+The right operand's reflected equality method takes precedence when it is a strict subclass of the
+left operand's type, so reversing the operands is still ambiguous for an `IntEnum` with a custom
+`__eq__`:
+
+```py
+from enum import IntEnum
+from typing import Literal
+
+class NeverEqualNumber(IntEnum):
+    ONE = 1
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+def _(number: Literal[NeverEqualNumber.ONE]):
+    if 1 == number:
+        reveal_type(number)  # revealed: NeverEqualNumber
+    else:
+        reveal_type(number)  # revealed: NeverEqualNumber
+```
+
+Boolean and integer values with the same runtime value are aliases under the standard `IntEnum`
+constructor:
+
+```py
+from enum import IntEnum
+from typing import Literal
+from typing_extensions import assert_never
+
+class BooleanNumber(IntEnum):
+    FALSE = False
+    ZERO = 0
+    TRUE = True
+    ONE = 1
+
+def _(number: Literal[BooleanNumber.ZERO]):
+    if number == BooleanNumber.FALSE:
+        reveal_type(number)  # revealed: Literal[BooleanNumber.FALSE]
+    else:
+        assert_never(number)
+
+    if number == 0:
+        reveal_type(number)  # revealed: Literal[BooleanNumber.FALSE]
+    else:
+        assert_never(number)
+```
+
 This narrowing behavior is only safe if the enum has no custom `__eq__`/`__ne__` method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -593,7 +593,7 @@ python-version = "3.11"
 ```
 
 ```py
-from enum import Enum, StrEnum
+from enum import Enum, IntEnum, StrEnum, auto
 from typing import Literal, assert_never, reveal_type
 
 class Color(StrEnum):
@@ -620,6 +620,62 @@ def test_enum_as_literal(y: Literal[Color.BLUE]) -> None:
             assert_never(y)
         case "b":
             reveal_type(y)  # revealed: Literal[Color.BLUE]
+        case _:
+            assert_never(y)
+
+class Number(IntEnum):
+    ONE = 1
+    TWO = 2
+
+def test_int_literal_as_enum(x: Literal[1]) -> None:
+    match x:
+        case Number.ONE:
+            reveal_type(x)  # revealed: Literal[1]
+        case _:
+            assert_never(x)
+
+def test_enum_as_int_literal(y: Literal[Number.ONE]) -> None:
+    match y:
+        case 1:
+            reveal_type(y)  # revealed: Literal[Number.ONE]
+        case _:
+            assert_never(y)
+
+class GeneratedNumber(IntEnum):
+    @staticmethod
+    def _generate_next_value_(name, start, count, last_values):
+        return 42
+
+    ANSWER = auto()
+
+def test_generated_int_enum(y: Literal[GeneratedNumber.ANSWER]) -> None:
+    match y:
+        case 1:
+            reveal_type(y)  # revealed: GeneratedNumber
+        case _:
+            reveal_type(y)  # revealed: GeneratedNumber
+
+class NeverEqualNumber(IntEnum):
+    ONE = 1
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+def test_reversed_custom_int_enum_equality(x: Literal[1]) -> None:
+    match x:
+        case NeverEqualNumber.ONE:
+            reveal_type(x)  # revealed: Literal[1]
+        case _:
+            reveal_type(x)  # revealed: Literal[1]
+
+class BooleanNumber(IntEnum):
+    FALSE = False
+    ZERO = 0
+
+def test_bool_int_enum_alias(y: Literal[BooleanNumber.ZERO]) -> None:
+    match y:
+        case BooleanNumber.FALSE:
+            reveal_type(y)  # revealed: BooleanNumber
         case _:
             assert_never(y)
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -22,6 +23,27 @@ use crate::{
     },
 };
 use ty_python_core::{definition::DefinitionKind, place_table, scope::ScopeId, use_def_map};
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::Update)]
+    struct EnumValueSemantics: u8 {
+        const USER_DEFINED_INIT = 1 << 0;
+        const USER_DEFINED_NEW = 1 << 1;
+        const STANDARD_INT_CONSTRUCTOR = 1 << 2;
+        const USER_DEFINED_GENERATE_NEXT_VALUE = 1 << 3;
+        const CUSTOM_METACLASS_HOOKS = 1 << 4;
+    }
+}
+
+impl get_size2::GetSize for EnumValueSemantics {}
+
+impl EnumValueSemantics {
+    fn has_standard_int_value_semantics(self) -> bool {
+        self.contains(Self::STANDARD_INT_CONSTRUCTOR)
+            && !self.contains(Self::USER_DEFINED_INIT)
+            && !self.contains(Self::CUSTOM_METACLASS_HOOKS)
+    }
+}
 
 #[derive(Debug, PartialEq, Eq, salsa::Update)]
 pub(crate) struct EnumMetadata<'db> {
@@ -52,9 +74,7 @@ pub(crate) struct EnumMetadata<'db> {
     /// When present, defines the value returned by calls to `auto()`
     pub(crate) generate_next_value_function: Option<FunctionType<'db>>,
 
-    /// Whether the enum metaclass may transform member values before they are
-    /// passed to enum construction hooks.
-    pub(crate) custom_enum_metaclass_new: bool,
+    value_semantics: EnumValueSemantics,
 }
 
 impl get_size2::GetSize for EnumMetadata<'_> {}
@@ -160,7 +180,7 @@ impl<'db> EnumMetadata<'db> {
             init_function: None,
             new_function: None,
             generate_next_value_function: None,
-            custom_enum_metaclass_new: false,
+            value_semantics: EnumValueSemantics::default(),
         }
     }
 
@@ -177,7 +197,7 @@ impl<'db> EnumMetadata<'db> {
             Some(annotation)
         } else if self.init_function.is_some()
             || self.new_function.is_some()
-            || self.custom_enum_metaclass_new
+            || self.has_custom_metaclass_hooks()
         {
             Some(Type::Dynamic(DynamicType::Any))
         } else if let Some(func_ty) = self.generate_next_value_function
@@ -187,6 +207,59 @@ impl<'db> EnumMetadata<'db> {
         } else {
             self.members.get(member_name).copied()
         }
+    }
+
+    /// Returns the statically known runtime value of an enum member.
+    ///
+    /// Custom construction hooks can replace the declared value. The standard `IntEnum`
+    /// constructor is an exception: it preserves integer literals and converts boolean literals
+    /// to their corresponding integer values. For `auto()` members with a user-defined
+    /// `_generate_next_value_`, the collected placeholder is not reliable enough to use here.
+    pub(crate) fn runtime_value_type(
+        &self,
+        db: &'db dyn Db,
+        member_name: &Name,
+    ) -> Option<Type<'db>> {
+        let member_name = self.resolve_member(member_name)?;
+        if self
+            .value_semantics
+            .contains(EnumValueSemantics::USER_DEFINED_INIT)
+            || self.has_custom_metaclass_hooks()
+        {
+            return None;
+        }
+
+        let declared_value = self.members.get(member_name).copied()?;
+        if self
+            .value_semantics
+            .contains(EnumValueSemantics::STANDARD_INT_CONSTRUCTOR)
+        {
+            if self.auto_members.contains(member_name)
+                && self
+                    .value_semantics
+                    .contains(EnumValueSemantics::USER_DEFINED_GENERATE_NEXT_VALUE)
+            {
+                return None;
+            }
+            declared_value.as_int_like_literal().map(Type::int_literal)
+        } else if self.new_function.is_some() {
+            None
+        } else if self.auto_members.contains(member_name) {
+            self.value_type(db, member_name)
+        } else {
+            Some(declared_value)
+        }
+    }
+
+    /// Returns whether this enum has standard `IntEnum` value-construction semantics.
+    pub(crate) fn has_standard_int_value_semantics(&self) -> bool {
+        self.value_semantics.has_standard_int_value_semantics()
+    }
+
+    /// Returns whether the enum metaclass may transform member values before construction hooks.
+    pub(crate) fn has_custom_metaclass_hooks(&self) -> bool {
+        self.value_semantics
+            .contains(EnumValueSemantics::CUSTOM_METACLASS_HOOKS)
     }
 
     /// Returns the type of `.name`/`._name_` for a given enum member.
@@ -214,7 +287,7 @@ impl<'db> EnumMetadata<'db> {
             Some(annotation)
         } else if self.init_function.is_some()
             || self.new_function.is_some()
-            || self.custom_enum_metaclass_new
+            || self.has_custom_metaclass_hooks()
         {
             Some(Type::Dynamic(DynamicType::Any))
         } else {
@@ -571,25 +644,43 @@ fn try_register_alias<'db>(
 /// value instead of the pre-generator placeholder used while collecting
 /// members.
 ///
-/// Returns `None` for `auto()` members when `__new__` or a custom metaclass can
-/// rewrite `_value_` before alias registration, because neither the generated
-/// value nor the placeholder is reliable alias evidence in that case.
+/// Returns `None` for `auto()` members when `__new__`, a custom metaclass, or an unmodeled custom
+/// `_generate_next_value_` can rewrite `_value_` before alias registration, because neither the
+/// generated value nor the placeholder is reliable alias evidence in that case.
+#[derive(Clone, Copy)]
+struct AliasDetectionContext<'db> {
+    generate_next_value_function: Option<FunctionType<'db>>,
+    unmodeled_generate_next_value: bool,
+    value_semantics: EnumValueSemantics,
+}
+
 fn alias_detection_value<'db>(
     db: &'db dyn Db,
     value_ty: Type<'db>,
     is_auto: bool,
-    generate_next_value_function: Option<FunctionType<'db>>,
-    user_defined_new_function: Option<FunctionType<'db>>,
-    custom_enum_metaclass_new: bool,
+    context: AliasDetectionContext<'db>,
 ) -> Option<Type<'db>> {
-    if !is_auto {
+    let value = if !is_auto {
         Some(value_ty)
-    } else if user_defined_new_function.is_some() || custom_enum_metaclass_new {
+    } else if context
+        .value_semantics
+        .contains(EnumValueSemantics::USER_DEFINED_NEW)
+        || context
+            .value_semantics
+            .contains(EnumValueSemantics::CUSTOM_METACLASS_HOOKS)
+        || context.unmodeled_generate_next_value
+    {
         None
-    } else if let Some(func_ty) = generate_next_value_function {
+    } else if let Some(func_ty) = context.generate_next_value_function {
         Some(func_ty.signature(db).overload_return_type_or_unknown(db))
     } else {
         Some(value_ty)
+    };
+
+    if context.value_semantics.has_standard_int_value_semantics() {
+        value?.as_int_like_literal().map(Type::int_literal)
+    } else {
+        value
     }
 }
 
@@ -638,7 +729,7 @@ pub(crate) fn enum_metadata<'db>(
                 init_function: None,
                 new_function: None,
                 generate_next_value_function: None,
-                custom_enum_metaclass_new: false,
+                value_semantics: EnumValueSemantics::default(),
             });
         }
     };
@@ -667,13 +758,58 @@ pub(crate) fn enum_metadata<'db>(
     let ignored_names = enum_ignored_names(db, scope_id);
 
     // Look up custom construction hooks, falling back to parent enum classes.
+    let user_defined_init = has_custom_hook_binding(db, scope_id, "__init__")
+        || inherited_user_defined_hook_binding(db, class, "__init__");
     let init_function = custom_init(db, scope_id).or_else(|| inherited_init(db, class));
+    let user_defined_new = has_custom_hook_binding(db, scope_id, "__new__")
+        || inherited_user_defined_hook_binding(db, class, "__new__");
     let user_defined_new_function =
         custom_new(db, scope_id).or_else(|| inherited_user_defined_new(db, class));
     let new_function = user_defined_new_function.or_else(|| inherited_new(db, class));
-    let custom_enum_metaclass_new = custom_enum_metaclass_new(db, class);
-    let generate_next_value_function = custom_generate_next_value(db, scope_id)
+    let custom_enum_metaclass_hooks = custom_enum_metaclass_hooks(db, class);
+    let user_defined_generate_next_value =
+        has_custom_hook_binding(db, scope_id, "_generate_next_value_")
+            || inherited_user_defined_hook_binding(db, class, "_generate_next_value_");
+    let user_defined_generate_next_value_function = custom_generate_next_value(db, scope_id)
+        .or_else(|| inherited_user_defined_generate_next_value(db, class));
+    let generate_next_value_function = user_defined_generate_next_value_function
         .or_else(|| inherited_generate_next_value(db, class));
+    let standard_int_new = KnownClass::IntEnum
+        .to_class_literal(db)
+        .to_class_type(db)
+        .and_then(|class| {
+            class
+                .own_class_member(db, None, "__new__")
+                .inner
+                .place
+                .raw_type()
+        });
+    let standard_int_constructor = !user_defined_new
+        && new_function.map(Type::FunctionLiteral) == standard_int_new
+        && ClassLiteral::Static(class)
+            .to_non_generic_instance(db)
+            .is_subtype_of(db, KnownClass::Int.to_instance(db));
+    let mut value_semantics = EnumValueSemantics::empty();
+    value_semantics.set(EnumValueSemantics::USER_DEFINED_INIT, user_defined_init);
+    value_semantics.set(EnumValueSemantics::USER_DEFINED_NEW, user_defined_new);
+    value_semantics.set(
+        EnumValueSemantics::STANDARD_INT_CONSTRUCTOR,
+        standard_int_constructor,
+    );
+    value_semantics.set(
+        EnumValueSemantics::USER_DEFINED_GENERATE_NEXT_VALUE,
+        user_defined_generate_next_value,
+    );
+    value_semantics.set(
+        EnumValueSemantics::CUSTOM_METACLASS_HOOKS,
+        custom_enum_metaclass_hooks,
+    );
+    let alias_detection_context = AliasDetectionContext {
+        generate_next_value_function,
+        unmodeled_generate_next_value: user_defined_generate_next_value
+            && user_defined_generate_next_value_function.is_none(),
+        value_semantics,
+    };
 
     let mut aliases = FxHashMap::default();
 
@@ -814,9 +950,7 @@ pub(crate) fn enum_metadata<'db>(
                 db,
                 value_ty,
                 auto_members.contains(name),
-                generate_next_value_function,
-                user_defined_new_function,
-                custom_enum_metaclass_new,
+                alias_detection_context,
             );
             if let Some(alias_value_ty) = alias_value_ty
                 && try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
@@ -865,7 +999,7 @@ pub(crate) fn enum_metadata<'db>(
 
     let custom_value_annotation = custom_value_annotation(db, scope_id);
     let value_annotation = custom_value_annotation.or_else(|| {
-        if custom_enum_metaclass_new {
+        if custom_enum_metaclass_hooks {
             inherited_user_defined_value_annotation(db, class)
         } else {
             inherited_value_annotation(db, class)
@@ -882,16 +1016,17 @@ pub(crate) fn enum_metadata<'db>(
         init_function,
         new_function,
         generate_next_value_function,
-        custom_enum_metaclass_new,
+        value_semantics,
     })
 }
 
-/// Returns whether an enum's metaclass has a custom `__new__` before the stdlib
+/// Returns whether an enum's metaclass has a custom value-transforming hook before the stdlib
 /// `EnumType`/`EnumMeta` implementation.
 ///
-/// Such a metaclass can rewrite the class dictionary's member values before the
-/// stdlib enum constructor validates and forwards them to `__new__`/`__init__`.
-fn custom_enum_metaclass_new<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
+/// `__prepare__` can return a namespace that rewrites assignments, and `__new__` can rewrite the
+/// completed class dictionary. Either hook can therefore change member values before the stdlib
+/// enum constructor validates and forwards them to `__new__`/`__init__`.
+fn custom_enum_metaclass_hooks<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
     let Some(metaclass) = class.metaclass(db).to_class_type(db) else {
         return false;
     };
@@ -902,7 +1037,11 @@ fn custom_enum_metaclass_new<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db
         .filter_map(ClassBase::into_class)
         .filter_map(|base| base.class_literal(db).as_static())
         .take_while(|base| base.known(db) != Some(KnownClass::EnumType))
-        .any(|base| custom_new(db, base.body_scope(db)).is_some())
+        .any(|base| {
+            ["__prepare__", "__new__"]
+                .into_iter()
+                .any(|name| has_custom_hook_binding(db, base.body_scope(db), name))
+        })
 }
 
 /// Iterates over parent enum classes in the MRO, skipping known enum
@@ -956,6 +1095,17 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
+/// Returns whether a user-defined parent enum declares the named hook.
+fn inherited_user_defined_hook_binding<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    name: &str,
+) -> bool {
+    iter_parent_enum_classes(db, class)
+        .filter(|base| base.known(db).is_none())
+        .any(|base| has_custom_hook_binding(db, base.body_scope(db), name))
+}
+
 /// Looks up an inherited `__init__` from parent enum classes in the MRO.
 fn inherited_init<'db>(
     db: &'db dyn Db,
@@ -989,6 +1139,27 @@ fn inherited_generate_next_value<'db>(
 ) -> Option<FunctionType<'db>> {
     iter_parent_enum_classes(db, class)
         .find_map(|base| custom_generate_next_value(db, base.body_scope(db)))
+}
+
+/// Looks up an inherited `_generate_next_value_` from user-defined parent enum classes in the MRO.
+fn inherited_user_defined_generate_next_value<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<FunctionType<'db>> {
+    iter_parent_enum_classes(db, class)
+        .filter(|base| base.known(db).is_none())
+        .find_map(|base| custom_generate_next_value(db, base.body_scope(db)))
+}
+
+/// Returns whether the scope contains a binding for the named enum hook.
+fn has_custom_hook_binding(db: &dyn Db, scope: ScopeId, name: &str) -> bool {
+    let Some(symbol_id) = place_table(db, scope).symbol_id(name) else {
+        return false;
+    };
+    use_def_map(db, scope)
+        .end_of_scope_symbol_bindings(symbol_id)
+        .next()
+        .is_some()
 }
 
 /// Returns the custom `__init__` function type if one is defined on the enum.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -5,7 +5,7 @@ use crate::{Db, place::PlaceAndQualifiers};
 use super::{
     EnumLiteralType, IntersectionBuilder, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
     Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
-    enums::{enum_member_literals, enum_metadata},
+    enums::{EnumMetadata, enum_member_literals, enum_metadata},
 };
 
 /// The result of evaluating a runtime comparison between two types.
@@ -86,6 +86,7 @@ pub(super) fn evaluate_type_equality<'db>(
     is_positive: bool,
 ) -> Option<Type<'db>> {
     enum_literal_constraint(db, left, right, ComparisonOperator::Equality, is_positive)
+        .or_else(|| standard_int_enum_constraint(db, left, right, is_positive))
         .or_else(|| builtin_literal_constraint(db, left, right, is_positive))
         .or_else(|| {
             if comparison_domain(db, left, right, ComparisonOperator::Equality)
@@ -97,6 +98,76 @@ pub(super) fn evaluate_type_equality<'db>(
                 None
             }
         })
+}
+
+/// Return a constraint for equality between a standard `IntEnum` and an integer-like literal.
+///
+/// This runs before the built-in literal shortcut only for the narrow enum/integer case. Running
+/// the full recursive comparison evaluator for every literal comparison makes guarded literal
+/// chains quadratic.
+fn standard_int_enum_constraint<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    if is_int_like_literal(right) && is_standard_int_enum_domain(db, left) {
+        return comparison_result(db, left, right, is_positive, ComparisonOperator::Equality)
+            .constraint(is_positive);
+    }
+
+    let LiteralValueTypeKind::Enum(right_enum) = right.as_literal_value_kind()? else {
+        return None;
+    };
+    let metadata = enum_metadata(db, right_enum.enum_class(db))?;
+    if !metadata.has_standard_int_value_semantics()
+        || KnownComparisonSemantics::of_instance(
+            db,
+            right_enum.enum_class_instance(db),
+            ComparisonOperator::Equality,
+        ) != Some(KnownComparisonSemantics::Int)
+    {
+        return None;
+    }
+    let right_value = metadata.runtime_value_type(db, right_enum.name(db))?;
+    builtin_literal_constraint(db, left, right_value, is_positive)
+}
+
+fn is_int_like_literal(ty: Type) -> bool {
+    matches!(
+        ty,
+        Type::LiteralValue(literal)
+            if matches!(
+                literal.kind(),
+                LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_)
+            )
+    )
+}
+
+fn is_standard_int_enum_domain(db: &dyn Db, ty: Type) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::LiteralValue(literal) => {
+            let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                return false;
+            };
+            enum_metadata(db, literal.enum_class(db))
+                .is_some_and(EnumMetadata::has_standard_int_value_semantics)
+        }
+        Type::NominalInstance(instance) => enum_metadata(db, instance.class_literal(db))
+            .is_some_and(EnumMetadata::has_standard_int_value_semantics),
+        Type::EnumComplement(complement) => enum_metadata(db, complement.enum_class(db))
+            .is_some_and(EnumMetadata::has_standard_int_value_semantics),
+        Type::Intersection(intersection) => {
+            intersection.enum_complement(db).is_some_and(|complement| {
+                is_standard_int_enum_domain(db, Type::EnumComplement(complement))
+            })
+        }
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_standard_int_enum_domain(db, *element)),
+        _ => false,
+    }
 }
 
 /// Return a constraint for `left` in a branch where `left != right` has the given truthiness.
@@ -1217,18 +1288,7 @@ fn known_literal_equality<'db>(
 /// Custom enum construction can replace the declared value, so members of such enums return `None`.
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
     let metadata = enum_metadata(db, literal.enum_class(db))?;
-    let name = metadata.resolve_member(literal.name(db))?;
-    if metadata.init_function.is_some()
-        || metadata.new_function.is_some()
-        || metadata.custom_enum_metaclass_new
-    {
-        return None;
-    }
-    if metadata.auto_members.contains(name) {
-        metadata.value_type(db, name)
-    } else {
-        metadata.members.get(name).copied()
-    }
+    metadata.runtime_value_type(db, literal.name(db))
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -255,7 +255,7 @@ fn check_class_declaration<'db>(
             let is_auto = enum_info.auto_members.contains(&member.name);
             let skip_type_check = (context.in_stub() && is_ellipsis)
                 || is_auto
-                || enum_info.custom_enum_metaclass_new;
+                || enum_info.has_custom_metaclass_hooks();
 
             if !skip_type_check {
                 if let Some(new_function) = enum_info.new_function {


### PR DESCRIPTION
## Summary

Stacks on #25788.

This recognizes equality between standard `IntEnum` members and their integer or boolean runtime values without moving the full recursive comparison evaluator onto ordinary literal comparisons.

Exact runtime-value handling now lives in cached enum metadata. It is enabled only when the enum uses the standard `IntEnum` constructor and has no user-defined value-construction hooks. Custom `__init__`, `__new__`, `_generate_next_value_`, metaclass `__prepare__`, and metaclass `__new__` paths remain conservative, including hooks assigned through `staticmethod`.

The change also normalizes boolean and integer values when registering aliases under standard `IntEnum` semantics, while avoiding placeholder-based aliases for unmodeled custom generators.

## Test plan

- `cargo nextest run -p ty_python_semantic -- mdtest::narrow/conditionals/eq.md`
- `cargo nextest run -p ty_python_semantic -- mdtest::narrow/match.md`
- `cargo nextest run -p ty_python_semantic`
- `uvx prek run --files crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md crates/ty_python_semantic/resources/mdtest/narrow/match.md crates/ty_python_semantic/src/types/enums.rs crates/ty_python_semantic/src/types/equality.rs crates/ty_python_semantic/src/types/overrides.rs`
