### PR TITLE
[ty] Report incompatible methods inherited from multiple bases

### DIFF
--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -231,7 +231,7 @@ static STATIC_FRAME: Benchmark = Benchmark::new(
         max_dep_date: "2025-08-09",
         python_version: SupportedPythonVersion::Py311,
     },
-    1810,
+    1830,
 );
 
 #[track_caller]

--- a/crates/ty_python_semantic/resources/mdtest/call/replace.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/replace.md
@@ -24,7 +24,7 @@ reveal_type(t)  # revealed: time
 
 ### Dataclasses
 
-Dataclasses support the `__replace__` protocol:
+Dataclasses synthesize a `__replace__` method whose receiver and return type are `Self`:
 
 ```py
 from dataclasses import dataclass

--- a/crates/ty_python_semantic/resources/mdtest/call/replace.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/replace.md
@@ -35,7 +35,7 @@ class Point:
     x: int
     y: int
 
-reveal_type(Point.__replace__)  # revealed: (self: Point, *, x: int = ..., y: int = ...) -> Point
+reveal_type(Point.__replace__)  # revealed: (self: Self, *, x: int = ..., y: int = ...) -> Self
 ```
 
 The `__replace__` method can either be called directly or through the `replace` function:

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -2134,7 +2134,7 @@ will be called when using `replace` (this is how `attrs` behaves):
 basic = Basic("1", "2")
 
 # __replace__ uses the converter input type (str):
-reveal_type(Basic.__replace__)  # revealed: (self: Basic, *, a: str = ..., b: str = ...) -> Basic
+reveal_type(Basic.__replace__)  # revealed: (self: Self, *, a: str = ..., b: str = ...) -> Self
 ```
 
 Converter fields inherited from a base class should also be validated correctly:

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -2127,13 +2127,10 @@ class ConverterWithDefault:
     incorrect2: int = field(default="0")
 ```
 
-We currently assume that the presence of a converter also implies that the this converter function
-will be called when using `replace` (this is how `attrs` behaves):
+We assume that `replace` calls field converters, matching `attrs`. The generated `__replace__`
+method therefore accepts the converter input type:
 
 ```py
-basic = Basic("1", "2")
-
-# __replace__ uses the converter input type (str):
 reveal_type(Basic.__replace__)  # revealed: (self: Self, *, a: str = ..., b: str = ...) -> Self
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -665,6 +665,18 @@ class OtherReceiverPath(ReceiverOverloads): ...
 # The receiver-specific overload only applies after the two paths meet again.
 class FinalReceiver(ReceiverOverride, OtherReceiverPath): ...  # error: [invalid-method-override]
 
+condition: bool
+
+class ConditionalSelfMethod:
+    if condition:
+        def copy(self) -> Self: ...
+
+    else:
+        def copy(self) -> Self: ...
+
+class ConditionalSelfOverride(ConditionalSelfMethod):
+    def copy(self) -> ConditionalSelfMethod: ...  # error: [invalid-method-override]
+
 class BrokenIntReturn(IntReturn):
     def method(self) -> str: ...  # error: [invalid-method-override]
 

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -868,6 +868,25 @@ info: parameter `x` has an incompatible type: `int` is not assignable to `str`
 info: This violates the Liskov Substitution Principle
 ```
 
+Cascade suppression follows nominal ancestry even when the parent uses a raw generic base:
+
+`raw_generic.pyi`:
+
+```pyi
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class GenericGrandparent(Generic[T]):
+    def method(self, original: int) -> None: ...
+
+class RawGenericParent(GenericGrandparent):  # error: [missing-type-argument]
+    def method(self, renamed: int) -> None: ...  # error: [invalid-method-override]
+
+class RawGenericChild(RawGenericParent):
+    def method(self, renamed: int) -> None: ...
+```
+
 `other_stub.pyi`:
 
 ```pyi

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -682,11 +682,13 @@ participate according to their position in the MRO: a leading dynamic base obscu
 wins, but a later dynamic base does not erase a known conflict.
 
 ```pyi
-from collections.abc import Callable
-from typing import Any, Generic, NamedTuple, TypeVar, overload
+from collections.abc import Callable, Coroutine
+from typing import Any, Concatenate, Generic, NamedTuple, ParamSpec, TypeVar, overload
 from typing_extensions import Self
 
 T = TypeVar("T")
+P = ParamSpec("P")
+Owner = TypeVar("Owner")
 
 class Intermediate(StrReturn): ...
 class IndirectConflict(Intermediate, IntReturn): ...  # error: [invalid-method-override]
@@ -739,6 +741,24 @@ class BrokenIntReturn(IntReturn):
 
 # The violation is defined on `BrokenIntReturn`; this class should not repeat it.
 class RedundantDirectBase(BrokenIntReturn, IntReturn): ...
+
+def async_decorator(
+    function: Callable[Concatenate[Owner, P], Coroutine[Any, Any, Any]],
+) -> Callable[Concatenate[Owner, P], Coroutine[Any, Any, None]]: ...
+
+class AsyncContract:
+    async def async_method(self, **kwargs: Any) -> None: ...
+
+class DecoratedAsyncOverride(AsyncContract):
+    @async_decorator
+    async def async_method(self, **kwargs: Any) -> None: ...
+
+class OtherAsyncPath(AsyncContract): ...
+
+# The decorated method's public callable type already differs from `AsyncContract` on the class
+# that defines it. Meeting the same contract through a second path does not introduce a new
+# conflict on this subclass.
+class DecoratedAsyncDiamond(DecoratedAsyncOverride, OtherAsyncPath): ...
 
 class ExplicitOverride(StrReturn, IntReturn):
     def method(self) -> str: ...  # error: [invalid-method-override]

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -594,7 +594,8 @@ The method selected by the MRO must satisfy every direct base class. A class the
 inherit incompatible methods from separate bases without defining a compatible override itself:
 
 ```pyi
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from enum import Enum
 
 class StrReturn:
     def method(self) -> str: ...
@@ -617,6 +618,62 @@ class StrIterator:
     def __iter__(self) -> Iterator[str]: ...
 
 class IncompatibleIterators(IntIterator, StrIterator): ...  # error: [invalid-method-override]
+class EnumIteratorConflict(IntIterator, StrIterator, Enum): ...  # error: [invalid-method-override]
+class StringEnum(str, Enum): ...
+
+class StrEnumMethod:
+    def __str__(self, value: int = 0) -> str: ...
+
+class IntEnumMethod:
+    def __str__(self, value: str = "") -> str: ...
+
+class EnumMethodConflict(StrEnumMethod, IntEnumMethod, Enum): ...  # error: [invalid-method-override]
+
+class IntStrDescriptor:
+    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
+
+class IntStrMixin:
+    __str__ = IntStrDescriptor()
+
+class StringEnumMethodConflict(IntStrMixin, str, Enum): ...  # error: [invalid-method-override]
+
+class StrUnderscore:
+    def _(self) -> str: ...
+
+class IntUnderscore:
+    def _(self) -> int: ...
+
+class IncompatibleUnderscore(StrUnderscore, IntUnderscore): ...  # error: [invalid-method-override]
+```
+
+`Flag` creation rewrites its bitwise operators on Python 3.11 and newer, but ordinary `Enum`
+creation does not:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```pyi
+from collections.abc import Callable
+from enum import Enum, Flag, ReprEnum
+
+class StrOr:
+    def __or__(self, other: object) -> str: ...
+
+class IntOr:
+    def __or__(self, other: object) -> int: ...
+
+class RewrittenFlagOr(StrOr, IntOr, Flag): ...
+class EnumOrConflict(StrOr, IntOr, Enum): ...  # error: [invalid-method-override]
+
+class ReprEnumStrDescriptor:
+    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
+
+class ReprEnumStrMixin:
+    __str__ = ReprEnumStrDescriptor()
+
+class RewrittenReprEnumStr(ReprEnumStrMixin, str, ReprEnum): ...
 ```
 
 The check follows inherited methods through intermediate bases, applies generic specializations, and
@@ -626,7 +683,7 @@ wins, but a later dynamic base does not erase a known conflict.
 
 ```pyi
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar, overload
+from typing import Any, Generic, NamedTuple, TypeVar, overload
 from typing_extensions import Self
 
 T = TypeVar("T")
@@ -701,7 +758,47 @@ class DescriptorMethod:
     method = CallableDescriptor()
 
 class DescriptorConflict(DescriptorMethod, StrReturn): ...  # error: [invalid-method-override]
+
+class ReceiverSensitiveDescriptor:
+    @overload
+    def __get__(self, instance: DescriptorReceiver, owner: type[DescriptorReceiver]) -> Callable[[], int]: ...
+    @overload
+    def __get__(self, instance: object, owner: type[object]) -> int: ...
+
+class DescriptorContract:
+    method = ReceiverSensitiveDescriptor()
+
+class DescriptorReceiver(StrReturn, DescriptorContract): ...  # error: [invalid-method-override]
+
+DynamicStrReturn = type("DynamicStrReturn", (), {"method": lambda self: ""})
+DynamicIntReturn = type("DynamicIntReturn", (), {"method": lambda self: 1})
+
+class DynamicClassConflict(DynamicStrReturn, DynamicIntReturn): ...  # error: [invalid-method-override]
+
+CallableNamedTuple = NamedTuple("CallableNamedTuple", [("method", Callable[[], int])])
+
+class DynamicNamedTupleConflict(CallableNamedTuple, StrReturn): ...  # error: [invalid-method-override]
 ```
+
+### Class members assigned in class methods
+
+These members also participate in inherited method checks:
+
+```py
+class ImplicitIntMethod:
+    @classmethod
+    def initialize(cls) -> None:
+        cls.implicit_method = lambda self: 1
+
+class ImplicitStrMethod:
+    @classmethod
+    def initialize(cls) -> None:
+        cls.implicit_method = lambda self: ""
+
+class ImplicitMethodConflict(ImplicitIntMethod, ImplicitStrMethod): ...  # error: [invalid-method-override]
+```
+
+### Synthesized inherited methods
 
 Synthesized methods participate in the contract from each base, regardless of which method wins in
 the MRO:
@@ -717,6 +814,8 @@ class SourceMake:
 
 class SynthesizedMethodWins(GeneratedMake, SourceMake): ...  # error: [invalid-method-override]
 class SourceMethodWins(SourceMake, GeneratedMake): ...  # error: [invalid-method-override]
+class GeneratedMakeChild(GeneratedMake): ...
+class InheritedSynthesizedMethodWins(GeneratedMakeChild, SourceMake): ...  # error: [invalid-method-override]
 ```
 
 ### Synthesized methods from both bases
@@ -740,6 +839,22 @@ class StrData:
     value: str
 
 class SynthesizedDataclassConflict(IntData, StrData): ...  # error: [invalid-method-override]
+
+@dataclass
+class OtherIntData:
+    value: int
+
+class CompatibleSynthesizedDataclasses(IntData, OtherIntData): ...
+
+class ReplaceContract:
+    def __replace__(self, *, value: str = "") -> "ReplaceContract":
+        raise NotImplementedError
+
+@dataclass
+class GeneratedReplace(ReplaceContract):
+    value: int
+
+class SynthesizedCascade(GeneratedReplace, ReplaceContract): ...  # error: [invalid-method-override]
 ```
 
 ### Dataclasses
@@ -955,6 +1070,9 @@ class RawGenericParent(GenericGrandparent):  # error: [missing-type-argument]
 
 class RawGenericChild(RawGenericParent):
     def method(self, renamed: int) -> None: ...
+
+class RawGenericDiamond(RawGenericParent, GenericGrandparent):  # error: [missing-type-argument]
+    ...
 ```
 
 `other_stub.pyi`:

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -780,6 +780,44 @@ CallableNamedTuple = NamedTuple("CallableNamedTuple", [("method", Callable[[], i
 class DynamicNamedTupleConflict(CallableNamedTuple, StrReturn): ...  # error: [invalid-method-override]
 ```
 
+### Standard-library Enum construction
+
+The same Enum rewrites apply while checking the standard-library Enum classes themselves. This
+requires a fallback because resolving `enum.Enum` from within `enum.pyi` can be cyclic:
+
+```toml
+[environment]
+python-version = "3.13"
+typeshed = "/src/typeshed"
+```
+
+`/src/typeshed/stdlib/builtins.pyi`:
+
+```pyi
+class object: ...
+class type(object): ...
+class str(object): ...
+class tuple: ...
+```
+
+`/src/typeshed/stdlib/enum.pyi`:
+
+```pyi
+class Enum:
+    def __format__(self, format_spec: str) -> str: ...
+
+class ReprEnum(Enum): ...
+class Flag(Enum): ...
+
+class DataType:
+    def __new__(cls) -> DataType: ...
+    def __format__(self, format_spec: str, /) -> str: ...
+
+class IntEnum(DataType, ReprEnum): ...
+class StrEnum(DataType, ReprEnum): ...
+class IntFlag(DataType, ReprEnum, Flag): ...
+```
+
 ### Class members assigned in class methods
 
 These members also participate in inherited method checks:

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -594,6 +594,8 @@ The method selected by the MRO must satisfy every direct base class. A class the
 inherit incompatible methods from separate bases without defining a compatible override itself:
 
 ```pyi
+from collections.abc import Iterator
+
 class StrReturn:
     def method(self) -> str: ...
 
@@ -607,6 +609,14 @@ class IncompatibleReturns(StrReturn, IntReturn): ...  # error: [invalid-method-o
 
 # `bool` is a subtype of `int`, so this order is compatible.
 class CompatibleCovariantReturn(BoolReturn, IntReturn): ...
+
+class IntIterator:
+    def __iter__(self) -> Iterator[int]: ...
+
+class StrIterator:
+    def __iter__(self) -> Iterator[str]: ...
+
+class IncompatibleIterators(IntIterator, StrIterator): ...  # error: [invalid-method-override]
 ```
 
 The check follows inherited methods through intermediate bases, applies generic specializations, and

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -625,7 +625,8 @@ participate according to their position in the MRO: a leading dynamic base obscu
 wins, but a later dynamic base does not erase a known conflict.
 
 ```pyi
-from typing import Any, Generic, TypeVar
+from collections.abc import Callable
+from typing import Any, Generic, TypeVar, overload
 from typing_extensions import Self
 
 T = TypeVar("T")
@@ -650,6 +651,20 @@ class InheritedSelf(IntMethod, SelfMethod): ...
 class ExplicitSelf(IntMethod, SelfMethod):
     def method(self, other: int) -> Self: ...
 
+class ReceiverOverloads:
+    @overload
+    def selected(self: FinalReceiver) -> int: ...
+    @overload
+    def selected(self) -> str: ...
+
+class ReceiverOverride(ReceiverOverloads):
+    def selected(self) -> str: ...
+
+class OtherReceiverPath(ReceiverOverloads): ...
+
+# The receiver-specific overload only applies after the two paths meet again.
+class FinalReceiver(ReceiverOverride, OtherReceiverPath): ...  # error: [invalid-method-override]
+
 class BrokenIntReturn(IntReturn):
     def method(self) -> str: ...  # error: [invalid-method-override]
 
@@ -665,10 +680,19 @@ class LaterDynamicBase(StrReturn, Any, IntReturn): ...  # error: [invalid-method
 class AttributeMask:
     method = lambda: ""
 
-class MaskedMethod(AttributeMask, IntReturn): ...
+class CallableAttributeMethod(AttributeMask, IntReturn): ...  # error: [invalid-method-override]
+
+class CallableDescriptor:
+    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
+
+class DescriptorMethod:
+    method = CallableDescriptor()
+
+class DescriptorConflict(DescriptorMethod, StrReturn): ...  # error: [invalid-method-override]
 ```
 
-Synthesized members also mask source methods later in the MRO:
+Synthesized methods participate in the contract from each base, regardless of which method wins in
+the MRO:
 
 ```pyi
 from typing import NamedTuple
@@ -679,7 +703,31 @@ class GeneratedMake(NamedTuple):
 class SourceMake:
     def _make(self) -> int: ...
 
-class MaskedBySynthesizedMember(GeneratedMake, SourceMake): ...
+class SynthesizedMethodWins(GeneratedMake, SourceMake): ...  # error: [invalid-method-override]
+class SourceMethodWins(SourceMake, GeneratedMake): ...  # error: [invalid-method-override]
+```
+
+### Synthesized methods from both bases
+
+The same applies when both methods are synthesized:
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from dataclasses import dataclass
+
+@dataclass
+class IntData:
+    value: int
+
+@dataclass
+class StrData:
+    value: str
+
+class SynthesizedDataclassConflict(IntData, StrData): ...  # error: [invalid-method-override]
 ```
 
 ### Dataclasses

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -588,6 +588,77 @@ class MultipleInheritanceSubclass(InstanceBase, ClassVarBase):
     attr: int
 ```
 
