### PR TITLE
[ty] Speed up module resolution for projects with many search paths

### DIFF
--- a/crates/ruff_db/src/files.rs
+++ b/crates/ruff_db/src/files.rs
@@ -117,6 +117,7 @@ impl Files {
                         .permissions(metadata.permissions())
                         .revision(metadata.revision()),
                     Ok(metadata) if metadata.file_type().is_directory() => builder
+                        .durability(Durability::MEDIUM.max(durability))
                         .status(FileStatus::IsADirectory)
                         .permissions(metadata.permissions())
                         .revision(metadata.revision()),

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -20,6 +20,16 @@ impl DirectoryListing {
             .map(|index| self.0[index].1)
     }
 
+    /// Returns whether any entry name starts with `prefix`.
+    pub fn contains_name_with_prefix(&self, prefix: &str) -> bool {
+        let index = self
+            .0
+            .partition_point(|(candidate, _)| candidate.as_str() < prefix);
+        self.0
+            .get(index)
+            .is_some_and(|(name, _)| name.starts_with(prefix))
+    }
+
     /// Returns whether `name` resolves to a file, following symbolic links.
     pub fn entry_is_file(&self, db: &dyn Db, directory: &SystemPath, name: &str) -> bool {
         match self.file_type(name) {
@@ -133,6 +143,8 @@ mod tests {
             listing.iter().map(|(name, _)| name).collect::<Vec<_>>(),
             ["a.py", "z.py"]
         );
+        assert!(listing.contains_name_with_prefix("a"));
+        assert!(!listing.contains_name_with_prefix("b"));
 
         Ok(())
     }

--- a/crates/ruff_db/src/files/directory.rs
+++ b/crates/ruff_db/src/files/directory.rs
@@ -39,6 +39,15 @@ impl DirectoryListing {
         }
     }
 
+    /// Returns whether `name` resolves to a directory, following symbolic links.
+    pub fn entry_is_directory(&self, db: &dyn Db, directory: &SystemPath, name: &str) -> bool {
+        match self.file_type(name) {
+            Some(FileType::Directory) => true,
+            Some(FileType::File) | None => false,
+            Some(FileType::Symlink) => db.system().is_directory(&directory.join(name)),
+        }
+    }
+
     /// Iterates over the entries in the directory in name order.
     pub fn iter(&self) -> impl Iterator<Item = (&str, FileType)> {
         self.0

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -124,17 +124,6 @@ pub trait System: Debug + Sync + Send {
         self.path_metadata(path).is_ok()
     }
 
-    /// Returns `true` if `path` exists on disk using the exact casing as specified in `path` for the parts after `prefix`.
-    ///
-    /// This is the same as [`Self::path_exists`] on case-sensitive systems.
-    ///
-    /// ## The use of prefix
-    ///
-    /// Prefix is only intended as an optimization for systems that can't efficiently check
-    /// if an entire path exists with the exact casing as specified in `path`. However,
-    /// implementations are allowed to check the casing of the entire path if they can do so efficiently.
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool;
-
     /// Returns the [`CaseSensitivity`] of the system's file system.
     fn case_sensitivity(&self) -> CaseSensitivity;
 

--- a/crates/ruff_db/src/system.rs
+++ b/crates/ruff_db/src/system.rs
@@ -11,7 +11,7 @@ use ruff_notebook::{Notebook, NotebookError};
 use ruff_python_ast::PySourceType;
 use std::error::Error;
 use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 pub use test::{DbWithTestSystem, DbWithWritableSystem, InMemorySystem, TestSystem};
 use walk_directory::WalkDirectoryBuilder;
 
@@ -124,9 +124,6 @@ pub trait System: Debug + Sync + Send {
         self.path_metadata(path).is_ok()
     }
 
-    /// Returns the [`CaseSensitivity`] of the system's file system.
-    fn case_sensitivity(&self) -> CaseSensitivity;
-
     /// Returns `true` if `path` exists and is a directory.
     fn is_directory(&self, path: &SystemPath) -> bool {
         self.path_metadata(path)
@@ -209,39 +206,6 @@ pub trait System: Debug + Sync + Send {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 
     fn dyn_clone(&self) -> Box<dyn System>;
-}
-
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-pub enum CaseSensitivity {
-    /// The case sensitivity of the file system is unknown.
-    ///
-    /// The file system is either case-sensitive or case-insensitive. A caller
-    /// should not assume either case.
-    #[default]
-    Unknown,
-
-    /// The file system is case-sensitive.
-    CaseSensitive,
-
-    /// The file system is case-insensitive.
-    CaseInsensitive,
-}
-
-impl CaseSensitivity {
-    /// Returns `true` if the file system is known to be case-sensitive.
-    pub const fn is_case_sensitive(self) -> bool {
-        matches!(self, Self::CaseSensitive)
-    }
-}
-
-impl fmt::Display for CaseSensitivity {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            CaseSensitivity::Unknown => f.write_str("unknown"),
-            CaseSensitivity::CaseSensitive => f.write_str("case-sensitive"),
-            CaseSensitivity::CaseInsensitive => f.write_str("case-insensitive"),
-        }
-    }
 }
 
 /// System trait for non-readonly systems.

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -6,7 +6,7 @@ use super::walk_directory::{
 };
 use crate::max_parallelism;
 use crate::system::{
-    CaseSensitivity, DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
+    DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
     SystemVirtualPath, WhichError, WhichResult, WritableSystem,
 };
 use filetime::FileTime;
@@ -25,8 +25,6 @@ pub struct OsSystem {
 struct OsSystemInner {
     cwd: SystemPathBuf,
 
-    case_sensitivity: CaseSensitivity,
-
     /// Overrides the user's configuration directory for testing.
     /// This is an `Option<Option<..>>` to allow setting an override of `None`.
     #[cfg(feature = "testing")]
@@ -38,10 +36,8 @@ impl OsSystem {
         let cwd = cwd.as_ref();
         assert!(cwd.as_utf8_path().is_absolute());
 
-        let case_sensitivity = detect_case_sensitivity(cwd);
-
         tracing::debug!(
-            "Architecture: {}, OS: {}, case-sensitive: {case_sensitivity}",
+            "Architecture: {}, OS: {}",
             std::env::consts::ARCH,
             std::env::consts::OS,
         );
@@ -50,7 +46,6 @@ impl OsSystem {
             // Spreading `..Default` because it isn't possible to feature gate the initializer of a single field.
             inner: Arc::new(OsSystemInner {
                 cwd: cwd.to_path_buf(),
-                case_sensitivity,
                 ..Default::default()
             }),
         }
@@ -114,10 +109,6 @@ impl System for OsSystem {
 
     fn path_exists(&self, path: &SystemPath) -> bool {
         path.as_std_path().exists()
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        self.inner.case_sensitivity
     }
 
     fn which(&self, name: &str) -> WhichResult {
@@ -475,45 +466,6 @@ pub(super) mod testing {
                 self.system.inner.user_config_directory_override.try_lock()
             {
                 *directory_override = self.previous.take();
-            }
-        }
-    }
-}
-
-#[cfg(not(unix))]
-fn detect_case_sensitivity(_path: &SystemPath) -> CaseSensitivity {
-    // 99% of windows systems aren't case sensitive Don't bother checking.
-    CaseSensitivity::Unknown
-}
-
-#[cfg(unix)]
-fn detect_case_sensitivity(path: &SystemPath) -> CaseSensitivity {
-    use std::os::unix::fs::MetadataExt;
-
-    let Ok(original_case_metadata) = path.as_std_path().metadata() else {
-        return CaseSensitivity::Unknown;
-    };
-
-    let upper_case = SystemPathBuf::from(path.as_str().to_uppercase());
-    if &*upper_case == path {
-        return CaseSensitivity::Unknown;
-    }
-
-    match upper_case.as_std_path().metadata() {
-        Ok(uppercase_meta) => {
-            // The file system is case insensitive if the upper case and mixed case paths have the same inode.
-            if uppercase_meta.ino() == original_case_metadata.ino() {
-                CaseSensitivity::CaseInsensitive
-            } else {
-                CaseSensitivity::CaseSensitive
-            }
-        }
-        // In the error case, the file system is case sensitive if the file in all upper case doesn't exist.
-        Err(error) => {
-            if error.kind() == std::io::ErrorKind::NotFound {
-                CaseSensitivity::CaseSensitive
-            } else {
-                CaseSensitivity::Unknown
             }
         }
     }

--- a/crates/ruff_db/src/system/os.rs
+++ b/crates/ruff_db/src/system/os.rs
@@ -11,9 +11,7 @@ use crate::system::{
 };
 use filetime::FileTime;
 use ruff_notebook::{Notebook, NotebookError};
-use rustc_hash::FxHashSet;
 use std::num::NonZeroUsize;
-use std::panic::RefUnwindSafe;
 use std::sync::Arc;
 use std::{any::Any, path::PathBuf};
 
@@ -26,8 +24,6 @@ pub struct OsSystem {
 #[derive(Default, Debug)]
 struct OsSystemInner {
     cwd: SystemPathBuf,
-
-    real_case_cache: CaseSensitivePathsCache,
 
     case_sensitivity: CaseSensitivity,
 
@@ -118,15 +114,6 @@ impl System for OsSystem {
 
     fn path_exists(&self, path: &SystemPath) -> bool {
         path.as_std_path().exists()
-    }
-
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        if self.case_sensitivity().is_case_sensitive() {
-            self.path_exists(path)
-        } else {
-            self.path_exists_case_sensitive_fast(path)
-                .unwrap_or_else(|| self.path_exists_case_sensitive_slow(path, prefix))
-        }
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {
@@ -242,94 +229,6 @@ impl System for OsSystem {
     }
 }
 
-impl OsSystem {
-    /// Path sensitive testing if a path exists by canonicalization the path and comparing it with `path`.
-    ///
-    /// This is faster than the slow path, because it requires a single system call for each path
-    /// instead of at least one system call for each component between `path` and `prefix`.
-    ///
-    /// However, using `canonicalize` to resolve the path's casing doesn't work in two cases:
-    /// * if `path` is a symlink, `canonicalize` returns the symlink's target and not the symlink's source path.
-    /// * on Windows: If `path` is a mapped network drive, `canonicalize` returns the UNC path
-    ///   (e.g. `Z:\` is mapped to `\\server\share` and `canonicalize` returns `\\?\UNC\server\share`).
-    ///
-    /// Symlinks and mapped network drives should be rare enough that this fast path is worth trying first,
-    /// even if it comes at a cost for those rare use cases.
-    fn path_exists_case_sensitive_fast(&self, path: &SystemPath) -> Option<bool> {
-        // This is a more forgiving version of `dunce::simplified` that removes all `\\?\` prefixes on Windows.
-        // We use this more forgiving version because we don't intend on using either path for anything other than comparison
-        // and the prefix is only relevant when passing the path to other programs and it's longer than 200 something
-        // characters.
-        fn simplify_ignore_verbatim(path: &SystemPath) -> &SystemPath {
-            if cfg!(windows) {
-                if path.as_utf8_path().as_str().starts_with(r"\\?\") {
-                    SystemPath::new(&path.as_utf8_path().as_str()[r"\\?\".len()..])
-                } else {
-                    path
-                }
-            } else {
-                path
-            }
-        }
-
-        let Ok(canonicalized) = path.as_std_path().canonicalize() else {
-            // The path doesn't exist or can't be accessed. The path doesn't exist.
-            return Some(false);
-        };
-
-        let Ok(canonicalized) = SystemPathBuf::from_path_buf(canonicalized) else {
-            // The original path is valid UTF8 but the canonicalized path isn't. This definitely suggests
-            // that a symlink is involved. Fall back to the slow path.
-            tracing::debug!(
-                "Falling back to the slow case-sensitive path existence check because the canonicalized path of `{path}` is not valid UTF-8"
-            );
-            return None;
-        };
-
-        let simplified_canonicalized = simplify_ignore_verbatim(&canonicalized);
-        let simplified = simplify_ignore_verbatim(path);
-
-        // Test if the paths differ by anything other than casing. If so, that suggests that
-        // `path` pointed to a symlink (or some other none reversible path normalization happened).
-        // In this case, fall back to the slow path.
-        if simplified_canonicalized.as_str().to_lowercase() != simplified.as_str().to_lowercase() {
-            tracing::debug!(
-                "Falling back to the slow case-sensitive path existence check for `{simplified}` because the canonicalized path `{simplified_canonicalized}` differs not only by casing"
-            );
-            return None;
-        }
-
-        // If there are no symlinks involved, then `path` exists only if it is the same as the canonicalized path.
-        Some(simplified_canonicalized == simplified)
-    }
-
-    fn path_exists_case_sensitive_slow(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        // Iterate over the sub-paths up to prefix and check if they match the casing as on disk.
-        for ancestor in path.ancestors() {
-            if ancestor == prefix {
-                break;
-            }
-
-            match self.inner.real_case_cache.has_name_case(ancestor) {
-                Ok(true) => {
-                    // Component has correct casing, continue with next component
-                }
-                Ok(false) => {
-                    // Component has incorrect casing
-                    return false;
-                }
-                Err(_) => {
-                    // Directory doesn't exist or can't be accessed. We can assume that the file with
-                    // the given casing doesn't exist.
-                    return false;
-                }
-            }
-        }
-
-        true
-    }
-}
-
 impl WritableSystem for OsSystem {
     fn create_new_file(&self, path: &SystemPath) -> Result<()> {
         std::fs::File::create_new(path).map(drop)
@@ -355,84 +254,6 @@ impl Default for OsSystem {
                 .unwrap_or_default(),
         )
     }
-}
-
-#[derive(Debug, Default)]
-struct CaseSensitivePathsCache {
-    by_lower_case: dashmap::DashMap<SystemPathBuf, ListedDirectory>,
-}
-
-impl CaseSensitivePathsCache {
-    /// Test if `path`'s file name uses the exact same casing as the file on disk.
-    ///
-    /// Returns `false` if the file doesn't exist.
-    ///
-    /// Components other than the file portion are ignored.
-    fn has_name_case(&self, path: &SystemPath) -> Result<bool> {
-        let Some(parent) = path.parent() else {
-            // The root path is always considered to exist.
-            return Ok(true);
-        };
-
-        let Some(file_name) = path.file_name() else {
-            // We can only get here for paths ending in `..` or the root path. Root paths are handled above.
-            // Return `true` for paths ending in `..` because `..` is the same regardless of casing.
-            return Ok(true);
-        };
-
-        let lower_case_path = SystemPathBuf::from(parent.as_str().to_lowercase());
-        let last_modification_time =
-            FileTime::from_last_modification_time(&parent.as_std_path().metadata()?);
-
-        let entry = self.by_lower_case.entry(lower_case_path);
-
-        if let dashmap::Entry::Occupied(entry) = &entry {
-            // Only do a cached lookup if the directory hasn't changed.
-            if entry.get().last_modification_time == last_modification_time {
-                tracing::trace!("Use cached case-sensitive entry for directory `{}`", parent);
-                return Ok(entry.get().names.contains(file_name));
-            }
-        }
-
-        tracing::trace!(
-            "Reading directory `{}` for its case-sensitive filenames",
-            parent
-        );
-        let start = std::time::Instant::now();
-        let mut names = FxHashSet::default();
-
-        for entry in parent.as_std_path().read_dir()? {
-            let Ok(entry) = entry else {
-                continue;
-            };
-
-            let Ok(name) = entry.file_name().into_string() else {
-                continue;
-            };
-
-            names.insert(name.into_boxed_str());
-        }
-
-        let directory = entry.insert(ListedDirectory {
-            last_modification_time,
-            names,
-        });
-
-        tracing::debug!(
-            "Caching the case-sensitive paths for directory `{parent}` took {:?}",
-            start.elapsed()
-        );
-
-        Ok(directory.names.contains(file_name))
-    }
-}
-
-impl RefUnwindSafe for CaseSensitivePathsCache {}
-
-#[derive(Debug, Eq, PartialEq)]
-struct ListedDirectory {
-    last_modification_time: FileTime,
-    names: FxHashSet<Box<str>>,
 }
 
 #[derive(Debug)]

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use crate::Db;
 use crate::files::File;
 use crate::system::{
-    CaseSensitivity, DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath,
-    SystemPathBuf, SystemVirtualPath, WhichError, WhichResult,
+    DirectoryEntry, MemoryFileSystem, Metadata, Result, System, SystemPath, SystemPathBuf,
+    SystemVirtualPath, WhichError, WhichResult,
 };
 
 use super::WritableSystem;
@@ -161,10 +161,6 @@ impl System for TestSystem {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        self.system().case_sensitivity()
     }
 
     fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {
@@ -424,10 +420,6 @@ impl System for InMemorySystem {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        CaseSensitivity::CaseSensitive
     }
 
     fn dyn_clone(&self) -> Box<dyn System> {

--- a/crates/ruff_db/src/system/test.rs
+++ b/crates/ruff_db/src/system/test.rs
@@ -163,10 +163,6 @@ impl System for TestSystem {
         self
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.system().path_exists_case_sensitive(path, prefix)
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.system().case_sensitivity()
     }
@@ -428,12 +424,6 @@ impl System for InMemorySystem {
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self
-    }
-
-    #[inline]
-    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
-        // The memory file system is case-sensitive.
-        self.path_exists(path)
     }
 
     fn case_sensitivity(&self) -> CaseSensitivity {

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -3,7 +3,6 @@ use std::io::Write;
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
-use ruff_db::Db as _;
 use ruff_db::files::{File, FileError, system_path_to_file};
 use ruff_db::source::source_text;
 use ruff_db::system::{
@@ -2215,28 +2214,19 @@ fn rename_files_casing_only() -> anyhow::Result<()> {
         "Expected `Lib` module not to exist"
     );
 
-    // Now rename `lib.py` to `Lib.py`
-    if case.db().system().case_sensitivity().is_case_sensitive() {
-        std::fs::rename(
-            case.project_path("lib.py").as_std_path(),
-            case.project_path("Lib.py").as_std_path(),
-        )
-        .context("Failed to rename `lib.py` to `Lib.py`")?;
-    } else {
-        // On case-insensitive file systems, renaming a file to a different casing is a no-op.
-        // Rename to a different name first
-        std::fs::rename(
-            case.project_path("lib.py").as_std_path(),
-            case.project_path("temp.py").as_std_path(),
-        )
-        .context("Failed to rename `lib.py` to `temp.py`")?;
+    // On case-insensitive file systems, renaming a file to a different casing is a no-op.
+    // Rename to a different name first.
+    std::fs::rename(
+        case.project_path("lib.py").as_std_path(),
+        case.project_path("temp.py").as_std_path(),
+    )
+    .context("Failed to rename `lib.py` to `temp.py`")?;
 
-        std::fs::rename(
-            case.project_path("temp.py").as_std_path(),
-            case.project_path("Lib.py").as_std_path(),
-        )
-        .context("Failed to rename `temp.py` to `Lib.py`")?;
-    }
+    std::fs::rename(
+        case.project_path("temp.py").as_std_path(),
+        case.project_path("Lib.py").as_std_path(),
+    )
+    .context("Failed to rename `temp.py` to `Lib.py`")?;
 
     let changes = case.stop_watch(event_for_file("Lib.py"));
     case.apply_changes(&changes, None);

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -1047,15 +1047,15 @@ mod tests {
     }
 
     #[test]
-    fn nested_file_does_not_invalidate_top_level_listing() -> anyhow::Result<()> {
+    fn deeply_nested_file_does_not_invalidate_top_level_listing() -> anyhow::Result<()> {
         let TestCase { mut db, src, .. } = TestCaseBuilder::new()
-            .with_src_files(&[("package/__init__.py", "")])
+            .with_src_files(&[("package/__init__.py", ""), ("package/sub/__init__.py", "")])
             .build();
 
         list_modules(&db);
         db.clear_salsa_events();
 
-        db.write_file(src.join("package/nested.py"), "")?;
+        db.write_file(src.join("package/sub/nested.py"), "")?;
         list_modules(&db);
 
         let events = db.take_salsa_events();

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -134,9 +134,14 @@ fn all_submodule_names_for_package<'db>(
     }
 
     fn find_package_init_system(db: &dyn Db, dir: &SystemPath) -> Option<File> {
-        system_path_to_file(db, dir.join("__init__.pyi"))
-            .or_else(|_| system_path_to_file(db, dir.join("__init__.py")))
-            .ok()
+        let listing = directory_listing(db, dir).ok()?;
+        if listing.entry_is_file(db, dir, "__init__.pyi") {
+            system_path_to_file(db, dir.join("__init__.pyi")).ok()
+        } else if listing.entry_is_file(db, dir, "__init__.py") {
+            system_path_to_file(db, dir.join("__init__.py")).ok()
+        } else {
+            None
+        }
     }
 
     fn find_package_init_vendored(db: &dyn Db, dir: &VendoredPath) -> Option<File> {

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -4,7 +4,9 @@ use std::fmt;
 use std::sync::Arc;
 
 use camino::{Utf8Path, Utf8PathBuf};
-use ruff_db::files::{File, FileError, FilePath, system_path_to_file, vendored_path_to_file};
+use ruff_db::files::{
+    File, FilePath, directory_listing, system_path_to_file, vendored_path_to_file,
+};
 use ruff_db::system::{System, SystemPath, SystemPathBuf};
 use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 
@@ -97,16 +99,14 @@ impl ModulePath {
             | SearchPathInner::SitePackages(search_path)
             | SearchPathInner::Editable(search_path)
             | SearchPathInner::StandardLibraryReal(search_path) => {
-                system_path_to_file(resolver.db, search_path.join(relative_path))
-                    == Err(FileError::IsADirectory)
+                system_path_is_directory(resolver.db, &search_path.join(relative_path))
             }
             SearchPathInner::StandardLibraryCustom(stdlib_root) => {
                 match query_stdlib_version(relative_path, resolver) {
                     TypeshedVersionsQueryResult::DoesNotExist => false,
                     TypeshedVersionsQueryResult::Exists
                     | TypeshedVersionsQueryResult::MaybeExists => {
-                        system_path_to_file(resolver.db, stdlib_root.join(relative_path))
-                            == Err(FileError::IsADirectory)
+                        system_path_is_directory(resolver.db, &stdlib_root.join(relative_path))
                     }
                 }
             }
@@ -136,23 +136,26 @@ impl ModulePath {
             | SearchPathInner::Editable(search_path) => {
                 let absolute_path = search_path.join(relative_path);
 
-                system_path_to_file(resolver.db, absolute_path.join("__init__.py")).is_ok()
-                    || system_path_to_file(resolver.db, absolute_path.join("__init__.pyi")).is_ok()
+                directory_contains_file(
+                    resolver.db,
+                    &absolute_path,
+                    &["__init__.py", "__init__.pyi"],
+                )
             }
             SearchPathInner::StandardLibraryReal(search_path) => {
                 let absolute_path = search_path.join(relative_path);
 
-                system_path_to_file(resolver.db, absolute_path.join("__init__.py")).is_ok()
+                directory_contains_file(resolver.db, &absolute_path, &["__init__.py"])
             }
             SearchPathInner::StandardLibraryCustom(search_path) => {
                 match query_stdlib_version(relative_path, resolver) {
                     TypeshedVersionsQueryResult::DoesNotExist => false,
                     TypeshedVersionsQueryResult::Exists
-                    | TypeshedVersionsQueryResult::MaybeExists => system_path_to_file(
+                    | TypeshedVersionsQueryResult::MaybeExists => directory_contains_file(
                         resolver.db,
-                        search_path.join(relative_path).join("__init__.pyi"),
-                    )
-                    .is_ok(),
+                        &search_path.join(relative_path),
+                        &["__init__.pyi"],
+                    ),
                 }
             }
             SearchPathInner::StandardLibraryVendored(search_path) => {
@@ -170,6 +173,9 @@ impl ModulePath {
     /// Get the `py.typed` info for this package (not considering parent packages)
     pub(super) fn py_typed(&self, resolver: &ResolverContext) -> PyTyped {
         let Some(py_typed_contents) = self.to_system_path().and_then(|path| {
+            if !directory_contains_file(resolver.db, &path, &["py.typed"]) {
+                return None;
+            }
             let py_typed_path = path.join("py.typed");
             let py_typed_file = system_path_to_file(resolver.db, py_typed_path).ok()?;
             // If we fail to read it let's say that's like it doesn't exist
@@ -222,17 +228,17 @@ impl ModulePath {
             | SearchPathInner::FirstParty(search_path)
             | SearchPathInner::SitePackages(search_path)
             | SearchPathInner::Editable(search_path) => {
-                system_path_to_file(db, search_path.join(relative_path)).ok()
+                system_path_to_file_if_listed(db, &search_path.join(relative_path))
             }
             SearchPathInner::StandardLibraryReal(search_path) => {
-                system_path_to_file(db, search_path.join(relative_path)).ok()
+                system_path_to_file_if_listed(db, &search_path.join(relative_path))
             }
             SearchPathInner::StandardLibraryCustom(stdlib_root) => {
                 match query_stdlib_version(relative_path, resolver) {
                     TypeshedVersionsQueryResult::DoesNotExist => None,
                     TypeshedVersionsQueryResult::Exists
                     | TypeshedVersionsQueryResult::MaybeExists => {
-                        system_path_to_file(db, stdlib_root.join(relative_path)).ok()
+                        system_path_to_file_if_listed(db, &stdlib_root.join(relative_path))
                     }
                 }
             }
@@ -367,6 +373,37 @@ impl PartialEq<ModulePath> for VendoredPathBuf {
     fn eq(&self, other: &ModulePath) -> bool {
         other.eq(self)
     }
+}
+
+fn directory_contains_file(db: &dyn Db, directory: &SystemPath, names: &[&str]) -> bool {
+    let Ok(listing) = directory_listing(db, directory) else {
+        return false;
+    };
+
+    names
+        .iter()
+        .any(|name| listing.entry_is_file(db, directory, name))
+}
+
+fn system_path_to_file_if_listed(db: &dyn Db, path: &SystemPath) -> Option<File> {
+    let Some((parent, name)) = path.parent().zip(path.file_name()) else {
+        return system_path_to_file(db, path).ok();
+    };
+
+    let listing = directory_listing(db, parent).ok()?;
+    if listing.entry_is_file(db, parent, name) {
+        system_path_to_file(db, path).ok()
+    } else {
+        None
+    }
+}
+
+fn system_path_is_directory(db: &dyn Db, path: &SystemPath) -> bool {
+    let Some((parent, name)) = path.parent().zip(path.file_name()) else {
+        return db.system().is_directory(path);
+    };
+
+    directory_listing(db, parent).is_ok_and(|listing| listing.entry_is_directory(db, parent, name))
 }
 
 #[must_use]

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1174,12 +1174,13 @@ fn resolve_name_impl<'a>(
     }
 
     discard_shadowed_namespace_candidates(db, &mut cur_candidates);
-    // Stub packages have priority over runtime packages regardless of
-    // search path ordering.
-    cur_candidates.sort_by_key(|candidate| !candidate.is_stub_package);
     if cur_candidates.is_empty() {
         return None;
     }
+
+    // Stub packages have priority over runtime packages regardless of
+    // search path ordering.
+    cur_candidates.sort_by_key(|candidate| !candidate.is_stub_package);
 
     let mut next_candidates = Vec::new();
 
@@ -1204,13 +1205,13 @@ fn resolve_name_impl<'a>(
         }
 
         discard_shadowed_namespace_candidates(db, &mut next_candidates);
+        if next_candidates.is_empty() {
+            return None;
+        }
 
         // Stub packages have priority over runtime packages regardless of
         // search path ordering.
         next_candidates.sort_by_key(|c| !c.is_stub_package);
-        if next_candidates.is_empty() {
-            return None;
-        }
 
         // Advance to the next level of candidates while reusing allocations
         // (we used `drain` so cur_candidates is empty)

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1183,10 +1183,6 @@ fn resolve_name_impl<'a>(
 
     let mut next_candidates = Vec::new();
 
-    // FIXME?: because we have to search every candidate on each step of this loop,
-    // in theory we can search them all in parallel. However we need to join the parallelism
-    // at the end of each iteration, and after the first iteration in 99% of cases we will have
-    // reduced down to a single candidate, so maybe meh?
     for component in components {
         for mut candidate in cur_candidates.drain(..) {
             if !candidate_may_exist(&context, &candidate, component)
@@ -1353,12 +1349,7 @@ fn resolve_name_in_search_path(
     // simply skip this check which also helps performance. If typeshed
     // ever uses namespace packages, ensure that this check also takes the
     // `VERSIONS` file into consideration.
-    if !package_path.search_path().is_standard_library()
-        && package_path.is_directory(context)
-        && package_path
-            .to_system_path()
-            .is_none_or(|path| file_name_matches_case(context.db, &path))
-    {
+    if !package_path.search_path().is_standard_library() && package_path.is_directory(context) {
         candidate.py_typed = package_path
             .py_typed(context)
             .inherit_parent(candidate.py_typed);
@@ -1412,26 +1403,7 @@ pub(super) fn resolve_file_module(
             .and_then(|path| path.to_file(resolver_state))
     })?;
 
-    // Vendored and virtual file systems are case sensitive.
-    if let Some(path) = file.path(resolver_state.db).as_system_path()
-        && !file_name_matches_case(resolver_state.db, path)
-    {
-        return None;
-    }
-
     Some(file)
-}
-
-fn file_name_matches_case(db: &dyn Db, path: &SystemPath) -> bool {
-    if db.system().case_sensitivity().is_case_sensitive() {
-        return true;
-    }
-
-    let Some((parent, name)) = path.parent().zip(path.file_name()) else {
-        return true;
-    };
-
-    directory_listing(db, parent).is_ok_and(|listing| listing.file_type(name).is_some())
 }
 
 /// Determines whether a package is a legacy namespace package.

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -1098,56 +1098,49 @@ fn resolve_name_impl<'a>(
     let python_version = db.python_version();
     let context = ResolverContext::new(db, python_version, mode);
     let is_non_shadowable = mode.is_non_shadowable(python_version.minor, name.as_str());
+    let mut components = name.components();
+    let root_component = components.next()?;
     let mut stub_name = None;
+    let mut cur_candidates = Vec::new();
 
-    let mut cur_candidates = search_paths
-        .filter_map(|search_path| {
-            // When a builtin module is imported, standard module resolution is bypassed:
-            // the module name always resolves to the stdlib module,
-            // even if there's a module of the same name in the first-party root
-            // (which would normally result in the stdlib module being overridden).
-            // TODO: offer a diagnostic if there is a first-party module of the same name
-            if is_non_shadowable && !search_path.is_standard_library() {
-                return None;
-            }
+    for search_path in search_paths {
+        // When a builtin module is imported, standard module resolution is bypassed:
+        // the module name always resolves to the stdlib module,
+        // even if there's a module of the same name in the first-party root
+        // (which would normally result in the stdlib module being overridden).
+        // TODO: offer a diagnostic if there is a first-party module of the same name
+        if is_non_shadowable && !search_path.is_standard_library() {
+            continue;
+        }
 
-            Some(ModuleResolutionCandidate {
-                path: search_path.to_module_path(),
-                module: ResolvedModule::NamespacePackage,
-                py_typed: PyTyped::Untyped,
-                is_stub_package: false,
-            })
-        })
-        .collect::<Vec<_>>();
-    let mut next_candidates = vec![];
+        let mut candidate = ModuleResolutionCandidate {
+            path: search_path.to_module_path(),
+            module: ResolvedModule::NamespacePackage,
+            py_typed: PyTyped::Untyped,
+            is_stub_package: false,
+        };
 
-    // FIXME?: because we have to search every candidate on each step of this loop,
-    // in theory we can search them all in parallel. However we need to join the parallelism
-    // at the end of each iteration, and after the first iteration in 99% of cases we will have
-    // reduced down to a single candidate, so maybe meh?
-    let mut is_root = true;
-    for component in name.components() {
-        // Search for the next component in every search-path
-        for mut candidate in cur_candidates.drain(..) {
-            // On the first iteration, look for `mypackage-stubs` as well
-            // Optimization: stdlib never has these `-stubs`
-            let stubs_allowed = is_root
-                && context.mode.stubs_allowed()
-                && !candidate.path.search_path().is_standard_library();
-            if stubs_allowed {
-                let stub_name = stub_name.get_or_insert_with(|| format!("{component}-stubs"));
+        if !candidate_may_exist(&context, &candidate, root_component) {
+            continue;
+        }
+
+        // On the first iteration, look for `mypackage-stubs` as well.
+        // Optimization: stdlib never has these `-stubs`.
+        let stubs_allowed = context.mode.stubs_allowed() && !search_path.is_standard_library();
+        if stubs_allowed {
+            let stub_name = stub_name.get_or_insert_with(|| format!("{root_component}-stubs"));
+            if candidate_may_exist(&context, &candidate, stub_name) {
                 let mut stub_candidate = candidate.clone();
                 if resolve_name_in_search_path(&context, &mut stub_candidate, stub_name).is_ok() {
-                    // `mypackage-stubs.py(i)` is not a valid result
+                    // `mypackage-stubs.py(i)` is not a valid result.
                     if matches!(stub_candidate.module, ResolvedModule::Module(_)) {
                         tracing::trace!(
-                            "Search path `{}` contains a module \
-                            named `{stub_name}` but a standalone module isn't a valid stub.",
-                            candidate.path.search_path()
+                            "Search path `{search_path}` contains a module named `{stub_name}` but \
+                             a standalone module isn't a valid stub."
                         );
                     } else {
                         stub_candidate.is_stub_package = true;
-                        next_candidates.push(stub_candidate);
+                        cur_candidates.push(stub_candidate);
                         // Don't break here: we always need to process the non-stub
                         // candidate for the same search path, because sub-packages
                         // within the stubs may override py_typed to partial and fall
@@ -1155,18 +1148,53 @@ fn resolve_name_impl<'a>(
                     }
                 }
             }
+        }
 
-            // On the root iteration when stubs are allowed, we can't break
-            // early because a stub package in a later search path has
-            // priority over a runtime package regardless of search path
-            // ordering. stdlib candidates are exempt since stub packages
-            // don't apply to stdlib modules. Thus, the `break`s below are
-            // guarded by `!stubs_allowed`.
+        // On the root iteration when stubs are allowed, we can't break
+        // early because a stub package in a later search path has
+        // priority over a runtime package regardless of search path
+        // ordering. stdlib candidates are exempt since stub packages
+        // don't apply to stdlib modules. Thus, the `break`s below are
+        // guarded by `!stubs_allowed`.
+        if resolve_name_in_search_path(&context, &mut candidate, root_component).is_err() {
+            if candidate.missing_submodule_is_terminal() && !stubs_allowed {
+                // Everything after this package should be shadowed out by
+                // this failure. But the previous results are still in play
+                // because they would have shadowed this one out anyway.
+                break;
+            }
+            continue;
+        }
 
-            if resolve_name_in_search_path(&context, &mut candidate, component).is_err() {
-                if candidate.missing_submodule_is_terminal() && !stubs_allowed {
+        let shadows_all = candidate.missing_submodule_is_terminal();
+        cur_candidates.push(candidate);
+        if shadows_all && !stubs_allowed {
+            break;
+        }
+    }
+
+    discard_shadowed_namespace_candidates(db, &mut cur_candidates);
+    // Stub packages have priority over runtime packages regardless of
+    // search path ordering.
+    cur_candidates.sort_by_key(|candidate| !candidate.is_stub_package);
+    if cur_candidates.is_empty() {
+        return None;
+    }
+
+    let mut next_candidates = Vec::new();
+
+    // FIXME?: because we have to search every candidate on each step of this loop,
+    // in theory we can search them all in parallel. However we need to join the parallelism
+    // at the end of each iteration, and after the first iteration in 99% of cases we will have
+    // reduced down to a single candidate, so maybe meh?
+    for component in components {
+        for mut candidate in cur_candidates.drain(..) {
+            if !candidate_may_exist(&context, &candidate, component)
+                || resolve_name_in_search_path(&context, &mut candidate, component).is_err()
+            {
+                if candidate.missing_submodule_is_terminal() {
                     // Everything after this package should be shadowed out by
-                    // this failure But the previous results are still in play
+                    // this failure. But the previous results are still in play
                     // because they would have shadowed this one out anyway.
                     break;
                 }
@@ -1174,63 +1202,12 @@ fn resolve_name_impl<'a>(
             }
             let shadows_all = candidate.missing_submodule_is_terminal();
             next_candidates.push(candidate);
-            if shadows_all && !stubs_allowed {
+            if shadows_all {
                 break;
             }
         }
 
-        // Now that we have several candidates, we need to reject candidates
-        // that are shadowed. There are only two valid situations where we
-        // could proceed into the next iteration with multiple candidates:
-        //
-        // * All candidates are namespace packages.
-        // * At least one candidate is a stub package.
-        //
-        // The existence of a single non-namespace package will shadow
-        // all namespace packages *regardless of search-path order*.
-        //
-        // This is implemented with the `retain` that follows.
-        //
-        // We can't do this "delete all namespace packages" eagerly because we want a
-        // `PyTyped::Partial` regular package to shadow namespace packages after it.
-        // (FIXME: I guess we could just set a flag not to add them...)
-
-        // Note that we intentionally do *not* filter out non-stub
-        // candidates when a stub package is found. Even when a
-        // non-namespace, non-partial stub exists, we keep non-stub
-        // candidates as fallbacks because sub-packages within the
-        // stubs may override py.typed to partial. The stub candidate
-        // is ordered first so it takes priority. The non-stub will
-        // only be used when the stub fails to find a submodule in a
-        // partial sub-package.
-
-        let found_non_namespace = next_candidates
-            .iter()
-            .any(|candidate| !candidate.is_any_namespace_package());
-        next_candidates.retain(|candidate| {
-            // TODO: it might be nice to emit a warning in the case that
-            // we found a legacy namespace package and this candidate is
-            // anything *else*. When that "else" is a regular package or
-            // module, then the logic below will drop the legacy namespace
-            // package under the presumption that regular modules always shadow
-            // _all_ namespace packages, regardless of search path order. But
-            // I suppose there could be a case where we found both a legacy
-            // namespace package and a non-legacy namespace package (and no
-            // regular packages/modules). In that case, this logic currently
-            // retains both candidates.
-
-            // Regular packages and modules both shadow namespace packages
-            // independent of search path order.
-            if found_non_namespace && candidate.is_any_namespace_package() {
-                tracing::trace!(
-                    "Discarding namespace package `{}` \
-                     because a non-namespace entry of the same name was found",
-                    candidate.to_str(db),
-                );
-                return false;
-            }
-            true
-        });
+        discard_shadowed_namespace_candidates(db, &mut next_candidates);
 
         // Stub packages have priority over runtime packages regardless of
         // search path ordering.
@@ -1242,10 +1219,68 @@ fn resolve_name_impl<'a>(
         // Advance to the next level of candidates while reusing allocations
         // (we used `drain` so cur_candidates is empty)
         std::mem::swap(&mut cur_candidates, &mut next_candidates);
-        is_root = false;
     }
 
     Some(cur_candidates)
+}
+
+fn discard_shadowed_namespace_candidates(
+    db: &dyn Db,
+    candidates: &mut Vec<ModuleResolutionCandidate>,
+) {
+    // Now that we have several candidates, we need to reject candidates
+    // that are shadowed. There are only two valid situations where we
+    // could proceed into the next iteration with multiple candidates:
+    //
+    // * All candidates are namespace packages.
+    // * At least one candidate is a stub package.
+    //
+    // The existence of a single non-namespace package will shadow
+    // all namespace packages *regardless of search-path order*.
+    //
+    // This is implemented with the `retain` that follows.
+    //
+    // We can't do this "delete all namespace packages" eagerly because we want a
+    // `PyTyped::Partial` regular package to shadow namespace packages after it.
+    // (FIXME: I guess we could just set a flag not to add them...)
+
+    let found_non_namespace = candidates
+        .iter()
+        .any(|candidate| !candidate.is_any_namespace_package());
+
+    // Note that we intentionally do *not* filter out non-stub
+    // candidates when a stub package is found. Even when a
+    // non-namespace, non-partial stub exists, we keep non-stub
+    // candidates as fallbacks because sub-packages within the
+    // stubs may override py.typed to partial. The stub candidate
+    // is ordered first so it takes priority. The non-stub will
+    // only be used when the stub fails to find a submodule in a
+    // partial sub-package.
+    candidates.retain(|candidate| {
+        // TODO: it might be nice to emit a warning in the case that
+        // we found a legacy namespace package and this candidate is
+        // anything *else*. When that "else" is a regular package or
+        // module, then the logic below will drop the legacy namespace
+        // package under the presumption that regular modules always shadow
+        // _all_ namespace packages, regardless of search path order. But
+        // I suppose there could be a case where we found both a legacy
+        // namespace package and a non-legacy namespace package (and no
+        // regular packages/modules). In that case, this logic currently
+        // retains both candidates.
+
+        // Regular packages and modules both shadow namespace packages
+        // independent of search path order.
+        if found_non_namespace && candidate.is_any_namespace_package() {
+            tracing::trace!(
+                "Discarding namespace package `{}` because a non-namespace entry of the same name \
+                 was found",
+                candidate.to_str(db),
+            );
+            false
+        } else {
+            true
+        }
+    });
 }
 
 /// Attempts to resolve a module name in a particular search path.
@@ -1318,25 +1353,40 @@ fn resolve_name_in_search_path(
     // simply skip this check which also helps performance. If typeshed
     // ever uses namespace packages, ensure that this check also takes the
     // `VERSIONS` file into consideration.
-    if !package_path.search_path().is_standard_library() && package_path.is_directory(context) {
-        if let Some(path) = package_path.to_system_path() {
-            let system = context.db.system();
-            if system.case_sensitivity().is_case_sensitive()
-                || system.path_exists_case_sensitive(
-                    &path,
-                    package_path.search_path().as_system_path().unwrap(),
-                )
-            {
-                candidate.py_typed = package_path
-                    .py_typed(context)
-                    .inherit_parent(candidate.py_typed);
-                candidate.module = ResolvedModule::NamespacePackage;
-                return Ok(());
-            }
-        }
+    if !package_path.search_path().is_standard_library()
+        && package_path.is_directory(context)
+        && package_path
+            .to_system_path()
+            .is_none_or(|path| file_name_matches_case(context.db, &path))
+    {
+        candidate.py_typed = package_path
+            .py_typed(context)
+            .inherit_parent(candidate.py_typed);
+        candidate.module = ResolvedModule::NamespacePackage;
+        return Ok(());
     }
 
     Err(())
+}
+
+/// Uses the parent directory's entries to reject candidates that cannot exist without performing
+/// individual file-system probes for every supported module layout.
+fn candidate_may_exist(
+    context: &ResolverContext,
+    candidate: &ModuleResolutionCandidate,
+    module_name: &str,
+) -> bool {
+    let Some(parent) = candidate.path.to_system_path() else {
+        return true;
+    };
+
+    let Ok(listing) = directory_listing(context.db, &parent) else {
+        return false;
+    };
+
+    // Other suffixes are harmless false positives; the normal probes still determine whether the
+    // module exists.
+    listing.contains_name_with_prefix(module_name)
 }
 
 type ResolvedNames = Vec<ModuleResolutionCandidate>;
@@ -1362,20 +1412,26 @@ pub(super) fn resolve_file_module(
             .and_then(|path| path.to_file(resolver_state))
     })?;
 
-    // For system files, test if the path has the correct casing.
-    // We can skip this step for vendored files or virtual files because
-    // those file systems are case sensitive (we wouldn't get to this point).
-    if let Some(path) = file.path(resolver_state.db).as_system_path() {
-        let system = resolver_state.db.system();
-        if !system.case_sensitivity().is_case_sensitive()
-            && !system
-                .path_exists_case_sensitive(path, module.search_path().as_system_path().unwrap())
-        {
-            return None;
-        }
+    // Vendored and virtual file systems are case sensitive.
+    if let Some(path) = file.path(resolver_state.db).as_system_path()
+        && !file_name_matches_case(resolver_state.db, path)
+    {
+        return None;
     }
 
     Some(file)
+}
+
+fn file_name_matches_case(db: &dyn Db, path: &SystemPath) -> bool {
+    if db.system().case_sensitivity().is_case_sensitive() {
+        return true;
+    }
+
+    let Some((parent, name)) = path.parent().zip(path.file_name()) else {
+        return true;
+    };
+
+    directory_listing(db, parent).is_ok_and(|listing| listing.file_type(name).is_some())
 }
 
 /// Determines whether a package is a legacy namespace package.
@@ -1720,6 +1776,54 @@ mod tests {
             Some(foo_module),
             path_to_module(&db, &FilePath::from(expected_foo_path))
         );
+    }
+
+    #[test]
+    fn missing_modules_do_not_create_file_inputs() {
+        let TestCase { db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("other.py", ""), ("package/__init__.py", "")])
+            .build();
+
+        for name in ["missing", "package.missing"] {
+            assert!(
+                resolve_module_confident(&db, &ModuleName::new_static(name).unwrap()).is_none()
+            );
+        }
+
+        for relative_path in [
+            "missing-stubs/__init__.pyi",
+            "missing-stubs/__init__.py",
+            "missing/__init__.pyi",
+            "missing/__init__.py",
+            "missing.pyi",
+            "missing.py",
+            "package/missing/__init__.pyi",
+            "package/missing/__init__.py",
+            "package/missing.pyi",
+            "package/missing.py",
+        ] {
+            assert_eq!(
+                db.files().try_system(&db, &src.join(relative_path)),
+                None,
+                "unexpected point probe for {relative_path}"
+            );
+        }
+    }
+
+    #[test]
+    fn stdlib_precedes_stub_package_in_site_packages() {
+        const TYPESHED: MockedTypeshed = MockedTypeshed {
+            stdlib_files: &[("foo.pyi", "")],
+            versions: "foo: 3.8-",
+        };
+
+        let TestCase { db, stdlib, .. } = TestCaseBuilder::new()
+            .with_mocked_typeshed(TYPESHED)
+            .with_site_packages_files(&[("foo-stubs/__init__.pyi", "")])
+            .build();
+
+        let foo = resolve_module_confident(&db, &ModuleName::new_static("foo").unwrap()).unwrap();
+        assert_eq!(foo.file(&db).unwrap().path(&db), &stdlib.join("foo.pyi"));
     }
 
     #[test]
@@ -2259,9 +2363,9 @@ mod tests {
     }
 
     #[test]
-    fn deleting_an_unrelated_file_doesnt_change_module_resolution() {
+    fn deleting_file_from_different_directory_doesnt_change_module_resolution() {
         let TestCase { mut db, src, .. } = TestCaseBuilder::new()
-            .with_src_files(&[("foo.py", "x = 1"), ("bar.py", "x = 2")])
+            .with_src_files(&[("foo.py", "x = 1"), ("other/bar.py", "x = 2")])
             .with_python_version(PythonVersion::PY38)
             .build();
 
@@ -2275,7 +2379,7 @@ mod tests {
             foo_module.kind(&db),
         );
 
-        let bar_path = src.join("bar.py");
+        let bar_path = src.join("other/bar.py");
         let bar = system_path_to_file(&db, &bar_path).expect("bar.py to exist");
 
         db.clear_salsa_events();
@@ -2883,9 +2987,7 @@ not_a_directory
         db.write_file(src.join("main.py"), "print('Hy')")
             .context("Failed to write `main.py`")?;
 
-        // The symlink triggers the slow-path in the `OsSystem`'s
-        // `exists_path_case_sensitive` code because canonicalizing the path
-        // for `a/__init__.py` results in `a-package/__init__.py`
+        // The lexical directory listing must accept the symlink named `a` while rejecting `A`.
         std::os::unix::fs::symlink(a_package_target.as_std_path(), a_src.as_std_path())
             .context("Failed to symlink `src/a` to `a-package`")?;
 

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -13,7 +13,7 @@ use ruff_db::file_revision::FileRevision;
 use ruff_db::files::{File, FilePath};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
-    CaseSensitivity, DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
+    DirectoryEntry, FileType, Metadata, Result, System, SystemPath, SystemPathBuf,
     SystemVirtualPath, SystemVirtualPathBuf, WhichResult, WritableSystem,
 };
 use ruff_notebook::{Notebook, NotebookError};
@@ -273,10 +273,6 @@ impl System for LSPSystem {
 
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        self.native_system.case_sensitivity()
     }
 
     fn env_var(&self, name: &str) -> std::result::Result<String, std::env::VarError> {

--- a/crates/ty_server/src/system.rs
+++ b/crates/ty_server/src/system.rs
@@ -181,10 +181,6 @@ impl System for LSPSystem {
         self.native_system.is_same_file(first, second)
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.native_system.path_exists_case_sensitive(path, prefix)
-    }
-
     fn source_type(&self, path: &SystemPath) -> Option<PySourceType> {
         let document = self.system_path_to_document(path)?;
         Self::source_type_from_document(document, path.extension())

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -4,8 +4,8 @@ use ruff_db::Db as SourceDb;
 use ruff_db::diagnostic::{Diagnostic, Severity};
 use ruff_db::files::{File, Files};
 use ruff_db::system::{
-    CaseSensitivity, DbWithWritableSystem, InMemorySystem, OsSystem, System, SystemPath,
-    SystemPathBuf, WhichResult, WritableSystem,
+    DbWithWritableSystem, InMemorySystem, OsSystem, System, SystemPath, SystemPathBuf, WhichResult,
+    WritableSystem,
 };
 use ruff_db::vendored::VendoredFileSystem;
 use ruff_notebook::{Notebook, NotebookError};
@@ -402,10 +402,6 @@ impl System for MdtestSystem {
         path: &ruff_db::system::SystemVirtualPath,
     ) -> Result<Notebook, NotebookError> {
         self.as_system().read_virtual_path_to_notebook(path)
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        self.as_system().case_sensitivity()
     }
 
     fn which(&self, name: &str) -> WhichResult {

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -404,11 +404,6 @@ impl System for MdtestSystem {
         self.as_system().read_virtual_path_to_notebook(path)
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, prefix: &SystemPath) -> bool {
-        self.as_system()
-            .path_exists_case_sensitive(&self.normalize_path(path), &self.normalize_path(prefix))
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         self.as_system().case_sensitivity()
     }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -7,7 +7,7 @@ use ruff_db::files::{File, FilePath, FileRange, system_path_to_file, vendored_pa
 use ruff_db::source::{SourceText, line_index, source_text};
 use ruff_db::system::walk_directory::WalkDirectoryBuilder;
 use ruff_db::system::{
-    CaseSensitivity, DirectoryEntry, MemoryFileSystem, Metadata, System, SystemPath, SystemPathBuf,
+    DirectoryEntry, MemoryFileSystem, Metadata, System, SystemPath, SystemPathBuf,
     SystemVirtualPath, WhichError, WhichResult, WritableSystem,
 };
 use ruff_db::vendored::VendoredPath;
@@ -1610,10 +1610,6 @@ impl System for WasmSystem {
         _path: &SystemVirtualPath,
     ) -> Result<Notebook, ruff_notebook::NotebookError> {
         Err(ruff_notebook::NotebookError::Io(not_found()))
-    }
-
-    fn case_sensitivity(&self) -> CaseSensitivity {
-        CaseSensitivity::CaseSensitive
     }
 
     fn which(&self, _name: &str) -> WhichResult {

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -1612,10 +1612,6 @@ impl System for WasmSystem {
         Err(ruff_notebook::NotebookError::Io(not_found()))
     }
 
-    fn path_exists_case_sensitive(&self, path: &SystemPath, _prefix: &SystemPath) -> bool {
-        self.path_exists(path)
-    }
-
     fn case_sensitivity(&self) -> CaseSensitivity {
         CaseSensitivity::CaseSensitive
     }


### PR DESCRIPTION
## Summary

Use the new `directory_listing` query to avoid repeated negative file probes while keeping invalidation scoped to the affected directory and candidate name. 

The module resolver probes multiple `File`s for every search path and import compoment. E.g. to resolve `module`, ty probes `module.py`, `module.pyi`, `module/__init__.py`, and `module/__init__.pyi` (and the same for stubs), even if the folder contains no file or directory prefixed with `module`. For a negative probe, each of those calls, ty creates a `File` (with status deleted). Each file creation requires a system call. It also results in ty retaining a lot of `File`'s with status `Deleted`.

This PR changes the module resolver to, similar to CPythons module finder, read the entire directory. Directories that contain no entry prefixed with `module` are immediately skipped. 

A nice added benefit of using `directory_listing` is that we get the comparison if the resolved module's name matches the import component, including casing, for free. And we can delete most of its infrastructure.


The main downside of this is that `resolve_name` is now less granular. Before, it only ran when the status of any relevant file changed. Now, it runs a file was added or removed from any tested directory. A newly added first-party can invalidate most module-resolution queries (because the first-party search path has high priority). However, the effect of this is limited because Salsa bails early if the `resolve_name` query returns the same resolved module (which should be true for most). I tested recheck performance for home assistant, and I didn't measure a significant difference 

  - origin/main at b708d72ba5: median watch recheck 0.953s
  - PR branch at 2df556fbd2: median watch recheck 0.987s

Based on the idea in https://github.com/lpetre/ruff/pull/2