### PR TITLE
[ty] Gate membership narrowing on `__contains__` semantics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -348,6 +348,10 @@ def tuple_with_any_slot(x: str | None, missing: Any) -> None:
     else:
         reveal_type(x)  # revealed: str | None
 
+def constrained_typevar_slot(x: T | None, y: T) -> None:
+    if x not in (y,):
+        reveal_type(x)  # revealed: None
+
 def local_literal_rhs(x: str | None) -> None:
     unavailable = [None, ""]
     if x not in unavailable:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -222,14 +222,14 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
 
 def broad_element_type(x: str | None, values: dict[str, int]):
     if x in values:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
     else:
         reveal_type(x)  # revealed: str | None
 
 def broad_element_type_with_unknown(values: dict[str, int]):
     x = [None][0]
     if x in values:
-        reveal_type(x)  # revealed: Unknown
+        reveal_type(x)  # revealed: None | Unknown
     else:
         reveal_type(x)  # revealed: None | Unknown
 ```
@@ -298,7 +298,7 @@ def broad_dict_element(x: str | None, values: dict[str, int]) -> None:
     if x not in values:
         reveal_type(x)  # revealed: str | None
     else:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str | None
 
 def union_tuple_slot(x: Literal[1, 2], values: tuple[Literal[1, 2]]) -> None:
     if x not in values:
@@ -473,20 +473,17 @@ def final_custom_contains(
 ## Exact containers inside assignment expressions
 
 An assignment expression does not change the containment behavior of the value it wraps. An exact
-list display can therefore still remove union members that cannot compare equal to any list item:
+tuple display can therefore still remove union members that cannot compare equal to any item:
 
 ```py
-from typing import final
+from typing import Literal, final
 
 @final
 class Token: ...
 
-@final
-class OtherToken: ...
-
-def assignment_expression(value: Token | None) -> None:
-    if value in (items := [OtherToken()]):
-        reveal_type(value)  # revealed: Never
+def assignment_expression(value: Token | Literal[1]) -> None:
+    if value in (items := (1,)):
+        reveal_type(value)  # revealed: Literal[1]
 ```
 
 ## Wrapped types with known containment

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -104,7 +104,7 @@ def _(x: str):
     if x in "abc":
         reveal_type(x)  # revealed: str
     else:
-        reveal_type(x)  # revealed: str
+        reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"] & ~Literal["c"]
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -587,6 +587,10 @@ def range_membership(value: Token | Literal[1], values: range) -> None:
     if value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
 
+def disjoint_range_membership(value: Literal["x", 1], values: range) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+
 def narrowed_to_tuple(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -352,6 +352,10 @@ def constrained_typevar_slot(x: T | None, y: T) -> None:
     if x not in (y,):
         reveal_type(x)  # revealed: None
 
+def nested_constrained_typevar_slot(x: tuple[T] | None, y: tuple[T]) -> None:
+    if x not in (y,):
+        reveal_type(x)  # revealed: None
+
 def local_literal_rhs(x: str | None) -> None:
     unavailable = [None, ""]
     if x not in unavailable:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -108,7 +108,9 @@ def _(x: str):
 ```
 
 ```py
-from typing import Literal
+from typing import Literal, TypeVar
+
+T = TypeVar("T", Literal["a"], Literal["d"])
 
 def _(x: Literal["a", "b", "c", "d"]):
     if x in "abc":
@@ -121,6 +123,12 @@ def substring(x: Literal["", "ab", "z"]):
         reveal_type(x)  # revealed: Literal["", "ab"]
     else:
         reveal_type(x)  # revealed: Literal["z"]
+
+def constrained_substring(x: T):
+    if x in "abc":
+        reveal_type(x)  # revealed: T@constrained_substring & Literal["a"]
+    else:
+        reveal_type(x)  # revealed: T@constrained_substring & Literal["d"]
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -99,10 +99,6 @@ def _(x: Foo):
 
 ## `in` for `str` and literal strings
 
-String membership checks for substrings, not only individual characters. This also applies through a
-constrained type variable. If the right-hand side could be one of several literal strings, the true
-branch keeps strings found in at least one possible value; the false branch remains unchanged.
-
 ```py
 def _(x: str):
     if x in "abc":
@@ -170,7 +166,7 @@ def empty_bytes(x: bytes):
 ## Byte containment
 
 `bytes` and `bytearray` accept byte subsequences and objects implementing `__index__`, not only the
-integers described by their iteration type. We therefore do not narrow the value being tested:
+integers described by their iteration type. We therefore leave the subject unchanged:
 
 ```py
 from typing import Literal, final

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -236,14 +236,14 @@ def test(x: Literal["a", "b", "c"] | None | int = None):
 
 def broad_element_type(x: str | None, values: dict[str, int]):
     if x in values:
-        reveal_type(x)  # revealed: str | None
+        reveal_type(x)  # revealed: str
     else:
         reveal_type(x)  # revealed: str | None
 
 def broad_element_type_with_unknown(values: dict[str, int]):
     x = [None][0]
     if x in values:
-        reveal_type(x)  # revealed: None | Unknown
+        reveal_type(x)  # revealed: Unknown
     else:
         reveal_type(x)  # revealed: None | Unknown
 ```
@@ -312,7 +312,7 @@ def broad_dict_element(x: str | None, values: dict[str, int]) -> None:
     if x not in values:
         reveal_type(x)  # revealed: str | None
     else:
-        reveal_type(x)  # revealed: str | None
+        reveal_type(x)  # revealed: str
 
 def union_tuple_slot(x: Literal[1, 2], values: tuple[Literal[1, 2]]) -> None:
     if x not in values:
