### PR TITLE
[ty] Reject legacy TypeVars in PEP 695 class bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/classes.md
@@ -107,6 +107,25 @@ class DoublyInvalid[T](Generic): ...
 reveal_mro(DoublyInvalid)  # revealed: (<class 'DoublyInvalid[Unknown]'>, Unknown, <class 'object'>)
 ```
 
+Legacy type variables also cannot be used to specialize another base class when the class uses PEP
+695 syntax. A PEP 695 type parameter with the same name shadows the legacy type variable.
+
+```py
+K = TypeVar("K")
+
+# error: [invalid-generic-class] "Legacy type variable `K` cannot be used in a PEP 695 class base"
+class Bad[V](dict[K, V]): ...
+class Good[K, V](dict[K, V]): ...
+class Base[T]: ...
+
+# TODO: error: [invalid-generic-class] "Legacy type variable `K` cannot be used in a PEP 695 class base"
+class NormalizedBad[V](Base[K | object]): ...
+
+class Methods[V]:
+    def method(self, value: V, legacy: K) -> V | K:
+        raise NotImplementedError
+```
+
 Generic classes implicitly inherit from `Generic`:
 
 ```py

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -729,6 +729,22 @@ pub(crate) fn check_static_class_definitions<'db>(
 
     // If the class is generic, verify that its generic context does not violate any of
     // the typevar scoping rules.
+    if class.has_pep_695_type_params(db)
+        && let Some(typevar) = class
+            .inherited_legacy_generic_context(db)
+            .and_then(|context| {
+                context
+                    .variables(db)
+                    .find(|typevar| !typevar.typevar(db).is_self(db))
+            })
+        && let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, class_node)
+    {
+        builder.into_diagnostic(format_args!(
+            "Legacy type variable `{}` cannot be used in a PEP 695 class base",
+            typevar.name(db),
+        ));
+    }
+
     if let (Some(legacy), Some(inherited)) = (
         class.legacy_generic_context(db),
         class.inherited_legacy_generic_context(db),

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -730,13 +730,10 @@ pub(crate) fn check_static_class_definitions<'db>(
     // If the class is generic, verify that its generic context does not violate any of
     // the typevar scoping rules.
     if class.has_pep_695_type_params(db)
-        && let Some(typevar) = class
-            .inherited_legacy_generic_context(db)
-            .and_then(|context| {
-                context
-                    .variables(db)
-                    .find(|typevar| !typevar.typevar(db).is_self(db))
-            })
+        && let Some(generic_context) = class.inherited_legacy_generic_context(db)
+        && let Some(typevar) = generic_context
+            .variables(db)
+            .find(|typevar| !typevar.typevar(db).is_self(db))
         && let Some(builder) = context.report_lint(&INVALID_GENERIC_CLASS, class_node)
     {
         builder.into_diagnostic(format_args!(


### PR DESCRIPTION
## Summary

PEP 695 requires classes that use the new type parameter syntax not to introduce traditional type variables through their base classes. Prior to this change, we prioritized the PEP 695 generic context and silently discarded a legacy context inherited from another generic base:

```python
from typing import TypeVar

K = TypeVar("K")

class Bad[V](dict[K, V]): ...
```

This reports `invalid-generic-class` when a PEP 695 class inherits a supported legacy generic context. A PEP 695 parameter with the same name continues to shadow the global TypeVar, and ordinary methods can still use the traditional implicit generic-function mechanism.

Generic base types are normalized before this validation runs, so for those cases, we just leave them as a TODO for now.
