### PR TITLE
[ty] Track directory changes independently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,6 +3063,7 @@ dependencies = [
  "anstyle",
  "arc-swap",
  "camino",
+ "compact_str",
  "dashmap",
  "dunce",
  "etcetera",

--- a/crates/ruff_db/Cargo.toml
+++ b/crates/ruff_db/Cargo.toml
@@ -26,6 +26,7 @@ ty_static = { workspace = true }
 anstyle = { workspace = true }
 arc-swap = { workspace = true }
 camino = { workspace = true }
+compact_str = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }
 filetime = { workspace = true }

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use dashmap::mapref::entry::Entry;
+pub use directory::{DirectoryListing, DirectoryListingError, directory_listing};
 pub use file_root::{FileRoot, FileRootKind};
 pub use path::FilePath;
 use ruff_notebook::{Notebook, NotebookError};
@@ -16,10 +17,13 @@ use crate::file_revision::FileRevision;
 use crate::files::file_root::FileRoots;
 use crate::files::private::FileStatus;
 use crate::source::SourceText;
-use crate::system::{SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf};
+use crate::system::{
+    SystemPath, SystemPathBuf, SystemVirtualPath, SystemVirtualPathBuf, deduplicate_nested_paths,
+};
 use crate::vendored::{VendoredPath, VendoredPathBuf};
 use crate::{Db, FxDashMap, vendored};
 
+mod directory;
 mod file_root;
 mod path;
 