+### Inherited methods from multiple bases
+
+The method selected by the MRO must satisfy every direct base class. A class therefore cannot
+inherit incompatible methods from separate bases without defining a compatible override itself:
+
+```pyi
+class StrReturn:
+    def method(self) -> str: ...
+
+class IntReturn:
+    def method(self) -> int: ...
+
+class BoolReturn:
+    def method(self) -> bool: ...
+
+class IncompatibleReturns(StrReturn, IntReturn): ...  # error: [invalid-method-override]
+
+# `bool` is a subtype of `int`, so this order is compatible.
+class CompatibleCovariantReturn(BoolReturn, IntReturn): ...
+```
+
+The check follows inherited methods through intermediate bases, applies generic specializations, and
+avoids repeating violations already reported on a base class or explicit override. Dynamic bases
+participate according to their position in the MRO: a leading dynamic base obscures which method
+wins, but a later dynamic base does not erase a known conflict.
+
+```pyi
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+class Intermediate(StrReturn): ...
+class IndirectConflict(Intermediate, IntReturn): ...  # error: [invalid-method-override]
+
+class GenericReturn(Generic[T]):
+    def method(self) -> T: ...
+
+class GenericConflict(StrReturn, GenericReturn[int]): ...  # error: [invalid-method-override]
+
+class BrokenIntReturn(IntReturn):
+    def method(self) -> str: ...  # error: [invalid-method-override]
+
+# The violation is defined on `BrokenIntReturn`; this class should not repeat it.
+class RedundantDirectBase(BrokenIntReturn, IntReturn): ...
+
+class ExplicitOverride(StrReturn, IntReturn):
+    def method(self) -> str: ...  # error: [invalid-method-override]
+
+class LeadingDynamicBase(Any, StrReturn, IntReturn): ...
+class LaterDynamicBase(StrReturn, Any, IntReturn): ...  # error: [invalid-method-override]
+
+class AttributeMask:
+    method = lambda: ""
+
+class MaskedMethod(AttributeMask, IntReturn): ...
+```
+
+Synthesized members also mask source methods later in the MRO:
+
+```pyi
+from typing import NamedTuple
+
+class GeneratedMake(NamedTuple):
+    value: int
+
+class SourceMake:
+    def _make(self) -> int: ...
+
+class MaskedBySynthesizedMember(GeneratedMake, SourceMake): ...
+```
+
 ### Dataclasses
 
 Dataclass fields are instance variables, even though they are usually declared in the class body.

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -616,6 +616,7 @@ wins, but a later dynamic base does not erase a known conflict.
 
 ```pyi
 from typing import Any, Generic, TypeVar
+from typing_extensions import Self
 
 T = TypeVar("T")
 
@@ -626,6 +627,18 @@ class GenericReturn(Generic[T]):
     def method(self) -> T: ...
 
 class GenericConflict(StrReturn, GenericReturn[int]): ...  # error: [invalid-method-override]
+
+class IntMethod(int):
+    def method(self, other: int) -> Self: ...
+
+class SelfMethod:
+    def method(self, other: Self) -> Self: ...
+
+# `Self` in `SelfMethod.method` specializes to the subclass, which is an `int`.
+class InheritedSelf(IntMethod, SelfMethod): ...
+
+class ExplicitSelf(IntMethod, SelfMethod):
+    def method(self, other: int) -> Self: ...
 
 class BrokenIntReturn(IntReturn):
     def method(self) -> str: ...  # error: [invalid-method-override]

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -588,333 +588,6 @@ class MultipleInheritanceSubclass(InstanceBase, ClassVarBase):
     attr: int
 ```
 
