### PR TITLE
[ty] Respect ParamSpec binding contexts

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -103,11 +103,22 @@ class OuterClass(Generic[T]):
 reveal_type(generic_context(OuterClass))
 
 class ParamSpecOuterClass(Generic[P]):
-    # error: [shadowed-type-variable]
-    # error: [shadowed-type-variable]
+    # snapshot: shadowed-type-variable
     class InnerClass(SingleParamSpec[P]): ...
     # revealed: None
     reveal_type(generic_context(InnerClass))
+```
+
+```snapshot
+error[shadowed-type-variable]: Generic class `InnerClass` uses ParamSpec `P` already bound by an enclosing scope
+  --> src/mdtest_snippet.py:64:7
+   |
+64 | class ParamSpecOuterClass(Generic[P]):
+   |       ------------------------------- ParamSpec `P` is bound in this enclosing scope
+65 |     # snapshot: shadowed-type-variable
+66 |     class InnerClass(SingleParamSpec[P]): ...
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `P` used in class definition here
+   |
 ```
 
 If you don't specialize a generic base class, we use the default specialization, which maps each

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/classes.md
@@ -101,6 +101,13 @@ class OuterClass(Generic[T]):
 
 # revealed: ty_extensions.GenericContext[T@OuterClass]
 reveal_type(generic_context(OuterClass))
+
+class ParamSpecOuterClass(Generic[P]):
+    # error: [shadowed-type-variable]
+    # error: [shadowed-type-variable]
+    class InnerClass(SingleParamSpec[P]): ...
+    # revealed: None
+    reveal_type(generic_context(InnerClass))
 ```
 
 If you don't specialize a generic base class, we use the default specialization, which maps each

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -751,23 +751,23 @@ any behavior specific to the legacy `ParamSpec` implementation.
 
 ### Binding contexts
 
