### PR TITLE
[ty] Reject legacy TypeVars in PEP 695 functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -35,6 +35,25 @@ def return_value[T](x: T) -> T:
     return x
 ```
 
+## Compatibility with legacy type variables
+
+A function with its own PEP 695 type parameter list cannot also introduce a legacy type variable.
+Functions without a PEP 695 list can still use the traditional implicit generic-function syntax.
+
+```py
+from typing import TypeVar
+
+K = TypeVar("K")
+
+class C[V]:
+    def legacy(self, value: V, other: K) -> V | K:
+        raise NotImplementedError
+
+    # error: [unbound-type-variable] "Legacy type variable `K` cannot be used in a function with PEP 695 type parameters"
+    def mixed[M](self, value: M, other: K) -> M | K:
+        raise NotImplementedError
+```
+
 Each typevar must also appear _somewhere_ in the parameter list:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -45,6 +45,9 @@ from typing import TypeVar
 
 K = TypeVar("K")
 
+def identity(value: K) -> K:
+    return value
+
 class C[V]:
     def legacy(self, value: V, other: K) -> V | K:
         raise NotImplementedError

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -44,6 +44,7 @@ Functions without a PEP 695 list can still use the traditional implicit generic-
 from typing import TypeVar
 
 K = TypeVar("K")
+L = TypeVar("L")
 
 def identity(value: K) -> K:
     return value
@@ -53,7 +54,8 @@ class C[V]:
         raise NotImplementedError
 
     # error: [unbound-type-variable] "Legacy type variable `K` cannot be used in a function with PEP 695 type parameters"
-    def mixed[M](self, value: M, other: K) -> M | K:
+    # error: [unbound-type-variable] "Legacy type variable `L` cannot be used in a function with PEP 695 type parameters"
+    def mixed[M](self, value: M, other: K, another: L) -> M | K | L:
         raise NotImplementedError
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -61,6 +61,21 @@ reveal_type(Valid[int, str, None]())  # revealed: Valid[int, str, None]
 class Invalid[S = T]: ...
 ```
 
+Traditional type variables cannot be used as defaults for functions with PEP 695 type parameters:
+
+```py
+from typing import ParamSpec, TypeVar
+
+K = TypeVar("K")
+P = ParamSpec("P")
+
+# error: [unbound-type-variable] "Legacy type variable `K` cannot be used in a function with PEP 695 type parameters"
+def legacy_default[T = K](): ...
+
+# error: [unbound-type-variable] "Legacy type variable `P` cannot be used in a function with PEP 695 type parameters"
+def paramspec_default[**Q = P](): ...
+```
+
 ### Invalid defaults
 
 A TypeVar default must be compatible with its bound or constraints.

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -74,6 +74,11 @@ def legacy_default[T = K](): ...
 
 # error: [unbound-type-variable] "Legacy type variable `P` cannot be used in a function with PEP 695 type parameters"
 def paramspec_default[**Q = P](): ...
