### PR TITLE
[ty] Bind Self using stable receiver types

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -514,151 +514,6 @@ def _(c: MyClass):
     c.field = c
 ```
 
-Truthiness narrowing applies to a specific value, not to every value of the same concrete class.
-These refinements should not be preserved when binding `Self` in an attribute or method return.
-
-Regression test for <https://github.com/astral-sh/ty/issues/3755>.
-
-```py
-from typing import Self
-from ty_extensions import AlwaysFalsy, AlwaysTruthy, Intersection, Not
-
-class Base:
-    values: list[Self]
-
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-    def replace(self, other: Self) -> None:
-        raise NotImplementedError
-
-    def preserve[T](self: Intersection[Self, T]) -> T:
-        raise NotImplementedError
-
-class Child(Base): ...
-class Other(Base): ...
-
-def truthy(value: Child | None) -> list[Child]:
-    if value:
-        reveal_type(value.values)  # revealed: list[Child]
-        reveal_type(value.copy())  # revealed: Child
-        reveal_type(value.preserve())  # revealed: Child & ~AlwaysFalsy
-        return value.values
-    raise ValueError
-
-type TruthyChild = Intersection[Child, Not[AlwaysFalsy]]
-
-def type_alias(value: TruthyChild) -> None:
-    reveal_type(value.copy())  # revealed: Child
-    reveal_type(Base.copy(value))  # revealed: Child
-
-def falsy(value: Child) -> None:
-    if not value:
-        reveal_type(value.copy())  # revealed: Child
-
-def union(value: Child | Other | None) -> None:
-    if value:
-        reveal_type(value.values)  # revealed: list[Child] | list[Other]
-        reveal_type(value.copy())  # revealed: Child | Other
-
-class Excluded: ...
-
-def positive_truthiness(
-    value: Intersection[Child, AlwaysTruthy, Not[Excluded]],
-) -> None:
-    reveal_type(value.copy())  # revealed: Child & ~Excluded
-
-def compound_negative(
-    value: Intersection[Child, Not[AlwaysFalsy | Excluded]],
-) -> None:
-    reveal_type(value.copy())  # revealed: Child & ~Excluded
-```
-
-Value-level refinements and synthesized structural refinements are removed from `Self` bindings,
-while nominal constraints, class-wide protocol constraints, and generic specializations are
-preserved.
-
-```py
-from collections import defaultdict
-from collections.abc import Iterable
-from enum import Enum
-from typing import Protocol, runtime_checkable
-from ty_extensions import Top
-
-def class_wide_protocol(
-    value: Intersection[
-        Iterable[str | type | None],
-        Top[defaultdict[str | type | None, object]],
-    ],
-) -> None:
-    copied: Iterable[str | type | None] = value.copy()
-
-def attribute_refinement(value: Child) -> None:
-    if hasattr(value, "name"):
-        reveal_type(value)  # revealed: Child & <Protocol with members 'name'>
-        reveal_type(value.values)  # revealed: list[Child]
-        reveal_type(value.copy())  # revealed: Child
-        reveal_type(Base.copy(value))  # revealed: Child
-
-@runtime_checkable
-class HasName(Protocol):
-    name: str
-
-def runtime_protocol_refinement(value: Child) -> None:
-    if isinstance(value, HasName):
-        reveal_type(value)  # revealed: Child & HasName
-        reveal_type(value.values)  # revealed: list[Child]
-        value.replace(Child())
-        narrowed: HasName = value.copy()  # error: [invalid-assignment]
-    else:
-        reveal_type(value.copy())  # revealed: Child
-
-class Copier(Protocol):
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-def protocol_owner(value: Copier) -> None:
-    reveal_type(value.copy())  # revealed: Copier
-
-class Box[T]:
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-def generic_specialization(value: Box[int] | None) -> None:
-    if value:
-        reveal_type(value.copy())  # revealed: Box[int]
-
-class Color(Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3
-
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-reveal_type(Color.copy(Color.RED))  # revealed: Color
-
-def enum_complement(value: Color) -> None:
-    if value is not Color.RED:
-        reveal_type(value.copy())  # revealed: Color
-
-class TupleChild(tuple[int | str, ...]):
-    other: Self
-
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-def exact_tuple_refinement(value: Intersection[TupleChild, tuple[int, int]]) -> None:
-    reveal_type(TupleChild.copy(value))  # revealed: TupleChild
-    reveal_type(value.other)  # revealed: TupleChild
-    exact: tuple[int, int] = value.copy()  # error: [invalid-assignment]
-
-def negative_exact_tuple_refinement(
-    value: Intersection[TupleChild, Not[tuple[int, int]]],
-) -> None:
-    reveal_type(value.copy())  # revealed: TupleChild
-```
-
 Self from class body annotations and method signatures represent the same logical type variable.
 When a method returns an attribute annotated with `Self` in the class body, the class-body `Self`
 and the method's `Self` should be considered the same type, even though they have different binding
@@ -724,6 +579,161 @@ class C(Generic[T]):
     def method(self) -> None:
         reveal_type(self)  # revealed: Self@method
         reveal_type(self.foo)  # revealed: T@C
+```
+
+## Binding `Self` after type narrowing
+
+Narrowing can tell us something about one object without telling us the same thing about another
+object of the same class. When an attribute or method uses `Self`, ty keeps the receiver's class and
+type arguments but does not copy facts that apply only to the receiver.
+
+Regression test for <https://github.com/astral-sh/ty/issues/3755>.
+
+```py
+from typing import Self
+from ty_extensions import AlwaysFalsy, Intersection, Not
+
+class Base:
+    values: list[Self]
+
+    def copy(self) -> Self:
+        return self
+
+    def replace(self, other: Self) -> None:
+        pass
+
+    def capture[T](self: Intersection[Self, T]) -> T:
+        return self
+
+class Child(Base): ...
+class Other(Base): ...
+
+def truthy_receiver(value: Child | None) -> None:
+    if value:
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
+
+        # An ordinary type variable still captures the narrowed receiver type.
+        reveal_type(value.capture())  # revealed: Child & ~AlwaysFalsy
+```
+
+Aliases, falsy branches, and unions follow the same rule. Unrelated narrowing is retained:
+
+```py
+type TruthyChild = Intersection[Child, Not[AlwaysFalsy]]
+
+def aliased_receiver(value: TruthyChild) -> None:
+    reveal_type(value.copy())  # revealed: Child
+    reveal_type(Base.copy(value))  # revealed: Child
+
+def falsy_receiver(value: Child) -> None:
+    if not value:
+        reveal_type(value.copy())  # revealed: Child
+
+def union_receiver(value: Child | Other | None) -> None:
+    if value:
+        reveal_type(value.values)  # revealed: list[Child] | list[Other]
+
+class Excluded: ...
+
+def unrelated_narrowing(value: Child) -> None:
+    if value and not isinstance(value, Excluded):
+        reveal_type(value.copy())  # revealed: Child & ~Excluded
+```
+
+Checks such as `hasattr` and `isinstance` describe the checked object. They must not constrain
+another object passed or returned as `Self`:
+
+```py
+from typing import Protocol, runtime_checkable
+
+def hasattr_narrowing(value: Child) -> None:
+    if hasattr(value, "name"):
+        reveal_type(value.values)  # revealed: list[Child]
+
+@runtime_checkable
+class HasName(Protocol):
+    name: str
+
+def runtime_protocol_narrowing(value: Child) -> None:
+    if isinstance(value, HasName):
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
+        value.replace(Child())
+    else:
+        reveal_type(value.copy())  # revealed: Child
+```
+
+Narrowing an `Iterable[...] | dict[...]` value to `defaultdict` retains the iterable element type.
+Calling `copy()` must preserve that information, but a separate runtime protocol check still only
+describes the checked object:
+
+```py
+from collections import defaultdict
+from collections.abc import Iterable
+
+def copy_narrowed_defaultdict(
+    value: Iterable[str | type | None] | dict[str | type | None, object],
+) -> Iterable[str | type | None]:
+    if isinstance(value, defaultdict):
+        if isinstance(value, HasName):
+            copied_with_name: HasName = value.copy()  # error: [invalid-assignment]
+        return value.copy()
+    raise TypeError
+```
+
+Generic arguments describe the class rather than one particular value, so they are retained:
+
+```py
+class Box[T]:
+    def copy(self) -> Self:
+        return self
+
+def generic_receiver(value: Box[int] | None) -> None:
+    if value:
+        reveal_type(value.copy())  # revealed: Box[int]
+```
+
+An enum member identifies one value. A method returning `Self` may return a different member of the
+same enum:
+
+```py
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+    def copy(self) -> Self:
+        return self
+
+reveal_type(Color.copy(Color.RED))  # revealed: Color
+
+def excluded_enum_member(value: Color) -> None:
+    if value is not Color.RED:
+        reveal_type(value.copy())  # revealed: Color
+```
+
+A tuple's exact length and element types describe that tuple value. Another value returned through
+`Self` may have a different shape, so only the tuple subclass is retained:
+
+```py
+class TupleChild(tuple[int | str, ...]):
+    other: Self
+
+    def copy(self) -> Self:
+        return self
+
+def exact_tuple_shape(value: Intersection[TupleChild, tuple[int, int]]) -> None:
+    reveal_type(value.copy())  # revealed: TupleChild
+    reveal_type(TupleChild.copy(value))  # revealed: TupleChild
+    reveal_type(value.other)  # revealed: TupleChild
+
+def excluded_tuple_shape(
+    value: Intersection[TupleChild, Not[tuple[int, int]]],
+) -> None:
+    reveal_type(value.copy())  # revealed: TupleChild
 ```
 
 ## Callable attributes that return `Self`

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -555,6 +555,7 @@ def falsy(value: Child) -> None:
 
 def union(value: Child | Other | None) -> None:
     if value:
+        reveal_type(value.values)  # revealed: list[Child] | list[Other]
         reveal_type(value.copy())  # revealed: Child | Other
 
 class Excluded: ...
@@ -563,6 +564,81 @@ def positive_truthiness(
     value: Intersection[Child, AlwaysTruthy, Not[Excluded]],
 ) -> None:
     reveal_type(value.copy())  # revealed: Child & ~Excluded
+
+def compound_negative(
+    value: Intersection[Child, Not[AlwaysFalsy | Excluded]],
+) -> None:
+    reveal_type(value.copy())  # revealed: Child & ~Excluded
+```
+
+Structural and value-level refinements are removed from `Self` bindings, while nominal constraints
+and generic specializations are preserved.
+
+```py
+from enum import Enum
+from typing import Protocol, Self, runtime_checkable
+from ty_extensions import Intersection
+
+class StableBase:
+    value: Self
+
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+class StableChild(StableBase): ...
+
+@runtime_checkable
+class WithName(Protocol):
+    name: str
+
+def explicit_intersection(value: Intersection[StableChild, WithName]) -> None:
+    reveal_type(value.value)  # revealed: StableChild
+    reveal_type(value.copy())  # revealed: StableChild
+    reveal_type(StableBase.copy(value))  # revealed: StableChild
+
+type NamedChild = Intersection[StableChild, WithName]
+
+def explicit_intersection_alias(value: NamedChild) -> None:
+    reveal_type(value.value)  # revealed: StableChild
+    reveal_type(value.copy())  # revealed: StableChild
+    reveal_type(StableBase.copy(value))  # revealed: StableChild
+
+def attribute_refinement(value: StableChild) -> None:
+    if hasattr(value, "name"):
+        reveal_type(value)  # revealed: StableChild & <Protocol with members 'name'>
+        reveal_type(value.value)  # revealed: StableChild
+        reveal_type(value.copy())  # revealed: StableChild
+        reveal_type(StableBase.copy(value))  # revealed: StableChild
+
+def protocol_refinement(value: StableChild) -> None:
+    if isinstance(value, WithName):
+        reveal_type(value)  # revealed: StableChild & WithName
+        reveal_type(value.value)  # revealed: StableChild
+        reveal_type(value.copy())  # revealed: StableChild
+        reveal_type(StableBase.copy(value))  # revealed: StableChild
+
+class Box[T]:
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+def generic_specialization(value: Box[int] | None) -> None:
+    if value:
+        reveal_type(value.copy())  # revealed: Box[int]
+
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+reveal_type(Color.RED.copy())  # revealed: Color
+reveal_type(Color.copy(Color.RED))  # revealed: Color
+
+def enum_complement(value: Color) -> None:
+    if value is not Color.RED:
+        reveal_type(value.copy())  # revealed: Color
 ```
 
 Self from class body annotations and method signatures represent the same logical type variable.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -529,6 +529,9 @@ class Base:
     def copy(self) -> Self:
         raise NotImplementedError
 
+    def replace(self, other: Self) -> None:
+        raise NotImplementedError
+
     def preserve[T](self: Intersection[Self, T]) -> T:
         raise NotImplementedError
 
@@ -571,21 +574,24 @@ def compound_negative(
     reveal_type(value.copy())  # revealed: Child & ~Excluded
 ```
 
-Structural and value-level refinements are removed from `Self` bindings, while nominal constraints
-and generic specializations are preserved.
+Value-level refinements and synthesized structural refinements are removed from `Self` bindings,
+while nominal constraints, declared protocols, and generic specializations are preserved.
 
 ```py
+from collections.abc import Callable, Iterable
 from enum import Enum
-from typing import Protocol, Self
+from typing import Self
 from ty_extensions import Intersection
 
-class WithName(Protocol):
-    name: str
-
-def explicit_intersection(value: Intersection[Child, WithName]) -> None:
-    reveal_type(value.values)  # revealed: list[Child]
-    reveal_type(value.copy())  # revealed: Child
-    reveal_type(Base.copy(value))  # revealed: Child
+def declared_protocol(
+    value: Intersection[Child, Iterable[str | type | None]],
+    other: Intersection[Child, Iterable[str | type | None]],
+) -> None:
+    reveal_type(value.values)  # revealed: list[Child & Iterable[str | type | None]]
+    reveal_type(value.copy())  # revealed: Child & Iterable[str | type | None]
+    reveal_type(Base.copy(value))  # revealed: Child & Iterable[str | type | None]
+    value.replace(other)
+    callback: Callable[[Child], None] = value.replace  # error: [invalid-assignment]
 
 def attribute_refinement(value: Child) -> None:
     if hasattr(value, "name"):

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -575,23 +575,23 @@ def compound_negative(
 ```
 
 Value-level refinements and synthesized structural refinements are removed from `Self` bindings,
-while nominal constraints, declared protocols, and generic specializations are preserved.
+while nominal constraints, class-wide protocol constraints, and generic specializations are
+preserved.
 
 ```py
-from collections.abc import Callable, Iterable
+from collections import defaultdict
+from collections.abc import Iterable
 from enum import Enum
-from typing import Self
-from ty_extensions import Intersection
+from typing import Protocol, Self, runtime_checkable
+from ty_extensions import Intersection, Not, Top
 
-def declared_protocol(
-    value: Intersection[Child, Iterable[str | type | None]],
-    other: Intersection[Child, Iterable[str | type | None]],
+def class_wide_protocol(
+    value: Intersection[
+        Iterable[str | type | None],
+        Top[defaultdict[str | type | None, object]],
+    ],
 ) -> None:
-    reveal_type(value.values)  # revealed: list[Child & Iterable[str | type | None]]
-    reveal_type(value.copy())  # revealed: Child & Iterable[str | type | None]
-    reveal_type(Base.copy(value))  # revealed: Child & Iterable[str | type | None]
-    value.replace(other)
-    callback: Callable[[Child], None] = value.replace  # error: [invalid-assignment]
+    copied: Iterable[str | type | None] = value.copy()
 
 def attribute_refinement(value: Child) -> None:
     if hasattr(value, "name"):
@@ -599,6 +599,29 @@ def attribute_refinement(value: Child) -> None:
         reveal_type(value.values)  # revealed: list[Child]
         reveal_type(value.copy())  # revealed: Child
         reveal_type(Base.copy(value))  # revealed: Child
+
+@runtime_checkable
+class HasName(Protocol):
+    name: str
+
+def runtime_protocol_refinement(value: Child) -> None:
+    if isinstance(value, HasName):
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
+        reveal_type(Base.copy(value))  # revealed: Child
+        value.replace(Child())
+        narrowed: HasName = value.copy()  # error: [invalid-assignment]
+    else:
+        reveal_type(value.copy())  # revealed: Child
+        reveal_type(Base.copy(value))  # revealed: Child
+
+class Copier(Protocol):
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+def protocol_owner(value: Copier) -> None:
+    reveal_type(value.copy())  # revealed: Copier
+    reveal_type(Copier.copy(value))  # revealed: Copier
 
 class Box[T]:
     def copy(self) -> Self:
@@ -621,6 +644,23 @@ reveal_type(Color.copy(Color.RED))  # revealed: Color
 def enum_complement(value: Color) -> None:
     if value is not Color.RED:
         reveal_type(value.copy())  # revealed: Color
+
+class TupleChild(tuple[int | str, ...]):
+    other: Self
+
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+def exact_tuple_refinement(value: Intersection[TupleChild, tuple[int, int]]) -> None:
+    reveal_type(value.copy())  # revealed: TupleChild
+    reveal_type(TupleChild.copy(value))  # revealed: TupleChild
+    reveal_type(value.other)  # revealed: TupleChild
+    exact: tuple[int, int] = value.copy()  # error: [invalid-assignment]
+
+def negative_exact_tuple_refinement(
+    value: Intersection[TupleChild, Not[tuple[int, int]]],
+) -> None:
+    reveal_type(value.copy())  # revealed: TupleChild
 ```
 
 Self from class body annotations and method signatures represent the same logical type variable.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -662,6 +662,15 @@ def runtime_protocol_narrowing(value: Child) -> None:
         value.replace(Child())
     else:
         reveal_type(value.copy())  # revealed: Child
+
+@runtime_checkable
+class HasItem[T](Protocol):
+    item: T
+
+def generic_runtime_protocol_narrowing(value: Child) -> None:
+    if isinstance(value, HasItem):
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
 ```
 
 Narrowing an `Iterable[...] | dict[...]` value to `defaultdict` retains the iterable element type.

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -582,8 +582,8 @@ preserved.
 from collections import defaultdict
 from collections.abc import Iterable
 from enum import Enum
-from typing import Protocol, Self, runtime_checkable
-from ty_extensions import Intersection, Not, Top
+from typing import Protocol, runtime_checkable
+from ty_extensions import Top
 
 def class_wide_protocol(
     value: Intersection[
@@ -606,14 +606,12 @@ class HasName(Protocol):
 
 def runtime_protocol_refinement(value: Child) -> None:
     if isinstance(value, HasName):
+        reveal_type(value)  # revealed: Child & HasName
         reveal_type(value.values)  # revealed: list[Child]
-        reveal_type(value.copy())  # revealed: Child
-        reveal_type(Base.copy(value))  # revealed: Child
         value.replace(Child())
         narrowed: HasName = value.copy()  # error: [invalid-assignment]
     else:
         reveal_type(value.copy())  # revealed: Child
-        reveal_type(Base.copy(value))  # revealed: Child
 
 class Copier(Protocol):
     def copy(self) -> Self:
@@ -621,7 +619,6 @@ class Copier(Protocol):
 
 def protocol_owner(value: Copier) -> None:
     reveal_type(value.copy())  # revealed: Copier
-    reveal_type(Copier.copy(value))  # revealed: Copier
 
 class Box[T]:
     def copy(self) -> Self:
@@ -652,7 +649,6 @@ class TupleChild(tuple[int | str, ...]):
         raise NotImplementedError
 
 def exact_tuple_refinement(value: Intersection[TupleChild, tuple[int, int]]) -> None:
-    reveal_type(value.copy())  # revealed: TupleChild
     reveal_type(TupleChild.copy(value))  # revealed: TupleChild
     reveal_type(value.other)  # revealed: TupleChild
     exact: tuple[int, int] = value.copy()  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -576,46 +576,23 @@ and generic specializations are preserved.
 
 ```py
 from enum import Enum
-from typing import Protocol, Self, runtime_checkable
+from typing import Protocol, Self
 from ty_extensions import Intersection
 
-class StableBase:
-    value: Self
-
-    def copy(self) -> Self:
-        raise NotImplementedError
-
-class StableChild(StableBase): ...
-
-@runtime_checkable
 class WithName(Protocol):
     name: str
 
-def explicit_intersection(value: Intersection[StableChild, WithName]) -> None:
-    reveal_type(value.value)  # revealed: StableChild
-    reveal_type(value.copy())  # revealed: StableChild
-    reveal_type(StableBase.copy(value))  # revealed: StableChild
+def explicit_intersection(value: Intersection[Child, WithName]) -> None:
+    reveal_type(value.values)  # revealed: list[Child]
+    reveal_type(value.copy())  # revealed: Child
+    reveal_type(Base.copy(value))  # revealed: Child
 
-type NamedChild = Intersection[StableChild, WithName]
-
-def explicit_intersection_alias(value: NamedChild) -> None:
-    reveal_type(value.value)  # revealed: StableChild
-    reveal_type(value.copy())  # revealed: StableChild
-    reveal_type(StableBase.copy(value))  # revealed: StableChild
-
-def attribute_refinement(value: StableChild) -> None:
+def attribute_refinement(value: Child) -> None:
     if hasattr(value, "name"):
-        reveal_type(value)  # revealed: StableChild & <Protocol with members 'name'>
-        reveal_type(value.value)  # revealed: StableChild
-        reveal_type(value.copy())  # revealed: StableChild
-        reveal_type(StableBase.copy(value))  # revealed: StableChild
-
-def protocol_refinement(value: StableChild) -> None:
-    if isinstance(value, WithName):
-        reveal_type(value)  # revealed: StableChild & WithName
-        reveal_type(value.value)  # revealed: StableChild
-        reveal_type(value.copy())  # revealed: StableChild
-        reveal_type(StableBase.copy(value))  # revealed: StableChild
+        reveal_type(value)  # revealed: Child & <Protocol with members 'name'>
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
+        reveal_type(Base.copy(value))  # revealed: Child
 
 class Box[T]:
     def copy(self) -> Self:
@@ -633,7 +610,6 @@ class Color(Enum):
     def copy(self) -> Self:
         raise NotImplementedError
 
-reveal_type(Color.RED.copy())  # revealed: Color
 reveal_type(Color.copy(Color.RED))  # revealed: Color
 
 def enum_complement(value: Color) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -514,6 +514,51 @@ def _(c: MyClass):
     c.field = c
 ```
 
+Truthiness narrowing applies to a specific value, not to every value of the same concrete class.
+These refinements should not be preserved when binding `Self` in an attribute or method return.
+
+Regression test for <https://github.com/astral-sh/ty/issues/3755>.
+
+```py
+from typing import Self
+from ty_extensions import AlwaysTruthy, Intersection, Not
+
+class Base:
+    values: list[Self]
+
+    def copy(self) -> Self:
+        raise NotImplementedError
+
+    def preserve[T](self: Intersection[Self, T]) -> T:
+        raise NotImplementedError
+
+class Child(Base): ...
+class Other(Base): ...
+
+def truthy(value: Child | None) -> list[Child]:
+    if value:
+        reveal_type(value.values)  # revealed: list[Child]
+        reveal_type(value.copy())  # revealed: Child
+        reveal_type(value.preserve())  # revealed: Child & ~AlwaysFalsy
+        return value.values
+    raise ValueError
+
+def falsy(value: Child) -> None:
+    if not value:
+        reveal_type(value.copy())  # revealed: Child
+
+def union(value: Child | Other | None) -> None:
+    if value:
+        reveal_type(value.copy())  # revealed: Child | Other
+
+class Excluded: ...
+
+def positive_truthiness(
+    value: Intersection[Child, AlwaysTruthy, Not[Excluded]],
+) -> None:
+    reveal_type(value.copy())  # revealed: Child & ~Excluded
+```
+
 Self from class body annotations and method signatures represent the same logical type variable.
 When a method returns an attribute annotated with `Self` in the class body, the class-body `Self`
 and the method's `Self` should be considered the same type, even though they have different binding

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -521,7 +521,7 @@ Regression test for <https://github.com/astral-sh/ty/issues/3755>.
 
 ```py
 from typing import Self
-from ty_extensions import AlwaysTruthy, Intersection, Not
+from ty_extensions import AlwaysFalsy, AlwaysTruthy, Intersection, Not
 
 class Base:
     values: list[Self]
@@ -542,6 +542,12 @@ def truthy(value: Child | None) -> list[Child]:
         reveal_type(value.preserve())  # revealed: Child & ~AlwaysFalsy
         return value.values
     raise ValueError
+
+type TruthyChild = Intersection[Child, Not[AlwaysFalsy]]
+
+def type_alias(value: TruthyChild) -> None:
+    reveal_type(value.copy())  # revealed: Child
+    reveal_type(Base.copy(value))  # revealed: Child
 
 def falsy(value: Child) -> None:
     if not value:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,10 +1863,10 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
-### `Self` binding uses the full intersection type
+### `Self` with multiple class constraints
 
-For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute or
-method. Once found, however, `Self` must be bound using the full `A & B` receiver.
+When a value has type `A & B`, attributes and methods declared as `Self` on `A` also have type
+`A & B`. Both class constraints describe the value's class.
 
 ```py
 from typing_extensions import Self
@@ -1883,7 +1883,6 @@ class B: ...
 def _(a_and_b: Intersection[A, B]):
     reveal_type(a_and_b.value)  # revealed: A & B
     reveal_type(a_and_b.method())  # revealed: A & B
-    reveal_type(A.method(a_and_b))  # revealed: A & B
 ```
 
 ### Descriptor binding uses the full intersection type

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,23 +1863,27 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
-### Method binding uses the full intersection type
+### `Self` binding uses the full intersection type
 
-For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the method. Once
-found, however, `Self` must be bound using the full `A & B` receiver.
+For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute or
+method. Once found, however, `Self` must be bound using the full `A & B` receiver.
 
 ```py
 from typing_extensions import Self
 from ty_extensions import Intersection
 
 class A:
+    value: Self
+
     def method(self) -> Self:
         return self
 
 class B: ...
 
 def _(a_and_b: Intersection[A, B]):
+    reveal_type(a_and_b.value)  # revealed: A & B
     reveal_type(a_and_b.method())  # revealed: A & B
+    reveal_type(A.method(a_and_b))  # revealed: A & B
 ```
 
 ### Descriptor binding uses the full intersection type

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,25 +1863,22 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
-### `Self` binding uses the full intersection type
+### Method binding uses the full intersection type
 
-For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute or
-method. Once found, however, `Self` must be bound using the full `A & B` receiver.
+For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the method. Once
+found, however, `Self` must be bound using the full `A & B` receiver.
 
 ```py
 from typing_extensions import Self
 from ty_extensions import Intersection
 
 class A:
-    value: Self
-
     def method(self) -> Self:
         return self
 
 class B: ...
 
 def _(a_and_b: Intersection[A, B]):
-    reveal_type(a_and_b.value)  # revealed: A & B
     reveal_type(a_and_b.method())  # revealed: A & B
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1863,22 +1863,25 @@ def _(a_and_b: Intersection[type[A], type[B]]):
     a_and_b.x = R()
 ```
 
-### Method binding uses the full intersection type
+### `Self` binding uses the full intersection type
 
-For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the method. Once
-found, however, `Self` must be bound using the full `A & B` receiver.
+For `Intersection[A, B]`, member lookup searches `A` and `B` separately to find the attribute or
+method. Once found, however, `Self` must be bound using the full `A & B` receiver.
 
 ```py
 from typing_extensions import Self
 from ty_extensions import Intersection
 
 class A:
+    value: Self
+
     def method(self) -> Self:
         return self
 
 class B: ...
 
 def _(a_and_b: Intersection[A, B]):
+    reveal_type(a_and_b.value)  # revealed: A & B
     reveal_type(a_and_b.method())  # revealed: A & B
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -711,10 +711,11 @@ reveal_type(x)  # revealed: object
 
 ## Narrowing on `Self` in `match` statements
 
-When performing narrowing on `self` inside methods on enums, we take into account that `Self` might
-refer to a subtype of the enum class, like `Literal[Answer.YES]`. This is why we do not simplify
-`Self & ~Literal[Answer.YES]` to `Literal[Answer.NO, Answer.MAYBE]`. Otherwise, we wouldn't be able
-to return `self` in the `assert_yes` method below:
+When performing narrowing on `self` inside methods on enums, we retain the `Self` type variable
+rather than simplifying `Self & ~Literal[Answer.YES]` to `Literal[Answer.NO, Answer.MAYBE]`.
+Otherwise, we wouldn't be able to return `self` in the `assert_yes` method below. When binding the
+method, however, the enum member identity is not preserved because another value returned through
+`Self` can be a different member of the same enum class:
 
 ```py
 from enum import Enum
@@ -777,7 +778,7 @@ class Answer(Enum):
 Answer.YES.is_yes_through_class_member()
 
 try:
-    reveal_type(Answer.MAYBE.assert_yes())  # revealed: Literal[Answer.MAYBE]
+    reveal_type(Answer.MAYBE.assert_yes())  # revealed: Answer
 except ValueError:
     pass
 ```

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -711,11 +711,10 @@ reveal_type(x)  # revealed: object
 
 ## Narrowing on `Self` in `match` statements
 
-When performing narrowing on `self` inside methods on enums, we retain the `Self` type variable
-rather than simplifying `Self & ~Literal[Answer.YES]` to `Literal[Answer.NO, Answer.MAYBE]`.
-Otherwise, we wouldn't be able to return `self` in the `assert_yes` method below. When binding the
-method, however, the enum member identity is not preserved because another value returned through
-`Self` can be a different member of the same enum class:
+Type narrowing inside these enum methods must retain `Self` rather than simplify
+`Self & ~Literal[Answer.YES]` to `Literal[Answer.NO, Answer.MAYBE]`. Otherwise, `assert_yes` could
+not return `self`. When a method is called on an enum member, `Self` guarantees the same enum class,
+not the same member, so `Answer.MAYBE.assert_yes()` has type `Answer`:
 
 ```py
 from enum import Enum

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7225,15 +7225,9 @@ fn self_typevar_owner_class_literal<'db>(
 /// whose truthiness is unknown. Similarly, a synthesized protocol produced by `hasattr` only
 /// describes the current value and must not become part of the `Self` specialization.
 ///
-/// Nominal constraints are preserved because they describe the receiver's concrete subtype. A
-/// protocol constraint is only preserved when that protocol owns `Self`; unrelated structural
-/// constraints can describe instance state. Type aliases are preserved unless projection changes
-/// their value.
-fn self_type_projection<'db>(
-    db: &'db dyn Db,
-    ty: Type<'db>,
-    owner_class: Option<ClassLiteral<'db>>,
-) -> Type<'db> {
+/// Nominal and declared protocol constraints are preserved because they describe the receiver's
+/// static subtype. Type aliases are preserved unless projection changes their value.
+fn self_type_projection<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
     struct SelfTypeProjection;
     struct NegativeSelfTypeProjection;
 
