### PR TITLE
Recognize Jira-style issue codes on the TODO line for TD003

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_todos/TD003.py
@@ -40,4 +40,8 @@ def foo(x):
 
 # TODO: A todo with a random number, 5431
 
+# TODO: PROJ-123 a todo with a Jira-style code on the same line
+
+# TODO: fix this TDO-3870
+
 # TODO: here's a TODO on the last line with no link

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -102,6 +102,8 @@ impl Violation for MissingTodoAuthor {
 ///
 /// # TODO(charlie): this comment has an issue code (matches the regex `[A-Z]+\-?\d+`)
 /// # SIXCHR-003
+///
+/// # TODO(charlie): PROJ-123 issue codes also work on the same line
 /// ```
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.269")]
@@ -251,6 +253,7 @@ static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"\s*(http|https)://.*", // issue link
         r"\s*#\d+.*",            // issue code - like "#003"
+        r"\s*[A-Z]+\-?\d+",     // issue code - like "PROJ-123"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
+++ b/crates/ruff_linter/src/rules/flake8_todos/rules/todos.rs
@@ -253,7 +253,7 @@ static ISSUE_LINK_TODO_LINE_REGEX_SET: LazyLock<RegexSet> = LazyLock::new(|| {
     RegexSet::new([
         r"\s*(http|https)://.*", // issue link
         r"\s*#\d+.*",            // issue code - like "#003"
-        r"\s*[A-Z]+\-?\d+",     // issue code - like "PROJ-123"
+        r"\s*[A-Z]+\-?\d+",      // issue code - like "PROJ-123"
     ])
     .unwrap()
 });

--- a/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_todos/snapshots/ruff_linter__rules__flake8_todos__tests__missing-todo-link_TD003.py.snap
@@ -51,14 +51,14 @@ TD003 Missing issue link for this TODO
 41 | # TODO: A todo with a random number, 5431
    |   ^^^^
 42 |
-43 | # TODO: here's a TODO on the last line with no link
+43 | # TODO: PROJ-123 a todo with a Jira-style code on the same line
    |
 
 TD003 Missing issue link for this TODO
-  --> TD003.py:43:3
+  --> TD003.py:47:3
    |
-41 | # TODO: A todo with a random number, 5431
-42 |
-43 | # TODO: here's a TODO on the last line with no link
+45 | # TODO: fix this TDO-3870
+46 |
+47 | # TODO: here's a TODO on the last line with no link
    |   ^^^^
    |


### PR DESCRIPTION
## Summary

TD003 flags TODO comments that don't have an issue link. URLs and `#123` style codes are already recognized on the same line as the TODO, but Jira-style codes like `PROJ-123` or `TDO-3870` are only recognized on a separate line below.

This adds the missing pattern to `ISSUE_LINK_TODO_LINE_REGEX_SET` so Jira-style codes are also accepted on the same line.

Before:
```python
# TODO(charlie): PROJ-123 fix this   # flagged
# TODO(charlie): fix this TDO-3870   # flagged
```

After:
```python
# TODO(charlie): PROJ-123 fix this   # ok
# TODO(charlie): fix this TDO-3870   # ok
```

Closes #16519

## Test plan

- Added two test cases to `TD003.py` with Jira-style codes on the TODO line
- Updated snapshot confirms the new cases are not flagged
- All existing `flake8_todos` tests pass