-### Inherited methods from multiple bases
-
-The method selected by the MRO must satisfy every direct base class. A class therefore cannot
-inherit incompatible methods from separate bases without defining a compatible override itself:
-
-```pyi
-from collections.abc import Callable, Iterator
-from enum import Enum
-
-class StrReturn:
-    def method(self) -> str: ...
-
-class IntReturn:
-    def method(self) -> int: ...
-
-class BoolReturn:
-    def method(self) -> bool: ...
-
-class IncompatibleReturns(StrReturn, IntReturn): ...  # error: [invalid-method-override]
-
-# `bool` is a subtype of `int`, so this order is compatible.
-class CompatibleCovariantReturn(BoolReturn, IntReturn): ...
-
-class IntIterator:
-    def __iter__(self) -> Iterator[int]: ...
-
-class StrIterator:
-    def __iter__(self) -> Iterator[str]: ...
-
-class IncompatibleIterators(IntIterator, StrIterator): ...  # error: [invalid-method-override]
-class EnumIteratorConflict(IntIterator, StrIterator, Enum): ...  # error: [invalid-method-override]
-class StringEnum(str, Enum): ...
-
-class StrEnumMethod:
-    def __str__(self, value: int = 0) -> str: ...
-
-class IntEnumMethod:
-    def __str__(self, value: str = "") -> str: ...
-
-class EnumMethodConflict(StrEnumMethod, IntEnumMethod, Enum): ...  # error: [invalid-method-override]
-
-class IntStrDescriptor:
-    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
-
-class IntStrMixin:
-    __str__ = IntStrDescriptor()
-
-class StringEnumMethodConflict(IntStrMixin, str, Enum): ...  # error: [invalid-method-override]
-
-class StrUnderscore:
-    def _(self) -> str: ...
-
-class IntUnderscore:
-    def _(self) -> int: ...
-
-class IncompatibleUnderscore(StrUnderscore, IntUnderscore): ...  # error: [invalid-method-override]
-```
-
-`Flag` creation rewrites its bitwise operators on Python 3.11 and newer, but ordinary `Enum`
-creation does not:
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```pyi
-from collections.abc import Callable
-from enum import Enum, Flag, ReprEnum
-
-class StrOr:
-    def __or__(self, other: object) -> str: ...
-
-class IntOr:
-    def __or__(self, other: object) -> int: ...
-
-class RewrittenFlagOr(StrOr, IntOr, Flag): ...
-class EnumOrConflict(StrOr, IntOr, Enum): ...  # error: [invalid-method-override]
-
-class ReprEnumStrDescriptor:
-    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
-
-class ReprEnumStrMixin:
-    __str__ = ReprEnumStrDescriptor()
-
-class RewrittenReprEnumStr(ReprEnumStrMixin, str, ReprEnum): ...
-```
-
-The check follows inherited methods through intermediate bases, applies generic specializations, and
-avoids repeating violations already reported on a base class or explicit override. Dynamic bases
-participate according to their position in the MRO: a leading dynamic base obscures which method
-wins, but a later dynamic base does not erase a known conflict.
-
-```pyi
-from collections.abc import Callable, Coroutine
-from typing import Any, Concatenate, Generic, NamedTuple, ParamSpec, TypeVar, overload
-from typing_extensions import Self
-
-T = TypeVar("T")
-P = ParamSpec("P")
-Owner = TypeVar("Owner")
-
-class Intermediate(StrReturn): ...
-class IndirectConflict(Intermediate, IntReturn): ...  # error: [invalid-method-override]
-
-class GenericReturn(Generic[T]):
-    def method(self) -> T: ...
-
-class GenericConflict(StrReturn, GenericReturn[int]): ...  # error: [invalid-method-override]
-
-class IntMethod(int):
-    def method(self, other: int) -> Self: ...
-
-class SelfMethod:
-    def method(self, other: Self) -> Self: ...
-
-# `Self` in `SelfMethod.method` specializes to the subclass, which is an `int`.
-class InheritedSelf(IntMethod, SelfMethod): ...
-
-class ExplicitSelf(IntMethod, SelfMethod):
-    def method(self, other: int) -> Self: ...
-
-class ReceiverOverloads:
-    @overload
-    def selected(self: FinalReceiver) -> int: ...
-    @overload
-    def selected(self) -> str: ...
-
-class ReceiverOverride(ReceiverOverloads):
-    def selected(self) -> str: ...
-
-class OtherReceiverPath(ReceiverOverloads): ...
-
-# The receiver-specific overload only applies after the two paths meet again.
-class FinalReceiver(ReceiverOverride, OtherReceiverPath): ...  # error: [invalid-method-override]
-
-condition: bool
-
-class ConditionalSelfMethod:
-    if condition:
-        def copy(self) -> Self: ...
-
-    else:
-        def copy(self) -> Self: ...
-
-class ConditionalSelfOverride(ConditionalSelfMethod):
-    def copy(self) -> ConditionalSelfMethod: ...  # error: [invalid-method-override]
-
-class BrokenIntReturn(IntReturn):
-    def method(self) -> str: ...  # error: [invalid-method-override]
-
-# The violation is defined on `BrokenIntReturn`; this class should not repeat it.
-class RedundantDirectBase(BrokenIntReturn, IntReturn): ...
-
-def async_decorator(
-    function: Callable[Concatenate[Owner, P], Coroutine[Any, Any, Any]],
-) -> Callable[Concatenate[Owner, P], Coroutine[Any, Any, None]]: ...
-
-class AsyncContract:
-    async def async_method(self, **kwargs: Any) -> None: ...
-
-class DecoratedAsyncOverride(AsyncContract):
-    @async_decorator
-    async def async_method(self, **kwargs: Any) -> None: ...
-
-class OtherAsyncPath(AsyncContract): ...
-
-# The decorated method's public callable type already differs from `AsyncContract` on the class
-# that defines it. Meeting the same contract through a second path does not introduce a new
-# conflict on this subclass.
-class DecoratedAsyncDiamond(DecoratedAsyncOverride, OtherAsyncPath): ...
-
-class ExplicitOverride(StrReturn, IntReturn):
-    def method(self) -> str: ...  # error: [invalid-method-override]
-
-class LeadingDynamicBase(Any, StrReturn, IntReturn): ...
-class LaterDynamicBase(StrReturn, Any, IntReturn): ...  # error: [invalid-method-override]
-
-class AttributeMask:
-    method = lambda: ""
-
-class CallableAttributeMethod(AttributeMask, IntReturn): ...  # error: [invalid-method-override]
-
-class CallableDescriptor:
-    def __get__(self, instance: object, owner: type[object]) -> Callable[[], int]: ...
-
-class DescriptorMethod:
-    method = CallableDescriptor()
-
-class DescriptorConflict(DescriptorMethod, StrReturn): ...  # error: [invalid-method-override]
-
-class ReceiverSensitiveDescriptor:
-    @overload
-    def __get__(self, instance: DescriptorReceiver, owner: type[DescriptorReceiver]) -> Callable[[], int]: ...
-    @overload
-    def __get__(self, instance: object, owner: type[object]) -> int: ...
-
-class DescriptorContract:
-    method = ReceiverSensitiveDescriptor()
-
-class DescriptorReceiver(StrReturn, DescriptorContract): ...  # error: [invalid-method-override]
-
-DynamicStrReturn = type("DynamicStrReturn", (), {"method": lambda self: ""})
-DynamicIntReturn = type("DynamicIntReturn", (), {"method": lambda self: 1})
-
-class DynamicClassConflict(DynamicStrReturn, DynamicIntReturn): ...  # error: [invalid-method-override]
-
-CallableNamedTuple = NamedTuple("CallableNamedTuple", [("method", Callable[[], int])])
-
-class DynamicNamedTupleConflict(CallableNamedTuple, StrReturn): ...  # error: [invalid-method-override]
-```
-
-### Standard-library Enum construction
-
-The same Enum rewrites apply while checking the standard-library Enum classes themselves. This
-requires a fallback because resolving `enum.Enum` from within `enum.pyi` can be cyclic:
-
-```toml
-[environment]
-python-version = "3.13"
-typeshed = "/src/typeshed"
-```
-
-`/src/typeshed/stdlib/builtins.pyi`:
-
-```pyi
-class object: ...
-class type(object): ...
-class str(object): ...
-class tuple: ...
-```
-
-`/src/typeshed/stdlib/enum.pyi`:
-
-```pyi
-class Enum:
-    def __format__(self, format_spec: str) -> str: ...
-
-class ReprEnum(Enum): ...
-class Flag(Enum): ...
-
-class DataType:
-    def __new__(cls) -> DataType: ...
-    def __format__(self, format_spec: str, /) -> str: ...
-
-class IntEnum(DataType, ReprEnum): ...
-class StrEnum(DataType, ReprEnum): ...
-class IntFlag(DataType, ReprEnum, Flag): ...
-```
-
-### Class members assigned in class methods
-
-These members also participate in inherited method checks:
-
-```py
-class ImplicitIntMethod:
-    @classmethod
-    def initialize(cls) -> None:
-        cls.implicit_method = lambda self: 1
-
-class ImplicitStrMethod:
-    @classmethod
-    def initialize(cls) -> None:
-        cls.implicit_method = lambda self: ""
-
-class ImplicitMethodConflict(ImplicitIntMethod, ImplicitStrMethod): ...  # error: [invalid-method-override]
-```
-
-### Synthesized inherited methods
-
-Synthesized methods participate in the contract from each base, regardless of which method wins in
-the MRO:
-
-```pyi
-from typing import NamedTuple
-
-class GeneratedMake(NamedTuple):
-    value: int
-
-class SourceMake:
-    def _make(self) -> int: ...
-
-class SynthesizedMethodWins(GeneratedMake, SourceMake): ...  # error: [invalid-method-override]
-class SourceMethodWins(SourceMake, GeneratedMake): ...  # error: [invalid-method-override]
-class GeneratedMakeChild(GeneratedMake): ...
-class InheritedSynthesizedMethodWins(GeneratedMakeChild, SourceMake): ...  # error: [invalid-method-override]
-```
-
-### Synthesized methods from both bases
-
-The same applies when both methods are synthesized:
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-from dataclasses import dataclass
-
-@dataclass
-class IntData:
-    value: int
-
-@dataclass
-class StrData:
-    value: str
-
-class SynthesizedDataclassConflict(IntData, StrData): ...  # error: [invalid-method-override]
-
-@dataclass
-class OtherIntData:
-    value: int
-
-class CompatibleSynthesizedDataclasses(IntData, OtherIntData): ...
-
-class ReplaceContract:
-    def __replace__(self, *, value: str = "") -> "ReplaceContract":
-        raise NotImplementedError
-
-@dataclass
-class GeneratedReplace(ReplaceContract):
-    value: int
-
-class SynthesizedCascade(GeneratedReplace, ReplaceContract): ...  # error: [invalid-method-override]
-```
-
 ### Dataclasses
 
 Dataclass fields are instance variables, even though they are usually declared in the class body.
@@ -960,6 +633,403 @@ class ProtocolImpl(ProtocolBase):
 class ProtocolWithClassVarImpl(ProtocolBase):
     class_attr = 0
     instance_attr = 0
+```
+
+## Inherited methods from multiple bases
+
+When several direct bases provide the same method, Python selects the first definition in the MRO.
+That method must also be compatible with the method required by every other direct base.
+
+### Basic compatibility
+
+```pyi
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class ReturnsBool:
+    def method(self) -> bool: ...
+
+class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+
+# `bool` is a subtype of `int`, so the selected method satisfies both bases.
+class CompatibleReturns(ReturnsBool, ReturnsInt): ...
+```
+
+```snapshot
+error[invalid-method-override]: Base classes for class `IncompatibleReturns` define method `method` incompatibly
+  --> src/mdtest_snippet.pyi:2:9
+   |
+ 2 |     def method(self) -> str: ...
+   |         ------ `ReturnsStr.method` defined here
+ 3 |
+ 4 | class ReturnsInt:
+ 5 |     def method(self) -> int: ...
+   |         ------ `ReturnsInt.method` defined here
+ 6 |
+ 7 | class ReturnsBool:
+ 8 |     def method(self) -> bool: ...
+ 9 |
+10 | class IncompatibleReturns(ReturnsStr, ReturnsInt): ...  # snapshot: invalid-method-override
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `ReturnsStr.method` is incompatible with `ReturnsInt.method`
+   |
+info: incompatible return types: `str` is not assignable to `int`
+info: This violates the Liskov Substitution Principle
+```
+
+A method found through an indirect base is still checked. Type arguments supplied to a generic base
+also affect the comparison:
+
+```pyi
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+class IntermediateReturnsStr(ReturnsStr): ...
+class IndirectConflict(IntermediateReturnsStr, ReturnsInt): ...  # error: [invalid-method-override]
+
+class GenericReturn(Generic[T]):
+    def method(self) -> T: ...
+
+class GenericConflict(ReturnsStr, GenericReturn[int]): ...  # error: [invalid-method-override]
+```
+
+A leading base of type `Any` can provide the selected method, so no definite conflict is known. An
+`Any` base later in the MRO does not hide a conflict between the known bases:
+
+```pyi
+class AnyFirst(Any, ReturnsStr, ReturnsInt): ...
+class AnyAfterSelectedMethod(ReturnsStr, Any, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+### Special methods and `Enum` classes
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+Dunder methods and a method named `_` are checked like other methods. `Enum` class creation only
+exempts methods that Python replaces:
+
+```pyi
+from collections.abc import Iterator
+from enum import Enum, Flag, ReprEnum
+
+class IteratesInts:
+    def __iter__(self) -> Iterator[int]: ...
+
+class IteratesStrings:
+    def __iter__(self) -> Iterator[str]: ...
+
+# error: [invalid-method-override] "define method `__iter__` incompatibly"
+class IncompatibleIterators(IteratesInts, IteratesStrings): ...
+
+class UnderscoreReturnsStr:
+    def _(self) -> str: ...
+
+class UnderscoreReturnsInt:
+    def _(self) -> int: ...
+
+# error: [invalid-method-override] "define method `_` incompatibly"
+class IncompatibleUnderscore(UnderscoreReturnsStr, UnderscoreReturnsInt): ...
+
+# error: [invalid-method-override] "define method `__iter__` incompatibly"
+class EnumIteratorConflict(IteratesInts, IteratesStrings, Enum): ...
+class ValidStringEnum(str, Enum): ...
+```
+
+`Flag` class creation replaces inherited bitwise operators. Ordinary `Enum` class creation does not:
+
+```pyi
+class OrReturnsStr:
+    def __or__(self, other: object) -> str: ...
+
+class OrReturnsInt:
+    def __or__(self, other: object) -> int: ...
+
+class FlagUsesGeneratedOr(OrReturnsStr, OrReturnsInt, Flag): ...
+
+# error: [invalid-method-override] "define method `__or__` incompatibly"
+class EnumOrConflict(OrReturnsStr, OrReturnsInt, Enum): ...
+```
+
+An unrelated mixin's `__str__` method is still checked for a regular `Enum`, while `ReprEnum`
+selects the string data type's implementation. The lambda keeps this test focused on the inherited
+conflict instead of reporting an explicit override on the mixin itself:
+
+```pyi
+class IntStrMixin:
+    __str__ = lambda self: 1
+
+class EnumStrConflict(IntStrMixin, str, Enum): ...  # error: [invalid-method-override] "define method `__str__` incompatibly"
+class ReprEnumUsesDataTypeStr(IntStrMixin, str, ReprEnum): ...
+```
+
+### Binding methods to the subclass
+
+`Self` is resolved using the subclass whose bases are being checked. Here, `Self` becomes
+`InheritedSelf`, which is a subtype of `int`:
+
+```pyi
+from collections.abc import Callable
+from typing import overload
+from typing_extensions import Self
+
+class IntMethod(int):
+    def method(self, other: int) -> Self: ...
+
+class SelfMethod:
+    def method(self, other: Self) -> Self: ...
+
+class InheritedSelf(IntMethod, SelfMethod): ...
+```
+
+The same binding is used when the subclass defines an explicit override:
+
+```pyi
+class ExplicitSelf(IntMethod, SelfMethod):
+    def method(self, other: int) -> Self: ...
+```
+
+An explicit receiver annotation can select an overload only after the method is bound to the final
+subclass:
+
+```pyi
+class ReceiverOverloads:
+    @overload
+    def selected(self: FinalReceiver) -> int: ...
+    @overload
+    def selected(self) -> str: ...
+
+class ReceiverOverride(ReceiverOverloads):
+    def selected(self) -> str: ...
+
+class OtherReceiverBase(ReceiverOverloads): ...
+
+# error: [invalid-method-override] "define method `selected` incompatibly"
+class FinalReceiver(ReceiverOverride, OtherReceiverBase): ...
+```
+
+A conditionally defined method can contain more than one function type, but each definition still
+binds `Self` to the subclass:
+
+```pyi
+condition: bool
+
+class ConditionalSelfMethod:
+    if condition:
+        def copy(self) -> Self: ...
+
+    else:
+        def copy(self) -> Self: ...
+
+class ConditionalSelfOverride(ConditionalSelfMethod):
+    def copy(self) -> ConditionalSelfMethod: ...  # error: [invalid-method-override]
+```
+
+Descriptors can also choose a different result for the final subclass:
+
+```pyi
+class StringMethod:
+    def method(self) -> str: ...
+
+class OverloadedDescriptor:
+    @overload
+    def __get__(self, instance: DescriptorConflict, owner: type[DescriptorConflict]) -> Callable[[], int]: ...
+    @overload
+    def __get__(self, instance: object, owner: type[object]) -> int: ...
+
+class DescriptorBase:
+    method = OverloadedDescriptor()
+
+# error: [invalid-method-override] "define method `method` incompatibly"
+class DescriptorConflict(StringMethod, DescriptorBase): ...
+```
+
+### Callable and generated methods
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+A callable class attribute can provide the selected method even when it was not written with `def`:
+
+```py
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import NamedTuple
+
+class ReturnsInt:
+    def method(self) -> int:
+        raise NotImplementedError
+
+class ReturnsStr:
+    def method(self) -> str:
+        raise NotImplementedError
+
+class LambdaMethod:
+    method = lambda self: ""
+
+class LambdaMethodConflict(LambdaMethod, ReturnsInt): ...  # error: [invalid-method-override]
+```
+
+The same rule applies to classes created with `type()` and to the functional `NamedTuple` syntax:
+
+```py
+TypeCallStrMethod = type("TypeCallStrMethod", (), {"method": lambda self: ""})
+TypeCallIntMethod = type("TypeCallIntMethod", (), {"method": lambda self: 1})
+
+class TypeCallConflict(TypeCallStrMethod, TypeCallIntMethod): ...  # error: [invalid-method-override]
+
+CallableNamedTuple = NamedTuple("CallableNamedTuple", [("method", Callable[[], int])])
+
+class FunctionalNamedTupleConflict(CallableNamedTuple, ReturnsStr): ...  # error: [invalid-method-override]
+```
+
+A callable assigned through `cls` in a classmethod must also be considered:
+
+```py
+class AssignsIntMethod:
+    @classmethod
+    def initialize(cls) -> None:
+        cls.method = lambda self: 1
+
+class AssignsStrMethod:
+    @classmethod
+    def initialize(cls) -> None:
+        cls.method = lambda self: ""
+
+class AssignedThroughClsConflict(AssignsIntMethod, AssignsStrMethod): ...  # error: [invalid-method-override]
+```
+
+Methods generated by `NamedTuple` and `@dataclass` are checked like methods written in source. Both
+base orders matter because either the generated method or the source method can be selected:
+
+```py
+class GeneratedMake(NamedTuple):
+    value: int
+
+class SourceMake:
+    def _make(self) -> int:
+        raise NotImplementedError
+
+# error: [invalid-method-override] "define method `_make` incompatibly"
+class GeneratedMethodFirst(GeneratedMake, SourceMake): ...
+class SourceMethodFirst(SourceMake, GeneratedMake): ...  # error: [invalid-method-override] "define method `_make` incompatibly"
+class GeneratedMakeChild(GeneratedMake): ...
+
+# error: [invalid-method-override] "define method `_make` incompatibly"
+class InheritedGeneratedMethodFirst(GeneratedMakeChild, SourceMake): ...
+```
+
+Generated methods from two dataclasses can be incompatible, but equivalent generated methods are
+accepted:
+
+```py
+@dataclass
+class IntData:
+    value: int
+
+@dataclass
+class StrData:
+    value: str
+
+# error: [invalid-method-override] "define method `__replace__` incompatibly"
+class GeneratedDataclassConflict(IntData, StrData): ...
+
+@dataclass
+class OtherIntData:
+    value: int
+
+class CompatibleGeneratedDataclasses(IntData, OtherIntData): ...
+```
+
+A generated method is also checked when its class inherited the conflicting source method:
+
+```py
+class ReplaceBase:
+    def __replace__(self, *, value: str = "") -> "ReplaceBase":
+        raise NotImplementedError
+
+@dataclass
+class GeneratedReplace(ReplaceBase):
+    value: int
+
+# error: [invalid-method-override] "define method `__replace__` incompatibly"
+class GeneratedReplaceConflict(GeneratedReplace, ReplaceBase): ...
+```
+
+### Existing errors are not repeated
+
+If the selected method was already incompatible with an ancestor on the class that defined it, a
+subclass inheriting the same ancestor through another base should not report the error again:
+
+```pyi
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+class ReturnsInt:
+    def method(self) -> int: ...
+
+class BrokenReturn(ReturnsInt):
+    def method(self) -> str: ...  # error: [invalid-method-override]
+
+class InheritsBrokenReturn(BrokenReturn, ReturnsInt): ...
+```
+
+A method defined directly on the subclass should likewise produce one ordinary override error, not a
+second inherited-method error:
+
+```pyi
+class ReturnsStr:
+    def method(self) -> str: ...
+
+class DefinesOwnMethod(ReturnsStr, ReturnsInt):
+    def method(self) -> str: ...  # error: [invalid-method-override]
+```
+
+A decorator can change the type of a method on the class that defines it. Inheriting the original
+base again through another base should not repeat that incompatibility:
+
+```pyi
+Owner = TypeVar("Owner")
+
+def changes_return_type(
+    method: Callable[[Owner], int],
+) -> Callable[[Owner], str]: ...
+
+class Contract:
+    def method(self) -> int: ...
+
+class DecoratedOverride(Contract):
+    @changes_return_type
+    def method(self) -> int: ...
+
+class OtherContractBase(Contract): ...
+class DecoratedDiamond(DecoratedOverride, OtherContractBase): ...
+```
+
+Using a generic base without type arguments does not change this rule. Neither a child override nor
+listing the generic ancestor as another direct base should repeat the parent's error:
+
+```pyi
+T = TypeVar("T")
+
+class GenericGrandparent(Generic[T]):
+    def method(self, original: int) -> None: ...
+
+class RawGenericParent(GenericGrandparent):  # error: [missing-type-argument]
+    def method(self, renamed: int) -> None: ...  # error: [invalid-method-override]
+
+class RawGenericChild(RawGenericParent):
+    def method(self, renamed: int) -> None: ...
+
+class RawGenericDiamond(RawGenericParent, GenericGrandparent):  # error: [missing-type-argument]
+    ...
 ```
 
 ## The entire class hierarchy is checked
@@ -1109,28 +1179,6 @@ error[invalid-method-override]: Invalid override of method `method`
    |
 info: parameter `x` has an incompatible type: `int` is not assignable to `str`
 info: This violates the Liskov Substitution Principle
-```
-
-Cascade suppression follows nominal ancestry even when the parent uses a raw generic base:
-
-`raw_generic.pyi`:
-
-```pyi
-from typing import Generic, TypeVar
-
-T = TypeVar("T")
-
-class GenericGrandparent(Generic[T]):
-    def method(self, original: int) -> None: ...
-
-class RawGenericParent(GenericGrandparent):  # error: [missing-type-argument]
-    def method(self, renamed: int) -> None: ...  # error: [invalid-method-override]
-
-class RawGenericChild(RawGenericParent):
-    def method(self, renamed: int) -> None: ...
-
-class RawGenericDiamond(RawGenericParent, GenericGrandparent):  # error: [missing-type-argument]
-    ...
 ```
 
 `other_stub.pyi`:

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -924,9 +924,8 @@ class MyMapping(MutableMapping[KT, VT]):
         raise NotImplementedError
     def update(self, arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> None: ...
 
-# TODO: We should emit an `invalid-method-override` diagnostic on
-# `DeferredChild1.method`. The `DeferredChild1`-specific overload applies to
-# this subclass, so its override cannot remove the `extra` parameter.
+# The `DeferredChild1`-specific overload applies to this subclass, so its override cannot remove
+# the `extra` parameter.
 class DeferredBase:
     @overload
     def method(self) -> None: ...
@@ -935,7 +934,7 @@ class DeferredBase:
     def method(self, extra: str = "") -> None: ...
 
 class DeferredChild1(DeferredBase):
-    def method(self) -> None: ...
+    def method(self) -> None: ...  # error: [invalid-method-override]
 
 # TODO: A strict Liskov check would emit an `invalid-method-override`
 # diagnostic here too. A subclass could inherit from both `DeferredChild1`

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -924,8 +924,8 @@ class MyMapping(MutableMapping[KT, VT]):
         raise NotImplementedError
     def update(self, arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> None: ...
 
-# The `DeferredChild1`-specific overload applies to this subclass, so its override cannot remove
-# the `extra` parameter.
+# An explicit receiver annotation can make an overload apply to one subclass but not another.
+# The `DeferredChild1`-specific overload applies here, so this override must accept `extra`.
 class DeferredBase:
     @overload
     def method(self) -> None: ...
@@ -936,9 +936,6 @@ class DeferredBase:
 class DeferredChild1(DeferredBase):
     def method(self) -> None: ...  # error: [invalid-method-override]
 
-# TODO: A strict Liskov check would emit an `invalid-method-override`
-# diagnostic here too. A subclass could inherit from both `DeferredChild1`
-# and `DeferredChild2`, making the receiver-specific overload applicable.
 class DeferredChild2(DeferredBase):
     def method(self) -> None: ...
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -453,10 +453,6 @@ struct DescriptorBinding<'db> {
 }
 
 impl<'db> MemberLookupContext<'db> {
-    fn from_receiver(receiver: Option<Type<'db>>) -> Self {
-        receiver.map_or(Self::Default, Self::Explicit)
-    }
-
     fn for_intersection(self, intersection: Type<'db>) -> Self {
         match self {
             Self::Default => Self::Intersection(intersection),
@@ -3490,26 +3486,22 @@ impl<'db> Type<'db> {
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        self.member_lookup_with_policy_and_receiver(db, name, policy, None)
+        self.member_lookup_with_policy_in_context(db, name, policy, MemberLookupContext::Default)
     }
 
-    /// Perform member lookup while optionally binding descriptors and `Self` to a more precise
-    /// receiver than the type whose members are being searched.
-    ///
-    /// Intersection member lookup searches each positive element separately, but the resulting
-    /// attribute is still bound to the full intersection.
-    fn member_lookup_with_policy_and_receiver(
+    /// Perform member lookup while binding descriptors and `Self` to a more precise receiver than
+    /// the type whose members are being searched.
+    fn member_lookup_with_receiver(
         self,
         db: &'db dyn Db,
         name: Name,
-        policy: MemberLookupPolicy,
-        receiver: Option<Type<'db>>,
+        receiver: Type<'db>,
     ) -> PlaceAndQualifiers<'db> {
         self.member_lookup_with_policy_in_context(
             db,
             name,
-            policy,
-            MemberLookupContext::from_receiver(receiver),
+            MemberLookupPolicy::default(),
+            MemberLookupContext::Explicit(receiver),
         )
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -435,6 +435,53 @@ enum InstanceFallbackShadowsNonDataDescriptor {
     No,
 }
 
+/// Controls how descriptors and `Self` are bound when a member is looked up through another type.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
+enum MemberLookupContext<'db> {
+    Default,
+    /// Intersection members bind `Self` to the full intersection, while descriptors retain the
+    /// owner of the element currently being searched.
+    Intersection(Type<'db>),
+    /// Explicit override lookups bind both the descriptor instance and owner to this receiver.
+    Explicit(Type<'db>),
+}
+
+#[derive(Clone, Debug, Copy)]
+struct DescriptorBinding<'db> {
+    receiver: Type<'db>,
+    owner: Type<'db>,
+}
+
+impl<'db> MemberLookupContext<'db> {
+    fn from_receiver(receiver: Option<Type<'db>>) -> Self {
+        receiver.map_or(Self::Default, Self::Explicit)
+    }
+
+    fn for_intersection(self, intersection: Type<'db>) -> Self {
+        match self {
+            Self::Default => Self::Intersection(intersection),
+            _ => self,
+        }
+    }
+
+    fn descriptor_binding(self, db: &'db dyn Db, fallback: Type<'db>) -> DescriptorBinding<'db> {
+        match self {
+            Self::Default => DescriptorBinding {
+                receiver: fallback,
+                owner: fallback.to_meta_type(db),
+            },
+            Self::Intersection(receiver) => DescriptorBinding {
+                receiver,
+                owner: fallback.to_meta_type(db),
+            },
+            Self::Explicit(receiver) => DescriptorBinding {
+                receiver,
+                owner: receiver.to_meta_type(db),
+            },
+        }
+    }
+}
+
 bitflags! {
     #[derive(Clone, Debug, Copy, PartialEq, Eq, Hash)]
     pub(crate) struct MemberLookupPolicy: u8 {
@@ -3300,12 +3347,13 @@ impl<'db> Type<'db> {
     fn invoke_descriptor_protocol(
         self,
         db: &'db dyn Db,
-        receiver: Type<'db>,
+        binding: DescriptorBinding<'db>,
         name: &str,
         fallback: PlaceAndQualifiers<'db>,
         policy: InstanceFallbackShadowsNonDataDescriptor,
         member_policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let DescriptorBinding { receiver, owner } = binding;
         let (
             PlaceAndQualifiers {
                 place: meta_attr,
@@ -3316,7 +3364,7 @@ impl<'db> Type<'db> {
             db,
             self.class_member_with_policy(db, name.into(), member_policy),
             Some(receiver),
-            self.to_meta_type(db),
+            owner,
         );
 
         let PlaceAndQualifiers {
@@ -3457,6 +3505,21 @@ impl<'db> Type<'db> {
         policy: MemberLookupPolicy,
         receiver: Option<Type<'db>>,
     ) -> PlaceAndQualifiers<'db> {
+        self.member_lookup_with_policy_in_context(
+            db,
+            name,
+            policy,
+            MemberLookupContext::from_receiver(receiver),
+        )
+    }
+
+    fn member_lookup_with_policy_in_context(
+        self,
+        db: &'db dyn Db,
+        name: Name,
+        policy: MemberLookupPolicy,
+        context: MemberLookupContext<'db>,
+    ) -> PlaceAndQualifiers<'db> {
         #[salsa::tracked(
             cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
             cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _, _| {
@@ -3469,36 +3532,31 @@ impl<'db> Type<'db> {
             this: Type<'db>,
             name: Name,
             policy: MemberLookupPolicy,
-            receiver: Option<Type<'db>>,
+            context: MemberLookupContext<'db>,
         ) -> PlaceAndQualifiers<'db> {
             tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);
             if let Some(fallback) = this.materialized_divergent_fallback() {
-                return fallback.member_lookup_with_policy_and_receiver(db, name, policy, receiver);
+                return fallback.member_lookup_with_policy_in_context(db, name, policy, context);
             }
 
             let name_str = name.as_str();
 
             match this {
                 Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
-                    elem.member_lookup_with_policy_and_receiver(
-                        db,
-                        name_str.into(),
-                        policy,
-                        receiver,
-                    )
+                    elem.member_lookup_with_policy_in_context(db, name_str.into(), policy, context)
                 }),
 
                 Type::Intersection(intersection) => {
                     if let Some(complement) = intersection.enum_complement(db) {
                         enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                     } else {
-                        let receiver = Some(receiver.unwrap_or(this));
+                        let context = context.for_intersection(this);
                         intersection.map_with_boundness_and_qualifiers(db, |elem| {
-                            elem.member_lookup_with_policy_and_receiver(
+                            elem.member_lookup_with_policy_in_context(
                                 db,
                                 name_str.into(),
                                 policy,
-                                receiver,
+                                context,
                             )
                         })
                     }
@@ -3636,12 +3694,7 @@ impl<'db> Type<'db> {
                     _ => {
                         KnownClass::MethodType
                             .to_instance(db)
-                            .member_lookup_with_policy_and_receiver(
-                                db,
-                                name.clone(),
-                                policy,
-                                receiver,
-                            )
+                            .member_lookup_with_policy_in_context(db, name.clone(), policy, context)
                             .or_fall_back_to(db, || {
                                 // If an attribute is not available on the bound method object,
                                 // it will be looked up on the underlying function object. This
@@ -3655,13 +3708,13 @@ impl<'db> Type<'db> {
                 Type::KnownBoundMethod(method) => method
                     .class()
                     .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_in_context(db, name, policy, context),
                 Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
                     .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_in_context(db, name, policy, context),
                 Type::DataclassDecorator(_) => KnownClass::FunctionType
                     .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_in_context(db, name, policy, context),
 
                 Type::Callable(_) | Type::DataclassTransformer(_) if name_str == "__call__" => {
                     Place::bound(this).into()
@@ -3670,11 +3723,12 @@ impl<'db> Type<'db> {
                 Type::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType
                         .to_instance(db)
-                        .member_lookup_with_policy_and_receiver(db, name, policy, receiver)
+                        .member_lookup_with_policy_in_context(db, name, policy, context)
                 }
 
-                Type::Callable(_) | Type::DataclassTransformer(_) => Type::object()
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                Type::Callable(_) | Type::DataclassTransformer(_) => {
+                    Type::object().member_lookup_with_policy_in_context(db, name, policy, context)
+                }
 
                 Type::NominalInstance(instance)
                     if matches!(name.as_str(), "major" | "minor")
@@ -3746,11 +3800,11 @@ impl<'db> Type<'db> {
 
                 Type::TypeAlias(alias) => alias
                     .value_type(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_in_context(db, name, policy, context),
 
                 _ if policy.no_instance_fallback() => this.invoke_descriptor_protocol(
                     db,
-                    receiver.unwrap_or(this),
+                    context.descriptor_binding(db, this),
                     name_str,
                     Place::Undefined.into(),
                     InstanceFallbackShadowsNonDataDescriptor::No,
@@ -3837,7 +3891,7 @@ impl<'db> Type<'db> {
                     let nominal_lookup = partial
                         .partial(db)
                         .into_functools_partial_instance(db)
-                        .member_lookup_with_policy_and_receiver(db, name.clone(), policy, receiver);
+                        .member_lookup_with_policy_in_context(db, name.clone(), policy, context);
                     if name_str == "func" {
                         match nominal_lookup.place {
                             Place::Defined(DefinedPlace {
@@ -3876,7 +3930,8 @@ impl<'db> Type<'db> {
                 | Type::TypeGuard(..)
                 | Type::TypeForm(..)
                 | Type::TypedDict(_) => {
-                    let receiver = receiver.unwrap_or(this);
+                    let binding = context.descriptor_binding(db, this);
+                    let receiver = binding.receiver;
 
                     // Enum members can be accessed through enum instances and other enum members,
                     // e.g. `answer.YES` or `Answer.YES.NO`.
@@ -3897,7 +3952,7 @@ impl<'db> Type<'db> {
 
                     let result = this.invoke_descriptor_protocol(
                         db,
-                        receiver,
+                        binding,
                         name_str,
                         fallback,
                         InstanceFallbackShadowsNonDataDescriptor::No,
@@ -3949,7 +4004,10 @@ impl<'db> Type<'db> {
 
                     let result = this.invoke_descriptor_protocol(
                         db,
-                        this,
+                        DescriptorBinding {
+                            receiver: this,
+                            owner: context.descriptor_binding(db, this).owner,
+                        },
                         name_str,
                         class_attr_fallback,
                         InstanceFallbackShadowsNonDataDescriptor::Yes,
@@ -4008,7 +4066,7 @@ impl<'db> Type<'db> {
             }
         }
 
-        member_lookup_with_policy_inner(db, self, name, policy, receiver)
+        member_lookup_with_policy_inner(db, self, name, policy, context)
     }
 
     /// Return the type of `len()` on a type if it is known more precisely than `int`,

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -11,6 +11,7 @@ pub(super) use self::named_tuple::{
 };
 pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, StaticClassLiteral, expanded_class_base_entries,
+    implicit_attribute_names,
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use super::{

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -9,9 +9,9 @@ use self::named_tuple::synthesize_namedtuple_class_member;
 pub(super) use self::named_tuple::{
     DynamicNamedTupleAnchor, DynamicNamedTupleLiteral, NamedTupleField, NamedTupleSpec,
 };
+pub(in crate::types) use self::static_literal::implicit_attribute_names;
 pub(crate) use self::static_literal::{
     ExpandedClassBaseEntry, StaticClassLiteral, expanded_class_base_entries,
-    implicit_attribute_names,
 };
 pub(super) use self::typed_dict::{DynamicTypedDictAnchor, DynamicTypedDictLiteral};
 use super::{

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -462,7 +462,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         }
     }
 
-    pub(crate) fn fields(self, db: &'db dyn Db) -> &'db [NamedTupleField<'db>] {
+    pub(in crate::types) fn fields(self, db: &'db dyn Db) -> &'db [NamedTupleField<'db>] {
         self.spec(db).fields(db)
     }
 

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -462,7 +462,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         }
     }
 
-    fn fields(self, db: &'db dyn Db) -> &'db [NamedTupleField<'db>] {
+    pub(crate) fn fields(self, db: &'db dyn Db) -> &'db [NamedTupleField<'db>] {
         self.spec(db).fields(db)
     }
 

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -3143,7 +3143,7 @@ fn explicit_bases_cycle_fn<'db>(
 }
 
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn implicit_attribute_names<'db>(
+pub(in crate::types) fn implicit_attribute_names<'db>(
     db: &'db dyn Db,
     class_body_scope: ScopeId<'db>,
 ) -> Box<[Name]> {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -17,12 +17,12 @@ use crate::{
     },
     reachability::{DeclarationsIteratorExtension, binding_reachability},
     types::{
-        ApplyTypeMappingVisitor, BoundTypeVarInstance, CallArguments, CallableType, ClassBase,
-        ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias,
-        GenericContext, KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy,
-        MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType,
-        Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
-        TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
+        ApplyTypeMappingVisitor, BindingContext, BoundTypeVarInstance, CallArguments, CallableType,
+        ClassBase, ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams,
+        GenericAlias, GenericContext, KnownClass, KnownInstanceType, MaterializationKind,
+        MemberLookupPolicy, MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters,
+        PropertyInstanceType, Signature, SpecialFormType, StaticMroError, SubclassOfType,
+        Truthiness, Type, TypeContext, TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
@@ -1606,10 +1606,15 @@ impl<'db> StaticClassLiteral<'db> {
             (CodeGeneratorKind::DataclassLike(_), "__replace__")
                 if Program::get(db).python_version(db) >= PythonVersion::PY313 =>
             {
+                let self_ty = Type::TypeVar(BoundTypeVarInstance::synthetic_self(
+                    db,
+                    instance_ty,
+                    BindingContext::Synthetic,
+                ));
                 let self_parameter = Parameter::positional_or_keyword(Name::new_static("self"))
-                    .with_annotated_type(instance_ty);
+                    .with_annotated_type(self_ty);
 
-                signature_from_fields(vec![self_parameter], instance_ty)
+                signature_from_fields(vec![self_parameter], self_ty)
             }
             (CodeGeneratorKind::DataclassLike(_), "__setattr__") => {
                 if self.is_frozen_dataclass(db) == Some(true) {
@@ -3138,7 +3143,10 @@ fn explicit_bases_cycle_fn<'db>(
 }
 
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>) -> Box<[Name]> {
+pub(crate) fn implicit_attribute_names<'db>(
+    db: &'db dyn Db,
+    class_body_scope: ScopeId<'db>,
+) -> Box<[Name]> {
     let index = semantic_index(db, class_body_scope.file(db));
     let mut names = Vec::new();
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -6142,6 +6142,48 @@ pub(super) fn report_invalid_method_override<'db>(
     }
 }
 
+pub(super) fn report_incompatible_base_method<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    member: &str,
+    override_method: (ClassType<'db>, Definition<'db>),
+    overridden_method: (ClassType<'db>, Definition<'db>),
+    error_context: impl FnOnce() -> ErrorContextTree<'db>,
+) {
+    let db = context.db();
+    let Some(builder) = context.report_lint(&INVALID_METHOD_OVERRIDE, class.header_range(db))
+    else {
+        return;
+    };
+
+    let (override_owner, override_definition) = override_method;
+    let (overridden_owner, overridden_definition) = overridden_method;
+    let class_name = class.name(db);
+    let override_method = format!("{}.{member}", override_owner.name(db));
+    let overridden_method = format!("{}.{member}", overridden_owner.name(db));
+    let mut diagnostic = builder.into_diagnostic(format_args!(
+        "Base classes for class `{class_name}` define method `{member}` incompatibly"
+    ));
+    diagnostic.set_primary_message(format_args!(
+        "`{override_method}` is incompatible with `{overridden_method}`"
+    ));
+
+    error_context().attach_to(db, &mut diagnostic);
+    diagnostic.info("This violates the Liskov Substitution Principle");
+
+    for (definition, method) in [
+        (override_definition, override_method),
+        (overridden_definition, overridden_method),
+    ] {
+        let file = definition.file(db);
+        let module = parsed_module(db, file).load(db);
+        diagnostic.annotate(
+            Annotation::secondary(Span::from(definition.focus_range(db, &module)))
+                .message(format_args!("`{method}` defined here")),
+        );
+    }
+}
+
 pub(super) fn report_overridden_final_method<'db>(
     context: &InferContext<'db, '_>,
     member: &str,

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -6159,21 +6159,21 @@ pub(super) fn report_incompatible_base_method<'db>(
     let (override_owner, override_definition) = override_method;
     let (overridden_owner, overridden_definition) = overridden_method;
     let class_name = class.name(db);
-    let override_method = format!("{}.{member}", override_owner.name(db));
-    let overridden_method = format!("{}.{member}", overridden_owner.name(db));
+    let override_owner_name = override_owner.name(db);
+    let overridden_owner_name = overridden_owner.name(db);
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Base classes for class `{class_name}` define method `{member}` incompatibly"
     ));
     diagnostic.set_primary_message(format_args!(
-        "`{override_method}` is incompatible with `{overridden_method}`"
+        "`{override_owner_name}.{member}` is incompatible with `{overridden_owner_name}.{member}`"
     ));
 
     error_context().attach_to(db, &mut diagnostic);
     diagnostic.info("This violates the Liskov Substitution Principle");
 
-    for (definition, method) in [
-        (override_definition, override_method),
-        (overridden_definition, overridden_method),
+    for (definition, owner_name) in [
+        (override_definition, override_owner_name),
+        (overridden_definition, overridden_owner_name),
     ] {
         let Some(definition) = definition else {
             continue;
@@ -6182,7 +6182,7 @@ pub(super) fn report_incompatible_base_method<'db>(
         let module = parsed_module(db, file).load(db);
         diagnostic.annotate(
             Annotation::secondary(Span::from(definition.focus_range(db, &module)))
-                .message(format_args!("`{method}` defined here")),
+                .message(format_args!("`{owner_name}.{member}` defined here")),
         );
     }
 }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -6146,8 +6146,8 @@ pub(super) fn report_incompatible_base_method<'db>(
     context: &InferContext<'db, '_>,
     class: StaticClassLiteral<'db>,
     member: &str,
-    override_method: (ClassType<'db>, Definition<'db>),
-    overridden_method: (ClassType<'db>, Definition<'db>),
+    override_method: (ClassType<'db>, Option<Definition<'db>>),
+    overridden_method: (ClassType<'db>, Option<Definition<'db>>),
     error_context: impl FnOnce() -> ErrorContextTree<'db>,
 ) {
     let db = context.db();
@@ -6175,6 +6175,9 @@ pub(super) fn report_incompatible_base_method<'db>(
         (override_definition, override_method),
         (overridden_definition, overridden_method),
     ] {
+        let Some(definition) = definition else {
+            continue;
+        };
         let file = definition.file(db);
         let module = parsed_module(db, file).load(db);
         diagnostic.annotate(

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -23,8 +23,7 @@ use crate::{
     },
 };
 use ty_python_core::{
-    attribute_scopes, definition::Definition, global_scope, place_table, scope::ScopeId,
-    semantic_index, use_def_map,
+    definition::Definition, global_scope, place_table, scope::ScopeId, use_def_map,
 };
 
 /// Iterate over all declarations and bindings that exist at the end
@@ -155,7 +154,7 @@ const SYNTHETIC_DATACLASS_ATTRIBUTES: &[&str] = &[
 /// Callers must perform an ordinary member lookup before using a candidate. Avoiding those lookups
 /// here is important for callers that only need names, because resolving every inherited member
 /// can populate a large number of retained Salsa query results.
-pub(crate) fn all_class_member_names<'db>(
+pub(super) fn all_class_member_names<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
 ) -> FxHashSet<Name> {
@@ -590,22 +589,15 @@ impl<'db> AllMembers<'db> {
         class_literal: StaticClassLiteral<'db>,
     ) {
         let class_body_scope = class_literal.body_scope(db);
-        let file = class_body_scope.file(db);
-        let index = semantic_index(db, file);
-        for function_scope_id in attribute_scopes(db, class_body_scope) {
-            for place_expr in index.place_table(function_scope_id).members() {
-                let Some(name) = place_expr.as_instance_attribute() else {
-                    continue;
-                };
-                let result = ty.member(db, name);
-                let Some(ty) = result.place.ignore_possibly_undefined() else {
-                    continue;
-                };
-                self.members.insert(Member {
-                    name: Name::new(name),
-                    ty,
-                });
-            }
+        for name in implicit_attribute_names(db, class_body_scope) {
+            let result = ty.member(db, name);
+            let Some(ty) = result.place.ignore_possibly_undefined() else {
+                continue;
+            };
+            self.members.insert(Member {
+                name: name.clone(),
+                ty,
+            });
         }
 
         // This is very similar to `extend_with_class_members`,

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -17,8 +17,9 @@ use crate::{
         place_from_declarations,
     },
     types::{
-        ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
-        SubclassOfInner, Type, TypeVarBoundOrConstraints, class::CodeGeneratorKind,
+        ClassBase, ClassLiteral, ClassType, KnownClass, KnownInstanceType, StaticClassLiteral,
+        SubclassOfInner, Type, TypeVarBoundOrConstraints,
+        class::{CodeGeneratorKind, implicit_attribute_names},
     },
 };
 use ty_python_core::{
@@ -147,6 +148,91 @@ const SYNTHETIC_DATACLASS_ATTRIBUTES: &[&str] = &[
     "__dataclass_fields__",
     "__dataclass_params__",
 ];
+
+/// Returns an over-approximation of the class-member names available through `class` without
+/// resolving their types.
+///
+/// Callers must perform an ordinary member lookup before using a candidate. Avoiding those lookups
+/// here is important for callers that only need names, because resolving every inherited member
+/// can populate a large number of retained Salsa query results.
+pub(crate) fn all_class_member_names<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+) -> FxHashSet<Name> {
+    fn extend_names_from_mro<'db>(
+        db: &'db dyn Db,
+        class: ClassType<'db>,
+        names: &mut FxHashSet<Name>,
+    ) {
+        for class in class.iter_mro(db).filter_map(ClassBase::into_class) {
+            match class.class_literal(db) {
+                ClassLiteral::Static(class_literal) => {
+                    let class_body_scope = class_literal.body_scope(db);
+                    names.extend(
+                        place_table(db, class_body_scope)
+                            .symbols()
+                            .filter(|symbol| symbol.is_local())
+                            .map(|symbol| symbol.name().clone()),
+                    );
+
+                    names.extend(
+                        implicit_attribute_names(db, class_body_scope)
+                            .iter()
+                            .cloned(),
+                    );
+                }
+                ClassLiteral::Dynamic(class_literal) => {
+                    names.extend(
+                        class_literal
+                            .members(db)
+                            .iter()
+                            .map(|(name, _)| name.clone()),
+                    );
+                }
+                ClassLiteral::DynamicNamedTuple(class_literal) => {
+                    names.extend(
+                        class_literal
+                            .fields(db)
+                            .iter()
+                            .map(|field| field.name.clone()),
+                    );
+                }
+                ClassLiteral::DynamicTypedDict(_) | ClassLiteral::DynamicEnum(_) => {}
+            }
+
+            match CodeGeneratorKind::from_class(db, class.class_literal(db)) {
+                Some(CodeGeneratorKind::NamedTuple) => {
+                    if let Some(fallback) = KnownClass::NamedTupleFallback
+                        .to_class_literal(db)
+                        .to_class_type(db)
+                    {
+                        extend_names_from_mro(db, fallback, names);
+                    }
+                }
+                Some(CodeGeneratorKind::DataclassLike(_)) => {
+                    names.extend(
+                        SYNTHETIC_DATACLASS_ATTRIBUTES
+                            .iter()
+                            .map(|name| Name::new_static(name)),
+                    );
+                }
+                Some(CodeGeneratorKind::TypedDict) => {
+                    if let Some(fallback) = KnownClass::TypedDictFallback
+                        .to_class_literal(db)
+                        .to_class_type(db)
+                    {
+                        extend_names_from_mro(db, fallback, names);
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+
+    let mut names = FxHashSet::default();
+    extend_names_from_mro(db, class, &mut names);
+    names
+}
 
 struct AllMembers<'db> {
     members: FxHashSet<Member<'db>>,

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -148,88 +148,96 @@ const SYNTHETIC_DATACLASS_ATTRIBUTES: &[&str] = &[
     "__dataclass_params__",
 ];
 
-/// Returns an over-approximation of the class-member names available through `class` without
-/// resolving their types.
+/// Returns an over-approximation of the member names defined by `class` without resolving their
+/// types.
 ///
 /// Callers must perform an ordinary member lookup before using a candidate. Avoiding those lookups
 /// here is important for callers that only need names, because resolving every inherited member
 /// can populate a large number of retained Salsa query results.
-pub(super) fn all_class_member_names<'db>(
+pub(super) fn own_class_member_names<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
 ) -> FxHashSet<Name> {
+    fn extend_names_from_class<'db>(
+        db: &'db dyn Db,
+        class: ClassType<'db>,
+        names: &mut FxHashSet<Name>,
+    ) {
+        match class.class_literal(db) {
+            ClassLiteral::Static(class_literal) => {
+                let class_body_scope = class_literal.body_scope(db);
+                names.extend(
+                    place_table(db, class_body_scope)
+                        .symbols()
+                        .filter(|symbol| symbol.is_local())
+                        .map(|symbol| symbol.name().clone()),
+                );
+
+                names.extend(
+                    implicit_attribute_names(db, class_body_scope)
+                        .iter()
+                        .cloned(),
+                );
+            }
+            ClassLiteral::Dynamic(class_literal) => {
+                names.extend(
+                    class_literal
+                        .members(db)
+                        .iter()
+                        .map(|(name, _)| name.clone()),
+                );
+            }
+            ClassLiteral::DynamicNamedTuple(class_literal) => {
+                names.extend(
+                    class_literal
+                        .fields(db)
+                        .iter()
+                        .map(|field| field.name.clone()),
+                );
+            }
+            ClassLiteral::DynamicTypedDict(_) | ClassLiteral::DynamicEnum(_) => {}
+        }
+
+        match CodeGeneratorKind::from_class(db, class.class_literal(db)) {
+            Some(CodeGeneratorKind::NamedTuple) => {
+                if let Some(fallback) = KnownClass::NamedTupleFallback
+                    .to_class_literal(db)
+                    .to_class_type(db)
+                {
+                    extend_names_from_mro(db, fallback, names);
+                }
+            }
+            Some(CodeGeneratorKind::DataclassLike(_)) => {
+                names.extend(
+                    SYNTHETIC_DATACLASS_ATTRIBUTES
+                        .iter()
+                        .map(|name| Name::new_static(name)),
+                );
+            }
+            Some(CodeGeneratorKind::TypedDict) => {
+                if let Some(fallback) = KnownClass::TypedDictFallback
+                    .to_class_literal(db)
+                    .to_class_type(db)
+                {
+                    extend_names_from_mro(db, fallback, names);
+                }
+            }
+            None => {}
+        }
+    }
+
     fn extend_names_from_mro<'db>(
         db: &'db dyn Db,
         class: ClassType<'db>,
         names: &mut FxHashSet<Name>,
     ) {
         for class in class.iter_mro(db).filter_map(ClassBase::into_class) {
-            match class.class_literal(db) {
-                ClassLiteral::Static(class_literal) => {
-                    let class_body_scope = class_literal.body_scope(db);
-                    names.extend(
-                        place_table(db, class_body_scope)
-                            .symbols()
-                            .filter(|symbol| symbol.is_local())
-                            .map(|symbol| symbol.name().clone()),
-                    );
-
-                    names.extend(
-                        implicit_attribute_names(db, class_body_scope)
-                            .iter()
-                            .cloned(),
-                    );
-                }
-                ClassLiteral::Dynamic(class_literal) => {
-                    names.extend(
-                        class_literal
-                            .members(db)
-                            .iter()
-                            .map(|(name, _)| name.clone()),
-                    );
-                }
-                ClassLiteral::DynamicNamedTuple(class_literal) => {
-                    names.extend(
-                        class_literal
-                            .fields(db)
-                            .iter()
-                            .map(|field| field.name.clone()),
-                    );
-                }
-                ClassLiteral::DynamicTypedDict(_) | ClassLiteral::DynamicEnum(_) => {}
-            }
-
-            match CodeGeneratorKind::from_class(db, class.class_literal(db)) {
-                Some(CodeGeneratorKind::NamedTuple) => {
-                    if let Some(fallback) = KnownClass::NamedTupleFallback
-                        .to_class_literal(db)
-                        .to_class_type(db)
-                    {
-                        extend_names_from_mro(db, fallback, names);
-                    }
-                }
-                Some(CodeGeneratorKind::DataclassLike(_)) => {
-                    names.extend(
-                        SYNTHETIC_DATACLASS_ATTRIBUTES
-                            .iter()
-                            .map(|name| Name::new_static(name)),
-                    );
-                }
-                Some(CodeGeneratorKind::TypedDict) => {
-                    if let Some(fallback) = KnownClass::TypedDictFallback
-                        .to_class_literal(db)
-                        .to_class_type(db)
-                    {
-                        extend_names_from_mro(db, fallback, names);
-                    }
-                }
-                None => {}
-            }
+            extend_names_from_class(db, class, names);
         }
     }
 
     let mut names = FxHashSet::default();
-    extend_names_from_mro(db, class, &mut names);
+    extend_names_from_class(db, class, &mut names);
     names
 }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -762,7 +762,9 @@ fn check_class_declaration<'db>(
             // since the child cannot fix the violation without contradicting its immediate parent's contract.
             // See: https://github.com/astral-sh/ty/issues/2000
             if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method {
-                if immediate_parent != superclass && immediate_parent.is_subclass_of(db, superclass)
+                if immediate_parent != superclass
+                    && immediate_parent
+                        .is_subtype_of_class_literal(db, superclass.class_literal(db))
                 {
                     // The immediate parent already defines this method and is different from the
                     // current ancestor we're checking. Check if the immediate parent's method is

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -29,7 +29,7 @@ use crate::{
             report_invalid_method_override, report_overridden_final_method,
             report_overridden_final_variable,
         },
-        enums::{EnumMetadata, enum_metadata},
+        enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
         list_members::{Member, MemberWithDefinition, all_end_of_scope_members},
         tuple::Tuple,
@@ -134,6 +134,7 @@ fn check_inherited_method_conflicts<'db>(
     }
 
     let class_instance = Type::instance(db, class_specialized);
+    let has_enum_semantics = is_enum_class_by_inheritance(db, class);
     let mut reported_members = FxHashSet::default();
 
     // Members from the first base win unless the class defines its own override. Compare that
@@ -147,7 +148,7 @@ fn check_inherited_method_conflicts<'db>(
             // example, enum data-type mixins inherit incompatible `__format__` methods from the
             // data type and `Enum`, but class creation resolves them using special enum semantics.
             if member_name == "_"
-                || is_dunder(member_name)
+                || (has_enum_semantics && is_dunder(member_name))
                 || is_mangled_private(member_name)
                 || reported_members.contains(&member)
             {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -16,8 +16,8 @@ use crate::{
     lint::LintId,
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
-        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, MemberLookupPolicy,
-        Parameter, Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
+        Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind},
         constraints::ConstraintSetBuilder,
@@ -138,10 +138,9 @@ fn check_inherited_method_conflicts<'db>(
 
     let class_instance = Type::instance(db, class_specialized);
     let has_enum_semantics = is_enum_class_by_inheritance(db, class)
-        || class.explicit_bases(db).iter().any(|base| {
-            base.to_class_type(db)
-                .is_some_and(|base| is_stdlib_enum_class(db, base.class_literal(db)))
-        });
+        || direct_bases
+            .iter()
+            .any(|base| is_stdlib_enum_class(db, base.class_literal(db)));
     let member_candidates = member_candidates_in_direct_bases(db, &direct_bases);
 
     'members: for (member, base_indices) in member_candidates {
@@ -173,10 +172,9 @@ fn check_inherited_method_conflicts<'db>(
             .filter_map(|base_index| {
                 let base = direct_bases[base_index];
                 let overridden_owner = defining_class_for_member(db, base, &member)?;
-                if has_dynamic_member_contract(db, overridden_owner, &member) {
-                    return None;
-                }
-                (override_owner != overridden_owner).then_some((base, overridden_owner))
+                (!has_dynamic_member_contract(db, overridden_owner, &member)
+                    && override_owner != overridden_owner)
+                    .then_some((base, overridden_owner))
             })
             .collect();
 
@@ -258,25 +256,17 @@ fn member_with_receiver_if_needed<'db>(
     name: &Name,
 ) -> PlaceAndQualifiers<'db> {
     let member = instance.member(db, name);
-    let Some(raw_member_type) = owner
+    if owner
         .own_class_member(db, None, name)
         .inner
         .place
         .raw_type()
-    else {
-        return member;
-    };
-
-    if !raw_member_requires_receiver_aware_lookup(db, raw_member_type) {
-        return member;
+        .is_some_and(|ty| raw_member_requires_receiver_aware_lookup(db, ty))
+    {
+        instance.member_lookup_with_receiver(db, name.clone(), receiver)
+    } else {
+        member
     }
-
-    instance.member_lookup_with_policy_and_receiver(
-        db,
-        name.clone(),
-        MemberLookupPolicy::default(),
-        Some(receiver),
-    )
 }
 
 fn raw_member_requires_receiver_aware_lookup<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
@@ -363,8 +353,9 @@ fn is_enum_rewritten_method<'db>(
 
 fn class_has_repr_enum_base<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
     class.explicit_bases(db).iter().any(|base| {
-        base.to_class_type(db)
-            .is_some_and(|base| is_stdlib_enum_class_named(db, base.class_literal(db), "ReprEnum"))
+        base.to_class_type(db).is_some_and(|base| {
+            base.name(db) == "ReprEnum" && is_stdlib_enum_class(db, base.class_literal(db))
+        })
     })
 }
 
@@ -389,10 +380,6 @@ fn is_stdlib_enum_class<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool 
                         db.system().is_same_file(left, right).unwrap_or(false)
                     })
         })
-}
-
-fn is_stdlib_enum_class_named<'db>(db: &'db dyn Db, class: ClassLiteral<'db>, name: &str) -> bool {
-    class.name(db) == name && is_stdlib_enum_class(db, class)
 }
 
 /// Returns the data type selected by `EnumType` for `class`.
@@ -502,9 +489,6 @@ fn inherited_conflict_exists_on_owner<'db>(
     override_owner: ClassType<'db>,
     overridden_owner: ClassType<'db>,
 ) -> bool {
-    if !override_owner.is_subtype_of_class_literal(db, overridden_owner.class_literal(db)) {
-        return false;
-    }
     if method_definition(db, override_owner, name).is_none()
         || overridden_owner.static_class_literal(db).is_none()
     {
@@ -546,24 +530,6 @@ fn inherited_conflict_exists_on_owner<'db>(
     };
 
     !override_type.is_assignable_to(db, overridden_callable.into_type(db))
-}
-
-/// Returns the source function when the normal override pass checks this member.
-fn checked_override_function<'db>(
-    class_kind: Option<CodeGeneratorKind<'db>>,
-    name: &Name,
-    ty: Type<'db>,
-) -> Option<FunctionType<'db>> {
-    let Type::FunctionLiteral(function) = ty else {
-        return None;
-    };
-    if is_constructor_like_method(name)
-        || (name == "__replace__"
-            && matches!(class_kind, Some(CodeGeneratorKind::DataclassLike(_))))
-    {
-        return None;
-    }
-    Some(function)
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
@@ -1017,11 +983,15 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Some(subclass_function) =
-                checked_override_function(class_kind, &member.name, member.ty)
-            else {
+            let Type::FunctionLiteral(subclass_function) = member.ty else {
                 continue;
             };
+            if is_constructor_like_method(&member.name)
+                || (&member.name == "__replace__"
+                    && matches!(class_kind, Some(CodeGeneratorKind::DataclassLike(_))))
+            {
+                continue;
+            }
 
             let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
             else {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -218,12 +218,12 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             }
 
-            // If the winning method was already incompatible with this ancestor on its defining
-            // class, the normal override checks reported the violation there. Repeat the check
-            // with that class as the receiver rather than assuming that nominal ancestry is
-            // sufficient: receiver-specific overloads can introduce a new conflict only on this
-            // subclass.
-            if inherited_conflict_already_reported(db, &member, override_owner, overridden_owner) {
+            // If the winning source method was already incompatible with this ancestor on its
+            // defining class, meeting the same contract through another path does not introduce a
+            // new conflict here. Repeat the check with that class as the receiver rather than
+            // assuming that nominal ancestry is sufficient: receiver-specific overloads can
+            // introduce a new conflict only on this subclass.
+            if inherited_conflict_exists_on_owner(db, &member, override_owner, overridden_owner) {
                 continue;
             }
 
@@ -494,9 +494,9 @@ fn method_definition<'db>(
     symbol_definition(db, scope, symbol)
 }
 
-/// Returns `true` if the winning method was already incompatible with the overridden method on
-/// the class that defines it.
-fn inherited_conflict_already_reported<'db>(
+/// Returns `true` if the winning source method was already incompatible with the overridden method
+/// on the class that defines it.
+fn inherited_conflict_exists_on_owner<'db>(
     db: &'db dyn Db,
     name: &Name,
     override_owner: ClassType<'db>,
@@ -505,7 +505,7 @@ fn inherited_conflict_already_reported<'db>(
     if !override_owner.is_subtype_of_class_literal(db, overridden_owner.class_literal(db)) {
         return false;
     }
-    if !normal_override_check_covers_member(db, override_owner, name)
+    if method_definition(db, override_owner, name).is_none()
         || overridden_owner.static_class_literal(db).is_none()
     {
         return false;
@@ -546,23 +546,6 @@ fn inherited_conflict_already_reported<'db>(
     };
 
     !override_type.is_assignable_to(db, overridden_callable.into_type(db))
-}
-
-/// Returns `true` if the normal override pass checks `owner`'s definition of `name`.
-fn normal_override_check_covers_member<'db>(
-    db: &'db dyn Db,
-    owner: ClassType<'db>,
-    name: &Name,
-) -> bool {
-    let Some((owner_literal, _)) = owner.static_class_literal(db) else {
-        return false;
-    };
-    let class_kind = CodeGeneratorKind::from_class(db, owner_literal.into());
-
-    all_end_of_scope_members(db, owner_literal.body_scope(db)).any(|member| {
-        member.member.name == *name
-            && checked_override_function(class_kind, name, member.member.ty).is_some()
-    })
 }
 
 /// Returns the source function when the normal override pass checks this member.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -5,15 +5,16 @@
 
 use bitflags::bitflags;
 use ruff_db::diagnostic::Annotation;
-use ruff_python_ast::helpers::is_dunder;
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
+use ty_module_resolver::KnownModule;
 
 use crate::{
-    Db,
+    Db, Program,
     lint::LintId,
-    place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
+    place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin, known_module_symbol},
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, MemberLookupPolicy,
         Parameter, Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -31,7 +32,9 @@ use crate::{
         },
         enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
-        list_members::{Member, MemberWithDefinition, all_end_of_scope_members, all_members},
+        list_members::{
+            Member, MemberWithDefinition, all_class_member_names, all_end_of_scope_members,
+        },
         tuple::Tuple,
     },
 };
@@ -135,26 +138,45 @@ fn check_inherited_method_conflicts<'db>(
 
     let class_instance = Type::instance(db, class_specialized);
     let has_enum_semantics = is_enum_class_by_inheritance(db, class);
-    let member_names = member_names_in_direct_bases(db, &direct_bases);
+    let member_candidates = member_candidates_in_direct_bases(db, &direct_bases);
 
-    'members: for member in member_names {
+    'members: for (member, base_indices) in member_candidates {
         let member_name = member.as_str();
-        // Enum data-type mixins inherit incompatible dunder methods from the data type and
-        // `Enum`, but class creation resolves them using special enum semantics.
-        if member_name == "_"
-            || (has_enum_semantics && is_dunder(member_name))
-            || is_mangled_private(member_name)
-            || is_constructor_like_method(member_name)
-        {
+        if is_mangled_private(member_name) || is_constructor_like_method(member_name) {
             continue;
         }
 
         let Some(override_owner) = defining_class_for_member(db, class_specialized, &member) else {
             continue;
         };
+        if has_dynamic_member_contract(db, override_owner, &member) {
+            continue;
+        }
+
+        // Enum data-type mixins inherit incompatible dunder methods from the data type and
+        // `Enum`, but class creation resolves them using special enum semantics.
+        if has_enum_semantics && is_enum_rewritten_method(db, class, override_owner, &member) {
+            continue;
+        }
 
         // Methods defined by the class itself are handled by the normal override pass.
         if override_owner.class_literal(db) == ClassLiteral::Static(class) {
+            continue;
+        }
+
+        let overridden_bases: SmallVec<[_; 2]> = base_indices
+            .into_iter()
+            .filter_map(|base_index| {
+                let base = direct_bases[base_index];
+                let overridden_owner = defining_class_for_member(db, base, &member)?;
+                if has_dynamic_member_contract(db, overridden_owner, &member) {
+                    return None;
+                }
+                (override_owner != overridden_owner).then_some((base, overridden_owner))
+            })
+            .collect();
+
+        if overridden_bases.is_empty() {
             continue;
         }
 
@@ -169,20 +191,18 @@ fn check_inherited_method_conflicts<'db>(
             continue;
         }
 
-        for base in &direct_bases {
-            let base_instance = Type::instance(db, *base);
-            let Some(overridden_owner) = defining_class_for_member(db, *base, &member) else {
-                continue;
-            };
-            if override_owner.class_literal(db) == overridden_owner.class_literal(db) {
-                continue;
-            }
+        for (base, overridden_owner) in overridden_bases {
+            let base_instance = Type::instance(db, base);
 
-            let Some(overridden_type) =
-                member_with_receiver_if_needed(db, base_instance, class_instance, &member)
-                    .place
-                    .ignore_possibly_undefined()
-            else {
+            let Some(overridden_type) = member_with_receiver_if_needed(
+                db,
+                base_instance,
+                class_instance,
+                overridden_owner,
+                &member,
+            )
+            .place
+            .ignore_possibly_undefined() else {
                 continue;
             };
             let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
@@ -230,14 +250,20 @@ fn member_with_receiver_if_needed<'db>(
     db: &'db dyn Db,
     instance: Type<'db>,
     receiver: Type<'db>,
+    owner: ClassType<'db>,
     name: &Name,
 ) -> PlaceAndQualifiers<'db> {
     let member = instance.member(db, name);
-    if !member
+    let Some(raw_member_type) = owner
+        .own_class_member(db, None, name)
+        .inner
         .place
         .raw_type()
-        .is_some_and(|ty| contains_receiver_sensitive_bound_method(db, ty))
-    {
+    else {
+        return member;
+    };
+
+    if !raw_member_requires_receiver_aware_lookup(db, raw_member_type) {
         return member;
     }
 
@@ -249,36 +275,155 @@ fn member_with_receiver_if_needed<'db>(
     )
 }
 
-fn contains_receiver_sensitive_bound_method<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+fn raw_member_requires_receiver_aware_lookup<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
     match ty {
-        Type::BoundMethod(method) => method.function(db).signature(db).is_receiver_sensitive(db),
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .copied()
-            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
-        Type::Intersection(intersection) => intersection
-            .positive(db)
-            .iter()
-            .copied()
-            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
-        _ => false,
+        Type::FunctionLiteral(function) => function.signature(db).is_receiver_sensitive(db),
+        Type::Callable(callable)
+            if callable.is_function_like(db)
+                || callable.is_classmethod_like(db)
+                || callable.is_staticmethod_like(db) =>
+        {
+            callable.signatures(db).is_receiver_sensitive(db)
+        }
+        Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
+        _ => !ty.class_member(db, "__get__".into()).place.is_undefined(),
     }
 }
 
-/// Returns the sorted names of members available through any direct base.
-fn member_names_in_direct_bases<'db>(
+/// Returns the sorted member names exposed by at least two direct bases, together with the bases
+/// that expose each name.
+fn member_candidates_in_direct_bases<'db>(
     db: &'db dyn Db,
     direct_bases: &[ClassType<'db>],
-) -> Vec<Name> {
-    let mut names: Vec<_> = direct_bases
-        .iter()
-        .flat_map(|base| all_members(db, Type::instance(db, *base)))
-        .map(|member| member.name)
+) -> Vec<(Name, SmallVec<[usize; 2]>)> {
+    let mut candidate_bases: FxHashMap<Name, SmallVec<[usize; 2]>> = FxHashMap::default();
+
+    for (base_index, base) in direct_bases.iter().enumerate() {
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "candidate names are sorted before diagnostics are emitted"
+        )]
+        for name in all_class_member_names(db, *base) {
+            candidate_bases.entry(name).or_default().push(base_index);
+        }
+    }
+
+    let mut candidates: Vec<_> = candidate_bases
+        .into_iter()
+        .filter(|(_, bases)| bases.len() > 1)
         .collect();
-    names.sort_unstable();
-    names.dedup();
-    names
+    candidates.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    candidates
+}
+
+/// Returns `true` for method names that `EnumType` replaces during class creation.
+fn is_enum_rewritten_method<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+    override_owner: ClassType<'db>,
+    name: &Name,
+) -> bool {
+    let name_str = name.as_str();
+
+    if Program::get(db).python_version(db) >= PythonVersion::PY311
+        && Type::ClassLiteral(ClassLiteral::Static(class))
+            .is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
+        && matches!(
+            name_str,
+            "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
+        )
+    {
+        return true;
+    }
+
+    if !matches!(
+        name_str,
+        "__repr__" | "__str__" | "__format__" | "__reduce_ex__"
+    ) {
+        return false;
+    }
+
+    if override_owner.is_known(db, KnownClass::Object) {
+        return true;
+    }
+
+    let data_type = enum_data_type(db, class);
+    if matches!(name_str, "__str__" | "__format__") && class_has_repr_enum_base(db, class) {
+        return data_type.is_some();
+    }
+
+    data_type.is_some_and(|data_type| {
+        defining_class_for_member(db, data_type, name) == Some(override_owner)
+    })
+}
+
+fn class_has_repr_enum_base<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
+    let Some(repr_enum) = known_module_symbol(db, KnownModule::Enum, "ReprEnum")
+        .place
+        .ignore_possibly_undefined()
+    else {
+        return false;
+    };
+
+    class.explicit_bases(db).contains(&repr_enum)
+}
+
+/// Returns the data type selected by `EnumType` for `class`.
+fn enum_data_type<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> Option<ClassType<'db>> {
+    let mut data_type: Option<ClassType<'db>> = None;
+
+    for base in class.explicit_bases(db) {
+        let base = base.to_class_type(db)?;
+        let Some(candidate) = enum_data_type_in_base_mro(db, base) else {
+            continue;
+        };
+        match data_type {
+            Some(existing) if existing.class_literal(db) != candidate.class_literal(db) => {
+                return None;
+            }
+            Some(_) => {}
+            None => data_type = Some(candidate),
+        }
+    }
+
+    data_type
+}
+
+/// Returns the data type contributed by one direct Enum base and its MRO.
+fn enum_data_type_in_base_mro<'db>(
+    db: &'db dyn Db,
+    base: ClassType<'db>,
+) -> Option<ClassType<'db>> {
+    let mut candidate = None;
+
+    for class in base.iter_mro(db).filter_map(ClassBase::into_class) {
+        if class.is_known(db, KnownClass::Object) {
+            continue;
+        }
+
+        if Type::ClassLiteral(class.class_literal(db))
+            .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
+        {
+            if let Some((enum_class, _)) = class.static_class_literal(db)
+                && let Some(data_type) = enum_data_type(db, enum_class)
+            {
+                return Some(data_type);
+            }
+            continue;
+        }
+
+        let defines_data_type = !class.own_class_member(db, None, "__new__").is_undefined()
+            || !class
+                .own_class_member(db, None, "__dataclass_fields__")
+                .is_undefined();
+        if defines_data_type {
+            return Some(candidate.unwrap_or(class));
+        }
+
+        candidate.get_or_insert(class);
+    }
+
+    None
 }
 
 /// Returns the class that provides the effective class member with the given name.
@@ -291,6 +436,19 @@ fn defining_class_for_member<'db>(
         .iter_mro(db)
         .filter_map(ClassBase::into_class)
         .find(|candidate| !candidate.own_class_member(db, None, name).is_undefined())
+}
+
+/// Returns `true` when the defining class does not provide a statically known contract for
+/// `name`.
+fn has_dynamic_member_contract<'db>(db: &'db dyn Db, owner: ClassType<'db>, name: &Name) -> bool {
+    matches!(
+        owner
+            .own_class_member(db, None, name)
+            .inner
+            .place
+            .raw_type(),
+        Some(Type::Dynamic(_) | Type::Divergent(_))
+    )
 }
 
 /// Returns the source definition if `class` defines `name` as a method.
@@ -316,7 +474,12 @@ fn inherited_conflict_already_reported<'db>(
     override_owner: ClassType<'db>,
     overridden_owner: ClassType<'db>,
 ) -> bool {
-    if !override_owner.is_subclass_of(db, overridden_owner) {
+    if !override_owner.is_subtype_of_class_literal(db, overridden_owner.class_literal(db)) {
+        return false;
+    }
+    if !normal_override_check_covers_member(db, override_owner, name)
+        || overridden_owner.static_class_literal(db).is_none()
+    {
         return false;
     }
 
@@ -343,6 +506,7 @@ fn inherited_conflict_already_reported<'db>(
         db,
         Type::instance(db, overridden_ancestor),
         owner_instance,
+        overridden_ancestor,
         name,
     )
     .place
@@ -354,6 +518,41 @@ fn inherited_conflict_already_reported<'db>(
     };
 
     !override_type.is_assignable_to(db, overridden_callable.into_type(db))
+}
+
+/// Returns `true` if the normal override pass checks `owner`'s definition of `name`.
+fn normal_override_check_covers_member<'db>(
+    db: &'db dyn Db,
+    owner: ClassType<'db>,
+    name: &Name,
+) -> bool {
+    let Some((owner_literal, _)) = owner.static_class_literal(db) else {
+        return false;
+    };
+    let class_kind = CodeGeneratorKind::from_class(db, owner_literal.into());
+
+    all_end_of_scope_members(db, owner_literal.body_scope(db)).any(|member| {
+        member.member.name == *name
+            && checked_override_function(class_kind, name, member.member.ty).is_some()
+    })
+}
+
+/// Returns the source function when the normal override pass checks this member.
+fn checked_override_function<'db>(
+    class_kind: Option<CodeGeneratorKind<'db>>,
+    name: &Name,
+    ty: Type<'db>,
+) -> Option<FunctionType<'db>> {
+    let Type::FunctionLiteral(function) = ty else {
+        return None;
+    };
+    if is_constructor_like_method(name)
+        || (name == "__replace__"
+            && matches!(class_kind, Some(CodeGeneratorKind::DataclassLike(_))))
+    {
+        return None;
+    }
+    Some(function)
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
@@ -641,6 +840,7 @@ fn check_class_declaration<'db>(
                 db,
                 Type::instance(db, superclass),
                 instance_of_class,
+                superclass,
                 &member.name,
             );
             let Place::Defined(DefinedPlace {
@@ -806,21 +1006,11 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Type::FunctionLiteral(subclass_function) = member.ty else {
+            let Some(subclass_function) =
+                checked_override_function(class_kind, &member.name, member.ty)
+            else {
                 continue;
             };
-
-            // Constructor methods are not checked for Liskov compliance
-            if is_constructor_like_method(&member.name) {
-                continue;
-            }
-
-            // Synthesized `__replace__` methods on dataclasses are not checked
-            if &member.name == "__replace__"
-                && matches!(class_kind, Some(CodeGeneratorKind::DataclassLike(_)))
-            {
-                continue;
-            }
 
             let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
             else {

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -9,12 +9,12 @@ use ruff_python_ast::{PythonVersion, name::Name};
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
-use ty_module_resolver::KnownModule;
+use ty_module_resolver::{KnownModule, resolve_module_confident};
 
 use crate::{
     Db, Program,
     lint::LintId,
-    place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin, known_module_symbol},
+    place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
         CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, MemberLookupPolicy,
         Parameter, Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
@@ -137,7 +137,11 @@ fn check_inherited_method_conflicts<'db>(
     }
 
     let class_instance = Type::instance(db, class_specialized);
-    let has_enum_semantics = is_enum_class_by_inheritance(db, class);
+    let has_enum_semantics = is_enum_class_by_inheritance(db, class)
+        || class.explicit_bases(db).iter().any(|base| {
+            base.to_class_type(db)
+                .is_some_and(|base| is_stdlib_enum_class(db, base.class_literal(db)))
+        });
     let member_candidates = member_candidates_in_direct_bases(db, &direct_bases);
 
     'members: for (member, base_indices) in member_candidates {
@@ -358,14 +362,37 @@ fn is_enum_rewritten_method<'db>(
 }
 
 fn class_has_repr_enum_base<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
-    let Some(repr_enum) = known_module_symbol(db, KnownModule::Enum, "ReprEnum")
-        .place
-        .ignore_possibly_undefined()
-    else {
-        return false;
-    };
+    class.explicit_bases(db).iter().any(|base| {
+        base.to_class_type(db)
+            .is_some_and(|base| is_stdlib_enum_class_named(db, base.class_literal(db), "ReprEnum"))
+    })
+}
 
-    class.explicit_bases(db).contains(&repr_enum)
+/// Returns `true` for a class defined by the standard-library `enum` module.
+///
+/// While checking `enum.pyi` itself, resolving `KnownClass::Enum` can be cyclic. Identifying these
+/// classes by their defining file lets the special Enum construction rules apply there as well.
+fn is_stdlib_enum_class<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    matches!(
+        class.name(db).as_str(),
+        "Enum" | "ReprEnum" | "IntEnum" | "StrEnum" | "Flag" | "IntFlag"
+    ) && resolve_module_confident(db, &KnownModule::Enum.name())
+        .and_then(|module| module.file(db))
+        .is_some_and(|file| {
+            let class_file = class.file(db);
+            file == class_file
+                || file
+                    .path(db)
+                    .as_system_path()
+                    .zip(class_file.path(db).as_system_path())
+                    .is_some_and(|(left, right)| {
+                        db.system().is_same_file(left, right).unwrap_or(false)
+                    })
+        })
+}
+
+fn is_stdlib_enum_class_named<'db>(db: &'db dyn Db, class: ClassLiteral<'db>, name: &str) -> bool {
+    class.name(db) == name && is_stdlib_enum_class(db, class)
 }
 
 /// Returns the data type selected by `EnumType` for `class`.
@@ -403,6 +430,7 @@ fn enum_data_type_in_base_mro<'db>(
 
         if Type::ClassLiteral(class.class_literal(db))
             .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
+            || is_stdlib_enum_class(db, class.class_literal(db))
         {
             if let Some((enum_class, _)) = class.static_class_literal(db)
                 && let Some(data_type) = enum_data_type(db, enum_class)

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -5,6 +5,7 @@
 
 use bitflags::bitflags;
 use ruff_db::diagnostic::Annotation;
+use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_mangled_private;
 use rustc_hash::FxHashSet;
@@ -24,8 +25,9 @@ use crate::{
             INVALID_ASSIGNMENT, INVALID_ATTRIBUTE_OVERRIDE, INVALID_DATACLASS,
             INVALID_EXPLICIT_OVERRIDE, INVALID_METHOD_OVERRIDE, INVALID_NAMED_TUPLE,
             INVALID_NAMED_TUPLE_OVERRIDE, MISSING_OVERRIDE_DECORATOR, OVERRIDE_OF_FINAL_METHOD,
-            OVERRIDE_OF_FINAL_VARIABLE, report_invalid_method_override,
-            report_overridden_final_method, report_overridden_final_variable,
+            OVERRIDE_OF_FINAL_VARIABLE, report_incompatible_base_method,
+            report_invalid_method_override, report_overridden_final_method,
+            report_overridden_final_variable,
         },
         enums::{EnumMetadata, enum_metadata},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
@@ -69,6 +71,10 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
     }
 
     let class_specialized = class.identity_specialization(db);
+    if configuration.check_method_liskov_violations() {
+        check_inherited_method_conflicts(context, class, class_specialized);
+    }
+
     let scope = class.body_scope(db);
     let own_class_members: FxHashSet<_> = all_end_of_scope_members(db, scope).collect();
     let enum_info = enum_metadata(db, class.into());
@@ -87,6 +93,184 @@ pub(super) fn check_class<'db>(context: &InferContext<'db, '_>, class: StaticCla
             &member,
         );
     }
+}
+
+/// Checks that the method selected by the MRO is compatible with the contract of every direct
+/// base class.
+///
+/// The normal override checks only inspect members defined in the subclass itself. With multiple
+/// inheritance, however, a method inherited from an earlier base can override an incompatible
+/// method inherited from a later base.
+fn check_inherited_method_conflicts<'db>(
+    context: &InferContext<'db, '_>,
+    class: StaticClassLiteral<'db>,
+    class_specialized: ClassType<'db>,
+) {
+    let db = context.db();
+    if class.try_mro(db, None).is_err() {
+        return;
+    }
+
+    let direct_bases: Vec<_> = class
+        .explicit_bases(db)
+        .iter()
+        .filter_map(|base| base.to_class_type(db))
+        .collect();
+
+    if direct_bases.len() < 2 {
+        return;
+    }
+
+    // Avoid cascading diagnostics for class definitions that are already invalid because two of
+    // their bases cannot coexist in an MRO (for example, due to incompatible instance layouts or
+    // inheritance from a final class).
+    let constraints = ConstraintSetBuilder::new();
+    if direct_bases.iter().enumerate().any(|(index, left)| {
+        direct_bases[index + 1..]
+            .iter()
+            .any(|right| !left.could_coexist_in_mro_with(db, *right, &constraints))
+    }) {
+        return;
+    }
+
+    let class_instance = Type::instance(db, class_specialized);
+    let mut reported_members = FxHashSet::default();
+
+    // Members from the first base win unless the class defines its own override. Compare that
+    // effective member against the contracts contributed by every later direct base.
+    for base in direct_bases.iter().skip(1) {
+        let base_instance = Type::instance(db, *base);
+
+        for member in method_names_in_mro(db, *base) {
+            let member_name = member.as_str();
+            // Dunder methods commonly have intentionally different signatures across mixins. For
+            // example, enum data-type mixins inherit incompatible `__format__` methods from the
+            // data type and `Enum`, but class creation resolves them using special enum semantics.
+            if member_name == "_"
+                || is_dunder(member_name)
+                || is_mangled_private(member_name)
+                || reported_members.contains(&member)
+            {
+                continue;
+            }
+
+            let Some(overridden_owner) = defining_class_for_member(db, *base, &member) else {
+                continue;
+            };
+            let Some(override_owner) = defining_class_for_member(db, class_specialized, &member)
+            else {
+                continue;
+            };
+
+            // There is no conflict if both MRO paths resolve to the same definition. If the
+            // subclass defines the winning member, the normal override pass reports any error. A
+            // violation inherited from a subclass of the later base is likewise reported where
+            // that invalid override is originally defined.
+            if override_owner.class_literal(db) == overridden_owner.class_literal(db)
+                || override_owner.class_literal(db) == ClassLiteral::Static(class)
+                || override_owner.is_subclass_of(db, overridden_owner)
+            {
+                continue;
+            }
+
+            let Some(override_definition) = method_definition(db, override_owner, &member) else {
+                continue;
+            };
+            let Some(overridden_definition) = method_definition(db, overridden_owner, &member)
+            else {
+                continue;
+            };
+
+            let Some(override_type) = class_instance
+                .member(db, &member)
+                .place
+                .ignore_possibly_undefined()
+            else {
+                continue;
+            };
+            let Some(overridden_type) = base_instance
+                .member(db, &member)
+                .place
+                .ignore_possibly_undefined()
+            else {
+                continue;
+            };
+            let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
+                continue;
+            };
+            if override_type.try_upcast_to_callable(db).is_none() {
+                continue;
+            }
+
+            let overridden_callable_type = overridden_callable.into_type(db);
+            if override_type.is_assignable_to(db, overridden_callable_type) {
+                continue;
+            }
+
+            reported_members.insert(member.clone());
+            report_incompatible_base_method(
+                context,
+                class,
+                &member,
+                (override_owner, override_definition),
+                (overridden_owner, overridden_definition),
+                || override_type.assignability_error_context(db, overridden_callable_type),
+            );
+        }
+    }
+}
+
+/// Returns the sorted names of source-defined methods available through a class's MRO.
+fn method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Vec<Name> {
+    let mut names = FxHashSet::default();
+
+    for superclass in class.iter_mro(db).filter_map(ClassBase::into_class) {
+        let Some((class_literal, _)) = superclass.static_class_literal(db) else {
+            continue;
+        };
+        let scope = class_literal.body_scope(db);
+        let table = place_table(db, scope);
+
+        for member in all_end_of_scope_members(db, scope) {
+            if table
+                .symbol_id(&member.member.name)
+                .is_some_and(|symbol| is_function_definition(db, scope, symbol))
+            {
+                names.insert(member.member.name);
+            }
+        }
+    }
+
+    let mut names: Vec<_> = names.into_iter().collect();
+    names.sort_unstable();
+    names
+}
+
+/// Returns the class that provides the effective class member with the given name.
+fn defining_class_for_member<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    name: &Name,
+) -> Option<ClassType<'db>> {
+    class
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .find(|candidate| !candidate.own_class_member(db, None, name).is_undefined())
+}
+
+/// Returns the source definition if `class` defines `name` as a method.
+fn method_definition<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    name: &Name,
+) -> Option<Definition<'db>> {
+    let (class_literal, _) = class.static_class_literal(db)?;
+    let scope = class_literal.body_scope(db);
+    let symbol = place_table(db, scope).symbol_id(name)?;
+    if !is_function_definition(db, scope, symbol) {
+        return None;
+    }
+    symbol_definition(db, scope, symbol)
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.
@@ -568,10 +752,12 @@ fn check_class_declaration<'db>(
             // since the child cannot fix the violation without contradicting its immediate parent's contract.
             // See: https://github.com/astral-sh/ty/issues/2000
             if let Some((immediate_parent, immediate_parent_type)) = immediate_parent_method {
-                if immediate_parent != superclass {
+                if immediate_parent != superclass && immediate_parent.is_subclass_of(db, superclass)
+                {
                     // The immediate parent already defines this method and is different from the
-                    // current ancestor we're checking. Check if the immediate parent's method
-                    // is also incompatible with this ancestor.
+                    // current ancestor we're checking. Check if the immediate parent's method is
+                    // also incompatible with this ancestor. Unrelated bases must still be checked:
+                    // the subclass is required to satisfy both contracts.
                     if !immediate_parent_type.is_assignable_to(db, superclass_type_as_type) {
                         // The immediate parent already has an LSP violation with this ancestor.
                         // Don't report the same violation for the child.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -31,7 +31,7 @@ use crate::{
         },
         enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
-        list_members::{Member, MemberWithDefinition, all_end_of_scope_members},
+        list_members::{Member, MemberWithDefinition, all_end_of_scope_members, all_members},
         tuple::Tuple,
     },
 };
@@ -135,60 +135,49 @@ fn check_inherited_method_conflicts<'db>(
 
     let class_instance = Type::instance(db, class_specialized);
     let has_enum_semantics = is_enum_class_by_inheritance(db, class);
-    let mut reported_members = FxHashSet::default();
+    let member_names = member_names_in_direct_bases(db, &direct_bases);
 
-    // Members from the first base win unless the class defines its own override. Compare that
-    // effective member against the contracts contributed by every later direct base.
-    for base in direct_bases.iter().skip(1) {
-        let base_instance = Type::instance(db, *base);
+    'members: for member in member_names {
+        let member_name = member.as_str();
+        // Enum data-type mixins inherit incompatible dunder methods from the data type and
+        // `Enum`, but class creation resolves them using special enum semantics.
+        if member_name == "_"
+            || (has_enum_semantics && is_dunder(member_name))
+            || is_mangled_private(member_name)
+            || is_constructor_like_method(member_name)
+        {
+            continue;
+        }
 
-        for member in method_names_in_mro(db, *base) {
-            let member_name = member.as_str();
-            // Dunder methods commonly have intentionally different signatures across mixins. For
-            // example, enum data-type mixins inherit incompatible `__format__` methods from the
-            // data type and `Enum`, but class creation resolves them using special enum semantics.
-            if member_name == "_"
-                || (has_enum_semantics && is_dunder(member_name))
-                || is_mangled_private(member_name)
-                || reported_members.contains(&member)
-            {
-                continue;
-            }
+        let Some(override_owner) = defining_class_for_member(db, class_specialized, &member) else {
+            continue;
+        };
 
+        // Methods defined by the class itself are handled by the normal override pass.
+        if override_owner.class_literal(db) == ClassLiteral::Static(class) {
+            continue;
+        }
+
+        let Some(override_type) = class_instance
+            .member(db, &member)
+            .place
+            .ignore_possibly_undefined()
+        else {
+            continue;
+        };
+        if override_type.try_upcast_to_callable(db).is_none() {
+            continue;
+        }
+
+        for base in &direct_bases {
+            let base_instance = Type::instance(db, *base);
             let Some(overridden_owner) = defining_class_for_member(db, *base, &member) else {
                 continue;
             };
-            let Some(override_owner) = defining_class_for_member(db, class_specialized, &member)
-            else {
-                continue;
-            };
-
-            // There is no conflict if both MRO paths resolve to the same definition. If the
-            // subclass defines the winning member, the normal override pass reports any error. A
-            // violation inherited from a subclass of the later base is likewise reported where
-            // that invalid override is originally defined.
-            if override_owner.class_literal(db) == overridden_owner.class_literal(db)
-                || override_owner.class_literal(db) == ClassLiteral::Static(class)
-                || override_owner.is_subclass_of(db, overridden_owner)
-            {
+            if override_owner.class_literal(db) == overridden_owner.class_literal(db) {
                 continue;
             }
 
-            let Some(override_definition) = method_definition(db, override_owner, &member) else {
-                continue;
-            };
-            let Some(overridden_definition) = method_definition(db, overridden_owner, &member)
-            else {
-                continue;
-            };
-
-            let Some(override_type) = class_instance
-                .member(db, &member)
-                .place
-                .ignore_possibly_undefined()
-            else {
-                continue;
-            };
             let Some(overridden_type) = base_instance
                 .member_lookup_with_policy_and_receiver(
                     db,
@@ -204,51 +193,52 @@ fn check_inherited_method_conflicts<'db>(
             let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
                 continue;
             };
-            if override_type.try_upcast_to_callable(db).is_none() {
-                continue;
-            }
 
             let overridden_callable_type = overridden_callable.into_type(db);
             if override_type.is_assignable_to(db, overridden_callable_type) {
                 continue;
             }
 
-            reported_members.insert(member.clone());
+            // If the winning method was already incompatible with this ancestor on its defining
+            // class, the normal override checks reported the violation there. Repeat the check
+            // with that class as the receiver rather than assuming that nominal ancestry is
+            // sufficient: receiver-specific overloads can introduce a new conflict only on this
+            // subclass.
+            if inherited_conflict_already_reported(db, &member, override_owner, overridden_owner) {
+                continue;
+            }
+
             report_incompatible_base_method(
                 context,
                 class,
                 &member,
-                (override_owner, override_definition),
-                (overridden_owner, overridden_definition),
+                (
+                    override_owner,
+                    method_definition(db, override_owner, &member),
+                ),
+                (
+                    overridden_owner,
+                    method_definition(db, overridden_owner, &member),
+                ),
                 || override_type.assignability_error_context(db, overridden_callable_type),
             );
+            continue 'members;
         }
     }
 }
 
-/// Returns the sorted names of source-defined methods available through a class's MRO.
-fn method_names_in_mro<'db>(db: &'db dyn Db, class: ClassType<'db>) -> Vec<Name> {
-    let mut names = FxHashSet::default();
-
-    for superclass in class.iter_mro(db).filter_map(ClassBase::into_class) {
-        let Some((class_literal, _)) = superclass.static_class_literal(db) else {
-            continue;
-        };
-        let scope = class_literal.body_scope(db);
-        let table = place_table(db, scope);
-
-        for member in all_end_of_scope_members(db, scope) {
-            if table
-                .symbol_id(&member.member.name)
-                .is_some_and(|symbol| is_function_definition(db, scope, symbol))
-            {
-                names.insert(member.member.name);
-            }
-        }
-    }
-
-    let mut names: Vec<_> = names.into_iter().collect();
+/// Returns the sorted names of members available through any direct base.
+fn member_names_in_direct_bases<'db>(
+    db: &'db dyn Db,
+    direct_bases: &[ClassType<'db>],
+) -> Vec<Name> {
+    let mut names: Vec<_> = direct_bases
+        .iter()
+        .flat_map(|base| all_members(db, Type::instance(db, *base)))
+        .map(|member| member.name)
+        .collect();
     names.sort_unstable();
+    names.dedup();
     names
 }
 
@@ -277,6 +267,56 @@ fn method_definition<'db>(
         return None;
     }
     symbol_definition(db, scope, symbol)
+}
+
+/// Returns `true` if the winning method was already incompatible with the overridden method on
+/// the class that defines it.
+fn inherited_conflict_already_reported<'db>(
+    db: &'db dyn Db,
+    name: &Name,
+    override_owner: ClassType<'db>,
+    overridden_owner: ClassType<'db>,
+) -> bool {
+    if !override_owner.is_subclass_of(db, overridden_owner) {
+        return false;
+    }
+
+    let Some(overridden_ancestor) = override_owner
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .find(|ancestor| ancestor.class_literal(db) == overridden_owner.class_literal(db))
+    else {
+        return false;
+    };
+
+    let owner_instance = Type::instance(db, override_owner);
+    let Some(override_type) = owner_instance
+        .member(db, name)
+        .place
+        .ignore_possibly_undefined()
+    else {
+        return false;
+    };
+    if override_type.try_upcast_to_callable(db).is_none() {
+        return false;
+    }
+    let Some(overridden_type) = Type::instance(db, overridden_ancestor)
+        .member_lookup_with_policy_and_receiver(
+            db,
+            name.clone(),
+            MemberLookupPolicy::default(),
+            Some(owner_instance),
+        )
+        .place
+        .ignore_possibly_undefined()
+    else {
+        return false;
+    };
+    let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
+        return false;
+    };
+
+    !override_type.is_assignable_to(db, overridden_callable.into_type(db))
 }
 
 /// Returns the first inherited `NamedTuple` field in the MRO for `field_name`.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -33,7 +33,7 @@ use crate::{
         enums::{EnumMetadata, enum_metadata, is_enum_class_by_inheritance},
         function::{FunctionDecorators, FunctionType, KnownFunction, OverloadLiteral},
         list_members::{
-            Member, MemberWithDefinition, all_class_member_names, all_end_of_scope_members,
+            Member, MemberWithDefinition, all_end_of_scope_members, own_class_member_names,
         },
         tuple::Tuple,
     },
