### PR TITLE
[ty] Test ecosystem-analyzer diagnostic pairing

### DIFF
--- a/.github/workflows/ty-ecosystem-analyzer.yaml
+++ b/.github/workflows/ty-ecosystem-analyzer.yaml
@@ -42,7 +42,7 @@ env:
   RUST_BACKTRACE: 1
   # Line-tables-only debug info: faster builds, backtraces still work.
   CARGO_PROFILE_PROFILING_DEBUG: line-tables-only
-  ECOSYSTEM_ANALYZER_COMMIT: 7e3a45ca84ad4a30ba90cb27af0b568f37608e84
+  ECOSYSTEM_ANALYZER_COMMIT: f221e914a98197d2b59fda5f96948a2678a5a2bc
 
 jobs:
   build-ty:

--- a/crates/ty_python_semantic/resources/mdtest/call/constructor.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/constructor.md
@@ -225,7 +225,7 @@ class E(SubclassFactory):
     def __init__(self, value: int) -> None:
         pass
 
-# TODO should also be - error: [invalid-argument-type] "Argument to `E.__init__` is incorrect: Expected `int`, found `<class 'E'>`"
+# TODO should also be - error: [invalid-argument-type] "Argument for `E.__init__` is incorrect: Expected `int`, found `<class 'E'>`"
 # error: [missing-argument] "No argument provided for required parameter `value` of `E.__init__`"
 E()
 ```
@@ -249,7 +249,7 @@ class ReturnsFactory:
     def __init__(self, value: int) -> None:
         pass
 
-# TODO should be - error: [invalid-argument-type] "Argument to `SelfFactory.__init__` is incorrect: Expected `int`, found `<class 'ReturnsFactory'>`"
+# TODO should be - error: [invalid-argument-type] "Argument for `SelfFactory.__init__` is incorrect: Expected `int`, found `<class 'ReturnsFactory'>`"
 ReturnsFactory()
 ```
 
@@ -1370,8 +1370,8 @@ def _(flag: bool) -> None:
             def __init__(self, x: int, y: int = 1): ...
 
     reveal_type(Foo(1))  # revealed: Foo
-    # error: [invalid-argument-type] "Argument to `Foo.__init__` is incorrect: Expected `int`, found `Literal["1"]`"
-    # error: [invalid-argument-type] "Argument to `Foo.__init__` is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument for `Foo.__init__` is incorrect: Expected `int`, found `Literal["1"]`"
+    # error: [invalid-argument-type] "Argument for `Foo.__init__` is incorrect: Expected `int`, found `Literal["1"]`"
     reveal_type(Foo("1"))  # revealed: Foo
     # error: [missing-argument] "No argument provided for required parameter `x` of `Foo.__init__`"
     # error: [missing-argument] "No argument provided for required parameter `x` of `Foo.__init__`"
@@ -1473,7 +1473,7 @@ class Foo:
     def __init__(self, x: str) -> None:
         self.x = x
 
-# error: [invalid-argument-type] "Argument to `Foo.__init__` is incorrect: Expected `str`, found `Literal[1]`"
+# error: [invalid-argument-type] "Argument for `Foo.__init__` is incorrect: Expected `str`, found `Literal[1]`"
 Foo(1)
 
 # error: [invalid-argument-type] "Argument to constructor `Foo.__new__` is incorrect: Expected `int`, found `Literal["x"]`"

--- a/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/subclass_of.md
@@ -20,7 +20,7 @@ class C:
 def _(subclass_of_c: type[C]):
     reveal_type(subclass_of_c(1))  # revealed: C
 
-    # error: [invalid-argument-type] "Argument to `C.__init__` is incorrect: Expected `int`, found `Literal["a"]`"
+    # error: [invalid-argument-type] "Argument for `C.__init__` is incorrect: Expected `int`, found `Literal["a"]`"
     reveal_type(subclass_of_c("a"))  # revealed: C
     # error: [missing-argument] "No argument provided for required parameter `x` of `C.__init__`"
     reveal_type(subclass_of_c())  # revealed: C

