### PR TITLE
[ty] Preserve failed constructor specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -1236,6 +1236,21 @@ class Box(Generic[T]):
 reveal_type(Box(1))  # revealed: Box[int]
 ```
 
+An invalid call to a non-overloaded constructor still has an unambiguous generic specialization. We
+preserve it while reporting the argument error:
+
+```py
+from typing import Generic, TypeVar
+
+U = TypeVar("U")
+
+class FallibleBox(Generic[U]):
+    def __init__(self, value: U, count: int) -> None: ...
+
+# error: [invalid-argument-type]
+reveal_type(FallibleBox("value", "bad"))  # revealed: FallibleBox[str]
+```
+
 ## Generic constructor inference from overloaded `__init__` self types
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -403,6 +403,22 @@ class D:
 D.f()
 ```
 
+When constructing a `classmethod` fails, we preserve the error but recover the descriptor's generic
+specialization. This prevents the unresolved type variables from causing additional errors when the
+attribute is accessed or called:
+
+```py
+class FormatChecker:
+    def checks(self, format, raises=()):
+        return lambda function: function
+
+    # error: [invalid-argument-type] "Argument to `classmethod.__init__` is incorrect"
+    cls_checks = classmethod(checks)
+
+reveal_type(FormatChecker.cls_checks)  # revealed: (...) -> Unknown
+FormatChecker.cls_checks("email", (ValueError,))
+```
+
 When a class method is accessed on a derived class, it is bound to that derived class:
 
 ```py

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -208,11 +208,19 @@ impl<'db> ConstructorBinding<'db> {
             .apply_optional_specialization(db, self.instance_return_specialization(db))
     }
 
-    fn first_matching_overload(&self) -> Option<&Binding<'db>> {
-        self.callable()
+    fn first_matching_or_only_overload(&self) -> Option<&Binding<'db>> {
+        let callable = self.callable();
+        callable
             .matching_overloads()
             .map(|(_, overload)| overload)
             .next()
+            // An invalid call to a non-overloaded constructor still has an unambiguous
+            // specialization. Use it to recover the constructed instance type instead of
+            // leaking the generic class's type variables into downstream expressions.
+            .or_else(|| match callable.overloads() {
+                [overload] => Some(overload),
+                _ => None,
+            })
     }
 
     /// Combine inferred specializations from this constructor and downstream constructors. The
@@ -233,7 +241,7 @@ impl<'db> ConstructorBinding<'db> {
 
         let mut combined: Option<Specialization<'db>> = None;
         let mut combine_binding_specialization = |binding: &ConstructorBinding<'db>| {
-            let Some(overload) = binding.first_matching_overload() else {
+            let Some(overload) = binding.first_matching_or_only_overload() else {
                 return;
             };
             let return_specialization = static_class_literal


### PR DESCRIPTION
## Summary

When a call to a non-overloaded generic constructor failed, we discarded the specialization inferred from its arguments because constructor return inference only considered successful overloads. This allowed the generic class's type variables to escape into later expressions:

```python
class Box[T]:
    def __init__(self, value: T, count: int) -> None: ...

reveal_type(Box("value", "bad"))  # Before: Box[T], after: Box[str]
```

This was especially noisy for failed `classmethod(...)` construction. The resulting descriptor retained typeshed's unspecialized `_P` and `_R_co`, which then caused unrelated call diagnostics when the attribute was accessed.

This change reuses the inferred specialization from the sole constructor overload even when that overload contains an error. We still report the original constructor error, but recover an accurate or gradual instance type for downstream analysis. Invalid overloaded constructor calls remain conservative because there is no unambiguous overload to use.