@@ -441,7 +441,7 @@ def custom_contains_literal_domain(
         reveal_type(x)  # revealed: Literal["present", "missing"]
 ```
 
-## Final and non-final iterable classes
+## Iterable classes without known containment
 
 An instance of a non-final class might be an instance of a subclass that defines `__contains__`. For
 a final class without `__contains__`, we know that membership falls back to iteration, so we can use
@@ -454,13 +454,6 @@ from typing import Literal, TypedDict, final
 
 class Payload(TypedDict):
     value: int
-
-def open_list_annotation(
-    x: Payload | Literal["missing"],
-    values: list[Literal["missing"]],
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
 
 class IteratesMissing:
     def __iter__(self) -> Iterator[Literal["missing"]]:
@@ -586,58 +579,114 @@ def range_membership(value: Token | Literal[1], values: range) -> None:
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 
-## Built-in containment with overridden iteration
+## Inherited built-in containment
 
-`list.__contains__` searches the values stored in the list. Overriding `__iter__` does not change
-which values membership can find:
+Subclasses that inherit a supported built-in `__contains__` use the built-in's containment domain.
+A visible override disables narrowing, including when it is inherited from an intermediate base.
+Overriding `__iter__` does not change the values searched by the inherited built-in method:
 
 ```py
 from collections.abc import Iterator
-from typing import Literal, TypedDict, final
-
-class Payload(TypedDict):
-    value: int
-
-@final
-class OverridesBuiltinIteration(list[object]):
-    def __iter__(self) -> Iterator[Literal["missing"]]:
-        yield "missing"
-
-def inherited_builtin_contains(
-    x: Payload | Literal["missing"],
-    values: OverridesBuiltinIteration,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-```
-
-## Tuple subclass containment
-
-As with `__len__`, `__bool__`, and `__eq__`, we assume that tuple subclasses do not override
-`tuple.__contains__`. Unsafe overrides will be reported at their definition site, so downstream
-narrowing continues to use the tuple's element types:
-
-```py
 from typing import Literal, TypedDict
 
 class Payload(TypedDict):
     value: int
 
-class ContainsEverything(tuple[Literal["missing"], ...]):
-    def __contains__(self, value: object) -> bool:
-        return True
+class MissingList(list[Literal["missing"]]): ...
+class MissingSet(set[Literal["missing"]]): ...
+class MissingFrozenSet(frozenset[Literal["missing"]]): ...
+class MissingDict(dict[Literal["missing"], object]): ...
+class MissingTuple(tuple[Literal["missing"], ...]): ...
 
-def custom_tuple_contains(x: Payload | Literal["missing"], values: ContainsEverything):
+def inherited_builtin_contains(
+    x: Payload | Literal["missing"],
+    values: MissingList | MissingSet | MissingFrozenSet | MissingDict | MissingTuple,
+):
     if x in values:
         reveal_type(x)  # revealed: Literal["missing"]
 
-class ContainsNothing(tuple[Literal[1]]):
+class OverridesBuiltinIteration(list[object]):
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+def overridden_iteration(
+    x: Payload | Literal["missing"],
+    values: OverridesBuiltinIteration,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+class ContainsEverythingList(list[Literal["missing"]]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class ContainsEverythingSet(set[Literal["missing"]]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class ContainsEverythingFrozenSet(frozenset[Literal["missing"]]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class ContainsEverythingDict(dict[Literal["missing"], object]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class ContainsEverythingTuple(tuple[Literal["missing"], ...]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class InheritsCustomContains(ContainsEverythingList): ...
+
+def custom_list_contains(
+    x: Payload | Literal["missing"],
+    values: ContainsEverythingList,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def custom_set_contains(
+    x: Payload | Literal["missing"],
+    values: ContainsEverythingSet,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def custom_frozenset_contains(
+    x: Payload | Literal["missing"],
+    values: ContainsEverythingFrozenSet,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def custom_dict_contains(
+    x: Payload | Literal["missing"],
+    values: ContainsEverythingDict,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def custom_tuple_contains(
+    x: Payload | Literal["missing"],
+    values: ContainsEverythingTuple,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def inherited_custom_contains(
+    x: Payload | Literal["missing"],
+    values: InheritsCustomContains,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+class ContainsNothingTuple(tuple[Literal[1]]):
     def __contains__(self, value: object) -> bool:
         return False
 
-def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothing):
+def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothingTuple):
     if x not in values:
-        reveal_type(x)  # revealed: None
+        reveal_type(x)  # revealed: Literal[1] | None
 ```
 
 ## No present-key narrowing without a `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -115,6 +115,12 @@ def _(x: Literal["a", "b", "c", "d"]):
         reveal_type(x)  # revealed: Literal["a", "b", "c"]
     else:
         reveal_type(x)  # revealed: Literal["d"]
+
+def substring(x: Literal["", "ab", "z"]):
+    if x in "abc":
+        reveal_type(x)  # revealed: Literal["", "ab"]
+    else:
+        reveal_type(x)  # revealed: Literal["z"]
 ```
 
 ```py
@@ -163,7 +169,7 @@ def bytes_subsequence(value: ByteSubstring | Literal[97]) -> None:
     if value in b"abc":
         reveal_type(value)  # revealed: ByteSubstring | Literal[97]
     else:
-        reveal_type(value)  # revealed: ByteSubstring
+        reveal_type(value)  # revealed: ByteSubstring | Literal[97]
 
 def bytes_index(value: ByteIndex | Literal[97], values: bytes) -> None:
     if value in values:
@@ -584,35 +590,6 @@ def inherited_builtin_contains(
 ):
     if x in values:
         reveal_type(x)  # revealed: Payload | Literal["missing"]
-```
-
-## Byte containment
-
-Unlike ordinary element-wise containment, `bytes` and `bytearray` accept objects with an `__index__`
-method as well as byte subsequences. Their iterator element type therefore cannot be used to remove
-broader union members:
-
-```py
-from typing import Literal, final
-
-@final
-class ByteIndex:
-    def __index__(self) -> int:
-        return 97
-
-def bytes_literal_contains_index(value: ByteIndex | Literal[97]) -> None:
-    if value in b"abc":
-        reveal_type(value)  # revealed: ByteIndex | Literal[97]
-
-@final
-class FinalBytearray(bytearray): ...
-
-def bytearray_contains_index(
-    value: ByteIndex | Literal[97],
-    values: FinalBytearray,
-) -> None:
-    if value in values:
-        reveal_type(value)  # revealed: ByteIndex | Literal[97]
 ```
 
 ## Custom containment methods on tuple subclasses

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -511,13 +511,15 @@ def assignment_expression(value: Token | Literal[1]) -> None:
         reveal_type(value)  # revealed: Literal[1]
 ```
 
-## Wrapped types with known containment
+## Wrapped and intersected types with known containment
 
 A type variable uses its upper bound or constraints, and a `NewType` uses its concrete base. Broad
-union members can be removed when every possible container has known containment behavior:
+union members can be removed when every possible container has known containment behavior. An
+intersection retains element constraints from all its iterable components once one component
+establishes known containment behavior:
 
 ```py
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Literal, NewType, TypeVar, final
 
 @final
@@ -584,6 +586,13 @@ def mixed_constraints(
 def range_membership(value: Token | Literal[1], values: range) -> None:
     if value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
+
+def narrowed_to_tuple(
+    value: Token | Literal[1],
+    values: Iterable[Literal[1]],
+) -> None:
+    if isinstance(values, tuple) and value in values:
+        reveal_type(value)  # revealed: Literal[1]
 ```
 
 ## Inherited built-in containment

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -722,7 +722,14 @@ We only synthesize a key-access protocol for string membership tests on right-ha
 include a `TypedDict`. Other membership tests can mean substring or element containment instead:
 
 ```py
-from typing import Literal
+from typing import Literal, TypedDict
+
+class Values(TypedDict):
+    present: int
+
+def typed_dict_container(value: Literal["present", 1], values: Values) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal["present"]
 
 def f(x: Literal["abc", "def"]):
     if "a" in x:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -800,8 +800,8 @@ def test(x: Status | int):
 
 ## Union with tuple and `Literal`
 
-We assume that tuple subclasses don't override `tuple.__eq__`, which only returns True for other
-tuples. So they are excluded from the narrowed type when disjoint from the RHS values.
+A built-in tuple cannot compare equal to a string literal, so the tuple arm is excluded from the
+narrowed type.
 
 ```py
 from typing import Literal

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -489,7 +489,7 @@ every possible container. A `NewType` uses the behavior of its underlying type.
 
 ```py
 from collections.abc import Iterable, Iterator, Sized
-from typing import Literal, NewType, TypeVar, final
+from typing import Any, Literal, NewType, TypeVar, final
 
 @final
 class Token: ...
@@ -545,7 +545,8 @@ def mixed_constraints(
 
 An `isinstance` check can also identify a concrete container. After narrowing to `tuple`, membership
 can use the tuple's item type. Checking only an unrelated protocol such as `Sized` does not tell us
-how membership works.
+how membership works. A custom `__contains__` from another intersection component can precede a
+known implementation in a concrete subclass, so that intersection also remains conservative.
 
 ```py
 def tuple_intersection(
@@ -560,6 +561,23 @@ def unrelated_intersection(
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, Sized) and value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+
+class ContainsEverything:
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class Items(list[Literal[1]]):
+    def __iter__(self) -> Iterator[Any]:
+        return super().__iter__()
+
+class Actual(ContainsEverything, Items): ...
+
+def custom_contains_precedes_builtin(
+    value: Token | Literal[1],
+    values: Items,
+) -> None:
+    if isinstance(values, ContainsEverything) and value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -112,26 +112,26 @@ from typing import Literal
 
 def _(x: Literal["a", "b", "c", "d"]):
     if x in "abc":
-        reveal_type(x)  # revealed: Literal["a", "b", "c", "d"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c"]
     else:
-        reveal_type(x)  # revealed: Literal["a", "b", "c", "d"]
+        reveal_type(x)  # revealed: Literal["d"]
 ```
 
 ```py
 def _(x: Literal["a", "b", "c", "e"]):
     if x in "abcd":
-        reveal_type(x)  # revealed: Literal["a", "b", "c", "e"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c"]
     else:
-        reveal_type(x)  # revealed: Literal["a", "b", "c", "e"]
+        reveal_type(x)  # revealed: Literal["e"]
 ```
 
 ```py
 def _(x: Literal[1, "a", "b", "c", "d"]):
     # error: [unsupported-operator]
     if x in "abc":
-        reveal_type(x)  # revealed: Literal[1, "a", "b", "c", "d"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c"]
     else:
-        reveal_type(x)  # revealed: Literal[1, "a", "b", "c", "d"]
+        reveal_type(x)  # revealed: Literal[1, "d"]
 
 def empty_string(x: str):
     if x in "":

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -129,6 +129,13 @@ def constrained_substring(x: T):
         reveal_type(x)  # revealed: T@constrained_substring & Literal["a"]
     else:
         reveal_type(x)  # revealed: T@constrained_substring & Literal["d"]
+
+def union_literal_haystack(x: Literal["a", "ab", "z"], flag: bool):
+    values = "abc" if flag else "def"
+    if x in values:
+        reveal_type(x)  # revealed: Literal["a", "ab"]
+    else:
+        reveal_type(x)  # revealed: Literal["a", "ab", "z"]
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -348,10 +348,6 @@ def tuple_with_any_slot(x: str | None, missing: Any) -> None:
     else:
         reveal_type(x)  # revealed: str | None
 
-def constrained_typevar_slot(x: T | None, y: T) -> None:
-    if x not in (y,):
-        reveal_type(x)  # revealed: None
-
 def nested_constrained_typevar_slot(x: tuple[T] | None, y: tuple[T]) -> None:
     if x not in (y,):
         reveal_type(x)  # revealed: None
@@ -585,8 +581,8 @@ def range_membership(value: Token | Literal[1], values: range) -> None:
 
 ## Inherited built-in containment
 
-Subclasses that inherit a supported built-in `__contains__` use the built-in's containment domain.
-A visible override disables narrowing, including when it is inherited from an intermediate base.
+Subclasses that inherit a supported built-in `__contains__` use the built-in's containment domain. A
+visible override disables narrowing, including when it is inherited from an intermediate base.
 Overriding `__iter__` does not change the values searched by the inherited built-in method:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -99,6 +99,10 @@ def _(x: Foo):
 
 ## `in` for `str` and literal strings
 
+String membership checks for substrings, not only individual characters. This also applies through a
+constrained type variable. If the right-hand side could be one of several literal strings, the true
+branch keeps strings found in at least one possible value; the false branch remains unchanged.
+
 ```py
 def _(x: str):
     if x in "abc":
@@ -166,8 +170,7 @@ def empty_bytes(x: bytes):
 ## Byte containment
 
 `bytes` and `bytearray` accept byte subsequences and objects implementing `__index__`, not only the
-integers described by their iteration type. We therefore leave the subject unchanged in the positive
-branch:
+integers described by their iteration type. We therefore do not narrow the value being tested:
 
 ```py
 from typing import Literal, final
@@ -355,10 +358,6 @@ def tuple_with_any_slot(x: str | None, missing: Any) -> None:
     else:
         reveal_type(x)  # revealed: str | None
 
-def nested_constrained_typevar_slot(x: tuple[T] | None, y: tuple[T]) -> None:
-    if x not in (y,):
-        reveal_type(x)  # revealed: None
-
 def local_literal_rhs(x: str | None) -> None:
     unavailable = [None, ""]
     if x not in unavailable:
@@ -419,15 +418,12 @@ def empty_tuple(x: Payload | Literal["missing"], values: tuple[()]):
 
 ## Custom containment methods
 
-A custom `__contains__` method can return `True` for values that the class would never produce
-during iteration. We therefore leave the subject type unchanged:
+When a class defines `__contains__`, membership need not check the values produced by iteration. The
+iterator's element type therefore cannot narrow the value being tested:
 
 ```py
 from collections.abc import Iterator
-from typing import Literal, TypedDict
-
-class Payload(TypedDict):
-    value: int
+from typing import Literal
 
 class ContainsEverything:
     def __iter__(self) -> Iterator[Literal["missing"]]:
@@ -436,11 +432,7 @@ class ContainsEverything:
     def __contains__(self, value: object) -> bool:
         return True
 
-def custom_contains(x: Payload | Literal["missing"], values: ContainsEverything):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-def custom_contains_literal_domain(
+def custom_contains(
     x: Literal["present", "missing"],
     values: ContainsEverything,
 ):
@@ -448,12 +440,11 @@ def custom_contains_literal_domain(
         reveal_type(x)  # revealed: Literal["present", "missing"]
 ```
 
-## Iterable classes without known containment
+## Classes that only define `__iter__`
 
-An instance of a non-final class might be an instance of a subclass that defines `__contains__`. For
-a final class without `__contains__`, we know that membership falls back to iteration, so we can use
-the iterable element type to narrow the subject. A final class with its own `__contains__` method
-remains conservative:
+A subclass can add `__contains__`, so an `__iter__` annotation on a non-final class is not enough to
+narrow a membership test. A final class cannot gain a new `__contains__` method through subclassing;
+if it only defines `__iter__`, membership is known to check the iterated values:
 
 ```py
 from collections.abc import Iterator
@@ -478,27 +469,11 @@ class FinalIterable:
 def final_iterable(x: Payload | Literal["missing"], values: FinalIterable):
     if x in values:
         reveal_type(x)  # revealed: Literal["missing"]
-
-@final
-class FinalContainsEverything:
-    def __iter__(self) -> Iterator[Literal["missing"]]:
-        yield "missing"
-
-    def __contains__(self, value: object) -> bool:
-        return True
-
-def final_custom_contains(
-    x: Payload | Literal["missing"],
-    values: FinalContainsEverything,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
 ```
 
-## Exact containers inside assignment expressions
+## Assignment expression on the right-hand side
 
-An assignment expression does not change the containment behavior of the value it wraps. An exact
-tuple display can therefore still remove union members that cannot compare equal to any item:
+A named expression around a tuple literal is still known to use tuple membership:
 
 ```py
 from typing import Literal, final
@@ -507,16 +482,14 @@ from typing import Literal, final
 class Token: ...
 
 def assignment_expression(value: Token | Literal[1]) -> None:
-    if value in (items := (1,)):
+    if value in (values := (1,)):
         reveal_type(value)  # revealed: Literal[1]
 ```
 
-## Wrapped and intersected types with known containment
+## Type wrappers and `isinstance` narrowing
 
-A type variable uses its upper bound or constraints, and a `NewType` uses its concrete base. Broad
-union members can be removed when every possible container has known containment behavior. An
-intersection retains element constraints from all its iterable components once one component
-establishes known containment behavior:
+A bound or constrained type variable can use its item type only if membership checks those items for
+every possible container. A `NewType` uses the behavior of its underlying type.
 
 ```py
 from collections.abc import Iterable, Iterator, Sized
@@ -525,25 +498,11 @@ from typing import Literal, NewType, TypeVar, final
 @final
 class Token: ...
 
-@final
-class FinalIterable:
-    def __iter__(self) -> Iterator[Literal[1]]:
-        yield 1
+WrappedTuple = NewType("WrappedTuple", tuple[Literal[1], ...])
 
-BoundFinalIterable = TypeVar("BoundFinalIterable", bound=FinalIterable)
-
-def bounded_final_iterable(
+def wrapped_tuple(
     value: Token | Literal[1],
-    values: BoundFinalIterable,
-) -> None:
-    if value in values:
-        reveal_type(value)  # revealed: Literal[1]
-
-WrappedFinalIterable = NewType("WrappedFinalIterable", FinalIterable)
-
-def wrapped_final_iterable(
-    value: Token | Literal[1],
-    values: WrappedFinalIterable,
+    values: WrappedTuple,
 ) -> None:
     if value in values:
         reveal_type(value)  # revealed: Literal[1]
@@ -574,7 +533,11 @@ class OpenIterable:
     def __iter__(self) -> Iterator[Literal[1]]:
         yield 1
 
-MixedContainers = TypeVar("MixedContainers", FinalIterable, OpenIterable)
+MixedContainers = TypeVar(
+    "MixedContainers",
+    tuple[Literal[1], ...],
+    OpenIterable,
+)
 
 def mixed_constraints(
     value: Token | Literal[1],
@@ -582,23 +545,21 @@ def mixed_constraints(
 ) -> None:
     if value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
+```
 
-def range_membership(value: Token | Literal[1], values: range) -> None:
-    if value in values:
-        reveal_type(value)  # revealed: Token | Literal[1]
+An `isinstance` check can also identify a concrete container. After narrowing to `tuple`, membership
+can use the tuple's item type. Checking only an unrelated protocol such as `Sized` does not tell us
+how membership works.
 
-def disjoint_range_membership(value: Literal["x", 1], values: range) -> None:
-    if value in values:
-        reveal_type(value)  # revealed: Literal[1]
-
-def narrowed_to_tuple(
+```py
+def tuple_intersection(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, tuple) and value in values:
         reveal_type(value)  # revealed: Literal[1]
 
-def narrowed_to_unknown_intersection(
+def unrelated_intersection(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
@@ -606,11 +567,24 @@ def narrowed_to_unknown_intersection(
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 
+## Range membership
+
+A `range` contains integers, so a string literal can be removed from the type of the tested value:
+
+```py
+from typing import Literal
+
+def range_membership(value: Literal["x", 1], values: range) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+```
+
 ## Inherited built-in containment
 
-Subclasses that inherit a supported built-in `__contains__` use the built-in's containment domain. A
-visible override disables narrowing, including when it is inherited from an intermediate base.
-Overriding `__iter__` does not change the values searched by the inherited built-in method:
+A subclass that does not define `__contains__` uses the method inherited from its built-in base.
+Membership still checks the built-in container's stored items if the subclass changes `__iter__`. If
+the subclass, or an intermediate base, defines `__contains__`, its iterator annotation no longer
+describes membership and cannot be used to narrow:
 
 ```py
 from collections.abc import Iterator
@@ -647,58 +621,7 @@ class ContainsEverythingList(list[Literal["missing"]]):
     def __contains__(self, value: object) -> bool:
         return True
 
-class ContainsEverythingSet(set[Literal["missing"]]):
-    def __contains__(self, value: object) -> bool:
-        return True
-
-class ContainsEverythingFrozenSet(frozenset[Literal["missing"]]):
-    def __contains__(self, value: object) -> bool:
-        return True
-
-class ContainsEverythingDict(dict[Literal["missing"], object]):
-    def __contains__(self, value: object) -> bool:
-        return True
-
-class ContainsEverythingTuple(tuple[Literal["missing"], ...]):
-    def __contains__(self, value: object) -> bool:
-        return True
-
 class InheritsCustomContains(ContainsEverythingList): ...
-
-def custom_list_contains(
-    x: Payload | Literal["missing"],
-    values: ContainsEverythingList,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-def custom_set_contains(
-    x: Payload | Literal["missing"],
-    values: ContainsEverythingSet,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-def custom_frozenset_contains(
-    x: Payload | Literal["missing"],
-    values: ContainsEverythingFrozenSet,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-def custom_dict_contains(
-    x: Payload | Literal["missing"],
-    values: ContainsEverythingDict,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-def custom_tuple_contains(
-    x: Payload | Literal["missing"],
-    values: ContainsEverythingTuple,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
 
 def inherited_custom_contains(
     x: Payload | Literal["missing"],
@@ -716,10 +639,11 @@ def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothingTuple):
         reveal_type(x)  # revealed: Literal[1] | None
 ```
 
-## No present-key narrowing without a `TypedDict`
+## `TypedDict` key membership
 
-We only synthesize a key-access protocol for string membership tests on right-hand-side values that
-include a `TypedDict`. Other membership tests can mean substring or element containment instead:
+Membership in a `TypedDict` checks its string keys, so the tested value can be narrowed to a
+possible key. We do not apply key-based narrowing to arbitrary values, because `in` may test
+substrings or elements instead:
 
 ```py
 from typing import Literal, TypedDict
@@ -877,17 +801,15 @@ def test(x: Status | int):
 
 ## Union with tuple and `Literal`
 
-A built-in tuple cannot compare equal to a string literal, so the tuple arm is excluded from the
-narrowed type.
+A built-in tuple cannot compare equal to a string literal, so the tuple alternative is excluded from
+the narrowed type.
 
 ```py
 from typing import Literal
 
 def test(x: Literal["none", "auto", "required"] | tuple[list[str], Literal["auto", "required"]]):
     if x in ("auto", "required"):
-        # tuple type is excluded because it's disjoint from the string literals
         reveal_type(x)  # revealed: Literal["auto", "required"]
     else:
-        # tuple type remains in the else branch
         reveal_type(x)  # revealed: Literal["none"] | tuple[list[str], Literal["auto", "required"]]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -104,7 +104,7 @@ def _(x: str):
     if x in "abc":
         reveal_type(x)  # revealed: str
     else:
-        reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"] & ~Literal["c"]
+        reveal_type(x)  # revealed: str
 ```
 
 ```py
@@ -112,26 +112,26 @@ from typing import Literal
 
 def _(x: Literal["a", "b", "c", "d"]):
     if x in "abc":
-        reveal_type(x)  # revealed: Literal["a", "b", "c"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c", "d"]
     else:
-        reveal_type(x)  # revealed: Literal["d"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c", "d"]
 ```
 
 ```py
 def _(x: Literal["a", "b", "c", "e"]):
     if x in "abcd":
-        reveal_type(x)  # revealed: Literal["a", "b", "c"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c", "e"]
     else:
-        reveal_type(x)  # revealed: Literal["e"]
+        reveal_type(x)  # revealed: Literal["a", "b", "c", "e"]
 ```
 
 ```py
 def _(x: Literal[1, "a", "b", "c", "d"]):
     # error: [unsupported-operator]
     if x in "abc":
-        reveal_type(x)  # revealed: Literal["a", "b", "c"]
+        reveal_type(x)  # revealed: Literal[1, "a", "b", "c", "d"]
     else:
-        reveal_type(x)  # revealed: Literal[1, "d"]
+        reveal_type(x)  # revealed: Literal[1, "a", "b", "c", "d"]
 
 def empty_string(x: str):
     if x in "":
@@ -394,11 +394,234 @@ def empty_tuple(x: Payload | Literal["missing"], values: tuple[()]):
 
 ## Custom containment methods
 
-Python uses `__contains__` when a class defines it. The method can return `True` for values that the
-class would never produce during iteration. We don't yet model this distinction. Instead, we
-determine possible membership matches from the class's iterable element type. The inferred type
-below therefore excludes `Payload`, even though `__contains__` returns `True` for it. This documents
-a known limitation:
+A custom `__contains__` method can return `True` for values that the class would never produce
+during iteration. We therefore leave the subject type unchanged:
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+class ContainsEverything:
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+    def __contains__(self, value: object) -> bool:
+        return True
+
+def custom_contains(x: Payload | Literal["missing"], values: ContainsEverything):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+def custom_contains_literal_domain(
+    x: Literal["present", "missing"],
+    values: ContainsEverything,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["present", "missing"]
+```
+
+## Final and non-final iterable classes
+
+An instance of a non-final class might be an instance of a subclass that defines `__contains__`. For
+a final class without `__contains__`, we know that membership falls back to iteration, so we can use
+the iterable element type to narrow the subject. A final class with its own `__contains__` method
+remains conservative:
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypedDict, final
+
+class Payload(TypedDict):
+    value: int
+
+class IteratesMissing:
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+def non_final_iterable(x: Payload | Literal["missing"], values: IteratesMissing):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+@final
+class FinalIterable:
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+def final_iterable(x: Payload | Literal["missing"], values: FinalIterable):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+@final
+class FinalContainsEverything:
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+    def __contains__(self, value: object) -> bool:
+        return True
+
+def final_custom_contains(
+    x: Payload | Literal["missing"],
+    values: FinalContainsEverything,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+```
+
+## Exact containers inside assignment expressions
+
+An assignment expression does not change the containment behavior of the value it wraps. An exact
+list display can therefore still remove union members that cannot compare equal to any list item:
+
+```py
+from typing import final
+
+@final
+class Token: ...
+
+@final
+class OtherToken: ...
+
+def assignment_expression(value: Token | None) -> None:
+    if value in (items := [OtherToken()]):
+        reveal_type(value)  # revealed: Never
+```
+
+## Wrapped types with known containment
+
+A type variable uses its upper bound or constraints, and a `NewType` uses its concrete base. Broad
+union members can be removed when every possible container has known containment behavior:
+
+```py
+from collections.abc import Iterator
+from typing import Literal, NewType, TypeVar, final
+
+@final
+class Token: ...
+
+@final
+class FinalIterable:
+    def __iter__(self) -> Iterator[Literal[1]]:
+        yield 1
+
+BoundFinalIterable = TypeVar("BoundFinalIterable", bound=FinalIterable)
+
+def bounded_final_iterable(
+    value: Token | Literal[1],
+    values: BoundFinalIterable,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+
+WrappedFinalIterable = NewType("WrappedFinalIterable", FinalIterable)
+
+def wrapped_final_iterable(
+    value: Token | Literal[1],
+    values: WrappedFinalIterable,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+
+BoundTuple = TypeVar("BoundTuple", bound=tuple[Literal[1], ...])
+
+def bounded_tuple(
+    value: Token | Literal[1],
+    values: BoundTuple,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+
+ConstrainedTuple = TypeVar(
+    "ConstrainedTuple",
+    tuple[Literal[1], ...],
+    tuple[Literal[1]],
+)
+
+def constrained_tuple(
+    value: Token | Literal[1],
+    values: ConstrainedTuple,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1]
+
+class OpenIterable:
+    def __iter__(self) -> Iterator[Literal[1]]:
+        yield 1
+
+MixedContainers = TypeVar("MixedContainers", FinalIterable, OpenIterable)
+
+def mixed_constraints(
+    value: Token | Literal[1],
+    values: MixedContainers,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+
+def range_membership(value: Token | Literal[1], values: range) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+```
+
+## Built-in containment with overridden iteration
+
+`list.__contains__` searches the values stored in the list. Overriding `__iter__` does not change
+which values membership can find:
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypedDict, final
+
+class Payload(TypedDict):
+    value: int
+
+@final
+class OverridesBuiltinIteration(list[object]):
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+def inherited_builtin_contains(
+    x: Payload | Literal["missing"],
+    values: OverridesBuiltinIteration,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+```
+
+## Byte containment
+
+Unlike ordinary element-wise containment, `bytes` and `bytearray` accept objects with an `__index__`
+method as well as byte subsequences. Their iterator element type therefore cannot be used to remove
+broader union members:
+
+```py
+from typing import Literal, final
+
+@final
+class ByteIndex:
+    def __index__(self) -> int:
+        return 97
+
+def bytes_literal_contains_index(value: ByteIndex | Literal[97]) -> None:
+    if value in b"abc":
+        reveal_type(value)  # revealed: ByteIndex | Literal[97]
+
+@final
+class FinalBytearray(bytearray): ...
+
+def bytearray_contains_index(
+    value: ByteIndex | Literal[97],
+    values: FinalBytearray,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: ByteIndex | Literal[97]
+```
+
+## Custom containment methods on tuple subclasses
+
+A tuple subclass can override `__contains__`, so its tuple element type does not necessarily
+describe containment:
 
 ```py
 from typing import Literal, TypedDict
@@ -410,10 +633,17 @@ class ContainsEverything(tuple[Literal["missing"], ...]):
     def __contains__(self, value: object) -> bool:
         return True
 
-def custom_contains(x: Payload | Literal["missing"], values: ContainsEverything):
+def custom_tuple_contains(x: Payload | Literal["missing"], values: ContainsEverything):
     if x in values:
-        # TODO: `x` can still be `Payload` because `values.__contains__` always returns `True`.
-        reveal_type(x)  # revealed: Literal["missing"]
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+class ContainsNothing(tuple[Literal[1]]):
+    def __contains__(self, value: object) -> bool:
+        return False
+
+def custom_tuple_not_in(x: Literal[1], values: ContainsNothing):
+    if x not in values:
+        reveal_type(x)  # revealed: Literal[1]
 ```
 
 ## No present-key narrowing without a `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -519,7 +519,7 @@ intersection retains element constraints from all its iterable components once o
 establishes known containment behavior:
 
 ```py
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Sized
 from typing import Literal, NewType, TypeVar, final
 
 @final
@@ -593,6 +593,13 @@ def narrowed_to_tuple(
 ) -> None:
     if isinstance(values, tuple) and value in values:
         reveal_type(value)  # revealed: Literal[1]
+
+def narrowed_to_unknown_intersection(
+    value: Token | Literal[1],
+    values: Iterable[Literal[1]],
+) -> None:
+    if isinstance(values, Sized) and value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
 ```
 
 ## Inherited built-in containment

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -455,6 +455,13 @@ from typing import Literal, TypedDict, final
 class Payload(TypedDict):
     value: int
 
+def open_list_annotation(
+    x: Payload | Literal["missing"],
+    values: list[Literal["missing"]],
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
 class IteratesMissing:
     def __iter__(self) -> Iterator[Literal["missing"]]:
         yield "missing"
@@ -604,10 +611,11 @@ def inherited_builtin_contains(
         reveal_type(x)  # revealed: Payload | Literal["missing"]
 ```
 
-## Custom containment methods on tuple subclasses
+## Tuple subclass containment
 
-A tuple subclass can override `__contains__`, so its tuple element type does not necessarily
-describe containment:
+As with `__len__`, `__bool__`, and `__eq__`, we assume that tuple subclasses do not override
+`tuple.__contains__`. Unsafe overrides will be reported at their definition site, so downstream
+narrowing continues to use the tuple's element types:
 
 ```py
 from typing import Literal, TypedDict
@@ -621,15 +629,15 @@ class ContainsEverything(tuple[Literal["missing"], ...]):
 
 def custom_tuple_contains(x: Payload | Literal["missing"], values: ContainsEverything):
     if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
+        reveal_type(x)  # revealed: Literal["missing"]
 
 class ContainsNothing(tuple[Literal[1]]):
     def __contains__(self, value: object) -> bool:
         return False
 
-def custom_tuple_not_in(x: Literal[1], values: ContainsNothing):
+def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothing):
     if x not in values:
-        reveal_type(x)  # revealed: Literal[1]
+        reveal_type(x)  # revealed: None
 ```
 
 ## No present-key narrowing without a `TypedDict`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -469,15 +469,57 @@ def final_iterable(x: Payload | Literal["missing"], values: FinalIterable):
         reveal_type(x)  # revealed: Literal["missing"]
 ```
 
-### Inherited built-in containment
+### Built-in containers
 
-A subclass that does not define `__contains__` uses the method inherited from its built-in base.
-Membership still checks the built-in container's stored items if the subclass changes `__iter__`. If
-the subclass, or an intermediate base, defines `__contains__`, its iterator annotation no longer
-describes membership and cannot be used to narrow:
+For `list`, `set`, `frozenset`, and `tuple`, ty uses the container's element type to describe the
+values compared by membership. For `dict`, it uses the key type.
 
 ```py
-from collections.abc import Iterator
+from typing import Literal, TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+def builtin_list(x: Payload | Literal["missing"], values: list[Literal["missing"]]):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def builtin_set(x: Payload | Literal["missing"], values: set[Literal["missing"]]):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def builtin_frozenset(
+    x: Payload | Literal["missing"],
+    values: frozenset[Literal["missing"]],
+):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def builtin_dict(
+    x: Payload | Literal["missing"],
+    values: dict[Literal["missing"], object],
+):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def builtin_tuple(x: Payload | Literal["missing"], values: tuple[Literal["missing"], ...]):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+```
+
+### Inherited built-in containment
+
+For subclasses of these built-ins, ty intentionally assumes that an unseen runtime subclass will not
+add an incompatible `__contains__`. This is unsound: only a statically visible custom implementation
+disables narrowing today. A future diagnostic should reject incompatible overrides at their
+definition.
+
+#### Inherited built-in implementations
+
+When no custom `__contains__` is visible in the MRO, a subclass uses the element or key type of its
+specialized built-in base.
+
+```py
 from typing import Literal, TypedDict
 
 class Payload(TypedDict):
@@ -495,6 +537,20 @@ def inherited_builtin_contains(
 ):
     if x in values:
         reveal_type(x)  # revealed: Literal["missing"]
+```
+
+#### Overridden iteration
+
+An inherited built-in `__contains__` still searches the values stored in the container if the
+subclass overrides `__iter__`. Here, the list stores arbitrary objects even though iteration is
+annotated to yield only `Literal["missing"]`.
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypedDict
+
+class Payload(TypedDict):
+    value: int
 
 class OverridesBuiltinIteration(list[object]):
     def __iter__(self) -> Iterator[Literal["missing"]]:
@@ -506,6 +562,18 @@ def overridden_iteration(
 ):
     if x in values:
         reveal_type(x)  # revealed: Payload | Literal["missing"]
+```
+
+#### Visible custom implementations
+
+A custom `__contains__` on the class or an intermediate base disables both positive and negative
+membership narrowing.
+
+```py
+from typing import Literal, TypedDict
+
+class Payload(TypedDict):
+    value: int
 
 class ContainsEverythingList(list[Literal["missing"]]):
     def __contains__(self, value: object) -> bool:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -482,14 +482,13 @@ def assignment_expression(value: Token | Literal[1]) -> None:
         reveal_type(value)  # revealed: Literal[1]
 ```
 
-## Type wrappers and `isinstance` narrowing
+## `NewType` containers
 
-A bound or constrained type variable can use its item type only if membership checks those items for
-every possible container. A `NewType` uses the behavior of its underlying type.
+A `NewType` uses the containment behavior of its underlying type, so membership in a wrapped tuple
+can narrow the tested value to the tuple's item type.
 
 ```py
-from collections.abc import Iterable, Iterator, Sized
-from typing import Any, Literal, NewType, TypeVar, final
+from typing import Literal, NewType, final
 
 @final
 class Token: ...
@@ -502,6 +501,20 @@ def wrapped_tuple(
 ) -> None:
     if value in values:
         reveal_type(value)  # revealed: Literal[1]
+```
+
+## Type-variable containers
+
+A bound or constrained type variable can use its item type only if membership checks those items for
+every possible container. Both possible values of `ConstrainedTuple` use tuple containment, while
+`MixedContainers` also permits an open iterable that could define arbitrary containment behavior.
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypeVar, final
+
+@final
+class Token: ...
 
 BoundTuple = TypeVar("BoundTuple", bound=tuple[Literal[1], ...])
 
@@ -543,12 +556,21 @@ def mixed_constraints(
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 
-An `isinstance` check can also identify a concrete container. After narrowing to `tuple`, membership
-can use the tuple's item type. Checking only an unrelated protocol such as `Sized` does not tell us
-how membership works. A custom `__contains__` from another intersection component can precede a
-known implementation in a concrete subclass, so that intersection also remains conservative.
+## Intersection containers
+
+An `isinstance` check can identify a concrete container within an intersection. After narrowing to
+`tuple`, membership uses the intersection's iterated element type. Checking only an unrelated
+protocol such as `Sized` does not establish how membership works. A custom `__contains__` from
+another intersection component could override a known implementation in a concrete subclass, so that
+intersection also remains conservative.
 
 ```py
+from collections.abc import Iterable, Iterator, Sized
+from typing import Any, Literal, final
+
+@final
+class Token: ...
+
 def tuple_intersection(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -107,6 +107,61 @@ def _(x: str):
         reveal_type(x)  # revealed: str & ~Literal["a"] & ~Literal["b"] & ~Literal["c"]
 ```
 
+Per-character exclusions are limited to haystacks of at most 128 characters. Longer haystacks do not
+synthesize a large intersection for a broad `str`, but they still narrow subjects that are already
+unions of string literals.
+
+```py
+from typing import Literal
+
+def at_exclusion_limit(x: str):
+    if x in (
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+    ):
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: str & ~Literal["a"]
+
+def above_exclusion_limit(x: str):
+    if x in (
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "a"
+    ):
+        reveal_type(x)  # revealed: str
+    else:
+        reveal_type(x)  # revealed: str
+
+def literal_union_above_exclusion_limit(x: Literal["a", "z"]):
+    if x in (
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaa"
+        "a"
+    ):
+        reveal_type(x)  # revealed: Literal["a"]
+    else:
+        reveal_type(x)  # revealed: Literal["z"]
+```
+
 ```py
 from typing import Literal, TypeVar
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -571,46 +571,71 @@ def mixed_constraints(
 
 ## Intersection containers
 
-An `isinstance` check can identify a concrete container within an intersection. After narrowing to
-`tuple`, membership uses the intersection's iterated element type. Checking only an unrelated
-protocol such as `Sized` does not establish how membership works. A custom `__contains__` from
-another intersection component could override a known implementation in a concrete subclass, so that
-intersection also remains conservative.
+### A component with known containment
+
+After the `isinstance` check, `values` has type `Iterable[Literal[1]] & tuple[object, ...]`. The
+`tuple` component establishes that membership compares against the tuple's elements, while the
+`Iterable` component constrains those elements to `Literal[1]`. The positive branch can therefore
+exclude `Token`.
 
 ```py
-from collections.abc import Iterable, Iterator, Sized
-from typing import Any, Literal, final
+from collections.abc import Iterable
+from typing import Literal, final
 
 @final
 class Token: ...
 
-def tuple_intersection(
+def tuple_component_establishes_containment(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, tuple) and value in values:
         reveal_type(value)  # revealed: Literal[1]
+```
 
-def unrelated_intersection(
+### No component with known containment
+
+Narrowing an iterable to `Sized` says nothing about how it implements membership. It could still be
+an instance of a class with a custom `__contains__` that accepts `Token`, so the positive branch
+must preserve both union members.
+
+```py
+from collections.abc import Iterable, Sized
+from typing import Literal, final
+
+@final
+class Token: ...
+
+def unrelated_protocol_does_not_establish_containment(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, Sized) and value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
+```
+
+### A component with custom containment
+
+`CustomContainsItems` shows that this intersection can be inhabited by a class whose MRO selects the
+custom `__contains__` before `list.__contains__`. The order of intersection components does not
+describe the runtime MRO, so the visible custom implementation prevents narrowing.
+
+```py
+from typing import Literal, final
+
+@final
+class Token: ...
 
 class ContainsEverything:
     def __contains__(self, value: object) -> bool:
         return True
 
-class Items(list[Literal[1]]):
-    def __iter__(self) -> Iterator[Any]:
-        return super().__iter__()
+class LiteralItems(list[Literal[1]]): ...
+class CustomContainsItems(ContainsEverything, LiteralItems): ...
 
-class Actual(ContainsEverything, Items): ...
-
-def custom_contains_precedes_builtin(
+def custom_containment_component_prevents_narrowing(
     value: Token | Literal[1],
-    values: Items,
+    values: LiteralItems,
 ) -> None:
     if isinstance(values, ContainsEverything) and value in values:
         reveal_type(value)  # revealed: Token | Literal[1]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -469,6 +469,66 @@ def final_iterable(x: Payload | Literal["missing"], values: FinalIterable):
         reveal_type(x)  # revealed: Literal["missing"]
 ```
 
+### Inherited built-in containment
+
+A subclass that does not define `__contains__` uses the method inherited from its built-in base.
+Membership still checks the built-in container's stored items if the subclass changes `__iter__`. If
+the subclass, or an intermediate base, defines `__contains__`, its iterator annotation no longer
+describes membership and cannot be used to narrow:
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+class MissingList(list[Literal["missing"]]): ...
+class MissingSet(set[Literal["missing"]]): ...
+class MissingFrozenSet(frozenset[Literal["missing"]]): ...
+class MissingDict(dict[Literal["missing"], object]): ...
+class MissingTuple(tuple[Literal["missing"], ...]): ...
+
+def inherited_builtin_contains(
+    x: Payload | Literal["missing"],
+    values: MissingList | MissingSet | MissingFrozenSet | MissingDict | MissingTuple,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+class OverridesBuiltinIteration(list[object]):
+    def __iter__(self) -> Iterator[Literal["missing"]]:
+        yield "missing"
+
+def overridden_iteration(
+    x: Payload | Literal["missing"],
+    values: OverridesBuiltinIteration,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+class ContainsEverythingList(list[Literal["missing"]]):
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class InheritsCustomContains(ContainsEverythingList): ...
+
+def inherited_custom_contains(
+    x: Payload | Literal["missing"],
+    values: InheritsCustomContains,
+):
+    if x in values:
+        reveal_type(x)  # revealed: Payload | Literal["missing"]
+
+class ContainsNothingTuple(tuple[Literal[1]]):
+    def __contains__(self, value: object) -> bool:
+        return False
+
+def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothingTuple):
+    if x not in values:
+        reveal_type(x)  # revealed: Literal[1] | None
+```
+
 ## Assignment expression on the right-hand side
 
 A named expression around a tuple literal is still known to use tuple membership:
@@ -653,66 +713,6 @@ from typing import Literal
 def range_membership(value: Literal["x", 1], values: range) -> None:
     if value in values:
         reveal_type(value)  # revealed: Literal[1]
-```
-
-## Inherited built-in containment
-
-A subclass that does not define `__contains__` uses the method inherited from its built-in base.
-Membership still checks the built-in container's stored items if the subclass changes `__iter__`. If
-the subclass, or an intermediate base, defines `__contains__`, its iterator annotation no longer
-describes membership and cannot be used to narrow:
-
-```py
-from collections.abc import Iterator
-from typing import Literal, TypedDict
-
-class Payload(TypedDict):
-    value: int
-
-class MissingList(list[Literal["missing"]]): ...
-class MissingSet(set[Literal["missing"]]): ...
-class MissingFrozenSet(frozenset[Literal["missing"]]): ...
-class MissingDict(dict[Literal["missing"], object]): ...
-class MissingTuple(tuple[Literal["missing"], ...]): ...
-
-def inherited_builtin_contains(
-    x: Payload | Literal["missing"],
-    values: MissingList | MissingSet | MissingFrozenSet | MissingDict | MissingTuple,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Literal["missing"]
-
-class OverridesBuiltinIteration(list[object]):
-    def __iter__(self) -> Iterator[Literal["missing"]]:
-        yield "missing"
-
-def overridden_iteration(
-    x: Payload | Literal["missing"],
-    values: OverridesBuiltinIteration,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-class ContainsEverythingList(list[Literal["missing"]]):
-    def __contains__(self, value: object) -> bool:
-        return True
-
-class InheritsCustomContains(ContainsEverythingList): ...
-
-def inherited_custom_contains(
-    x: Payload | Literal["missing"],
-    values: InheritsCustomContains,
-):
-    if x in values:
-        reveal_type(x)  # revealed: Payload | Literal["missing"]
-
-class ContainsNothingTuple(tuple[Literal[1]]):
-    def __contains__(self, value: object) -> bool:
-        return False
-
-def custom_tuple_not_in(x: Literal[1] | None, values: ContainsNothingTuple):
-    if x not in values:
-        reveal_type(x)  # revealed: Literal[1] | None
 ```
 
 ## `TypedDict` key membership

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -191,6 +191,13 @@ def union_literal_haystack(x: Literal["a", "ab", "z"], flag: bool):
         reveal_type(x)  # revealed: Literal["a", "ab"]
     else:
         reveal_type(x)  # revealed: Literal["a", "ab", "z"]
+
+def mixed_literal_union_haystack(
+    x: Literal["a", "z", "missing"],
+    values: Literal["abc"] | tuple[Literal["z"]],
+):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["a", "z"]
 ```
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -851,9 +851,13 @@ def custom_container_union(
 
 ## Intersection containers
 
-Until these intersections can be simplified to a concrete container with the correct element type,
-membership narrowing remains conservative even if one component has known containment behavior. For
-example, `Iterable[Literal[1]] & tuple[object, ...]` does not narrow the tested value.
+### A component with known containment
+
+After the `isinstance` check, `values` has type `Iterable[Literal[1]] & tuple[object, ...]`. Until
+[this intersection can be simplified](https://github.com/astral-sh/ty/issues/3890) to
+`tuple[Literal[1], ...]`, membership narrowing preserves the behavior from before containment
+semantics were checked: the `tuple` component establishes that membership compares against its
+elements, while the `Iterable` component constrains those elements to `Literal[1]`.
 
 ```py
 from collections.abc import Iterable
@@ -862,11 +866,59 @@ from typing import Literal, final
 @final
 class Token: ...
 
-def unsimplified_container_intersection(
+def tuple_component_establishes_containment(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, tuple) and value in values:
+        reveal_type(value)  # revealed: Literal[1]
+```
+
+### No component with known containment
+
+Narrowing an iterable to `Sized` says nothing about how it implements membership. It could still be
+an instance of a class with a custom `__contains__` that accepts `Token`, so the positive branch
+must preserve both union members.
+
+```py
+from collections.abc import Iterable, Sized
+from typing import Literal, final
+
+@final
+class Token: ...
+
+def unrelated_protocol_does_not_establish_containment(
+    value: Token | Literal[1],
+    values: Iterable[Literal[1]],
+) -> None:
+    if isinstance(values, Sized) and value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+```
+
+### A component with custom containment
+
+`CustomContainsItems` shows that this intersection can be inhabited by a class whose MRO selects the
+custom `__contains__` before `list.__contains__`. The order of intersection components does not
+describe the runtime MRO, so the visible custom implementation prevents narrowing.
+
+```py
+from typing import Literal, final
+
+@final
+class Token: ...
+
+class ContainsEverything:
+    def __contains__(self, value: object) -> bool:
+        return True
+
+class LiteralItems(list[Literal[1]]): ...
+class CustomContainsItems(ContainsEverything, LiteralItems): ...
+
+def custom_containment_component_prevents_narrowing(
+    value: Token | Literal[1],
+    values: LiteralItems,
+) -> None:
+    if isinstance(values, ContainsEverything) and value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -844,12 +844,9 @@ def custom_container_union(
 
 ## Intersection containers
 
-### A component with known containment
-
-After the `isinstance` check, `values` has type `Iterable[Literal[1]] & tuple[object, ...]`. The
-`tuple` component establishes that membership compares against the tuple's elements, while the
-`Iterable` component constrains those elements to `Literal[1]`. The positive branch can therefore
-exclude `Token`.
+Until these intersections can be simplified to a concrete container with the correct element type,
+membership narrowing remains conservative even if one component has known containment behavior. For
+example, `Iterable[Literal[1]] & tuple[object, ...]` does not narrow the tested value.
 
 ```py
 from collections.abc import Iterable
@@ -858,59 +855,11 @@ from typing import Literal, final
 @final
 class Token: ...
 
-def tuple_component_establishes_containment(
+def unsimplified_container_intersection(
     value: Token | Literal[1],
     values: Iterable[Literal[1]],
 ) -> None:
     if isinstance(values, tuple) and value in values:
-        reveal_type(value)  # revealed: Literal[1]
-```
-
-### No component with known containment
-
-Narrowing an iterable to `Sized` says nothing about how it implements membership. It could still be
-an instance of a class with a custom `__contains__` that accepts `Token`, so the positive branch
-must preserve both union members.
-
-```py
-from collections.abc import Iterable, Sized
-from typing import Literal, final
-
-@final
-class Token: ...
-
-def unrelated_protocol_does_not_establish_containment(
-    value: Token | Literal[1],
-    values: Iterable[Literal[1]],
-) -> None:
-    if isinstance(values, Sized) and value in values:
-        reveal_type(value)  # revealed: Token | Literal[1]
-```
-
-### A component with custom containment
-
-`CustomContainsItems` shows that this intersection can be inhabited by a class whose MRO selects the
-custom `__contains__` before `list.__contains__`. The order of intersection components does not
-describe the runtime MRO, so the visible custom implementation prevents narrowing.
-
-```py
-from typing import Literal, final
-
-@final
-class Token: ...
-
-class ContainsEverything:
-    def __contains__(self, value: object) -> bool:
-        return True
-
-class LiteralItems(list[Literal[1]]): ...
-class CustomContainsItems(ContainsEverything, LiteralItems): ...
-
-def custom_containment_component_prevents_narrowing(
-    value: Token | Literal[1],
-    values: LiteralItems,
-) -> None:
-    if isinstance(values, ContainsEverything) and value in values:
         reveal_type(value)  # revealed: Token | Literal[1]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -414,6 +414,8 @@ def empty_tuple(x: Payload | Literal["missing"], values: tuple[()]):
 
 ## Custom containment methods
 
+### Classes that define `__contains__`
+
 When a class defines `__contains__`, membership need not check the values produced by iteration. The
 iterator's element type therefore cannot narrow the value being tested:
 
@@ -436,7 +438,7 @@ def custom_contains(
         reveal_type(x)  # revealed: Literal["present", "missing"]
 ```
 
-## Classes that only define `__iter__`
+### Classes that only define `__iter__`
 
 A subclass can add `__contains__`, so an `__iter__` annotation on a non-final class is not enough to
 narrow a membership test. A final class cannot gain a new `__contains__` method through subclassing;

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -531,10 +531,26 @@ class MissingFrozenSet(frozenset[Literal["missing"]]): ...
 class MissingDict(dict[Literal["missing"], object]): ...
 class MissingTuple(tuple[Literal["missing"], ...]): ...
 
-def inherited_builtin_contains(
+def inherited_list_contains(x: Payload | Literal["missing"], values: MissingList):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def inherited_set_contains(x: Payload | Literal["missing"], values: MissingSet):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def inherited_frozenset_contains(
     x: Payload | Literal["missing"],
-    values: MissingList | MissingSet | MissingFrozenSet | MissingDict | MissingTuple,
+    values: MissingFrozenSet,
 ):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def inherited_dict_contains(x: Payload | Literal["missing"], values: MissingDict):
+    if x in values:
+        reveal_type(x)  # revealed: Literal["missing"]
+
+def inherited_tuple_contains(x: Payload | Literal["missing"], values: MissingTuple):
     if x in values:
         reveal_type(x)  # revealed: Literal["missing"]
 ```
@@ -694,6 +710,78 @@ MixedContainers = TypeVar(
 def mixed_constraints(
     value: Token | Literal[1],
     values: MixedContainers,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+```
+
+## Union containers
+
+Membership narrowing requires every possible container in a union to have known element-based
+containment. If they do, ty combines their element types. If any alternative has unknown or custom
+containment behavior, the tested value remains unchanged.
+
+### All alternatives have known containment
+
+Both alternatives use known built-in containment, so the positive branch is limited to the union of
+their element types.
+
+```py
+from typing import Literal, final
+
+@final
+class Token: ...
+
+def known_container_union(
+    value: Token | Literal[1, 2],
+    values: list[Literal[1]] | set[Literal[2]],
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Literal[1, 2]
+```
+
+### An alternative has unknown containment
+
+A non-final iterable can have a runtime subclass with a custom `__contains__`, so its iterator type
+does not establish which values membership accepts.
+
+```py
+from collections.abc import Iterator
+from typing import Literal, final
+
+@final
+class Token: ...
+
+class OpenIterable:
+    def __iter__(self) -> Iterator[Literal[1]]:
+        yield 1
+
+def partially_known_container_union(
+    value: Token | Literal[1],
+    values: tuple[Literal[1], ...] | OpenIterable,
+) -> None:
+    if value in values:
+        reveal_type(value)  # revealed: Token | Literal[1]
+```
+
+### An alternative has custom containment
+
+A visible custom `__contains__` can accept values outside the other alternative's element type, so
+the union does not narrow the tested value.
+
+```py
+from typing import Literal, final
+
+@final
+class Token: ...
+
+class ContainsEverything:
+    def __contains__(self, value: object) -> bool:
+        return True
+
+def custom_container_union(
+    value: Token | Literal[1],
+    values: tuple[Literal[1], ...] | ContainsEverything,
 ) -> None:
     if value in values:
         reveal_type(value)  # revealed: Token | Literal[1]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -506,8 +506,8 @@ def wrapped_tuple(
 ## Type-variable containers
 
 A bound or constrained type variable can use its item type only if membership checks those items for
-every possible container. Both possible values of `ConstrainedTuple` use tuple containment, while
-`MixedContainers` also permits an open iterable that could define arbitrary containment behavior.
+every possible container. `BoundTuple` and both possible values of `ConstrainedTuple` use tuple
+containment.
 
 ```py
 from collections.abc import Iterator
@@ -537,6 +537,19 @@ def constrained_tuple(
 ) -> None:
     if value in values:
         reveal_type(value)  # revealed: Literal[1]
+```
+
+A constrained type variable remains conservative if any constraint has unknown containment behavior.
+`OpenIterable` is not final, so a subclass could define `__contains__` that accepts a `Token` even
+though iteration only yields `Literal[1]`. Because `MixedContainers` permits such an instance,
+membership does not narrow the tested value.
+
+```py
+from collections.abc import Iterator
+from typing import Literal, TypeVar, final
+
+@final
+class Token: ...
 
 class OpenIterable:
     def __iter__(self) -> Iterator[Literal[1]]:

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -172,7 +172,6 @@ pub(super) fn equality_exclusion_constraint<'db>(
     ty: Type<'db>,
 ) -> Option<Type<'db>> {
     let ty = ty.resolve_type_alias(db);
-    // Built-in literals need their full equality domain, such as `Literal[1, True]` for `1`.
     builtin_literal_constraint(db, ty, ty, ComparisonOperator::Equality, false)
         .or_else(|| ty.is_single_valued(db).then(|| ty.negate(db)))
         .or_else(|| {

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -172,6 +172,7 @@ pub(super) fn equality_exclusion_constraint<'db>(
     ty: Type<'db>,
 ) -> Option<Type<'db>> {
     let ty = ty.resolve_type_alias(db);
+    // Built-in literals need their full equality domain, such as `Literal[1, True]` for `1`.
     builtin_literal_constraint(db, ty, ty, ComparisonOperator::Equality, false)
         .or_else(|| ty.is_single_valued(db).then(|| ty.negate(db)))
         .or_else(|| {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -175,11 +175,19 @@ fn narrow_string_membership<'db>(
         }
     };
 
-    let narrowed = match lhs_domain {
+    let mut narrowed = match lhs_domain {
         Type::Union(union) => union.filter(db, keep),
-        _ if keep(&lhs_domain) => return None,
+        _ if keep(&lhs_domain) => lhs_domain,
         _ => Type::Never,
     };
+
+    if !is_contained {
+        let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
+        for character in haystack.chars() {
+            builder = builder.add_negative(Type::single_char_string_literal(db, character));
+        }
+        narrowed = builder.build();
+    }
 
     (narrowed != lhs_domain).then_some(narrowed)
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -68,14 +68,10 @@ fn elementwise_containment_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option
             }
             Some(builder.build())
         }
-        Type::TypeVar(type_var) => match type_var.typevar(db).bound_or_constraints(db)? {
-            TypeVarBoundOrConstraints::UpperBound(bound) => {
-                elementwise_containment_domain(db, bound)
-            }
-            TypeVarBoundOrConstraints::Constraints(constraints) => {
-                elementwise_containment_domain(db, constraints.as_type(db))
-            }
-        },
+        Type::TypeVar(type_var) => elementwise_containment_domain(
+            db,
+            type_var.typevar(db).bound_or_constraints(db)?.as_type(db),
+        ),
         Type::NewTypeInstance(newtype) => {
             elementwise_containment_domain(db, newtype.concrete_base_type(db))
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -72,7 +72,9 @@ fn expression_uses_elementwise_containment(expr: &ast::Expr) -> bool {
 ///
 /// Open nominal types are excluded because a subclass can override `__contains__`. For final
 /// nominal types, an inherited built-in `__contains__` method cannot be paired with an overridden
-/// iterator whose element type no longer describes the values searched by containment.
+/// iterator whose element type no longer describes the values searched by containment. Tuple
+/// subclasses are an exception: as with other tuple dunder methods, we assume that unsafe
+/// overrides are reported at their definition site.
 fn type_uses_elementwise_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     let ty = ty.resolve_type_alias(db);
 
@@ -99,10 +101,8 @@ fn type_uses_elementwise_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> boo
         }
         Type::TypedDict(_) => true,
         Type::NominalInstance(instance)
-            if matches!(
-                instance.known_class(db),
-                Some(KnownClass::Tuple | KnownClass::Range)
-            ) =>
+            if instance.tuple_spec(db).is_some()
+                || instance.has_known_class(db, KnownClass::Range) =>
         {
             true
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -169,10 +169,8 @@ fn narrow_string_membership<'db>(
         let element = element.resolve_type_alias(db);
         if let Some(needle) = element.as_string_literal() {
             haystack.contains(needle.value(db)) == is_contained
-        } else if is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)) {
-            false
         } else {
-            true
+            !(is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)))
         }
     };
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -165,6 +165,7 @@ fn narrow_string_membership<'db>(
     is_contained: bool,
 ) -> Option<Type<'db>> {
     let lhs_ty = lhs_ty.resolve_type_alias(db);
+    let lhs_domain = lhs_ty.flatten_typevars(db);
     let keep = |element: &Type<'db>| {
         let element = element.resolve_type_alias(db);
         if let Some(needle) = element.as_string_literal() {
@@ -174,13 +175,13 @@ fn narrow_string_membership<'db>(
         }
     };
 
-    let narrowed = match lhs_ty {
+    let narrowed = match lhs_domain {
         Type::Union(union) => union.filter(db, keep),
-        _ if keep(&lhs_ty) => return None,
+        _ if keep(&lhs_domain) => return None,
         _ => Type::Never,
     };
 
-    (narrowed != lhs_ty).then_some(narrowed)
+    (narrowed != lhs_domain).then_some(narrowed)
 }
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -79,6 +79,21 @@ fn elementwise_containment_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option
         Type::NewTypeInstance(newtype) => {
             elementwise_containment_domain(db, newtype.concrete_base_type(db))
         }
+        Type::Intersection(intersection) => {
+            // A known positive component establishes the containment behavior. Replace that
+            // component with its containment domain, but retain the other components so that
+            // their element types still constrain iteration.
+            let mut has_known_domain = false;
+            let domain = intersection.map_positive(db, |element| {
+                if let Some(domain) = elementwise_containment_domain(db, *element) {
+                    has_known_domain = true;
+                    domain
+                } else {
+                    *element
+                }
+            });
+            has_known_domain.then_some(domain)
+        }
         Type::TypedDict(_) => Some(ty),
         Type::NominalInstance(instance) => {
             // Walk the MRO until we find either a visible override or a supported built-in

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -72,6 +72,10 @@ impl<'db> Type<'db> {
 
         match ty {
             Type::Union(union) => {
+                // Combine elementwise containment for `not in`, ordinary `in` unions, and unions
+                // reached through wrappers such as type variables. Positive unions that contain
+                // string literals are distributed in `evaluate_expr_in` instead because substring
+                // semantics depend on the value of each literal haystack.
                 let mut builder = UnionBuilder::new(db);
                 let mut has_unknown_behavior = false;
                 for element in union.elements(db) {
@@ -2979,10 +2983,21 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
     fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let rhs_ty = rhs_ty.resolve_type_alias(self.db);
+
+        // The supported containers compare against their iterated elements, so union arms can be
+        // combined. String membership also accepts multi-character substrings, so evaluate literal
+        // haystacks separately, including when they occur in a union.
         if let Some(haystack) = rhs_ty.as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), true);
         }
-        if let Type::Union(union) = rhs_ty {
+        if let Type::Union(union) = rhs_ty
+            && union.elements(self.db).iter().any(|element| {
+                element
+                    .resolve_type_alias(self.db)
+                    .as_string_literal()
+                    .is_some()
+            })
+        {
             let mut builder = UnionBuilder::new(self.db);
             for element in union.elements(self.db) {
                 builder = builder.add(self.evaluate_expr_in(lhs_ty, *element)?);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -52,153 +52,9 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
-enum ContainmentBehavior<'db> {
-    /// Membership compares against the elements yielded by the wrapped type. Callers use
-    /// [`Type::try_iterate`] to determine the types that may be contained.
-    Elementwise(Type<'db>),
-    /// A statically visible `__contains__` defines different membership behavior.
-    Custom,
-    /// No containment behavior can be established from the static type.
-    Unknown,
-}
+mod containment;
 
-impl<'db> Type<'db> {
-    /// Return the containment behavior known for this type.
-    ///
-    /// For subclasses that inherit a known built-in `__contains__`, the stored type is the
-    /// specialized built-in base rather than `self`. This preserves the built-in element type even
-    /// if the subclass overrides `__iter__`.
-    fn containment_behavior(self, db: &'db dyn Db) -> ContainmentBehavior<'db> {
-        let ty = self.resolve_type_alias(db);
-
-        match ty {
-            Type::Union(union) => {
-                // Combine elementwise containment for `not in`, ordinary `in` unions, and unions
-                // reached through wrappers such as type variables. Positive unions that contain
-                // string literals are distributed in `evaluate_expr_in` instead because substring
-                // semantics depend on the value of each literal haystack.
-                let mut builder = UnionBuilder::new(db);
-                let mut has_unknown_behavior = false;
-                for element in union.elements(db) {
-                    match element.containment_behavior(db) {
-                        ContainmentBehavior::Elementwise(membership_type) => {
-                            builder = builder.add(membership_type);
-                        }
-                        ContainmentBehavior::Custom => return ContainmentBehavior::Custom,
-                        ContainmentBehavior::Unknown => has_unknown_behavior = true,
-                    }
-                }
-                if has_unknown_behavior {
-                    ContainmentBehavior::Unknown
-                } else {
-                    ContainmentBehavior::Elementwise(builder.build())
-                }
-            }
-            Type::TypeVar(type_var) => type_var
-                .typevar(db)
-                .bound_or_constraints(db)
-                .map_or(ContainmentBehavior::Unknown, |bound_or_constraints| {
-                    bound_or_constraints.as_type(db).containment_behavior(db)
-                }),
-            Type::NewTypeInstance(newtype) => {
-                newtype.concrete_base_type(db).containment_behavior(db)
-            }
-            Type::TypedDict(_) => ContainmentBehavior::Elementwise(ty),
-            Type::NominalInstance(instance) => {
-                // Walk the MRO until we find either a visible override or a supported built-in
-                // implementation. Returning the built-in base preserves its specialization;
-                // normal member lookup specializes inherited signatures for the subclass instead.
-                for base in instance.class(db).iter_mro(db) {
-                    let class = match base {
-                        ClassBase::Class(class) => class,
-                        ClassBase::Generic | ClassBase::Protocol => continue,
-                        ClassBase::Any
-                        | ClassBase::Dynamic(_)
-                        | ClassBase::Divergent(_)
-                        | ClassBase::TypedDict(_) => {
-                            return ContainmentBehavior::Unknown;
-                        }
-                    };
-                    if matches!(
-                        class.known(db),
-                        Some(
-                            KnownClass::List
-                                | KnownClass::Set
-                                | KnownClass::FrozenSet
-                                | KnownClass::Dict
-                                | KnownClass::Tuple
-                                | KnownClass::Range
-                        )
-                    ) {
-                        return ContainmentBehavior::Elementwise(Type::instance(db, class));
-                    }
-                    if !class
-                        .own_class_member(db, None, "__contains__")
-                        .is_undefined()
-                    {
-                        return ContainmentBehavior::Custom;
-                    }
-                }
-                if instance.class(db).is_final(db) {
-                    ContainmentBehavior::Elementwise(ty)
-                } else {
-                    ContainmentBehavior::Unknown
-                }
-            }
-            _ => ContainmentBehavior::Unknown,
-        }
-    }
-
-    fn elementwise_membership_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        match self.containment_behavior(db) {
-            ContainmentBehavior::Elementwise(membership_type) => Some(membership_type),
-            ContainmentBehavior::Custom | ContainmentBehavior::Unknown => None,
-        }
-    }
-}
-
-/// Maximum haystack length for which we synthesize a negative type per character.
-const MAX_STRING_MEMBERSHIP_EXCLUSIONS: usize = 128;
-
-/// Narrow membership in a known string literal using substring semantics.
-fn narrow_string_membership<'db>(
-    db: &'db dyn Db,
-    lhs_ty: Type<'db>,
-    haystack: &str,
-    is_contained: bool,
-) -> Option<Type<'db>> {
-    let lhs_ty = lhs_ty.resolve_type_alias(db);
-    let flattened_lhs_ty = lhs_ty.flatten_typevars(db);
-    let keep = |element: &Type<'db>| {
-        let element = element.resolve_type_alias(db);
-        if let Some(needle) = element.as_string_literal() {
-            haystack.contains(needle.value(db)) == is_contained
-        } else {
-            !(is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)))
-        }
-    };
-
-    let mut narrowed = match flattened_lhs_ty {
-        Type::Union(union) => union.filter(db, keep),
-        _ if keep(&flattened_lhs_ty) => flattened_lhs_ty,
-        _ => Type::Never,
-    };
-
-    if !is_contained
-        && haystack
-            .chars()
-            .nth(MAX_STRING_MEMBERSHIP_EXCLUSIONS)
-            .is_none()
-    {
-        let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
-        for character in haystack.chars() {
-            builder = builder.add_negative(Type::single_char_string_literal(db, character));
-        }
-        narrowed = builder.build();
-    }
-
-    (narrowed != flattened_lhs_ty).then_some(narrowed)
-}
+use self::containment::{elements_of, narrow_string_membership};
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
 ///
@@ -3006,7 +2862,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             let narrowed = builder.build();
             return (narrowed != lhs_ty).then_some(narrowed);
         }
-        let membership_type = rhs_ty.elementwise_membership_type(self.db)?;
+        let membership_type = elements_of(self.db, rhs_ty)?;
         let iterable = membership_type.try_iterate(self.db).ok()?;
 
         if iterable
@@ -3097,7 +2953,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), false);
         }
-        let membership_type = rhs_ty.elementwise_membership_type(self.db)?;
+        let membership_type = elements_of(self.db, rhs_ty)?;
         let iterable = membership_type.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
         let mut builder = IntersectionBuilder::new(self.db);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -52,64 +52,38 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
-/// Return whether an expression constructs a value whose membership operation compares against
-/// the values described by its iteration type.
-fn expression_uses_elementwise_containment(expr: &ast::Expr) -> bool {
-    matches!(
-        expr,
-        ast::Expr::Tuple(_)
-            | ast::Expr::List(_)
-            | ast::Expr::Set(_)
-            | ast::Expr::Dict(_)
-            | ast::Expr::Generator(_)
-            | ast::Expr::ListComp(_)
-            | ast::Expr::SetComp(_)
-            | ast::Expr::DictComp(_)
-    )
-}
-
-/// Return whether membership for `ty` compares against the values described by its iteration type.
+/// Return the type whose iteration domain describes the values searched by membership for `ty`.
 ///
-/// Open nominal types are excluded because a subclass can override `__contains__`. For final
-/// nominal types, an inherited built-in `__contains__` method cannot be paired with an overridden
-/// iterator whose element type no longer describes the values searched by containment. Tuple
-/// subclasses are an exception: as with other tuple dunder methods, we assume that unsafe
-/// overrides are reported at their definition site.
-fn type_uses_elementwise_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+/// For subclasses that inherit a known built-in `__contains__`, this returns the specialized
+/// built-in base rather than `ty` itself. This preserves the built-in containment domain even if
+/// the subclass overrides `__iter__`.
+fn elementwise_containment_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
     let ty = ty.resolve_type_alias(db);
 
     match ty {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| type_uses_elementwise_containment(db, *element)),
-        Type::TypeVar(type_var) => {
-            type_var
-                .typevar(db)
-                .bound_or_constraints(db)
-                .is_some_and(|bound_or_constraints| match bound_or_constraints {
-                    TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        type_uses_elementwise_containment(db, bound)
-                    }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        type_uses_elementwise_containment(db, constraints.as_type(db))
-                    }
-                })
+        Type::Union(union) => {
+            let mut builder = UnionBuilder::new(db);
+            for element in union.elements(db) {
+                builder = builder.add(elementwise_containment_domain(db, *element)?);
+            }
+            Some(builder.build())
         }
+        Type::TypeVar(type_var) => match type_var.typevar(db).bound_or_constraints(db)? {
+            TypeVarBoundOrConstraints::UpperBound(bound) => {
+                elementwise_containment_domain(db, bound)
+            }
+            TypeVarBoundOrConstraints::Constraints(constraints) => {
+                elementwise_containment_domain(db, constraints.as_type(db))
+            }
+        },
         Type::NewTypeInstance(newtype) => {
-            type_uses_elementwise_containment(db, newtype.concrete_base_type(db))
+            elementwise_containment_domain(db, newtype.concrete_base_type(db))
         }
-        Type::TypedDict(_) => true,
-        Type::NominalInstance(instance)
-            if instance.tuple_spec(db).is_some()
-                || instance.has_known_class(db, KnownClass::Range) =>
-        {
-            true
-        }
-        Type::NominalInstance(instance) if instance.class(db).is_final(db) => {
-            // Walk the MRO to preserve the identity of the class that defines `__contains__`;
-            // normal member lookup specializes inherited method signatures for the subclass.
-            let mut overrides_iteration = false;
+        Type::TypedDict(_) => Some(ty),
+        Type::NominalInstance(instance) => {
+            // Walk the MRO until we find either a visible override or a supported built-in
+            // implementation. Returning the built-in base preserves its specialization; normal
+            // member lookup specializes inherited signatures for the subclass instead.
             for base in instance.class(db).iter_mro(db) {
                 let class = match base {
                     ClassBase::Class(class) => class,
@@ -118,43 +92,33 @@ fn type_uses_elementwise_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> boo
                     | ClassBase::Dynamic(_)
                     | ClassBase::Divergent(_)
                     | ClassBase::TypedDict(_) => {
-                        return false;
+                        return None;
                     }
                 };
-                if class
+                if matches!(
+                    class.known(db),
+                    Some(
+                        KnownClass::List
+                            | KnownClass::Set
+                            | KnownClass::FrozenSet
+                            | KnownClass::Dict
+                            | KnownClass::Tuple
+                            | KnownClass::Range
+                    )
+                ) {
+                    return Some(Type::instance(db, class));
+                }
+                if !class
                     .own_class_member(db, None, "__contains__")
                     .is_undefined()
                 {
-                    overrides_iteration |=
-                        !class.own_class_member(db, None, "__iter__").is_undefined();
-                    continue;
+                    return None;
                 }
-                return !overrides_iteration
-                    && matches!(
-                        class.known(db),
-                        Some(
-                            KnownClass::List
-                                | KnownClass::Set
-                                | KnownClass::FrozenSet
-                                | KnownClass::Dict
-                                | KnownClass::Tuple
-                                | KnownClass::Range
-                        )
-                    );
             }
-            true
+            instance.class(db).is_final(db).then_some(ty)
         }
-        _ => false,
+        _ => None,
     }
-}
-
-fn membership_uses_elementwise_containment<'db>(
-    db: &'db dyn Db,
-    rhs_ty: Type<'db>,
-    rhs_expr: Option<&ast::Expr>,
-) -> bool {
-    rhs_expr.is_some_and(|expr| expression_uses_elementwise_containment(expr.expression_value()))
-        || type_uses_elementwise_containment(db, rhs_ty)
 }
 
 /// Narrow membership in a known string literal using substring semantics.
@@ -2974,20 +2938,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    fn evaluate_expr_in(
-        &self,
-        lhs_ty: Type<'db>,
-        rhs_ty: Type<'db>,
-        rhs_expr: Option<&ast::Expr>,
-    ) -> Option<Type<'db>> {
+    fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), true);
         }
-        if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
-            return None;
-        }
-
-        let iterable = rhs_ty.try_iterate(self.db).ok()?;
+        let containment_domain = elementwise_containment_domain(self.db, rhs_ty)?;
+        let iterable = containment_domain.try_iterate(self.db).ok()?;
 
         if iterable
             .as_fixed_length()
@@ -3073,19 +3029,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         (narrowed != lhs_ty).then_some(narrowed)
     }
 
-    fn evaluate_expr_not_in(
-        &self,
-        lhs_ty: Type<'db>,
-        rhs_ty: Type<'db>,
-        rhs_expr: Option<&ast::Expr>,
-    ) -> Option<Type<'db>> {
+    fn evaluate_expr_not_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), false);
         }
-        if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
-            return None;
-        }
-        let iterable = rhs_ty.try_iterate(self.db).ok()?;
+        let containment_domain = elementwise_containment_domain(self.db, rhs_ty)?;
+        let iterable = containment_domain.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
         let mut builder = IntersectionBuilder::new(self.db);
         let mut constrained = false;
@@ -3106,7 +3055,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         lhs_ty: Type<'db>,
         rhs_ty: Type<'db>,
-        rhs_expr: Option<&ast::Expr>,
         op: ast::CmpOp,
         is_positive: bool,
     ) -> Option<Type<'db>> {
@@ -3129,8 +3077,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             }
             ast::CmpOp::Is => Some(rhs_ty),
-            ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty, rhs_expr),
-            ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty, rhs_expr),
+            ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
+            ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,
         }
     }
@@ -3573,8 +3521,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             // - `if x not in y`
             if narrowable_ast(left)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(left)
-                && let Some(ty) =
-                    self.evaluate_expr_compare_op(lhs_ty, rhs_ty, Some(right), *op, is_positive)
+                && let Some(ty) = self.evaluate_expr_compare_op(lhs_ty, rhs_ty, *op, is_positive)
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -3596,8 +3543,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             if !matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn)
                 && narrowable_ast(right)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(right)
-                && let Some(ty) =
-                    self.evaluate_expr_compare_op(rhs_ty, lhs_ty, Some(left), *op, is_positive)
+                && let Some(ty) = self.evaluate_expr_compare_op(rhs_ty, lhs_ty, *op, is_positive)
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -3973,7 +3919,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let value_ty = infer_same_file_expression_type(self.db, value, TypeContext::default());
 
         let mut constraints = self
-            .evaluate_expr_compare_op(subject_ty, value_ty, None, ast::CmpOp::Eq, is_positive)
+            .evaluate_expr_compare_op(subject_ty, value_ty, ast::CmpOp::Eq, is_positive)
             .map(|ty| {
                 NarrowingConstraints::from_iter([(place, NarrowingConstraint::intersection(ty))])
             })

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -181,6 +181,9 @@ impl<'db> Type<'db> {
     }
 }
 
+/// Maximum haystack length for which we synthesize a negative type per character.
+const MAX_STRING_MEMBERSHIP_EXCLUSIONS: usize = 128;
+
 /// Narrow membership in a known string literal using substring semantics.
 fn narrow_string_membership<'db>(
     db: &'db dyn Db,
@@ -205,7 +208,12 @@ fn narrow_string_membership<'db>(
         _ => Type::Never,
     };
 
-    if !is_contained {
+    if !is_contained
+        && haystack
+            .chars()
+            .nth(MAX_STRING_MEMBERSHIP_EXCLUSIONS)
+            .is_none()
+    {
         let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
         for character in haystack.chars() {
             builder = builder.add_negative(Type::single_char_string_literal(db, character));

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2939,8 +2939,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     }
 
     fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
+        let rhs_ty = rhs_ty.resolve_type_alias(self.db);
+        if let Some(haystack) = rhs_ty.as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), true);
+        }
+        if let Type::Union(union) = rhs_ty {
+            let mut builder = UnionBuilder::new(self.db);
+            for element in union.elements(self.db) {
+                builder = builder.add(self.evaluate_expr_in(lhs_ty, *element)?);
+            }
+            let narrowed = builder.build();
+            return (narrowed != lhs_ty).then_some(narrowed);
         }
         let containment_domain = elementwise_containment_domain(self.db, rhs_ty)?;
         let iterable = containment_domain.try_iterate(self.db).ok()?;

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -98,35 +98,6 @@ impl<'db> Type<'db> {
             Type::NewTypeInstance(newtype) => {
                 newtype.concrete_base_type(db).containment_behavior(db)
             }
-            Type::Intersection(intersection) => {
-                // Replace known positive components with the types whose elements membership
-                // compares against, but retain unknown components so that their element types
-                // still constrain iteration. A visible custom implementation can precede a known
-                // implementation in the MRO of a concrete intersection inhabitant, so it makes
-                // the combined containment behavior custom.
-                let mut has_elementwise_behavior = false;
-                let mut has_custom_behavior = false;
-                let membership_type = intersection.map_positive(db, |element| {
-                    match element.containment_behavior(db) {
-                        ContainmentBehavior::Elementwise(membership_type) => {
-                            has_elementwise_behavior = true;
-                            membership_type
-                        }
-                        ContainmentBehavior::Custom => {
-                            has_custom_behavior = true;
-                            *element
-                        }
-                        ContainmentBehavior::Unknown => *element,
-                    }
-                });
-                if has_custom_behavior {
-                    ContainmentBehavior::Custom
-                } else if has_elementwise_behavior {
-                    ContainmentBehavior::Elementwise(membership_type)
-                } else {
-                    ContainmentBehavior::Unknown
-                }
-            }
             Type::TypedDict(_) => ContainmentBehavior::Elementwise(ty),
             Type::NominalInstance(instance) => {
                 // Walk the MRO until we find either a visible override or a supported built-in

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -53,7 +53,8 @@ use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
 enum ContainmentBehavior<'db> {
-    /// Membership compares against the elements of this type.
+    /// Membership compares against the elements yielded by the wrapped type. Callers use
+    /// [`Type::try_iterate`] to determine the types that may be contained.
     Elementwise(Type<'db>),
     /// A statically visible `__contains__` defines different membership behavior.
     Custom,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -157,6 +157,34 @@ fn membership_uses_elementwise_containment<'db>(
         || type_uses_elementwise_containment(db, rhs_ty)
 }
 
+/// Narrow membership in a known string literal using substring semantics.
+fn narrow_string_membership<'db>(
+    db: &'db dyn Db,
+    lhs_ty: Type<'db>,
+    haystack: &str,
+    is_contained: bool,
+) -> Option<Type<'db>> {
+    let lhs_ty = lhs_ty.resolve_type_alias(db);
+    let keep = |element: &Type<'db>| {
+        let element = element.resolve_type_alias(db);
+        if let Some(needle) = element.as_string_literal() {
+            haystack.contains(needle.value(db)) == is_contained
+        } else if is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)) {
+            false
+        } else {
+            true
+        }
+    };
+
+    let narrowed = match lhs_ty {
+        Type::Union(union) => union.filter(db, keep),
+        _ if keep(&lhs_ty) => return None,
+        _ => Type::Never,
+    };
+
+    (narrowed != lhs_ty).then_some(narrowed)
+}
+
 /// Return the type constraints that `test` would place on `symbol` if true and false.
 ///
 /// For example, if we have this code:
