### PR TITLE
[ty] Preserve functional dataclass class identity

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclass_transform.md
@@ -856,6 +856,7 @@ Other parameters from normal dataclasses can also be set on models created using
 
 ```py
 from typing_extensions import dataclass_transform, TypeVar, Callable
+from ty_extensions import static_assert
 
 T = TypeVar("T", bound=type)
 
@@ -874,6 +875,12 @@ class WithSlots:
     name: str
 
 reveal_type(WithSlots.__slots__)  # revealed: tuple[Literal["name"]]
+
+class FunctionalModel:
+    name: str
+
+functional_model = fancy_model(slots=True)(FunctionalModel)
+static_assert(FunctionalModel is functional_model)
 ```
 
 ### Using metaclass-based transformers

--- a/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
+++ b/crates/ty_python_semantic/resources/mdtest/dataclasses/dataclasses.md
@@ -1939,6 +1939,129 @@ dataclass(B)("a")
 reveal_type(dataclass(B)(3).x)  # revealed: int
 ```
 
+The returned class has the same nominal typing identity as the input class. This remains true for
+final and generic classes:
+
+```py
+from typing import final, Generic, TypeVar
+from ty_extensions import TypeOf, is_disjoint_from, is_equivalent_to, static_assert
+
+T = TypeVar("T")
+
+@final
+class Point:
+    x: int
+
+functional_point = dataclass(Point)
+
+def accepts_point(value: Point) -> None: ...
+
+accepts_point(functional_point(1))
+
+static_assert(is_equivalent_to(Point, TypeOf[functional_point(1)]))
+static_assert(not is_disjoint_from(Point, TypeOf[functional_point(1)]))
+static_assert(Point is functional_point)
+static_assert(is_equivalent_to(TypeOf[Point], TypeOf[functional_point]))
+static_assert(not is_disjoint_from(TypeOf[Point], TypeOf[functional_point]))
+
+class Box(Generic[T]):
+    value: T
+
+functional_box = dataclass(Box)
+
+def accepts_int_box(value: Box[int]) -> None: ...
+
+accepts_int_box(functional_box[int](1))
+accepts_int_box(functional_box[str]("one"))  # error: [invalid-argument-type]
+static_assert(Box is functional_box)
+static_assert(is_equivalent_to(TypeOf[Box[int]], TypeOf[functional_box[int]]))
+static_assert(not is_disjoint_from(TypeOf[Box[int]], TypeOf[functional_box[int]]))
+```
+
+With `slots=True`, `dataclass` returns a new runtime class, so the returned class keeps a distinct
+nominal identity:
+
+```py
+@final
+class SlottedPoint:
+    x: int
+
+functional_slotted_point = dataclass(slots=True)(SlottedPoint)
+
+def accepts_slotted_point(value: SlottedPoint) -> None: ...
+
+accepts_slotted_point(functional_slotted_point(1))  # error: [invalid-argument-type]
+static_assert(is_disjoint_from(SlottedPoint, TypeOf[functional_slotted_point(1)]))
+static_assert(SlottedPoint is not functional_slotted_point)
+static_assert(is_disjoint_from(TypeOf[SlottedPoint], TypeOf[functional_slotted_point]))
+
+another_slotted_point = dataclass(slots=True)(SlottedPoint)
+static_assert(functional_slotted_point is not another_slotted_point)
+static_assert(is_disjoint_from(TypeOf[functional_slotted_point], TypeOf[another_slotted_point]))
+
+redecorated_slotted_point = dataclass(functional_slotted_point)
+static_assert(redecorated_slotted_point is functional_slotted_point)
+static_assert(SlottedPoint is not redecorated_slotted_point)
+
+slotted_box = dataclass(slots=True)(Box)
+static_assert(Box is not slotted_box)
+static_assert(is_disjoint_from(TypeOf[Box[int]], TypeOf[slotted_box[int]]))
+```
+
+If `slots` is not statically known, the returned class may or may not be the input class. Ty does
+not allow the returned instances where the input class is required, but preserves the possibility
+that the two classes are identical:
+
+```py
+def dynamic_bool() -> bool:
+    return bool()
+
+@final
+class MaybeSlottedPoint:
+    x: int
+
+maybe_slotted_point = dataclass(slots=dynamic_bool())(MaybeSlottedPoint)
+
+def accepts_maybe_slotted_point(value: MaybeSlottedPoint) -> None: ...
+
+# error: [invalid-argument-type]
+accepts_maybe_slotted_point(maybe_slotted_point(1))
+reveal_type(MaybeSlottedPoint is maybe_slotted_point)  # revealed: bool
+static_assert(not is_disjoint_from(MaybeSlottedPoint, TypeOf[maybe_slotted_point(1)]))
+static_assert(not is_disjoint_from(TypeOf[MaybeSlottedPoint], TypeOf[maybe_slotted_point]))
+
+redecorated_maybe_slotted_point = dataclass(maybe_slotted_point)
+static_assert(redecorated_maybe_slotted_point is maybe_slotted_point)
+reveal_type(MaybeSlottedPoint is redecorated_maybe_slotted_point)  # revealed: bool
+static_assert(not is_disjoint_from(TypeOf[MaybeSlottedPoint], TypeOf[redecorated_maybe_slotted_point]))
+
+class MaybeBox(Generic[T]):
+    value: T
+
+maybe_box = dataclass(slots=dynamic_bool())(MaybeBox)
+reveal_type(MaybeBox is maybe_box)  # revealed: bool
+static_assert(not is_disjoint_from(TypeOf[MaybeBox[int]], TypeOf[maybe_box[int]]))
+
+class UnionPoint:
+    x: int
+
+class OtherUnionPoint:
+    x: int
+
+# Every branch of a union-valued input receives a fresh identity.
+union_slotted_point = dataclass(slots=True)(UnionPoint if dynamic_bool() else OtherUnionPoint)
+static_assert(UnionPoint is not union_slotted_point)
+static_assert(OtherUnionPoint is not union_slotted_point)
+static_assert(is_disjoint_from(TypeOf[UnionPoint], TypeOf[union_slotted_point]))
+static_assert(is_disjoint_from(TypeOf[OtherUnionPoint], TypeOf[union_slotted_point]))
+
+# A union-valued decorator preserves the identity behavior of each branch.
+maybe_slotted_decorator = dataclass(slots=True) if dynamic_bool() else dataclass()
+maybe_decorated_union_point = maybe_slotted_decorator(UnionPoint)
+reveal_type(UnionPoint is maybe_decorated_union_point)  # revealed: bool
+static_assert(not is_disjoint_from(TypeOf[UnionPoint], TypeOf[maybe_decorated_union_point]))
+```
+
 ## Internals
 
 The `dataclass` decorator returns the class itself. This means that the type of `Person` is `type`,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -98,7 +98,10 @@ pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::any_over_type;
 use crate::{Db, FxOrderSet, Program};
-pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
+pub(crate) use class::{
+    ClassLiteral, ClassType, DataclassApplicationId, GenericAlias, NominalClassIdentity,
+    StaticClassLiteral,
+};
 pub use class::{KnownClass, MethodDecorator};
 use instance::Protocol;
 pub use instance::{NominalInstanceType, ProtocolInstanceType};
@@ -774,6 +777,12 @@ bitflags! {
         const KW_ONLY = 1 << 7;
         const SLOTS = 1 << 8   ;
         const WEAKREF_SLOT = 1 << 9;
+        /// The `slots` argument is not statically known and may cause `dataclass` to return a new
+        /// runtime class.
+        const SLOTS_MAY_BE_TRUE = 1 << 10;
+        /// The decorator follows stdlib `dataclass` semantics, where `slots=True` returns a new
+        /// runtime class. Dataclass-transform decorators do not make this guarantee.
+        const SLOTS_CREATE_NEW_CLASS = 1 << 11;
     }
 }
 
@@ -832,13 +841,20 @@ pub struct DataclassParams<'db> {
 
     #[returns(deref)]
     field_specifiers: Box<[Type<'db>]>,
+
+    /// Runtime class identity is stored with the dataclass metadata so ordinary metadata updates
+    /// can preserve it without adding another field to the interned class-literal structures.
+    nominal_identity: NominalClassIdentity<'db>,
 }
 
 impl get_size2::GetSize for DataclassParams<'_> {}
 
 impl<'db> DataclassParams<'db> {
     fn default_params(db: &'db dyn Db) -> Self {
-        Self::from_flags(db, DataclassFlags::default())
+        Self::from_flags(
+            db,
+            DataclassFlags::default() | DataclassFlags::SLOTS_CREATE_NEW_CLASS,
+        )
     }
 
     fn from_flags(db: &'db dyn Db, flags: DataclassFlags) -> Self {
@@ -847,7 +863,12 @@ impl<'db> DataclassParams<'db> {
             .ignore_possibly_undefined()
             .unwrap_or_else(Type::unknown);
 
-        Self::new(db, flags, vec![dataclasses_field].into_boxed_slice())
+        Self::new(
+            db,
+            flags,
+            vec![dataclasses_field].into_boxed_slice(),
+            NominalClassIdentity::original(db),
+        )
     }
 
     fn from_transformer_params(db: &'db dyn Db, params: DataclassTransformerParams<'db>) -> Self {
@@ -855,7 +876,36 @@ impl<'db> DataclassParams<'db> {
             db,
             DataclassFlags::from(params.flags(db)),
             params.field_specifiers(db),
+            NominalClassIdentity::original(db),
         )
+    }
+
+    pub(crate) fn with_nominal_identity(
+        self,
+        db: &'db dyn Db,
+        nominal_identity: NominalClassIdentity<'db>,
+    ) -> Self {
+        if self.nominal_identity(db) == nominal_identity {
+            self
+        } else {
+            Self::new(
+                db,
+                self.flags(db),
+                self.field_specifiers(db),
+                nominal_identity,
+            )
+        }
+    }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        let nominal_identity =
+            self.nominal_identity(db)
+                .after_dataclass_application(db, self.flags(db), application);
+        self.with_nominal_identity(db, nominal_identity)
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -873,7 +923,12 @@ impl<'db> DataclassParams<'db> {
             })
             .collect::<Option<Box<_>>>()?;
 
-        Some(Self::new(db, self.flags(db), field_specifiers))
+        Some(Self::new(
+            db,
+            self.flags(db),
+            field_specifiers,
+            self.nominal_identity(db),
+        ))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -1590,30 +1590,14 @@ impl<'db> Bindings<'db> {
                         }
                     }
 
-                    Type::DataclassDecorator(params) => match overload.parameter_types() {
-                        [Some(Type::ClassLiteral(class_literal))] => {
-                            if let Some(target) = invalid_dataclass_target(db, class_literal) {
-                                overload
-                                    .errors
-                                    .push(BindingError::InvalidDataclassApplication(target));
-                            } else {
-                                overload.set_return_type(Type::from(
-                                    class_literal.with_dataclass_params(db, Some(params)),
-                                ));
-                            }
+                    Type::DataclassDecorator(params) => {
+                        if let [Some(input)] = overload.parameter_types()
+                            && let Some(return_ty) =
+                                apply_dataclass_params(db, *input, params, &mut overload.errors)
+                        {
+                            overload.set_return_type(return_ty);
                         }
-                        [Some(Type::GenericAlias(generic_alias))] => {
-                            let new_origin = generic_alias
-                                .origin(db)
-                                .with_dataclass_params(db, Some(params));
-                            overload.set_return_type(Type::GenericAlias(GenericAlias::new(
-                                db,
-                                new_origin,
-                                generic_alias.specialization(db),
-                            )));
-                        }
-                        _ => {}
-                    },
+                    }
 
                     Type::BoundMethod(bound_method)
                         if bound_method.self_instance(db).is_property_instance() =>
@@ -2205,7 +2189,7 @@ impl<'db> Bindings<'db> {
                                 versioned_parameters @ ..,
                             ] = overload.parameter_types()
                             {
-                                let mut flags = DataclassFlags::empty();
+                                let mut flags = DataclassFlags::SLOTS_CREATE_NEW_CLASS;
 
                                 if to_bool(init, true) {
                                     flags |= DataclassFlags::INIT;
@@ -2226,6 +2210,18 @@ impl<'db> Bindings<'db> {
                                     flags |= DataclassFlags::FROZEN;
                                 }
 
+                                let set_slots_flags =
+                                    |flags: &mut DataclassFlags, slots: &Option<Type<'db>>| {
+                                        if let Some(slots) = slots {
+                                            let truthiness = slots.bool(db);
+                                            if truthiness.is_always_true() {
+                                                *flags |= DataclassFlags::SLOTS;
+                                            } else if truthiness.may_be_true() {
+                                                *flags |= DataclassFlags::SLOTS_MAY_BE_TRUE;
+                                            }
+                                        }
+                                    };
+
                                 match versioned_parameters {
                                     // Python < 3.10.
                                     [] => {}
@@ -2237,9 +2233,7 @@ impl<'db> Bindings<'db> {
                                         if to_bool(kw_only, false) {
                                             flags |= DataclassFlags::KW_ONLY;
                                         }
-                                        if to_bool(slots, false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
+                                        set_slots_flags(&mut flags, slots);
                                     }
                                     // Python >= 3.11.
                                     [match_args, kw_only, slots, weakref_slot] => {
@@ -2249,9 +2243,7 @@ impl<'db> Bindings<'db> {
                                         if to_bool(kw_only, false) {
                                             flags |= DataclassFlags::KW_ONLY;
                                         }
-                                        if to_bool(slots, false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
+                                        set_slots_flags(&mut flags, slots);
                                         if to_bool(weakref_slot, false) {
                                             flags |= DataclassFlags::WEAKREF_SLOT;
                                         }
@@ -2406,6 +2398,7 @@ impl<'db> Bindings<'db> {
                                     db,
                                     flags,
                                     dataclass_params.field_specifiers(db),
+                                    dataclass_params.nominal_identity(db),
                                 );
 
                                 // The dataclass_transform spec doesn't clarify how to tell whether
@@ -6970,6 +6963,40 @@ pub(crate) enum InvalidDataclassTarget {
     TypedDict,
     Enum,
     Protocol,
+}
+
+fn apply_dataclass_params<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    params: DataclassParams<'db>,
+    errors: &mut Vec<BindingError<'db>>,
+) -> Option<Type<'db>> {
+    match ty {
+        Type::ClassLiteral(class_literal) => {
+            if let Some(target) = invalid_dataclass_target(db, &class_literal) {
+                errors.push(BindingError::InvalidDataclassApplication(target));
+                None
+            } else {
+                Some(Type::from(
+                    class_literal.with_dataclass_params(db, Some(params)),
+                ))
+            }
+        }
+        Type::GenericAlias(generic_alias) => {
+            let new_origin = generic_alias
+                .origin(db)
+                .with_dataclass_params(db, Some(params));
+            Some(Type::GenericAlias(GenericAlias::new(
+                db,
+                new_origin,
+                generic_alias.specialization(db),
+            )))
+        }
+        Type::Union(union) => union.try_map(db, |element| {
+            apply_dataclass_params(db, *element, params, errors)
+        }),
+        _ => None,
+    }
 }
 
 /// Returns the invalid dataclass target for a class literal, if any.

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -38,7 +38,7 @@ use crate::types::signatures::{
 };
 use crate::types::tuple::TupleSpec;
 use crate::types::{
-    ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassParams,
+    ApplyTypeMappingVisitor, CallableType, CallableTypes, DataclassFlags, DataclassParams,
     FindLegacyTypeVarsVisitor, IntersectionType, TypeContext, TypeMapping, UnionBuilder,
     VarianceInferable,
 };
@@ -56,6 +56,7 @@ use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast};
 use ruff_text_size::TextRange;
 use ty_python_core::definition::Definition;
+use ty_python_core::scope::ScopeId;
 use ty_python_core::{place_table, use_def_map};
 
 mod dynamic_literal;
@@ -64,6 +65,114 @@ mod known;
 mod named_tuple;
 mod static_literal;
 mod typed_dict;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct DataclassApplicationId<'db> {
+    scope: ScopeId<'db>,
+    offset: u32,
+}
+
+impl<'db> DataclassApplicationId<'db> {
+    pub(crate) fn new(scope: ScopeId<'db>, offset: u32) -> Self {
+        Self { scope, offset }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub enum NominalClassIdentityKind<'db> {
+    Original,
+    FreshDataclass(DataclassApplicationId<'db>),
+    MaybeFreshDataclass {
+        input: NominalClassIdentity<'db>,
+        application: DataclassApplicationId<'db>,
+    },
+}
+
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+pub struct NominalClassIdentity<'db> {
+    kind: NominalClassIdentityKind<'db>,
+}
+
+impl get_size2::GetSize for NominalClassIdentity<'_> {}
+
+impl<'db> NominalClassIdentity<'db> {
+    pub(crate) fn original(db: &'db dyn Db) -> Self {
+        Self::new(db, NominalClassIdentityKind::Original)
+    }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        flags: DataclassFlags,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        if !flags.contains(DataclassFlags::SLOTS_CREATE_NEW_CLASS) {
+            return self;
+        }
+
+        if flags.contains(DataclassFlags::SLOTS) {
+            Self::new(db, NominalClassIdentityKind::FreshDataclass(application))
+        } else if flags.contains(DataclassFlags::SLOTS_MAY_BE_TRUE) {
+            Self::new(
+                db,
+                NominalClassIdentityKind::MaybeFreshDataclass {
+                    input: self,
+                    application,
+                },
+            )
+        } else {
+            self
+        }
+    }
+
+    fn nominal_identity_with(self, db: &'db dyn Db, other: Self) -> NominalIdentity {
+        if self == other {
+            NominalIdentity::Same
+        } else if self.may_have_same_identity_as(db, other) {
+            NominalIdentity::PossiblySame
+        } else {
+            NominalIdentity::Distinct
+        }
+    }
+
+    fn may_have_same_identity_as(self, db: &'db dyn Db, other: Self) -> bool {
+        match self.kind(db) {
+            NominalClassIdentityKind::Original => other.may_be_original(db),
+            NominalClassIdentityKind::FreshDataclass(application) => {
+                other.may_be_dataclass_application(db, application)
+            }
+            NominalClassIdentityKind::MaybeFreshDataclass { input, application } => {
+                input.may_have_same_identity_as(db, other)
+                    || other.may_be_dataclass_application(db, application)
+            }
+        }
+    }
+
+    fn may_be_original(self, db: &'db dyn Db) -> bool {
+        match self.kind(db) {
+            NominalClassIdentityKind::Original => true,
+            NominalClassIdentityKind::FreshDataclass(_) => false,
+            NominalClassIdentityKind::MaybeFreshDataclass { input, .. } => {
+                input.may_be_original(db)
+            }
+        }
+    }
+
+    fn may_be_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> bool {
+        match self.kind(db) {
+            NominalClassIdentityKind::Original => false,
+            NominalClassIdentityKind::FreshDataclass(other) => application == other,
+            NominalClassIdentityKind::MaybeFreshDataclass {
+                input,
+                application: other,
+            } => application == other || input.may_be_dataclass_application(db, application),
+        }
+    }
+}
 
 /// A category of classes with code generation capabilities (with synthesized methods).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
@@ -269,6 +378,19 @@ impl<'db> GenericAlias<'db> {
     pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
         self.origin(db).is_typed_dict(db)
     }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        let origin = self.origin(db).after_dataclass_application(db, application);
+        if origin == self.origin(db) {
+            self
+        } else {
+            Self::new(db, origin, self.specialization(db))
+        }
+    }
 }
 
 impl<'db> From<GenericAlias<'db>> for Type<'db> {
@@ -336,7 +458,66 @@ pub enum ClassLiteral<'db> {
     DynamicEnum(DynamicEnumLiteral<'db>),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum NominalIdentity {
+    Same,
+    Distinct,
+    PossiblySame,
+}
+
 impl<'db> ClassLiteral<'db> {
+    /// Return whether two class literals have the same nominal typing identity.
+    ///
+    /// Class metadata can change when a class decorator is called imperatively. The updated class
+    /// literal is a distinct interned value, but both literals still originate from the same class
+    /// definition and therefore have the same nominal identity for type relations. A dataclass
+    /// application with `slots=True` is an exception because it creates a new runtime class.
+    pub(crate) fn has_same_nominal_identity_as(self, db: &'db dyn Db, other: Self) -> bool {
+        self.nominal_identity_with(db, other) == NominalIdentity::Same
+    }
+
+    pub(crate) fn may_have_same_nominal_identity_as(self, db: &'db dyn Db, other: Self) -> bool {
+        self.nominal_identity_with(db, other) != NominalIdentity::Distinct
+    }
+
+    pub(crate) fn is_definitely_distinct_from(self, db: &'db dyn Db, other: Self) -> bool {
+        self.nominal_identity_with(db, other) == NominalIdentity::Distinct
+    }
+
+    fn nominal_identity_with(self, db: &'db dyn Db, other: Self) -> NominalIdentity {
+        if self == other {
+            return NominalIdentity::Same;
+        }
+
+        match (self, other) {
+            (Self::Static(left), Self::Static(right))
+                if left.body_scope(db) == right.body_scope(db) =>
+            {
+                left.nominal_identity(db)
+                    .nominal_identity_with(db, right.nominal_identity(db))
+            }
+            (Self::Dynamic(left), Self::Dynamic(right)) if left.anchor(db) == right.anchor(db) => {
+                left.nominal_identity(db)
+                    .nominal_identity_with(db, right.nominal_identity(db))
+            }
+            _ => NominalIdentity::Distinct,
+        }
+    }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        match self {
+            Self::Static(class) => Self::Static(class.after_dataclass_application(db, application)),
+            Self::Dynamic(class) => {
+                Self::Dynamic(class.after_dataclass_application(db, application))
+            }
+            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) | Self::DynamicEnum(_) => self,
+        }
+    }
+
     /// Return a `ClassLiteral` representing the class `builtins.object`
     pub(super) fn object(db: &'db dyn Db) -> Self {
         KnownClass::Object
@@ -897,6 +1078,30 @@ impl<'db> ClassType<'db> {
         }
     }
 
+    fn has_same_nominal_origin_as(self, db: &'db dyn Db, other: Self) -> bool {
+        match (self, other) {
+            (Self::NonGeneric(left), Self::NonGeneric(right)) => {
+                left.has_same_nominal_identity_as(db, right)
+            }
+            (Self::Generic(_), Self::Generic(_)) => self
+                .class_literal(db)
+                .has_same_nominal_identity_as(db, other.class_literal(db)),
+            _ => false,
+        }
+    }
+
+    fn may_have_same_nominal_origin_as(self, db: &'db dyn Db, other: Self) -> bool {
+        match (self, other) {
+            (Self::NonGeneric(left), Self::NonGeneric(right)) => {
+                left.may_have_same_nominal_identity_as(db, right)
+            }
+            (Self::Generic(_), Self::Generic(_)) => self
+                .class_literal(db)
+                .may_have_same_nominal_identity_as(db, other.class_literal(db)),
+            _ => false,
+        }
+    }
+
     /// Returns the underlying class literal and specialization, if any.
     ///
     /// For a non-generic class, this returns the class literal directly.
@@ -1008,7 +1213,10 @@ impl<'db> ClassType<'db> {
     ) -> bool {
         self.iter_mro(db)
             .filter_map(ClassBase::into_class)
-            .any(|base| base.class_literal(db) == class_literal)
+            .any(|base| {
+                base.class_literal(db)
+                    .has_same_nominal_identity_as(db, class_literal)
+            })
     }
 
     pub(super) fn apply_type_mapping_impl<'a>(
@@ -1282,11 +1490,11 @@ impl<'db> ClassType<'db> {
             .iter_mro(db)
             .filter_map(ClassBase::into_class)
             .any(|class| match (self, class) {
-                (ClassType::NonGeneric(this_class), ClassType::NonGeneric(other_class)) => {
-                    this_class == other_class
+                (ClassType::NonGeneric(_), ClassType::NonGeneric(_)) => {
+                    self.may_have_same_nominal_origin_as(db, class)
                 }
                 (ClassType::Generic(this_alias), ClassType::Generic(other_alias)) => {
-                    this_alias.origin(db) == other_alias.origin(db)
+                    self.may_have_same_nominal_origin_as(db, class)
                         && !specializations_are_disjoint(
                             this_alias.specialization(db),
                             other_alias.specialization(db),
@@ -1314,7 +1522,8 @@ impl<'db> ClassType<'db> {
             .filter_map(ClassType::into_generic_alias)
             .any(|self_alias| {
                 other_generic_bases.iter().any(|other_alias| {
-                    self_alias.origin(db) == other_alias.origin(db)
+                    ClassType::Generic(self_alias)
+                        .has_same_nominal_origin_as(db, ClassType::Generic(*other_alias))
                         && specializations_are_disjoint(
                             self_alias.specialization(db),
                             other_alias.specialization(db),
@@ -1384,6 +1593,24 @@ impl<'db> ClassType<'db> {
     ) -> bool {
         if self == other {
             return true;
+        }
+
+        match (self, other) {
+            (ClassType::NonGeneric(_), ClassType::NonGeneric(_))
+                if self.may_have_same_nominal_origin_as(db, other) =>
+            {
+                return true;
+            }
+            (ClassType::Generic(left), ClassType::Generic(right))
+                if self.may_have_same_nominal_origin_as(db, other)
+                    && !specializations_are_disjoint(
+                        left.specialization(db),
+                        right.specialization(db),
+                    ) =>
+            {
+                return true;
+            }
+            _ => {}
         }
 
         if self.is_final(db) {
@@ -2154,11 +2381,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // Fast path: if source and target are the same class (possibly with different
         // specializations), we can compare them directly without walking the MRO.
         match (source, target) {
-            (ClassType::NonGeneric(source), ClassType::NonGeneric(target)) if source == target => {
+            (ClassType::NonGeneric(_), ClassType::NonGeneric(_))
+                if source.has_same_nominal_origin_as(db, target) =>
+            {
                 return self.always();
             }
             (ClassType::Generic(source_alias), ClassType::Generic(target_alias))
-                if source_alias.origin(db) == target_alias.origin(db) =>
+                if source.has_same_nominal_origin_as(db, target) =>
             {
                 return self.check_specialization_pair(
                     db,
@@ -2187,18 +2416,19 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                 ClassBase::Class(source) => match (source, target) {
                     // Two non-generic classes match if they have the same class literal.
-                    (
-                        ClassType::NonGeneric(source_literal),
-                        ClassType::NonGeneric(target_literal),
-                    ) => {
-                        ConstraintSet::from_bool(self.constraints, source_literal == target_literal)
+                    (source @ ClassType::NonGeneric(_), target @ ClassType::NonGeneric(_)) => {
+                        ConstraintSet::from_bool(
+                            self.constraints,
+                            source.has_same_nominal_origin_as(db, target),
+                        )
                     }
 
                     // Two generic classes match if they have the same origin and compatible specializations.
                     (ClassType::Generic(source), ClassType::Generic(target)) => {
                         ConstraintSet::from_bool(
                             self.constraints,
-                            source.origin(db) == target.origin(db),
+                            ClassType::Generic(source)
+                                .has_same_nominal_origin_as(db, ClassType::Generic(target)),
                         )
                         .and(db, self.constraints, || {
                             self.check_specialization_pair(

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -9,7 +9,8 @@ use crate::{
         ClassBase, ClassLiteral, ClassType, DataclassParams, KnownClass, MemberLookupPolicy,
         SubclassOfType, Type,
         class::{
-            ClassMemberResult, CodeGeneratorKind, DisjointBase, InstanceMemberResult, MroLookup,
+            ClassMemberResult, CodeGeneratorKind, DataclassApplicationId, DisjointBase,
+            InstanceMemberResult, MroLookup, NominalClassIdentity,
         },
         definition_expression_type, extract_fixed_length_iterable_element_types,
         member::Member,
@@ -522,6 +523,8 @@ impl<'db> DynamicClassLiteral<'db> {
         db: &'db dyn Db,
         dataclass_params: Option<DataclassParams<'db>>,
     ) -> Self {
+        let dataclass_params = dataclass_params
+            .map(|params| params.with_nominal_identity(db, self.nominal_identity(db)));
         Self::new(
             db,
             self.name(db).clone(),
@@ -529,6 +532,36 @@ impl<'db> DynamicClassLiteral<'db> {
             self.members(db),
             self.has_dynamic_namespace(db),
             dataclass_params,
+        )
+    }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        let Some(params) = self.dataclass_params(db) else {
+            return self;
+        };
+        let params = params.after_dataclass_application(db, application);
+        if Some(params) == self.dataclass_params(db) {
+            return self;
+        }
+
+        Self::new(
+            db,
+            self.name(db).clone(),
+            self.anchor(db).clone(),
+            self.members(db),
+            self.has_dynamic_namespace(db),
+            Some(params),
+        )
+    }
+
+    pub(crate) fn nominal_identity(self, db: &'db dyn Db) -> NominalClassIdentity<'db> {
+        self.dataclass_params(db).map_or_else(
+            || NominalClassIdentity::original(db),
+            |params| params.nominal_identity(db),
         )
     }
 }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -26,9 +26,10 @@ use crate::{
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
-            ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicTypedDictLiteral, Field,
-            FieldKind, InstanceMemberResult, MetaclassError, MetaclassErrorKind, MethodDecorator,
-            MroLookup, NamedTupleField, SlotsKind, synthesize_namedtuple_class_member,
+            ClassMemberResult, CodeGeneratorKind, DataclassApplicationId, DisjointBase,
+            DynamicTypedDictLiteral, Field, FieldKind, InstanceMemberResult, MetaclassError,
+            MetaclassErrorKind, MethodDecorator, MroLookup, NamedTupleField, NominalClassIdentity,
+            SlotsKind, synthesize_namedtuple_class_member,
             typed_dict::{TypedDictFields, synthesize_typed_dict_method, typed_dict_class_member},
         },
         context::InferContext,
@@ -155,6 +156,8 @@ impl<'db> StaticClassLiteral<'db> {
         db: &'db dyn Db,
         dataclass_params: Option<DataclassParams<'db>>,
     ) -> Self {
+        let dataclass_params = dataclass_params
+            .map(|params| params.with_nominal_identity(db, self.nominal_identity(db)));
         Self::new(
             db,
             self.name(db).clone(),
@@ -169,6 +172,43 @@ impl<'db> StaticClassLiteral<'db> {
             self.has_type_params(db),
             self.has_explicit_bases(db),
             self.has_explicit_metaclass(db),
+        )
+    }
+
+    pub(crate) fn after_dataclass_application(
+        self,
+        db: &'db dyn Db,
+        application: DataclassApplicationId<'db>,
+    ) -> Self {
+        let Some(params) = self.dataclass_params(db) else {
+            return self;
+        };
+        let params = params.after_dataclass_application(db, application);
+        if Some(params) == self.dataclass_params(db) {
+            return self;
+        }
+
+        Self::new(
+            db,
+            self.name(db).clone(),
+            self.body_scope(db),
+            self.known(db),
+            self.deprecated(db),
+            self.type_check_only(db),
+            Some(params),
+            self.dataclass_transformer_params(db),
+            self.total_ordering(db),
+            self.has_decorators(db),
+            self.has_type_params(db),
+            self.has_explicit_bases(db),
+            self.has_explicit_metaclass(db),
+        )
+    }
+
+    pub(crate) fn nominal_identity(self, db: &'db dyn Db) -> NominalClassIdentity<'db> {
+        self.dataclass_params(db).map_or_else(
+            || NominalClassIdentity::original(db),
+            |params| params.nominal_identity(db),
         )
     }
 
@@ -773,8 +813,12 @@ impl<'db> StaticClassLiteral<'db> {
                         }
                     }
 
-                    *transformer_params =
-                        DataclassParams::new(db, flags, transformer_params.field_specifiers(db));
+                    *transformer_params = DataclassParams::new(
+                        db,
+                        flags,
+                        transformer_params.field_specifiers(db),
+                        transformer_params.nominal_identity(db),
+                    );
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -98,13 +98,14 @@ use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
-    DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
-    IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
-    MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
-    SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
-    infer_complete_scope_types, infer_scope_types, is_discarded_dict_key_assignment, todo_type,
+    DataclassApplicationId, DataclassParams, DynamicType, GenericAlias, InferenceFlags,
+    InternedConstraintSet, InternedType, IntersectionBuilder, IntersectionType, KnownClass,
+    KnownInstanceType, KnownUnion, LiteralValueTypeKind, MemberLookupPolicy, ParamSpecAttrKind,
+    Parameter, Parameters, SentinelInstance, Signature, SpecialFormType, SubclassOfType, Type,
+    TypeAliasType, TypeAndQualifiers, TypeContext, TypeQualifiers, TypeVarBoundOrConstraints,
+    TypeVarKind, TypeVarVariance, TypedDictType, UnionAccumulator, UnionBuilder, UnionType,
+    any_over_type, binding_type, infer_complete_scope_types, infer_scope_types,
+    is_discarded_dict_key_assignment, todo_type,
 };
 use crate::{AnalysisSettings, Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
@@ -8257,6 +8258,77 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.infer_call_expression_impl(call_expression, callable_type, tcx)
     }
 
+    pub(super) fn dataclass_application_id(
+        &self,
+        node_index: ast::NodeIndex,
+    ) -> DataclassApplicationId<'db> {
+        let db = self.db();
+        let scope = self.scope();
+        let scope_anchor = scope
+            .node(db)
+            .node_index()
+            .unwrap_or(ast::NodeIndex::from(0));
+        let scope_anchor = scope_anchor
+            .as_u32()
+            .expect("scope anchor should not be NodeIndex::NONE");
+        let node_index = node_index
+            .as_u32()
+            .expect("dataclass application should not be NodeIndex::NONE");
+        DataclassApplicationId::new(scope, node_index - scope_anchor)
+    }
+
+    pub(super) fn apply_dataclass_application(
+        &self,
+        ty: Type<'db>,
+        node_index: ast::NodeIndex,
+        params: DataclassParams<'db>,
+    ) -> Type<'db> {
+        fn apply<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            application: DataclassApplicationId<'db>,
+            params: DataclassParams<'db>,
+        ) -> Type<'db> {
+            match ty {
+                Type::ClassLiteral(class) => {
+                    let class = class.with_dataclass_params(db, Some(params));
+                    Type::ClassLiteral(class.after_dataclass_application(db, application))
+                }
+                Type::GenericAlias(alias) => {
+                    let origin = alias.origin(db).with_dataclass_params(db, Some(params));
+                    let alias = GenericAlias::new(db, origin, alias.specialization(db));
+                    Type::GenericAlias(alias.after_dataclass_application(db, application))
+                }
+                Type::Union(union) => {
+                    union.map(db, |element| apply(db, *element, application, params))
+                }
+                _ => ty,
+            }
+        }
+
+        apply(
+            self.db(),
+            ty,
+            self.dataclass_application_id(node_index),
+            params,
+        )
+    }
+
+    pub(super) fn dataclass_params_for_callable(
+        &self,
+        callable: Type<'db>,
+    ) -> Option<DataclassParams<'db>> {
+        match callable {
+            Type::DataclassDecorator(params) => Some(params),
+            Type::FunctionLiteral(function)
+                if function.is_known(self.db(), KnownFunction::Dataclass) =>
+            {
+                Some(DataclassParams::default_params(self.db()))
+            }
+            _ => None,
+        }
+    }
+
     fn infer_call_expression_impl(
         &mut self,
         call_expression: &ast::ExprCall,
@@ -8749,6 +8821,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                     }
                     _ => {}
+                }
+
+                if let Some(params) = self.dataclass_params_for_callable(binding_type) {
+                    let return_ty = self.apply_dataclass_application(
+                        overload.return_type(),
+                        call_expression.node_index().load(),
+                        params,
+                    );
+                    overload.set_return_type(return_ty);
                 }
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,7 +1,7 @@
 use crate::place::Place;
 use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
-    SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
+    NominalClassIdentity, SpecialFormType, StaticClassLiteral, SubclassOfType, Type, TypeContext,
     call::CallError,
     callable::CallableFunctionProvenance,
     function::KnownFunction,
@@ -13,7 +13,7 @@ use crate::types::{
     special_form::TypeQualifier,
 };
 use ruff_python_ast::name::Name;
-use ruff_python_ast::{self as ast, helpers::any_over_expr};
+use ruff_python_ast::{self as ast, HasNodeIndex, helpers::any_over_expr};
 use ty_module_resolver::{KnownModule, file_to_module};
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
@@ -121,7 +121,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let mut metadata_applies_to_original_class = true;
         let mut deprecated = None;
         let mut type_check_only = false;
-        let mut dataclass_params = None;
+        let mut dataclass_params: Option<DataclassParams<'db>> = None;
         let mut dataclass_transformer_params = None;
         let mut total_ordering = false;
         let has_explicit_bases = class_node
@@ -182,7 +182,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_function_literal()
                 .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
             {
-                dataclass_params = Some(DataclassParams::default_params(db));
+                let nominal_identity = dataclass_params.map_or_else(
+                    || NominalClassIdentity::original(db),
+                    |params| params.nominal_identity(db),
+                );
+                dataclass_params = Some(
+                    DataclassParams::default_params(db).with_nominal_identity(db, nominal_identity),
+                );
                 continue;
             }
 
@@ -195,7 +201,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
 
             if let Type::DataclassDecorator(params) = decorator_ty {
-                dataclass_params = Some(params);
+                let nominal_identity = dataclass_params.map_or_else(
+                    || NominalClassIdentity::original(db),
+                    |params| params.nominal_identity(db),
+                );
+                dataclass_params = Some(
+                    params
+                        .with_nominal_identity(db, nominal_identity)
+                        .after_dataclass_application(
+                            db,
+                            self.dataclass_application_id(decorator.expression.node_index().load()),
+                        ),
+                );
                 continue;
             }
 
@@ -254,10 +271,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     .rev()
                     .find_map(|overload| overload.dataclass_transformer_params(db));
                 if let Some(transformer_params) = transformer_params {
-                    dataclass_params = Some(DataclassParams::from_transformer_params(
-                        db,
-                        transformer_params,
-                    ));
+                    let nominal_identity = dataclass_params.map_or_else(
+                        || NominalClassIdentity::original(db),
+                        |params| params.nominal_identity(db),
+                    );
+                    dataclass_params = Some(
+                        DataclassParams::from_transformer_params(db, transformer_params)
+                            .with_nominal_identity(db, nominal_identity),
+                    );
                     continue;
                 }
             }
@@ -324,13 +345,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => apply_class_decorator(db, decorator_ty, inferred_ty),
             };
-            let decorated_ty = match decorator_result {
+            let mut decorated_ty = match decorator_result {
                 Ok(return_ty) => return_ty,
                 Err(CallError(_, bindings)) => {
                     bindings.report_diagnostics(&self.context, decorator_node.into());
                     bindings.return_type(db)
                 }
             };
+            if let Some(params) = self.dataclass_params_for_callable(decorator_ty) {
+                decorated_ty = self.apply_dataclass_application(
+                    decorated_ty,
+                    decorator_node.expression.node_index().load(),
+                    params,
+                );
+            }
             let decorated_ty = match decorated_ty {
                 Type::DataclassDecorator(_) | Type::DataclassTransformer(_) => Type::unknown(),
                 decorated_ty => decorated_ty,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1108,6 +1108,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.check_type_pair(db, source, target_alias.value_type(db))
             }),
 
+            (Type::ClassLiteral(source), Type::ClassLiteral(target)) => ConstraintSet::from_bool(
+                self.constraints,
+                source.has_same_nominal_identity_as(db, target),
+            ),
+
             // Annotation unions retain type aliases so recursive aliases can be represented.
             // Normalize direct alias elements together before checking the union so reductions
             // that depend on multiple elements, such as all members of an enum, are visible.
@@ -2672,6 +2677,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 !left_sentinel.is_same_sentinel(db, right_sentinel),
             ),
 
+            (Type::ClassLiteral(left), Type::ClassLiteral(right)) => ConstraintSet::from_bool(
+                self.constraints,
+                left.is_definitely_distinct_from(db, right),
+            ),
+
             // any single-valued type is disjoint from another single-valued type
             // iff the two types are nonequal
             (
@@ -2838,7 +2848,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::GenericAlias(left_alias), Type::GenericAlias(right_alias)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    left_alias.origin(db) != right_alias.origin(db),
+                    ClassLiteral::Static(left_alias.origin(db)).is_definitely_distinct_from(
+                        db,
+                        ClassLiteral::Static(right_alias.origin(db)),
+                    ),
                 )
                 .or(db, self.constraints, || {
                     self.check_specialization_pair(


### PR DESCRIPTION
## Summary

Calling `dataclass` without `slots=True` returns the input class with dataclass metadata and generated methods:

```python
from dataclasses import dataclass

class Point:
    x: int

functional_point = dataclass(Point)

def accepts_point(value: Point) -> None: ...

accepts_point(functional_point(1))
```

Internally, adding dataclass metadata creates a distinct interned class literal. We previously used interned-value equality for nominal class relations, so the returned class was not assignable to the original class and class-object comparisons also treated the two references as distinct.

This defines nominal class identity independently from decorator metadata and applies it consistently to instance relations, class-object relations, MRO checks, generic aliases, and disjointness. Each stdlib `dataclass(slots=True)` application receives a fresh identity because it creates a new runtime class. When `slots` is not statically known, we reject identity-dependent assignments while retaining that the result may still be the input class; later dataclass applications preserve that uncertainty. Union-valued inputs and union-valued decorator expressions are handled branch-by-branch so class-preserving and class-creating paths remain correlated. Dataclass-transform decorators do not acquire the stdlib fresh-class behavior.