-A `ParamSpec` bound by an enclosing definition cannot be inferred again by a nested definition:
+A nested definition can use a `ParamSpec` from an enclosing class or function without adding it to
+its own generic context:
 
 ```py
-from typing import Callable, Generic, ParamSpec, overload
+from typing import Callable, Generic, ParamSpec
+from ty_extensions import generic_context
 
 P = ParamSpec("P")
 
 class C(Generic[P]):
-    @overload
-    # error: [invalid-overload] "Implementation does not accept all arguments of this overload"
-    def f(self: "C[P]", *args: P.args, **kwargs: P.kwargs): ...
-    @overload
-    def f(self: "C[P]"): ...
-    def f(self: "C[P]"): ...
+    def method(self, *args: P.args, **kwargs: P.kwargs): ...
+
+# revealed: ty_extensions.GenericContext[Self@method]
+reveal_type(generic_context(C.method))
 
 def outer(_: Callable[P, None]):
     def inner(_: Callable[P, None]): ...
 
-    inner(lambda: None)  # error: [invalid-argument-type]
+    reveal_type(generic_context(inner))  # revealed: None
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/paramspec.md
@@ -748,3 +748,26 @@ class ParamSpecWithDefault6(Generic[PAnother]):
 The semantics of `ParamSpec` are described in
 [the PEP 695 `ParamSpec` document](./../pep695/paramspec.md) to avoid duplication unless there are
 any behavior specific to the legacy `ParamSpec` implementation.
+
+### Binding contexts
+
+A `ParamSpec` bound by an enclosing definition cannot be inferred again by a nested definition:
+
+```py
+from typing import Callable, Generic, ParamSpec, overload
+
+P = ParamSpec("P")
+
+class C(Generic[P]):
+    @overload
+    # error: [invalid-overload] "Implementation does not accept all arguments of this overload"
+    def f(self: "C[P]", *args: P.args, **kwargs: P.kwargs): ...
+    @overload
+    def f(self: "C[P]"): ...
+    def f(self: "C[P]"): ...
+
+def outer(_: Callable[P, None]):
+    def inner(_: Callable[P, None]): ...
+
+    inner(lambda: None)  # error: [invalid-argument-type]
+```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6380,7 +6380,12 @@ impl<'db> Type<'db> {
                 {
                     Some(*bound_typevar)
                 }
-                TypeVarKind::ParamSpec => {
+                TypeVarKind::ParamSpec
+                    if binding_context.is_none_or(|binding_context| {
+                        bound_typevar.binding_context(db)
+                            == BindingContext::Definition(binding_context)
+                    }) =>
+                {
                     // For `ParamSpec`, we're only interested in `P` itself, not `P.args` or
                     // `P.kwargs`.
                     Some(bound_typevar.without_paramspec_attr(db))

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -362,6 +362,14 @@ impl<'db> StaticClassLiteral<'db> {
                 self.typevars.borrow_mut().insert(bound_typevar);
             }
 
+            fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+                // The generic context contains the base class's formal type parameters, not type
+                // variables referenced by this class's base expression.
+                for ty in alias.specialization(db).types(db) {
+                    self.visit_type(db, *ty);
+                }
+            }
+
             fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
                 walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
             }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5922,17 +5922,23 @@ pub(crate) fn report_shadowed_type_variable<'db>(
     kind: &str,
     name: &ast::name::Name,
     range: TextRange,
+    is_paramspec: bool,
     other_typevar: BoundTypeVarInstance<'db>,
 ) {
     let db = context.db();
     let Some(builder) = context.report_lint(&SHADOWED_TYPE_VARIABLE, range) else {
         return;
     };
+    let typevar_kind = if is_paramspec {
+        "ParamSpec"
+    } else {
+        "type variable"
+    };
     let mut diagnostic = builder.into_diagnostic(format_args!(
-        "Generic {kind} `{name}` uses type variable `{typevar_name}` already bound by an enclosing scope",
+        "Generic {kind} `{name}` uses {typevar_kind} `{typevar_name}` already bound by an enclosing scope",
     ));
     diagnostic.set_concise_message(format_args!(
-        "Generic {kind} `{name}` uses type variable `{typevar_name}` already bound by an enclosing scope",
+        "Generic {kind} `{name}` uses {typevar_kind} `{typevar_name}` already bound by an enclosing scope",
     ));
     diagnostic.set_primary_message(format_args!(
         "`{typevar_name}` used in {kind} definition here"
@@ -5945,9 +5951,15 @@ pub(crate) fn report_shadowed_type_variable<'db>(
         Type::FunctionLiteral(function) => function.spans(db).signature,
         _ => return,
     };
-    diagnostic.annotate(Annotation::secondary(span).message(format_args!(
-        "Type variable `{typevar_name}` is bound in this enclosing scope",
-    )));
+    if other_typevar.is_paramspec(db) {
+        diagnostic.annotate(Annotation::secondary(span).message(format_args!(
+            "ParamSpec `{typevar_name}` is bound in this enclosing scope"
+        )));
+    } else {
+        diagnostic.annotate(Annotation::secondary(span).message(format_args!(
+            "Type variable `{typevar_name}` is bound in this enclosing scope"
+        )));
+    }
 }
 
 // I tried refactoring this function to placate Clippy,

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -30,7 +30,7 @@ use crate::types::{
     ProtocolInstanceType, SpecialFormType, SubclassOfInner, Type, TypeContext, TypeVarVariance,
     binding_type, protocol_class::ProtocolClass,
 };
-use crate::types::{KnownInstanceType, MemberLookupPolicy, TypedDictType, UnionType};
+use crate::types::{KnownInstanceType, MemberLookupPolicy, TypeVarKind, TypedDictType, UnionType};
 use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
 use itertools::Itertools;
 use ruff_db::source::source_text;
@@ -5922,17 +5922,19 @@ pub(crate) fn report_shadowed_type_variable<'db>(
     kind: &str,
     name: &ast::name::Name,
     range: TextRange,
-    is_paramspec: bool,
+    type_var_kind: TypeVarKind,
     other_typevar: BoundTypeVarInstance<'db>,
 ) {
     let db = context.db();
     let Some(builder) = context.report_lint(&SHADOWED_TYPE_VARIABLE, range) else {
         return;
     };
-    let typevar_kind = if is_paramspec {
-        "ParamSpec"
-    } else {
-        "type variable"
+    let typevar_kind = match type_var_kind {
+        TypeVarKind::Legacy
+        | TypeVarKind::Pep695
+        | TypeVarKind::TypingSelf
+        | TypeVarKind::Pep613Alias => "type variable",
+        TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => "ParamSpec",
     };
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Generic {kind} `{name}` uses {typevar_kind} `{typevar_name}` already bound by an enclosing scope",

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -3,7 +3,7 @@ use crate::{
     reachability::ReachabilityConstraintsExtension,
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
-        TypeContext, UnionType,
+        TypeContext, TypeVarKind, UnionType,
         diagnostic::{
             FINAL_ON_NON_METHOD, INVALID_PARAMETER_DEFAULT, INVALID_PARAMSPEC, INVALID_TYPE_FORM,
             USELESS_OVERLOAD_BODY, add_type_expression_reference_link,
@@ -434,13 +434,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let param_name = type_param.name();
                 for enclosing in enclosing_generic_contexts(db, self.index, current_scope) {
                     if let Some(other_typevar) = enclosing.binds_named_typevar(db, &param_name.id) {
+                        let kind = match type_param {
+                            ast::TypeParam::TypeVar(_) => TypeVarKind::Pep695,
+                            ast::TypeParam::ParamSpec(_) => TypeVarKind::Pep695ParamSpec,
+                            // TODO: should be `TypeVarKind::Pep695TypeVarTuple`
+                            ast::TypeParam::TypeVarTuple(_) => TypeVarKind::Pep695,
+                        };
                         report_shadowed_type_variable(
                             &self.context,
                             &param_name.id,
                             "function",
                             &function.name.id,
                             function.name.range(),
-                            matches!(type_param, ast::TypeParam::ParamSpec(_)),
+                            kind,
                             other_typevar,
                         );
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -440,6 +440,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             "function",
                             &function.name.id,
                             function.name.range(),
+                            matches!(type_param, ast::TypeParam::ParamSpec(_)),
                             other_typevar,
                         );
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -861,6 +861,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                                 "class",
                                 &class_node.name.id,
                                 class.header_range(db),
+                                self_typevar.is_paramspec(db),
                                 other_typevar,
                             );
                         }
@@ -880,6 +881,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                             "class",
                             &class_node.name.id,
                             class.header_range(db),
+                            base_typevar.is_paramspec(db),
                             other_typevar,
                         );
                     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -861,7 +861,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                                 "class",
                                 &class_node.name.id,
                                 class.header_range(db),
-                                self_typevar.is_paramspec(db),
+                                self_typevar.kind(db),
                                 other_typevar,
                             );
                         }
@@ -881,7 +881,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                             "class",
                             &class_node.name.id,
                             class.header_range(db),
-                            base_typevar.is_paramspec(db),
+                            base_typevar.kind(db),
                             other_typevar,
                         );
                     }


### PR DESCRIPTION
## Summary

`find_legacy_typevars` accepts an optional binding context so that it only collects variables introduced by the current definition. Prior to this change, we applied that filter to legacy `TypeVar`s but ignored it for `ParamSpec`, allowing an enclosing class or function's `ParamSpec` to be collected and inferred again.

This applies the same binding-context check to `ParamSpec` while continuing to normalize `P.args` and `P.kwargs` back to `P`.