@@ -7246,25 +7240,25 @@ fn self_type_projection<'db>(
     fn transform<'db>(
         db: &'db dyn Db,
         ty: Type<'db>,
-        owner_class: Option<ClassLiteral<'db>>,
         visitors: &ProjectionVisitors<'db>,
     ) -> Type<'db> {
         match ty {
             Type::TypeAlias(alias) => visitors.positive.visit_type(db, ty, || {
                 let value_type = alias.value_type(db);
-                let transformed = transform(db, value_type, owner_class, visitors);
+                let transformed = transform(db, value_type, visitors);
                 if transformed == value_type {
                     ty
                 } else {
                     transformed
                 }
             }),
-            Type::Union(union) => union
-                .map_leave_aliases(db, |element| transform(db, *element, owner_class, visitors)),
+            Type::Union(union) => {
+                union.map_leave_aliases(db, |element| transform(db, *element, visitors))
+            }
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
-                    builder = builder.add_positive(transform(db, *positive, owner_class, visitors));
+                    builder = builder.add_positive(transform(db, *positive, visitors));
                 }
                 for negative in intersection.negative(db) {
                     if let Some(negative) = transform_negative(db, *negative, visitors) {
@@ -7274,20 +7268,15 @@ fn self_type_projection<'db>(
                 builder.build()
             }
             Type::EnumComplement(complement) => {
-                transform(db, complement.to_intersection(db), owner_class, visitors)
+                transform(db, complement.to_intersection(db), visitors)
             }
             Type::LiteralValue(literal) => literal.fallback_instance(db),
-            Type::ProtocolInstance(protocol) => {
-                let is_owner = owner_class.is_some_and(|owner_class| {
-                    protocol.to_nominal_instance().is_some_and(|instance| {
-                        instance
-                            .class(db)
-                            .is_subtype_of_class_literal(db, owner_class)
-                    })
-                });
-                if is_owner { ty } else { Type::object() }
-            }
-            Type::AlwaysTruthy | Type::AlwaysFalsy => Type::object(),
+            Type::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::Synthesized(_),
+                ..
+            })
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy => Type::object(),
             _ => ty,
         }
     }