@@ -110,17 +110,16 @@ fn check_inherited_method_conflicts<'db>(
     class_specialized: ClassType<'db>,
 ) {
     let db = context.db();
-    if class.try_mro(db, None).is_err() {
-        return;
-    }
-
-    let direct_bases: Vec<_> = class
+    let direct_bases: SmallVec<[_; 2]> = class
         .explicit_bases(db)
         .iter()
         .filter_map(|base| base.to_class_type(db))
         .collect();
 
     if direct_bases.len() < 2 {
+        return;
+    }
+    if class.try_mro(db, None).is_err() {
         return;
     }
 
@@ -137,24 +136,29 @@ fn check_inherited_method_conflicts<'db>(
     }
 
     let class_instance = Type::instance(db, class_specialized);
+    let member_candidates = member_candidates_in_direct_bases(db, &direct_bases);
+    if member_candidates.is_empty() {
+        return;
+    }
     let has_enum_semantics = is_enum_class_by_inheritance(db, class)
         || direct_bases
             .iter()
             .any(|base| is_stdlib_enum_class(db, base.class_literal(db)));
-    let member_candidates = member_candidates_in_direct_bases(db, &direct_bases);
 
-    'members: for (member, base_indices) in member_candidates {
+    'members: for member in member_candidates {
         let member_name = member.as_str();
         if is_mangled_private(member_name) || is_constructor_like_method(member_name) {
             continue;
         }
 
