### PR TITLE
[ty] respect client's content format preference

### DIFF
--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -78,6 +78,15 @@ impl FromStr for SupportedCommand {
     }
 }
 
+/// Returns the preferred markup kind, derived from preference list.
+fn preferred_markup_kind<'a>(
+    formats: impl IntoIterator<Item = &'a MarkupKind>,
+) -> Option<&'a MarkupKind> {
+    formats
+        .into_iter()
+        .find(|markup_kind| matches!(markup_kind, MarkupKind::Markdown | MarkupKind::PlainText))
+}
+
 impl ResolvedClientCapabilities {
     /// Returns `true` if the client supports workspace diagnostic refresh.
     pub(crate) const fn supports_workspace_diagnostic_refresh(self) -> bool {
@@ -264,35 +273,20 @@ impl ResolvedClientCapabilities {
         }
 
         if text_document
-            .and_then(|text_document| {
-                Some(
-                    text_document
-                        .hover
-                        .as_ref()?
-                        .content_format
-                        .as_ref()?
-                        .contains(&MarkupKind::Markdown),
-                )
-            })
-            .unwrap_or_default()
+            .and_then(|document| document.hover.as_ref())
+            .and_then(|hover| hover.content_format.as_ref())
+            .and_then(preferred_markup_kind)
+            .is_some_and(|first_supported| matches!(first_supported, MarkupKind::Markdown))
         {
             flags |= Self::PREFER_MARKDOWN_IN_HOVER;
         }
 
         if text_document
-            .and_then(|text_document| {
-                Some(
-                    text_document
-                        .completion
-                        .as_ref()?
-                        .completion_item
-                        .as_ref()?
-                        .documentation_format
-                        .as_ref()?
-                        .contains(&MarkupKind::Markdown),
-                )
-            })
-            .unwrap_or_default()
+            .and_then(|document| document.completion.as_ref())
+            .and_then(|completion| completion.completion_item.as_ref())
+            .and_then(|completion_item| completion_item.documentation_format.as_ref())
+            .and_then(preferred_markup_kind)
+            .is_some_and(|first_supported| matches!(first_supported, MarkupKind::Markdown))
         {
             flags |= Self::PREFER_MARKDOWN_IN_COMPLETION;
         }

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -79,11 +79,9 @@ impl FromStr for SupportedCommand {
 }
 
 /// Returns the preferred markup kind, derived from preference list.
-fn preferred_markup_kind<'a>(
-    formats: impl IntoIterator<Item = &'a MarkupKind>,
-) -> Option<&'a MarkupKind> {
+fn preferred_markup_kind(formats: &[MarkupKind]) -> Option<&MarkupKind> {
     formats
-        .into_iter()
+        .iter()
         .find(|markup_kind| matches!(markup_kind, MarkupKind::Markdown | MarkupKind::PlainText))
 }
 
@@ -274,9 +272,8 @@ impl ResolvedClientCapabilities {
 
         if text_document
             .and_then(|document| document.hover.as_ref())
-            .and_then(|hover| hover.content_format.as_ref())
-            .and_then(preferred_markup_kind)
-            .is_some_and(|first_supported| matches!(first_supported, MarkupKind::Markdown))
+            .and_then(|hover| preferred_markup_kind(hover.content_format.as_deref()?))
+            == Some(&MarkupKind::Markdown)
         {
             flags |= Self::PREFER_MARKDOWN_IN_HOVER;
         }
@@ -284,9 +281,10 @@ impl ResolvedClientCapabilities {
         if text_document
             .and_then(|document| document.completion.as_ref())
             .and_then(|completion| completion.completion_item.as_ref())
-            .and_then(|completion_item| completion_item.documentation_format.as_ref())
-            .and_then(preferred_markup_kind)
-            .is_some_and(|first_supported| matches!(first_supported, MarkupKind::Markdown))
+            .and_then(|completion_item| {
+                preferred_markup_kind(completion_item.documentation_format.as_deref()?)
+            })
+            == Some(&MarkupKind::Markdown)
         {
             flags |= Self::PREFER_MARKDOWN_IN_COMPLETION;
         }

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -594,56 +594,74 @@ take({\"\"})
 }
 
 #[test]
-fn documentation_format_preference() -> Result<()> {
-    let cases = [
-        (
-            vec![MarkupKind::Markdown, MarkupKind::PlainText],
-            MarkupKind::Markdown,
-        ),
-        (
-            vec![MarkupKind::PlainText, MarkupKind::Markdown],
-            MarkupKind::PlainText,
-        ),
-        (vec![MarkupKind::Markdown], MarkupKind::Markdown),
-        (vec![MarkupKind::PlainText], MarkupKind::PlainText),
-    ];
-
-    for (formats, expected_format) in cases {
-        let workspace_root = SystemPath::new("src");
-        let foo = SystemPath::new("src/foo.py");
-        let foo_content = r#"\
-    def foo_with_documentation() -> None:
-        """
-        Example doc comment
-        """
-        ...
-
-    fo
-    "#;
-        let mut server = TestServerBuilder::new()?
-            .with_workspace(workspace_root, None)?
-            .with_file(foo, foo_content)?
-            .with_completion_documentation_format(formats)
-            .build()
-            .wait_until_workspaces_are_initialized();
-
-        server.open_text_document(foo, foo_content, 1);
-
-        let completions = server.completion_request(&server.file_uri(foo), Position::new(6, 1));
-
-        let completion = completions
-            .into_iter()
-            .find(|completion| completion.label == "foo_with_documentation")
-            .expect("Completion of function should exist");
-        let documentation = completion
-            .documentation
-            .expect("Expected documentation in hover");
-
-        let Documentation::MarkupContent(markup) = documentation else {
-            panic!("Expected markup documentation");
-        };
-
-        assert_eq!(markup.kind, expected_format);
-    }
+fn documentation_prefers_markdown_when_listed_first() -> Result<()> {
+    assert_eq!(
+        documentation_format(vec![MarkupKind::Markdown, MarkupKind::PlainText])?,
+        MarkupKind::Markdown,
+    );
     Ok(())
+}
+
+#[test]
+fn documentation_prefers_plain_text_when_listed_first() -> Result<()> {
+    assert_eq!(
+        documentation_format(vec![MarkupKind::PlainText, MarkupKind::Markdown])?,
+        MarkupKind::PlainText,
+    );
+    Ok(())
+}
+
+#[test]
+fn documentation_supports_only_markdown() -> Result<()> {
+    assert_eq!(
+        documentation_format(vec![MarkupKind::Markdown])?,
+        MarkupKind::Markdown
+    );
+    Ok(())
+}
+
+#[test]
+fn documentation_supports_only_plain_text() -> Result<()> {
+    assert_eq!(
+        documentation_format(vec![MarkupKind::PlainText])?,
+        MarkupKind::PlainText
+    );
+    Ok(())
+}
+
+fn documentation_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = r#"def foo_with_documentation() -> None:
+    """
+    Example doc comment
+    """
+    ...
+
+foo_
+"#;
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .with_completion_documentation_format(formats)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let completions = server.completion_request(&server.file_uri(foo), Position::new(6, 4));
+
+    let completion = completions
+        .into_iter()
+        .find(|completion| completion.label == "foo_with_documentation")
+        .expect("Completion of function should exist");
+    let documentation = completion
+        .documentation
+        .expect("Expected documentation in completion");
+
+    let Documentation::MarkupContent(markup) = documentation else {
+        panic!("Expected markup documentation");
+    };
+
+    Ok(markup.kind)
 }

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use lsp_types::Position;
+use lsp_types::{Documentation, MarkupKind, Position};
 use ruff_db::system::SystemPath;
 use ty_server::ClientOptions;
 
@@ -590,5 +590,61 @@ take({\"\"})
     ]
     "#);
 
+    Ok(())
+}
+
+#[test]
+fn documentation_format_preference() -> Result<()> {
+    let cases = [
+        (
+            vec![MarkupKind::Markdown, MarkupKind::PlainText],
+            MarkupKind::Markdown,
+        ),
+        (
+            vec![MarkupKind::PlainText, MarkupKind::Markdown],
+            MarkupKind::PlainText,
+        ),
+        (vec![MarkupKind::Markdown], MarkupKind::Markdown),
+        (vec![MarkupKind::PlainText], MarkupKind::PlainText),
+    ];
+
+    for (formats, expected_format) in cases {
+        let workspace_root = SystemPath::new("src");
+        let foo = SystemPath::new("src/foo.py");
+        let foo_content = r#"\
+    def foo_with_documentation() -> None:
+        """
+        Example doc comment
+        """
+        ...
+
+    fo
+    "#;
+        let mut server = TestServerBuilder::new()?
+            .with_workspace(workspace_root, None)?
+            .with_file(foo, foo_content)?
+            .with_completion_documentation_format(formats)
+            .build()
+            .wait_until_workspaces_are_initialized();
+
+        server.open_text_document(foo, foo_content, 1);
+
+        let completions = server.completion_request(&server.file_uri(foo), Position::new(6, 1));
+
+        let completion = completions
+            .into_iter()
+            .find(|completion| completion.label == "foo_with_documentation")
+            .expect("Completion of function should exist");
+        let documentation = completion
+            .documentation
+            .expect("Expected documentation in hover");
+
+        let Documentation::MarkupContent(markup) = documentation else {
+            panic!("Expected markup documentation");
+        };
+
+        // TODO: should pass
+        // assert_eq!(markup.kind, expected_format);
+    }
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -643,8 +643,7 @@ fn documentation_format_preference() -> Result<()> {
             panic!("Expected markup documentation");
         };
 
-        // TODO: should pass
-        // assert_eq!(markup.kind, expected_format);
+        assert_eq!(markup.kind, expected_format);
     }
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -631,8 +631,8 @@ fn documentation_supports_only_plain_text() -> Result<()> {
 
 fn documentation_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
     let workspace_root = SystemPath::new("src");
-    let foo = SystemPath::new("src/foo.py");
-    let foo_content = r#"def foo_with_documentation() -> None:
+    let document_path = SystemPath::new("src/foo.py");
+    let document_content = r#"def foo_with_documentation() -> None:
     """
     Example doc comment
     """
@@ -642,14 +642,15 @@ foo_
 "#;
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
-        .with_file(foo, foo_content)?
+        .with_file(document_path, document_content)?
         .with_completion_documentation_format(formats)
         .build()
         .wait_until_workspaces_are_initialized();
 
-    server.open_text_document(foo, foo_content, 1);
+    server.open_text_document(document_path, document_content, 1);
 
-    let completions = server.completion_request(&server.file_uri(foo), Position::new(6, 4));
+    let completions =
+        server.completion_request(&server.file_uri(document_path), Position::new(6, 4));
 
     let completion = completions
         .into_iter()

--- a/crates/ty_server/tests/e2e/hover.rs
+++ b/crates/ty_server/tests/e2e/hover.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use lsp_types::{Contents, MarkupKind, Position};
+use ruff_db::system::SystemPath;
+
+use crate::TestServerBuilder;
+
+#[test]
+fn hover_content_format_preference() -> Result<()> {
+    let cases = [
+        (
+            vec![MarkupKind::Markdown, MarkupKind::PlainText],
+            MarkupKind::Markdown,
+        ),
+        (
+            vec![MarkupKind::PlainText, MarkupKind::Markdown],
+            MarkupKind::PlainText,
+        ),
+        (vec![MarkupKind::Markdown], MarkupKind::Markdown),
+        (vec![MarkupKind::PlainText], MarkupKind::PlainText),
+    ];
+
+    for (formats, expected_format) in cases {
+        let workspace_root = SystemPath::new("src");
+        let foo = SystemPath::new("src/foo.py");
+        let foo_content = "\
+    x: int = 1
+    ";
+
+        let mut server = TestServerBuilder::new()?
+            .with_workspace(workspace_root, None)?
+            .with_file(foo, foo_content)?
+            .with_hover_content_format(formats)
+            .build()
+            .wait_until_workspaces_are_initialized();
+
+        server.open_text_document(foo, foo_content, 1);
+
+        let hover = server
+            .hover_request(foo, Position::new(0, 0))
+            .expect("Expected a hover response");
+        let Contents::MarkupContent(markup) = hover.contents else {
+            panic!("Expected markup content");
+        };
+
+        // TODO: should pass
+        // assert_eq!(markup.kind, expected_format);
+    }
+
+    Ok(())
+}

--- a/crates/ty_server/tests/e2e/hover.rs
+++ b/crates/ty_server/tests/e2e/hover.rs
@@ -5,45 +5,63 @@ use ruff_db::system::SystemPath;
 use crate::TestServerBuilder;
 
 #[test]
-fn hover_content_format_preference() -> Result<()> {
-    let cases = [
-        (
-            vec![MarkupKind::Markdown, MarkupKind::PlainText],
-            MarkupKind::Markdown,
-        ),
-        (
-            vec![MarkupKind::PlainText, MarkupKind::Markdown],
-            MarkupKind::PlainText,
-        ),
-        (vec![MarkupKind::Markdown], MarkupKind::Markdown),
-        (vec![MarkupKind::PlainText], MarkupKind::PlainText),
-    ];
+fn prefers_markdown_when_listed_first() -> Result<()> {
+    assert_eq!(
+        hover_content_format(vec![MarkupKind::Markdown, MarkupKind::PlainText])?,
+        MarkupKind::Markdown,
+    );
+    Ok(())
+}
 
-    for (formats, expected_format) in cases {
-        let workspace_root = SystemPath::new("src");
-        let foo = SystemPath::new("src/foo.py");
-        let foo_content = "\
+#[test]
+fn prefers_plain_text_when_listed_first() -> Result<()> {
+    assert_eq!(
+        hover_content_format(vec![MarkupKind::PlainText, MarkupKind::Markdown])?,
+        MarkupKind::PlainText,
+    );
+    Ok(())
+}
+
+#[test]
+fn supports_only_markdown() -> Result<()> {
+    assert_eq!(
+        hover_content_format(vec![MarkupKind::Markdown])?,
+        MarkupKind::Markdown
+    );
+    Ok(())
+}
+
+#[test]
+fn supports_only_plain_text() -> Result<()> {
+    assert_eq!(
+        hover_content_format(vec![MarkupKind::PlainText])?,
+        MarkupKind::PlainText
+    );
+    Ok(())
+}
+
+fn hover_content_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
     x: int = 1
     ";
 
-        let mut server = TestServerBuilder::new()?
-            .with_workspace(workspace_root, None)?
-            .with_file(foo, foo_content)?
-            .with_hover_content_format(formats)
-            .build()
-            .wait_until_workspaces_are_initialized();
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .with_hover_content_format(formats)
+        .build()
+        .wait_until_workspaces_are_initialized();
 
-        server.open_text_document(foo, foo_content, 1);
+    server.open_text_document(foo, foo_content, 1);
 
-        let hover = server
-            .hover_request(foo, Position::new(0, 0))
-            .expect("Expected a hover response");
-        let Contents::MarkupContent(markup) = hover.contents else {
-            panic!("Expected markup content");
-        };
+    let hover = server
+        .hover_request(foo, Position::new(0, 0))
+        .expect("Expected a hover response");
+    let Contents::MarkupContent(markup) = hover.contents else {
+        panic!("Expected markup content");
+    };
 
-        assert_eq!(markup.kind, expected_format);
-    }
-
-    Ok(())
+    Ok(markup.kind)
 }

--- a/crates/ty_server/tests/e2e/hover.rs
+++ b/crates/ty_server/tests/e2e/hover.rs
@@ -42,8 +42,7 @@ fn hover_content_format_preference() -> Result<()> {
             panic!("Expected markup content");
         };
 
-        // TODO: should pass
-        // assert_eq!(markup.kind, expected_format);
+        assert_eq!(markup.kind, expected_format);
     }
 
     Ok(())

--- a/crates/ty_server/tests/e2e/hover.rs
+++ b/crates/ty_server/tests/e2e/hover.rs
@@ -42,22 +42,22 @@ fn supports_only_plain_text() -> Result<()> {
 
 fn hover_content_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
     let workspace_root = SystemPath::new("src");
-    let foo = SystemPath::new("src/foo.py");
-    let foo_content = "\
+    let document_path = SystemPath::new("src/foo.py");
+    let document_content = "\
     x: int = 1
     ";
 
     let mut server = TestServerBuilder::new()?
         .with_workspace(workspace_root, None)?
-        .with_file(foo, foo_content)?
+        .with_file(document_path, document_content)?
         .with_hover_content_format(formats)
         .build()
         .wait_until_workspaces_are_initialized();
 
-    server.open_text_document(foo, foo_content, 1);
+    server.open_text_document(document_path, document_content, 1);
 
     let hover = server
-        .hover_request(foo, Position::new(0, 0))
+        .hover_request(document_path, Position::new(0, 0))
         .expect("Expected a hover response");
     let Contents::MarkupContent(markup) = hover.contents else {
         panic!("Expected markup content");

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -33,6 +33,7 @@ mod commands;
 mod completions;
 mod configuration;
 mod folding_range;
+mod hover;
 mod initialize;
 mod inlay_hints;
 mod notebook;

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1361,6 +1361,22 @@ impl TestServerBuilder {
         self
     }
 
+    /// Set the completion documentation format preference for the client
+    pub(crate) fn with_completion_documentation_format(
+        mut self,
+        formats: Vec<lsp_types::MarkupKind>,
+    ) -> Self {
+        self.client_capabilities
+            .text_document
+            .get_or_insert_default()
+            .completion
+            .get_or_insert_default()
+            .completion_item
+            .get_or_insert_default()
+            .documentation_format = Some(formats);
+        self
+    }
+
     /// Set custom client capabilities (overrides any previously set capabilities)
     #[expect(dead_code)]
     pub(crate) fn with_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1350,6 +1350,17 @@ impl TestServerBuilder {
         self
     }
 
+    /// Set the hover content format preference for the client
+    pub(crate) fn with_hover_content_format(mut self, formats: Vec<lsp_types::MarkupKind>) -> Self {
+        self.client_capabilities
+            .text_document
+            .get_or_insert_default()
+            .hover
+            .get_or_insert_default()
+            .content_format = Some(formats);
+        self
+    }
+
     /// Set custom client capabilities (overrides any previously set capabilities)
     #[expect(dead_code)]
     pub(crate) fn with_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {


### PR DESCRIPTION
## Summary

* Respect client's content format preference in hover and completion documentation order. Previously ty would incorrectly choose Markdown even when the plain text is earlier.
* Closes https://github.com/astral-sh/ty/issues/3366

## Test Plan

* Wrote several e2e tests for both hover and completions
* Run the entire test suite with nextest
