### PR TITLE
[ty] Support options in functional dataclass calls

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1924,19 +1924,42 @@ C(1) < C(2)  # ok
 
 ### Using `dataclass` as a function
 
+Calling `dataclass` with a class returns a class with a generated constructor:
+
 ```py
 from dataclasses import dataclass
 
-class B:
+class Point:
     x: int
 
-# error: [missing-argument]
-dataclass(B)()
+dataclass(Point)()  # error: [missing-argument]
+dataclass(Point)("one")  # error: [invalid-argument-type]
 
-# error: [invalid-argument-type]
-dataclass(B)("a")
+reveal_type(dataclass(Point)(1).x)  # revealed: int
+```
 
-reveal_type(dataclass(B)(3).x)  # revealed: int
+Options can be passed in the same call:
+
+```py
+class Ordered:
+    x: int
+
+ordered = dataclass(Ordered, order=True)
+
+ordered(1) < ordered(2)
+ordered("one")  # error: [invalid-argument-type]
+```
+
+Passing `None` explicitly returns a decorator that uses the supplied options:
+
+```py
+class Item:
+    x: int
+
+ordered_item = dataclass(None, order=True)(Item)
+
+reveal_type(ordered_item)  # revealed: <class 'Item'>
+ordered_item(1) < ordered_item(2)
 ```
 
 ## Internals

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4287,7 +4287,7 @@ impl<'db> Type<'db> {
                             Parameter::positional_only(Some(Name::new_static("cls")))
                                 .with_annotated_type(cls_ty),
                         );
-                        parameters.extend(decorator_factory_parameters.iter().cloned());
+                        parameters.extend_from_slice(&decorator_factory_parameters);
                         parameters
                     };
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4280,24 +4280,30 @@ impl<'db> Type<'db> {
                         decorator_factory_parameters.push(bool_parameter("weakref_slot", false));
                     }
 
+                    let parameters_with_cls = |cls_ty| {
+                        let mut parameters =
+                            Vec::with_capacity(decorator_factory_parameters.len() + 1);
+                        parameters.push(
+                            Parameter::positional_only(Some(Name::new_static("cls")))
+                                .with_annotated_type(cls_ty),
+                        );
+                        parameters.extend(decorator_factory_parameters.iter().cloned());
+                        parameters
+                    };
+
                     CallableBinding::from_overloads(
                         self,
                         [
-                            // def dataclass(cls: None, /) -> Callable[[type[_T]], type[_T]]: ...
+                            // def dataclass(cls: None, /, *, ...) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::new(
-                                    db,
-                                    [Parameter::positional_only(Some(Name::new_static("cls")))
-                                        .with_annotated_type(Type::none(db))],
-                                ),
+                                Parameters::new(db, parameters_with_cls(Type::none(db))),
                                 Type::unknown(),
                             ),
-                            // def dataclass(cls: type[_T], /) -> type[_T]: ...
+                            // def dataclass(cls: type[_T], /, *, ...) -> type[_T]: ...
                             Signature::new(
                                 Parameters::new(
                                     db,
-                                    [Parameter::positional_only(Some(Name::new_static("cls")))
-                                        .with_annotated_type(KnownClass::Type.to_instance(db))],
+                                    parameters_with_cls(KnownClass::Type.to_instance(db)),
                                 ),
                                 Type::unknown(),
                             ),

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2195,6 +2195,15 @@ impl<'db> Bindings<'db> {
                         }
 
                         Some(KnownFunction::Dataclass) => {
+                            let parameter_types = overload.parameter_types();
+                            let (cls_argument, dataclass_parameter_types) = overload
+                                .signature
+                                .parameters()
+                                .positional_only_by_name("cls")
+                                .map_or((None, parameter_types), |(index, _)| {
+                                    (parameter_types[index], &parameter_types[index + 1..])
+                                });
+
                             if let [
                                 init,
                                 repr,
@@ -2203,7 +2212,7 @@ impl<'db> Bindings<'db> {
                                 unsafe_hash,
                                 frozen,
                                 versioned_parameters @ ..,
-                            ] = overload.parameter_types()
+                            ] = dataclass_parameter_types
                             {
                                 let mut flags = DataclassFlags::empty();
 
@@ -2261,22 +2270,25 @@ impl<'db> Bindings<'db> {
 
                                 let params = DataclassParams::from_flags(db, flags);
 
-                                overload.set_return_type(Type::DataclassDecorator(params));
-                            }
+                                if cls_argument.is_none_or(|cls_ty| cls_ty.is_none(db)) {
+                                    overload.set_return_type(Type::DataclassDecorator(params));
+                                }
 
-                            // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`)
-                            if let [Some(Type::ClassLiteral(class_literal)), ..] =
-                                overload.parameter_types()
-                            {
-                                if let Some(target) = invalid_dataclass_target(db, class_literal) {
-                                    overload
-                                        .errors
-                                        .push(BindingError::InvalidDataclassApplication(target));
-                                } else {
-                                    let params = DataclassParams::default_params(db);
-                                    overload.set_return_type(Type::from(
-                                        class_literal.with_dataclass_params(db, Some(params)),
-                                    ));
+                                // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`).
+                                if let Some(Type::ClassLiteral(class_literal)) =
+                                    cls_argument.as_ref()
+                                {
+                                    if let Some(target) =
+                                        invalid_dataclass_target(db, class_literal)
+                                    {
+                                        overload.errors.push(
+                                            BindingError::InvalidDataclassApplication(target),
+                                        );
+                                    } else {
+                                        overload.set_return_type(Type::from(
+                                            class_literal.with_dataclass_params(db, Some(params)),
+                                        ));
+                                    }
                                 }
                             }
                         }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2200,9 +2200,10 @@ impl<'db> Bindings<'db> {
                                 .signature
                                 .parameters()
                                 .positional_only_by_name("cls")
-                                .map_or((None, parameter_types), |(index, _)| {
+                                .map(|(index, _)| {
                                     (parameter_types[index], &parameter_types[index + 1..])
-                                });
+                                })
+                                .unwrap_or((None, parameter_types));
 
                             if let [
                                 init,


### PR DESCRIPTION
## Summary

`dataclass` accepts the same keyword options when it is called directly with a class as when it is used as a decorator factory:

```python
from dataclasses import dataclass

class Example:
    value: int

ordered = dataclass(Example, order=True)
ordered(1) < ordered(2)
```

Previously, our synthetic overloads only accepted these options when `cls` was omitted. Valid calls such as `dataclass(Example, frozen=True)` therefore produced `no-matching-overload`, and direct applications always used the default dataclass parameters.

This adds the keyword-only options to the direct-call overloads and reads dataclass arguments by parameter name, allowing the computed parameters to be applied consistently to decorator factories, explicit `None` calls, and direct class arguments.