-        let Some(override_owner) = defining_class_for_member(db, class_specialized, &member) else {
+        let Some(override_member) = defining_class_for_member(db, class_specialized, &member)
+        else {
             continue;
         };
-        if has_dynamic_member_contract(db, override_owner, &member) {
+        if override_member.has_dynamic_contract() || !override_member.may_produce_callable(db) {
             continue;
         }
+        let override_owner = override_member.owner;
 
         // Enum data-type mixins inherit incompatible dunder methods from the data type and
         // `Enum`, but class creation resolves them using special enum semantics.
@@ -167,14 +171,15 @@ fn check_inherited_method_conflicts<'db>(
             continue;
         }
 
-        let overridden_bases: SmallVec<[_; 2]> = base_indices
-            .into_iter()
-            .filter_map(|base_index| {
-                let base = direct_bases[base_index];
-                let overridden_owner = defining_class_for_member(db, base, &member)?;
-                (!has_dynamic_member_contract(db, overridden_owner, &member)
-                    && override_owner != overridden_owner)
-                    .then_some((base, overridden_owner))
+        let overridden_bases: SmallVec<[_; 2]> = direct_bases
+            .iter()
+            .copied()
+            .filter_map(|base| {
+                let overridden_member = defining_class_for_member(db, base, &member)?;
+                (!overridden_member.has_dynamic_contract()
+                    && overridden_member.may_produce_callable(db)
+                    && override_owner != overridden_member.owner)
+                    .then_some((base, overridden_member.owner))
             })
             .collect();
 
@@ -284,29 +289,68 @@ fn raw_member_requires_receiver_aware_lookup<'db>(db: &'db dyn Db, ty: Type<'db>
     }
 }
 
-/// Returns the sorted member names exposed by at least two direct bases, together with the bases
-/// that expose each name.
+/// Returns the sorted member names exposed by at least two direct bases and defined on an MRO
+/// branch that is not shared by every direct base.
+///
+/// A conflict requires at least one distinct defining class. A name defined only by classes common
+/// to every base resolves to the same owner along every path and cannot conflict.
 fn member_candidates_in_direct_bases<'db>(
     db: &'db dyn Db,
     direct_bases: &[ClassType<'db>],
-) -> Vec<(Name, SmallVec<[usize; 2]>)> {
-    let mut candidate_bases: FxHashMap<Name, SmallVec<[usize; 2]>> = FxHashMap::default();
+) -> Vec<Name> {
+    let [first_base, remaining_bases @ ..] = direct_bases else {
+        return Vec::new();
+    };
 
-    for (base_index, base) in direct_bases.iter().enumerate() {
+    let mut common_classes: FxHashSet<_> = first_base
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .collect();
+
+    for base in remaining_bases {
+        let classes: FxHashSet<_> = base
+            .iter_mro(db)
+            .filter_map(ClassBase::into_class)
+            .collect();
+        common_classes.retain(|class| classes.contains(class));
+    }
+
+    let mut candidate_base_counts: FxHashMap<Name, (usize, bool)> = FxHashMap::default();
+    for base in direct_bases {
+        let mut base_names: FxHashMap<Name, bool> = FxHashMap::default();
+        for class in base.iter_mro(db).filter_map(ClassBase::into_class) {
+            let is_distinct_branch = !common_classes.contains(&class);
+
+            #[expect(
+                clippy::iter_over_hash_type,
+                reason = "candidate names are sorted before diagnostics are emitted"
+            )]
+            for name in own_class_member_names(db, class) {
+                base_names
+                    .entry(name)
+                    .and_modify(|is_branch| *is_branch |= is_distinct_branch)
+                    .or_insert(is_distinct_branch);
+            }
+        }
+
         #[expect(
             clippy::iter_over_hash_type,
             reason = "candidate names are sorted before diagnostics are emitted"
         )]