@@ -2945,6 +2973,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         rhs_ty: Type<'db>,
         rhs_expr: Option<&ast::Expr>,
     ) -> Option<Type<'db>> {
+        if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
+            return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), true);
+        }
         if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
             return None;
         }
@@ -3040,6 +3071,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         rhs_ty: Type<'db>,
         rhs_expr: Option<&ast::Expr>,
     ) -> Option<Type<'db>> {
+        if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
+            return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), false);
+        }
         if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3068,6 +3068,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
     fn evaluate_expr_not_in(
         &self,
+        lhs_ty: Type<'db>,
         rhs_ty: Type<'db>,
         rhs_expr: Option<&ast::Expr>,
     ) -> Option<Type<'db>> {
@@ -3122,7 +3123,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             }
             ast::CmpOp::Is => Some(rhs_ty),
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty, rhs_expr),
-            ast::CmpOp::NotIn => self.evaluate_expr_not_in(rhs_ty, rhs_expr),
+            ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty, rhs_expr),
             _ => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -52,83 +52,132 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
-/// Return the type whose iteration domain describes the values searched by membership for `ty`.
-///
-/// For subclasses that inherit a known built-in `__contains__`, this returns the specialized
-/// built-in base rather than `ty` itself. This preserves the built-in containment domain even if
-/// the subclass overrides `__iter__`.
-fn elementwise_containment_domain<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-    let ty = ty.resolve_type_alias(db);
+enum ContainmentBehavior<'db> {
+    /// Membership compares against the elements of this type.
+    Elementwise(Type<'db>),
+    /// A statically visible `__contains__` defines different membership behavior.
+    Custom,
+    /// No containment behavior can be established from the static type.
+    Unknown,
+}
 