@@ -7327,14 +7316,17 @@ fn self_type_projection<'db>(
                 .then_some(ty),
             Type::EnumComplement(_)
             | Type::LiteralValue(_)
-            | Type::ProtocolInstance(_)
+            | Type::ProtocolInstance(ProtocolInstanceType {
+                inner: Protocol::Synthesized(_),
+                ..
+            })
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => None,
             _ => Some(ty),
         }
     }
 
-    transform(db, ty, owner_class, &ProjectionVisitors::default())
+    transform(db, ty, &ProjectionVisitors::default())
 }
 
 /// Information needed to bind `Self` typevars to a concrete type.
@@ -7375,7 +7367,7 @@ impl<'db> SelfBinding<'db> {
         }
 
         let owner_class = self_typevar_owner_class_literal(db, bound_typevar);
-        let self_type = self_type_projection(db, self.ty, owner_class);
+        let self_type = self_type_projection(db, self.ty);
 
         // Fast path for the common method-signature case where the bound `Self`
         // carries the same binding context as this mapping.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7225,9 +7225,14 @@ fn self_typevar_owner_class_literal<'db>(
 /// whose truthiness is unknown. Similarly, a synthesized protocol produced by `hasattr` only
 /// describes the current value and must not become part of the `Self` specialization.
 ///