-        for name in all_class_member_names(db, *base) {
-            candidate_bases.entry(name).or_default().push(base_index);
+        for (name, is_distinct_branch) in base_names {
+            let (base_count, has_distinct_branch) = candidate_base_counts.entry(name).or_default();
+            *base_count += 1;
+            *has_distinct_branch |= is_distinct_branch;
         }
     }
 
-    let mut candidates: Vec<_> = candidate_bases
+    let mut candidates: Vec<_> = candidate_base_counts
         .into_iter()
-        .filter(|(_, bases)| bases.len() > 1)
+        .filter_map(|(name, (base_count, has_distinct_branch))| {
+            (base_count > 1 && has_distinct_branch).then_some(name)
+        })
         .collect();
-    candidates.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+    candidates.sort_unstable();
     candidates
 }
 
@@ -319,13 +363,12 @@ fn is_enum_rewritten_method<'db>(
 ) -> bool {
     let name_str = name.as_str();
 
-    if Program::get(db).python_version(db) >= PythonVersion::PY311
+    if matches!(
+        name_str,
+        "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
+    ) && Program::get(db).python_version(db) >= PythonVersion::PY311
         && Type::ClassLiteral(ClassLiteral::Static(class))
             .is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
-        && matches!(
-            name_str,
-            "__or__" | "__and__" | "__xor__" | "__ror__" | "__rand__" | "__rxor__" | "__invert__"
-        )
     {
         return true;
     }
@@ -347,7 +390,8 @@ fn is_enum_rewritten_method<'db>(
     }
 
     data_type.is_some_and(|data_type| {
-        defining_class_for_member(db, data_type, name) == Some(override_owner)
+        defining_class_for_member(db, data_type, name)
+            .is_some_and(|member| member.owner == override_owner)
     })
 }
 