-    match ty {
-        Type::Union(union) => {
-            let mut builder = UnionBuilder::new(db);
-            for element in union.elements(db) {
-                builder = builder.add(elementwise_containment_domain(db, *element)?);
-            }
-            Some(builder.build())
-        }
-        Type::TypeVar(type_var) => elementwise_containment_domain(
-            db,
-            type_var.typevar(db).bound_or_constraints(db)?.as_type(db),
-        ),
-        Type::NewTypeInstance(newtype) => {
-            elementwise_containment_domain(db, newtype.concrete_base_type(db))
-        }
-        Type::Intersection(intersection) => {
-            // A known positive component establishes the containment behavior. Replace that
-            // component with its containment domain, but retain the other components so that
-            // their element types still constrain iteration.
-            let mut has_known_domain = false;
-            let domain = intersection.map_positive(db, |element| {
-                if let Some(domain) = elementwise_containment_domain(db, *element) {
-                    has_known_domain = true;
-                    domain
-                } else {
-                    *element
-                }
-            });
-            has_known_domain.then_some(domain)
-        }
-        Type::TypedDict(_) => Some(ty),
-        Type::NominalInstance(instance) => {
-            // Walk the MRO until we find either a visible override or a supported built-in
-            // implementation. Returning the built-in base preserves its specialization; normal
-            // member lookup specializes inherited signatures for the subclass instead.
-            for base in instance.class(db).iter_mro(db) {
-                let class = match base {
-                    ClassBase::Class(class) => class,
-                    ClassBase::Generic | ClassBase::Protocol => continue,
-                    ClassBase::Any
-                    | ClassBase::Dynamic(_)
-                    | ClassBase::Divergent(_)
-                    | ClassBase::TypedDict(_) => {
-                        return None;
+impl<'db> Type<'db> {
+    /// Return the containment behavior known for this type.
+    ///
+    /// For subclasses that inherit a known built-in `__contains__`, the stored type is the
+    /// specialized built-in base rather than `self`. This preserves the built-in element type even
+    /// if the subclass overrides `__iter__`.
+    fn containment_behavior(self, db: &'db dyn Db) -> ContainmentBehavior<'db> {
+        let ty = self.resolve_type_alias(db);
+
+        match ty {
+            Type::Union(union) => {
+                let mut builder = UnionBuilder::new(db);
+                let mut has_unknown_behavior = false;
+                for element in union.elements(db) {
+                    match element.containment_behavior(db) {
+                        ContainmentBehavior::Elementwise(membership_type) => {
+                            builder = builder.add(membership_type);
+                        }
+                        ContainmentBehavior::Custom => return ContainmentBehavior::Custom,
+                        ContainmentBehavior::Unknown => has_unknown_behavior = true,
                     }
-                };
-                if matches!(
-                    class.known(db),
-                    Some(
-                        KnownClass::List
-                            | KnownClass::Set
-                            | KnownClass::FrozenSet
-                            | KnownClass::Dict
-                            | KnownClass::Tuple
-                            | KnownClass::Range
-                    )
-                ) {
-                    return Some(Type::instance(db, class));
                 }
-                if !class
-                    .own_class_member(db, None, "__contains__")
-                    .is_undefined()
-                {
-                    return None;
+                if has_unknown_behavior {
+                    ContainmentBehavior::Unknown
+                } else {
+                    ContainmentBehavior::Elementwise(builder.build())
                 }
             }
-            instance.class(db).is_final(db).then_some(ty)
+            Type::TypeVar(type_var) => type_var
+                .typevar(db)
+                .bound_or_constraints(db)
+                .map_or(ContainmentBehavior::Unknown, |bound_or_constraints| {
+                    bound_or_constraints.as_type(db).containment_behavior(db)
+                }),
+            Type::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).containment_behavior(db)
+            }
+            Type::Intersection(intersection) => {
+                // Replace known positive components with the types whose elements membership
+                // compares against, but retain unknown components so that their element types
+                // still constrain iteration. A visible custom implementation can precede a known
+                // implementation in the MRO of a concrete intersection inhabitant, so it makes
+                // the combined containment behavior custom.
+                let mut has_elementwise_behavior = false;
+                let mut has_custom_behavior = false;
+                let membership_type = intersection.map_positive(db, |element| {
+                    match element.containment_behavior(db) {
+                        ContainmentBehavior::Elementwise(membership_type) => {
+                            has_elementwise_behavior = true;
+                            membership_type
+                        }
+                        ContainmentBehavior::Custom => {
+                            has_custom_behavior = true;
+                            *element
+                        }
+                        ContainmentBehavior::Unknown => *element,
+                    }
+                });
+                if has_custom_behavior {
+                    ContainmentBehavior::Custom
+                } else if has_elementwise_behavior {
+                    ContainmentBehavior::Elementwise(membership_type)
+                } else {
+                    ContainmentBehavior::Unknown
+                }
+            }
+            Type::TypedDict(_) => ContainmentBehavior::Elementwise(ty),
+            Type::NominalInstance(instance) => {
+                // Walk the MRO until we find either a visible override or a supported built-in
+                // implementation. Returning the built-in base preserves its specialization;
+                // normal member lookup specializes inherited signatures for the subclass instead.
+                for base in instance.class(db).iter_mro(db) {
+                    let class = match base {
+                        ClassBase::Class(class) => class,
+                        ClassBase::Generic | ClassBase::Protocol => continue,
+                        ClassBase::Any
+                        | ClassBase::Dynamic(_)
+                        | ClassBase::Divergent(_)
+                        | ClassBase::TypedDict(_) => {
+                            return ContainmentBehavior::Unknown;
+                        }
+                    };
+                    if matches!(
+                        class.known(db),
+                        Some(
+                            KnownClass::List
+                                | KnownClass::Set
+                                | KnownClass::FrozenSet
+                                | KnownClass::Dict
+                                | KnownClass::Tuple
+                                | KnownClass::Range
+                        )
+                    ) {
+                        return ContainmentBehavior::Elementwise(Type::instance(db, class));
+                    }
+                    if !class
+                        .own_class_member(db, None, "__contains__")
+                        .is_undefined()
+                    {
+                        return ContainmentBehavior::Custom;
+                    }
+                }
+                if instance.class(db).is_final(db) {
+                    ContainmentBehavior::Elementwise(ty)
+                } else {
+                    ContainmentBehavior::Unknown
+                }
+            }
+            _ => ContainmentBehavior::Unknown,
         }
-        _ => None,
+    }
+
+    fn elementwise_membership_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        match self.containment_behavior(db) {
+            ContainmentBehavior::Elementwise(membership_type) => Some(membership_type),
+            ContainmentBehavior::Custom | ContainmentBehavior::Unknown => None,
+        }
     }
 }
 
@@ -140,7 +189,7 @@ fn narrow_string_membership<'db>(
     is_contained: bool,
 ) -> Option<Type<'db>> {
     let lhs_ty = lhs_ty.resolve_type_alias(db);
-    let lhs_domain = lhs_ty.flatten_typevars(db);
+    let flattened_lhs_ty = lhs_ty.flatten_typevars(db);
     let keep = |element: &Type<'db>| {
         let element = element.resolve_type_alias(db);
         if let Some(needle) = element.as_string_literal() {
@@ -150,9 +199,9 @@ fn narrow_string_membership<'db>(
         }
     };
 
-    let mut narrowed = match lhs_domain {
+    let mut narrowed = match flattened_lhs_ty {
         Type::Union(union) => union.filter(db, keep),
-        _ if keep(&lhs_domain) => lhs_domain,
+        _ if keep(&flattened_lhs_ty) => flattened_lhs_ty,
         _ => Type::Never,
     };
 
@@ -164,7 +213,7 @@ fn narrow_string_membership<'db>(
         narrowed = builder.build();
     }
 
-    (narrowed != lhs_domain).then_some(narrowed)
+    (narrowed != flattened_lhs_ty).then_some(narrowed)
 }
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
@@ -2962,8 +3011,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             let narrowed = builder.build();
             return (narrowed != lhs_ty).then_some(narrowed);
         }
