### PR TITLE
[ty] Compact semantic index tables

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -60,7 +60,7 @@ use crate::use_def::{
     EnclosingSnapshotKey, FlowSnapshot, FutureDefinitions, PreviousDefinitions, ScopedDefinitionId,
     ScopedEnclosingSnapshotId, UseDefMapBuilder,
 };
-use crate::{Db, Statement, StatementNodeKey};
+use crate::{Db, PlaceTable, Statement, StatementNodeKey};
 use crate::{
     DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken,
     NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
@@ -2494,10 +2494,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         assert_eq!(&self.current_assignments, &[]);
 
+        let empty_place_table = Arc::new(PlaceTable::default());
         let mut place_tables: IndexVec<_, _> = self
             .place_tables
             .into_iter()
-            .map(|builder| Arc::new(builder.finish()))
+            .map(|builder| {
+                let table = builder.finish();
+                if table.is_empty() {
+                    Arc::clone(&empty_place_table)
+                } else {
+                    Arc::new(table)
+                }
+            })
             .collect();
 
         let mut use_def_maps: IndexVec<_, _> = self
@@ -2512,6 +2520,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         place_tables.shrink_to_fit();
         use_def_maps.shrink_to_fit();
         self.scope_ids_by_scope.shrink_to_fit();
+        self.expressions_by_node.shrink_to_fit();
+        self.statements_by_node.shrink_to_fit();
+        self.scopes_by_node.shrink_to_fit();
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();
         let uses_by_collection = FrozenMap::from_entries(

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -9,7 +9,6 @@ use smallvec::SmallVec;
 
 use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
-use std::ops::{Deref, DerefMut};
 
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
@@ -421,16 +420,115 @@ pub struct ScopedMemberId;
 
 /// The members of a scope. Allows lookup by member path and [`ScopedMemberId`].
 #[derive(Default, get_size2::GetSize)]
-pub(super) struct MemberTable {
+pub(super) enum MemberTable {
+    #[default]
+    Empty,
+    Single(Member),
+    Many {
+        members: IndexVec<ScopedMemberId, Member>,
+
+        /// Map from member path to its ID.
+        ///
+        /// Uses a hash table to avoid storing the path twice.
+        lookup: hashbrown::HashTable<ScopedMemberId>,
+    },
+}
+
+impl MemberTable {
+    /// Returns the member with the given ID.
+    ///
+    /// ## Panics
+    /// If the ID is not valid for this table.
+    #[track_caller]
+    pub(crate) fn member(&self, id: ScopedMemberId) -> &Member {
+        match self {
+            Self::Empty => panic!("Invalid member ID {id:?} for empty member table"),
+            Self::Single(member) if id == ScopedMemberId::from_usize(0) => member,
+            Self::Single(_) => panic!("Invalid member ID {id:?} for single-entry member table"),
+            Self::Many { members, .. } => &members[id],
+        }
+    }
+
+    /// Returns an iterator over all members in the table.
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Member> {
+        self.as_slice().iter()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    fn as_slice(&self) -> &[Member] {
+        match self {
+            Self::Empty => &[],
+            Self::Single(member) => std::slice::from_ref(member),
+            Self::Many { members, .. } => &members.raw,
+        }
+    }
+
+    fn hash_member_expression_ref(member: &MemberExprRef) -> u64 {
+        hash_single(member)
+    }
+
+    /// Returns the ID of the member with the given expression, if it exists.
+    pub(crate) fn member_id<'a>(
+        &self,
+        member: impl Into<MemberExprRef<'a>>,
+    ) -> Option<ScopedMemberId> {
+        let member = member.into();
+        match self {
+            Self::Empty => None,
+            Self::Single(existing) => {
+                (existing.expression == member).then_some(ScopedMemberId::from_usize(0))
+            }
+            Self::Many { members, lookup } => {
+                let hash = Self::hash_member_expression_ref(&member);
+                lookup
+                    .find(hash, |id| members[*id].expression == member)
+                    .copied()
+            }
+        }
+    }
+
+    pub(crate) fn place_id_by_instance_attribute_name(&self, name: &str) -> Option<ScopedMemberId> {
+        for (index, member) in self.iter().enumerate() {
+            if member.is_instance_attribute_named(name) {
+                return Some(ScopedMemberId::from_usize(index));
+            }
+        }
+
+        None
+    }
+}
+
+impl PartialEq for MemberTable {
+    fn eq(&self, other: &Self) -> bool {
+        // It's sufficient to compare the members as the map is only a reverse lookup.
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for MemberTable {}
+
+impl std::fmt::Debug for MemberTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("MemberTable")
+            .field(&self.as_slice())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct MemberTableBuilder {
     members: IndexVec<ScopedMemberId, Member>,
 
     /// Map from member path to its ID.
     ///
     /// Uses a hash table to avoid storing the path twice.
-    map: hashbrown::HashTable<ScopedMemberId>,
+    lookup: hashbrown::HashTable<ScopedMemberId>,
 }
 
-impl MemberTable {
+impl MemberTableBuilder {
     /// Returns the member with the given ID.
     ///
     /// ## Panics
@@ -454,65 +552,29 @@ impl MemberTable {
         self.members.iter()
     }
 
-    fn hash_member_expression_ref(member: &MemberExprRef) -> u64 {
-        hash_single(member)
-    }
-
     /// Returns the ID of the member with the given expression, if it exists.
     pub(crate) fn member_id<'a>(
         &self,
         member: impl Into<MemberExprRef<'a>>,
     ) -> Option<ScopedMemberId> {
         let member = member.into();
-        let hash = Self::hash_member_expression_ref(&member);
-        self.map
+        let hash = MemberTable::hash_member_expression_ref(&member);
+        self.lookup
             .find(hash, |id| self.members[*id].expression == member)
             .copied()
     }
 
-    pub(crate) fn place_id_by_instance_attribute_name(&self, name: &str) -> Option<ScopedMemberId> {
-        for (id, member) in self.members.iter_enumerated() {
-            if member.is_instance_attribute_named(name) {
-                return Some(id);
-            }
-        }
-
-        None
-    }
-}
-
-impl PartialEq for MemberTable {
-    fn eq(&self, other: &Self) -> bool {
-        // It's sufficient to compare the members as the map is only a reverse lookup.
-        self.members == other.members
-    }
-}
-
-impl Eq for MemberTable {}
-
-impl std::fmt::Debug for MemberTable {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("MemberTable").field(&self.members).finish()
-    }
-}
-
-#[derive(Debug, Default)]
-pub(super) struct MemberTableBuilder {
-    table: MemberTable,
-}
-
-impl MemberTableBuilder {
     /// Adds a member to the table or updates the flags of an existing member if it already exists.
     ///
     /// Members are identified by their expression, which is hashed to find the entry in the table.
     pub(super) fn add(&mut self, mut member: Member) -> (ScopedMemberId, bool) {
         let member_ref = member.expression.as_ref();
         let hash = MemberTable::hash_member_expression_ref(&member_ref);
-        let entry = self.table.map.entry(
+        let entry = self.lookup.entry(
             hash,
-            |id| self.table.members[*id].expression.as_ref() == member.expression.as_ref(),
+            |id| self.members[*id].expression.as_ref() == member.expression.as_ref(),
             |id| {
-                let ref_expr = self.table.members[*id].expression.as_ref();
+                let ref_expr = self.members[*id].expression.as_ref();
                 MemberTable::hash_member_expression_ref(&ref_expr)
             },
         );
@@ -530,7 +592,7 @@ impl MemberTableBuilder {
             Entry::Vacant(entry) => {
                 member.expression.shrink_to_fit();
 
-                let id = self.table.members.push(member);
+                let id = self.members.push(member);
                 entry.insert(id);
                 (id, true)
             }
@@ -538,27 +600,23 @@ impl MemberTableBuilder {
     }
 
     pub(super) fn build(self) -> MemberTable {
-        let mut table = self.table;
-        table.members.shrink_to_fit();
-        table.map.shrink_to_fit(|id| {
-            let ref_expr = table.members[*id].expression.as_ref();
-            MemberTable::hash_member_expression_ref(&ref_expr)
-        });
-        table
-    }
-}
+        let Self {
+            mut members,
+            mut lookup,
+        } = self;
 
-impl Deref for MemberTableBuilder {
-    type Target = MemberTable;
-
-    fn deref(&self) -> &Self::Target {
-        &self.table
-    }
-}
-
-impl DerefMut for MemberTableBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.table
+        match members.len() {
+            0 => MemberTable::Empty,
+            1 => MemberTable::Single(members.into_iter().next().unwrap()),
+            _ => {
+                members.shrink_to_fit();
+                lookup.shrink_to_fit(|id| {
+                    let ref_expr = members[*id].expression.as_ref();
+                    MemberTable::hash_member_expression_ref(&ref_expr)
+                });
+                MemberTable::Many { members, lookup }
+            }
+        }
     }
 }
 

--- a/crates/ty_python_core/src/place.rs
+++ b/crates/ty_python_core/src/place.rs
@@ -163,7 +163,7 @@ pub enum ScopedPlaceId {
     Member(ScopedMemberId),
 }
 
-#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+#[derive(Debug, Default, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct PlaceTable {
     symbols: SymbolTable,
     members: MemberTable,
@@ -248,6 +248,10 @@ impl PlaceTable {
 
     pub fn member_id_by_instance_attribute_name(&self, name: &str) -> Option<ScopedMemberId> {
         self.members.place_id_by_instance_attribute_name(name)
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.symbols.is_empty() && self.members.is_empty()
     }
 }
 
@@ -341,17 +345,16 @@ impl PlaceTableBuilder {
             let member = self.member.member(id);
 
             // iterate over parents
-            for parent_id in
-                ParentPlaceIter::for_member(member.expression(), &self.symbols, &self.member)
-            {
-                match parent_id {
-                    ScopedPlaceId::Symbol(scoped_symbol_id) => {
-                        self.associated_symbol_members[scoped_symbol_id].push(id);
-                    }
-                    ScopedPlaceId::Member(scoped_member_id) => {
-                        self.associated_sub_members[scoped_member_id].push(id);
-                    }
+            let mut parent = member.expression().as_ref();
+            while let Some(parent_member) = parent.parent() {
+                if let Some(parent_id) = self.member.member_id(parent_member.clone()) {
+                    self.associated_sub_members[parent_id].push(id);
                 }
+                parent = parent_member;
+            }
+
+            if let Some(parent_id) = self.symbols.symbol_id(parent.symbol_name()) {
+                self.associated_symbol_members[parent_id].push(id);
             }
         }
 

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -4,7 +4,6 @@ use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
-use std::ops::{Deref, DerefMut};
 
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]
@@ -158,16 +157,98 @@ impl Symbol {
 ///
 /// Allows lookup by name and a symbol's ID.
 #[derive(Default, get_size2::GetSize)]
-pub(super) struct SymbolTable {
+pub(super) enum SymbolTable {
+    #[default]
+    Empty,
+    Single(Symbol),
+    Many {
+        symbols: IndexVec<ScopedSymbolId, Symbol>,
+
+        /// Map from symbol name to its ID.
+        ///
+        /// Uses a hash table to avoid storing the name twice.
+        lookup: hashbrown::HashTable<ScopedSymbolId>,
+    },
+}
+
+impl SymbolTable {
+    /// Look up a symbol by its ID.
+    ///
+    /// ## Panics
+    /// If the ID is not valid for this symbol table.
+    #[track_caller]
+    pub(crate) fn symbol(&self, id: ScopedSymbolId) -> &Symbol {
+        match self {
+            Self::Empty => panic!("Invalid symbol ID {id:?} for empty symbol table"),
+            Self::Single(symbol) if id == ScopedSymbolId::from_usize(0) => symbol,
+            Self::Single(_) => panic!("Invalid symbol ID {id:?} for single-entry symbol table"),
+            Self::Many { symbols, .. } => &symbols[id],
+        }
+    }
+
+    /// Look up the ID of a symbol by its name.
+    pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        match self {
+            Self::Empty => None,
+            Self::Single(symbol) => (symbol.name == name).then_some(ScopedSymbolId::from_usize(0)),
+            Self::Many { symbols, lookup } => lookup
+                .find(Self::hash_name(name), |id| symbols[*id].name == name)
+                .copied(),
+        }
+    }
+
+    /// Iterate over the symbols in this symbol table.
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, Symbol> {
+        self.as_slice().iter()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    fn as_slice(&self) -> &[Symbol] {
+        match self {
+            Self::Empty => &[],
+            Self::Single(symbol) => std::slice::from_ref(symbol),
+            Self::Many { symbols, .. } => &symbols.raw,
+        }
+    }
+
+    fn hash_name(name: &str) -> u64 {
+        let mut h = FxHasher::default();
+        name.hash(&mut h);
+        h.finish()
+    }
+}
+
+impl PartialEq for SymbolTable {
+    fn eq(&self, other: &Self) -> bool {
+        // It's sufficient to compare the symbols as the map is only a reverse lookup.
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl Eq for SymbolTable {}
+
+impl std::fmt::Debug for SymbolTable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SymbolTable")
+            .field(&self.as_slice())
+            .finish()
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) struct SymbolTableBuilder {
     symbols: IndexVec<ScopedSymbolId, Symbol>,
 
     /// Map from symbol name to its ID.
     ///
     /// Uses a hash table to avoid storing the name twice.
-    map: hashbrown::HashTable<ScopedSymbolId>,
+    lookup: hashbrown::HashTable<ScopedSymbolId>,
 }
 
-impl SymbolTable {
+impl SymbolTableBuilder {
     /// Look up a symbol by its ID.
     ///
     /// ## Panics
@@ -188,8 +269,10 @@ impl SymbolTable {
 
     /// Look up the ID of a symbol by its name.
     pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        self.map
-            .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
+        self.lookup
+            .find(SymbolTable::hash_name(name), |id| {
+                self.symbols[*id].name == name
+            })
             .copied()
     }
 
@@ -198,41 +281,13 @@ impl SymbolTable {
         self.symbols.iter()
     }
 
-    fn hash_name(name: &str) -> u64 {
-        let mut h = FxHasher::default();
-        name.hash(&mut h);
-        h.finish()
-    }
-}
-
-impl PartialEq for SymbolTable {
-    fn eq(&self, other: &Self) -> bool {
-        // It's sufficient to compare the symbols as the map is only a reverse lookup.
-        self.symbols == other.symbols
-    }
-}
-
-impl Eq for SymbolTable {}
-
-impl std::fmt::Debug for SymbolTable {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("SymbolTable").field(&self.symbols).finish()
-    }
-}
-
-#[derive(Debug, Default)]
-pub(super) struct SymbolTableBuilder {
-    table: SymbolTable,
-}
-
-impl SymbolTableBuilder {
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
         let hash = SymbolTable::hash_name(symbol.name());
-        let entry = self.table.map.entry(
+        let entry = self.lookup.entry(
             hash,
-            |id| &self.table.symbols[*id].name == symbol.name(),
-            |id| SymbolTable::hash_name(&self.table.symbols[*id].name),
+            |id| &self.symbols[*id].name == symbol.name(),
+            |id| SymbolTable::hash_name(&self.symbols[*id].name),
         );
 
         match entry {
@@ -247,7 +302,7 @@ impl SymbolTableBuilder {
             }
             Entry::Vacant(entry) => {
                 symbol.name.shrink_to_fit();
-                let id = self.table.symbols.push(symbol);
+                let id = self.symbols.push(symbol);
                 entry.insert(id);
                 (id, true)
             }
@@ -255,25 +310,19 @@ impl SymbolTableBuilder {
     }
 
     pub(super) fn build(self) -> SymbolTable {
-        let mut table = self.table;
-        table.symbols.shrink_to_fit();
-        table
-            .map
-            .shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
-        table
-    }
-}
+        let Self {
+            mut symbols,
+            mut lookup,
+        } = self;
 
-impl Deref for SymbolTableBuilder {
-    type Target = SymbolTable;
-
-    fn deref(&self) -> &Self::Target {
-        &self.table
-    }
-}
-
-impl DerefMut for SymbolTableBuilder {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.table
+        match symbols.len() {
+            0 => SymbolTable::Empty,
+            1 => SymbolTable::Single(symbols.into_iter().next().unwrap()),
+            _ => {
+                symbols.shrink_to_fit();
+                lookup.shrink_to_fit(|id| SymbolTable::hash_name(&symbols[*id].name));
+                SymbolTable::Many { symbols, lookup }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Compact semantic index storage for files with no or single symbols/members:

- Represent finalized symbol and member tables as `Empty`, `Single`, or `Many` variants.
- Keep builder-time lookup behavior in dedicated builders, then finalize into the compact table representation.
- Reuse a shared empty `PlaceTable` and shrink retained node maps before storing the semantic index.

This targets retained memory in semantic index data structures while preserving the existing lookup behavior.

## Validation

- `CARGO_TARGET_DIR=/home/dev-user/.codex/worktrees/b2c3/ruff/target CARGO_PROFILE_DEV_OPT_LEVEL=1 INSTA_FORCE_PASS=1 INSTA_UPDATE=always CARGO_PROFILE_DEV_DEBUG="line-tables-only" MDTEST_UPDATE_SNAPSHOTS=1 cargo test -p ty_python_core -p ty_python_semantic`
- `uvx prek run --files crates/ty_python_core/src/builder.rs crates/ty_python_core/src/member.rs crates/ty_python_core/src/place.rs crates/ty_python_core/src/symbol.rs`

## Notes

This PR intentionally excludes the end-of-batch parsed-module clearing experiment.