-/// Nominal and declared protocol constraints are preserved because they describe the receiver's
-/// static subtype. Type aliases are preserved unless projection changes their value.
-fn self_type_projection<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+/// Nominal constraints are preserved because they describe the receiver's concrete subtype. A
+/// protocol constraint is preserved only when it owns `Self` or is implied by the remaining
+/// receiver type. Type aliases are preserved unless projection changes their value.
+fn self_type_projection<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    owner_class: Option<ClassLiteral<'db>>,
+) -> Type<'db> {
     struct SelfTypeProjection;
     struct NegativeSelfTypeProjection;
 
@@ -7240,25 +7245,25 @@ fn self_type_projection<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
     fn transform<'db>(
         db: &'db dyn Db,
         ty: Type<'db>,
+        owner_class: Option<ClassLiteral<'db>>,
         visitors: &ProjectionVisitors<'db>,
     ) -> Type<'db> {
         match ty {
             Type::TypeAlias(alias) => visitors.positive.visit_type(db, ty, || {
                 let value_type = alias.value_type(db);
-                let transformed = transform(db, value_type, visitors);
+                let transformed = transform(db, value_type, owner_class, visitors);
                 if transformed == value_type {
                     ty
                 } else {
                     transformed
                 }
             }),
-            Type::Union(union) => {
-                union.map_leave_aliases(db, |element| transform(db, *element, visitors))
-            }
+            Type::Union(union) => union
+                .map_leave_aliases(db, |element| transform(db, *element, owner_class, visitors)),
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
-                    builder = builder.add_positive(transform(db, *positive, visitors));
+                    builder = builder.add_positive(transform(db, *positive, owner_class, visitors));
                 }
                 for negative in intersection.negative(db) {
                     if let Some(negative) = transform_negative(db, *negative, visitors) {
@@ -7268,17 +7273,36 @@ fn self_type_projection<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
                 builder.build()
             }
             Type::EnumComplement(complement) => {
-                transform(db, complement.to_intersection(db), visitors)
+                transform(db, complement.to_intersection(db), owner_class, visitors)
             }
             Type::LiteralValue(literal) => literal.fallback_instance(db),
-            Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::Synthesized(_),
-                ..
-            })
-            | Type::AlwaysTruthy
-            | Type::AlwaysFalsy => Type::object(),
+            Type::NominalInstance(instance) if instance.own_tuple_spec(db).is_some() => {
+                Type::homogeneous_tuple(db, Type::object())
+            }
+            Type::ProtocolInstance(protocol) => {
+                if protocol_is_owner(db, protocol, owner_class) {
+                    ty
+                } else {
+                    Type::object()
+                }
+            }
+            Type::AlwaysTruthy | Type::AlwaysFalsy => Type::object(),
             _ => ty,
         }
+    }
+
+    fn protocol_is_owner<'db>(
+        db: &'db dyn Db,
+        protocol: ProtocolInstanceType<'db>,
+        owner_class: Option<ClassLiteral<'db>>,
+    ) -> bool {
+        owner_class.is_some_and(|owner_class| {
+            protocol.to_nominal_instance().is_some_and(|instance| {
+                instance
+                    .class(db)
+                    .is_subtype_of_class_literal(db, owner_class)
+            })
+        })
     }
 
     fn transform_negative<'db>(
@@ -7314,19 +7338,17 @@ fn self_type_projection<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
                 .chain(intersection.negative(db))
                 .all(|element| transform_negative(db, *element, visitors) == Some(*element))
                 .then_some(ty),
+            Type::NominalInstance(instance) if instance.own_tuple_spec(db).is_some() => None,
             Type::EnumComplement(_)
             | Type::LiteralValue(_)
-            | Type::ProtocolInstance(ProtocolInstanceType {
-                inner: Protocol::Synthesized(_),
-                ..
-            })
+            | Type::ProtocolInstance(_)
             | Type::AlwaysTruthy
             | Type::AlwaysFalsy => None,
             _ => Some(ty),
         }
     }
 