-        let containment_domain = elementwise_containment_domain(self.db, rhs_ty)?;
-        let iterable = containment_domain.try_iterate(self.db).ok()?;
+        let membership_type = rhs_ty.elementwise_membership_type(self.db)?;
+        let iterable = membership_type.try_iterate(self.db).ok()?;
 
         if iterable
             .as_fixed_length()
@@ -2986,7 +3035,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Apply equality compatibility without losing the container's declared element domain.
+    /// Apply equality compatibility without losing the container's declared element type.
     ///
     /// Generic equality retains disjoint single-valued arms when an element subclass could define
     /// custom equality. Membership narrowing instead removes those arms unless the equality
@@ -3053,8 +3102,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
             return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), false);
         }
-        let containment_domain = elementwise_containment_domain(self.db, rhs_ty)?;
-        let iterable = containment_domain.try_iterate(self.db).ok()?;
+        let membership_type = rhs_ty.elementwise_membership_type(self.db)?;
+        let iterable = membership_type.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
         let mut builder = IntersectionBuilder::new(self.db);
         let mut constrained = false;

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -52,21 +52,109 @@ use ruff_python_ast::{BoolOp, ExprBoolOp};
 use rustc_hash::FxHashMap;
 use smallvec::{SmallVec, smallvec, smallvec_inline};
 
