### PR TITLE
Mark PLE0241 duplicate-bases fix as always unsafe

### DIFF
--- a/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/duplicate_bases.rs
@@ -36,21 +36,9 @@ use crate::{Fix, FixAvailability, Violation};
 /// ```
 ///
 /// ## Fix safety
-/// This rule's fix is marked as unsafe if there's comments in the
-/// base classes, as comments may be removed.
-///
-/// For example, the fix would be marked as unsafe in the following case:
-/// ```python
-/// class Foo:
-///     pass
-///
-///
-/// class Bar(
-///     Foo,  # comment
-///     Foo,
-/// ):
-///     pass
-/// ```
+/// This rule's fix is marked as unsafe because removing duplicate base
+/// classes can change runtime behavior even when the duplicate appears
+/// redundant.
 ///
 /// ## References
 /// - [Python documentation: Class definitions](https://docs.python.org/3/reference/compound_stmts.html#class-definitions)
@@ -102,14 +90,7 @@ pub(crate) fn duplicate_bases(checker: &Checker, name: &str, arguments: Option<&
                         checker.tokens(),
                     )
                     .map(|edit| {
-                        Fix::applicable_edit(
-                            edit,
-                            if checker.comment_ranges().intersects(arguments.range()) {
-                                Applicability::Unsafe
-                            } else {
-                                Applicability::Safe
-                            },
-                        )
+                        Fix::applicable_edit(edit, Applicability::Unsafe)
                     })
                 });
             }

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0241_duplicate_bases.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLE0241_duplicate_bases.py.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ruff_linter/src/rules/pylint/mod.rs
+assertion_line: 260
 ---
 PLE0241 [*] Duplicate base `A` for class `F1`
   --> duplicate_bases.py:13:13
@@ -18,6 +19,7 @@ help: Remove duplicate base
 14 |     ...
 15 |
 16 |
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `F2`
   --> duplicate_bases.py:17:13
@@ -35,6 +37,7 @@ help: Remove duplicate base
 18 |     ...
 19 |
 20 |
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `F3`
   --> duplicate_bases.py:23:5
@@ -54,6 +57,7 @@ help: Remove duplicate base
 22 |     A
 23 | ):
 24 |     ...
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `F4`
   --> duplicate_bases.py:30:5
@@ -73,6 +77,7 @@ help: Remove duplicate base
 30 | ):
 31 |     ...
 32 |
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `G1`
   --> duplicate_bases.py:36:13
@@ -91,6 +96,7 @@ help: Remove duplicate base
 37 |     ...
 38 |
 39 |
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `G2`
   --> duplicate_bases.py:40:13
@@ -108,6 +114,7 @@ help: Remove duplicate base
 41 |     ...
 42 |
 43 |
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `G3`
   --> duplicate_bases.py:46:5
@@ -127,6 +134,7 @@ help: Remove duplicate base
 46 |     B
 47 | ):
 48 |     ...
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `A` for class `G4`
   --> duplicate_bases.py:54:5
@@ -146,6 +154,7 @@ help: Remove duplicate base
 54 |     B,
 55 | ):
 56 |     ...
+note: This is an unsafe fix and may change runtime behavior
 
 PLE0241 [*] Duplicate base `Foo` for class `Bar`
   --> duplicate_bases.py:76:5


### PR DESCRIPTION
## Summary

Fixes #18712

Removing duplicate base classes changes runtime behavior. For example, `class C(int, int): ...` raises `TypeError: duplicate base class int` at runtime, but after the autofix the module imports successfully.

Previously the fix was marked safe when base classes had no comments; it should always be unsafe.

## Test plan

- Updated PLE0241 snapshot to include unsafe-fix notes
- `cargo test -p ruff_linter duplicate_bases`