-    transform(db, ty, &ProjectionVisitors::default())
+    transform(db, ty, owner_class, &ProjectionVisitors::default())
 }
 
 /// Information needed to bind `Self` typevars to a concrete type.
@@ -7367,7 +7389,7 @@ impl<'db> SelfBinding<'db> {
         }
 
         let owner_class = self_typevar_owner_class_literal(db, bound_typevar);
-        let self_type = self_type_projection(db, self.ty);
+        let self_type = self_type_projection(db, self.ty, owner_class);
 
         // Fast path for the common method-signature case where the bound `Self`
         // carries the same binding context as this mapping.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7227,39 +7227,68 @@ fn self_typevar_owner_class_literal<'db>(
 ///
 /// Here, `value` is narrowed to `Child & ~AlwaysFalsy`, but `copy` returns a different `Child`
 /// whose truthiness is unknown.
+///
+/// Type aliases are preserved unless removing a refinement requires expanding their value type.
 fn self_binding_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    let intersection = match ty {
-        Type::Union(union) => return union.map(db, |element| self_binding_type(db, *element)),
-        Type::Intersection(intersection) => intersection,
-        _ => return ty,
-    };
+    struct SelfBindingTypeTransformation;
 
-    let is_truthiness_refinement =
-        |ty: &Type<'db>| matches!(ty, Type::AlwaysTruthy | Type::AlwaysFalsy);
-    if !intersection
-        .positive(db)
-        .iter()
-        .chain(intersection.negative(db))
-        .any(is_truthiness_refinement)
-    {
-        return ty;
+    fn transform<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        visitor: &TypeTransformer<'db, SelfBindingTypeTransformation>,
+    ) -> Type<'db> {
+        visitor.visit_type(db, ty, || {
+            let intersection = match ty {
+                Type::TypeAlias(alias) => {
+                    let value_type = alias.value_type(db);
+                    let transformed = transform(db, value_type, visitor);
+                    return if transformed == value_type {
+                        ty
+                    } else {
+                        transformed
+                    };
+                }
+                Type::Union(union) => {
+                    return union.map_leave_aliases(db, |element| transform(db, *element, visitor));
+                }
+                Type::Intersection(intersection) => intersection,
+                _ => return ty,
+            };
+
+            let is_truthiness_refinement = |ty: &Type<'db>| {
+                matches!(
+                    ty.resolve_type_alias(db),
+                    Type::AlwaysTruthy | Type::AlwaysFalsy
+                )
+            };
+            if !intersection
+                .positive(db)
+                .iter()
+                .chain(intersection.negative(db))
+                .any(is_truthiness_refinement)
+            {
+                return ty;
+            }
+
+            intersection
+                .negative(db)
+                .iter()
+                .filter(|ty| !is_truthiness_refinement(ty))
+                .fold(
+                    IntersectionBuilder::new(db).positive_elements(
+                        intersection
+                            .positive(db)
+                            .iter()
+                            .filter(|ty| !is_truthiness_refinement(ty))
+                            .copied(),
+                    ),
+                    |builder, negative| builder.add_negative(*negative),
+                )
+                .build()
+        })
     }
 
-    intersection
-        .negative(db)
-        .iter()
-        .filter(|ty| !is_truthiness_refinement(ty))
-        .fold(
-            IntersectionBuilder::new(db).positive_elements(
-                intersection
-                    .positive(db)
-                    .iter()
-                    .filter(|ty| !is_truthiness_refinement(ty))
-                    .copied(),
-            ),
-            |builder, negative| builder.add_negative(*negative),
-        )
-        .build()
+    transform(db, ty, &TypeTransformer::default())
 }
 
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7206,6 +7206,62 @@ fn self_typevar_owner_class_literal<'db>(
         .map(|class| class.class_literal(db))
 }
 
+/// Remove value-level truthiness refinements from a receiver before using it to bind `Self`.
+///
+/// A different instance returned through `Self` is not necessarily truthy or falsy just because
+/// the receiver was narrowed by a condition.
+///
+/// ```python
+/// from typing import Self
+///
+/// class Base:
+///     def copy(self) -> Self: ...
+///
+/// class Child(Base): ...
+///
+/// def copy_if_truthy(value: Child | None) -> Child:
+///     if value:
+///         return value.copy()
+///     raise ValueError
+/// ```
+///
+/// Here, `value` is narrowed to `Child & ~AlwaysFalsy`, but `copy` returns a different `Child`
+/// whose truthiness is unknown.
+fn self_binding_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    let intersection = match ty {
+        Type::Union(union) => return union.map(db, |element| self_binding_type(db, *element)),
+        Type::Intersection(intersection) => intersection,
+        _ => return ty,
+    };
+
+    let is_truthiness_refinement =
+        |ty: &Type<'db>| matches!(ty, Type::AlwaysTruthy | Type::AlwaysFalsy);
+    if !intersection
+        .positive(db)
+        .iter()
+        .chain(intersection.negative(db))
+        .any(is_truthiness_refinement)
+    {
+        return ty;
+    }
+
+    intersection
+        .negative(db)
+        .iter()
+        .filter(|ty| !is_truthiness_refinement(ty))
+        .fold(
+            IntersectionBuilder::new(db).positive_elements(
+                intersection
+                    .positive(db)
+                    .iter()
+                    .filter(|ty| !is_truthiness_refinement(ty))
+                    .copied(),
+            ),
+            |builder, negative| builder.add_negative(*negative),
+        )
+        .build()
+}
+
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 fn class_mro_literals<'db>(
     db: &'db dyn Db,
@@ -7245,6 +7301,7 @@ impl<'db> SelfBinding<'db> {
         self_type: Type<'db>,
         binding_context: Option<BindingContext<'db>>,
     ) -> Self {
+        let self_type = self_binding_type(db, self_type);
         let class_literal = match self_type {
             Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
                 self_typevar_owner_class_literal(db, typevar)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7303,6 +7303,44 @@ fn class_mro_literals<'db>(
         .collect()
 }
 
+/// Returns whether `self_type` can be proven to inherit from `owner_class`.
+///
+/// Unlike [`Type::nominal_class`], this can prove inheritance through a union or a positive
+/// intersection element without choosing a single nominal class for the entire type.
+fn self_type_inherits_owner<'db>(
+    db: &'db dyn Db,
+    self_type: Type<'db>,
+    owner_class: ClassLiteral<'db>,
+) -> bool {
+    struct SelfTypeOwnerCheck;
+
+    fn check<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        owner_class: ClassLiteral<'db>,
+        visitor: &CycleDetector<SelfTypeOwnerCheck, Type<'db>, bool>,
+    ) -> bool {
+        if let Some(class) = ty.nominal_class(db) {
+            return class.is_subtype_of_class_literal(db, owner_class);
+        }
+
+        visitor.visit(ty, || match ty {
+            Type::TypeAlias(alias) => check(db, alias.value_type(db), owner_class, visitor),
+            Type::Union(union) => union
+                .elements(db)
+                .iter()
+                .all(|element| check(db, *element, owner_class, visitor)),
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .any(|element| check(db, *element, owner_class, visitor)),
+            _ => false,
+        })
+    }
+
+    check(db, self_type, owner_class, &CycleDetector::new(false))
+}
+
 /// Information needed to bind `Self` typevars to a concrete type.
 ///
 /// Uses MRO-based matching: a `Self` typevar is bound only if its owner class
@@ -7359,13 +7397,20 @@ impl<'db> SelfBinding<'db> {
             return true;
         }
 
-        // Check that the Self typevar's owner class is in the MRO of the self type's class.
-        // If we can't determine either class, conservatively don't bind.
-        self.class_literal.is_some_and(|class_literal| {
-            let class_mro = class_mro_literals(db, class_literal);
-            self_typevar_owner_class_literal(db, bound_typevar)
-                .is_none_or(|owner_class| class_mro.contains(&owner_class))
-        })
+        // Check that the self type inherits from the Self typevar's owner class. The common case
+        // uses the single nominal class found when constructing this binding. For a union or
+        // intersection, inspect its elements without choosing one as the nominal class of the
+        // entire type.
+        match (
+            self.class_literal,
+            self_typevar_owner_class_literal(db, bound_typevar),
+        ) {
+            (Some(class_literal), owner_class) => owner_class.is_none_or(|owner_class| {
+                class_mro_literals(db, class_literal).contains(&owner_class)
+            }),
+            (None, Some(owner_class)) => self_type_inherits_owner(db, self.ty, owner_class),
+            (None, None) => false,
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7226,8 +7226,8 @@ fn self_typevar_owner_class_literal<'db>(
 /// describes the current value and must not become part of the `Self` specialization.
 ///
 /// Nominal constraints are preserved because they describe the receiver's concrete subtype. A
-/// protocol constraint is preserved only when it owns `Self`; protocol behavior guaranteed by the
-/// nominal receiver is already represented there. Type aliases are preserved unless projection
+/// class-based protocol constraint is preserved when it owns `Self` or when a class in the same
+/// intersection is known to implement that protocol. Type aliases are preserved unless projection
 /// changes their value.
 fn self_type_projection<'db>(
     db: &'db dyn Db,
@@ -7241,6 +7241,32 @@ fn self_type_projection<'db>(
     struct ProjectionVisitors<'db> {
         positive: TypeTransformer<'db, SelfTypeProjection>,
         negative: CycleDetector<NegativeSelfTypeProjection, Type<'db>, Option<Type<'db>>>,
+    }
+
+    fn protocol_is_guaranteed_by_top_class<'db>(
+        db: &'db dyn Db,
+        intersection: IntersectionType<'db>,
+        protocol: ProtocolInstanceType<'db>,
+    ) -> bool {
+        let Some(protocol_instance) = protocol.to_nominal_instance() else {
+            return false;
+        };
+        let unknown_protocol = Type::instance(
+            db,
+            protocol_instance
+                .class_literal(db)
+                .unknown_specialization(db),
+        )
+        .top_materialization(db);
+
+        intersection.positive(db).iter().any(|positive| {
+            positive
+                .class_specialization(db)
+                .is_some_and(|(_, specialization)| {
+                    specialization.materialization_kind(db) == Some(MaterializationKind::Top)
+                })
+                && positive.is_subtype_of(db, unknown_protocol)
+        })
     }
 
     fn transform<'db>(