-/// Return whether `ty` includes a value with bytes-like containment semantics.
+/// Return whether an expression constructs a value whose membership operation compares against
+/// the values described by its iteration type.
+fn expression_uses_elementwise_containment(expr: &ast::Expr) -> bool {
+    matches!(
+        expr,
+        ast::Expr::Tuple(_)
+            | ast::Expr::List(_)
+            | ast::Expr::Set(_)
+            | ast::Expr::Dict(_)
+            | ast::Expr::Generator(_)
+            | ast::Expr::ListComp(_)
+            | ast::Expr::SetComp(_)
+            | ast::Expr::DictComp(_)
+    )
+}
+
+/// Return whether membership for `ty` compares against the values described by its iteration type.
 ///
-/// `bytes` and `bytearray` accept byte subsequences and objects implementing `__index__`, so their
-/// iteration element type does not describe every value that can satisfy a membership test.
-fn has_bytes_like_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
-    match ty.resolve_type_alias(db) {
+/// Open nominal types are excluded because a subclass can override `__contains__`. For final
+/// nominal types, an inherited built-in `__contains__` method cannot be paired with an overridden
+/// iterator whose element type no longer describes the values searched by containment.
+fn type_uses_elementwise_containment<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    let ty = ty.resolve_type_alias(db);
+
+    match ty {
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .any(|element| has_bytes_like_containment(db, *element)),
-        ty => {
-            ty.is_subtype_of(db, KnownClass::Bytes.to_instance(db))
-                || ty.is_subtype_of(db, KnownClass::Bytearray.to_instance(db))
+            .all(|element| type_uses_elementwise_containment(db, *element)),
+        Type::TypeVar(type_var) => {
+            type_var
+                .typevar(db)
+                .bound_or_constraints(db)
+                .is_some_and(|bound_or_constraints| match bound_or_constraints {
+                    TypeVarBoundOrConstraints::UpperBound(bound) => {
+                        type_uses_elementwise_containment(db, bound)
+                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => {
+                        type_uses_elementwise_containment(db, constraints.as_type(db))
+                    }
+                })
         }
+        Type::NewTypeInstance(newtype) => {
+            type_uses_elementwise_containment(db, newtype.concrete_base_type(db))
+        }
+        Type::TypedDict(_) => true,
+        Type::NominalInstance(instance)
+            if matches!(
+                instance.known_class(db),
+                Some(KnownClass::Tuple | KnownClass::Range)
+            ) =>
+        {
+            true
+        }
+        Type::NominalInstance(instance) if instance.class(db).is_final(db) => {
+            // Walk the MRO to preserve the identity of the class that defines `__contains__`;
+            // normal member lookup specializes inherited method signatures for the subclass.
+            let mut overrides_iteration = false;
+            for base in instance.class(db).iter_mro(db) {
+                let class = match base {
+                    ClassBase::Class(class) => class,
+                    ClassBase::Generic | ClassBase::Protocol => continue,
+                    ClassBase::Any
+                    | ClassBase::Dynamic(_)
+                    | ClassBase::Divergent(_)
+                    | ClassBase::TypedDict(_) => {
+                        return false;
+                    }
+                };
+                if class
+                    .own_class_member(db, None, "__contains__")
+                    .is_undefined()
+                {
+                    overrides_iteration |=
+                        !class.own_class_member(db, None, "__iter__").is_undefined();
+                    continue;
+                }
+                return !overrides_iteration
+                    && matches!(
+                        class.known(db),
+                        Some(
+                            KnownClass::List
+                                | KnownClass::Set
+                                | KnownClass::FrozenSet
+                                | KnownClass::Dict
+                                | KnownClass::Tuple
+                                | KnownClass::Range
+                        )
+                    );
+            }
+            true
+        }
+        _ => false,
     }
+}
+
+fn membership_uses_elementwise_containment<'db>(
+    db: &'db dyn Db,
+    rhs_ty: Type<'db>,
+    rhs_expr: Option<&ast::Expr>,
+) -> bool {
+    rhs_expr.is_some_and(|expr| expression_uses_elementwise_containment(expr.expression_value()))
+        || type_uses_elementwise_containment(db, rhs_ty)
 }
 
 /// Return the type constraints that `test` would place on `symbol` if true and false.
@@ -2851,21 +2939,19 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    fn evaluate_expr_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
-        if has_bytes_like_containment(self.db, rhs_ty) {
+    fn evaluate_expr_in(
+        &self,
+        lhs_ty: Type<'db>,
+        rhs_ty: Type<'db>,
+        rhs_expr: Option<&ast::Expr>,
+    ) -> Option<Type<'db>> {
+        if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
             return None;
         }
 
         let iterable = rhs_ty.try_iterate(self.db).ok()?;
 
-        // A fixed-length iteration spec with no elements does not imply that membership is always
-        // false: `"" in ""` is true. Exact tuples are the fixed-length containers here whose
-        // membership is known to test their elements individually.
-        if matches!(
-            rhs_ty.resolve_type_alias(self.db),
-            Type::NominalInstance(instance)
-                if instance.has_known_class(self.db, KnownClass::Tuple)
-        ) && iterable
+        if iterable
             .as_fixed_length()
             .is_some_and(|fixed| fixed.all_elements().is_empty())
         {
@@ -2949,7 +3035,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         (narrowed != lhs_ty).then_some(narrowed)
     }
 
-    fn evaluate_expr_not_in(&self, rhs_ty: Type<'db>) -> Option<Type<'db>> {
+    fn evaluate_expr_not_in(
+        &self,
+        rhs_ty: Type<'db>,
+        rhs_expr: Option<&ast::Expr>,
+    ) -> Option<Type<'db>> {
+        if !membership_uses_elementwise_containment(self.db, rhs_ty, rhs_expr) {
+            return None;
+        }
         let iterable = rhs_ty.try_iterate(self.db).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
         let mut builder = IntersectionBuilder::new(self.db);
@@ -2971,6 +3064,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         lhs_ty: Type<'db>,
         rhs_ty: Type<'db>,
+        rhs_expr: Option<&ast::Expr>,
         op: ast::CmpOp,
         is_positive: bool,
     ) -> Option<Type<'db>> {
@@ -2993,8 +3087,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 }
             }
             ast::CmpOp::Is => Some(rhs_ty),