@@ -441,29 +485,51 @@ fn enum_data_type_in_base_mro<'db>(
     None
 }
 
-/// Returns the class that provides the effective class member with the given name.
+#[derive(Clone, Copy)]
+struct DefiningClassMember<'db> {
+    owner: ClassType<'db>,
+    raw_type: Option<Type<'db>>,
+}
+
+impl<'db> DefiningClassMember<'db> {
+    fn has_dynamic_contract(self) -> bool {
+        matches!(self.raw_type, Some(Type::Dynamic(_) | Type::Divergent(_)))
+    }
+
+    /// Returns `true` if descriptor binding could produce a callable member.
+    fn may_produce_callable(self, db: &'db dyn Db) -> bool {
+        let Some(raw_type) = self.raw_type else {
+            return true;
+        };
+
+        raw_type.try_upcast_to_callable(db).is_some()
+            || (!matches!(
+                raw_type,
+                Type::Dynamic(_) | Type::Divergent(_) | Type::Never
+            ) && !raw_type
+                .class_member(db, "__get__".into())
+                .place
+                .is_undefined())
+    }
+}
+
+/// Returns the class that provides the effective class member with the given name and the member's
+/// raw type before descriptor binding.
 fn defining_class_for_member<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
     name: &Name,
-) -> Option<ClassType<'db>> {
+) -> Option<DefiningClassMember<'db>> {
     class
         .iter_mro(db)
         .filter_map(ClassBase::into_class)