@@ -7264,7 +7290,19 @@ fn self_type_projection<'db>(
             Type::Intersection(intersection) => {
                 let mut builder = IntersectionBuilder::new(db);
                 for positive in intersection.positive(db) {
-                    builder = builder.add_positive(transform(db, *positive, owner_class, visitors));
+                    // Narrowing `Iterable[T] | dict[...]` to `defaultdict` produces
+                    // `Iterable[T] & Top[defaultdict[Unknown, Unknown]]`. Keep `Iterable[T]`
+                    // because `defaultdict` implements `Iterable`; it is the only remaining source
+                    // of `T`. This does not preserve a runtime protocol check unless the class
+                    // itself implements that protocol.
+                    if let Type::ProtocolInstance(protocol) = positive
+                        && protocol_is_guaranteed_by_top_class(db, intersection, *protocol)
+                    {
+                        builder = builder.add_positive(*positive);
+                    } else {
+                        builder =
+                            builder.add_positive(transform(db, *positive, owner_class, visitors));
+                    }
                 }
                 for negative in intersection.negative(db) {
                     if let Some(negative) = transform_negative(db, *negative, visitors) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7260,11 +7260,12 @@ fn self_type_projection<'db>(
         .top_materialization(db);
 
         intersection.positive(db).iter().any(|positive| {
-            positive
-                .class_specialization(db)
-                .is_some_and(|(_, specialization)| {
-                    specialization.materialization_kind(db) == Some(MaterializationKind::Top)
-                })
+            matches!(positive, Type::NominalInstance(_))
+                && positive
+                    .class_specialization(db)
+                    .is_some_and(|(_, specialization)| {
+                        specialization.materialization_kind(db) == Some(MaterializationKind::Top)
+                    })
                 && positive.is_subtype_of(db, unknown_protocol)
         })
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7303,44 +7303,6 @@ fn class_mro_literals<'db>(
         .collect()
 }
 
-/// Returns whether `self_type` can be proven to inherit from `owner_class`.
-///
-/// Unlike [`Type::nominal_class`], this can prove inheritance through a union or a positive
-/// intersection element without choosing a single nominal class for the entire type.
-fn self_type_inherits_owner<'db>(
-    db: &'db dyn Db,
-    self_type: Type<'db>,
-    owner_class: ClassLiteral<'db>,
-) -> bool {
-    struct SelfTypeOwnerCheck;
-
-    fn check<'db>(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        owner_class: ClassLiteral<'db>,
-        visitor: &CycleDetector<SelfTypeOwnerCheck, Type<'db>, bool>,
-    ) -> bool {
-        if let Some(class) = ty.nominal_class(db) {
-            return class.is_subtype_of_class_literal(db, owner_class);
-        }
-
-        visitor.visit(ty, || match ty {
-            Type::TypeAlias(alias) => check(db, alias.value_type(db), owner_class, visitor),
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .all(|element| check(db, *element, owner_class, visitor)),
-            Type::Intersection(intersection) => intersection
-                .positive(db)
-                .iter()
-                .any(|element| check(db, *element, owner_class, visitor)),
-            _ => false,
-        })
-    }
-
-    check(db, self_type, owner_class, &CycleDetector::new(false))
-}
-
 /// Information needed to bind `Self` typevars to a concrete type.
 ///
 /// Uses MRO-based matching: a `Self` typevar is bound only if its owner class
@@ -7397,20 +7359,13 @@ impl<'db> SelfBinding<'db> {
             return true;
         }
 
-        // Check that the self type inherits from the Self typevar's owner class. The common case
-        // uses the single nominal class found when constructing this binding. For a union or
-        // intersection, inspect its elements without choosing one as the nominal class of the
-        // entire type.
-        match (
-            self.class_literal,
-            self_typevar_owner_class_literal(db, bound_typevar),
-        ) {
-            (Some(class_literal), owner_class) => owner_class.is_none_or(|owner_class| {
-                class_mro_literals(db, class_literal).contains(&owner_class)
-            }),
-            (None, Some(owner_class)) => self_type_inherits_owner(db, self.ty, owner_class),
-            (None, None) => false,
-        }
+        // Check that the Self typevar's owner class is in the MRO of the self type's class.
+        // If we can't determine either class, conservatively don't bind.
+        self.class_literal.is_some_and(|class_literal| {
+            let class_mro = class_mro_literals(db, class_literal);
+            self_typevar_owner_class_literal(db, bound_typevar)
+                .is_none_or(|owner_class| class_mro.contains(&owner_class))
+        })
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6033,7 +6033,7 @@ impl<'db> Type<'db> {
         // early. This is not just an optimization, it also prevents us from infinitely expanding
         // the type, if it's something that can contain a `Self` reference.
         match type_mapping {
-            TypeMapping::BindSelf(binding) if self == binding.self_type() => return self,
+            TypeMapping::BindSelf(binding) if self == binding.ty => return self,
             _ => {}
         }
 
@@ -7226,8 +7226,9 @@ fn self_typevar_owner_class_literal<'db>(
 /// describes the current value and must not become part of the `Self` specialization.
 ///
 /// Nominal constraints are preserved because they describe the receiver's concrete subtype. A
-/// protocol constraint is preserved only when it owns `Self` or is implied by the remaining
-/// receiver type. Type aliases are preserved unless projection changes their value.
+/// protocol constraint is preserved only when it owns `Self`; protocol behavior guaranteed by the
+/// nominal receiver is already represented there. Type aliases are preserved unless projection
+/// changes their value.
 fn self_type_projection<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -7279,30 +7280,16 @@ fn self_type_projection<'db>(
             Type::NominalInstance(instance) if instance.own_tuple_spec(db).is_some() => {
                 Type::homogeneous_tuple(db, Type::object())
             }
-            Type::ProtocolInstance(protocol) => {
-                if protocol_is_owner(db, protocol, owner_class) {
-                    ty
-                } else {
-                    Type::object()
-                }
+            Type::ProtocolInstance(protocol)
+                if !protocol.to_nominal_instance().zip(owner_class).is_some_and(
+                    |(instance, owner)| instance.class(db).is_subtype_of_class_literal(db, owner),
+                ) =>
+            {
+                Type::object()
             }
             Type::AlwaysTruthy | Type::AlwaysFalsy => Type::object(),
             _ => ty,
         }
-    }
-
-    fn protocol_is_owner<'db>(
-        db: &'db dyn Db,
-        protocol: ProtocolInstanceType<'db>,
-        owner_class: Option<ClassLiteral<'db>>,
-    ) -> bool {
-        owner_class.is_some_and(|owner_class| {
-            protocol.to_nominal_instance().is_some_and(|instance| {
-                instance
-                    .class(db)
-                    .is_subtype_of_class_literal(db, owner_class)
-            })
-        })
     }
 
     fn transform_negative<'db>(
@@ -7358,16 +7345,6 @@ fn self_type_projection<'db>(
 pub struct SelfBinding<'db> {
     ty: Type<'db>,
     binding_context: Option<BindingContext<'db>>,
-}
-
-impl<'db> SelfBinding<'db> {
-    pub(crate) fn self_type(&self) -> Type<'db> {
-        self.ty
-    }
-
-    pub(crate) fn binding_context(&self) -> Option<BindingContext<'db>> {
-        self.binding_context
-    }
 }
 
 impl<'db> SelfBinding<'db> {
@@ -7498,8 +7475,8 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => context,
             TypeMapping::BindSelf(binding) => {
-                if binding.binding_context().is_some() {
-                    context.remove_self(db, binding.binding_context())
+                if binding.binding_context.is_some() {
+                    context.remove_self(db, binding.binding_context)
                 } else {
                     context
                 }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1124,8 +1124,7 @@ impl<'db> Type<'db> {
 
     /// Bind `Self` type variables in this type to a concrete self type.
     ///
-    /// Uses MRO-based matching: a `Self` typevar is only bound if its owner class
-    /// is in the MRO of the self type's class.
+    /// A `Self` typevar is only bound if the projected receiver is a subtype of its owner.
     ///
     /// Types that defer `Self` binding to call time (functions, bound methods, function-like
     /// callables) are skipped; see `supports_self_binding`.
@@ -7313,14 +7312,12 @@ fn self_type_projection<'db>(
             }),
             Type::Union(union) => {
                 let mut builder = UnionBuilder::new(db);
-                let mut retained = false;
                 for element in union.elements(db) {
                     if let Some(element) = transform_negative(db, *element, visitors) {
                         builder = builder.add(element);
-                        retained = true;
                     }
                 }
-                retained.then(|| builder.build())
+                (!builder.is_empty()).then(|| builder.build())
             }
             Type::Intersection(intersection) => intersection
                 .positive(db)
@@ -7340,60 +7337,9 @@ fn self_type_projection<'db>(
     transform(db, ty, owner_class, &ProjectionVisitors::default())
 }
 
-/// Returns whether `self_type` can be proven to inherit from `owner_class`.
-///
-/// Unlike [`Type::nominal_class`], this can prove inheritance through a union or a positive
-/// intersection element without choosing a single nominal class for the entire type.
-fn self_type_inherits_owner<'db>(
-    db: &'db dyn Db,
-    self_type: Type<'db>,
-    owner_class: ClassLiteral<'db>,
-) -> bool {
-    struct SelfTypeOwnerCheck;
-
-    fn check<'db>(
-        db: &'db dyn Db,
-        ty: Type<'db>,
-        owner_class: ClassLiteral<'db>,
-        visitor: &CycleDetector<SelfTypeOwnerCheck, Type<'db>, bool>,
-    ) -> bool {
-        if let Some(class) = ty.nominal_class(db) {
-            return class.is_subtype_of_class_literal(db, owner_class);
-        }
-
-        visitor.visit(ty, || match ty {
-            Type::TypeAlias(alias) => check(db, alias.value_type(db), owner_class, visitor),
-            Type::Union(union) => union
-                .elements(db)
-                .iter()
-                .all(|element| check(db, *element, owner_class, visitor)),
-            Type::Intersection(intersection) => intersection
-                .positive(db)
-                .iter()
-                .any(|element| check(db, *element, owner_class, visitor)),
-            _ => false,
-        })
-    }
-
-    check(db, self_type, owner_class, &CycleDetector::new(false))
-}
-
-#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-fn class_mro_literals<'db>(
-    db: &'db dyn Db,
-    class_literal: ClassLiteral<'db>,
-) -> Box<[ClassLiteral<'db>]> {
-    class_literal
-        .iter_mro(db)
-        .filter_map(ClassBase::into_class)
-        .map(|class| class.class_literal(db))
-        .collect()
-}
-
 /// Information needed to bind `Self` typevars to a concrete type.
 ///
