### PR TITLE
[ty] Reject explicit __hash__ with unsafe_hash

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -605,6 +605,28 @@ class WithUnsafeHash:
 reveal_type(WithUnsafeHash.__hash__)  # revealed: (self: WithUnsafeHash) -> int
 ```
 
+Defining `__hash__` when `unsafe_hash=True` raises an error:
+
+```py
+from dataclasses import dataclass
+
+@dataclass(unsafe_hash=True)
+class WithExplicitHash:
+    # error: [invalid-dataclass-override] "Cannot overwrite attribute `__hash__` in dataclass `WithExplicitHash` with `unsafe_hash=True`"
+    def __hash__(self) -> int:
+        return 0
+
+@dataclass(unsafe_hash=True)
+class WithHashAssignment:
+    # error: [invalid-dataclass-override] "Cannot overwrite attribute `__hash__` in dataclass `WithHashAssignment` with `unsafe_hash=True`"
+    __hash__ = None
+
+@dataclass
+class WithoutUnsafeHash:
+    def __hash__(self) -> int:
+        return 0
+```
+
 ### `frozen`
 
 If true (the default is False), assigning to fields will generate a diagnostic.

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -609,6 +609,7 @@ Defining `__hash__` when `unsafe_hash=True` raises an error:
 
 ```py
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 @dataclass(unsafe_hash=True)
 class WithExplicitHash:
@@ -628,10 +629,42 @@ class WithImplicitHashAssignment:
 
     __hash__ = None
 
