### PR TITLE
Detect repeated signed and complex dictionary keys

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pyflakes/F601.py
+++ b/crates/ruff_linter/resources/test/fixtures/pyflakes/F601.py
@@ -71,3 +71,12 @@ x = {
 
 x = {(f(), 2): 1, (f(), 2.0): 2}
 x = {9007199254740993: 1, 9007199254740993 + 0j: 2}
+
+# Regression test for: https://github.com/astral-sh/ruff/pull/25982#pullrequestreview-4495269928
+x = {False: 1, -0: 2}
+x = {-0: 1, False: 2}
+x = {True: 1, 1 + 0j: 2}
+x = {1 + 0j: 1, True: 2}
+x = {-1: 1, -1 + 0j: 2}
+x = {-1 + 0j: 1, -1: 2}
+x = {-1 + 2j: 1, -1 + 2j: 2}

--- a/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
+++ b/crates/ruff_linter/src/rules/pyflakes/rules/repeated_keys.rs
@@ -170,15 +170,8 @@ pub(crate) fn repeated_keys(checker: &Checker, dict: &ast::ExprDict) {
             Entry::Occupied(mut entry) => {
                 let (seen_key, seen_values) = entry.get_mut();
                 match key {
-                    Expr::StringLiteral(_)
-                    | Expr::BytesLiteral(_)
-                    | Expr::NumberLiteral(_)
-                    | Expr::BooleanLiteral(_)
-                    | Expr::NoneLiteral(_)
-                    | Expr::EllipsisLiteral(_)
-                    | Expr::Tuple(_)
-                    | Expr::FString(_)
-                        if checker.is_rule_enabled(Rule::MultiValueRepeatedKeyLiteral) =>
+                    key if is_literal_key(key)
+                        && checker.is_rule_enabled(Rule::MultiValueRepeatedKeyLiteral) =>
                     {
                         let mut diagnostic = checker.report_diagnostic(
                             MultiValueRepeatedKeyLiteral {
@@ -241,5 +234,52 @@ pub(crate) fn repeated_keys(checker: &Checker, dict: &ast::ExprDict) {
                 }
             }
         }
+    }
+}
+
+fn is_literal_key(expr: &Expr) -> bool {
+    match expr {
+        Expr::StringLiteral(_)
+        | Expr::BytesLiteral(_)
+        | Expr::NumberLiteral(_)
+        | Expr::BooleanLiteral(_)
+        | Expr::NoneLiteral(_)
+        | Expr::EllipsisLiteral(_)
+        | Expr::Tuple(_)
+        | Expr::FString(_) => true,
+        Expr::UnaryOp(ast::ExprUnaryOp {
+            op: ast::UnaryOp::UAdd | ast::UnaryOp::USub,
+            operand,
+            ..
+        }) => signed_number_literal(operand).is_some(),
+        Expr::BinOp(ast::ExprBinOp {
+            left,
+            op: ast::Operator::Add | ast::Operator::Sub,
+            right,
+            ..
+        }) => {
+            signed_number_literal(left).is_some_and(|number| {
+                matches!(number.value, ast::Number::Int(_) | ast::Number::Float(_))
+            }) && matches!(
+                right.as_ref(),
+                Expr::NumberLiteral(ast::ExprNumberLiteral {
+                    value: ast::Number::Complex { .. },
+                    ..
+                })
+            )
+        }
+        _ => false,
+    }
+}
+
+fn signed_number_literal(expr: &Expr) -> Option<&ast::ExprNumberLiteral> {
+    match expr {
+        Expr::NumberLiteral(number) => Some(number),
+        Expr::UnaryOp(ast::ExprUnaryOp {
+            op: ast::UnaryOp::UAdd | ast::UnaryOp::USub,
+            operand,
+            ..
+        }) => signed_number_literal(operand),
+        _ => None,
     }
 }

--- a/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F601_F601.py.snap
+++ b/crates/ruff_linter/src/rules/pyflakes/snapshots/ruff_linter__rules__pyflakes__tests__F601_F601.py.snap
@@ -395,3 +395,83 @@ F601 Dictionary key literal `False` repeated (`False` hashes to the same value a
 70 | }
    |
 help: Remove repeated key literal `False`
+
+F601 Dictionary key literal `-0` repeated (`-0` hashes to the same value as `False`)
+  --> F601.py:76:16
+   |
+75 | # Regression test for: https://github.com/astral-sh/ruff/pull/25982#pullrequestreview-4495269928
+76 | x = {False: 1, -0: 2}
+   |                ^^
+77 | x = {-0: 1, False: 2}
+78 | x = {True: 1, 1 + 0j: 2}
+   |
+help: Remove repeated key literal `-0`
+
+F601 Dictionary key literal `False` repeated (`False` hashes to the same value as `-0`)
+  --> F601.py:77:13
+   |
+75 | # Regression test for: https://github.com/astral-sh/ruff/pull/25982#pullrequestreview-4495269928
+76 | x = {False: 1, -0: 2}
+77 | x = {-0: 1, False: 2}
+   |             ^^^^^
+78 | x = {True: 1, 1 + 0j: 2}
+79 | x = {1 + 0j: 1, True: 2}
+   |
+help: Remove repeated key literal `False`
+
+F601 Dictionary key literal `1 + 0j` repeated (`1 + 0j` hashes to the same value as `True`)
+  --> F601.py:78:15
+   |
+76 | x = {False: 1, -0: 2}
+77 | x = {-0: 1, False: 2}
+78 | x = {True: 1, 1 + 0j: 2}
+   |               ^^^^^^
+79 | x = {1 + 0j: 1, True: 2}
+80 | x = {-1: 1, -1 + 0j: 2}
+   |
+help: Remove repeated key literal `1 + 0j`
+
+F601 Dictionary key literal `True` repeated (`True` hashes to the same value as `1 + 0j`)
+  --> F601.py:79:17
+   |
+77 | x = {-0: 1, False: 2}
+78 | x = {True: 1, 1 + 0j: 2}
+79 | x = {1 + 0j: 1, True: 2}
+   |                 ^^^^
+80 | x = {-1: 1, -1 + 0j: 2}
+81 | x = {-1 + 0j: 1, -1: 2}
+   |
+help: Remove repeated key literal `True`
+
+F601 Dictionary key literal `-1 + 0j` repeated (`-1 + 0j` hashes to the same value as `-1`)
+  --> F601.py:80:13
+   |
+78 | x = {True: 1, 1 + 0j: 2}
+79 | x = {1 + 0j: 1, True: 2}
+80 | x = {-1: 1, -1 + 0j: 2}
+   |             ^^^^^^^
+81 | x = {-1 + 0j: 1, -1: 2}
+82 | x = {-1 + 2j: 1, -1 + 2j: 2}
+   |
+help: Remove repeated key literal `-1 + 0j`
+
+F601 Dictionary key literal `-1` repeated (`-1` hashes to the same value as `-1 + 0j`)
+  --> F601.py:81:18
+   |
+79 | x = {1 + 0j: 1, True: 2}
+80 | x = {-1: 1, -1 + 0j: 2}
+81 | x = {-1 + 0j: 1, -1: 2}
+   |                  ^^
+82 | x = {-1 + 2j: 1, -1 + 2j: 2}
+   |
+help: Remove repeated key literal `-1`
+
+F601 Dictionary key literal `-1 + 2j` repeated
+  --> F601.py:82:18
+   |
+80 | x = {-1: 1, -1 + 0j: 2}
+81 | x = {-1 + 0j: 1, -1: 2}
+82 | x = {-1 + 2j: 1, -1 + 2j: 2}
+   |                  ^^^^^^^
+   |
+help: Remove repeated key literal `-1 + 2j`


### PR DESCRIPTION
## Summary

F601 hashes dictionary keys with `HashableExpr`, but it only reported duplicate literal AST nodes, tuples, and f-strings. Signed numbers and constructed complex numbers are represented as unary or binary expressions, so the numeric-key equivalences added in #25982 were order-dependent:

```python
{False: 1, -0: 2}  # missed
{-0: 1, False: 2}  # reported
```

This recognizes signed numeric and constructed complex expressions as literal keys without treating arbitrary unary or binary expressions as literals. F601 now reports the later key in either order for both `False`/`-0` and `True`/`1 + 0j`.