-/// Uses MRO-based matching: a `Self` typevar is bound only if its owner class
-/// is in the MRO of the self type's class.
+/// A `Self` typevar is only bound if the projected receiver is a subtype of its owner.
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub struct SelfBinding<'db> {
     ty: Type<'db>,
@@ -7437,18 +7383,15 @@ impl<'db> SelfBinding<'db> {
             return Some(self_type);
         }
 
-        let class_literal = self_type
-            .nominal_class(db)
-            .map(|class| class.class_literal(db));
-        let inherits_owner = match (class_literal, owner_class) {
-            (Some(class_literal), owner_class) => owner_class.is_none_or(|owner_class| {
-                class_mro_literals(db, class_literal).contains(&owner_class)
-            }),
-            (None, Some(owner_class)) => self_type_inherits_owner(db, self_type, owner_class),
+        match (self_type.nominal_class(db), owner_class) {
+            (Some(class), Some(owner_class)) => class.is_subtype_of_class_literal(db, owner_class),
+            (None, Some(owner_class)) => {
+                self_type.is_subtype_of(db, owner_class.to_non_generic_instance(db))
+            }
+            (Some(_), None) => true,
             (None, None) => false,
-        };
-
-        inherits_owner.then_some(self_type)
+        }
+        .then_some(self_type)
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1136,7 +1136,7 @@ impl<'db> Type<'db> {
 
         self.apply_type_mapping(
             db,
-            &TypeMapping::BindSelf(SelfBinding::new(db, self_type, None)),
+            &TypeMapping::BindSelf(SelfBinding::new(self_type, None)),
             TypeContext::default(),
         )
     }
@@ -7206,10 +7206,7 @@ fn self_typevar_owner_class_literal<'db>(
         .map(|class| class.class_literal(db))
 }
 
-/// Remove value-level truthiness refinements from a receiver before using it to bind `Self`.
-///
-/// A different instance returned through `Self` is not necessarily truthy or falsy just because
-/// the receiver was narrowed by a condition.
+/// Project a receiver type onto the facts that are stable across values represented by `Self`.
 ///
 /// ```python
 /// from typing import Self
@@ -7225,70 +7222,160 @@ fn self_typevar_owner_class_literal<'db>(
 ///     raise ValueError
 /// ```
 ///
-/// Here, `value` is narrowed to `Child & ~AlwaysFalsy`, but `copy` returns a different `Child`
-/// whose truthiness is unknown.
+/// Here, `value` is narrowed to `Child & ~AlwaysFalsy`, but `copy` can return a different `Child`
+/// whose truthiness is unknown. Similarly, a synthesized protocol produced by `hasattr` only
+/// describes the current value and must not become part of the `Self` specialization.
 ///
-/// Type aliases are preserved unless removing a refinement requires expanding their value type.
-fn self_binding_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
-    struct SelfBindingTypeTransformation;
+/// Nominal constraints are preserved because they describe the receiver's concrete subtype. A
+/// protocol constraint is only preserved when that protocol owns `Self`; unrelated structural
+/// constraints can describe instance state. Type aliases are preserved unless projection changes
+/// their value.
+fn self_type_projection<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    owner_class: Option<ClassLiteral<'db>>,
+) -> Type<'db> {
+    struct SelfTypeProjection;
+    struct NegativeSelfTypeProjection;
+
+    #[derive(Default)]
+    struct ProjectionVisitors<'db> {
+        positive: TypeTransformer<'db, SelfTypeProjection>,
+        negative: CycleDetector<NegativeSelfTypeProjection, Type<'db>, Option<Type<'db>>>,
+    }
 
     fn transform<'db>(
         db: &'db dyn Db,
         ty: Type<'db>,
-        visitor: &TypeTransformer<'db, SelfBindingTypeTransformation>,
+        owner_class: Option<ClassLiteral<'db>>,
+        visitors: &ProjectionVisitors<'db>,
     ) -> Type<'db> {
-        visitor.visit_type(db, ty, || {
-            let intersection = match ty {
-                Type::TypeAlias(alias) => {
-                    let value_type = alias.value_type(db);
-                    let transformed = transform(db, value_type, visitor);
-                    return if transformed == value_type {
+        match ty {
+            Type::TypeAlias(alias) => visitors.positive.visit_type(db, ty, || {
+                let value_type = alias.value_type(db);
+                let transformed = transform(db, value_type, owner_class, visitors);
+                if transformed == value_type {
+                    ty
+                } else {
+                    transformed
+                }
+            }),
+            Type::Union(union) => union
+                .map_leave_aliases(db, |element| transform(db, *element, owner_class, visitors)),
+            Type::Intersection(intersection) => {
+                let mut builder = IntersectionBuilder::new(db);
+                for positive in intersection.positive(db) {
+                    builder = builder.add_positive(transform(db, *positive, owner_class, visitors));
+                }
+                for negative in intersection.negative(db) {
+                    if let Some(negative) = transform_negative(db, *negative, visitors) {
+                        builder = builder.add_negative(negative);
+                    }
+                }
+                builder.build()
+            }
+            Type::EnumComplement(complement) => {
+                transform(db, complement.to_intersection(db), owner_class, visitors)
+            }
+            Type::LiteralValue(literal) => literal.fallback_instance(db),
+            Type::ProtocolInstance(protocol) => {
+                let is_owner = owner_class.is_some_and(|owner_class| {
+                    protocol.to_nominal_instance().is_some_and(|instance| {
+                        instance
+                            .class(db)
+                            .is_subtype_of_class_literal(db, owner_class)
+                    })
+                });
+                if is_owner { ty } else { Type::object() }
+            }
+            Type::AlwaysTruthy | Type::AlwaysFalsy => Type::object(),
+            _ => ty,
+        }
+    }
+
+    fn transform_negative<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        visitors: &ProjectionVisitors<'db>,
+    ) -> Option<Type<'db>> {
+        // A widened negative constraint cannot be retained: `~Literal[1]`, for example, does not
+        // imply `~int`. Unions are decomposed because `~(A | B)` implies both `~A` and `~B`.
+        match ty {
+            Type::TypeAlias(alias) => visitors.negative.visit(ty, || {
+                let value_type = alias.value_type(db);
+                transform_negative(db, value_type, visitors).map(|transformed| {
+                    if transformed == value_type {
                         ty
                     } else {
                         transformed
-                    };
+                    }
+                })
+            }),
+            Type::Union(union) => {
+                let mut builder = UnionBuilder::new(db);
+                let mut retained = false;
+                for element in union.elements(db) {
+                    if let Some(element) = transform_negative(db, *element, visitors) {
+                        builder = builder.add(element);
+                        retained = true;
+                    }
                 }
-                Type::Union(union) => {
-                    return union.map_leave_aliases(db, |element| transform(db, *element, visitor));
-                }
-                Type::Intersection(intersection) => intersection,
-                _ => return ty,
-            };
-
-            let is_truthiness_refinement = |ty: &Type<'db>| {
-                matches!(
-                    ty.resolve_type_alias(db),
-                    Type::AlwaysTruthy | Type::AlwaysFalsy
-                )
-            };
-            if !intersection
+                retained.then(|| builder.build())
+            }
+            Type::Intersection(intersection) => intersection
                 .positive(db)
                 .iter()
                 .chain(intersection.negative(db))
-                .any(is_truthiness_refinement)
-            {
-                return ty;
-            }
+                .all(|element| transform_negative(db, *element, visitors) == Some(*element))
+                .then_some(ty),
+            Type::EnumComplement(_)
+            | Type::LiteralValue(_)
+            | Type::ProtocolInstance(_)
+            | Type::AlwaysTruthy
+            | Type::AlwaysFalsy => None,
+            _ => Some(ty),
+        }
+    }
 
