### PR TITLE
[ty] Diagnose zero-step slices on lists

### DIFF
--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -938,7 +938,7 @@ a: int = ''
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3050" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3055" target="_blank">View source</a>
 </small>
 
 
@@ -972,7 +972,7 @@ C.instance_var = 3  # error: Cannot assign to instance variable
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3310" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3315" target="_blank">View source</a>
 </small>
 
 
@@ -1333,7 +1333,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3443" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3448" target="_blank">View source</a>
 </small>
 
 
@@ -1533,7 +1533,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3521" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3526" target="_blank">View source</a>
 </small>
 
 
@@ -1690,7 +1690,7 @@ class B(metaclass=f): ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3345" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3350" target="_blank">View source</a>
 </small>
 
 
@@ -2237,7 +2237,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3481" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3486" target="_blank">View source</a>
 </small>
 
 
@@ -2596,7 +2596,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3256" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3261" target="_blank">View source</a>
 </small>
 
 
@@ -2627,7 +2627,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3281" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3286" target="_blank">View source</a>
 </small>
 
 
@@ -2662,7 +2662,7 @@ def f(x: dict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3231" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3236" target="_blank">View source</a>
 </small>
 
 
@@ -2968,7 +2968,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3204" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3209" target="_blank">View source</a>
 </small>
 
 
@@ -3426,7 +3426,7 @@ def test(): -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3078" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3083" target="_blank">View source</a>
 </small>
 
 
@@ -3453,7 +3453,7 @@ cast(int, f())  # Redundant
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3099" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3104" target="_blank">View source</a>
 </small>
 
 
@@ -3485,7 +3485,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3125" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3130" target="_blank">View source</a>
 </small>
 
 
@@ -3519,7 +3519,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3026" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3031" target="_blank">View source</a>
 </small>
 
 
@@ -3875,7 +3875,7 @@ A().foo  # AttributeError: 'A' object has no attribute 'foo'
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3152" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L3157" target="_blank">View source</a>
 </small>
 
 
@@ -4302,11 +4302,17 @@ Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.
 
 **What it does**
 
-Checks for step size 0 in slices.
+Checks for a step size of zero in slices when the operation is known to fail.
 
 **Why is this bad?**
 
-A slice with a step size of zero will raise a `ValueError` at runtime.
+Python's built-in sequence types raise a `ValueError` when sliced with a step size of zero.
+
+**Known problems**
+
+This check is not exhaustive. It reports zero-step slices for certain built-in sequence
+types where the operation is known to fail. A custom `__getitem__` implementation can
+accept or reject such a slice, so ty cannot detect every runtime failure.
 
 **Examples**
 

--- a/crates/ty_python_semantic/resources/mdtest/subscript/stepsize_zero.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/stepsize_zero.md
@@ -1,16 +1,26 @@
 # Stepsize zero in slices
 
-We raise a `zero-stepsize-in-slice` diagnostic when trying to slice a literal string, bytes, tuple,
-or a `list` with a step size of zero (see tests in `string.md`, `bytes.md` and `tuple.md`). A `list`
-type includes exact `list` instances that reject it, even though subclasses can override
-`__getitem__`. But we don't want to raise this diagnostic when slicing a custom type, including such
-a subclass:
+We raise a `zero-stepsize-in-slice` diagnostic when a built-in sequence is known to reject a step
+size of zero. The check is not exhaustive because custom types and subclasses can decide how to
+handle slices in `__getitem__`.
 
 ```py
 from typing import Any
 
-values = list(range(10))
-values[1:10:0]  # error: [zero-stepsize-in-slice]
+def builtins(
+    values: list[int],
+    mutable_bytes: bytearray,
+    view: memoryview,
+    numbers: range,
+    immutable_bytes: bytes,
+    text: str,
+) -> None:
+    values[1:10:0]  # error: [zero-stepsize-in-slice]
+    mutable_bytes[1:10:0]  # error: [zero-stepsize-in-slice]
+    view[1:10:0]  # error: [zero-stepsize-in-slice]
+    numbers[1:10:0]  # error: [zero-stepsize-in-slice]
+    immutable_bytes[1:10:0]  # error: [zero-stepsize-in-slice]
+    text[1:10:0]  # error: [zero-stepsize-in-slice]
 
 class ZeroSafeList(list[int]):
     def __getitem__(self, key: Any) -> Any:

--- a/crates/ty_python_semantic/resources/mdtest/subscript/stepsize_zero.md
+++ b/crates/ty_python_semantic/resources/mdtest/subscript/stepsize_zero.md
@@ -1,10 +1,23 @@
 # Stepsize zero in slices
 
-We raise a `zero-stepsize-in-slice` diagnostic when trying to slice a literal string, bytes, or
-tuple with a step size of zero (see tests in `string.md`, `bytes.md` and `tuple.md`). But we don't
-want to raise this diagnostic when slicing a custom type:
+We raise a `zero-stepsize-in-slice` diagnostic when trying to slice a literal string, bytes, tuple,
+or a `list` with a step size of zero (see tests in `string.md`, `bytes.md` and `tuple.md`). A `list`
+type includes exact `list` instances that reject it, even though subclasses can override
+`__getitem__`. But we don't want to raise this diagnostic when slicing a custom type, including such
+a subclass:
 
 ```py
+from typing import Any
+
+values = list(range(10))
+values[1:10:0]  # error: [zero-stepsize-in-slice]
+
+class ZeroSafeList(list[int]):
+    def __getitem__(self, key: Any) -> Any:
+        return 0
+
+ZeroSafeList()[0:1:0]  # No error
+
 class MySequence:
     def __getitem__(self, s: slice) -> int:
         return 0

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -41,6 +41,7 @@ pub enum KnownClass {
     Object,
     Bytes,
     Bytearray,
+    Memoryview,
     Type,
     Int,
     Float,
@@ -48,6 +49,7 @@ pub enum KnownClass {
     Str,
     List,
     Tuple,
+    Range,
     Set,
     FrozenSet,
     Dict,
@@ -219,6 +221,8 @@ impl KnownClass {
             | Self::Type
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::FrozenSet
             | Self::Property
             | Self::SpecialForm
@@ -283,6 +287,8 @@ impl KnownClass {
             | KnownClass::Object
             | KnownClass::Bytes
             | KnownClass::Bytearray
+            | KnownClass::Memoryview
+            | KnownClass::Range
             | KnownClass::Type
             | KnownClass::Int
             | KnownClass::Float
@@ -383,6 +389,8 @@ impl KnownClass {
             | KnownClass::Object
             | KnownClass::Bytes
             | KnownClass::Bytearray
+            | KnownClass::Memoryview
+            | KnownClass::Range
             | KnownClass::Type
             | KnownClass::Int
             | KnownClass::Float
@@ -484,6 +492,8 @@ impl KnownClass {
             | KnownClass::Object
             | KnownClass::Bytes
             | KnownClass::Bytearray
+            | KnownClass::Memoryview
+            | KnownClass::Range
             | KnownClass::Type
             | KnownClass::Int
             | KnownClass::Float
@@ -606,6 +616,8 @@ impl KnownClass {
             | Self::Object
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::Tuple
             | Self::Int
             | Self::Float
@@ -698,6 +710,8 @@ impl KnownClass {
             | KnownClass::Object
             | KnownClass::Bytes
             | KnownClass::Bytearray
+            | KnownClass::Memoryview
+            | KnownClass::Range
             | KnownClass::Type
             | KnownClass::Int
             | KnownClass::Float
@@ -796,7 +810,9 @@ impl KnownClass {
             Self::Object => "object",
             Self::Bytes => "bytes",
             Self::Bytearray => "bytearray",
+            Self::Memoryview => "memoryview",
             Self::Tuple => "tuple",
+            Self::Range => "range",
             Self::Int => "int",
             Self::Float => "float",
             Self::Complex => "complex",
@@ -1158,6 +1174,8 @@ impl KnownClass {
             | Self::Object
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::Type
             | Self::Int
             | Self::Float
@@ -1274,6 +1292,8 @@ impl KnownClass {
             | Self::Object
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::Type
             | Self::Int
             | Self::Float
@@ -1378,6 +1398,8 @@ impl KnownClass {
             | Self::Object
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::Tuple
             | Self::Int
             | Self::Float
@@ -1479,7 +1501,9 @@ impl KnownClass {
             "object" => &[Self::Object],
             "bytes" => &[Self::Bytes],
             "bytearray" => &[Self::Bytearray],
+            "memoryview" => &[Self::Memoryview],
             "tuple" => &[Self::Tuple],
+            "range" => &[Self::Range],
             "type" => &[Self::Type],
             "int" => &[Self::Int],
             "float" => &[Self::Float],
@@ -1586,6 +1610,8 @@ impl KnownClass {
             | Self::Object
             | Self::Bytes
             | Self::Bytearray
+            | Self::Memoryview
+            | Self::Range
             | Self::Type
             | Self::Int
             | Self::Float

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -3006,10 +3006,15 @@ declare_lint! {
 
 declare_lint! {
     /// ## What it does
-    /// Checks for step size 0 in slices.
+    /// Checks for a step size of zero in slices when the operation is known to fail.
     ///
     /// ## Why is this bad?
-    /// A slice with a step size of zero will raise a `ValueError` at runtime.
+    /// Python's built-in sequence types raise a `ValueError` when sliced with a step size of zero.
+    ///
+    /// ## Known problems
+    /// This check is not exhaustive. It reports zero-step slices for certain built-in sequence
+    /// types where the operation is known to fail. A custom `__getitem__` implementation can
+    /// accept or reject such a slice, so ty cannot detect every runtime failure.
     ///
     /// ## Examples
     /// ```python

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display};
 
 use itertools::Itertools;
 use ruff_python_ast as ast;
+use ty_module_resolver::{KnownModule, file_to_module};
 
 use crate::Db;
 use crate::subscript::{PyIndex, PySlice};
@@ -19,7 +20,7 @@ use super::diagnostic::{
     report_not_subscriptable, report_slice_step_size_zero,
 };
 use super::infer::TypeContext;
-use super::instance::SliceLiteral;
+use super::instance::{NominalInstanceType, SliceLiteral};
 use super::special_form::SpecialFormType;
 use super::tuple::TupleSpec;
 use super::{
@@ -522,6 +523,18 @@ fn typed_dict_subscript<'db>(
     )
 }
 
+fn builtin_sequence_rejects_zero_step<'db>(
+    db: &'db dyn Db,
+    instance: NominalInstanceType<'db>,
+) -> bool {
+    let class = instance.class_literal(db);
+    matches!(
+        class.name(db).as_str(),
+        "list" | "bytearray" | "memoryview" | "range" | "bytes" | "str"
+    ) && file_to_module(db, class.file(db))
+        .is_some_and(|module| module.is_known(db, KnownModule::Builtins))
+}
+
 impl<'db> Type<'db> {
     pub(super) fn subscript(
         self,
@@ -584,9 +597,9 @@ impl<'db> Type<'db> {
             }
 
             (
-                Type::NominalInstance(maybe_list_nominal),
+                Type::NominalInstance(maybe_sequence_nominal),
                 Type::NominalInstance(maybe_slice_nominal),
-            ) if maybe_list_nominal.has_known_class(db, KnownClass::List)
+            ) if builtin_sequence_rejects_zero_step(db, maybe_sequence_nominal)
                 && maybe_slice_nominal
                     .slice_literal(db)
                     .is_some_and(|slice| slice.step == Some(0)) =>

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -583,6 +583,20 @@ impl<'db> Type<'db> {
                 Some(typed_dict_subscript(db, typed_dict, slice_ty))
             }
 
+            (
+                Type::NominalInstance(maybe_list_nominal),
+                Type::NominalInstance(maybe_slice_nominal),
+            ) if maybe_list_nominal.has_known_class(db, KnownClass::List)
+                && maybe_slice_nominal
+                    .slice_literal(db)
+                    .is_some_and(|slice| slice.step == Some(0)) =>
+            {
+                Some(Err(SubscriptError::new(
+                    value_ty,
+                    SubscriptErrorKind::SliceStepSizeZero,
+                )))
+            }
+
             // Ex) Given `("a", "b", "c", "d")[1]`, return `"b"`
             (Type::NominalInstance(nominal), Type::LiteralValue(literal)) if literal.is_int() => {
                 let i64_int = literal.as_int().unwrap();

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -4,7 +4,6 @@ use std::fmt::{self, Display};
 
 use itertools::Itertools;
 use ruff_python_ast as ast;
-use ty_module_resolver::{KnownModule, file_to_module};
 
 use crate::Db;
 use crate::subscript::{PyIndex, PySlice};
@@ -20,7 +19,7 @@ use super::diagnostic::{
     report_not_subscriptable, report_slice_step_size_zero,
 };
 use super::infer::TypeContext;
-use super::instance::{NominalInstanceType, SliceLiteral};
+use super::instance::SliceLiteral;
 use super::special_form::SpecialFormType;
 use super::tuple::TupleSpec;
 use super::{
@@ -523,18 +522,6 @@ fn typed_dict_subscript<'db>(
     )
 }
 
-fn builtin_sequence_rejects_zero_step<'db>(
-    db: &'db dyn Db,
-    instance: NominalInstanceType<'db>,
-) -> bool {
-    let class = instance.class_literal(db);
-    matches!(
-        class.name(db).as_str(),
-        "list" | "bytearray" | "memoryview" | "range" | "bytes" | "str"
-    ) && file_to_module(db, class.file(db))
-        .is_some_and(|module| module.is_known(db, KnownModule::Builtins))
-}
-
 impl<'db> Type<'db> {
     pub(super) fn subscript(
         self,
@@ -599,7 +586,18 @@ impl<'db> Type<'db> {
             (
                 Type::NominalInstance(maybe_sequence_nominal),
                 Type::NominalInstance(maybe_slice_nominal),
-            ) if builtin_sequence_rejects_zero_step(db, maybe_sequence_nominal)
+            ) if matches!(
+                maybe_sequence_nominal.known_class(db),
+                Some(
+                    KnownClass::List
+                        | KnownClass::Tuple
+                        | KnownClass::Str
+                        | KnownClass::Bytes
+                        | KnownClass::Bytearray
+                        | KnownClass::Range
+                        | KnownClass::Memoryview
+                )
+            )
                 && maybe_slice_nominal
                     .slice_literal(db)
                     .is_some_and(|slice| slice.step == Some(0)) =>

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -1522,7 +1522,7 @@
         },
         "zero-stepsize-in-slice": {
           "title": "detects a slice step size of zero",
-          "description": "## What it does\nChecks for step size 0 in slices.\n\n## Why is this bad?\nA slice with a step size of zero will raise a `ValueError` at runtime.\n\n## Examples\n```python\nl = list(range(10))\nl[1:10:0]  # ValueError: slice step cannot be zero\n```",
+          "description": "## What it does\nChecks for a step size of zero in slices when the operation is known to fail.\n\n## Why is this bad?\nPython's built-in sequence types raise a `ValueError` when sliced with a step size of zero.\n\n## Known problems\nThis check is not exhaustive. It reports zero-step slices for certain built-in sequence\ntypes where the operation is known to fail. A custom `__getitem__` implementation can\naccept or reject such a slice, so ty cannot detect every runtime failure.\n\n## Examples\n```python\nl = list(range(10))\nl[1:10:0]  # ValueError: slice step cannot be zero\n```",
           "default": "error",
           "oneOf": [
             {


### PR DESCRIPTION
## Summary

A slice with a step size of zero always fails for an exact `list`, but we currently only report `zero-stepsize-in-slice` for string, bytes, and tuple literals:

```python
values = list(range(10))
result = values[1:10:0]  # error: [zero-stepsize-in-slice]
reveal_type(result)  # list[int]
```

We now report the diagnostic when the receiver type is `list` or another known built-in while preserving the inferred result type for error recovery.

(A hypothetical subclass could override `__getitem__` to accept a zero step, but the `list` type includes exact `list` instances that are known to reject it. Subclasses with their own nominal type and custom sequence types continue through normal subscript dispatch without this diagnostic.)

Closes https://github.com/astral-sh/ty/issues/3736.