@@ -58,6 +62,9 @@ pub struct Files {
 
 #[derive(Default)]
 struct FilesInner {
+    /// Lookup table that maps system directories to Salsa inputs.
+    directories: directory::Directories,
+
     /// Lookup table that maps [`SystemPathBuf`]s to salsa interned [`File`] instances.
     ///
     /// The map also stores entries for files that don't exist on the file system. This is necessary
@@ -75,6 +82,12 @@ struct FilesInner {
 }
 
 impl Files {
+    /// Returns the Salsa input for the system directory at `path`.
+    fn directory(&self, db: &dyn Db, path: &SystemPath) -> directory::Directory {
+        let absolute = SystemPath::absolute(path, db.system().current_directory());
+        self.inner.directories.get_or_create(db, absolute)
+    }
+
     /// Looks up a file by its `path`.
     ///
     /// For a non-existing file, creates a new salsa [`File`] ingredient and stores it for future lookups.
@@ -204,17 +217,6 @@ impl Files {
         roots.at(&absolute)
     }
 
-    /// The same as [`Self::root`] but panics if no root is found.
-    #[track_caller]
-    pub fn expect_root(&self, db: &dyn Db, path: &SystemPath) -> FileRoot {
-        if let Some(root) = self.root(db, path) {
-            return root;
-        }
-
-        let roots = self.inner.roots.read().unwrap();
-        panic!("No root found for path '{path}'. Known roots: {roots:#?}");
-    }
-
     /// Adds a new root for `path` and returns the root.
     ///
     /// The root isn't added nor is the file root's kind updated if a root for `path` already exists.
@@ -223,13 +225,6 @@ impl Files {
 
         let absolute = SystemPath::absolute(path, db.system().current_directory());
         roots.try_add(db, absolute, kind)
-    }
-
-    /// Updates the revision of the root for `path`.
-    pub fn touch_root(db: &mut dyn Db, path: &SystemPath) {
-        if let Some(root) = db.files().root(db, path) {
-            root.set_revision(db).to(FileRevision::now());
-        }
     }
 
     /// Refreshes the state of all known files under `paths` recursively.
@@ -246,10 +241,12 @@ impl Files {
         I: IntoIterator<Item = P>,
     {
         let current_directory = db.system().current_directory();
-        let paths = paths
-            .into_iter()
-            .map(|path| SystemPath::absolute(path.as_ref(), current_directory))
-            .collect::<BTreeSet<_>>();
+        let paths = deduplicate_nested_paths(
+            paths
+                .into_iter()
+                .map(|path| SystemPath::absolute(path.as_ref(), current_directory)),
+        )
+        .collect::<BTreeSet<_>>();
 
         if paths.is_empty() {
             return;
@@ -267,18 +264,7 @@ impl Files {
             }
         }
 
-        let roots = inner.roots.read().unwrap();
-
-        for root in roots.all() {
-            let root_path = root.path(db);
-            if paths
-                .range(root_path.to_path_buf()..)
-                .next()
-                .is_some_and(|path| path.starts_with(root_path))
-            {
-                root.set_revision(db).to(FileRevision::now());
-            }
-        }
+        inner.directories.touch_recursive(db, &paths);
     }
 
     /// Refreshes the state of all known files.
@@ -296,11 +282,7 @@ impl Files {
             File::sync_system_path(db, entry.key(), Some(*entry.value()));
         }
 
-        let roots = inner.roots.read().unwrap();
-
-        for root in roots.all() {
-            root.set_revision(db).to(FileRevision::now());
-        }
+        inner.directories.touch_all(db);
     }
 }
 
@@ -315,6 +297,7 @@ impl fmt::Debug for Files {
             map.finish()
         } else {
             f.debug_struct("Files")
+                .field("directories", &self.inner.directories.len())
                 .field("system_by_path", &self.inner.system_by_path.len())
                 .field(
                     "system_virtual_by_path",
@@ -371,6 +354,11 @@ pub struct File {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for File {}
 
+struct SyncPathResult {
+    status_changed: bool,
+    is_directory: bool,
+}
+
 impl File {
     /// Reads the content of the file into a [`String`].
     ///
@@ -425,19 +413,17 @@ impl File {
 
     /// Refreshes the file metadata by querying the file system if needed.
     ///
-    /// This also "touches" the file root associated with the given path.
-    /// This means that any Salsa queries that depend on the corresponding
-    /// root's revision will become invalidated.
+    /// Directory listings are invalidated if the path's file status changed, its prior status is
+    /// unknown, or if `path` is itself a directory.
     pub fn sync_path(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
-        Files::touch_root(db, &absolute);
-        Self::sync_system_path(db, &absolute, None);
+        let result = Self::sync_system_path(db, &absolute, None);
+        Self::touch_directories_after_sync(db, &absolute, result);
     }
 
     /// Refreshes *only* the file metadata by querying the file system if needed.
     ///
-    /// This specifically does not touch any file root associated with the
-    /// given file path.
+    /// This specifically does not invalidate any directory listings.
     pub fn sync_path_only(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
         Self::sync_system_path(db, &absolute, None);
@@ -456,8 +442,8 @@ impl File {
 
         match path {
             FilePath::System(system) => {
-                Files::touch_root(db, &system);
-                Self::sync_system_path(db, &system, Some(self));
+                let result = Self::sync_system_path(db, &system, Some(self));
+                Self::touch_directories_after_sync(db, &system, result);
             }
             FilePath::Vendored(_) => {
                 // Readonly, can never be out of date.
@@ -470,9 +456,12 @@ impl File {
 
     /// Private method providing the implementation for [`Self::sync_path`] and [`Self::sync`] for
     /// system paths.
-    fn sync_system_path(db: &mut dyn Db, path: &SystemPath, file: Option<File>) {
+    fn sync_system_path(db: &mut dyn Db, path: &SystemPath, file: Option<File>) -> SyncPathResult {
         let Some(file) = file.or_else(|| db.files().try_system(db, path)) else {
-            return;
+            return SyncPathResult {
+                status_changed: true,
+                is_directory: true,
+            };
         };
 
         let (status, revision, permission) = match db.system().path_metadata(path) {
@@ -489,7 +478,10 @@ impl File {
 
         let mut clear_override = false;
 
-        if file.status(db) != status {
+        let old_status = file.status(db);
+        let status_changed = old_status != status;
+
+        if status_changed {
             tracing::debug!("Updating the status of `{}`", file.path(db));
             file.set_status(db).to(status);
             clear_override = true;
@@ -508,6 +500,25 @@ impl File {
 
         if clear_override && file.source_text_override(db).is_some() {
             file.set_source_text_override(db).to(None);
+        }
+
+        SyncPathResult {
+            status_changed,
+            is_directory: old_status == FileStatus::IsADirectory
+                || status == FileStatus::IsADirectory,
+        }
+    }
+
+    fn touch_directories_after_sync(db: &mut dyn Db, path: &SystemPath, result: SyncPathResult) {
+        let inner = Arc::clone(&db.files().inner);
+
+        if result.status_changed || result.is_directory {
+            inner.directories.touch(db, path);
+        }
+        if result.status_changed
+            && let Some(parent) = path.parent()
+        {
+            inner.directories.touch(db, parent);
         }
     }
 

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -246,6 +246,11 @@ impl Files {
             return;
         }
 
+        let parents = paths
+            .iter()
+            .filter_map(|path| path.parent().map(SystemPath::to_path_buf))
+            .collect::<BTreeSet<_>>();
+
         let inner = Arc::clone(&db.files().inner);
         for entry in inner.system_by_path.iter_mut() {
             let path = entry.key();
@@ -253,9 +258,7 @@ impl Files {
                 .range(..=path.to_path_buf())
                 .next_back()
                 .is_some_and(|candidate| path.starts_with(candidate.as_path()))
-                || paths
-                    .iter()
-                    .any(|candidate| candidate.parent() == Some(path.as_path()))
+                || parents.contains(path)
             {
                 File::sync_system_path(db, path, Some(*entry.value()));
             }
@@ -409,7 +412,7 @@ impl File {
     pub fn sync_path(db: &mut dyn Db, path: &SystemPath) {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
         let result = Self::sync_system_path(db, &absolute, None);
-        Self::touch_directories_after_sync(db, &absolute, result);
+        Self::touch_parent_directory_after_sync(db, &absolute, result);
     }
 
     /// Refreshes *only* the file metadata by querying the file system if needed.
@@ -434,7 +437,7 @@ impl File {
         match path {
             FilePath::System(system) => {
                 let result = Self::sync_system_path(db, &system, Some(self));
-                Self::touch_directories_after_sync(db, &system, result);
+                Self::touch_parent_directory_after_sync(db, &system, result);
             }
             FilePath::Vendored(_) => {
                 // Readonly, can never be out of date.
@@ -497,7 +500,11 @@ impl File {
         SyncPathResult { status_changed }
     }
 
-    fn touch_directories_after_sync(db: &mut dyn Db, path: &SystemPath, result: SyncPathResult) {
+    fn touch_parent_directory_after_sync(
+        db: &mut dyn Db,
+        path: &SystemPath,
+        result: SyncPathResult,
+    ) {
         if result.status_changed
             && let Some(parent) = path.parent()
         {

--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -3,7 +3,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use dashmap::mapref::entry::Entry;
-pub use directory::{DirectoryListing, DirectoryListingError, directory_listing};
+pub use directory::{
+    DirectoryListing, DirectoryListingError, directory_listing, system_path_to_directory,
+};
 pub use file_root::{FileRoot, FileRootKind};
 pub use path::FilePath;
 use ruff_notebook::{Notebook, NotebookError};
@@ -62,9 +64,6 @@ pub struct Files {
 
 #[derive(Default)]
 struct FilesInner {
-    /// Lookup table that maps system directories to Salsa inputs.
-    directories: directory::Directories,
-
     /// Lookup table that maps [`SystemPathBuf`]s to salsa interned [`File`] instances.
     ///
     /// The map also stores entries for files that don't exist on the file system. This is necessary
@@ -82,18 +81,12 @@ struct FilesInner {
 }
 
 impl Files {
-    /// Returns the Salsa input for the system directory at `path`.
-    fn directory(&self, db: &dyn Db, path: &SystemPath) -> directory::Directory {
-        let absolute = SystemPath::absolute(path, db.system().current_directory());
-        self.inner.directories.get_or_create(db, absolute)
-    }
-
     /// Looks up a file by its `path`.
     ///
     /// For a non-existing file, creates a new salsa [`File`] ingredient and stores it for future lookups.
     ///
     /// The operation always succeeds even if the path doesn't exist on disk, isn't accessible or if the path points to a directory.
-    /// In these cases, a file with status [`FileStatus::NotFound`] is returned.
+    /// In these cases, a file with the appropriate [`FileStatus`] is returned.
     fn system(&self, db: &dyn Db, path: &SystemPath) -> File {
         let absolute = SystemPath::absolute(path, db.system().current_directory());
 
@@ -123,9 +116,10 @@ impl Files {
                     Ok(metadata) if metadata.file_type().is_file() => builder
                         .permissions(metadata.permissions())
                         .revision(metadata.revision()),
-                    Ok(metadata) if metadata.file_type().is_directory() => {
-                        builder.status(FileStatus::IsADirectory)
-                    }
+                    Ok(metadata) if metadata.file_type().is_directory() => builder
+                        .status(FileStatus::IsADirectory)
+                        .permissions(metadata.permissions())
+                        .revision(metadata.revision()),
                     _ => builder
                         .status(FileStatus::NotFound)
                         .status_durability(Durability::MEDIUM.max(durability)),
@@ -259,12 +253,13 @@ impl Files {
                 .range(..=path.to_path_buf())
                 .next_back()
                 .is_some_and(|candidate| path.starts_with(candidate.as_path()))
+                || paths
+                    .iter()
+                    .any(|candidate| candidate.parent() == Some(path.as_path()))
             {
                 File::sync_system_path(db, path, Some(*entry.value()));
             }
         }
-
-        inner.directories.touch_recursive(db, &paths);
     }
 
     /// Refreshes the state of all known files.
@@ -281,8 +276,6 @@ impl Files {
         for entry in inner.system_by_path.iter_mut() {
             File::sync_system_path(db, entry.key(), Some(*entry.value()));
         }
-
-        inner.directories.touch_all(db);
     }
 }
 
@@ -297,7 +290,6 @@ impl fmt::Debug for Files {
             map.finish()
         } else {
             f.debug_struct("Files")
-                .field("directories", &self.inner.directories.len())
                 .field("system_by_path", &self.inner.system_by_path.len())
                 .field(
                     "system_virtual_by_path",
@@ -311,7 +303,7 @@ impl fmt::Debug for Files {
 
 impl std::panic::RefUnwindSafe for Files {}
 
-/// A file that's either stored on the host system's file system or in the vendored file system.
+/// A file-system path that's either stored on the host system's file system or in the vendored file system.
 ///
 /// # Ordering
 /// Ordering is based on the file's salsa-assigned id and not on its values.
@@ -328,7 +320,7 @@ pub struct File {
     #[default]
     pub permissions: Option<u32>,
 
-    /// The file revision. A file has changed if the revisions don't compare equal.
+    /// The path revision. A file or directory has changed if the revisions don't compare equal.
     #[default]
     pub revision: FileRevision,
 
@@ -356,7 +348,6 @@ impl get_size2::GetSize for File {}
 
 struct SyncPathResult {
     status_changed: bool,
-    is_directory: bool,
 }
 
 impl File {
@@ -460,7 +451,6 @@ impl File {
         let Some(file) = file.or_else(|| db.files().try_system(db, path)) else {
             return SyncPathResult {
                 status_changed: true,
-                is_directory: true,
             };
         };
 
@@ -470,9 +460,11 @@ impl File {
                 metadata.revision(),
                 metadata.permissions(),
             ),
-            Ok(metadata) if metadata.file_type().is_directory() => {
-                (FileStatus::IsADirectory, FileRevision::zero(), None)
-            }
+            Ok(metadata) if metadata.file_type().is_directory() => (
+                FileStatus::IsADirectory,
+                metadata.revision(),
+                metadata.permissions(),
+            ),
             _ => (FileStatus::NotFound, FileRevision::zero(), None),
         };
 
@@ -502,23 +494,14 @@ impl File {
             file.set_source_text_override(db).to(None);
         }
 
-        SyncPathResult {
-            status_changed,
-            is_directory: old_status == FileStatus::IsADirectory
-                || status == FileStatus::IsADirectory,
-        }
+        SyncPathResult { status_changed }
     }
 
     fn touch_directories_after_sync(db: &mut dyn Db, path: &SystemPath, result: SyncPathResult) {
-        let inner = Arc::clone(&db.files().inner);
-
-        if result.status_changed || result.is_directory {
-            inner.directories.touch(db, path);
-        }
         if result.status_changed
             && let Some(parent) = path.parent()
         {
-            inner.directories.touch(db, parent);
+            Self::sync_system_path(db, parent, None);
         }
     }
 

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -1,26 +1,13 @@
-use std::collections::BTreeSet;
-
 use compact_str::CompactString;
-use salsa::{Durability, Setter};
 
-use crate::file_revision::FileRevision;
-use crate::system::{FileType, SystemPath, SystemPathBuf};
-use crate::{Db, FxDashMap};
-
-/// A system directory whose direct children are tracked by Salsa.
-#[salsa::input(debug, heap_size=ruff_memory_usage::heap_size)]
-pub(super) struct Directory {
-    /// The path of the directory (immutable).
-    #[returns(deref)]
-    path: Box<SystemPath>,
-
-    /// Changes whenever an entry is added, removed, or changes type.
-    revision: FileRevision,
-}
-
-impl get_size2::GetSize for Directory {}
+use super::private::FileStatus;
+use super::{File, FilePath};
+use crate::Db;
+use crate::system::{FileType, SystemPath};
 
 /// A cached snapshot of the direct children in a directory.
+///
+/// The entries are sorted by name for efficient lookups.
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub struct DirectoryListing(Box<[(CompactString, FileType)]>);
 
@@ -67,24 +54,54 @@ impl From<std::io::Error> for DirectoryListingError {
     }
 }
 
+/// Interns a directory system path and returns a salsa `File` ingredient.
+///
+/// Returns `Err` if the path doesn't exist, isn't accessible, or if the path doesn't point to a directory.
+#[inline]
+pub fn system_path_to_directory(
+    db: &dyn Db,
+    path: impl AsRef<SystemPath>,
+) -> Result<File, DirectoryListingError> {
+    let file = db.files().system(db, path.as_ref());
+
+    match file.status(db) {
+        FileStatus::IsADirectory => Ok(file),
+        FileStatus::Exists => Err(std::io::Error::from(std::io::ErrorKind::NotADirectory).into()),
+        FileStatus::NotFound => Err(std::io::Error::from(std::io::ErrorKind::NotFound).into()),
+    }
+}
+
 #[inline]
 pub fn directory_listing<'db>(
     db: &'db dyn Db,
     path: &SystemPath,
-) -> Result<&'db DirectoryListing, &'db DirectoryListingError> {
-    directory_listing_query(db, db.files().directory(db, path))
+) -> Result<&'db DirectoryListing, DirectoryListingError> {
+    let directory = system_path_to_directory(db, path)?;
+    directory_listing_query(db, directory).map_err(Clone::clone)
 }
 
 #[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
 fn directory_listing_query(
     db: &dyn Db,
-    directory: Directory,
+    directory: File,
 ) -> Result<DirectoryListing, DirectoryListingError> {
-    directory.revision(db);
+    let _ = directory.revision(db);
+    let _ = directory.permissions(db);
+
+    let path = match directory.path(db) {
+        FilePath::System(path) => path,
+        FilePath::Vendored(_) | FilePath::SystemVirtual(_) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "directory listings are only supported for system paths",
+            )
+            .into());
+        }
+    };
 
     let mut entries = db
         .system()
-        .read_directory(directory.path(db))?
+        .read_directory(path)?
         .filter_map(|entry| {
             let entry = entry.ok()?;
             let file_type = entry.file_type();
@@ -96,74 +113,6 @@ fn directory_listing_query(
 
     entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
     Ok(DirectoryListing(entries.into_boxed_slice()))
-}
-
-#[derive(Default)]
-pub(super) struct Directories {
-    by_path: FxDashMap<SystemPathBuf, Directory>,
-}
-
-impl Directories {
-    pub(super) fn get_or_create(&self, db: &dyn Db, path: SystemPathBuf) -> Directory {
-        if let Some(directory) = self.by_path.get(&path) {
-            return *directory;
-        }
-
-        *self.by_path.entry(path.clone()).or_insert_with(|| {
-            let durability = db
-                .files()
-                .root(db, &path)
-                .map_or(Durability::default(), |root| root.durability(db));
-            let durability = Durability::MEDIUM.max(durability);
-
-            Directory::builder(Box::from(path), FileRevision::now())
-                .durability(durability)
-                .path_durability(Durability::HIGH)
-                .new(db)
-        })
-    }
-
-    pub(super) fn touch(&self, db: &mut dyn Db, path: &SystemPath) {
-        if let Some(directory) = self.by_path.get(path).map(|directory| *directory) {
-            directory.set_revision(db).to(FileRevision::now());
-        }
-    }
-
-    pub(super) fn touch_recursive(&self, db: &mut dyn Db, paths: &BTreeSet<SystemPathBuf>) {
-        let parents = paths
-            .iter()
-            .filter_map(|path| path.parent().map(SystemPath::to_path_buf))
-            .collect::<BTreeSet<_>>();
-        let directories = self
-            .by_path
-            .iter()
-            .filter(|entry| {
-                let path = entry.key();
-                parents.contains(path) || paths.iter().any(|candidate| path.starts_with(candidate))
-            })
-            .map(|entry| *entry.value())
-            .collect::<Vec<_>>();
-
-        for directory in directories {
-            directory.set_revision(db).to(FileRevision::now());
-        }
-    }
-
-    pub(super) fn touch_all(&self, db: &mut dyn Db) {
-        let directories = self
-            .by_path
-            .iter()
-            .map(|entry| *entry.value())
-            .collect::<Vec<_>>();
-
-        for directory in directories {
-            directory.set_revision(db).to(FileRevision::now());
-        }
-    }
-
-    pub(super) fn len(&self) -> usize {
-        self.by_path.len()
-    }
 }
 
 #[cfg(test)]
@@ -230,7 +179,7 @@ mod tests {
         db.write_file("src/a.py", "old")?;
         system_path_to_file(&db, SystemPath::new("src/a.py")).unwrap();
 
-        let directory = db.files().directory(&db, SystemPath::new("src"));
+        let directory = db.files().system(&db, SystemPath::new("src"));
         directory_listing(&db, SystemPath::new("src")).unwrap();
         let revision = directory.revision(&db);
 

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -117,13 +117,12 @@ fn directory_listing_query(
 
 #[cfg(test)]
 mod tests {
-    use crate::Db as _;
-    use crate::files::{File, directory_listing, system_path_to_file};
-    use crate::system::{DbWithWritableSystem as _, SystemPath, WritableSystem as _};
+    use crate::files::directory_listing;
+    use crate::system::{DbWithWritableSystem as _, SystemPath};
     use crate::tests::TestDb;
 
     #[test]
-    fn listing_is_sorted_and_cached() -> std::io::Result<()> {
+    fn listing_is_sorted() -> std::io::Result<()> {
         let mut db = TestDb::new();
         db.write_file("src/z.py", "")?;
         db.write_file("src/a.py", "")?;
@@ -133,21 +132,6 @@ mod tests {
         assert_eq!(
             listing.iter().map(|(name, _)| name).collect::<Vec<_>>(),
             ["a.py", "z.py"]
-        );
-
-        db.writable_system()
-            .write_file(SystemPath::new("src/new.py"), "")?;
-        assert_eq!(
-            directory_listing(&db, path).unwrap().file_type("new.py"),
-            None
-        );
-
-        File::sync_path(&mut db, SystemPath::new("src/new.py"));
-        assert!(
-            directory_listing(&db, path)
-                .unwrap()
-                .file_type("new.py")
-                .is_some()
         );
 
         Ok(())
@@ -171,109 +155,5 @@ mod tests {
                 .kind,
             std::io::ErrorKind::NotFound
         );
-    }
-
-    #[test]
-    fn content_change_does_not_invalidate_directory() -> std::io::Result<()> {
-        let mut db = TestDb::new();
-        db.write_file("src/a.py", "old")?;
-        system_path_to_file(&db, SystemPath::new("src/a.py")).unwrap();
-
-        let directory = db.files().system(&db, SystemPath::new("src"));
-        directory_listing(&db, SystemPath::new("src")).unwrap();
-        let revision = directory.revision(&db);
-
-        db.writable_system()
-            .write_file(SystemPath::new("src/a.py"), "new")?;
-        File::sync_path(&mut db, SystemPath::new("src/a.py"));
-
-        assert_eq!(directory.revision(&db), revision);
-        Ok(())
-    }
-
-    #[test]
-    fn structural_changes_invalidate_directory() -> std::io::Result<()> {
-        let mut db = TestDb::new();
-        db.write_file("src/existing.py", "")?;
-        let existing = system_path_to_file(&db, SystemPath::new("src/existing.py")).unwrap();
-
-        let directory = SystemPath::new("src");
-        assert!(
-            directory_listing(&db, directory)
-                .unwrap()
-                .file_type("existing.py")
-                .is_some()
-        );
-
-        db.writable_system()
-            .memory_file_system()
-            .remove_file("src/existing.py")?;
-        existing.sync(&mut db);
-        assert_eq!(
-            directory_listing(&db, directory)
-                .unwrap()
-                .file_type("existing.py"),
-            None
-        );
-
-        db.writable_system()
-            .write_file(SystemPath::new("src/new.py"), "")?;
-        File::sync_path(&mut db, SystemPath::new("src/new.py"));
-        assert!(
-            directory_listing(&db, directory)
-                .unwrap()
-                .file_type("new.py")
-                .is_some()
-        );
-
-        Ok(())
-    }
-
-    #[test]
-    fn syncing_directory_invalidates_its_listing() -> std::io::Result<()> {
-        let mut db = TestDb::new();
-        db.write_file("src/a.py", "")?;
-
-        let directory = SystemPath::new("src");
-        directory_listing(&db, directory).unwrap();
-
-        db.writable_system()
-            .write_file(SystemPath::new("src/new.py"), "")?;
-        File::sync_path(&mut db, SystemPath::new("src"));
-
-        assert!(
-            directory_listing(&db, directory)
-                .unwrap()
-                .file_type("new.py")
-                .is_some()
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn recursive_sync_invalidates_parent_listing() -> std::io::Result<()> {
-        let mut db = TestDb::new();
-        db.writable_system()
-            .memory_file_system()
-            .create_directory_all("src/package")?;
-
-        let src = SystemPath::new("src");
-        assert!(
-            directory_listing(&db, src)
-                .unwrap()
-                .file_type("package")
-                .is_some()
-        );
-
-        db.writable_system()
-            .memory_file_system()
-            .remove_directory("src/package")?;
-        crate::files::Files::sync_all_recursive(&mut db, [SystemPath::new("src/package")]);
-
-        assert_eq!(
-            directory_listing(&db, src).unwrap().file_type("package"),
-            None
-        );
-        Ok(())
     }
 }

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -1,0 +1,330 @@
+use std::collections::BTreeSet;
+
+use compact_str::CompactString;
+use salsa::{Durability, Setter};
+
+use crate::file_revision::FileRevision;
+use crate::system::{FileType, SystemPath, SystemPathBuf};
+use crate::{Db, FxDashMap};
+
+/// A system directory whose direct children are tracked by Salsa.
+#[salsa::input(debug, heap_size=ruff_memory_usage::heap_size)]
+pub(super) struct Directory {
+    /// The path of the directory (immutable).
+    #[returns(deref)]
+    path: Box<SystemPath>,
+
+    /// Changes whenever an entry is added, removed, or changes type.
+    revision: FileRevision,
+}
+
+impl get_size2::GetSize for Directory {}
+
+/// A cached snapshot of the direct children in a directory.
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
+pub struct DirectoryListing(Box<[(CompactString, FileType)]>);
+
+impl DirectoryListing {
+    /// Returns the type of the entry named `name`, if present.
+    pub fn file_type(&self, name: &str) -> Option<FileType> {
+        self.0
+            .binary_search_by(|(candidate, _)| candidate.as_str().cmp(name))
+            .ok()
+            .map(|index| self.0[index].1)
+    }
+
+    /// Returns whether `name` resolves to a file, following symbolic links.
+    pub fn entry_is_file(&self, db: &dyn Db, directory: &SystemPath, name: &str) -> bool {
+        match self.file_type(name) {
+            Some(FileType::File) => true,
+            Some(FileType::Directory) | None => false,
+            Some(FileType::Symlink) => super::system_path_to_file(db, directory.join(name)).is_ok(),
+        }
+    }
+
+    /// Iterates over the entries in the directory in name order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, FileType)> {
+        self.0
+            .iter()
+            .map(|(name, file_type)| (name.as_str(), *file_type))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize, thiserror::Error)]
+#[error("{message}")]
+pub struct DirectoryListingError {
+    #[get_size(ignore)]
+    kind: std::io::ErrorKind,
+    message: Box<str>,
+}
+
+impl From<std::io::Error> for DirectoryListingError {
+    fn from(error: std::io::Error) -> Self {
+        Self {
+            kind: error.kind(),
+            message: error.to_string().into_boxed_str(),
+        }
+    }
+}
+
+#[inline]
+pub fn directory_listing<'db>(
+    db: &'db dyn Db,
+    path: &SystemPath,
+) -> Result<&'db DirectoryListing, &'db DirectoryListingError> {
+    directory_listing_query(db, db.files().directory(db, path))
+}
+
+#[salsa::tracked(returns(as_ref), heap_size=ruff_memory_usage::heap_size)]
+fn directory_listing_query(
+    db: &dyn Db,
+    directory: Directory,
+) -> Result<DirectoryListing, DirectoryListingError> {
+    directory.revision(db);
+
+    let mut entries = db
+        .system()
+        .read_directory(directory.path(db))?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let file_type = entry.file_type();
+            let path = entry.into_path();
+            let name = path.file_name()?;
+            Some((CompactString::from(name), file_type))
+        })
+        .collect::<Vec<_>>();
+
+    entries.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+    Ok(DirectoryListing(entries.into_boxed_slice()))
+}
+
+#[derive(Default)]
+pub(super) struct Directories {
+    by_path: FxDashMap<SystemPathBuf, Directory>,
+}
+
+impl Directories {
+    pub(super) fn get_or_create(&self, db: &dyn Db, path: SystemPathBuf) -> Directory {
+        if let Some(directory) = self.by_path.get(&path) {
+            return *directory;
+        }
+
+        *self.by_path.entry(path.clone()).or_insert_with(|| {
+            let durability = db
+                .files()
+                .root(db, &path)
+                .map_or(Durability::default(), |root| root.durability(db));
+            let durability = Durability::MEDIUM.max(durability);
+
+            Directory::builder(Box::from(path), FileRevision::now())
+                .durability(durability)
+                .path_durability(Durability::HIGH)
+                .new(db)
+        })
+    }
+
+    pub(super) fn touch(&self, db: &mut dyn Db, path: &SystemPath) {
+        if let Some(directory) = self.by_path.get(path).map(|directory| *directory) {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn touch_recursive(&self, db: &mut dyn Db, paths: &BTreeSet<SystemPathBuf>) {
+        let parents = paths
+            .iter()
+            .filter_map(|path| path.parent().map(SystemPath::to_path_buf))
+            .collect::<BTreeSet<_>>();
+        let directories = self
+            .by_path
+            .iter()
+            .filter(|entry| {
+                let path = entry.key();
+                parents.contains(path) || paths.iter().any(|candidate| path.starts_with(candidate))
+            })
+            .map(|entry| *entry.value())
+            .collect::<Vec<_>>();
+
+        for directory in directories {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn touch_all(&self, db: &mut dyn Db) {
+        let directories = self
+            .by_path
+            .iter()
+            .map(|entry| *entry.value())
+            .collect::<Vec<_>>();
+
+        for directory in directories {
+            directory.set_revision(db).to(FileRevision::now());
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.by_path.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Db as _;
+    use crate::files::{File, directory_listing, system_path_to_file};
+    use crate::system::{DbWithWritableSystem as _, SystemPath, WritableSystem as _};
+    use crate::tests::TestDb;
+
+    #[test]
+    fn listing_is_sorted_and_cached() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/z.py", "")?;
+        db.write_file("src/a.py", "")?;
+
+        let path = SystemPath::new("src");
+        let listing = directory_listing(&db, path).unwrap();
+        assert_eq!(
+            listing.iter().map(|(name, _)| name).collect::<Vec<_>>(),
+            ["a.py", "z.py"]
+        );
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        assert_eq!(
+            directory_listing(&db, path).unwrap().file_type("new.py"),
+            None
+        );
+
+        File::sync_path(&mut db, SystemPath::new("src/new.py"));
+        assert!(
+            directory_listing(&db, path)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn empty_and_unavailable_listing() {
+        let db = TestDb::new();
+
+        assert_eq!(
+            directory_listing(&db, SystemPath::new("/"))
+                .unwrap()
+                .iter()
+                .next(),
+            None
+        );
+
+        assert_eq!(
+            directory_listing(&db, SystemPath::new("missing"))
+                .unwrap_err()
+                .kind,
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn content_change_does_not_invalidate_directory() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/a.py", "old")?;
+        system_path_to_file(&db, SystemPath::new("src/a.py")).unwrap();
+
+        let directory = db.files().directory(&db, SystemPath::new("src"));
+        directory_listing(&db, SystemPath::new("src")).unwrap();
+        let revision = directory.revision(&db);
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/a.py"), "new")?;
+        File::sync_path(&mut db, SystemPath::new("src/a.py"));
+
+        assert_eq!(directory.revision(&db), revision);
+        Ok(())
+    }
+
+    #[test]
+    fn structural_changes_invalidate_directory() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/existing.py", "")?;
+        let existing = system_path_to_file(&db, SystemPath::new("src/existing.py")).unwrap();
+
+        let directory = SystemPath::new("src");
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("existing.py")
+                .is_some()
+        );
+
+        db.writable_system()
+            .memory_file_system()
+            .remove_file("src/existing.py")?;
+        existing.sync(&mut db);
+        assert_eq!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("existing.py"),
+            None
+        );
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        File::sync_path(&mut db, SystemPath::new("src/new.py"));
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn syncing_directory_invalidates_its_listing() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("src/a.py", "")?;
+
+        let directory = SystemPath::new("src");
+        directory_listing(&db, directory).unwrap();
+
+        db.writable_system()
+            .write_file(SystemPath::new("src/new.py"), "")?;
+        File::sync_path(&mut db, SystemPath::new("src"));
+
+        assert!(
+            directory_listing(&db, directory)
+                .unwrap()
+                .file_type("new.py")
+                .is_some()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn recursive_sync_invalidates_parent_listing() -> std::io::Result<()> {
+        let mut db = TestDb::new();
+        db.writable_system()
+            .memory_file_system()
+            .create_directory_all("src/package")?;
+
+        let src = SystemPath::new("src");
+        assert!(
+            directory_listing(&db, src)
+                .unwrap()
+                .file_type("package")
+                .is_some()
+        );
+
+        db.writable_system()
+            .memory_file_system()
+            .remove_directory("src/package")?;
+        crate::files::Files::sync_all_recursive(&mut db, [SystemPath::new("src/package")]);
+
+        assert_eq!(
+            directory_listing(&db, src).unwrap().file_type("package"),
+            None
+        );
+        Ok(())
+    }
+}

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -1,10 +1,7 @@
-use std::fmt::Formatter;
-
 use path_slash::PathExt;
 use salsa::Durability;
 
 use crate::Db;
-use crate::file_revision::FileRevision;
 use crate::system::{SystemPath, SystemPathBuf};
 
 /// A root path for files tracked by the database.
@@ -13,9 +10,7 @@ use crate::system::{SystemPath, SystemPathBuf};
 /// * static module resolution paths
 /// * the project root
 ///
-/// The main usage of file roots is to determine a file's durability. But it can also be used
-/// to make a salsa query dependent on whether a file in a root has changed without writing any
-/// manual invalidation logic.
+/// File roots determine the durability of files and directories.
 #[salsa::input(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct FileRoot {
     /// The path of a root is guaranteed to never change.
@@ -24,11 +19,6 @@ pub struct FileRoot {
 
     /// The kind of the root at the time of its creation.
     pub kind_at_time_of_creation: FileRootKind,
-
-    /// A revision that changes when the contents of the source root change.
-    ///
-    /// The revision changes when a new file was added, removed, or changed inside this source root.
-    pub revision: FileRevision,
 }
 
 impl FileRoot {
@@ -58,7 +48,6 @@ impl FileRootKind {
 #[derive(Default)]
 pub(super) struct FileRoots {
     by_path: matchit::Router<FileRoot>,
-    roots: Vec<FileRoot>,
 }
 
 impl FileRoots {
@@ -88,9 +77,8 @@ impl FileRoots {
         let mut route = normalized_path.replace('{', "{{").replace('}', "}}");
 
         // Insert a new source root
-        let root = FileRoot::builder(path, kind, FileRevision::now())
+        let root = FileRoot::builder(path, kind)
             .durability(Durability::HIGH)
-            .revision_durability(kind.durability())
             .new(db);
 
         // Insert a path that matches the root itself
@@ -103,7 +91,6 @@ impl FileRoots {
         route.push_str("{*filepath}");
 
         self.by_path.insert(route, root).unwrap();
-        self.roots.push(root);
 
         root
     }
@@ -114,21 +101,5 @@ impl FileRoots {
         let normalized_path = path.as_std_path().to_slash().unwrap();
         let entry = self.by_path.at(&normalized_path).ok()?;
         Some(*entry.value)
-    }
-
-    pub(super) fn all(&self) -> impl Iterator<Item = FileRoot> + '_ {
-        self.roots.iter().copied()
-    }
-}
-
-impl std::fmt::Debug for FileRoots {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("FileRoots").field(&self.roots).finish()
-    }
-}
-
-impl PartialEq for FileRoots {
-    fn eq(&self, other: &Self) -> bool {
-        self.roots.eq(&other.roots)
     }
 }

--- a/crates/ruff_db/src/files/file_root.rs
+++ b/crates/ruff_db/src/files/file_root.rs
@@ -15,7 +15,7 @@ use crate::system::{SystemPath, SystemPathBuf};
 pub struct FileRoot {
     /// The path of a root is guaranteed to never change.
     #[returns(deref)]
-    pub path: SystemPathBuf,
+    pub path: Box<SystemPath>,
 
     /// The kind of the root at the time of its creation.
     pub kind_at_time_of_creation: FileRootKind,
@@ -77,7 +77,7 @@ impl FileRoots {
         let mut route = normalized_path.replace('{', "{{").replace('}', "}}");
 
         // Insert a new source root
-        let root = FileRoot::builder(path, kind)
+        let root = FileRoot::builder(path.into(), kind)
             .durability(Durability::HIGH)
             .new(db);
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -341,7 +341,7 @@ impl Metadata {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Hash, get_size2::GetSize)]
 pub enum FileType {
     File,
     Directory,

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -522,24 +522,22 @@ fn get_or_create_file<'a>(
         }
     }
 
-    if !paths.contains_key(normalized) {
-        if let Some(parent) = normalized.parent().map(Utf8Path::to_path_buf) {
-            touch_directory(paths, &parent);
-        }
-
-        paths.insert(
-            normalized.to_path_buf(),
-            Entry::File(File {
-                content: Box::default(),
-                last_modified: file_time_now(),
-            }),
-        );
+    if let Some(parent) = normalized.parent().map(Utf8Path::to_path_buf)
+        && !paths.contains_key(normalized)
+    {
+        touch_directory(paths, &parent);
     }
 
-    match paths.get_mut(normalized) {
-        Some(Entry::File(file)) => Ok(file),
-        Some(Entry::Directory(_)) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
-        None => Err(not_found()),
+    let entry = paths.entry(normalized.to_path_buf()).or_insert_with(|| {
+        Entry::File(File {
+            content: Box::default(),
+            last_modified: file_time_now(),
+        })
+    });
+
+    match entry {
+        Entry::File(file) => Ok(file),
+        Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
     }
 }
 

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -168,10 +168,14 @@ impl MemoryFileSystem {
         let mut by_path = self.inner.by_path.write().unwrap();
         match by_path.entry(normalized) {
             btree_map::Entry::Vacant(entry) => {
+                let parent = entry.key().parent().map(Utf8Path::to_path_buf);
                 entry.insert(Entry::File(File {
                     content: Box::default(),
                     last_modified: file_time_now(),
                 }));
+                if let Some(parent) = parent {
+                    touch_directory(&mut by_path, &parent);
+                }
 
                 Ok(())
             }
@@ -193,10 +197,14 @@ impl MemoryFileSystem {
         let mut by_path = self.inner.by_path.write().unwrap();
 
         let normalized = self.normalize_path(path.as_ref());
+        let existed = matches!(by_path.get(&normalized), Some(Entry::File(_)));
 
         let file = get_or_create_file(&mut by_path, &normalized)?;
         file.content = content.as_ref().to_vec().into_boxed_slice();
         file.last_modified = file_time_now();
+        if !existed && let Some(parent) = normalized.parent() {
+            touch_directory(&mut by_path, parent);
+        }
 
         Ok(())
     }
@@ -278,7 +286,11 @@ impl MemoryFileSystem {
             match by_path.entry(normalized) {
                 btree_map::Entry::Occupied(entry) => match entry.get() {
                     Entry::File(_) => {
+                        let parent = entry.key().parent().map(Utf8Path::to_path_buf);
                         entry.remove();
+                        if let Some(parent) = parent {
+                            touch_directory(&mut by_path, &parent);
+                        }
                         Ok(())
                     }
                     Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
@@ -345,7 +357,11 @@ impl MemoryFileSystem {
             match by_path.entry(normalized.clone()) {
                 btree_map::Entry::Occupied(entry) => match entry.get() {
                     Entry::Directory(_) => {
+                        let parent = entry.key().parent().map(Utf8Path::to_path_buf);
                         entry.remove();
+                        if let Some(parent) = parent {
+                            touch_directory(&mut by_path, &parent);
+                        }
                         Ok(())
                     }
                     Entry::File(_) => Err(io::Error::from(io::ErrorKind::NotADirectory)),
@@ -473,7 +489,9 @@ fn create_dir_all(
 
     for component in normalized.components() {
         path.push(component);
+        let mut inserted = false;
         let entry = paths.entry(path.clone()).or_insert_with(|| {
+            inserted = true;
             Entry::Directory(Directory {
                 last_modified: file_time_now(),
             })
@@ -482,9 +500,19 @@ fn create_dir_all(
         if entry.is_file() {
             return Err(io::Error::from(io::ErrorKind::NotADirectory));
         }
+
+        if inserted && let Some(parent) = path.parent().map(Utf8Path::to_path_buf) {
+            touch_directory(paths, &parent);
+        }
     }
 
     Ok(())
+}
+
+fn touch_directory(paths: &mut RwLockWriteGuard<BTreeMap<Utf8PathBuf, Entry>>, path: &Utf8Path) {
+    if let Some(Entry::Directory(directory)) = paths.get_mut(path) {
+        directory.last_modified = file_time_now();
+    }
 }
 
 fn get_or_create_file<'a>(

--- a/crates/ruff_db/src/system/memory_fs.rs
+++ b/crates/ruff_db/src/system/memory_fs.rs
@@ -197,14 +197,9 @@ impl MemoryFileSystem {
         let mut by_path = self.inner.by_path.write().unwrap();
 
         let normalized = self.normalize_path(path.as_ref());
-        let existed = matches!(by_path.get(&normalized), Some(Entry::File(_)));
-
         let file = get_or_create_file(&mut by_path, &normalized)?;
         file.content = content.as_ref().to_vec().into_boxed_slice();
         file.last_modified = file_time_now();
-        if !existed && let Some(parent) = normalized.parent() {
-            touch_directory(&mut by_path, parent);
-        }
 
         Ok(())
     }
@@ -527,16 +522,24 @@ fn get_or_create_file<'a>(
         }
     }
 
-    let entry = paths.entry(normalized.to_path_buf()).or_insert_with(|| {
-        Entry::File(File {
-            content: Box::default(),
-            last_modified: file_time_now(),
-        })
-    });
+    if !paths.contains_key(normalized) {
+        if let Some(parent) = normalized.parent().map(Utf8Path::to_path_buf) {
+            touch_directory(paths, &parent);
+        }
 
-    match entry {
-        Entry::File(file) => Ok(file),
-        Entry::Directory(_) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
+        paths.insert(
+            normalized.to_path_buf(),
+            Entry::File(File {
+                content: Box::default(),
+                last_modified: file_time_now(),
+            }),
+        );
+    }
+
+    match paths.get_mut(normalized) {
+        Some(Entry::File(file)) => Ok(file),
+        Some(Entry::Directory(_)) => Err(io::Error::from(io::ErrorKind::IsADirectory)),
+        None => Err(not_found()),
     }
 }
 
@@ -807,6 +810,24 @@ mod tests {
         let timestamp2 = fs.metadata(path)?.revision();
 
         assert_ne!(timestamp1, timestamp2);
+
+        Ok(())
+    }
+
+    #[test]
+    fn touch_new_file_updates_parent_directory() -> Result<()> {
+        let fs = MemoryFileSystem::new();
+        let directory = SystemPath::new("src");
+        fs.create_directory_all(directory)?;
+        let before = fs.metadata(directory)?.revision();
+
+        // Sleep to ensure that the timestamp changes
+        std::thread::sleep(Duration::from_millis(1));
+
+        fs.touch(SystemPath::new("src/new.py"))?;
+        let after = fs.metadata(directory)?.revision();
+
+        assert_ne!(before, after);
 
         Ok(())
     }

--- a/crates/ruff_db/src/testing.rs
+++ b/crates/ruff_db/src/testing.rs
@@ -35,19 +35,41 @@ pub fn assert_const_function_query_was_not_run<Db, Q, QDb, R>(
     // any event of that ingredient.
     let query_name = query_name(&query);
 
-    let event = events.iter().find(|event| {
-        if let salsa::EventKind::WillExecute { database_key } = event.kind {
-            db.ingredient_debug_name(database_key.ingredient_index()) == query_name
-        } else {
-            false
-        }
-    });
+    let event = find_will_execute_event_by_name(db, query_name, None, events);
 
     db.attach(|_| {
         if let Some(will_execute_event) = event {
             panic!(
                 "Expected query {query_name}() not to have run but it did: {will_execute_event:?}\n\n{events:#?}"
             );
+        }
+    });
+}
+
+pub fn assert_function_query_was_not_run_by_name<Db>(
+    db: &Db,
+    query_name: &str,
+    input: Option<salsa::Id>,
+    events: &[salsa::Event],
+) where
+    Db: salsa::Database,
+{
+    let will_execute_event = find_will_execute_event_by_name(db, query_name, input, events);
+
+    db.attach(|_| {
+        if let Some(will_execute_event) = will_execute_event {
+            match input {
+                Some(input) => {
+                    panic!(
+                        "Expected query {query_name}({input:?}) not to have run but it did: {will_execute_event:?}\n\n{events:#?}"
+                    );
+                }
+                None => {
+                    panic!(
+                        "Expected query {query_name} not to have run for any input but it did: {will_execute_event:?}\n\n{events:#?}"
+                    );
+                }
+            }
         }
     });
 }
@@ -87,16 +109,25 @@ where
 {
     let query_name = query_name(&query);
 
-    let event = events.iter().find(|event| {
+    let event = find_will_execute_event_by_name(db, query_name, Some(input.as_id()), events);
+
+    (query_name, event)
+}
+
+pub fn find_will_execute_event_by_name<'a>(
+    db: &dyn salsa::Database,
+    query_name: &str,
+    input: Option<salsa::Id>,
+    events: &'a [salsa::Event],
+) -> Option<&'a salsa::Event> {
+    events.iter().find(|event| {
         if let salsa::EventKind::WillExecute { database_key } = event.kind {
             db.ingredient_debug_name(database_key.ingredient_index()) == query_name
-                && database_key.key_index() == input.as_id()
+                && input.is_none_or(|input| database_key.key_index() == input)
         } else {
             false
         }
-    });
-
-    (query_name, event)
+    })
 }
 
 fn query_name<Q>(_query: &Q) -> &'static str {

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -555,6 +555,52 @@ fn new_file() -> anyhow::Result<()> {
 }
 
 #[test]
+fn new_directory_with_python_files() -> anyhow::Result<()> {
+    let mut case = setup([("bar.py", "")])?;
+    let bar_path = case.project_path("bar.py");
+    let bar_file = case.system_file(&bar_path).unwrap();
+    let package_path = case.project_path("package");
+    let init_path = package_path.join("__init__.py");
+    let module_path = package_path.join("module.py");
+
+    case.assert_indexed_project_files([bar_file]);
+    assert!(
+        resolve_module_confident(
+            case.db(),
+            &ModuleName::new_static("package.module").unwrap()
+        )
+        .is_none()
+    );
+
+    std::fs::create_dir(package_path.as_std_path())?;
+    std::fs::write(init_path.as_std_path(), "")?;
+    std::fs::write(module_path.as_std_path(), "")?;
+
+    let changes = case.stop_watch(|event: &ChangeEvent| {
+        matches!(
+            event.file_name(),
+            Some("package" | "__init__.py" | "module.py")
+        )
+    });
+
+    case.apply_changes(&changes, None);
+
+    let init = case.system_file(&init_path).expect("__init__.py to exist");
+    let module = case.system_file(&module_path).expect("module.py to exist");
+
+    case.assert_indexed_project_files([bar_file, init, module]);
+    assert!(
+        resolve_module_confident(
+            case.db(),
+            &ModuleName::new_static("package.module").unwrap()
+        )
+        .is_some()
+    );
+
+    Ok(())
+}
+
+#[test]
 fn new_non_python_file_is_not_indexed() -> anyhow::Result<()> {
     let mut case = setup([("bar.py", "")])?;
     let bar_path = case.project_path("bar.py");
@@ -880,6 +926,7 @@ fn deleted_file() -> anyhow::Result<()> {
     let foo = case.system_file(&foo_path)?;
 
     assert!(foo.exists(case.db()));
+    assert!(resolve_module_confident(case.db(), &ModuleName::new_static("foo").unwrap()).is_some());
     case.assert_indexed_project_files([foo]);
 
     std::fs::remove_file(foo_path.as_std_path())?;
@@ -889,6 +936,7 @@ fn deleted_file() -> anyhow::Result<()> {
     case.apply_changes(&changes, None);
 
     assert!(!foo.exists(case.db()));
+    assert!(resolve_module_confident(case.db(), &ModuleName::new_static("foo").unwrap()).is_none());
     case.assert_indexed_project_files([]);
 
     Ok(())

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -394,9 +394,10 @@ mod tests {
     use ruff_db::Db as _;
     use ruff_db::files::{File, FilePath, FileRootKind};
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem, SystemPath, SystemPathBuf};
-    use ruff_db::testing::assert_function_query_was_not_run;
+    use ruff_db::testing::{
+        assert_function_query_was_not_run, assert_function_query_was_not_run_by_name,
+    };
     use ruff_python_ast::PythonVersion;
-    use salsa::Database as _;
     use salsa::plumbing::AsId as _;
 
     use crate::db::{Db, tests::TestDb};
@@ -409,24 +410,6 @@ mod tests {
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
     use super::list_modules;
-
-    fn assert_query_was_not_run(
-        db: &TestDb,
-        query_name: &str,
-        input: Option<salsa::Id>,
-        events: &[salsa::Event],
-    ) {
-        assert!(
-            !events.iter().any(|event| {
-                let salsa::EventKind::WillExecute { database_key } = event.kind else {
-                    return false;
-                };
-                db.ingredient_debug_name(database_key.ingredient_index()) == query_name
-                    && input.is_none_or(|input| database_key.key_index() == input)
-            }),
-            "Expected {query_name} not to run:\n{events:#?}"
-        );
-    }
 
     struct ModuleDebugSnapshot<'db> {
         db: &'db dyn Db,
@@ -1076,7 +1059,7 @@ mod tests {
         list_modules(&db);
 
         let events = db.take_salsa_events();
-        assert_query_was_not_run(&db, "list_modules_in", None, &events);
+        assert_function_query_was_not_run_by_name(&db, "list_modules_in", None, &events);
 
         Ok(())
     }
@@ -1107,7 +1090,7 @@ mod tests {
         package.all_submodules(&db);
 
         let events = db.take_salsa_events();
-        assert_query_was_not_run(
+        assert_function_query_was_not_run_by_name(
             &db,
             "all_submodule_names_for_package",
             Some(package_id),
@@ -1685,8 +1668,9 @@ not_a_directory
         db.write_file(src.join("main.py"), "print('Hy')")
             .context("Failed to write `main.py`")?;
 
-        // Directory listings preserve the source entry's casing even though resolving the symlink
-        // for `a/__init__.py` results in `a-package/__init__.py`.
+        // The symlink triggers the slow-path in the `OsSystem`'s
+        // `exists_path_case_sensitive` code because canonicalizing the path
+        // for `a/__init__.py` results in `a-package/__init__.py`
         std::os::unix::fs::symlink(a_package_target.as_std_path(), a_src.as_std_path())
             .context("Failed to symlink `src/a` to `a-package`")?;
 

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1,5 +1,6 @@
 use std::collections::btree_map::{BTreeMap, Entry};
 
+use ruff_db::files::directory_listing;
 use ruff_python_ast::PythonVersion;
 
 use crate::db::Db;
@@ -77,19 +78,12 @@ fn list_modules_in<'db>(
     let mut lister = Lister::new(db, search_path.path(db));
     match search_path.path(db).as_path() {
         SystemOrVendoredPathRef::System(system_search_path) => {
-            // Read the revision on the corresponding file root to
-            // register an explicit dependency on this directory. When
-            // the revision gets bumped, the cache that Salsa creates
-            // for this routine will be invalidated.
-            let root = db.files().expect_root(db, system_search_path);
-            let _ = root.revision(db);
-
-            let Ok(it) = db.system().read_directory(system_search_path) else {
+            let Ok(listing) = directory_listing(db, system_search_path) else {
                 return vec![];
             };
-            for result in it {
-                let Ok(entry) = result else { continue };
-                lister.add_path(&entry.path().into(), entry.file_type().into());
+            for (name, file_type) in listing.iter() {
+                let path = system_search_path.join(name);
+                lister.add_path(&path.as_path().into(), file_type.into());
             }
         }
         SystemOrVendoredPathRef::Vendored(vendored_search_path) => {
@@ -402,6 +396,8 @@ mod tests {
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
     use ruff_python_ast::PythonVersion;
+    use salsa::Database as _;
+    use salsa::plumbing::AsId as _;
 
     use crate::db::{Db, tests::TestDb};
     use crate::module::Module;
@@ -413,6 +409,24 @@ mod tests {
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
     use super::list_modules;
+
+    fn assert_query_was_not_run(
+        db: &TestDb,
+        query_name: &str,
+        input: Option<salsa::Id>,
+        events: &[salsa::Event],
+    ) {
+        assert!(
+            !events.iter().any(|event| {
+                let salsa::EventKind::WillExecute { database_key } = event.kind else {
+                    return false;
+                };
+                db.ingredient_debug_name(database_key.ingredient_index()) == query_name
+                    && input.is_none_or(|input| database_key.key_index() == input)
+            }),
+            "Expected {query_name} not to run:\n{events:#?}"
+        );
+    }
 
     struct ModuleDebugSnapshot<'db> {
         db: &'db dyn Db,
@@ -1050,6 +1064,60 @@ mod tests {
     }
 
     #[test]
+    fn nested_file_does_not_invalidate_top_level_listing() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("package/__init__.py", "")])
+            .build();
+
+        list_modules(&db);
+        db.clear_salsa_events();
+
+        db.write_file(src.join("package/nested.py"), "")?;
+        list_modules(&db);
+
+        let events = db.take_salsa_events();
+        assert_query_was_not_run(&db, "list_modules_in", None, &events);
+
+        Ok(())
+    }
+
+    #[test]
+    fn sibling_file_does_not_invalidate_package_submodules() -> anyhow::Result<()> {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("package/__init__.py", "")])
+            .build();
+
+        let package_id = {
+            let package = list_modules(&db)
+                .iter()
+                .find(|module| module.name(&db).as_str() == "package")
+                .copied()
+                .expect("package to exist");
+            package.all_submodules(&db);
+            package.as_id()
+        };
+        db.clear_salsa_events();
+
+        db.write_file(src.join("sibling.py"), "")?;
+        let package = list_modules(&db)
+            .iter()
+            .find(|module| module.name(&db).as_str() == "package")
+            .copied()
+            .expect("package to exist");
+        package.all_submodules(&db);
+
+        let events = db.take_salsa_events();
+        assert_query_was_not_run(
+            &db,
+            "all_submodule_names_for_package",
+            Some(package_id),
+            &events,
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn removing_file_on_which_module_resolution_depends_invalidates_previously_successful_query_that_now_fails()
     -> anyhow::Result<()> {
         const SRC: &[FileSpec] = &[("foo.py", "x = 1"), ("foo/__init__.py", "x = 2")];
@@ -1617,9 +1685,8 @@ not_a_directory
         db.write_file(src.join("main.py"), "print('Hy')")
             .context("Failed to write `main.py`")?;
 
-        // The symlink triggers the slow-path in the `OsSystem`'s
-        // `exists_path_case_sensitive` code because canonicalizing the path
-        // for `a/__init__.py` results in `a-package/__init__.py`
+        // Directory listings preserve the source entry's casing even though resolving the symlink
+        // for `a/__init__.py` results in `a-package/__init__.py`.
         std::os::unix::fs::symlink(a_package_target.as_std_path(), a_src.as_std_path())
             .context("Failed to symlink `src/a` to `a-package`")?;
 

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -1,7 +1,7 @@
 use std::fmt::Formatter;
 use std::str::FromStr;
 
-use ruff_db::files::{File, system_path_to_file, vendored_path_to_file};
+use ruff_db::files::{File, directory_listing, system_path_to_file, vendored_path_to_file};
 use ruff_db::system::SystemPath;
 use ruff_db::vendored::VendoredPath;
 use salsa::Database;
@@ -166,27 +166,17 @@ fn all_submodule_names_for_package<'db>(
 
     Some(match path.parent()? {
         SystemOrVendoredPathRef::System(parent_directory) => {
-            // Read the revision on the corresponding file root to
-            // register an explicit dependency on this directory
-            // tree. When the revision gets bumped, the cache
-            // that Salsa creates does for this routine will be
-            // invalidated.
-            let root = db.files().expect_root(db, parent_directory);
-            let _ = root.revision(db);
-
-            db.system()
-                .read_directory(parent_directory)
-                .inspect_err(|err| {
+            directory_listing(db, parent_directory)
+                .inspect_err(|error| {
                     tracing::debug!(
                         "Failed to read {parent_directory:?} when looking for \
-                         its possible submodules: {err}"
+                         its possible submodules: {error}"
                     );
                 })
                 .ok()?
-                .flatten()
-                .filter(|entry| {
-                    let ty = entry.file_type();
-                    let path = entry.path();
+                .iter()
+                .filter(|(name, ty)| {
+                    let path = SystemPath::new(name);
                     is_submodule(
                         ty.is_directory(),
                         ty.is_file(),
@@ -194,18 +184,17 @@ fn all_submodule_names_for_package<'db>(
                         path.extension(),
                     )
                 })
-                .filter_map(|entry| {
-                    let stem = entry.path().file_stem()?;
+                .filter_map(|(entry_name, file_type)| {
+                    let relative = SystemPath::new(entry_name);
+                    let stem = relative.file_stem()?;
+                    let path = parent_directory.join(relative);
                     let mut name = module.name(db).clone();
                     name.extend(&ModuleName::new(stem)?);
 
-                    let (kind, file) = if entry.file_type().is_directory() {
-                        (
-                            ModuleKind::Package,
-                            find_package_init_system(db, entry.path())?,
-                        )
+                    let (kind, file) = if file_type.is_directory() {
+                        (ModuleKind::Package, find_package_init_system(db, &path)?)
                     } else {
-                        let file = system_path_to_file(db, entry.path()).ok()?;
+                        let file = system_path_to_file(db, &path).ok()?;
                         (ModuleKind::Module, file)
                     };
                     Some(Module::file_module(

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -38,7 +38,7 @@ use std::iter::FusedIterator;
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
 use ruff_db::files::{File, FilePath, FileRootKind, directory_listing, system_path_to_file};
-use ruff_db::source::{SourceText, source_text};
+use ruff_db::source::source_text;
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{
@@ -843,64 +843,68 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         // The Python documentation specifies that `.pth` files in `site-packages`
         // are processed in alphabetical order. `DirectoryListing` is already sorted.
         // https://docs.python.org/3/library/site.html#module-site
-        let all_pth_files = listing
-            .iter()
-            .filter(|(name, file_type)| {
-                !file_type.is_directory() && SystemPath::new(name).extension() == Some("pth")
-            })
-            .filter_map(|(name, _)| {
-                let path = site_packages_dir.join(name);
-                // Track each `.pth` file independently so content changes invalidate this query.
-                let file = system_path_to_file(db, &path)
-                    .inspect_err(|error| {
-                        tracing::warn!("Failed to open .pth file `{path}`: {error}");
-                    })
-                    .ok()?;
-                let contents = source_text(db, file);
-                if let Some(error) = contents.read_error() {
-                    tracing::warn!("Failed to read .pth file `{path}`: {error}");
+        let pth_files = listing.iter().filter(|(name, file_type)| {
+            !file_type.is_directory() && SystemPath::new(name).extension() == Some("pth")
+        });
+
+        for (name, _) in pth_files {
+            let path = site_packages_dir.join(name);
+            // Track each `.pth` file independently so content changes invalidate this query.
+            let Ok(file) = system_path_to_file(db, &path).inspect_err(|error| {
+                tracing::warn!("Failed to open .pth file `{path}`: {error}");
+            }) else {
+                continue;
+            };
+            let contents = source_text(db, file);
+            if let Some(error) = contents.read_error() {
+                tracing::warn!("Failed to read .pth file `{path}`: {error}");
+                continue;
+            }
+
+            let installations = contents.lines().filter_map(|line| {
+                let line = line.trim_end();
+                if line.is_empty()
+                    || line.starts_with('#')
+                    || line.starts_with("import ")
+                    || line.starts_with("import\t")
+                {
                     return None;
                 }
 
-                Some(PthFile {
-                    contents,
-                    site_packages: site_packages_dir,
-                })
-            })
-            .collect::<Vec<_>>();
+                Some(SystemPath::absolute(line, site_packages_dir))
+            });
 
-        let installations = all_pth_files.iter().flat_map(PthFile::items);
+            for installation in installations {
+                let installation = system
+                    .canonicalize_path(&installation)
+                    .unwrap_or(installation);
 
-        for installation in installations {
-            let installation = system
-                .canonicalize_path(&installation)
-                .unwrap_or(installation);
+                if existing_paths.insert(Cow::Owned(installation.clone())) {
+                    match SearchPath::editable(system, installation.clone()) {
+                        Ok(search_path) => {
+                            tracing::debug!(
+                                "Adding editable installation to module resolution path {path}",
+                                path = installation
+                            );
 
-            if existing_paths.insert(Cow::Owned(installation.clone())) {
-                match SearchPath::editable(system, installation.clone()) {
-                    Ok(search_path) => {
-                        tracing::debug!(
-                            "Adding editable installation to module resolution path {path}",
-                            path = installation
-                        );
-
-                        // Register a file root for editable installs that are outside any other root
-                        // (Most importantly, don't register a root for editable installations from the project
-                        // directory as that would change the durability of files within those folders).
-                        // Not having an exact file root for editable installs just means that
-                        // some queries (like `list_modules_in`) will run slightly more frequently
-                        // than they would otherwise.
-                        if let Some(dynamic_path) = search_path.as_system_path() {
-                            if files.root(db, dynamic_path).is_none() {
-                                files.try_add_root(db, dynamic_path, FileRootKind::SearchPath);
+                            // Register a file root for editable installs that are outside any other root
+                            // (Most importantly, don't register a root for editable installations from the project
+                            // directory as that would change the durability of files within those folders).
+                            // Not having an exact file root for editable installs just means that
+                            // some queries (like `list_modules_in`) will run slightly more frequently
+                            // than they would otherwise.
+                            if let Some(dynamic_path) = search_path.as_system_path() {
+                                if files.root(db, dynamic_path).is_none() {
+                                    files.try_add_root(db, dynamic_path, FileRootKind::SearchPath);
+                                }
                             }
+
+                            dynamic_paths.push(search_path);
                         }
 
-                        dynamic_paths.push(search_path);
-                    }
-
-                    Err(error) => {
-                        tracing::debug!("Skipping editable installation: {error}");
+                        Err(error) => {
+                            tracing::debug!("Skipping editable installation: {error}");
+                        }
                     }
                 }
             }
@@ -949,42 +953,6 @@ impl<'db> Iterator for SearchPathIterator<'db> {
 }
 
 impl FusedIterator for SearchPathIterator<'_> {}
-
-/// Represents a single `.pth` file in a `site-packages` directory.
-/// One or more lines in a `.pth` file may be a (relative or absolute)
-/// path that represents an editable installation of a package.
-struct PthFile<'db> {
-    contents: SourceText,
-    site_packages: &'db SystemPath,
-}
-
-impl<'db> PthFile<'db> {
-    /// Yield paths in this `.pth` file that appear to represent editable installations,
-    /// and should therefore be added as module-resolution search paths.
-    fn items(&'db self) -> impl Iterator<Item = SystemPathBuf> + 'db {
-        let PthFile {
-            contents,
-            site_packages,
-        } = self;
-
-        // Empty lines or lines starting with '#' are ignored by the Python interpreter.
-        // Lines that start with "import " or "import\t" do not represent editable installs at all;
-        // instead, these are lines that are executed by Python at startup.
-        // https://docs.python.org/3/library/site.html#module-site
-        contents.lines().filter_map(move |line| {
-            let line = line.trim_end();
-            if line.is_empty()
-                || line.starts_with('#')
-                || line.starts_with("import ")
-                || line.starts_with("import\t")
-            {
-                return None;
-            }
-
-            Some(SystemPath::absolute(line, site_packages))
-        })
-    }
-}
 
 /// A thin wrapper around `ModuleName` to make it a Salsa ingredient.
 ///

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -37,8 +37,9 @@ use std::iter::FusedIterator;
 
 use rustc_hash::{FxBuildHasher, FxHashSet};
 
-use ruff_db::files::{File, FilePath, FileRootKind};
-use ruff_db::system::{DirectoryEntry, System, SystemPath, SystemPathBuf};
+use ruff_db::files::{File, FilePath, FileRootKind, directory_listing, system_path_to_file};
+use ruff_db::source::{SourceText, source_text};
+use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{
     self as ast, PySourceType, PythonVersion,
@@ -386,36 +387,26 @@ fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
             ))
         })?;
 
-    // Read the revision on the corresponding file root to
-    // register an explicit dependency on this directory. When
-    // the revision gets bumped, the cache that Salsa creates
-    // for this routine will be invalidated.
-    //
-    // (This is conditional because ruff uses this code too and doesn't set roots)
-    if let Some(root) = db.files().root(db, base_path) {
-        let _ = root.revision(db);
-    }
-
     // Only allow searching up to the first-party path's root
     let mut search_paths = Vec::new();
     for rel_dir in rel_path.ancestors() {
         let candidate_path = base_path.join(rel_dir);
-        if !system.is_directory(&candidate_path) {
+        let Ok(listing) = directory_listing(db, &candidate_path) else {
             continue;
-        }
+        };
         // Any dir that isn't a proper package is plausibly some test/script dir that could be
         // added as a search-path at runtime. Notably this reflects pytest's default mode where
         // it adds every dir with a .py to the search-paths (making all test files root modules),
         // unless they see an `__init__.py`, in which case they assume you don't want that.
-        let isnt_regular_package = !system.is_file(&candidate_path.join("__init__.py"))
-            && !system.is_file(&candidate_path.join("__init__.pyi"));
+        let isnt_regular_package = !listing.entry_is_file(db, &candidate_path, "__init__.py")
+            && !listing.entry_is_file(db, &candidate_path, "__init__.pyi");
         // Any dir with a pyproject.toml or ty.toml is a valid relative desperate search-path and
         // we want all of those to also be valid absolute desperate search-paths. It doesn't
         // make any sense for a folder to have `pyproject.toml` and `__init__.py` but let's
         // not let something cursed and spooky happen, ok? d
         if isnt_regular_package
-            || system.is_file(&candidate_path.join("pyproject.toml"))
-            || system.is_file(&candidate_path.join("ty.toml"))
+            || listing.entry_is_file(db, &candidate_path, "pyproject.toml")
+            || listing.entry_is_file(db, &candidate_path, "ty.toml")
         {
             let search_path = SearchPath::first_party(system, candidate_path).ok()?;
             search_paths.push(search_path);
@@ -460,22 +451,15 @@ fn relative_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
             ))
         })?;
 
-    // Read the revision on the corresponding file root to
-    // register an explicit dependency on this directory. When
-    // the revision gets bumped, the cache that Salsa creates
-    // for this routine will be invalidated.
-    //
-    // (This is conditional because ruff uses this code too and doesn't set roots)
-    if let Some(root) = db.files().root(db, base_path) {
-        let _ = root.revision(db);
-    }
-
     // Only allow searching up to the first-party path's root
     for rel_dir in rel_path.ancestors() {
         let candidate_path = base_path.join(rel_dir);
+        let Ok(listing) = directory_listing(db, &candidate_path) else {
+            continue;
+        };
         // Any dir with a pyproject.toml or ty.toml might be a project root
-        if system.is_file(&candidate_path.join("pyproject.toml"))
-            || system.is_file(&candidate_path.join("ty.toml"))
+        if listing.entry_is_file(db, &candidate_path, "pyproject.toml")
+            || listing.entry_is_file(db, &candidate_path, "ty.toml")
         {
             let search_path = SearchPath::first_party(system, candidate_path).ok()?;
             return Some(search_path);
@@ -838,15 +822,6 @@ pub(crate) fn dynamic_resolution_paths<'db>(
             continue;
         }
 
-        let site_packages_root = files.expect_root(db, site_packages_dir);
-
-        // This query needs to be re-executed each time a `.pth` file
-        // is added, modified or removed from the `site-packages` directory.
-        // However, we don't use Salsa queries to read the source text of `.pth` files;
-        // we use the APIs on the `System` trait directly. As such, add a dependency on the
-        // site-package directory's revision.
-        site_packages_root.revision(db);
-
         dynamic_paths.push(site_packages_search_path.clone());
 
         // As well as modules installed directly into `site-packages`,
@@ -855,8 +830,8 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         // containing a (relative or absolute) path.
         // Each of these paths may point to an editable install of a package,
         // so should be considered an additional search path.
-        let pth_file_iterator = match PthFileIterator::new(db, site_packages_dir) {
-            Ok(iterator) => iterator,
+        let listing = match directory_listing(db, site_packages_dir) {
+            Ok(listing) => listing,
             Err(error) => {
                 tracing::warn!(
                     "Failed to search for editable installation in {site_packages_dir}: {error}"
@@ -866,10 +841,33 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         };
 
         // The Python documentation specifies that `.pth` files in `site-packages`
-        // are processed in alphabetical order, so collecting and then sorting is necessary.
+        // are processed in alphabetical order. `DirectoryListing` is already sorted.
         // https://docs.python.org/3/library/site.html#module-site
-        let mut all_pth_files: Vec<PthFile> = pth_file_iterator.collect();
-        all_pth_files.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        let all_pth_files = listing
+            .iter()
+            .filter(|(name, file_type)| {
+                !file_type.is_directory() && SystemPath::new(name).extension() == Some("pth")
+            })
+            .filter_map(|(name, _)| {
+                let path = site_packages_dir.join(name);
+                // Track each `.pth` file independently so content changes invalidate this query.
+                let file = system_path_to_file(db, &path)
+                    .inspect_err(|error| {
+                        tracing::warn!("Failed to open .pth file `{path}`: {error}");
+                    })
+                    .ok()?;
+                let contents = source_text(db, file);
+                if let Some(error) = contents.read_error() {
+                    tracing::warn!("Failed to read .pth file `{path}`: {error}");
+                    return None;
+                }
+
+                Some(PthFile {
+                    contents,
+                    site_packages: site_packages_dir,
+                })
+            })
+            .collect::<Vec<_>>();
 
         let installations = all_pth_files.iter().flat_map(PthFile::items);
 
@@ -956,8 +954,7 @@ impl FusedIterator for SearchPathIterator<'_> {}
 /// One or more lines in a `.pth` file may be a (relative or absolute)
 /// path that represents an editable installation of a package.
 struct PthFile<'db> {
-    path: SystemPathBuf,
-    contents: String,
+    contents: SourceText,
     site_packages: &'db SystemPath,
 }
 
@@ -966,7 +963,6 @@ impl<'db> PthFile<'db> {
     /// and should therefore be added as module-resolution search paths.
     fn items(&'db self) -> impl Iterator<Item = SystemPathBuf> + 'db {
         let PthFile {
-            path: _,
             contents,
             site_packages,
         } = self;
@@ -987,67 +983,6 @@ impl<'db> PthFile<'db> {
 
             Some(SystemPath::absolute(line, site_packages))
         })
-    }
-}
-
-/// Iterator that yields a [`PthFile`] instance for every `.pth` file
-/// found in a given `site-packages` directory.
-struct PthFileIterator<'db> {
-    db: &'db dyn Db,
-    directory_iterator: Box<dyn Iterator<Item = std::io::Result<DirectoryEntry>> + 'db>,
-    site_packages: &'db SystemPath,
-}
-
-impl<'db> PthFileIterator<'db> {
-    fn new(db: &'db dyn Db, site_packages: &'db SystemPath) -> std::io::Result<Self> {
-        Ok(Self {
-            db,
-            directory_iterator: db.system().read_directory(site_packages)?,
-            site_packages,
-        })
-    }
-}
-
-impl<'db> Iterator for PthFileIterator<'db> {
-    type Item = PthFile<'db>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let PthFileIterator {
-            db,
-            directory_iterator,
-            site_packages,
-        } = self;
-
-        let system = db.system();
-
-        loop {
-            let entry_result = directory_iterator.next()?;
-            let Ok(entry) = entry_result else {
-                continue;
-            };
-            let file_type = entry.file_type();
-            if file_type.is_directory() {
-                continue;
-            }
-            let path = entry.into_path();
-            if path.extension() != Some("pth") {
-                continue;
-            }
-
-            let contents = match system.read_to_string(&path) {
-                Ok(contents) => contents,
-                Err(error) => {
-                    tracing::warn!("Failed to read .pth file `{path}`: {error}");
-                    continue;
-                }
-            };
-
-            return Some(PthFile {
-                path,
-                contents,
-                site_packages,
-            });
-        }
     }
 }
 
@@ -2754,6 +2689,66 @@ not_a_directory
             ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
             &events,
         );
+    }
+
+    #[test]
+    fn nested_site_packages_change_does_not_invalidate_dynamic_resolution_paths() {
+        const SITE_PACKAGES: &[FileSpec] = &[("_foo.pth", "/x/src"), ("package/__init__.py", "")];
+
+        let TestCase {
+            mut db,
+            site_packages,
+            ..
+        } = TestCaseBuilder::new()
+            .with_site_packages_files(SITE_PACKAGES)
+            .build();
+
+        dynamic_resolution_paths(
+            &db,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+        );
+        db.clear_salsa_events();
+
+        db.write_file(site_packages.join("package/nested.py"), "")
+            .unwrap();
+        dynamic_resolution_paths(
+            &db,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+        );
+
+        let events = db.take_salsa_events();
+        assert_function_query_was_not_run(
+            &db,
+            dynamic_resolution_paths,
+            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::StubsAllowed),
+            &events,
+        );
+    }
+
+    #[test]
+    fn modifying_pth_file_invalidates_dynamic_resolution_paths() {
+        const SITE_PACKAGES: &[FileSpec] = &[("_editable.pth", "/x/src")];
+
+        let TestCase {
+            mut db,
+            site_packages,
+            ..
+        } = TestCaseBuilder::new()
+            .with_site_packages_files(SITE_PACKAGES)
+            .build();
+        db.write_files([("/x/src/foo.py", ""), ("/y/src/bar.py", "")])
+            .unwrap();
+
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("foo").unwrap()).is_some());
+
+        let pth_path = site_packages.join("_editable.pth");
+        db.memory_file_system()
+            .write_file(&pth_path, "/y/src")
+            .unwrap();
+        File::sync_path_only(&mut db, &pth_path);
+
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("foo").unwrap()).is_none());
+        assert!(resolve_module_confident(&db, &ModuleName::new_static("bar").unwrap()).is_some());
     }
 
     #[test]

--- a/crates/ty_module_resolver/src/testing.rs
+++ b/crates/ty_module_resolver/src/testing.rs
@@ -109,11 +109,6 @@ pub(crate) struct TestCaseBuilder<T> {
     site_packages_files: Vec<FileSpec>,
     // Additional file roots (beyond site_packages, src and stdlib)
     // that should be registered with the `Db` abstraction.
-    //
-    // This is necessary to make testing "list modules" work. Namely,
-    // "list modules" relies on caching via a file root's revision,
-    // and if file roots aren't registered, then the implementation
-    // can't access the root's revision.
     roots: Vec<SystemPathBuf>,
 }
 
@@ -259,13 +254,6 @@ impl TestCaseBuilder<MockedTypeshed> {
 
         db = db.with_search_paths(search_paths);
 
-        // This root is needed for correct Salsa tracking.
-        // Namely, a `SearchPath` is treated as an input, and
-        // thus the revision number must be bumped accordingly
-        // when the directory tree changes. We rely on detecting
-        // this revision from the file root. If we don't add them
-        // here, they won't get added.
-        //
         // Roots for other search paths are added as part of
         // search path initialization in `SearchPaths::from_settings`,
         // and any remaining are added below.

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -7,11 +7,9 @@ use std::collections::BTreeSet;
 use super::ignore::IgnoreFiles;
 use crate::walk::ProjectFilesWalker;
 use ruff_db::Db as _;
-use ruff_db::file_revision::FileRevision;
-use ruff_db::files::{File, FileRootKind, Files, system_path_to_file};
-use ruff_db::system::{SystemPath, SystemPathBuf, deduplicate_nested_paths};
+use ruff_db::files::{File, Files, system_path_to_file};
+use ruff_db::system::{SystemPath, SystemPathBuf};
 use rustc_hash::FxHashSet;
-use salsa::Setter;
 use ty_python_core::program::{FallibleStrategy, Program};
 
 /// Represents the result of applying changes to the project database.
@@ -138,35 +136,6 @@ impl ProjectDatabase {
                 ChangeEvent::Changed { path, kind: _ } | ChangeEvent::Opened(path) => {
                     if synced_files.insert(path.to_path_buf()) {
                         File::sync_path_only(self, path);
-                        if let Some(root) = self.files().root(self, path) {
-                            match root.kind_at_time_of_creation(self) {
-                                // When a file inside the root of
-                                // the project is changed, we don't
-                                // want to mark the entire root as
-                                // having changed too. In theory it
-                                // might make sense to, but at time
-                                // of writing, the file root revision
-                                // on a project is used to invalidate
-                                // the submodule files found within a
-                                // directory. If we bumped the revision
-                                // on every change within a project,
-                                // then this caching technique would be
-                                // effectively useless.
-                                //
-                                // It's plausible we should explore
-                                // a more robust cache invalidation
-                                // strategy that models more directly
-                                // what we care about. For example, by
-                                // keeping track of directories and
-                                // their direct children explicitly,
-                                // and then keying the submodule cache
-                                // off of that instead. ---AG
-                                FileRootKind::Project => {}
-                                FileRootKind::SearchPath => {
-                                    root.set_revision(self).to(FileRevision::now());
-                                }
-                            }
-                        }
                     }
                 }
 
@@ -277,7 +246,7 @@ impl ProjectDatabase {
             }
         }
 
-        Files::sync_all_recursive(self, deduplicate_nested_paths(sync_recursively));
+        Files::sync_all_recursive(self, sync_recursively);
 
         if reload_project {
             // The active project root may have been deleted. Start rediscovery from


### PR DESCRIPTION
## Summary

There are a few places where we read directory contents. Each of those call sites adds a dependency on `FileRoot::revision` to ensure that the enclosing query is invalidated when the directory's contents change. The granularity of `FileRoot` is per search path. That is, we create a `FileRoot` for each search path, and we bump the `FileRevision` whenever a new file is added, a file is removed, or a file's metadata is changed within this entire subtree. This has worked fine so far, but we now also plan on reading directories in the module resolver (https://github.com/astral-sh/ruff/pull/25962), where we want more granular query invalidation. 

This PR extends `File` to also track the metadata and revision of directories. This allows us to have a new `directory_listing` query. It reads and caches the directory content and adds the dependency on `directory.revision`. This, in turn, allows us to remove `revision` from `FileRoot,` and it is now back to its original intended purpose: Defining the durability of a file or directory within a subtree (third-party dependencies have durability HIGH, whereas first-party files have a durability of Medium)

I considered a new `Directory` input. In fact, that's how this implementation started. However, during review, I realized that we need to track the exact same information as in `File` and `File` already tracks whether a path "is a directory". Ultimately, using `File` felt easier and is also not much of a stretch, given that this is also the case on unix.

the upside of this change is that `list_modules` (used by completion) now is only invalidated if the specific directory changes, and not for every change to its file root.

## Test Plan

Existing tests