### PR TITLE
[ty] Fix invalid type variable default tests

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -99,18 +99,13 @@ def i[T: (int, str) = Any](): ...
 When the default is a TypeVar, its upper bound must be assignable to the outer TypeVar's bound:
 
 ```py
-from typing import TypeVar
-
-T1 = TypeVar("T1", bound=int)
-T3 = TypeVar("T3", bound=str)
-
 # OK: `float` in a type expression means `int | float`,
 # and the upper bound of `T1` (`int`) is assignable to `int | float`
-def f[S: float = T1](): ...
+def f[T1: int, S: float = T1](): ...
 
 # `T3` has bound `str`, which is not assignable to `int | float`
 # error: [invalid-type-variable-default] "Default `T3` of TypeVar `U` is not assignable to upper bound `int | float` of `U` because its upper bound `str` is not assignable to `int | float`"
-def g[U: float = T3](): ...
+def g[T3: str, U: float = T3](): ...
 ```
 
 #### An unbounded default TypeVar has an implicit `object` bound
@@ -119,12 +114,8 @@ An unbounded TypeVar has an implicit upper bound of `object`, which is not assig
 restrictive bound:
 
 ```py
-from typing import TypeVar
-
-T1 = TypeVar("T1")
-
 # error: [invalid-type-variable-default] "Default `T1` of TypeVar `S` is not assignable to upper bound `int` of `S` because its upper bound `object` is not assignable to `int`"
-def f[S: int = T1](): ...
+def f[T1, S: int = T1](): ...
 ```
 
 #### A constrained default TypeVar's constraints must all be assignable to the outer bound
@@ -132,22 +123,17 @@ def f[S: int = T1](): ...
 When the default TypeVar has constraints, every constraint must be assignable to the outer bound:
 
 ```py
-from typing import TypeVar
-
-T1 = TypeVar("T1", int, str)
-T2 = TypeVar("T2", int, bool)
-
 # OK: `T1`'s constraints are `int` and `str`,
 # which are both assignable to `object`
-def f[S: object = T1](): ...
+def f[T1: (int, str), S: object = T1](): ...
 
 # `T1` has constraint `str`, which is not assignable to bound `int`
 # error: [invalid-type-variable-default] "Default `T1` of TypeVar `U` is not assignable to upper bound `int` of `U` because constraint `str` of `T1` is not assignable to `int`"
-def g[U: int = T1](): ...
+def g[T1: (int, str), U: int = T1](): ...
 
 # OK: `T2`'s constraints are `int` and `bool`,
 # which are both assignable to `int`
-def h[V: int = T2](): ...
+def h[T2: (int, bool), V: int = T2](): ...
 ```
 
 #### Local type-parameter defaults
@@ -176,17 +162,13 @@ When the default TypeVar has constraints, they must all appear in the outer Type
 list:
 
 ```py
-from typing import TypeVar
-
-T1 = TypeVar("T1", int, str)
-
 # OK: `T1`'s constraints ({int, str}) are a subset
 # of `S`'s constraints ({int, str, bool})
-def f[S: (int, str, bool) = T1](): ...
+def f[T1: (int, str), S: (int, str, bool) = T1](): ...
 
 # `T1` has constraint `int` which is not one of `U`'s constraints ({bool, complex})
 # error: [invalid-type-variable-default]
-def g[U: (bool, complex) = T1](): ...
+def g[T1: (int, str), U: (bool, complex) = T1](): ...
 ```
 
 #### Invalid constraints with default (no cascading diagnostic)
@@ -205,18 +187,13 @@ A bounded or unbounded TypeVar (one without constraints) cannot be used as the d
 constrained TypeVar, because there is no guarantee it will satisfy any of the constraints:
 
 ```py
-from typing import TypeVar
-
-T1 = TypeVar("T1", bound=int)
-T2 = TypeVar("T2")
-
 # `T1` has a bound but no constraints
 # error: [invalid-type-variable-default]
-def f[S: (float, str) = T1](): ...
+def f[T1: int, S: (float, str) = T1](): ...
 
 # `T2` has no bound or constraints
 # error: [invalid-type-variable-default]
-def g[U: (str, bytes) = T2](): ...
+def g[T2, U: (str, bytes) = T2](): ...
 ```
 
 ### Type variables with an upper bound


### PR DESCRIPTION
## Summary

Several tests for PEP 695 type-parameter defaults used traditional `TypeVar`s declared outside the function. Those examples are themselves invalid because a function cannot combine a PEP 695 type-parameter list with traditional type variables introduced by the same function.

This updates the existing fixtures to declare both type variables in the PEP 695 parameter list. The tests continue to cover bound and constraint compatibility for defaults without also relying on invalid legacy type-variable usage.

(This is a precursor to https://github.com/astral-sh/ruff/pull/25979, which starts to flag those invalid usages.)