+
+# error: [unbound-type-variable] "Legacy type variable `K` cannot be used in a function with PEP 695 type parameters"
+# error: [unbound-type-variable] "Legacy type variable `K` cannot be used in a function with PEP 695 type parameters"
+def multiple_legacy_defaults[T = K, U = K](value: K) -> K:
+    return value
 ```
 
 ### Invalid defaults

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -613,7 +613,8 @@ impl<'db> GenericContext<'db> {
                 {
                     Some(legacy_ctx.merge(db, ctx))
                 } else {
-                    // TODO: Raise a diagnostic — mixing PEP 695 and legacy typevars is not allowed
+                    // Invalid mixes retained in the inferred signature are reported during
+                    // post-inference validation.
                     Some(ctx)
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -56,15 +56,12 @@ fn check_pep695_function_legacy_typevars<'db>(
 ) {
     let db = context.db();
     let node = last_definition.node(db, context.file(), context.module());
-    if node.type_params.is_none() {
+    let Some(type_params) = node.type_params.as_deref() else {
         return;
-    }
+    };
 
-    let legacy_default = node
-        .type_params
-        .as_deref()
-        .into_iter()
-        .flatten()
+    let legacy_default = type_params
+        .iter()
         .filter_map(ast::TypeParam::default)
         .find_map(|default| {
             find_over_type(db, file_expression_type(default), false, |ty| {

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -97,16 +97,14 @@ fn check_pep695_function_legacy_typevars<'db>(
         return;
     };
 
-    let Some(typevar) = legacy_context
+    for typevar in legacy_context
         .variables(db)
         .map(|typevar| typevar.typevar(db))
-        .find(|typevar| !typevar.is_self(db))
-    else {
-        return;
-    };
-
-    let range = find_typevar_annotation_range(context, node, typevar, file_expression_type);
-    report_pep695_function_legacy_typevar(context, typevar, range);
+        .filter(|typevar| !typevar.is_self(db))
+    {
+        let range = find_typevar_annotation_range(context, node, typevar, file_expression_type);
+        report_pep695_function_legacy_typevar(context, typevar, range);
+    }
 }
 
 fn report_pep695_function_legacy_typevar<'db>(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -3,8 +3,12 @@ use crate::{
     types::{
         KnownInstanceType, Signature, Type, TypeVarKind,
         context::InferContext,
-        diagnostic::{INVALID_LEGACY_POSITIONAL_PARAMETER, INVALID_TYPE_VARIABLE_DEFAULT},
+        diagnostic::{
+            INVALID_LEGACY_POSITIONAL_PARAMETER, INVALID_TYPE_VARIABLE_DEFAULT,
+            UNBOUND_TYPE_VARIABLE,
+        },
         function::{FunctionDecorators, OverloadLiteral},
+        generics::GenericContext,
         infer_definition_types,
         signatures::ReturnCallableTypeVarScope,
         typevar::TypeVarInstance,
@@ -36,11 +40,60 @@ pub(crate) fn check_function_definition<'db>(
     if last_definition.has_known_decorator(db, FunctionDecorators::NO_TYPE_CHECK) {
         return;
     }
+    let lexical_signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Lexical);
     let signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
     check_legacy_positional_only_convention(context, last_definition, &signature);
+    check_pep695_function_legacy_typevars(
+        context,
+        last_definition,
+        &lexical_signature,
+        file_expression_type,
+    );
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);
     check_legacy_typevar_ordering(context, last_definition, &signature, file_expression_type);
+}
+
+/// Check that a function using PEP 695 syntax does not also introduce legacy type variables.
+fn check_pep695_function_legacy_typevars<'db>(
+    context: &InferContext<'db, '_>,
+    last_definition: OverloadLiteral<'db>,
+    signature: &Signature<'db>,
+    file_expression_type: &impl Fn(&ast::Expr) -> Type<'db>,
+) {
+    let db = context.db();
+    let node = last_definition.node(db, context.file(), context.module());
+    if node.type_params.is_none() {
+        return;
+    }
+
+    let Some(definition) = signature.definition() else {
+        return;
+    };
+    let Some(legacy_context) = GenericContext::from_function_params(
+        db,
+        definition,
+        signature.parameters(),
+        signature.return_ty,
+    ) else {
+        return;
+    };
+
+    let Some(typevar) = legacy_context
+        .variables(db)
+        .map(|typevar| typevar.typevar(db))
+        .find(|typevar| !typevar.is_self(db))
+    else {
+        return;
+    };
+
+    let range = find_typevar_annotation_range(context, node, typevar, file_expression_type);
+    if let Some(builder) = context.report_lint(&UNBOUND_TYPE_VARIABLE, range) {
+        builder.into_diagnostic(format_args!(
+            "Legacy type variable `{}` cannot be used in a function with PEP 695 type parameters",
+            typevar.name(db),
+        ));
+    }
 }
 
 /// Check for invalid applications of the pre-PEP-570 positional-only parameter convention.

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -40,16 +40,10 @@ pub(crate) fn check_function_definition<'db>(
     if last_definition.has_known_decorator(db, FunctionDecorators::NO_TYPE_CHECK) {
         return;
     }
-    let lexical_signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Lexical);
     let signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
     check_legacy_positional_only_convention(context, last_definition, &signature);
-    check_pep695_function_legacy_typevars(
-        context,
-        last_definition,
-        &lexical_signature,
-        file_expression_type,
-    );
+    check_pep695_function_legacy_typevars(context, last_definition, file_expression_type);
     check_legacy_typevar_defaults(context, last_definition, &signature, file_expression_type);
     check_legacy_typevar_ordering(context, last_definition, &signature, file_expression_type);
 }
@@ -58,7 +52,6 @@ pub(crate) fn check_function_definition<'db>(
 fn check_pep695_function_legacy_typevars<'db>(
     context: &InferContext<'db, '_>,
     last_definition: OverloadLiteral<'db>,
-    signature: &Signature<'db>,
     file_expression_type: &impl Fn(&ast::Expr) -> Type<'db>,
 ) {
     let db = context.db();
@@ -92,6 +85,7 @@ fn check_pep695_function_legacy_typevars<'db>(
         return;
     }
 
+    let signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Lexical);
     let Some(definition) = signature.definition() else {
         return;
     };

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -67,6 +67,31 @@ fn check_pep695_function_legacy_typevars<'db>(
         return;
     }
 
+    let legacy_default = node
+        .type_params
+        .as_deref()
+        .into_iter()
+        .flatten()
+        .filter_map(ast::TypeParam::default)
+        .find_map(|default| {
+            find_over_type(db, file_expression_type(default), false, |ty| {
+                if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
+                    && matches!(
+                        typevar.kind(db),
+                        TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+                    )
+                {
+                    Some((typevar, default.range()))
+                } else {
+                    None
+                }
+            })
+        });
+    if let Some((typevar, range)) = legacy_default {
+        report_pep695_function_legacy_typevar(context, typevar, range);
+        return;
+    }
+
     let Some(definition) = signature.definition() else {
         return;
     };
@@ -88,6 +113,15 @@ fn check_pep695_function_legacy_typevars<'db>(
     };
 
     let range = find_typevar_annotation_range(context, node, typevar, file_expression_type);
+    report_pep695_function_legacy_typevar(context, typevar, range);
+}
+
+fn report_pep695_function_legacy_typevar<'db>(
+    context: &InferContext<'db, '_>,
+    typevar: TypeVarInstance<'db>,
+    range: TextRange,
+) {
+    let db = context.db();
     if let Some(builder) = context.report_lint(&UNBOUND_TYPE_VARIABLE, range) {
         builder.into_diagnostic(format_args!(
             "Legacy type variable `{}` cannot be used in a function with PEP 695 type parameters",

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -60,25 +60,27 @@ fn check_pep695_function_legacy_typevars<'db>(
         return;
     };
 
-    let legacy_default = type_params
-        .iter()
-        .filter_map(ast::TypeParam::default)
-        .find_map(|default| {
-            find_over_type(db, file_expression_type(default), false, |ty| {
-                if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
-                    && matches!(
-                        typevar.kind(db),
-                        TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
-                    )
-                {
-                    Some((typevar, default.range()))
-                } else {
-                    None
-                }
-            })
-        });
-    if let Some((typevar, range)) = legacy_default {
-        report_pep695_function_legacy_typevar(context, typevar, range);
+    let mut has_legacy_default = false;
+    for default in type_params.iter().filter_map(ast::TypeParam::default) {
+        let Some(typevar) = find_over_type(db, file_expression_type(default), false, |ty| {
+            if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
+                && matches!(
+                    typevar.kind(db),
+                    TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+                )
+            {
+                Some(typevar)
+            } else {
+                None
+            }
+        }) else {
+            continue;
+        };
+
+        report_pep695_function_legacy_typevar(context, typevar, default.range());
+        has_legacy_default = true;
+    }
+    if has_legacy_default {
         return;
     }
 


### PR DESCRIPTION
## Summary

A function with its own PEP 695 type parameter list cannot also introduce a traditional `TypeVar` or `ParamSpec`. Prior to this change, we discovered the legacy generic context while building the signature but discarded it when merging with the PEP 695 context without reporting an error:

```python
from typing import TypeVar

K = TypeVar("K")

def method[M](value: M, other: K) -> M | K:
    raise NotImplementedError
```

With #25975, we now pass the `generics_syntax_compatibility` test in the conformance suite.