-@dataclass
-class WithoutUnsafeHash:
-    def __hash__(self) -> int:
-        return 0
+@dataclass(unsafe_hash=True)
+class WithTypeCheckingOnlyHash:
+    if TYPE_CHECKING:
+        def __hash__(self) -> int:
+            return 0
+
+@dataclass(unsafe_hash=True)
+class WithTypeCheckingOnlyEq:
+    if TYPE_CHECKING:
+        def __eq__(self, other: object) -> bool:
+            return False
+
+    __hash__ = None  # TODO: error: [invalid-dataclass-override]
+
+def conditional_dataclass(condition: bool) -> None:
+    @dataclass(unsafe_hash=True)
+    class WithConditionalImplicitHash:
+        if condition:
+            def __eq__(self, other: object) -> bool:
+                return False
+
+            __hash__ = None
+
+    @dataclass(unsafe_hash=True)
+    class WithConditionalExplicitHash:
+        if condition:
+            # TODO: error: [invalid-dataclass-override]
+            def __hash__(self) -> int:
+                return 0
+
+@dataclass(unsafe_hash=True)
+class WithNotTypeCheckingHash:
+    if not TYPE_CHECKING:
+        # TODO: error: [invalid-dataclass-override]
+        def __hash__(self) -> int:
+            return 0
 ```
 
 ### `frozen`

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -621,6 +621,13 @@ class WithHashAssignment:
     # error: [invalid-dataclass-override] "Cannot overwrite attribute `__hash__` in dataclass `WithHashAssignment` with `unsafe_hash=True`"
     __hash__ = None
 
+@dataclass(unsafe_hash=True)
+class WithImplicitHashAssignment:
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, WithImplicitHashAssignment)
+
+    __hash__ = None
+
 @dataclass
 class WithoutUnsafeHash:
     def __hash__(self) -> int:

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1882,36 +1882,47 @@ impl<'db> StaticClassLiteral<'db> {
             let symbol = table.symbol(symbol_id);
             let name = symbol.name();
 
-            if name == "__hash__"
-                && let CodeGeneratorKind::DataclassLike(_) = field_policy
-                && self.has_dataclass_param(db, field_policy, DataclassFlags::UNSAFE_HASH)
-            {
-                let binding =
-                    place_from_bindings(db, use_def.end_of_scope_symbol_bindings(symbol_id));
-                if let Some(definition) = binding.first_definition
-                    && let Some(builder) = context.report_lint(
-                        &INVALID_DATACLASS_OVERRIDE,
-                        definition.focus_range(db, context.module()),
-                    )
-                {
-                    let mut diagnostic = builder.into_diagnostic(format_args!(
-                        "Cannot overwrite attribute `__hash__` in dataclass `{}` with `unsafe_hash=True`",
-                        self.name(db)
-                    ));
-                    diagnostic.info(name);
-                }
-                continue;
-            }
-
-            let Some(Type::FunctionLiteral(literal)) = attr.place.ignore_possibly_undefined()
-            else {
-                continue;
-            };
-
             match name.as_str() {
+                "__hash__" => {
+                    if let CodeGeneratorKind::DataclassLike(_) = field_policy
+                        && self.has_dataclass_param(db, field_policy, DataclassFlags::UNSAFE_HASH)
+                    {
+                        let binding = place_from_bindings(
+                            db,
+                            use_def.end_of_scope_symbol_bindings(symbol_id),
+                        );
+                        let is_implicit_hash = binding
+                            .place
+                            .ignore_possibly_undefined()
+                            .is_some_and(|ty| ty.is_none(db))
+                            && table.symbol_id("__eq__").is_some_and(|symbol_id| {
+                                place_from_bindings(
+                                    db,
+                                    use_def.end_of_scope_symbol_bindings(symbol_id),
+                                )
+                                .place
+                                .is_definitely_bound()
+                            });
+                        if !is_implicit_hash
+                            && let Some(definition) = binding.first_definition
+                            && let Some(builder) = context.report_lint(
+                                &INVALID_DATACLASS_OVERRIDE,
+                                definition.focus_range(db, context.module()),
+                            )
+                        {
+                            let mut diagnostic = builder.into_diagnostic(format_args!(
+                                "Cannot overwrite attribute `__hash__` in dataclass `{}` with `unsafe_hash=True`",
+                                self.name(db)
+                            ));
+                            diagnostic.info(name);
+                        }
+                    }
+                }
                 "__setattr__" | "__delattr__" => {
                     if let CodeGeneratorKind::DataclassLike(_) = field_policy
                         && self.is_frozen_dataclass(db) == Some(true)
+                        && let Some(Type::FunctionLiteral(literal)) =
+                            attr.place.ignore_possibly_undefined()
                     {
                         if let Some(builder) = context.report_lint(
                             &INVALID_DATACLASS_OVERRIDE,
@@ -1929,6 +1940,8 @@ impl<'db> StaticClassLiteral<'db> {
                 "__lt__" | "__le__" | "__gt__" | "__ge__" => {
                     if let CodeGeneratorKind::DataclassLike(_) = field_policy
                         && self.has_dataclass_param(db, field_policy, DataclassFlags::ORDER)
+                        && let Some(Type::FunctionLiteral(literal)) =
+                            attr.place.ignore_possibly_undefined()
                     {
                         if let Some(builder) = context.report_lint(
                             &INVALID_DATACLASS_OVERRIDE,

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1882,6 +1882,27 @@ impl<'db> StaticClassLiteral<'db> {
             let symbol = table.symbol(symbol_id);
             let name = symbol.name();
 
+            if name == "__hash__"
+                && let CodeGeneratorKind::DataclassLike(_) = field_policy
+                && self.has_dataclass_param(db, field_policy, DataclassFlags::UNSAFE_HASH)
+            {
+                let binding =
+                    place_from_bindings(db, use_def.end_of_scope_symbol_bindings(symbol_id));
+                if let Some(definition) = binding.first_definition
+                    && let Some(builder) = context.report_lint(
+                        &INVALID_DATACLASS_OVERRIDE,
+                        definition.focus_range(db, context.module()),
+                    )
+                {
+                    let mut diagnostic = builder.into_diagnostic(format_args!(
+                        "Cannot overwrite attribute `__hash__` in dataclass `{}` with `unsafe_hash=True`",
+                        self.name(db)
+                    ));
+                    diagnostic.info(name);
+                }
+                continue;
+            }
+
             let Some(Type::FunctionLiteral(literal)) = attr.place.ignore_possibly_undefined()
             else {
                 continue;

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -22,7 +22,7 @@ use crate::{
         GenericContext, KnownClass, KnownInstanceType, MaterializationKind, MemberLookupPolicy,
         MetaclassCandidate, MetaclassTransformInfo, Parameter, Parameters, PropertyInstanceType,
         Signature, SpecialFormType, StaticMroError, SubclassOfType, Truthiness, Type, TypeContext,
-        TypeMapping, TypeVarVariance, UnionBuilder, UnionType,
+        TypeMapping, TypeVarVariance, UnionBuilder, UnionType, binding_type,
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
@@ -1887,30 +1887,37 @@ impl<'db> StaticClassLiteral<'db> {
                     if let CodeGeneratorKind::DataclassLike(_) = field_policy
                         && self.has_dataclass_param(db, field_policy, DataclassFlags::UNSAFE_HASH)
                     {
-                        let binding = place_from_bindings(
-                            db,
-                            use_def.end_of_scope_symbol_bindings(symbol_id),
-                        );
-                        // CPython treats `__hash__ = None` as implicit when the class also defines
-                        // `__eq__`, allowing the dataclass decorator to replace it.
-                        let is_implicit_hash = binding
-                            .place
-                            .ignore_possibly_undefined()
-                            .is_some_and(|ty| ty.is_none(db))
+                        // Only report a single, definitely-bound runtime definition. Conditional
+                        // and multiple definitions remain false negatives.
+                        let Some(definition) = use_def
+                            .end_of_scope_symbol_bindings(symbol_id)
+                            .exactly_one()
+                            .ok()
+                            .and_then(|binding| binding.binding.definition())
+                        else {
+                            continue;
+                        };
+                        let definition_range = definition.focus_range(db, context.module());
+                        if semantic_index(db, class_body_scope.file(db)).is_in_type_checking_block(
+                            class_body_scope.file_scope_id(db),
+                            definition_range.range(),
+                        ) {
+                            continue;
+                        }
+
+                        // The type-checking binding model cannot correlate conditions across
+                        // symbols, so treat any `__eq__` definition as potentially paired.
+                        if binding_type(db, definition).is_none(db)
                             && table.symbol_id("__eq__").is_some_and(|symbol_id| {
-                                place_from_bindings(
-                                    db,
-                                    use_def.end_of_scope_symbol_bindings(symbol_id),
-                                )
-                                .place
-                                .is_definitely_bound()
-                            });
-                        if !is_implicit_hash
-                            && let Some(definition) = binding.first_definition
-                            && let Some(builder) = context.report_lint(
-                                &INVALID_DATACLASS_OVERRIDE,
-                                definition.focus_range(db, context.module()),
-                            )
+                                use_def
+                                    .reachable_symbol_bindings(symbol_id)
+                                    .any(|binding| binding.binding.definition().is_some())
+                            })
+                        {
+                            continue;
+                        }
+                        if let Some(builder) =
+                            context.report_lint(&INVALID_DATACLASS_OVERRIDE, definition_range)
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Cannot overwrite attribute `__hash__` in dataclass `{}` with `unsafe_hash=True`",

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1891,6 +1891,8 @@ impl<'db> StaticClassLiteral<'db> {
                             db,
                             use_def.end_of_scope_symbol_bindings(symbol_id),
                         );
+                        // CPython treats `__hash__ = None` as implicit when the class also defines
+                        // `__eq__`, allowing the dataclass decorator to replace it.
                         let is_implicit_hash = binding
                             .place
                             .ignore_possibly_undefined()


### PR DESCRIPTION
## Summary

`@dataclass(unsafe_hash=True)` always generates `__hash__`, and Python raises an exception if the runtime class namespace already contains an explicit binding for that attribute:

```python
from dataclasses import dataclass

@dataclass(unsafe_hash=True)
class Entry:
    def __hash__(self) -> int:
        return 0
```

We already synthesize the generated method, but did not validate the class-body conflict. This reports the existing `invalid-dataclass-override` diagnostic for unambiguous method definitions and explicit assignments such as `__hash__ = None`. We still allow `__hash__ = None` when the class also defines `__eq__`, because Python treats that as an implicit marker that the dataclass decorator may replace.

The check is intentionally conservative when the type-checking bindings do not establish the runtime class namespace. We skip conditional or multiple definitions and definitions that only exist under `TYPE_CHECKING`; TODO mdtests document the resulting false negatives. This avoids diagnosing valid cases where the same condition guards both `__eq__` and `__hash__ = None`.

Other type checkers do not appear to enforce this dataclass-specific runtime rule. In a focused comparison, mypy 2.1.0 and Pyright 1.1.410 only emitted generic assignment errors for `__hash__ = None`, including valid implicit and conditionally correlated cases, while missing explicit method conflicts. Pyrefly 1.0.0 did not report any of the conflicts. This check therefore follows CPython's dataclass behavior rather than matching an existing checker.
