### PR TITLE
[ty] Avoid caching receiver-independent override lookups

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -665,6 +665,18 @@ class OtherReceiverPath(ReceiverOverloads): ...
 # The receiver-specific overload only applies after the two paths meet again.
 class FinalReceiver(ReceiverOverride, OtherReceiverPath): ...  # error: [invalid-method-override]
 
+condition: bool
+
+class ConditionalSelfMethod:
+    if condition:
+        def copy(self) -> Self: ...
+
+    else:
+        def copy(self) -> Self: ...
+
+class ConditionalSelfOverride(ConditionalSelfMethod):
+    def copy(self) -> ConditionalSelfMethod: ...  # error: [invalid-method-override]
+
 class BrokenIntReturn(IntReturn):
     def method(self) -> str: ...  # error: [invalid-method-override]
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -178,15 +178,10 @@ fn check_inherited_method_conflicts<'db>(
                 continue;
             }
 
-            let Some(overridden_type) = base_instance
-                .member_lookup_with_policy_and_receiver(
-                    db,
-                    member.clone(),
-                    MemberLookupPolicy::default(),
-                    Some(class_instance),
-                )
-                .place
-                .ignore_possibly_undefined()
+            let Some(overridden_type) =
+                member_with_receiver_if_needed(db, base_instance, class_instance, &member)
+                    .place
+                    .ignore_possibly_undefined()
             else {
                 continue;
             };
@@ -224,6 +219,50 @@ fn check_inherited_method_conflicts<'db>(
             );
             continue 'members;
         }
+    }
+}
+
+/// Looks up `name` on `instance`, binding receiver-sensitive signatures to `receiver`.
+///
+/// Most method signatures are independent of the concrete receiver. Reusing the ordinary member
+/// lookup for those methods avoids retaining a separate Salsa query result for every subclass.
+fn member_with_receiver_if_needed<'db>(
+    db: &'db dyn Db,
+    instance: Type<'db>,
+    receiver: Type<'db>,
+    name: &Name,
+) -> PlaceAndQualifiers<'db> {
+    let member = instance.member(db, name);
+    if !member
+        .place
+        .raw_type()
+        .is_some_and(|ty| contains_receiver_sensitive_bound_method(db, ty))
+    {
+        return member;
+    }
+
+    instance.member_lookup_with_policy_and_receiver(
+        db,
+        name.clone(),
+        MemberLookupPolicy::default(),
+        Some(receiver),
+    )
+}
+
+fn contains_receiver_sensitive_bound_method<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    match ty {
+        Type::BoundMethod(method) => method.function(db).signature(db).is_receiver_sensitive(db),
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .copied()
+            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .copied()
+            .any(|element| contains_receiver_sensitive_bound_method(db, element)),
+        _ => false,
     }
 }
 
@@ -300,16 +339,14 @@ fn inherited_conflict_already_reported<'db>(
     if override_type.try_upcast_to_callable(db).is_none() {
         return false;
     }
-    let Some(overridden_type) = Type::instance(db, overridden_ancestor)
-        .member_lookup_with_policy_and_receiver(
-            db,
-            name.clone(),
-            MemberLookupPolicy::default(),
-            Some(owner_instance),
-        )
-        .place
-        .ignore_possibly_undefined()
-    else {
+    let Some(overridden_type) = member_with_receiver_if_needed(
+        db,
+        Type::instance(db, overridden_ancestor),
+        owner_instance,
+        name,
+    )
+    .place
+    .ignore_possibly_undefined() else {
         return false;
     };
     let Some(overridden_callable) = overridden_type.try_upcast_to_callable(db) else {
@@ -600,13 +637,12 @@ fn check_class_declaration<'db>(
                     .unwrap_or_default();
             }
 
-            let superclass_instance_member = Type::instance(db, superclass)
-                .member_lookup_with_policy_and_receiver(
-                    db,
-                    member.name.clone(),
-                    MemberLookupPolicy::default(),
-                    Some(instance_of_class),
-                );
+            let superclass_instance_member = member_with_receiver_if_needed(
+                db,
+                Type::instance(db, superclass),
+                instance_of_class,
+                &member.name,
+            );
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -133,6 +133,16 @@ impl<'db> PartialSignatureApplication<'db> {
 }
 
 impl<'db> CallableSignature<'db> {
+    /// Returns `true` if binding this callable to a different receiver can change its signatures.
+    pub(crate) fn is_receiver_sensitive(&self, db: &'db dyn Db) -> bool {
+        let has_multiple_overloads = self.overloads.len() > 1;
+        self.overloads.iter().any(|signature| {
+            signature.needs_self_mapping(db, false)
+                || (has_multiple_overloads
+                    && signature.has_explicit_positional_receiver_annotation())
+        })
+    }
+
     pub(crate) fn single(signature: Signature<'db>) -> Self {
         Self {
             overloads: smallvec_inline![signature],


### PR DESCRIPTION
## Summary

This is stacked on #25968.

That PR binds inherited method lookups to the concrete subclass receiver so `Self` annotations and receiver-specific overloads are checked correctly. Applying receiver-aware lookup to every method, however, creates distinct cached Salsa results for each method and subclass even when the method's signature cannot depend on its receiver.

This keeps ordinary member lookup for receiver-independent methods and repeats lookup with the concrete subclass only when a callable contains `Self` or has multiple overloads with explicit receiver annotations. The sensitivity check follows bound methods through union and intersection types so conditionally defined methods retain correct `Self` behavior.

## Memory

Compared with the parent branch on the four memory-report projects, retained memory decreased by 943 kB for Sphinx, 630 kB for Prefect, 97 kB for Trio, and 23 kB for Flake8. The full ty semantic suite remains green.