-        .find(|candidate| !candidate.own_class_member(db, None, name).is_undefined())
-}
-
-/// Returns `true` when the defining class does not provide a statically known contract for
-/// `name`.
-fn has_dynamic_member_contract<'db>(db: &'db dyn Db, owner: ClassType<'db>, name: &Name) -> bool {
-    matches!(
-        owner
-            .own_class_member(db, None, name)
-            .inner
-            .place
-            .raw_type(),
-        Some(Type::Dynamic(_) | Type::Divergent(_))
-    )
+        .find_map(|owner| {
+            let member = owner.own_class_member(db, None, name);
+            (!member.is_undefined()).then(|| DefiningClassMember {
+                owner,
+                raw_type: member.inner.place.raw_type(),
+            })
+        })
 }
 
 /// Returns the source definition if `class` defines `name` as a method.

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -15,8 +15,8 @@ use crate::{
     lint::LintId,
     place::{DefinedPlace, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
-        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, Parameter, Parameters,
-        Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
+        CallableType, ClassBase, ClassLiteral, ClassType, KnownClass, MemberLookupPolicy,
+        Parameter, Parameters, Signature, StaticClassLiteral, Type, TypeContext, TypeQualifiers,
         call::CallArguments,
         class::{CodeGeneratorKind, FieldKind},
         constraints::ConstraintSetBuilder,
@@ -189,7 +189,12 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             };
             let Some(overridden_type) = base_instance
-                .member(db, &member)
+                .member_lookup_with_policy_and_receiver(
+                    db,
+                    member.clone(),
+                    MemberLookupPolicy::default(),
+                    Some(class_instance),
+                )
                 .place
                 .ignore_possibly_undefined()
             else {
@@ -554,8 +559,13 @@ fn check_class_declaration<'db>(
                     .unwrap_or_default();
             }
 
-            let superclass_instance_member =
-                Type::instance(db, superclass).member(db, &member.name);
+            let superclass_instance_member = Type::instance(db, superclass)
+                .member_lookup_with_policy_and_receiver(
+                    db,
+                    member.name.clone(),
+                    MemberLookupPolicy::default(),
+                    Some(instance_of_class),
+                );
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -178,15 +178,10 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             }
 
-            let Some(overridden_type) = base_instance
-                .member_lookup_with_policy_and_receiver(
-                    db,
-                    member.clone(),
-                    MemberLookupPolicy::default(),
-                    Some(class_instance),
-                )
-                .place
-                .ignore_possibly_undefined()
+            let Some(overridden_type) =
+                member_with_receiver_if_needed(db, base_instance, class_instance, &member)
+                    .place
+                    .ignore_possibly_undefined()
             else {
                 continue;
             };
@@ -224,6 +219,50 @@ fn check_inherited_method_conflicts<'db>(
             );
             continue 'members;
         }
+    }
+}
+
+/// Looks up `name` on `instance`, binding receiver-sensitive signatures to `receiver`.
+///
+/// Most method signatures are independent of the concrete receiver. Reusing the ordinary member
+/// lookup for those methods avoids retaining a separate Salsa query result for every subclass.
+fn member_with_receiver_if_needed<'db>(
+    db: &'db dyn Db,
+    instance: Type<'db>,
+    receiver: Type<'db>,
+    name: &Name,
+) -> PlaceAndQualifiers<'db> {
+    let member = instance.member(db, name);
+    if !member
+        .place
+        .raw_type()
+        .is_some_and(|ty| contains_receiver_sensitive_bound_method(db, ty))
+    {
+        return member;
+    }
+
+    instance.member_lookup_with_policy_and_receiver(
+        db,
+        name.clone(),
+        MemberLookupPolicy::default(),
+        Some(receiver),
+    )
+}
+
+fn contains_receiver_sensitive_bound_method<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::BoundMethod(method) => method.function(db).signature(db).is_receiver_sensitive(db),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .copied()
+            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .copied()
+            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
+        _ => false,
     }
 }
 
@@ -300,16 +339,14 @@ fn inherited_conflict_already_reported<'db>(
     if override_type.try_upcast_to_callable(db).is_none() {
         return false;
     }
-    let Some(overridden_type) = Type::instance(db, overridden_ancestor)
-        .member_lookup_with_policy_and_receiver(
-            db,
-            name.clone(),
-            MemberLookupPolicy::default(),
-            Some(owner_instance),
-        )
-        .place
-        .ignore_possibly_undefined()
-    else {
+    let Some(overridden_type) = member_with_receiver_if_needed(
+        db,
+        Type::instance(db, overridden_ancestor),
+        owner_instance,
+        name,
+    )
+    .place
+    .ignore_possibly_undefined() else {
         return false;
     };
     let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
@@ -600,13 +637,12 @@ fn check_class_declaration<'db>(
                     .unwrap_or_default();
             }
 
-            let superclass_instance_member = Type::instance(db, superclass)
-                .member_lookup_with_policy_and_receiver(
-                    db,
-                    member.name.clone(),
-                    MemberLookupPolicy::default(),
-                    Some(instance_of_class),
-                );
+            let superclass_instance_member = member_with_receiver_if_needed(
+                db,
+                Type::instance(db, superclass),
+                instance_of_class,
+                &member.name,
+            );
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -17,9 +17,10 @@ use crate::{
     },
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, CallableType, ClassBase, ClassType,
-        ErrorContext, FindLegacyTypeVarsVisitor, InstanceFallbackShadowsNonDataDescriptor,
-        KnownFunction, MemberLookupPolicy, PropertyInstanceType, ProtocolInstanceType, Signature,
-        StaticClassLiteral, Type, TypeMapping, TypeQualifiers, TypeVarVariance, VarianceInferable,
+        DescriptorBinding, ErrorContext, FindLegacyTypeVarsVisitor,
+        InstanceFallbackShadowsNonDataDescriptor, KnownFunction, MemberLookupPolicy,
+        PropertyInstanceType, ProtocolInstanceType, Signature, StaticClassLiteral, Type,
+        TypeMapping, TypeQualifiers, TypeVarVariance, VarianceInferable,
         constraints::{ConstraintSet, IteratorConstraintsExtension, OptionConstraintsExtension},
         context::InferContext,
         diagnostic::report_undeclared_protocol_member,
@@ -705,7 +706,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     }) = ty
                         .invoke_descriptor_protocol(
                             db,
-                            ty,
+                            DescriptorBinding {
+                                receiver: ty,
+                                owner: ty.to_meta_type(db),
+                            },
                             member.name,
                             Place::Undefined.into(),
                             InstanceFallbackShadowsNonDataDescriptor::No,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -133,6 +133,16 @@ impl<'db> PartialSignatureApplication<'db> {
 }
 
 impl<'db> CallableSignature<'db> {
+    /// Returns `true` if binding this callable to a different receiver can change its signatures.
+    pub(crate) fn is_receiver_sensitive(&self, db: &'db dyn Db) -> bool {
+        let has_multiple_overloads = self.overloads.len() > 1;
+        self.overloads.iter().any(|signature| {
+            signature.needs_self_mapping(db, false)
+                || (has_multiple_overloads
+                    && signature.has_explicit_positional_receiver_annotation())
+        })
+    }
+
     pub(crate) fn single(signature: Signature<'db>) -> Self {
         Self {
             overloads: smallvec_inline![signature],


### PR DESCRIPTION
## Summary

The `invalid-method-override` rule currently checks methods defined explicitly on a subclass, but does not catch incompatible methods inherited from separate bases:

```python
class A:
    def f(self) -> str: ...

class B:
    def f(self) -> int: ...

class C(A, B): ...  # error: invalid-method-override
```

Python resolves `C.f` to `A.f`, but `C` is also a subtype of `B` and must satisfy the contract of `B.f`.

This resolves each effective inherited method on the new class, binds it using the new class as the receiver, and compares it against the corresponding contract from every direct base. Source definitions improve the diagnostic annotations when available, but are not required for the semantic check. This covers ordinary dunder methods, assigned and descriptor-produced methods, and synthesized methods from constructs such as `NamedTuple` and dataclasses.

To keep the check bounded, we first collect names exposed by at least two direct bases, reuse the normal cached member lookup for receiver-independent methods, and perform an explicit receiver-aware lookup only when binding can change the result. Cascade suppression rechecks the method on its defining owner instead of relying on nominal ancestry alone, preserving conflicts that only appear on a final receiver-specific subclass. Enum methods are exempted only when Enum construction actually rewrites that method.

Closes https://github.com/astral-sh/ty/issues/3751.
