### PR TITLE
[ty] Respect explicit receivers on bound methods

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -1052,7 +1052,7 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
-from typing import Callable, final
+from typing import Any, Callable, final
 
 @final
 class Disjoint: ...
@@ -1065,10 +1065,20 @@ class Explicit:
     def forward(self: Explicit) -> None:
         reveal_type(self)  # revealed: Explicit
 
+    def nested_dynamic(self: tuple[Any]) -> None: ...
+    def nested_generic[T](self: tuple[T]) -> None: ...
+    def class_object_generic[T](self: type[T]) -> None: ...
+    def compatible_generic[T](self: T) -> None: ...
+
 # error: [invalid-argument-type] "Argument to bound method `Explicit.bad` is incorrect: Expected `Disjoint`, found `Explicit`"
 Explicit().bad()
 
 Explicit().forward()
+
+invalid_dynamic_callback: Callable[[], None] = Explicit().nested_dynamic  # error: [invalid-assignment]
+invalid_generic_callback: Callable[[], None] = Explicit().nested_generic  # error: [invalid-assignment]
+invalid_class_object_callback: Callable[[], None] = Explicit().class_object_generic  # error: [invalid-assignment]
+compatible_generic_callback: Callable[[], None] = Explicit().compatible_generic
 
 class ExplicitGeneric[T]:
     def special(self: ExplicitGeneric[int]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -1052,7 +1052,7 @@ python-version = "3.12"
 ```py
 from __future__ import annotations
 
-from typing import final
+from typing import Callable, final
 
 @final
 class Disjoint: ...
@@ -1078,6 +1078,14 @@ ExplicitGeneric[int]().special()
 
 # TODO: this should be an `invalid-argument-type` error
 ExplicitGeneric[str]().special()
+
+class InvariantExplicitGeneric[T]:
+    value: T
+
+    def special(self: InvariantExplicitGeneric[int]) -> None: ...
+
+valid_callback: Callable[[], None] = InvariantExplicitGeneric[int]().special
+invalid_callback: Callable[[], None] = InvariantExplicitGeneric[str]().special  # error: [invalid-assignment]
 ```
 
 ## Binding a method fixes `Self`

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -932,16 +932,14 @@ class G3(A3):
     def method(self: object) -> Self: ...  # fine
 
 class H3(A3):
-    # TODO: we should emit `invalid-method-override` here
-    # (`A3.method()` can be called on any instance of `A3`,
+    # `A3.method()` can be called on any instance of `A3`,
     # but `H3.method()` can only be called on objects that are
-    # instances of `str`)
-    def method(self: str) -> Self: ...
+    # instances of `str`.
+    def method(self: str) -> Self: ...  # error: [invalid-method-override]
 
 class I3(A3):
-    # TODO: we should emit `invalid-method-override` here
-    # (`I3.method()` cannot be called with any inhabited type!)
-    def method(self: Never) -> Self: ...
+    # `I3.method()` cannot be called with any inhabited type.
+    def method(self: Never) -> Self: ...  # error: [invalid-method-override]
 
 class A4:
     def method[T: int](self, x: T) -> T: ...

--- a/crates/ty_python_semantic/resources/mdtest/liskov.md
+++ b/crates/ty_python_semantic/resources/mdtest/liskov.md
@@ -952,6 +952,21 @@ class B4(A4):
     def method(self, x: int) -> int: ...
 ```
 
+## Explicit receivers on inherited methods
+
+An inherited method with an explicit receiver only constrains subclasses accepted by that receiver:
+
+```pyi
+class Base:
+    def method(self: Included, value: object) -> None: ...
+
+class Included(Base):
+    def method(self, value: int) -> None: ...  # error: [invalid-method-override]
+
+class Excluded(Base):
+    def method(self, value: int) -> None: ...  # fine
+```
+
 ## Generic methods on generic classes work as expected
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/override.md
+++ b/crates/ty_python_semantic/resources/mdtest/override.md
@@ -924,9 +924,8 @@ class MyMapping(MutableMapping[KT, VT]):
         raise NotImplementedError
     def update(self, arg: MapOrItems[KT, VT] = (), /, **kw: VT) -> None: ...
 
-# TODO: We should emit an `invalid-method-override` diagnostic on
-# `DeferredChild1.method`. The `DeferredChild1`-specific overload applies to
-# this subclass, so its override cannot remove the `extra` parameter.
+# The `DeferredChild1`-specific overload applies to this subclass, so its override cannot remove
+# the `extra` parameter.
 class DeferredBase:
     @overload
     def method(self) -> None: ...
@@ -935,7 +934,7 @@ class DeferredBase:
     def method(self, extra: str = "") -> None: ...
 
 class DeferredChild1(DeferredBase):
-    def method(self) -> None: ...
+    def method(self) -> None: ...  # error: [invalid-method-override]
 
 # TODO: A strict Liskov check would emit an `invalid-method-override`
 # diagnostic here too. A subclass could inherit from both `DeferredChild1`

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -109,6 +109,10 @@ impl<'db> BoundMethodType<'db> {
             );
         };
 
+        if !signature.can_possibly_bind_self_to(db, self.self_instance(db)) {
+            return CallableSignature::from_overloads([]);
+        }
+
         CallableSignature::single(signature.bind_self(db, Some(typing_self_type)))
     }
 

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -381,6 +381,25 @@ fn check_class_declaration<'db>(
                 break;
             };
 
+            // Compare an explicitly restricted superclass method as bound to the subclass. The
+            // defining superclass may not satisfy its own receiver annotation even though the
+            // subclass does.
+            let superclass_type = match (superclass_type, type_on_subclass_instance) {
+                (Type::BoundMethod(superclass_method), Type::BoundMethod(subclass_method))
+                    if superclass_method
+                        .function(db)
+                        .signature(db)
+                        .overloads
+                        .iter()
+                        .any(Signature::has_explicit_positional_receiver_annotation) =>
+                {
+                    Type::BoundMethod(
+                        superclass_method.map_self_type(db, |_| subclass_method.self_instance(db)),
+                    )
+                }
+                _ => superclass_type,
+            };
+
             subclass_overrides_superclass_declaration = true;
 
             // Record the first overridden superclass member that is subject to the missing override

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1032,7 +1032,7 @@ impl<'db> Signature<'db> {
         &self,
         db: &'db dyn Db,
         self_type: Type<'db>,
-        unresolved_is_compatible: bool,
+        unresolved_subclass_is_compatible: bool,
         predicate: impl for<'c> FnOnce(ConstraintSet<'db, 'c>) -> bool,
     ) -> bool {
         // A dynamic receiver might be compatible with any explicit receiver annotation.
@@ -1085,10 +1085,13 @@ impl<'db> Signature<'db> {
                 return true;
             }
         }
-        if unresolved_is_compatible
-            && (expected_self_ty.has_dynamic(db)
-                || expected_self_ty.has_typevar_or_typevar_instance(db))
+        if unresolved_subclass_is_compatible
+            && let Type::SubclassOf(subclass_of) = expected_self_ty
+            && (subclass_of.is_dynamic() || subclass_of.is_type_var())
+            && self_type.is_assignable_to(db, KnownClass::Type.to_instance(db))
         {
+            // An unresolved `type[...]` receiver can accept a class object, but unresolved
+            // components nested in an unrelated type do not make that outer type compatible.
             return true;
         }
 

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -1016,6 +1016,25 @@ impl<'db> Signature<'db> {
     /// This is used to prune impossible overloads when a method is bound to a concrete receiver.
     /// If a signature has no positional first parameter, we conservatively keep it.
     pub(crate) fn can_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
+        self.self_binding_satisfies(db, self_type, false, |constraints| {
+            constraints.is_always_satisfied(db)
+        })
+    }
+
+    /// Returns `true` if this signature's first parameter might accept the bound `self` type.
+    pub(crate) fn can_possibly_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
+        self.self_binding_satisfies(db, self_type, true, |constraints| {
+            !constraints.is_never_satisfied(db)
+        })
+    }
+
+    fn self_binding_satisfies(
+        &self,
+        db: &'db dyn Db,
+        self_type: Type<'db>,
+        unresolved_is_compatible: bool,
+        predicate: impl for<'c> FnOnce(ConstraintSet<'db, 'c>) -> bool,
+    ) -> bool {
         // A dynamic receiver might be compatible with any explicit receiver annotation.
         if self_type.is_dynamic() {
             return true;
@@ -1066,16 +1085,20 @@ impl<'db> Signature<'db> {
                 return true;
             }
         }
+        if unresolved_is_compatible
+            && (expected_self_ty.has_dynamic(db)
+                || expected_self_ty.has_typevar_or_typevar_instance(db))
+        {
+            return true;
+        }
 
         let constraints = ConstraintSetBuilder::new();
-        self_type
-            .when_assignable_to(
-                db,
-                expected_self_ty,
-                &constraints,
-                self.inferable_typevars(db),
-            )
-            .is_always_satisfied(db)
+        predicate(self_type.when_assignable_to(
+            db,
+            expected_self_ty,
+            &constraints,
+            self.inferable_typevars(db),
+        ))
     }
 
     pub(crate) fn has_explicit_positional_receiver_annotation(&self) -> bool {


### PR DESCRIPTION
## Summary

Bound methods with a single signature previously discarded the receiver parameter without checking whether an explicit `self` annotation accepted the bound instance. This allowed an incompatible method to be treated as a zero-argument callback:

```python
from collections.abc import Callable

class C[T]:
    value: T

    def only_int(self: C[int]) -> None: ...

callback: Callable[[], None] = C[str]().only_int
```

We now reuse the receiver compatibility check before exposing a single bound signature. Concrete incompatibilities produce no callable signature, while unresolved generic receivers remain conservatively compatible. This also enables the existing override checks for methods whose explicit receivers are disjoint from their owning class.