--- a/crates/ty_python_semantic/resources/mdtest/call/union.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/union.md
@@ -113,7 +113,7 @@ class B:
 
 def _(flag: bool):
     cls = A if flag else B
-    # error: [invalid-argument-type] "Argument to `B.__init__` is incorrect: Expected `str`, found `Literal[1]`"
+    # error: [invalid-argument-type] "Argument for `B.__init__` is incorrect: Expected `str`, found `Literal[1]`"
     reveal_type(cls(1))  # revealed: A | B
 ```
 
@@ -129,8 +129,8 @@ class B:
     def __init__(self, x: int) -> None: ...
 
 def _(factory: type[A] | type[B]):
-    # error: [invalid-argument-type] "Argument to `A.__init__` is incorrect: Expected `int`, found `Literal["hello"]`"
-    # error: [invalid-argument-type] "Argument to `B.__init__` is incorrect: Expected `int`, found `Literal["hello"]`"
+    # error: [invalid-argument-type] "Argument for `A.__init__` is incorrect: Expected `int`, found `Literal["hello"]`"
+    # error: [invalid-argument-type] "Argument for `B.__init__` is incorrect: Expected `int`, found `Literal["hello"]`"
     factory("hello")
 ```
 
@@ -155,8 +155,8 @@ class IntDiag(DeferredDiagBase[int]): ...
 class StrDiag(DeferredDiagBase[str]): ...
 
 def _(factory: type[IntDiag] | type[StrDiag]):
-    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `int`, found `float`"
-    # error: [invalid-argument-type] "Argument to `DeferredDiagBase.__init__` is incorrect: Expected `str`, found `float`"
+    # error: [invalid-argument-type] "Argument for `DeferredDiagBase.__init__` is incorrect: Expected `int`, found `float`"
+    # error: [invalid-argument-type] "Argument for `DeferredDiagBase.__init__` is incorrect: Expected `str`, found `float`"
     factory(1.2)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/class/super.md
+++ b/crates/ty_python_semantic/resources/mdtest/class/super.md
@@ -807,7 +807,7 @@ class Parent:
 
 class Child(Parent):
     def __init__(self, children: Mapping[str, Child] | None = None) -> None:
-        # error: [invalid-argument-type] "Argument to `Parent.__init__` is incorrect: Expected `Mapping[str, Self@__init__] | None`, found `Mapping[str, Child] | None`"
+        # error: [invalid-argument-type] "Argument for `Parent.__init__` is incorrect: Expected `Mapping[str, Self@__init__] | None`, found `Mapping[str, Child] | None`"
         super().__init__(children)
 
 # The fix is to use `Self` consistently in the subclass:

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -170,7 +170,7 @@ from typing import Self
 class B:
     def __init__(self, x: int) -> None: ...
     def clone(self: Self) -> Self:
-        # error: [invalid-argument-type] "Argument to `B.__init__` is incorrect: Expected `int`, found `Literal["x"]`"
+        # error: [invalid-argument-type] "Argument for `B.__init__` is incorrect: Expected `int`, found `Literal["x"]`"
         self.__class__("x")
         return self.__class__(1)
 ```

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -7092,9 +7092,13 @@ impl<'db> BindingError<'db> {
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
-                    callable_description
-                        .map(|description| format!(" to {description}"))
-                        .unwrap_or_default()
+                    callable_description.map_or_else(String::new, |description| {
+                        if description.kind.is_none() {
+                            format!(" for {description}")
+                        } else {
+                            format!(" to {description}")
+                        }
+                    })
                 ));
                 if matches!(
                     provenance,


### PR DESCRIPTION
## Summary

This deliberately changes `invalid-argument-type` wording for `__init__` calls from “Argument to …” to “Argument for …”. The diagnostic count and locations should stay stable, while duplicate constructor diagnostics on a single line exercise ecosystem-analyzer’s current greedy diff-pairing bug.

The goal of this draft PR is to capture the buggy report with Ruff’s current ecosystem-analyzer pin, then update the pin to astral-sh/ecosystem-analyzer#77 and compare the rerun. This PR is experimental and is not intended to merge.