-            ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
-            ast::CmpOp::NotIn => self.evaluate_expr_not_in(rhs_ty),
+            ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty, rhs_expr),
+            ast::CmpOp::NotIn => self.evaluate_expr_not_in(rhs_ty, rhs_expr),
             _ => None,
         }
     }
@@ -3437,7 +3531,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             // - `if x not in y`
             if narrowable_ast(left)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(left)
-                && let Some(ty) = self.evaluate_expr_compare_op(lhs_ty, rhs_ty, *op, is_positive)
+                && let Some(ty) =
+                    self.evaluate_expr_compare_op(lhs_ty, rhs_ty, Some(right), *op, is_positive)
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -3459,7 +3554,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             if !matches!(op, ast::CmpOp::In | ast::CmpOp::NotIn)
                 && narrowable_ast(right)
                 && let Some(narrowable) = PlaceExpr::try_from_expr(right)
-                && let Some(ty) = self.evaluate_expr_compare_op(rhs_ty, lhs_ty, *op, is_positive)
+                && let Some(ty) =
+                    self.evaluate_expr_compare_op(rhs_ty, lhs_ty, Some(left), *op, is_positive)
             {
                 let place = self.expect_place(&narrowable);
                 let constraint = NarrowingConstraint::intersection(ty);
@@ -3835,7 +3931,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let value_ty = infer_same_file_expression_type(self.db, value, TypeContext::default());
 
         let mut constraints = self
-            .evaluate_expr_compare_op(subject_ty, value_ty, ast::CmpOp::Eq, is_positive)
+            .evaluate_expr_compare_op(subject_ty, value_ty, None, ast::CmpOp::Eq, is_positive)
             .map(|ty| {
                 NarrowingConstraints::from_iter([(place, NarrowingConstraint::intersection(ty))])
             })

--- a/crates/ty_python_semantic/src/types/narrow/containment.rs
+++ b/crates/ty_python_semantic/src/types/narrow/containment.rs
@@ -47,6 +47,38 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
                 containment_behavior(db, bound_or_constraints.as_type(db))
             }),
         Type::NewTypeInstance(newtype) => containment_behavior(db, newtype.concrete_base_type(db)),
