### PR TITLE
[ty] Respect `@no_type_check` in function validation

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
+++ b/crates/ty_python_semantic/resources/mdtest/suppressions/no_type_check.md
@@ -87,6 +87,17 @@ def test() -> Undefined:
     return x + 5
 ```
 
+## Errors in function declarations
+
+Post-inference checks on the function declaration are also suppressed.
+
+```py
+from typing import no_type_check
+
+@no_type_check
+def positional(x: int, __y: str): ...
+```
+
 ## `no_type_check` on classes isn't supported
 
 ty does not support decorating classes with `no_type_check`. The behavior of `no_type_check` when

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -4,7 +4,7 @@ use crate::{
         KnownInstanceType, Signature, Type, TypeVarKind,
         context::InferContext,
         diagnostic::{INVALID_LEGACY_POSITIONAL_PARAMETER, INVALID_TYPE_VARIABLE_DEFAULT},
-        function::OverloadLiteral,
+        function::{FunctionDecorators, OverloadLiteral},
         infer_definition_types,
         signatures::ReturnCallableTypeVarScope,
         typevar::TypeVarInstance,
@@ -33,6 +33,9 @@ pub(crate) fn check_function_definition<'db>(
     };
 
     let last_definition = function_type.literal(db).last_definition;
+    if last_definition.has_known_decorator(db, FunctionDecorators::NO_TYPE_CHECK) {
+        return;
+    }
     let signature = last_definition.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
     check_legacy_positional_only_convention(context, last_definition, &signature);


### PR DESCRIPTION
## Summary

`@no_type_check` promises to suppress errors in a function declaration and body, but diagnostics emitted during post-inference function validation were not suppressed:

```python
from typing import no_type_check

@no_type_check
def positional(x: int, __y: str): ...
```

Post-inference validation runs from the function's enclosing inference context, so the decorated function is not visible through the usual ancestor-scope suppression check. This returns before running those declaration checks when the function itself has a known `@no_type_check` decorator.
