### PR TITLE
[ty] Compact place provenance

### DIFF
--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -2,6 +2,7 @@ use itertools::Either;
 use ruff_db::files::File;
 use ruff_index::IndexSlice;
 use ruff_python_ast::PythonVersion;
+use salsa::plumbing::{AsId, FromId, Id};
 use ty_module_resolver::{
     KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
 };
@@ -97,40 +98,88 @@ impl PublicTypePolicy {
 }
 
 /// The source definition provenance for a place.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-pub(crate) enum Provenance<'db> {
+///
+/// A Salsa ID's low word is nonzero, so a zero low word encodes the two states without a source
+/// definition. All other values preserve the complete Salsa ID, including its generation.
+#[derive(Clone, Copy, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct Provenance<'db> {
+    bits: [u32; 2],
+    marker: std::marker::PhantomData<Definition<'db>>,
+}
+
+static_assertions::assert_eq_size!(Provenance<'_>, [u32; 2]);
+static_assertions::assert_eq_align!(Provenance<'_>, u32);
+
+impl<'db> Provenance<'db> {
     /// No source definition is known.
-    #[default]
-    Unknown,
-    /// Exactly one source definition is known.
-    SingleDefinition(Definition<'db>),
+    pub(crate) const UNKNOWN: Self = Self::sentinel(0);
+
     /// Multiple distinct source definitions contribute to the place. Instead of storing all of
     /// them, or selecting one arbitrarily, we currently discard provenance information in this
     /// case.
-    MultipleDefinitions,
-}
+    const MULTIPLE_DEFINITIONS: Self = Self::sentinel(1);
 
-impl<'db> Provenance<'db> {
+    const fn sentinel(generation: u32) -> Self {
+        Self {
+            bits: [0, generation],
+            marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Exactly one source definition is known.
+    pub(crate) fn single(definition: Definition<'db>) -> Self {
+        let bits = definition.as_id().as_bits();
+        Self {
+            bits: [bits as u32, (bits >> u32::BITS) as u32],
+            marker: std::marker::PhantomData,
+        }
+    }
+
     pub(crate) fn from_definition(definition: Option<Definition<'db>>) -> Self {
-        definition.map_or(Self::Unknown, Self::SingleDefinition)
+        definition.map_or(Self::UNKNOWN, Self::single)
     }
 
     /// Merge the provenance from two places.
     pub(crate) fn or(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Unknown, provenance) | (provenance, Self::Unknown) => provenance,
-            (Self::MultipleDefinitions, _) | (_, Self::MultipleDefinitions) => {
-                Self::MultipleDefinitions
-            }
-            (Self::SingleDefinition(left), Self::SingleDefinition(right)) if left == right => self,
-            (Self::SingleDefinition(_), Self::SingleDefinition(_)) => Self::MultipleDefinitions,
+        if self == Self::UNKNOWN {
+            other
+        } else if other == Self::UNKNOWN || self == other {
+            self
+        } else {
+            Self::MULTIPLE_DEFINITIONS
         }
     }
 
     pub(crate) fn definition(self) -> Option<Definition<'db>> {
-        match self {
-            Self::SingleDefinition(definition) => Some(definition),
-            Self::Unknown | Self::MultipleDefinitions => None,
+        if self == Self::UNKNOWN || self == Self::MULTIPLE_DEFINITIONS {
+            None
+        } else {
+            Some(self.single_definition())
+        }
+    }
+
+    fn single_definition(self) -> Definition<'db> {
+        let bits = u64::from(self.bits[0]) | (u64::from(self.bits[1]) << u32::BITS);
+        Definition::from_id(Id::from_bits(bits))
+    }
+}
+
+impl Default for Provenance<'_> {
+    fn default() -> Self {
+        Self::UNKNOWN
+    }
+}
+
+impl std::fmt::Debug for Provenance<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if *self == Self::UNKNOWN {
+            f.write_str("Unknown")
+        } else if *self == Self::MULTIPLE_DEFINITIONS {
+            f.write_str("MultipleDefinitions")
+        } else {
+            f.debug_tuple("SingleDefinition")
+                .field(&self.single_definition())
+                .finish()
         }
     }
 }
