### PR TITLE
[ty] Clarify type variable kind names

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6386,7 +6386,7 @@ impl<'db> Type<'db> {
                 {
                     Some(*bound_typevar)
                 }
-                TypeVarKind::ParamSpec
+                TypeVarKind::LegacyParamSpec
                     if binding_context.is_none_or(|binding_context| {
                         bound_typevar.binding_context(db)
                             == BindingContext::Definition(binding_context)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6378,7 +6378,7 @@ impl<'db> Type<'db> {
     ) {
         let matching_typevar = |bound_typevar: &BoundTypeVarInstance<'db>| {
             match bound_typevar.typevar(db).kind(db) {
-                TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::TypingSelf
+                TypeVarKind::LegacyTypeVar | TypeVarKind::Pep613Alias | TypeVarKind::TypingSelf
                     if binding_context.is_none_or(|binding_context| {
                         bound_typevar.binding_context(db)
                             == BindingContext::Definition(binding_context)

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5939,7 +5939,7 @@ pub(crate) fn report_shadowed_type_variable<'db>(
         | TypeVarKind::Pep695
         | TypeVarKind::TypingSelf
         | TypeVarKind::Pep613Alias => "type variable",
-        TypeVarKind::ParamSpec | TypeVarKind::Pep695ParamSpec => "ParamSpec",
+        TypeVarKind::LegacyParamSpec | TypeVarKind::Pep695ParamSpec => "ParamSpec",
     };
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Generic {kind} `{name}` uses {typevar_kind} `{typevar_name}` already bound by an enclosing scope",

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5935,8 +5935,8 @@ pub(crate) fn report_shadowed_type_variable<'db>(
         return;
     };
     let typevar_kind = match type_var_kind {
-        TypeVarKind::Legacy
-        | TypeVarKind::Pep695
+        TypeVarKind::LegacyTypeVar
+        | TypeVarKind::Pep695TypeVar
         | TypeVarKind::TypingSelf
         | TypeVarKind::Pep613Alias => "type variable",
         TypeVarKind::LegacyParamSpec | TypeVarKind::Pep695ParamSpec => "ParamSpec",

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -435,10 +435,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 for enclosing in enclosing_generic_contexts(db, self.index, current_scope) {
                     if let Some(other_typevar) = enclosing.binds_named_typevar(db, &param_name.id) {
                         let kind = match type_param {
-                            ast::TypeParam::TypeVar(_) => TypeVarKind::Pep695,
+                            ast::TypeParam::TypeVar(_) => TypeVarKind::Pep695TypeVar,
                             ast::TypeParam::ParamSpec(_) => TypeVarKind::Pep695ParamSpec,
                             // TODO: should be `TypeVarKind::Pep695TypeVarTuple`
-                            ast::TypeParam::TypeVarTuple(_) => TypeVarKind::Pep695,
+                            ast::TypeParam::TypeVarTuple(_) => TypeVarKind::Pep695TypeVar,
                         };
                         report_shadowed_type_variable(
                             &self.context,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -66,7 +66,7 @@ fn check_pep695_function_legacy_typevars<'db>(
             if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
                 && matches!(
                     typevar.kind(db),
-                    TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+                    TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
                 )
             {
                 Some(typevar)
@@ -206,7 +206,7 @@ fn check_legacy_typevar_defaults<'db>(
         // by `check_default_for_outer_scope_typevars` in the type parameter scope.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
         ) {
             continue;
         }
@@ -331,7 +331,7 @@ fn check_legacy_typevar_ordering<'db>(
         // Only check legacy TypeVars; PEP 695 ordering is validated by the parser.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::ParamSpec
+            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
         ) {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -66,7 +66,9 @@ fn check_pep695_function_legacy_typevars<'db>(
             if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
                 && matches!(
                     typevar.kind(db),
-                    TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
+                    TypeVarKind::LegacyTypeVar
+                        | TypeVarKind::Pep613Alias
+                        | TypeVarKind::LegacyParamSpec
                 )
             {
                 Some(typevar)
@@ -206,7 +208,7 @@ fn check_legacy_typevar_defaults<'db>(
         // by `check_default_for_outer_scope_typevars` in the type parameter scope.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
+            TypeVarKind::LegacyTypeVar | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
         ) {
             continue;
         }
@@ -331,7 +333,7 @@ fn check_legacy_typevar_ordering<'db>(
         // Only check legacy TypeVars; PEP 695 ordering is validated by the parser.
         if !matches!(
             typevar.kind(db),
-            TypeVarKind::Legacy | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
+            TypeVarKind::LegacyTypeVar | TypeVarKind::Pep613Alias | TypeVarKind::LegacyParamSpec
         ) {
             continue;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -69,7 +69,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if bound_or_constraint.is_some() || default.is_some() {
             self.deferred.insert(definition);
         }
-        let identity = TypeVarIdentity::new(db, &name.id, Some(definition), TypeVarKind::Pep695);
+        let identity =
+            TypeVarIdentity::new(db, &name.id, Some(definition), TypeVarKind::Pep695TypeVar);
         let ty = Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db,
             identity,
@@ -1253,7 +1254,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             target_name.clone(),
             Some(definition),
-            TypeVarKind::Legacy,
+            TypeVarKind::LegacyTypeVar,
         );
         Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db,

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -915,7 +915,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             db,
             target_name.clone(),
             Some(definition),
-            TypeVarKind::ParamSpec,
+            TypeVarKind::LegacyParamSpec,
         );
         Type::KnownInstance(KnownInstanceType::TypeVar(TypeVarInstance::new(
             db, identity, None, variance, default,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1240,7 +1240,7 @@ pub enum TypeVarKind {
     /// `typing.Self`
     TypingSelf,
     /// `P = ParamSpec("P")`
-    ParamSpec,
+    LegacyParamSpec,
     /// `def foo[**P]() -> None: ...`
     Pep695ParamSpec,
     /// `Alias: typing.TypeAlias = T`
@@ -1249,7 +1249,7 @@ pub enum TypeVarKind {
 
 impl TypeVarKind {
     pub(super) const fn is_paramspec(self) -> bool {
-        matches!(self, Self::ParamSpec | Self::Pep695ParamSpec)
+        matches!(self, Self::LegacyParamSpec | Self::Pep695ParamSpec)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -638,7 +638,7 @@ impl<'db> TypeVarInstance<'db> {
     pub fn bind_pep695(self, db: &'db dyn Db) -> Option<BoundTypeVarInstance<'db>> {
         if !matches!(
             self.identity(db).kind(db),
-            TypeVarKind::Pep695 | TypeVarKind::Pep695ParamSpec
+            TypeVarKind::Pep695TypeVar | TypeVarKind::Pep695ParamSpec
         ) {
             return None;
         }
@@ -945,7 +945,7 @@ impl<'db> BoundTypeVarInstance<'db> {
             db,
             name,
             None, // definition
-            TypeVarKind::Pep695,
+            TypeVarKind::Pep695TypeVar,
         );
         let typevar = TypeVarInstance::new(
             db,
@@ -1234,9 +1234,9 @@ impl<'db> BoundTypeVarInstance<'db> {
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
 pub enum TypeVarKind {
     /// `T = TypeVar("T")`
-    Legacy,
+    LegacyTypeVar,
     /// `def foo[T](x: T) -> T: ...`
-    Pep695,
+    Pep695TypeVar,
     /// `typing.Self`
     TypingSelf,
     /// `P = ParamSpec("P")`


### PR DESCRIPTION
## Summary

This is a follow-up to #25979. The `TypeVarKind` variants previously used the broad names `Legacy`, `Pep695`, and `ParamSpec`, making it unclear whether a variant represented a `TypeVar` or `ParamSpec` and which declaration syntax produced it.

This renames them to `LegacyTypeVar`, `Pep695TypeVar`, and `LegacyParamSpec`, complementing the existing `Pep695ParamSpec` variant. The names now identify both the parameter kind and declaration style without changing behavior.