+        Type::Intersection(intersection) => {
+            // Preserve the narrowing already supported on main for unsimplified intersections
+            // such as `Iterable[T] & tuple[object, ...]`. Replacing the component that establishes
+            // containment with its stored iteration type while retaining the unknown component
+            // lets `try_iterate` recover `T`. This is a temporary workaround for the intersection
+            // not simplifying to `tuple[T, ...]`; remove this arm once that simplification is
+            // implemented:
+            // https://github.com/astral-sh/ty/issues/3890
+            // The generic intersection work in the following PR is intended to support that fix:
+            // https://github.com/astral-sh/ruff/pull/26365
+            let mut has_elements_of = false;
+            let mut has_custom_behavior = false;
+            let elements_of =
+                intersection.map_positive(db, |element| match containment_behavior(db, *element) {
+                    ContainmentBehavior::ElementsOf(elements_of) => {
+                        has_elements_of = true;
+                        elements_of
+                    }
+                    ContainmentBehavior::Custom => {
+                        has_custom_behavior = true;
+                        *element
+                    }
+                    ContainmentBehavior::Unknown => *element,
+                });
+            if has_custom_behavior {
+                ContainmentBehavior::Custom
+            } else if has_elements_of {
+                ContainmentBehavior::ElementsOf(elements_of)
+            } else {
+                ContainmentBehavior::Unknown
+            }
+        }
         Type::TypedDict(_) => ContainmentBehavior::ElementsOf(ty),
         Type::NominalInstance(instance) => {
             // Walk the MRO until we find either a visible override or a supported built-in

--- a/crates/ty_python_semantic/src/types/narrow/containment.rs
+++ b/crates/ty_python_semantic/src/types/narrow/containment.rs
@@ -14,10 +14,6 @@ enum ContainmentBehavior<'db> {
 }
 
 /// Return the containment behavior known for this type.
-///
-/// For subclasses that inherit a known built-in `__contains__`, the stored type is the specialized
-/// built-in base rather than `ty`. This preserves the built-in element type even if the subclass
-/// overrides `__iter__`.
 fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehavior<'db> {
     let ty = ty.resolve_type_alias(db);
 
@@ -54,8 +50,7 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
         Type::TypedDict(_) => ContainmentBehavior::ElementsOf(ty),
         Type::NominalInstance(instance) => {
             // Walk the MRO until we find either a visible override or a supported built-in
-            // implementation. Returning the built-in base preserves its specialization; normal
-            // member lookup specializes inherited signatures for the subclass instead.
+            // implementation.
             for base in instance.class(db).iter_mro(db) {
                 let class = match base {
                     ClassBase::Class(class) => class,
@@ -76,6 +71,16 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
                             | KnownClass::Range
                     )
                 ) {
+                    // For built-ins with a known containment behavior, we always store the
+                    // built-in base (not `self`), even if `self` is a subclass of the built-in. At
+                    // runtime, a custom `__iter__` on a subclass of a built-in container does not
+                    // change the `__contains__` behavior of the built-in; storing the built-in
+                    // instead of the subclass ensures we model that correctly. We end up calling
+                    // `try_iterate` on the stored type, so otherwise we would wrongly prefer the
+                    // `__iter__` annotation. (It is always true for all types that `__contains__`
+                    // takes precedence over `__iter__` for containment checks, but this is only
+                    // relevant to us for built-ins, since user types with `__contains__` have
+                    // containment behavior that we can't understand and don't try to model.)
                     return ContainmentBehavior::ElementsOf(Type::instance(db, class));
                 }
                 if !class

--- a/crates/ty_python_semantic/src/types/narrow/containment.rs
+++ b/crates/ty_python_semantic/src/types/narrow/containment.rs
@@ -1,0 +1,147 @@
+use crate::{
+    Db,
+    types::{ClassBase, IntersectionBuilder, KnownClass, Type, UnionBuilder},
+};
+
+enum ContainmentBehavior<'db> {
+    /// Membership compares against the elements yielded by the wrapped type. Callers use
+    /// [`Type::try_iterate`] to determine the types that may be contained.
+    ElementsOf(Type<'db>),
+    /// A statically visible `__contains__` defines different membership behavior.
+    Custom,
+    /// No containment behavior can be established from the static type.
+    Unknown,
+}
+
+/// Return the containment behavior known for this type.
+///
+/// For subclasses that inherit a known built-in `__contains__`, the stored type is the specialized
+/// built-in base rather than `ty`. This preserves the built-in element type even if the subclass
+/// overrides `__iter__`.
+fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehavior<'db> {
+    let ty = ty.resolve_type_alias(db);
+
+    match ty {
+        Type::Union(union) => {
+            // Combine element containment for `not in`, ordinary `in` unions, and unions reached
+            // through wrappers such as type variables. Positive unions that contain string
+            // literals are distributed in `evaluate_expr_in` instead because substring semantics
+            // depend on the value of each literal haystack.
+            let mut builder = UnionBuilder::new(db);
+            let mut has_unknown_behavior = false;
+            for element in union.elements(db) {
+                match containment_behavior(db, *element) {
+                    ContainmentBehavior::ElementsOf(elements_of) => {
+                        builder = builder.add(elements_of);
+                    }
+                    ContainmentBehavior::Custom => return ContainmentBehavior::Custom,
+                    ContainmentBehavior::Unknown => has_unknown_behavior = true,
+                }
+            }
+            if has_unknown_behavior {
+                ContainmentBehavior::Unknown
+            } else {
+                ContainmentBehavior::ElementsOf(builder.build())
+            }
+        }
+        Type::TypeVar(type_var) => type_var
+            .typevar(db)
+            .bound_or_constraints(db)
+            .map_or(ContainmentBehavior::Unknown, |bound_or_constraints| {
+                containment_behavior(db, bound_or_constraints.as_type(db))
+            }),
+        Type::NewTypeInstance(newtype) => containment_behavior(db, newtype.concrete_base_type(db)),
+        Type::TypedDict(_) => ContainmentBehavior::ElementsOf(ty),
+        Type::NominalInstance(instance) => {
+            // Walk the MRO until we find either a visible override or a supported built-in
+            // implementation. Returning the built-in base preserves its specialization; normal
+            // member lookup specializes inherited signatures for the subclass instead.
+            for base in instance.class(db).iter_mro(db) {
+                let class = match base {
+                    ClassBase::Class(class) => class,
+                    ClassBase::Generic | ClassBase::Protocol => continue,
+                    ClassBase::Any
+                    | ClassBase::Dynamic(_)
+                    | ClassBase::Divergent(_)
+                    | ClassBase::TypedDict(_) => return ContainmentBehavior::Unknown,
+                };
+                if matches!(
+                    class.known(db),
+                    Some(
+                        KnownClass::List
+                            | KnownClass::Set
+                            | KnownClass::FrozenSet
+                            | KnownClass::Dict
+                            | KnownClass::Tuple
+                            | KnownClass::Range
+                    )
+                ) {
+                    return ContainmentBehavior::ElementsOf(Type::instance(db, class));
+                }
+                if !class
+                    .own_class_member(db, None, "__contains__")
+                    .is_undefined()
+                {
+                    return ContainmentBehavior::Custom;
+                }
+            }
+            if instance.class(db).is_final(db) {
+                ContainmentBehavior::ElementsOf(ty)
+            } else {
+                ContainmentBehavior::Unknown
+            }
+        }
+        _ => ContainmentBehavior::Unknown,
+    }
+}
+
+/// Return the type whose iterated elements may satisfy membership for `ty`.
+pub(super) fn elements_of<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    match containment_behavior(db, ty) {
+        ContainmentBehavior::ElementsOf(elements_of) => Some(elements_of),
+        ContainmentBehavior::Custom | ContainmentBehavior::Unknown => None,
+    }
+}
+
+/// Maximum haystack length for which we synthesize a negative type per character.
+const MAX_STRING_MEMBERSHIP_EXCLUSIONS: usize = 128;
+
+/// Narrow membership in a known string literal using substring semantics.
+pub(super) fn narrow_string_membership<'db>(
+    db: &'db dyn Db,
+    lhs_ty: Type<'db>,
+    haystack: &str,
+    is_contained: bool,
+) -> Option<Type<'db>> {
+    let lhs_ty = lhs_ty.resolve_type_alias(db);
+    let flattened_lhs_ty = lhs_ty.flatten_typevars(db);
+    let keep = |element: &Type<'db>| {
+        let element = element.resolve_type_alias(db);
+        if let Some(needle) = element.as_string_literal() {
+            haystack.contains(needle.value(db)) == is_contained
+        } else {
+            !(is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)))
+        }
+    };
+
+    let mut narrowed = match flattened_lhs_ty {
+        Type::Union(union) => union.filter(db, keep),
+        _ if keep(&flattened_lhs_ty) => flattened_lhs_ty,
+        _ => Type::Never,
+    };
+
+    if !is_contained
+        && haystack
+            .chars()
+            .nth(MAX_STRING_MEMBERSHIP_EXCLUSIONS)
+            .is_none()
+    {
+        let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
+        for character in haystack.chars() {
+            builder = builder.add_negative(Type::single_char_string_literal(db, character));
+        }
+        narrowed = builder.build();
+    }
+
+    (narrowed != flattened_lhs_ty).then_some(narrowed)
+}


### PR DESCRIPTION
## Summary

In #25955, we started to reuse our equality logic to narrow membership tests (`in`, `not in`). This PR then defines when the right-hand side of an `in` or `not in` test has behavior that is precise enough for us to use that reasoning.

For nominal types, we walk the statically visible MRO. `list`, `set`, `frozenset`, `dict`, `tuple`, and `range` use the "containment domain" of their specialized built-in base when we reach that base before any custom `__contains__` implementation. Final classes that only define `__iter__` can also use their iteration domain, while open iterable classes remain conservative because a subclass could add `__contains__`.

A visible `__contains__` override on the class or an intermediate base disables narrowing:

```python
from typing import Literal, TypedDict

class Payload(TypedDict):
    value: int

class MissingList(list[Literal["missing"]]):
    pass

class ContainsEverything(list[Literal["missing"]]):
    def __contains__(self, value: object) -> bool:
        return True

def inherited(value: Payload | Literal["missing"], values: MissingList) -> None:
    if value in values:
        reveal_type(value)  # Literal["missing"]

def overridden(value: Payload | Literal["missing"], values: ContainsEverything) -> None:
    if value in values:
        reveal_type(value)  # Payload | Literal["missing"]
```

The rule is intentionally unsound for open subclasses of built-ins. At runtime, a `list[T]` could be a subclass that overrides `__contains__`, but we assume it isn't. This matches our existing policy for tuple dunder methods, where we assume unsafe overrides will eventually be reported at the definition site.