@@ -145,6 +194,9 @@ pub(crate) struct DefinedPlace<'db> {
     pub(crate) provenance: Provenance<'db>,
 }
 
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(DefinedPlace<'_>, [u32; 7]);
+
 impl<'db> DefinedPlace<'db> {
     pub(crate) fn new(ty: Type<'db>) -> Self {
         Self {
@@ -152,7 +204,7 @@ impl<'db> DefinedPlace<'db> {
             origin: TypeOrigin::Inferred,
             definedness: Definedness::AlwaysDefined,
             public_type_policy: PublicTypePolicy::Raw,
-            provenance: Provenance::Unknown,
+            provenance: Provenance::UNKNOWN,
         }
     }
 
@@ -172,7 +224,7 @@ impl<'db> DefinedPlace<'db> {
     }
 
     pub(crate) fn with_definition(mut self, definition: Definition<'db>) -> Self {
-        self.provenance = Provenance::SingleDefinition(definition);
+        self.provenance = Provenance::single(definition);
         self
     }
 
@@ -221,6 +273,9 @@ pub(crate) enum Place<'db> {
     #[default]
     Undefined,
 }
+
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(Place<'_>, [u32; 7]);
 
 impl<'db> Place<'db> {
     /// Constructor that creates a [`Place`] with type origin [`TypeOrigin::Inferred`] and definedness [`Definedness::AlwaysDefined`].
@@ -358,7 +413,7 @@ impl<'db> Place<'db> {
                 {
                     Place::Defined(DefinedPlace {
                         ty: dunder_get_return_ty,
-                        provenance: Provenance::Unknown,
+                        provenance: Provenance::UNKNOWN,
                         ..defined
                     })
                 } else {
@@ -781,6 +836,9 @@ pub(crate) struct PlaceAndQualifiers<'db> {
     pub(crate) place: Place<'db>,
     pub(crate) qualifiers: TypeQualifiers,
 }
+
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(PlaceAndQualifiers<'_>, [u32; 8]);
 
 impl<'db> PlaceAndQualifiers<'db> {
     pub(crate) fn unbound() -> Self {
@@ -1506,7 +1564,7 @@ fn place_from_bindings_impl<'db>(
     };
 
     let mut first_definition = None;
-    let mut provenance = Provenance::Unknown;
+    let mut provenance = Provenance::UNKNOWN;
     // special handling for synthetic loop header definitions and nested bindings definitions
     let mut only_non_shadowing_bindings = true;
 
@@ -1631,7 +1689,7 @@ fn place_from_bindings_impl<'db>(
             }
 
             first_definition.get_or_insert(binding);
-            provenance = provenance.or(Provenance::SingleDefinition(binding));
+            provenance = provenance.or(Provenance::single(binding));
             let binding_ty = binding_type(db, binding);
             Some((
                 narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
@@ -1878,7 +1936,7 @@ fn place_from_declarations_impl<'db>(
     };
 
     let mut first_declaration = None;
-    let mut provenance = Provenance::Unknown;
+    let mut provenance = Provenance::UNKNOWN;
     let mut all_declarations_definitely_reachable = true;
 
     let mut types = declarations.filter_map(|declaration_with_constraint| {
@@ -1909,7 +1967,7 @@ fn place_from_declarations_impl<'db>(
         } else {
             let declared_type = inferred_declaration(db, declaration).declared()?;
             first_declaration.get_or_insert(declaration);
-            provenance = provenance.or(Provenance::SingleDefinition(declaration));
+            provenance = provenance.or(Provenance::single(declaration));
             all_declarations_definitely_reachable =
                 all_declarations_definitely_reachable && static_reachability.is_always_true();
 
@@ -2279,6 +2337,31 @@ mod tests {
     use crate::db::tests::setup_db;
 
     #[test]
+    fn provenance_round_trip_and_merge() {
+        let first_id = Id::from_bits(1 | (7 << 32));
+        let first: Definition<'static> = Definition::from_id(first_id);
+        let second: Definition<'static> = Definition::from_id(Id::from_bits(2));
+
+        let single = Provenance::single(first);
+        assert_eq!(
+            single.definition().map(|definition| definition.as_id()),
+            Some(first_id)
+        );
+        assert_eq!(single.or(Provenance::UNKNOWN), single);
+        assert_eq!(Provenance::UNKNOWN.or(single), single);
+        assert_eq!(single.or(Provenance::single(first)), single);
+        assert_eq!(
+            single.or(Provenance::single(second)),
+            Provenance::MULTIPLE_DEFINITIONS
+        );
+        assert_eq!(
+            Provenance::MULTIPLE_DEFINITIONS.or(single),
+            Provenance::MULTIPLE_DEFINITIONS
+        );
+        assert!(Provenance::MULTIPLE_DEFINITIONS.definition().is_none());
+    }
+
+    #[test]
     fn test_symbol_or_fall_back_to() {
         use Definedness::{AlwaysDefined, PossiblyUndefined};
         use TypeOrigin::Inferred;
@@ -2295,7 +2378,7 @@ mod tests {
                 origin: Inferred,
                 definedness: PossiblyUndefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .with_qualifiers(TypeQualifiers::empty())
         };
@@ -2305,7 +2388,7 @@ mod tests {
                 origin: Inferred,
                 definedness: PossiblyUndefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .with_qualifiers(TypeQualifiers::empty())
         };
@@ -2316,7 +2399,7 @@ mod tests {
                 origin: Inferred,
                 definedness: AlwaysDefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .with_qualifiers(TypeQualifiers::empty())
         };
@@ -2326,7 +2409,7 @@ mod tests {
                 origin: Inferred,
                 definedness: AlwaysDefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .with_qualifiers(TypeQualifiers::empty())
         };
@@ -2351,7 +2434,7 @@ mod tests {
                 origin: Inferred,
                 definedness: PossiblyUndefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .into()
         );
@@ -2362,7 +2445,7 @@ mod tests {
                 origin: Inferred,
                 definedness: AlwaysDefined,
                 public_type_policy: PublicTypePolicy::Raw,
-                provenance: Provenance::Unknown,
+                provenance: Provenance::UNKNOWN,
             })
             .into()
         );

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3158,7 +3158,7 @@ impl<'db> Type<'db> {
                             origin,
                             definedness: boundness,
                             public_type_policy,
-                            provenance: Provenance::Unknown,
+                            provenance: Provenance::UNKNOWN,
                         })
                     })
                     .with_provenance(attribute_provenance)
@@ -3197,7 +3197,7 @@ impl<'db> Type<'db> {
                                 origin,
                                 definedness,
                                 public_type_policy,
-                                provenance: Provenance::Unknown,
+                                provenance: Provenance::UNKNOWN,
                             })
                         })
                         .with_provenance(attribute_provenance)
@@ -6963,7 +6963,7 @@ impl<'db> IntersectionType<'db> {
         let positive = self.positive(db);
         let mut successful_bindings = Vec::with_capacity(positive.len());
         let mut last_error = None;
-        let mut error_provenance = Provenance::Unknown;
+        let mut error_provenance = Provenance::UNKNOWN;
 
         for element in positive {
             match element.try_call_dunder_with_policy(db, name, argument_types, tcx, policy) {
@@ -7010,7 +7010,7 @@ impl<'db> UnionType<'db> {
         let mut unbound_on: Vec<Type<'db>> = Vec::new();
         let mut any_defined = false;
         let mut possibly_undefined = false;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
 
         for element in elements {
             match element
@@ -7624,13 +7624,16 @@ pub(crate) struct TypeAndQualifiers<'db> {
     provenance: Provenance<'db>,
 }
 
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(TypeAndQualifiers<'_>, [u32; 7]);
+
 impl<'db> TypeAndQualifiers<'db> {
     pub(crate) fn new(inner: Type<'db>, origin: TypeOrigin, qualifiers: TypeQualifiers) -> Self {
         Self {
             inner,
             origin,
             qualifiers,
-            provenance: Provenance::Unknown,
+            provenance: Provenance::UNKNOWN,
         }
     }
 
@@ -7639,7 +7642,7 @@ impl<'db> TypeAndQualifiers<'db> {
             inner,
             origin: TypeOrigin::Declared,
             qualifiers: TypeQualifiers::empty(),
-            provenance: Provenance::Unknown,
+            provenance: Provenance::UNKNOWN,
         }
     }
 
@@ -8196,7 +8199,7 @@ impl<'db> ModuleLiteralType<'db> {
                 return PlaceAndQualifiers {
                     place: Place::Defined(DefinedPlace {
                         ty: outcome.return_type(db),
-                        provenance: Provenance::Unknown,
+                        provenance: Provenance::UNKNOWN,
                         ..place
                     }),
                     qualifiers: TypeQualifiers::FROM_MODULE_GETATTR,

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -216,7 +216,7 @@ impl<'db> CallDunderError<'db> {
     pub(super) fn provenance(&self) -> Provenance<'db> {
         match self {
             Self::CallError(_, _, provenance) => *provenance,
-            Self::PossiblyUnbound { .. } | Self::MethodNotAvailable => Provenance::Unknown,
+            Self::PossiblyUnbound { .. } | Self::MethodNotAvailable => Provenance::UNKNOWN,
         }
     }
 

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2458,7 +2458,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         let mut union = UnionBuilder::new(db);
         let mut union_qualifiers = TypeQualifiers::empty();
         let mut is_definitely_bound = false;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
 
         for superclass in self.mro_iter {
             match superclass {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2198,7 +2198,7 @@ impl<'db> StaticClassLiteral<'db> {
         let mut qualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
 
         let mut is_attribute_bound = false;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
 
         let file = class_body_scope.file(db);
         let module = parsed_module(db, file).load(db);
@@ -2482,7 +2482,7 @@ impl<'db> StaticClassLiteral<'db> {
                 };
 
                 if let Some(inferred_ty) = inferred_ty {
-                    provenance = provenance.or(Provenance::SingleDefinition(binding));
+                    provenance = provenance.or(Provenance::single(binding));
                     union_of_inferred_types = union_of_inferred_types.add(inferred_ty);
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -904,6 +904,9 @@ pub(crate) struct DefinitionInference<'db> {
     extra: Option<Box<DefinitionInferenceExtra<'db>>>,
 }
 
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(DefinitionInference<'_>, [u64; 7]);
+
 /// The binding and declaration types inferred for a definition region.
 ///
 /// Almost all regions contain a single binding, optionally paired with a declaration for the same
@@ -917,6 +920,9 @@ enum DefinitionTypes<'db> {
     BindingAndDeclaration(TypeAndQualifiers<'db>),
     Other(Box<OtherDefinitionTypes<'db>>),
 }
+
+#[cfg(all(target_pointer_width = "64", not(debug_assertions)))]
+static_assertions::assert_eq_size!(DefinitionTypes<'_>, [u64; 4]);
 
 type DefinitionBinding<'db> = (Definition<'db>, Type<'db>);
 type DefinitionDeclaration<'db> = (Definition<'db>, TypeAndQualifiers<'db>);

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -247,7 +247,7 @@ impl<'db> UnionType<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
         for ty in self.elements(db) {
             let ty_member = transform_fn(ty);
             match ty_member {
@@ -303,7 +303,7 @@ impl<'db> UnionType<'db> {
         let mut all_unbound = true;
         let mut possibly_unbound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
         for ty in self.elements(db) {
             let PlaceAndQualifiers {
                 place: ty_member,
@@ -830,7 +830,7 @@ impl<'db> IntersectionType<'db> {
         let mut all_unbound = true;
         let mut any_definitely_bound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
         for ty in self.positive_elements_or_object(db) {
             let ty_member = transform_fn(&ty);
             match ty_member {
@@ -882,7 +882,7 @@ impl<'db> IntersectionType<'db> {
         let mut all_unbound = true;
         let mut any_definitely_bound = false;
         let mut origin = TypeOrigin::Declared;
-        let mut provenance = Provenance::Unknown;
+        let mut provenance = Provenance::UNKNOWN;
         for ty in self.positive_elements_or_object(db) {
             let PlaceAndQualifiers {
                 place: member,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1573,7 +1573,7 @@ impl<'db> TypeVarConstraints<'db> {
                         Definedness::AlwaysDefined
                     },
                     public_type_policy: PublicTypePolicy::Raw,
-                    provenance: Provenance::Unknown,
+                    provenance: Provenance::UNKNOWN,
                 })
             },
             qualifiers,


### PR DESCRIPTION
## Summary

`Provenance` is embedded in several frequently cached semantic result types, but its three-variant enum representation increases the size of every containing value.

This stores provenance in the same two-word representation as a Salsa ID. Valid definitions retain both the ID index and generation, while two otherwise-invalid zero-index encodings represent unknown and multiple-definition provenance. Layout assertions keep the affected place and definition-inference types compact, and round-trip and merge coverage verifies the encoding.

In the memory report, this reduced total retained memory by 0.24–0.58% across Flake8, Trio, Sphinx, and Prefect, saving 82 kB to 3.05 MB. Retained memory for `place_by_id` fell by roughly 7%, while `infer_definition_types` fell by 2.3–2.5%. The typing-conformance and ecosystem comparisons reported no diagnostic changes.
