### PR TITLE
[refurb] Avoid FURB142 fix when loop variable is used afterwards

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB142.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB142.py
@@ -65,6 +65,10 @@ for x in (1, 2, 3):
 else:
     pass
 
+# x is used outside the loop. Don't flag.
+for x in (1, 2, 3):
+    s.add(x)
+print(x)
 
 async def f(y):
     async for x in y:

--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB142_shadow.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB142_shadow.py
@@ -1,0 +1,4 @@
+# Don't fix when loop variable shadows a non-LoopVar outer binding
+x = 0
+for x in (1, 2, 3):
+    s.add(x)

--- a/crates/ruff_linter/src/rules/refurb/helpers.rs
+++ b/crates/ruff_linter/src/rules/refurb/helpers.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use ruff_python_ast::PythonVersion;
+use ruff_python_ast::{ExprList, ExprName, ExprTuple, PythonVersion};
 use ruff_python_ast::{self as ast, Expr, name::Name, token::parenthesized_range};
 use ruff_python_codegen::Generator;
-use ruff_python_semantic::{ResolvedReference, SemanticModel};
-use ruff_text_size::{Ranged, TextRange};
+use ruff_python_semantic::{ResolvedReference, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::checkers::ast::Checker;
 use crate::rules::flake8_async::rules::blocking_open_call::is_open_call_from_pathlib;
@@ -449,6 +449,105 @@ pub(super) fn parenthesize_loop_iter_if_necessary<'a>(
         }
         _ => Cow::Borrowed(iter_in_source),
     }
+}
+
+/// Find the names in a `for` loop target
+/// that are assigned to during iteration.
+///
+/// ```python
+/// for ((), [(a,), [[b]]], c.d, e[f], *[*g]) in h:
+///     #      ^      ^                   ^
+///     ...
+/// ```
+pub(super) fn binding_names(for_target: &Expr) -> Vec<&ExprName> {
+    fn collect_names<'a>(expr: &'a Expr, names: &mut Vec<&'a ExprName>) {
+        match expr {
+            Expr::Name(name) => names.push(name),
+
+            Expr::Starred(starred) => collect_names(&starred.value, names),
+
+            Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. }) => elts
+                .iter()
+                .for_each(|element| collect_names(element, names)),
+
+            _ => {}
+        }
+    }
+
+    let mut names = vec![];
+    collect_names(for_target, &mut names);
+    names
+}
+
+/// Detects if loop variables are used outside the loop. E.g.
+/// 
+/// ```python
+/// for a in [1, 2, 3]:
+///     print(a + 1)
+/// print(a)  # `a` is used outside the loop
+/// ```
+/// 
+/// ```python
+/// a = 1
+/// for a in [1, 2, 3]: # here loop variable `a` shadows the outer `a` and changes its value.
+///     print(a + 1)
+/// # a = 3 here
+/// ```
+pub(super) fn loop_variables_are_used_outside_loop(
+    binding_names: &[&ExprName],
+    loop_range: TextRange,
+    semantic: &SemanticModel,
+    scope_id: ScopeId,
+) -> bool {
+    let find_binding_id = |name: &ExprName, offset: TextSize| {
+        semantic.simulate_runtime_load_at_location_in_scope(
+            name.id.as_str(),
+            TextRange::at(offset, 0.into()),
+            scope_id,
+            TypingOnlyBindingsStatus::Disallowed,
+        )
+    };
+
+    // If the load simulation succeeds at the position right before the loop,
+    // that binding is shadowed.
+    // ```python
+    //   a = 1
+    //   for a in b: ...
+    // # ^ Load here
+    // ```
+    let name_overwrites_outer = |name: &ExprName| {
+    let Some(id) = find_binding_id(name, loop_range.start()) else {
+            return false;
+        };
+        !semantic.binding(id).kind.is_loop_var()
+    };
+
+    let name_is_used_later = |name: &ExprName| {
+        let Some(binding_id) = semantic.resolve_name(name) else {
+            return false;
+        };
+
+        let binding = semantic.binding(binding_id);
+        
+        // verify this binding belongs to THIS loop (not a different for x)
+        if !name.range().contains_range(binding.range) {
+            return false;
+        }
+
+        for reference_id in semantic.binding(binding_id).references() {
+            let reference = semantic.reference(reference_id);
+
+            if !loop_range.contains_range(reference.range()) {
+                return true;
+            }
+        }
+
+        false
+    };
+
+    binding_names
+        .iter()
+        .any(|name| name_overwrites_outer(name) || name_is_used_later(name))
 }
 
 #[derive(Copy, Clone)]