-            intersection
-                .negative(db)
+    transform(db, ty, owner_class, &ProjectionVisitors::default())
+}
+
+/// Returns whether `self_type` can be proven to inherit from `owner_class`.
+///
+/// Unlike [`Type::nominal_class`], this can prove inheritance through a union or a positive
+/// intersection element without choosing a single nominal class for the entire type.
+fn self_type_inherits_owner<'db>(
+    db: &'db dyn Db,
+    self_type: Type<'db>,
+    owner_class: ClassLiteral<'db>,
+) -> bool {
+    struct SelfTypeOwnerCheck;
+
+    fn check<'db>(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        owner_class: ClassLiteral<'db>,
+        visitor: &CycleDetector<SelfTypeOwnerCheck, Type<'db>, bool>,
+    ) -> bool {
+        if let Some(class) = ty.nominal_class(db) {
+            return class.is_subtype_of_class_literal(db, owner_class);
+        }
+
+        visitor.visit(ty, || match ty {
+            Type::TypeAlias(alias) => check(db, alias.value_type(db), owner_class, visitor),
+            Type::Union(union) => union
+                .elements(db)
                 .iter()
-                .filter(|ty| !is_truthiness_refinement(ty))
-                .fold(
-                    IntersectionBuilder::new(db).positive_elements(
-                        intersection
-                            .positive(db)
-                            .iter()
-                            .filter(|ty| !is_truthiness_refinement(ty))
-                            .copied(),
-                    ),
-                    |builder, negative| builder.add_negative(*negative),
-                )
-                .build()
+                .all(|element| check(db, *element, owner_class, visitor)),
+            Type::Intersection(intersection) => intersection
+                .positive(db)
+                .iter()
+                .any(|element| check(db, *element, owner_class, visitor)),
+            _ => false,
         })
     }
 
-    transform(db, ty, &TypeTransformer::default())
+    check(db, self_type, owner_class, &CycleDetector::new(false))
 }
 
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
@@ -7310,7 +7397,6 @@ fn class_mro_literals<'db>(
 #[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub struct SelfBinding<'db> {
     ty: Type<'db>,
-    class_literal: Option<ClassLiteral<'db>>,
     binding_context: Option<BindingContext<'db>>,
 }
 
@@ -7325,47 +7411,44 @@ impl<'db> SelfBinding<'db> {
 }
 
 impl<'db> SelfBinding<'db> {
-    pub(crate) fn new(
-        db: &'db dyn Db,
-        self_type: Type<'db>,
-        binding_context: Option<BindingContext<'db>>,
-    ) -> Self {
-        let self_type = self_binding_type(db, self_type);
-        let class_literal = match self_type {
-            Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
-                self_typevar_owner_class_literal(db, typevar)
-            }
-            _ => self_type
-                .nominal_class(db)
-                .map(|class| class.class_literal(db)),
-        };
-
+    pub(crate) fn new(self_type: Type<'db>, binding_context: Option<BindingContext<'db>>) -> Self {
         Self {
             ty: self_type,
-            class_literal,
             binding_context,
         }
     }
 
-    /// Returns whether `bound_typevar` should be replaced by this binding's concrete self type.
-    fn should_bind(&self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) -> bool {
+    /// Returns the projected receiver type if it can bind `bound_typevar`.
+    fn binding_type(
+        &self,
+        db: &'db dyn Db,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> Option<Type<'db>> {
         if !bound_typevar.typevar(db).is_self(db) {
-            return false;
+            return None;
         }
+
+        let owner_class = self_typevar_owner_class_literal(db, bound_typevar);
+        let self_type = self_type_projection(db, self.ty, owner_class);
 
         // Fast path for the common method-signature case where the bound `Self`
         // carries the same binding context as this mapping.
         if self.binding_context == Some(bound_typevar.binding_context(db)) {
-            return true;
+            return Some(self_type);
         }
 
-        // Check that the Self typevar's owner class is in the MRO of the self type's class.
-        // If we can't determine either class, conservatively don't bind.
-        self.class_literal.is_some_and(|class_literal| {
-            let class_mro = class_mro_literals(db, class_literal);
-            self_typevar_owner_class_literal(db, bound_typevar)
-                .is_none_or(|owner_class| class_mro.contains(&owner_class))
-        })
+        let class_literal = self_type
+            .nominal_class(db)
+            .map(|class| class.class_literal(db));
+        let inherits_owner = match (class_literal, owner_class) {
+            (Some(class_literal), owner_class) => owner_class.is_none_or(|owner_class| {
+                class_mro_literals(db, class_literal).contains(&owner_class)
+            }),
+            (None, Some(owner_class)) => self_type_inherits_owner(db, self_type, owner_class),
+            (None, None) => false,
+        };
+
+        inherits_owner.then_some(self_type)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -32,7 +32,8 @@ use crate::types::{
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
     TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
-    infer_definition_types, inferred_declaration, self_binding_type,
+    infer_definition_types, inferred_declaration, self_type_projection,
+    self_typevar_owner_class_literal,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2664,8 +2665,13 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (Type::TypeVar(bound_typevar), ty) | (ty, Type::TypeVar(bound_typevar))
                 if bound_typevar.is_inferable(self.db, self.inferable) =>
             {
+                let argument = ty;
                 let ty = if bound_typevar.typevar(self.db).is_self(self.db) {
-                    self_binding_type(self.db, ty)
+                    self_type_projection(
+                        self.db,
+                        ty,
+                        self_typevar_owner_class_literal(self.db, bound_typevar),
+                    )
                 } else {
                     ty
                 };
@@ -2691,7 +2697,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         {
                             return Err(SpecializationError::MismatchedBound {
                                 bound_typevar,
-                                argument: ty,
+                                argument,
                             });
                         }
                         self.add_type_mapping(bound_typevar, ty, polarity);
@@ -2763,7 +2769,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         }
                         return Err(SpecializationError::MismatchedConstraint {
                             bound_typevar,
-                            argument: ty,
+                            argument,
                         });
                     }
                     _ => self.add_type_mapping(bound_typevar, ty, polarity),

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -33,7 +33,6 @@ use crate::types::{
     MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
     TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
     infer_definition_types, inferred_declaration, self_type_projection,
-    self_typevar_owner_class_literal,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2667,11 +2666,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             {
                 let argument = ty;
                 let ty = if bound_typevar.typevar(self.db).is_self(self.db) {
-                    self_type_projection(
-                        self.db,
-                        ty,
-                        self_typevar_owner_class_literal(self.db, bound_typevar),
-                    )
+                    self_type_projection(self.db, ty)
                 } else {
                     ty
                 };

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -33,6 +33,7 @@ use crate::types::{
     MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
     TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
     infer_definition_types, inferred_declaration, self_type_projection,
+    self_typevar_owner_class_literal,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2666,7 +2667,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             {
                 let argument = ty;
                 let ty = if bound_typevar.typevar(self.db).is_self(self.db) {
-                    self_type_projection(self.db, ty)
+                    self_type_projection(
+                        self.db,
+                        ty,
+                        self_typevar_owner_class_literal(self.db, bound_typevar),
+                    )
                 } else {
                     ty
                 };

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -32,7 +32,7 @@ use crate::types::{
     ClassLiteral, FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, KnownInstanceType,
     MaterializationKind, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
     TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
-    infer_definition_types, inferred_declaration,
+    infer_definition_types, inferred_declaration, self_binding_type,
 };
 use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -2664,6 +2664,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             (Type::TypeVar(bound_typevar), ty) | (ty, Type::TypeVar(bound_typevar))
                 if bound_typevar.is_inferable(self.db, self.inferable) =>
             {
+                let ty = if bound_typevar.typevar(self.db).is_self(self.db) {
+                    self_binding_type(self.db, ty)
+                } else {
+                    ty
+                };
                 match bound_typevar.typevar(self.db).bound_or_constraints(self.db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         if polarity.is_contravariant() {

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -991,8 +991,7 @@ impl<'db> Signature<'db> {
         if let Some(self_type) = self_type
             && self.needs_self_mapping(db, removed_receiver)
         {
-            let self_mapping =
-                TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
+            let self_mapping = TypeMapping::BindSelf(SelfBinding::new(self_type, binding_context));
             parameters = parameters.apply_type_mapping_impl(
                 db,
                 &self_mapping,
@@ -1090,7 +1089,6 @@ impl<'db> Signature<'db> {
         }
 
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(
-            db,
             self_type,
             self.definition.map(BindingContext::Definition),
         ));

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1077,13 +1077,9 @@ impl<'db> BoundTypeVarInstance<'db> {
                     }
                 })
                 .unwrap_or(Type::TypeVar(self)),
-            TypeMapping::BindSelf(binding) => {
-                if binding.should_bind(db, self) {
-                    binding.self_type()
-                } else {
-                    Type::TypeVar(self)
-                }
-            }
+            TypeMapping::BindSelf(binding) => binding
+                .binding_type(db, self)
+                .unwrap_or(Type::TypeVar(self)),
             TypeMapping::ReplaceSelf { new_upper_bound } => {
                 if self.typevar(db).is_self(db) {
                     Type::TypeVar(BoundTypeVarInstance::synthetic_self(


### PR DESCRIPTION
## Summary

After a condition narrows a value, the receiver may be represented as an intersection:

```python
from typing import Self

class Base:
    values: list[Self]

class Child(Base): ...

def f(value: Child | None) -> list[Child]:
    if value:
        reveal_type(value)  # revealed: Child & ~AlwaysFalsy
        reveal_type(value.values)  # revealed: list[Child]
        return value.values
    raise ValueError
```

Previously, the second `reveal_type` reported `list[Self@Base]`. The `Self` binding logic expects a receiver with a single nominal class, so it can't bind `Child & ~AlwaysFalsy` to `Self@Base`. But binding `Self` to the entire intersection wouldn't be correct either: `value.values` can contain other `Child` instances that are not necessarily truthy!

With this PR, we now removes types that describe only the current value (like truthiness), then bind `Self` using the remaining concrete subtype. In the above example, `value.values` is therefore `list[Child]`.

Closes https://github.com/astral-sh/ty/issues/3755.