--- a/crates/ruff_linter/src/rules/refurb/mod.rs
+++ b/crates/ruff_linter/src/rules/refurb/mod.rs
@@ -28,6 +28,7 @@ mod tests {
     #[test_case(Rule::IfExprMinMax, Path::new("FURB136.py"))]
     #[test_case(Rule::ReimplementedStarmap, Path::new("FURB140.py"))]
     #[test_case(Rule::ForLoopSetMutations, Path::new("FURB142.py"))]
+    #[test_case(Rule::ForLoopSetMutations, Path::new("FURB142_shadow.py"))]
     #[test_case(Rule::SliceCopy, Path::new("FURB145.py"))]
     #[test_case(Rule::UnnecessaryEnumerate, Path::new("FURB148.py"))]
     #[test_case(Rule::MathConstant, Path::new("FURB152.py"))]

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_set_mutations.rs
@@ -3,7 +3,7 @@ use ruff_python_ast::{Expr, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 
 use crate::checkers::ast::Checker;
-use crate::rules::refurb::helpers::IterLocation;
+use crate::rules::refurb::helpers::{IterLocation, binding_names, loop_variables_are_used_outside_loop};
 use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 
 use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
@@ -101,6 +101,12 @@ pub(crate) fn for_loop_set_mutations(checker: &Checker, for_stmt: &StmtFor) {
     let [arg] = expr_call.arguments.args.as_ref() else {
         return;
     };
+
+    let binding_names = binding_names(&for_stmt.target);
+
+    if loop_variables_are_used_outside_loop(&binding_names, for_stmt.range, checker.semantic(), checker.semantic().scope_id) {
+        return;
+    }
 
     let locator = checker.locator();
     let content = match (for_stmt.target.as_ref(), arg) {

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -1,11 +1,11 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{Expr, ExprList, ExprName, ExprTuple, Stmt, StmtFor};
+use ruff_python_ast::{Expr, ExprName, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
-use ruff_python_semantic::{Binding, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
-use ruff_text_size::{Ranged, TextRange, TextSize};
+use ruff_python_semantic::{Binding, ScopeId};
+use ruff_text_size::Ranged;
 
 use crate::checkers::ast::Checker;
-use crate::rules::refurb::helpers::IterLocation;
+use crate::rules::refurb::helpers::{IterLocation, binding_names, loop_variables_are_used_outside_loop};
 use crate::{AlwaysFixableViolation, Applicability, Edit, Fix};
 
 use crate::rules::refurb::helpers::parenthesize_loop_iter_if_necessary;
@@ -106,34 +106,6 @@ pub(crate) fn for_loop_writes_stmt(checker: &Checker, for_stmt: &StmtFor) {
     for_loop_writes(checker, for_stmt, scope_id, &[]);
 }
 
-/// Find the names in a `for` loop target
-/// that are assigned to during iteration.
-///
-/// ```python
-/// for ((), [(a,), [[b]]], c.d, e[f], *[*g]) in h:
-///     #      ^      ^                   ^
-///     ...
-/// ```
-fn binding_names(for_target: &Expr) -> Vec<&ExprName> {
-    fn collect_names<'a>(expr: &'a Expr, names: &mut Vec<&'a ExprName>) {
-        match expr {
-            Expr::Name(name) => names.push(name),
-
-            Expr::Starred(starred) => collect_names(&starred.value, names),
-
-            Expr::List(ExprList { elts, .. }) | Expr::Tuple(ExprTuple { elts, .. }) => elts
-                .iter()
-                .for_each(|element| collect_names(element, names)),
-
-            _ => {}
-        }
-    }
-
-    let mut names = vec![];
-    collect_names(for_target, &mut names);
-    names
-}
-
 /// FURB122
 fn for_loop_writes(
     checker: &Checker,
@@ -223,50 +195,4 @@ fn for_loop_writes(
             for_stmt.range,
         )
         .set_fix(fix);
-}
-
-fn loop_variables_are_used_outside_loop(
-    binding_names: &[&ExprName],
-    loop_range: TextRange,
-    semantic: &SemanticModel,
-    scope_id: ScopeId,
-) -> bool {
-    let find_binding_id = |name: &ExprName, offset: TextSize| {
-        semantic.simulate_runtime_load_at_location_in_scope(
-            name.id.as_str(),
-            TextRange::at(offset, 0.into()),
-            scope_id,
-            TypingOnlyBindingsStatus::Disallowed,
-        )
-    };
-
-    // If the load simulation succeeds at the position right before the loop,
-    // that binding is shadowed.
-    // ```python
-    //   a = 1
-    //   for a in b: ...
-    // # ^ Load here
-    // ```
-    let name_overwrites_outer =
-        |name: &ExprName| find_binding_id(name, loop_range.start()).is_some();
-
-    let name_is_used_later = |name: &ExprName| {
-        let Some(binding_id) = find_binding_id(name, loop_range.end()) else {
-            return false;
-        };
-
-        for reference_id in semantic.binding(binding_id).references() {
-            let reference = semantic.reference(reference_id);
-
-            if !loop_range.contains_range(reference.range()) {
-                return true;
-            }
-        }
-
-        false
-    };
-
-    binding_names
-        .iter()
-        .any(|name| name_overwrites_outer(name) || name_is_used_later(name))
 }

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap.new
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap.new
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/refurb/mod.rs
+assertion_line: 66
 ---
 FURB122 [*] Use of `f.write` in a for loop
   --> FURB122.py:10:9

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142.py.snap
@@ -270,169 +270,189 @@ help: Replace with `.update()`
 47 | # False negative
 note: This is an unsafe fix and may change runtime behavior
 
-FURB142 [*] Use of `set.discard()` in a for loop
-  --> FURB142.py:83:1
+FURB142 [*] Use of `set.add()` in a for loop
+  --> FURB142.py:69:1
    |
-81 |   s = set()
-82 |
-83 | / for x in lambda: 0:
-84 | |     s.discard(-x)
+68 |   # x is used outside the loop. Don't flag.
+69 | / for x in (1, 2, 3):
+70 | |     s.add(x)
+   | |____________^
+71 |   print(x)
+   |
+help: Replace with `.update()`
+66 |     pass
+67 |
+68 | # x is used outside the loop. Don't flag.
+   - for x in (1, 2, 3):
+   -     s.add(x)
+69 + s.update((1, 2, 3))
+70 | print(x)
+71 |
+72 | async def f(y):
+
+FURB142 [*] Use of `set.discard()` in a for loop
+  --> FURB142.py:87:1
+   |
+85 |   s = set()
+86 |
+87 | / for x in lambda: 0:
+88 | |     s.discard(-x)
    | |_________________^
-85 |
-86 |   for x in (1,) if True else (2,):
+89 |
+90 |   for x in (1,) if True else (2,):
    |
 help: Replace with `.difference_update()`
-80 |
-81 | s = set()
-82 |
+84 |
+85 | s = set()
+86 |
    - for x in lambda: 0:
    -     s.discard(-x)
-83 + s.difference_update(-x for x in (lambda: 0))
-84 |
-85 | for x in (1,) if True else (2,):
-86 |     s.add(-x)
+87 + s.difference_update(-x for x in (lambda: 0))
+88 |
+89 | for x in (1,) if True else (2,):
+90 |     s.add(-x)
 
 FURB142 [*] Use of `set.add()` in a for loop
-  --> FURB142.py:86:1
-   |
-84 |       s.discard(-x)
-85 |
-86 | / for x in (1,) if True else (2,):
-87 | |     s.add(-x)
-   | |_____________^
-88 |
-89 |   # don't add extra parens
-   |
-help: Replace with `.update()`
-83 | for x in lambda: 0:
-84 |     s.discard(-x)
-85 |
-   - for x in (1,) if True else (2,):
-   -     s.add(-x)
-86 + s.update(-x for x in ((1,) if True else (2,)))
-87 |
-88 | # don't add extra parens
-89 | for x in (lambda: 0):
-
-FURB142 [*] Use of `set.discard()` in a for loop
   --> FURB142.py:90:1
    |
-89 |   # don't add extra parens
-90 | / for x in (lambda: 0):
-91 | |     s.discard(-x)
-   | |_________________^
-92 |
-93 |   for x in ((1,) if True else (2,)):
-   |
-help: Replace with `.difference_update()`
-87 |     s.add(-x)
-88 |
-89 | # don't add extra parens
-   - for x in (lambda: 0):
-   -     s.discard(-x)
-90 + s.difference_update(-x for x in (lambda: 0))
-91 |
-92 | for x in ((1,) if True else (2,)):
-93 |     s.add(-x)
-
-FURB142 [*] Use of `set.add()` in a for loop
-  --> FURB142.py:93:1
-   |
-91 |       s.discard(-x)
-92 |
-93 | / for x in ((1,) if True else (2,)):
-94 | |     s.add(-x)
+88 |       s.discard(-x)
+89 |
+90 | / for x in (1,) if True else (2,):
+91 | |     s.add(-x)
    | |_____________^
-95 |
-96 |   # don't add parens directly in function call
+92 |
+93 |   # don't add extra parens
    |
 help: Replace with `.update()`
-90 | for x in (lambda: 0):
-91 |     s.discard(-x)
-92 |
-   - for x in ((1,) if True else (2,)):
+87 | for x in lambda: 0:
+88 |     s.discard(-x)
+89 |
+   - for x in (1,) if True else (2,):
    -     s.add(-x)
-93 + s.update(-x for x in ((1,) if True else (2,)))
-94 |
-95 | # don't add parens directly in function call
-96 | for x in lambda: 0:
+90 + s.update(-x for x in ((1,) if True else (2,)))
+91 |
+92 | # don't add extra parens
+93 | for x in (lambda: 0):
 
 FURB142 [*] Use of `set.discard()` in a for loop
-   --> FURB142.py:97:1
-    |
- 96 |   # don't add parens directly in function call
- 97 | / for x in lambda: 0:
- 98 | |     s.discard(x)
-    | |________________^
- 99 |
-100 |   for x in (1,) if True else (2,):
-    |
+  --> FURB142.py:94:1
+   |
+93 |   # don't add extra parens
+94 | / for x in (lambda: 0):
+95 | |     s.discard(-x)
+   | |_________________^
+96 |
+97 |   for x in ((1,) if True else (2,)):
+   |
 help: Replace with `.difference_update()`
-94  |     s.add(-x)
-95  |
-96  | # don't add parens directly in function call
-    - for x in lambda: 0:
-    -     s.discard(x)
-97  + s.difference_update(lambda: 0)
-98  |
-99  | for x in (1,) if True else (2,):
-100 |     s.add(x)
+91 |     s.add(-x)
+92 |
+93 | # don't add extra parens
+   - for x in (lambda: 0):
+   -     s.discard(-x)
+94 + s.difference_update(-x for x in (lambda: 0))
+95 |
+96 | for x in ((1,) if True else (2,)):
+97 |     s.add(-x)
 
 FURB142 [*] Use of `set.add()` in a for loop
-   --> FURB142.py:100:1
+   --> FURB142.py:97:1
     |
- 98 |       s.discard(x)
+ 95 |       s.discard(-x)
+ 96 |
+ 97 | / for x in ((1,) if True else (2,)):
+ 98 | |     s.add(-x)
+    | |_____________^
  99 |
-100 | / for x in (1,) if True else (2,):
-101 | |     s.add(x)
-    | |____________^
-102 |
-103 |   # https://github.com/astral-sh/ruff/issues/21098
+100 |   # don't add parens directly in function call
     |
 help: Replace with `.update()`
-97  | for x in lambda: 0:
-98  |     s.discard(x)
+94  | for x in (lambda: 0):
+95  |     s.discard(-x)
+96  |
+    - for x in ((1,) if True else (2,)):
+    -     s.add(-x)
+97  + s.update(-x for x in ((1,) if True else (2,)))
+98  |
+99  | # don't add parens directly in function call
+100 | for x in lambda: 0:
+
+FURB142 [*] Use of `set.discard()` in a for loop
+   --> FURB142.py:101:1
+    |
+100 |   # don't add parens directly in function call
+101 | / for x in lambda: 0:
+102 | |     s.discard(x)
+    | |________________^
+103 |
+104 |   for x in (1,) if True else (2,):
+    |
+help: Replace with `.difference_update()`
+98  |     s.add(-x)
 99  |
-    - for x in (1,) if True else (2,):
-    -     s.add(x)
-100 + s.update((1,) if True else (2,))
-101 |
-102 | # https://github.com/astral-sh/ruff/issues/21098
-103 | for x in ("abc", "def"):
+100 | # don't add parens directly in function call
+    - for x in lambda: 0:
+    -     s.discard(x)
+101 + s.difference_update(lambda: 0)
+102 |
+103 | for x in (1,) if True else (2,):
+104 |     s.add(x)
 
 FURB142 [*] Use of `set.add()` in a for loop
    --> FURB142.py:104:1
     |
-103 |   # https://github.com/astral-sh/ruff/issues/21098
-104 | / for x in ("abc", "def"):
-105 | |     s.add(c for c in x)
-    | |_______________________^
+102 |       s.discard(x)
+103 |
+104 | / for x in (1,) if True else (2,):
+105 | |     s.add(x)
+    | |____________^
 106 |
-107 |   # don't add extra parens for already parenthesized generators
+107 |   # https://github.com/astral-sh/ruff/issues/21098
     |
 help: Replace with `.update()`
-101 |     s.add(x)
-102 |
-103 | # https://github.com/astral-sh/ruff/issues/21098
-    - for x in ("abc", "def"):
-    -     s.add(c for c in x)
-104 + s.update((c for c in x) for x in ("abc", "def"))
+101 | for x in lambda: 0:
+102 |     s.discard(x)
+103 |
+    - for x in (1,) if True else (2,):
+    -     s.add(x)
+104 + s.update((1,) if True else (2,))
 105 |
-106 | # don't add extra parens for already parenthesized generators
+106 | # https://github.com/astral-sh/ruff/issues/21098
 107 | for x in ("abc", "def"):
 
 FURB142 [*] Use of `set.add()` in a for loop
    --> FURB142.py:108:1
     |
-107 |   # don't add extra parens for already parenthesized generators
+107 |   # https://github.com/astral-sh/ruff/issues/21098
 108 | / for x in ("abc", "def"):
-109 | |     s.add((c for c in x))
+109 | |     s.add(c for c in x)
+    | |_______________________^
+110 |
+111 |   # don't add extra parens for already parenthesized generators
+    |
+help: Replace with `.update()`
+105 |     s.add(x)
+106 |
+107 | # https://github.com/astral-sh/ruff/issues/21098
+    - for x in ("abc", "def"):
+    -     s.add(c for c in x)
+108 + s.update((c for c in x) for x in ("abc", "def"))
+109 |
+110 | # don't add extra parens for already parenthesized generators
+111 | for x in ("abc", "def"):
+
+FURB142 [*] Use of `set.add()` in a for loop
+   --> FURB142.py:112:1
+    |
+111 |   # don't add extra parens for already parenthesized generators
+112 | / for x in ("abc", "def"):
+113 | |     s.add((c for c in x))
     | |_________________________^
     |
 help: Replace with `.update()`
-105 |     s.add(c for c in x)
-106 |
-107 | # don't add extra parens for already parenthesized generators
+109 |     s.add(c for c in x)
+110 |
+111 | # don't add extra parens for already parenthesized generators
     - for x in ("abc", "def"):
     -     s.add((c for c in x))
-108 + s.update((c for c in x) for x in ("abc", "def"))
+112 + s.update((c for c in x) for x in ("abc", "def"))

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142_shadow.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB142_FURB142_shadow.py.snap
@@ -1,0 +1,4 @@
+---
+source: crates/ruff_linter/src/rules/refurb/mod.rs
+---
+


### PR DESCRIPTION
## Summary

Resolves #18575.

The fix for `for-loop-set-mutations` [FURB142](https://docs.astral.sh/ruff/rules/for-loop-set-mutations/) transforms a `for` loop like `for x in items: s.add(x)` into `s.update(items)`, removing the `for` statement entirely. If the loop variable `x` is referenced after the loop, this fix silently deletes the binding, causing a `NameError` — or silently changes which outer variable `x` refers to.

The same check already exists in the sister rule FURB122 (`for-loop-writes`). This PR moves `binding_names` and `loop_variables_are_used_outside_loop` from `for_loop_writes.rs` to `refurb/helpers.rs` and reuses them in FURB142.

Additionally, `name_overwrites_outer` is fixed to ignore peer `LoopVar` bindings in the same scope. Without this, consecutive `for x` loops in the same function incorrectly block each other's fixes because the first loop's `x` binding is still visible at the position before the second loop.

## Test Plan

- Updated `FURB142.py` snapshot: all `for x` loops now receive fixes (previously only the first one was fixed)
- Added `FURB142_shadow.py` fixture: verifies fix is skipped when loop variable shadows a non-LoopVar outer binding
- FURB122 snapshot updated for the `name_overwrites_outer` change