### PR TITLE
[ty] Refine structural pattern exhaustiveness

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -43,9 +43,10 @@ use crate::place::{
     match_subject_place_expressions,
 };
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
-    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
+    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
+    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
+    SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -2045,37 +2046,38 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Pattern::MatchClass(pattern) => {
                 let cls = self.add_standalone_expression(&pattern.cls);
 
-                // TODO: A class pattern with only irrefutable subpatterns can still fail if
-                // extracting an attribute named by `__match_args__` or a keyword fails. We retain
-                // this existing approximation because treating all class patterns with arguments
-                // as refutable caused a large ecosystem change. Follow-up work should determine
-                // irrefutability by analyzing the class's attributes and `__match_args__`.
-                PatternPredicateKind::Class(
-                    cls,
-                    if pattern
+                PatternPredicateKind::Class(ClassPatternPredicateKind {
+                    class: cls,
+                    positional: pattern
                         .arguments
                         .patterns
                         .iter()
-                        .all(ast::Pattern::is_irrefutable)
-                        && pattern
-                            .arguments
-                            .keywords
-                            .iter()
-                            .all(|kw| kw.pattern.is_irrefutable())
-                    {
-                        ClassPatternKind::Irrefutable
-                    } else {
-                        ClassPatternKind::Refutable
-                    },
-                )
+                        .map(|pattern| self.predicate_kind(pattern))
+                        .collect(),
+                    keywords: pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .map(|keyword| ClassPatternKeywordPredicateKind {
+                            attr: keyword.attr.id.clone(),
+                            pattern: self.predicate_kind(&keyword.pattern),
+                        })
+                        .collect(),
+                })
             }
             ast::Pattern::MatchMapping(pattern) => {
                 // `case {}` and `case {**rest}` match every mapping, while keyed mapping
                 // patterns are refutable (`case {"x": _}` may fail for some mappings).
-                PatternPredicateKind::Mapping(if pattern.keys.is_empty() {
-                    ClassPatternKind::Irrefutable
-                } else {
-                    ClassPatternKind::Refutable
+                PatternPredicateKind::Mapping(MappingPatternPredicateKind {
+                    entries: pattern
+                        .keys
+                        .iter()
+                        .zip(&pattern.patterns)
+                        .map(|(key, pattern)| MappingPatternEntryPredicateKind {
+                            key: self.add_standalone_expression(key),
+                            pattern: self.predicate_kind(pattern),
+                        })
+                        .collect(),
                 })
             }
             ast::Pattern::MatchSequence(pattern) => {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -44,9 +44,9 @@ use crate::place::{
 };
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
-    MappingPatternEntryPredicateKind, MappingPatternPredicateKind, PatternPredicate,
-    PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
-    SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
+    MappingPatternEntryPredicateKind, PatternPredicate, PatternPredicateKind, Predicate,
+    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
+    StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
 use crate::re_exports::exported_names;
@@ -2066,10 +2066,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 })
             }
             ast::Pattern::MatchMapping(pattern) => {
-                // `case {}` and `case {**rest}` match every mapping, while keyed mapping
-                // patterns are refutable (`case {"x": _}` may fail for some mappings).
-                PatternPredicateKind::Mapping(MappingPatternPredicateKind {
-                    entries: pattern
+                // Retain keyed entries for subject-aware exhaustiveness analysis.
+                PatternPredicateKind::Mapping(
+                    pattern
                         .keys
                         .iter()
                         .zip(&pattern.patterns)
@@ -2078,7 +2077,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             pattern: self.predicate_kind(pattern),
                         })
                         .collect(),
-                })
+                )
             }
             ast::Pattern::MatchSequence(pattern) => {
                 PatternPredicateKind::Sequence(SequencePatternPredicateKind {

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -190,18 +190,6 @@ pub struct ClassPatternKeywordPredicateKind<'db> {
     pub pattern: PatternPredicateKind<'db>,
 }
 
-/// Structural details for a mapping pattern.
-#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
-pub struct MappingPatternPredicateKind<'db> {
-    pub entries: Box<[MappingPatternEntryPredicateKind<'db>]>,
-}
-
-impl MappingPatternPredicateKind<'_> {
-    pub fn is_irrefutable(&self) -> bool {
-        self.entries.is_empty()
-    }
-}
-
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct MappingPatternEntryPredicateKind<'db> {
     pub key: Expression<'db>,
@@ -216,7 +204,7 @@ pub enum PatternPredicateKind<'db> {
     Value(Expression<'db>),
     Or(Box<[PatternPredicateKind<'db>]>),
     Class(ClassPatternPredicateKind<'db>),
-    Mapping(MappingPatternPredicateKind<'db>),
+    Mapping(Box<[MappingPatternEntryPredicateKind<'db>]>),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Star(Option<Name>),

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -144,18 +144,6 @@ pub struct SubjectElementPatternPredicate<'db> {
     pub target: ExpressionNodeKey,
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-pub enum ClassPatternKind {
-    Irrefutable,
-    Refutable,
-}
-
-impl ClassPatternKind {
-    pub fn is_irrefutable(self) -> bool {
-        matches!(self, ClassPatternKind::Irrefutable)
-    }
-}
-
 /// Structural details for sequence patterns that affect narrowing and reachability.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct SequencePatternPredicateKind<'db> {
@@ -182,6 +170,44 @@ impl<'db> SequencePatternPredicateKind<'db> {
     }
 }
 
+/// Structural details for a class pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternPredicateKind<'db> {
+    pub class: Expression<'db>,
+    pub positional: Box<[PatternPredicateKind<'db>]>,
+    pub keywords: Box<[ClassPatternKeywordPredicateKind<'db>]>,
+}
+
+impl ClassPatternPredicateKind<'_> {
+    pub fn is_argumentless(&self) -> bool {
+        self.positional.is_empty() && self.keywords.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternKeywordPredicateKind<'db> {
+    pub attr: Name,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
+/// Structural details for a mapping pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternPredicateKind<'db> {
+    pub entries: Box<[MappingPatternEntryPredicateKind<'db>]>,
+}
+
+impl MappingPatternPredicateKind<'_> {
+    pub fn is_irrefutable(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternEntryPredicateKind<'db> {
+    pub key: Expression<'db>,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
 /// Pattern structure used for type narrowing, static reachability, and inferring the types of
 /// names bound by a successful match.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
@@ -189,8 +215,8 @@ pub enum PatternPredicateKind<'db> {
     Singleton(Singleton),
     Value(Expression<'db>),
     Or(Box<[PatternPredicateKind<'db>]>),
-    Class(Expression<'db>, ClassPatternKind),
-    Mapping(ClassPatternKind),
+    Class(ClassPatternPredicateKind<'db>),
+    Mapping(MappingPatternPredicateKind<'db>),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Star(Option<Name>),

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -209,7 +209,8 @@ def _(target: FooSub | str):
 
 ### Dynamic class
 
-A dynamically typed class pattern is not known to match every subject, so later cases remain
+A dynamically typed class expression may match any value, but we cannot prove which values it does
+not match. The failed branch therefore keeps the original subject type, and later cases remain
 reachable.
 
 ```py
@@ -223,10 +224,24 @@ def _(target: int | str):
             reveal_type(target)  # revealed: (int & Any) | (str & Any)
             y = 1
         case _:
-            reveal_type(target)  # revealed: (int & Any) | (str & Any)
+            reveal_type(target)  # revealed: int | str
             y = 2
 
     reveal_type(y)  # revealed: Literal[1, 2]
+
+def dynamic_attribute_value_pattern_preserves_fallthrough(target: int) -> None:
+    match target:
+        case DynamicClass(real=0):
+            pass
+        case _:
+            target.missing  # error: [unresolved-attribute]
+
+def dynamic_attribute_capture_preserves_fallthrough(target: int) -> None:
+    match target:
+        case DynamicClass(real=_):
+            pass
+        case _:
+            target.missing  # error: [unresolved-attribute]
 ```
 
 ### Subclass-of type
@@ -289,6 +304,20 @@ def _(subj: int | abc.Callable[..., str]) -> None:
             y = 3
 
     reveal_type(y)  # revealed: Literal[2, 3]
+
+def callable_then_int(subj: abc.Callable[..., str] | int) -> int:
+    match subj:
+        case abc.Callable():
+            return 1
+        case int():
+            return 2
+
+def int_then_callable(subj: abc.Callable[..., str] | int) -> int:
+    match subj:
+        case int():
+            return 1
+        case abc.Callable():
+            return 2
 ```
 
 ### With arguments
@@ -334,6 +363,15 @@ def _(target: Point | Other):
             reveal_type(target)  # revealed: Point
         case Other():
             reveal_type(target)  # revealed: Other
+
+def ordered_or_class_pattern_preserves_fallthrough(target: Point):
+    y = 1
+
+    match target:
+        case Point(missing=_) | Other():
+            y = 2
+
+    reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
 ## Singleton match

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -229,13 +229,6 @@ def _(target: int | str):
 
     reveal_type(y)  # revealed: Literal[1, 2]
 
-def dynamic_attribute_value_pattern_preserves_fallthrough(target: int) -> None:
-    match target:
-        case DynamicClass(real=0):
-            pass
-        case _:
-            target.missing  # error: [unresolved-attribute]
-
 def dynamic_attribute_capture_preserves_fallthrough(target: int) -> None:
     match target:
         case DynamicClass(real=_):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -732,6 +732,505 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
             reveal_type(item)  # revealed: Never
 ```
 
+## Exhaustive positional patterns for built-in classes
+
+Python defines a fixed set of built-in classes whose single positional subpattern receives the
+entire subject. This example checks every such class, including nested sequence and `or` patterns:
+
+```py
+def builtin_positional_patterns_are_exhaustive(
+    value: tuple[
+        bool,
+        bytearray,
+        bytes,
+        dict[object, object],
+        float,
+        frozenset[object],
+        int,
+        list[object],
+        set[object],
+        str,
+        tuple[object, ...],
+    ],
+) -> int:
+    match value:
+        case (
+            bool(_),
+            bytearray(_),
+            bytes(_),
+            dict(_),
+            (int(_) | float(_)),
+            frozenset(_),
+            int(_),
+            list(_),
+            set(_),
+            str(_),
+            tuple(_),
+        ):
+            return 1
+```
+
+## Runtime dictionary class patterns
+
+A `TypedDict` value is a dictionary at runtime, so argumentless `dict` and `Mapping` patterns always
+match it. The positional `dict` pattern does as well:
+
+```py
+from collections.abc import Mapping
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def typed_dict_argumentless_dict_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case dict():
+            return 1
+
+def typed_dict_mapping_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case Mapping():
+            return 1
+
+def typed_dict_positional_dict_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case dict(_):
+            return 1
+```
+
+## Required `TypedDict` keys
+
+A mapping pattern is exhaustive for a `TypedDict` when every key in the pattern names a required
+field and every nested pattern accepts the field's complete type. Optional, absent, and non-string
+keys are not guaranteed to be present.
+
+```py
+from typing import Literal, TypedDict
+
+class RequiredPayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class OptionalPayload(TypedDict, total=False):
+    value: int
+
+def required_keys_are_exhaustive(value: RequiredPayload) -> int:
+    match value:
+        case {"tag": "int", "value": int()}:
+            return 1
+
+def optional_key_is_not_exhaustive(
+    value: OptionalPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {"value": _}:
+            return 1
+
+def absent_key_is_not_exhaustive(
+    value: RequiredPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {"missing": _}:
+            return 1
+
+def non_string_key_is_not_exhaustive(
+    value: RequiredPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {1: _}:
+            return 1
+```
+
+## `NamedTuple` positional patterns
+
+A `NamedTuple` provides a generated `__match_args__` tuple containing all of its fields:
+
+```py
+from typing import NamedTuple
+
+class NamedPoint(NamedTuple):
+    x: int
+    label: str
+
+def named_tuple_positional_pattern_is_exhaustive(value: NamedPoint) -> int:
+    match value:
+        case NamedPoint(_, _):
+            return 1
+```
+
+## Positional patterns for built-in subclasses
+
+Subclasses inherit this positional behavior. The positional subpattern still needs to match the
+entire value, so a literal subpattern is not exhaustive:
+
+```py
+class MyInt(int): ...
+
+def builtin_subclass_positional_pattern_is_exhaustive(value: MyInt) -> int:
+    match value:
+        case MyInt(_):
+            return 1
+
+def builtin_base_positional_pattern_is_exhaustive_for_subclass(value: MyInt) -> int:
+    match value:
+        case int(_):
+            return 1
+
+def nested_builtin_positional_pattern_is_exhaustive_for_subclass(
+    value: tuple[MyInt],
+) -> int:
+    match value:
+        case [int(_)]:
+            return 1
+
+def builtin_positional_literal_is_not_exhaustive(
+    value: MyInt,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case int(0):
+            return 1
+```
+
+## Resolving `__match_args__`
+
+For other positional class patterns, Python reads `__match_args__` from the pattern class. The
+attribute must be definitely present and must be a fixed tuple of literal attribute names. The
+selected attributes must also be definitely present on the subject:
+
+```py
+class MyIntWithDefinitelyBoundMatchArgs(int):
+    __match_args__ = ("real",)
+
+def builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
+    value: MyIntWithDefinitelyBoundMatchArgs,
+) -> int:
+    match value:
+        case MyIntWithDefinitelyBoundMatchArgs(_):
+            return 1
+
+def nested_builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
+    value: tuple[MyIntWithDefinitelyBoundMatchArgs],
+) -> int:
+    match value:
+        case [MyIntWithDefinitelyBoundMatchArgs(_)]:
+            return 1
+
+class MyIntWithMissingMatchArg(int):
+    __match_args__ = ("missing",)
+
+def builtin_subclass_with_missing_match_arg_is_not_exhaustive(
+    value: MyIntWithMissingMatchArg,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case MyIntWithMissingMatchArg(_):
+            return 1
+
+class MatchArgsMeta(type):
+    __match_args__ = ("missing",)
+
+class MyIntWithMetaclassMatchArgs(int, metaclass=MatchArgsMeta): ...
+
+def builtin_subclass_with_metaclass_match_args_is_not_exhaustive(
+    value: MyIntWithMetaclassMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case MyIntWithMetaclassMatchArgs(_):
+            return 1
+
+class KnownAttributes:
+    __match_args__ = ("x", "y")
+    x: int = 0
+    y: int = 0
+
+def fixed_match_args_are_exhaustive(value: KnownAttributes) -> int:
+    match value:
+        case KnownAttributes(_, _):
+            return 1
+
+class WidenedMatchArgs:
+    __match_args__: tuple[str, ...] = ("x",)
+    x: int = 0
+
+def widened_match_args_does_not_identify_an_attribute(
+    value: WidenedMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case WidenedMatchArgs(_):
+            return 1
+
+class AnnotatedMatchArgs(int):
+    __match_args__: tuple[str, ...]
+
+def annotated_match_args_is_not_exhaustive(
+    value: AnnotatedMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case AnnotatedMatchArgs(_):
+            return 1
+
+flag: bool = bool()
+
+class PossiblyBoundMatchArgs:
+    if flag:
+        __match_args__ = ("x",)
+    x: int = 0
+
+def possibly_bound_match_args_is_not_exhaustive(
+    value: PossiblyBoundMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyBoundMatchArgs(_):
+            return 1
+```
+
+## Properties and declared attributes
+
+Properties and declared attributes count as present when checking exhaustiveness, even though
+descriptor access can raise `AttributeError` and an annotated attribute can be absent at runtime:
+
+```py
+from typing import Literal
+
+class FallibleProperty:
+    __match_args__ = ("x",)
+
+    @property
+    def x(self) -> Literal[1]:
+        raise AttributeError
+
+def direct_fallible_property_is_statically_exhaustive(value: FallibleProperty) -> int:
+    match value:
+        case FallibleProperty(_):
+            return 1
+
+def fallible_property_value_pattern_is_statically_exhaustive(value: FallibleProperty) -> int:
+    match value:
+        case FallibleProperty(x=1):
+            return 1
+
+class DeclaredLiteralAttribute:
+    x: Literal[1]
+
+def declared_literal_attribute_subpattern_is_exhaustive(
+    value: DeclaredLiteralAttribute,
+) -> int:
+    match value:
+        case DeclaredLiteralAttribute(x=1):
+            return 1
+```
+
+## Non-final subclasses
+
+A non-final subclass can have a runtime subclass that overrides attribute access, so the fallback
+remains reachable. The same rule applies inside a sequence pattern:
+
+```py
+class BaseWithX:
+    x: int = 0
+
+class NonFinalChild(BaseWithX): ...
+
+def non_final_subclass_preserves_fallback(value: NonFinalChild) -> None:
+    match value:
+        case BaseWithX(x=_):
+            pass
+        case _:
+            reveal_type(value)  # revealed: NonFinalChild
+
+def nested_non_final_subclass_is_not_exhaustive(
+    value: tuple[NonFinalChild],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case [BaseWithX(x=_)]:
+            return 1
+```
+
+## Runtime-checkable protocol patterns
+
+Runtime-checkable protocols use `isinstance` at runtime. A non-final subject class can have a
+runtime subclass whose member behavior differs, so the fallback remains reachable even when the
+class defines or declares every protocol member:
+
+```py
+from typing import Protocol, final, runtime_checkable
+
+@runtime_checkable
+class RuntimeProtocolWithX(Protocol):
+    x: int
+
+class RuntimeProtocolImplementer:
+    x: int = 0
+
+def runtime_protocol_pattern_is_not_exhaustive_for_non_final_implementer(
+    value: RuntimeProtocolImplementer,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case RuntimeProtocolWithX(x=_):
+            return 1
+
+class DeclaredRuntimeProtocolImplementer:
+    x: int
+
+def argumentless_runtime_protocol_pattern_is_not_exhaustive(
+    value: DeclaredRuntimeProtocolImplementer,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case RuntimeProtocolWithX():
+            return 1
+
+@final
+class FinalDeclaredRuntimeProtocolImplementer:
+    x: int
+
+# TODO: This is currently considered exhaustive because the declared `x` member counts as present
+# on a final class. At runtime, however, `x` may never have been initialized, so the protocol check
+# can fail.
+def final_declared_runtime_protocol_implementer(
+    value: FinalDeclaredRuntimeProtocolImplementer,
+) -> int:
+    match value:
+        case RuntimeProtocolWithX():
+            return 1
+
+def nested_argumentless_runtime_protocol_pattern_is_not_exhaustive(
+    value: tuple[DeclaredRuntimeProtocolImplementer],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            return 1
+
+def nested_argumentless_runtime_protocol_union_preserves_fallback(
+    value: tuple[DeclaredRuntimeProtocolImplementer | int],
+) -> None:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            pass
+        case [DeclaredRuntimeProtocolImplementer()]:
+            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
+
+def nested_argumentless_runtime_protocol_list_preserves_fallback(
+    value: list[DeclaredRuntimeProtocolImplementer | int],
+) -> None:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            pass
+        case [DeclaredRuntimeProtocolImplementer()]:
+            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
+```
+
+## Final subclasses
+
+A final class has no subclasses, so an attribute known on the subject can make a base-class pattern
+exhaustive. The special positional behavior of built-in classes still comes from the pattern class,
+not from another base of the subject class:
+
+```py
+from typing import final
+
+class BaseWithoutX: ...
+
+@final
+class FinalChildWithX(BaseWithoutX):
+    x: int = 0
+
+def final_subclass_member_is_exhaustive(value: FinalChildWithX) -> int:
+    match value:
+        case BaseWithoutX(x=_):
+            return 1
+
+def nested_final_subclass_member_is_exhaustive(
+    value: tuple[FinalChildWithX],
+) -> int:
+    match value:
+        case [BaseWithoutX(x=_)]:
+            return 1
+
+class PlainBase: ...
+
+@final
+class IntPlainChild(int, PlainBase): ...
+
+def builtin_positional_behavior_comes_from_pattern_class(
+    value: IntPlainChild,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PlainBase(_):
+            return 1
+```
+
+## Nested class patterns
+
+Every nested pattern must match all possible values of the attribute it receives:
+
+```py
+from typing import Literal
+
+class Inner:
+    x: int = 0
+
+class Outer:
+    inner: Inner = Inner()
+
+def nested_class_subpattern_is_exhaustive(value: tuple[Outer]) -> int:
+    match value:
+        case [Outer(inner=Inner(x=_))]:
+            return 1
+
+class LiteralAttribute:
+    x: Literal[1] = 1
+
+def literal_attribute_subpattern_is_exhaustive(value: LiteralAttribute) -> int:
+    match value:
+        case LiteralAttribute(x=1):
+            return 1
+```
+
+## Missing class-pattern attributes
+
+A class pattern can fail after its `isinstance` check if a requested attribute is missing. This
+preserves both direct fallthrough and fallthrough from a nested sequence pattern:
+
+```py
+class MissingAttributes:
+    __match_args__ = ("x", "missing")
+    x: int = 0
+
+class OtherClass: ...
+
+def keyword_class_pattern_preserves_direct_fallback(
+    value: MissingAttributes | OtherClass,
+) -> None:
+    match value:
+        case MissingAttributes(missing=_):
+            pass
+        case _:
+            reveal_type(value)  # revealed: MissingAttributes | OtherClass
+
+def keyword_class_pattern_in_sequence_preserves_fallback(
+    value: tuple[MissingAttributes],
+) -> None:
+    match value:
+        case [MissingAttributes(_, _)]:
+            pass
+        case _:
+            reveal_type(value)  # revealed: tuple[MissingAttributes]
+```
+
+
 ## Sequence exhaustiveness
 
 Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1230,7 +1230,6 @@ def keyword_class_pattern_in_sequence_preserves_fallback(
             reveal_type(value)  # revealed: tuple[MissingAttributes]
 ```
 
-
 ## Sequence exhaustiveness
 
 Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1220,6 +1220,8 @@ A class pattern can fail after its `isinstance` check if a requested attribute i
 preserves both direct fallthrough and fallthrough from a nested sequence pattern:
 
 ```py
+from typing import final
+
 class MissingAttributes:
     __match_args__ = ("x", "missing")
     x: int = 0
@@ -1243,6 +1245,22 @@ def keyword_class_pattern_in_sequence_preserves_fallback(
             pass
         case _:
             reveal_type(value)  # revealed: tuple[MissingAttributes]
+
+def attribute_condition() -> bool:
+    return bool()
+
+@final
+class PossiblyMissingAttribute:
+    if attribute_condition():
+        x: int = 0
+
+def possibly_missing_attribute_is_not_exhaustive(
+    value: PossiblyMissingAttribute,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyMissingAttribute(x=_):
+            return 1
 ```
 
 ## Sequence exhaustiveness

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1045,8 +1045,8 @@ def declared_literal_attribute_subpattern_is_exhaustive(
 
 ## Non-final subclasses
 
-A non-final subclass can have a runtime subclass that overrides attribute access, so the fallback
-remains reachable. The same rule applies inside a sequence pattern:
+Exhaustiveness follows the static member model, so a member inherited by a non-final subclass is
+treated as present. The same rule applies inside a sequence pattern:
 
 ```py
 class BaseWithX:
@@ -1054,17 +1054,12 @@ class BaseWithX:
 
 class NonFinalChild(BaseWithX): ...
 
-def non_final_subclass_preserves_fallback(value: NonFinalChild) -> None:
+def non_final_subclass_member_is_exhaustive(value: NonFinalChild) -> int:
     match value:
         case BaseWithX(x=_):
-            pass
-        case _:
-            reveal_type(value)  # revealed: NonFinalChild
+            return 1
 
-def nested_non_final_subclass_is_not_exhaustive(
-    value: tuple[NonFinalChild],
-    # error: [invalid-return-type]
-) -> int:
+def nested_non_final_subclass_member_is_exhaustive(value: tuple[NonFinalChild]) -> int:
     match value:
         case [BaseWithX(x=_)]:
             return 1
@@ -1072,12 +1067,11 @@ def nested_non_final_subclass_is_not_exhaustive(
 
 ## Runtime-checkable protocol patterns
 
-Runtime-checkable protocols use `isinstance` at runtime. A non-final subject class can have a
-runtime subclass whose member behavior differs, so the fallback remains reachable even when the
-class defines or declares every protocol member:
+Runtime-checkable protocol patterns also follow the static member model. A subject that statically
+satisfies the protocol is treated as exhaustive regardless of whether its class is final:
 
 ```py
-from typing import Protocol, final, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 @runtime_checkable
 class RuntimeProtocolWithX(Protocol):
@@ -1086,10 +1080,7 @@ class RuntimeProtocolWithX(Protocol):
 class RuntimeProtocolImplementer:
     x: int = 0
 
-def runtime_protocol_pattern_is_not_exhaustive_for_non_final_implementer(
-    value: RuntimeProtocolImplementer,
-    # error: [invalid-return-type]
-) -> int:
+def runtime_protocol_pattern_is_exhaustive(value: RuntimeProtocolImplementer) -> int:
     match value:
         case RuntimeProtocolWithX(x=_):
             return 1
@@ -1097,31 +1088,15 @@ def runtime_protocol_pattern_is_not_exhaustive_for_non_final_implementer(
 class DeclaredRuntimeProtocolImplementer:
     x: int
 
-def argumentless_runtime_protocol_pattern_is_not_exhaustive(
+def argumentless_runtime_protocol_pattern_is_exhaustive(
     value: DeclaredRuntimeProtocolImplementer,
-    # error: [invalid-return-type]
 ) -> int:
     match value:
         case RuntimeProtocolWithX():
             return 1
 
-@final
-class FinalDeclaredRuntimeProtocolImplementer:
-    x: int
-
-# TODO: This is currently considered exhaustive because the declared `x` member counts as present
-# on a final class. At runtime, however, `x` may never have been initialized, so the protocol check
-# can fail.
-def final_declared_runtime_protocol_implementer(
-    value: FinalDeclaredRuntimeProtocolImplementer,
-) -> int:
-    match value:
-        case RuntimeProtocolWithX():
-            return 1
-
-def nested_argumentless_runtime_protocol_pattern_is_not_exhaustive(
+def nested_argumentless_runtime_protocol_pattern_is_exhaustive(
     value: tuple[DeclaredRuntimeProtocolImplementer],
-    # error: [invalid-return-type]
 ) -> int:
     match value:
         case [RuntimeProtocolWithX()]:
@@ -1136,46 +1111,41 @@ def nested_argumentless_runtime_protocol_union_preserves_fallback(
         case [DeclaredRuntimeProtocolImplementer()]:
             reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
 
-def nested_argumentless_runtime_protocol_list_preserves_fallback(
+def nested_argumentless_runtime_protocol_list_does_not_narrow_fallthrough(
     value: list[DeclaredRuntimeProtocolImplementer | int],
 ) -> None:
     match value:
         case [RuntimeProtocolWithX()]:
             pass
         case [DeclaredRuntimeProtocolImplementer()]:
-            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
+            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer | int
 ```
 
-## Final subclasses
+## Subject-class members
 
-A final class has no subclasses, so an attribute known on the subject can make a base-class pattern
-exhaustive. The special positional behavior of built-in classes still comes from the pattern class,
-not from another base of the subject class:
+A member known on the static subject type can make a base-class pattern exhaustive. The special
+positional behavior of built-in classes still comes from the pattern class, not from another base of
+the subject class:
 
 ```py
-from typing import final
-
 class BaseWithoutX: ...
 
-@final
-class FinalChildWithX(BaseWithoutX):
+class ChildWithX(BaseWithoutX):
     x: int = 0
 
-def final_subclass_member_is_exhaustive(value: FinalChildWithX) -> int:
+def subclass_member_is_exhaustive(value: ChildWithX) -> int:
     match value:
         case BaseWithoutX(x=_):
             return 1
 
-def nested_final_subclass_member_is_exhaustive(
-    value: tuple[FinalChildWithX],
+def nested_subclass_member_is_exhaustive(
+    value: tuple[ChildWithX],
 ) -> int:
     match value:
         case [BaseWithoutX(x=_)]:
             return 1
 
 class PlainBase: ...
-
-@final
 class IntPlainChild(int, PlainBase): ...
 
 def builtin_positional_behavior_comes_from_pattern_class(

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -976,7 +976,10 @@ def annotated_match_args_is_not_exhaustive(
         case AnnotatedMatchArgs(_):
             return 1
 
-flag: bool = bool()
+def condition() -> bool:
+    return bool()
+
+flag = condition()
 
 class PossiblyBoundMatchArgs:
     if flag:
@@ -989,6 +992,18 @@ def possibly_bound_match_args_is_not_exhaustive(
 ) -> int:
     match value:
         case PossiblyBoundMatchArgs(_):
+            return 1
+
+class PossiblyBoundIntMatchArgs(int):
+    if flag:
+        __match_args__ = ("missing",)
+
+def possibly_bound_match_args_does_not_enable_match_self(
+    value: PossiblyBoundIntMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyBoundIntMatchArgs(_):
             return 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1236,7 +1236,14 @@ Sequence patterns also contribute to negative narrowing and exhaustiveness. Exac
 make a match exhaustive.
 
 ```py
+from typing import final
 from typing_extensions import assert_never
+
+class LengthBase:
+    x: int
+
+@final
+class LengthChild(LengthBase): ...
 
 def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
     match subj:
@@ -1267,6 +1274,16 @@ def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) 
             return left + right
         case _:
             assert_never(value)
+
+# Checking an element against its subject type does not replace the sequence pattern's length
+# check. This one-element pattern cannot match a two-element tuple.
+def subject_aware_element_keeps_length_check(
+    value: tuple[LengthChild, LengthChild],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case [LengthBase(x=_)]:
+            return 1
 
 def test_match_exact_tuple_element_union_is_exhaustive(x: tuple[int | str]) -> int:
     match x:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1071,7 +1071,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Mapping(kind) => {
             let mapping_ty = mapping_pattern_type(db);
             if subject_ty.is_subtype_of(db, mapping_ty) {
-                if kind.is_irrefutable() {
+                if kind.is_empty() {
                     Truthiness::AlwaysTrue
                 } else {
                     Truthiness::Ambiguous

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -202,9 +202,9 @@ use crate::{
     types::{
         CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        equality_truthiness, expand_type, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-        sequence_pattern_type_builder, singleton_pattern_type,
+        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
+        infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
+        pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
     },
 };
 use ruff_index::{Idx, IndexSlice};
@@ -491,7 +491,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 
     let truthiness =
-        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty);
+        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty, None);
 
     if truthiness == Truthiness::AlwaysTrue && predicate.guard(db).is_some() {
         // Fall back to ambiguous, the guard might change the result.
@@ -980,6 +980,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
+    precomputed_definite_match_ty: Option<Type<'db>>,
 ) -> Truthiness {
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
@@ -1014,9 +1015,20 @@ fn analyze_single_pattern_predicate_kind<'db>(
                         .add_negative(UnionType::from_elements(db, excluded_types.iter()))
                         .build();
 
-                    excluded_types.push(definite_match_pattern_type(db, p));
+                    let definitely_matched =
+                        definite_match_pattern_type_for_subject(db, p, narrowed_subject_ty);
+                    excluded_types.push(definitely_matched);
 
-                    analyze_single_pattern_predicate_kind(db, p, narrowed_subject_ty)
+                    if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
+                        Truthiness::AlwaysTrue
+                    } else {
+                        analyze_single_pattern_predicate_kind(
+                            db,
+                            p,
+                            narrowed_subject_ty,
+                            Some(definitely_matched),
+                        )
+                    }
                 })
                 // this is just a "max", but with a slight optimization:
                 // `AlwaysTrue` is the "greatest" possible element, so we short-circuit if we get there
@@ -1033,34 +1045,28 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 });
             truthiness
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
+        PatternPredicateKind::Class(kind) => {
             let class_ty =
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
-                        Some(Type::instance(db, class.top_materialization(db)))
-                    }
+                match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        Some(callable_pattern_type(db))
+                        callable_pattern_type(db)
                     }
-                    _ => None,
+                    _ => return Truthiness::Ambiguous,
                 };
+            let definitely_matched = precomputed_definite_match_ty.unwrap_or_else(|| {
+                definite_match_pattern_type_for_subject(db, predicate_kind, subject_ty)
+            });
 
-            class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
-                if subject_ty.is_subtype_of(db, class_ty) {
-                    if kind.is_irrefutable() {
-                        Truthiness::AlwaysTrue
-                    } else {
-                        // A class pattern like `case Point(x=0, y=0)` is not irrefutable,
-                        // i.e. it does not match all instances of `Point`. This means that
-                        // we can't tell for sure if this pattern will match or not.
-                        Truthiness::Ambiguous
-                    }
-                } else if subject_ty.is_disjoint_from(db, class_ty) {
-                    Truthiness::AlwaysFalse
-                } else {
-                    Truthiness::Ambiguous
-                }
-            })
+            if subject_ty.is_equivalent_to(db, definitely_matched)
+                || subject_ty.is_subtype_of(db, definitely_matched)
+            {
+                Truthiness::AlwaysTrue
+            } else if subject_ty.is_disjoint_from(db, class_ty) {
+                Truthiness::AlwaysFalse
+            } else {
+                Truthiness::Ambiguous
+            }
         }
         PatternPredicateKind::Mapping(kind) => {
             let mapping_ty = mapping_pattern_type(db);
@@ -1092,7 +1098,14 @@ fn analyze_single_pattern_predicate_kind<'db>(
         }
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty))
+            .map(|p| {
+                analyze_single_pattern_predicate_kind(
+                    db,
+                    p,
+                    subject_ty,
+                    precomputed_definite_match_ty,
+                )
+            })
             .unwrap_or(Truthiness::AlwaysTrue),
         PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -37,8 +37,8 @@ pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
     callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-    pattern_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,8 +35,9 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, exact_sequence_pattern_type,
-    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
+    callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
+    exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
+    pattern_fallthrough_type,
     sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -163,6 +163,25 @@ impl KnownClass {
         matches!(self, Self::SpecialForm)
     }
 
+    /// Return whether class patterns with a single positional subpattern match against the
+    /// subject itself when `__match_args__` is undefined.
+    pub(crate) const fn has_match_self_flag(self) -> bool {
+        matches!(
+            self,
+            Self::Bool
+                | Self::Bytearray
+                | Self::Bytes
+                | Self::Dict
+                | Self::Float
+                | Self::FrozenSet
+                | Self::Int
+                | Self::List
+                | Self::Set
+                | Self::Str
+                | Self::Tuple
+        )
+    }
+
     /// Determine whether instances of this class are always truthy, always falsy,
     /// or have an ambiguous truthiness.
     ///

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -163,25 +163,6 @@ impl KnownClass {
         matches!(self, Self::SpecialForm)
     }
 
-    /// Return whether class patterns with a single positional subpattern match against the
-    /// subject itself when `__match_args__` is undefined.
-    pub(crate) const fn has_match_self_flag(self) -> bool {
-        matches!(
-            self,
-            Self::Bool
-                | Self::Bytearray
-                | Self::Bytes
-                | Self::Dict
-                | Self::Float
-                | Self::FrozenSet
-                | Self::Int
-                | Self::List
-                | Self::Set
-                | Self::Str
-                | Self::Tuple
-        )
-    }
-
     /// Determine whether instances of this class are always truthy, always falsy,
     /// or have an ambiguous truthiness.
     ///

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2483,7 +2483,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     rest,
                 } = match_mapping;
                 for key in keys {
-                    self.infer_expression(key, TypeContext::default());
+                    self.infer_maybe_standalone_expression(key, TypeContext::default());
                 }
                 for pattern in patterns {
                     self.infer_nested_match_pattern(pattern);

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -393,6 +393,10 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                     if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
                         return subject_ty;
                     }
+                    let class_ty = Type::instance(db, class.top_materialization(db));
+                    if kind.is_argumentless() && subject_ty.is_subtype_of(db, class_ty) {
+                        return Type::Never;
+                    }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_argumentless()
@@ -434,16 +438,9 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
         _ => return Type::Never,
     }
 
-    let subject_independent_ty = definite_match_pattern_type(db, kind);
-    // The subject-aware checks above can reject an otherwise exhaustive-looking pattern. Do not
-    // let the less precise fallback reintroduce that conclusion.
-    if subject_ty.is_subtype_of(db, subject_independent_ty) {
-        return Type::Never;
-    }
-
     IntersectionBuilder::new(db)
         .add_positive(subject_ty)
-        .add_positive(subject_independent_ty)
+        .add_positive(definite_match_pattern_type(db, kind))
         .build()
 }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -2,7 +2,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
 use ty_python_core::predicate::{
-    ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicateKind,
+    ClassPatternPredicateKind, MappingPatternEntryPredicateKind, PatternPredicateKind,
     SequencePatternPredicateKind,
 };
 
@@ -59,6 +59,129 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Bytearray.to_instance(db))
 }
 
+fn sequence_pattern_getitem_method<'db>(
+    db: &'db dyn Db,
+    indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
+    fallback_return_type: Option<Type<'db>>,
+) -> CallableType<'db> {
+    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
+
+    let overloads = indexed_element_types
+        .into_iter()
+        .map(|(index, element_type)| {
+            Signature::new(
+                Parameters::new(
+                    db,
+                    [
+                        self_parameter(),
+                        Parameter::positional_only(Some(Name::new_static("index")))
+                            .with_annotated_type(Type::int_literal(index)),
+                    ],
+                ),
+                element_type,
+            )
+        });
+    let fallback_overload = fallback_return_type.map(|fallback_return_type| {
+        Signature::new(
+            Parameters::new(
+                db,
+                [
+                    self_parameter(),
+                    Parameter::positional_only(Some(Name::new_static("index")))
+                        .with_annotated_type(KnownClass::Int.to_instance(db)),
+                ],
+            ),
+            fallback_return_type,
+        )
+    });
+
+    CallableType::new(
+        db,
+        CallableSignature::from_overloads(overloads.chain(fallback_overload)),
+        CallableTypeKind::FunctionLike,
+        CallableFunctionProvenance::None,
+    )
+}
+
+/// Build the structural type used for a fixed-length sequence pattern.
+///
+/// For a pattern like:
+///
+/// ```python
+/// match value:
+///     case [int(), str()]:
+///         ...
+/// ```
+///
+/// this returns the sequence-pattern runtime type plus a synthesized protocol
+/// whose `__len__` and indexed `__getitem__` methods encode the fixed length
+/// and element types.
+pub(crate) fn exact_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    element_types: impl ExactSizeIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    let Ok(length) = i64::try_from(element_types.len()) else {
+        return sequence_pattern_type_builder(db).build();
+    };
+
+    // `False == 0` and `True == 1`, so the protocol must accept both literals.
+    let length_type = match length {
+        0 => UnionType::from_two_elements(db, Type::int_literal(0), Type::bool_literal(false)),
+        1 => UnionType::from_two_elements(db, Type::int_literal(1), Type::bool_literal(true)),
+        _ => Type::int_literal(length),
+    };
+
+    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
+
+    let len_signature = Signature::new(Parameters::new(db, [self_parameter()]), length_type);
+    let len_method = CallableType::function_like(db, len_signature);
+
+    let getitem_method = (element_types.len() > 0).then(|| {
+        (
+            "__getitem__",
+            sequence_pattern_getitem_method(db, (0..length).zip(element_types), None),
+        )
+    });
+
+    let protocol = Type::protocol_with_methods(
+        db,
+        std::iter::once(("__len__", len_method)).chain(getitem_method),
+    );
+
+    sequence_pattern_type_builder(db)
+        .add_positive(protocol)
+        .build()
+}
+
+/// Build the structural type used for a sequence pattern containing `*rest`.
+///
+/// Fixed prefix elements use non-negative indices and fixed suffix elements use
+/// negative indices. Other integer indices retain the sequence's element type.
+pub(crate) fn starred_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    prefix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
+    suffix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    if prefix_element_types.len() == 0 && suffix_element_types.len() == 0 {
+        return sequence_pattern_type_builder(db).build();
+    }
+
+    let Ok(suffix_length) = i64::try_from(suffix_element_types.len()) else {
+        return sequence_pattern_type_builder(db).build();
+    };
+
+    let indexed_element_types = (0_i64..)
+        .zip(prefix_element_types)
+        .chain((-suffix_length..0).zip(suffix_element_types));
+    let getitem_method =
+        sequence_pattern_getitem_method(db, indexed_element_types, Some(Type::object()));
+    let protocol = Type::protocol_with_methods(db, [("__getitem__", getitem_method)]);
+
+    sequence_pattern_type_builder(db)
+        .add_positive(protocol)
+        .build()
+}
+
 /// Return whether every value in `subject_ty` is statically guaranteed to match this class pattern.
 ///
 /// Attribute subpatterns are checked recursively against their statically known member types. A
@@ -110,8 +233,7 @@ fn class_pattern_is_exhaustive(
         return !subject_is_non_final_subclass;
     }
 
-    let positional_sources =
-        class_pattern_positional_sources(db, Some(class), kind.positional.len());
+    let positional_sources = class_pattern_positional_sources(db, class, kind.positional.len());
     let extracts_attribute = !kind.keywords.is_empty()
         || positional_sources
             .iter()
@@ -146,7 +268,6 @@ enum ClassMatchArgs<'db> {
     PossiblyUndefined,
 }
 
-#[derive(Clone)]
 enum ClassPatternPositionalSource {
     MatchSelf,
     Attribute(Name),
@@ -184,21 +305,30 @@ fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
         .iter_mro(db)
         .filter_map(ClassBase::into_class)
         .any(|base| {
-            base.class_literal(db)
-                .known(db)
-                .is_some_and(KnownClass::has_match_self_flag)
+            matches!(
+                base.class_literal(db).known(db),
+                Some(
+                    KnownClass::Bool
+                        | KnownClass::Bytearray
+                        | KnownClass::Bytes
+                        | KnownClass::Dict
+                        | KnownClass::Float
+                        | KnownClass::FrozenSet
+                        | KnownClass::Int
+                        | KnownClass::List
+                        | KnownClass::Set
+                        | KnownClass::Str
+                        | KnownClass::Tuple
+                )
+            )
         })
 }
 
 fn class_pattern_positional_sources(
     db: &dyn Db,
-    class: Option<ClassLiteral<'_>>,
+    class: ClassLiteral<'_>,
     positional_count: usize,
 ) -> Vec<ClassPatternPositionalSource> {
-    let Some(class) = class else {
-        return vec![ClassPatternPositionalSource::Unknown; positional_count];
-    };
-
     let fixed = match class_match_args_type(db, class) {
         ClassMatchArgs::Undefined if class_has_match_self_flag(db, class) => {
             return (0..positional_count)
@@ -264,10 +394,10 @@ fn pattern_is_exhaustive_for_subject(
 /// guarantee that a particular key is present.
 fn mapping_pattern_is_exhaustive(
     db: &dyn Db,
-    kind: &MappingPatternPredicateKind<'_>,
+    entries: &[MappingPatternEntryPredicateKind<'_>],
     subject_ty: Type<'_>,
 ) -> bool {
-    if kind.is_irrefutable() {
+    if entries.is_empty() {
         return subject_ty.is_subtype_of(db, mapping_pattern_type(db));
     }
 
@@ -275,7 +405,7 @@ fn mapping_pattern_is_exhaustive(
         return false;
     };
 
-    kind.entries.iter().all(|entry| {
+    entries.iter().all(|entry| {
         let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
         let Some(key) = key_ty.as_string_literal() else {
             return false;
@@ -623,7 +753,7 @@ fn subject_independent_definite_match_pattern_type<'db>(
             })
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_irrefutable() {
+            if kind.is_empty() {
                 Some(mapping_pattern_type(db))
             } else {
                 None
@@ -640,129 +770,6 @@ fn subject_independent_definite_match_pattern_type<'db>(
         PatternPredicateKind::Value(_) => None,
         _ => Some(definite_match_pattern_type(db, kind)),
     }
-}
-
-fn sequence_pattern_getitem_method<'db>(
-    db: &'db dyn Db,
-    indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
-    fallback_return_type: Option<Type<'db>>,
-) -> CallableType<'db> {
-    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
-
-    let overloads = indexed_element_types
-        .into_iter()
-        .map(|(index, element_type)| {
-            Signature::new(
-                Parameters::new(
-                    db,
-                    [
-                        self_parameter(),
-                        Parameter::positional_only(Some(Name::new_static("index")))
-                            .with_annotated_type(Type::int_literal(index)),
-                    ],
-                ),
-                element_type,
-            )
-        });
-    let fallback_overload = fallback_return_type.map(|fallback_return_type| {
-        Signature::new(
-            Parameters::new(
-                db,
-                [
-                    self_parameter(),
-                    Parameter::positional_only(Some(Name::new_static("index")))
-                        .with_annotated_type(KnownClass::Int.to_instance(db)),
-                ],
-            ),
-            fallback_return_type,
-        )
-    });
-
-    CallableType::new(
-        db,
-        CallableSignature::from_overloads(overloads.chain(fallback_overload)),
-        CallableTypeKind::FunctionLike,
-        CallableFunctionProvenance::None,
-    )
-}
-
-/// Build the structural type used for a fixed-length sequence pattern.
-///
-/// For a pattern like:
-///
-/// ```python
-/// match value:
-///     case [int(), str()]:
-///         ...
-/// ```
-///
-/// this returns the sequence-pattern runtime type plus a synthesized protocol
-/// whose `__len__` and indexed `__getitem__` methods encode the fixed length
-/// and element types.
-pub(crate) fn exact_sequence_pattern_type<'db>(
-    db: &'db dyn Db,
-    element_types: impl ExactSizeIterator<Item = Type<'db>>,
-) -> Type<'db> {
-    let Ok(length) = i64::try_from(element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
-    };
-
-    // `False == 0` and `True == 1`, so the protocol must accept both literals.
-    let length_type = match length {
-        0 => UnionType::from_two_elements(db, Type::int_literal(0), Type::bool_literal(false)),
-        1 => UnionType::from_two_elements(db, Type::int_literal(1), Type::bool_literal(true)),
-        _ => Type::int_literal(length),
-    };
-
-    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
-
-    let len_signature = Signature::new(Parameters::new(db, [self_parameter()]), length_type);
-    let len_method = CallableType::function_like(db, len_signature);
-
-    let getitem_method = (element_types.len() > 0).then(|| {
-        (
-            "__getitem__",
-            sequence_pattern_getitem_method(db, (0..length).zip(element_types), None),
-        )
-    });
-
-    let protocol = Type::protocol_with_methods(
-        db,
-        std::iter::once(("__len__", len_method)).chain(getitem_method),
-    );
-
-    sequence_pattern_type_builder(db)
-        .add_positive(protocol)
-        .build()
-}
-
-/// Build the structural type used for a sequence pattern containing `*rest`.
-///
-/// Fixed prefix elements use non-negative indices and fixed suffix elements use
-/// negative indices. Other integer indices retain the sequence's element type.
-pub(crate) fn starred_sequence_pattern_type<'db>(
-    db: &'db dyn Db,
-    prefix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
-    suffix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
-) -> Type<'db> {
-    if prefix_element_types.len() == 0 && suffix_element_types.len() == 0 {
-        return sequence_pattern_type_builder(db).build();
-    }
-
-    let Ok(suffix_length) = i64::try_from(suffix_element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
-    };
-
-    let indexed_element_types = (0_i64..)
-        .zip(prefix_element_types)
-        .chain((-suffix_length..0).zip(suffix_element_types));
-    let getitem_method =
-        sequence_pattern_getitem_method(db, indexed_element_types, Some(Type::object()));
-    let protocol = Type::protocol_with_methods(db, [("__getitem__", getitem_method)]);
-
-    sequence_pattern_type_builder(db)
-        .add_positive(protocol)
-        .build()
 }
 
 /// Return the values that are guaranteed to match `kind`.
@@ -799,7 +806,7 @@ pub(crate) fn definite_match_pattern_type<'db>(
             }
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_irrefutable() {
+            if kind.is_empty() {
                 mapping_pattern_type(db)
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -184,14 +184,12 @@ pub(crate) fn starred_sequence_pattern_type<'db>(
 
 /// Return whether every value in `subject_ty` is statically guaranteed to match this class pattern.
 ///
-/// Attribute subpatterns are checked recursively against their statically known member types. A
-/// non-final subclass can override attribute access, so the pattern is not guaranteed to match it.
-/// A final subclass can provide members that are absent from the class named in the pattern.
+/// Attribute subpatterns are checked recursively against their statically known member types. The
+/// subject's class can provide members that are absent from the class named in the pattern.
 ///
 /// ```python
 /// class Base: ...
 ///
-/// @final
 /// class Child(Base):
 ///     x: int
 ///
@@ -211,37 +209,11 @@ fn class_pattern_is_exhaustive(
         return false;
     }
 
-    let is_protocol = class.is_protocol(db);
-    if kind.is_argumentless() && !is_protocol {
+    if kind.is_argumentless() {
         return true;
     }
 
-    let subject_is_non_final_subclass = if is_typed_dict_match {
-        false
-    } else {
-        let Some(subject_class) = subject_ty.nominal_class(db) else {
-            return false;
-        };
-        let subject_class_literal = subject_class.class_literal(db);
-        subject_class_literal != class && !subject_class_literal.is_final(db)
-    };
-
-    // TODO: A non-final subject class also admits subclasses that can override attribute access.
-    // Decide whether it should remain exhaustive under the static member model or be treated like
-    // a non-final subclass of the class named in the pattern.
-    if kind.is_argumentless() {
-        return !subject_is_non_final_subclass;
-    }
-
     let positional_sources = class_pattern_positional_sources(db, class, kind.positional.len());
-    let extracts_attribute = !kind.keywords.is_empty()
-        || positional_sources
-            .iter()
-            .any(|source| !matches!(source, ClassPatternPositionalSource::MatchSelf));
-    if subject_is_non_final_subclass && (is_protocol || extracts_attribute) {
-        return false;
-    }
-
     if !kind.keywords.iter().all(|keyword| {
         member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
     }) {
@@ -468,8 +440,8 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// This is an under-approximation used for negative narrowing and ordered alternatives: callers
 /// may subtract the result from `subject_ty` under ty's static member model. A subject-independent
 /// pattern can return a type wider than `subject_ty`; for example, `case Base()` returns `Base`
-/// even for a `Child` subject. Class patterns need the current subject type when the subject is a
-/// non-final subclass, while an exact or final class can make member extraction exhaustive.
+/// even for a `Child` subject. Class patterns need the current subject type when member extraction
+/// depends on the subject's statically known members.
 /// A subject-independent pattern can return its context-free definite-match type directly. A
 /// mapping pattern can use required `TypedDict` fields to establish that every subject value
 /// contains its keys.
@@ -481,7 +453,6 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// class Base:
 ///     x: int
 ///
-/// @final
 /// class Child(Base):
 ///     pass
 ///
@@ -722,8 +693,8 @@ fn is_same_enum_pattern_domain<'db>(
 /// Return the definite-match type when it does not depend on the current subject type.
 ///
 /// `None` means that callers must use subject-aware analysis instead of falling back to the
-/// context-free approximation. In particular, protocol and attribute class patterns are not
-/// guaranteed to match a non-final subclass even when static subtyping says otherwise.
+/// context-free approximation. In particular, attribute class patterns can depend on members of
+/// the static subject type.
 fn subject_independent_definite_match_pattern_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
@@ -732,9 +703,7 @@ fn subject_independent_definite_match_pattern_type<'db>(
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
                 Type::ClassLiteral(class)
-                    if kind.is_argumentless()
-                        && !class.is_protocol(db)
-                        && !typed_dict_matches_class_pattern(db, class) =>
+                    if kind.is_argumentless() && !typed_dict_matches_class_pattern(db, class) =>
                 {
                     Some(Type::instance(db, class.top_materialization(db)))
                 }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -2,18 +2,20 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
 use ty_python_core::predicate::{
-    ClassPatternKind, PatternPredicateKind, SequencePatternPredicateKind,
+    ClassPatternPredicateKind, MappingPatternPredicateKind, PatternPredicateKind,
+    SequencePatternPredicateKind,
 };
 
 use crate::Db;
+use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    CallableType, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter, Parameters,
-    Signature, SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
-    infer_same_file_expression_type,
+    CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
+    Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, binding_type,
+    equality_truthiness, infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -34,6 +36,19 @@ pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
     Type::Callable(CallableType::unknown(db)).top_materialization(db)
 }
 
+/// Return whether every runtime value represented by a `TypedDict` satisfies `class`.
+///
+/// `TypedDict` is not a nominal subtype of `dict` in the static type system, but every runtime
+/// value is a dictionary. A `TypedDict` therefore matches class patterns such as `dict()`,
+/// `Mapping()`, and `MutableMapping()`.
+fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+    let Some(dict) = KnownClass::Dict.to_class_literal(db).as_class_literal() else {
+        return false;
+    };
+    Type::instance(db, dict.top_materialization(db))
+        .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
+}
+
 pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
     IntersectionBuilder::new(db)
         .add_positive(KnownClass::Sequence.to_instance(db).top_materialization(db))
@@ -44,129 +59,193 @@ pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<
         .add_negative(KnownClass::Bytearray.to_instance(db))
 }
 
-fn sequence_pattern_getitem_method<'db>(
-    db: &'db dyn Db,
-    indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
-    fallback_return_type: Option<Type<'db>>,
-) -> CallableType<'db> {
-    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
-
-    let overloads = indexed_element_types
-        .into_iter()
-        .map(|(index, element_type)| {
-            Signature::new(
-                Parameters::new(
-                    db,
-                    [
-                        self_parameter(),
-                        Parameter::positional_only(Some(Name::new_static("index")))
-                            .with_annotated_type(Type::int_literal(index)),
-                    ],
-                ),
-                element_type,
-            )
-        });
-    let fallback_overload = fallback_return_type.map(|fallback_return_type| {
-        Signature::new(
-            Parameters::new(
-                db,
-                [
-                    self_parameter(),
-                    Parameter::positional_only(Some(Name::new_static("index")))
-                        .with_annotated_type(KnownClass::Int.to_instance(db)),
-                ],
-            ),
-            fallback_return_type,
-        )
-    });
-
-    CallableType::new(
-        db,
-        CallableSignature::from_overloads(overloads.chain(fallback_overload)),
-        CallableTypeKind::FunctionLike,
-        CallableFunctionProvenance::None,
-    )
-}
-
-/// Build the structural type used for a fixed-length sequence pattern.
+/// Return whether every value in `subject_ty` is statically guaranteed to match this class pattern.
 ///
-/// For a pattern like:
+/// Attribute subpatterns are checked recursively against their statically known member types. A
+/// non-final subclass can override attribute access, so the pattern is not guaranteed to match it.
+/// A final subclass can provide members that are absent from the class named in the pattern.
 ///
 /// ```python
-/// match value:
-///     case [int(), str()]:
-///         ...
+/// class Base: ...
+///
+/// @final
+/// class Child(Base):
+///     x: int
+///
+/// # Exhaustive for a `Child` subject because `Child.x` is definitely bound.
+/// case Base(x=_): ...
 /// ```
-///
-/// this returns the sequence-pattern runtime type plus a synthesized protocol
-/// whose `__len__` and indexed `__getitem__` methods encode the fixed length
-/// and element types.
-pub(crate) fn exact_sequence_pattern_type<'db>(
-    db: &'db dyn Db,
-    element_types: impl ExactSizeIterator<Item = Type<'db>>,
-) -> Type<'db> {
-    let Ok(length) = i64::try_from(element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
-    };
-
-    // `False == 0` and `True == 1`, so the protocol must accept both literals.
-    let length_type = match length {
-        0 => UnionType::from_two_elements(db, Type::int_literal(0), Type::bool_literal(false)),
-        1 => UnionType::from_two_elements(db, Type::int_literal(1), Type::bool_literal(true)),
-        _ => Type::int_literal(length),
-    };
-
-    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
-
-    let len_signature = Signature::new(Parameters::new(db, [self_parameter()]), length_type);
-    let len_method = CallableType::function_like(db, len_signature);
-
-    let getitem_method = (element_types.len() > 0).then(|| {
-        (
-            "__getitem__",
-            sequence_pattern_getitem_method(db, (0..length).zip(element_types), None),
-        )
-    });
-
-    let protocol = Type::protocol_with_methods(
-        db,
-        std::iter::once(("__len__", len_method)).chain(getitem_method),
-    );
-
-    sequence_pattern_type_builder(db)
-        .add_positive(protocol)
-        .build()
-}
-
-/// Build the structural type used for a sequence pattern containing `*rest`.
-///
-/// Fixed prefix elements use non-negative indices and fixed suffix elements use
-/// negative indices. Other integer indices retain the sequence's element type.
-pub(crate) fn starred_sequence_pattern_type<'db>(
-    db: &'db dyn Db,
-    prefix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
-    suffix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
-) -> Type<'db> {
-    if prefix_element_types.len() == 0 && suffix_element_types.len() == 0 {
-        return sequence_pattern_type_builder(db).build();
+fn class_pattern_is_exhaustive(
+    db: &dyn Db,
+    class: ClassLiteral<'_>,
+    subject_ty: Type<'_>,
+    kind: &ClassPatternPredicateKind<'_>,
+) -> bool {
+    let class_instance_ty = Type::instance(db, class.top_materialization(db));
+    let is_typed_dict_match =
+        matches!(subject_ty, Type::TypedDict(_)) && typed_dict_matches_class_pattern(db, class);
+    if !is_typed_dict_match && !subject_ty.is_subtype_of(db, class_instance_ty) {
+        return false;
     }
 
-    let Ok(suffix_length) = i64::try_from(suffix_element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
+    let is_protocol = class.is_protocol(db);
+    if kind.is_argumentless() && !is_protocol {
+        return true;
+    }
+
+    let subject_is_non_final_subclass = if is_typed_dict_match {
+        false
+    } else {
+        let Some(subject_class) = subject_ty.nominal_class(db) else {
+            return false;
+        };
+        let subject_class_literal = subject_class.class_literal(db);
+        subject_class_literal != class && !subject_class_literal.is_final(db)
     };
 
-    let indexed_element_types = (0_i64..)
-        .zip(prefix_element_types)
-        .chain((-suffix_length..0).zip(suffix_element_types));
-    let getitem_method =
-        sequence_pattern_getitem_method(db, indexed_element_types, Some(Type::object()));
-    let protocol = Type::protocol_with_methods(db, [("__getitem__", getitem_method)]);
+    // TODO: A non-final subject class also admits subclasses that can override attribute access.
+    // Decide whether it should remain exhaustive under the static member model or be treated like
+    // a non-final subclass of the class named in the pattern.
+    if kind.is_argumentless() {
+        return !subject_is_non_final_subclass;
+    }
 
-    sequence_pattern_type_builder(db)
-        .add_positive(protocol)
-        .build()
+    let positional_sources =
+        class_pattern_positional_sources(db, Some(class), kind.positional.len());
+    let extracts_attribute = !kind.keywords.is_empty()
+        || positional_sources
+            .iter()
+            .any(|source| !matches!(source, ClassPatternPositionalSource::MatchSelf));
+    if subject_is_non_final_subclass && (is_protocol || extracts_attribute) {
+        return false;
+    }
+
+    if !kind.keywords.iter().all(|keyword| {
+        member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
+    }) {
+        return false;
+    }
+
+    kind.positional
+        .iter()
+        .zip(positional_sources)
+        .all(|(pattern, source)| match source {
+            ClassPatternPositionalSource::MatchSelf => {
+                pattern_is_exhaustive_for_subject(db, pattern, subject_ty)
+            }
+            ClassPatternPositionalSource::Attribute(name) => {
+                member_pattern_is_exhaustive(db, subject_ty, name.as_str(), pattern)
+            }
+            ClassPatternPositionalSource::Unknown => false,
+        })
 }
 
+enum ClassMatchArgs<'db> {
+    Undefined,
+    Defined(Type<'db>),
+    PossiblyUndefined,
+}
+
+#[derive(Clone)]
+enum ClassPatternPositionalSource {
+    MatchSelf,
+    Attribute(Name),
+    Unknown,
+}
+
+/// Resolve `__match_args__` through the pattern class, including its metaclass.
+///
+/// Inferred assignments retain their literal binding type, while an explicit annotation remains
+/// authoritative. `PossiblyUndefined` is distinct from `Undefined` because only a truly absent
+/// `__match_args__` enables match-self behavior.
+fn class_match_args_type<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> ClassMatchArgs<'db> {
+    match Type::ClassLiteral(class).member(db, "__match_args__").place {
+        Place::Defined(
+            place @ DefinedPlace {
+                ty,
+                origin,
+                provenance,
+                ..
+            },
+        ) if place.is_definitely_defined() => ClassMatchArgs::Defined(if origin.is_declared() {
+            ty
+        } else {
+            provenance
+                .definition()
+                .map_or(ty, |definition| binding_type(db, definition))
+        }),
+        Place::Defined(_) => ClassMatchArgs::PossiblyUndefined,
+        Place::Undefined => ClassMatchArgs::Undefined,
+    }
+}
+
+fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+    class
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .any(|base| {
+            base.class_literal(db)
+                .known(db)
+                .is_some_and(KnownClass::has_match_self_flag)
+        })
+}
+
+fn class_pattern_positional_sources(
+    db: &dyn Db,
+    class: Option<ClassLiteral<'_>>,
+    positional_count: usize,
+) -> Vec<ClassPatternPositionalSource> {
+    let Some(class) = class else {
+        return vec![ClassPatternPositionalSource::Unknown; positional_count];
+    };
+
+    let fixed = match class_match_args_type(db, class) {
+        ClassMatchArgs::Undefined if class_has_match_self_flag(db, class) => {
+            return (0..positional_count)
+                .map(|index| {
+                    if index == 0 {
+                        ClassPatternPositionalSource::MatchSelf
+                    } else {
+                        ClassPatternPositionalSource::Unknown
+                    }
+                })
+                .collect();
+        }
+        ClassMatchArgs::Defined(match_args) => match_args
+            .exact_tuple_instance_spec(db)
+            .and_then(|tuple| tuple.as_fixed_length().cloned()),
+        ClassMatchArgs::Undefined | ClassMatchArgs::PossiblyUndefined => None,
+    };
+
+    (0..positional_count)
+        .map(|index| {
+            fixed
+                .as_ref()
+                .and_then(|tuple| tuple.elements_slice().get(index))
+                .and_then(|ty| ty.as_string_literal())
+                .map(|literal| {
+                    ClassPatternPositionalSource::Attribute(Name::new(literal.value(db)))
+                })
+                .unwrap_or(ClassPatternPositionalSource::Unknown)
+        })
+        .collect()
+}
+
+/// Return whether `name` is definitely bound and `pattern` consumes its entire static member type.
+fn member_pattern_is_exhaustive(
+    db: &dyn Db,
+    instance_ty: Type<'_>,
+    name: &str,
+    pattern: &PatternPredicateKind<'_>,
+) -> bool {
+    let place = instance_ty.member(db, name).place;
+    place.is_definitely_bound()
+        && place
+            .raw_type()
+            .is_some_and(|member_ty| pattern_is_exhaustive_for_subject(db, pattern, member_ty))
+}
+
+/// Return whether `pattern` is statically guaranteed to match every value in `subject_ty`.
 fn pattern_is_exhaustive_for_subject(
     db: &dyn Db,
     pattern: &PatternPredicateKind<'_>,
@@ -178,6 +257,40 @@ fn pattern_is_exhaustive_for_subject(
     )
 }
 
+/// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
+///
+/// A nonempty mapping pattern is exhaustive for a `TypedDict` only when every key names a required
+/// field and every nested pattern exhausts that field's declared type. Other mapping types do not
+/// guarantee that a particular key is present.
+fn mapping_pattern_is_exhaustive(
+    db: &dyn Db,
+    kind: &MappingPatternPredicateKind<'_>,
+    subject_ty: Type<'_>,
+) -> bool {
+    if kind.is_irrefutable() {
+        return subject_ty.is_subtype_of(db, mapping_pattern_type(db));
+    }
+
+    let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(db) else {
+        return false;
+    };
+
+    kind.entries.iter().all(|entry| {
+        let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
+        let Some(key) = key_ty.as_string_literal() else {
+            return false;
+        };
+        typed_dict.item(db, key.value(db)).is_some_and(|field| {
+            field.is_required()
+                && pattern_is_exhaustive_for_subject(db, &entry.pattern, field.declared_ty)
+        })
+    })
+}
+
+/// Return whether an exact tuple subject is fully consumed by a sequence pattern.
+///
+/// Each aligned element is checked with the subject-aware matcher so nested class patterns use the
+/// tuple element's actual static type.
 fn sequence_pattern_is_exhaustive_for_subject(
     db: &dyn Db,
     kind: &SequencePatternPredicateKind<'_>,
@@ -219,46 +332,32 @@ fn sequence_pattern_is_exhaustive_for_subject(
         .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
 }
 
-fn subject_independent_definite_match_pattern_type<'db>(
-    db: &'db dyn Db,
-    kind: &PatternPredicateKind<'db>,
-) -> Option<Type<'db>> {
-    match kind {
-        PatternPredicateKind::Singleton(_)
-        | PatternPredicateKind::Class(_, ClassPatternKind::Irrefutable)
-        | PatternPredicateKind::Mapping(ClassPatternKind::Irrefutable) => {
-            Some(definite_match_pattern_type(db, kind))
-        }
-        PatternPredicateKind::Sequence(sequence) if sequence.is_irrefutable() => {
-            Some(definite_match_pattern_type(db, kind))
-        }
-        PatternPredicateKind::Or(patterns) => {
-            let patterns = patterns
-                .iter()
-                .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
-                .collect::<Option<Vec<_>>>()?;
-            Some(UnionType::from_elements(db, patterns))
-        }
-        PatternPredicateKind::As(Some(pattern), _) => {
-            subject_independent_definite_match_pattern_type(db, pattern)
-        }
-        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => Some(Type::object()),
-        PatternPredicateKind::Value(_)
-        | PatternPredicateKind::Class(_, ClassPatternKind::Refutable)
-        | PatternPredicateKind::Mapping(ClassPatternKind::Refutable)
-        | PatternPredicateKind::Sequence(_) => None,
-    }
-}
-
-/// Return values that are statically guaranteed to match `kind`, using `subject_ty` to recognize
-/// cases where the pattern covers a complete subject arm.
+/// Return the values that are statically guaranteed to match `kind`, using `subject_ty` when the
+/// answer depends on the subject.
 ///
-/// Unlike [`definite_match_pattern_type`], this can recognize guarantees that depend on the
-/// current subject. For example, both `Literal[True]` and `Literal[1]` are guaranteed to match the
-/// value pattern `1` because match value patterns use equality. The returned type can include
-/// values outside `subject_ty`; callers intersect it with the subject before using it for negative
-/// narrowing. Keeping the non-exhaustive part independent of the subject also prevents each case
-/// in a long match statement from embedding all previous negative constraints again.
+/// This is an under-approximation used for negative narrowing and ordered alternatives: callers
+/// may subtract the result from `subject_ty` under ty's static member model. A subject-independent
+/// pattern can return a type wider than `subject_ty`; for example, `case Base()` returns `Base`
+/// even for a `Child` subject. Class patterns need the current subject type when the subject is a
+/// non-final subclass, while an exact or final class can make member extraction exhaustive.
+/// A subject-independent pattern can return its context-free definite-match type directly. A
+/// mapping pattern can use required `TypedDict` fields to establish that every subject value
+/// contains its keys.
+/// This treats access to a definitely bound descriptor as successful even though the descriptor
+/// could raise at runtime. The same rule is propagated through nested sequence, `or`, and `as`
+/// patterns.
+///
+/// ```python
+/// class Base:
+///     x: int
+///
+/// @final
+/// class Child(Base):
+///     pass
+///
+/// # For a `tuple[Child]` subject, this checks `x` on `Child`, not only on `Base`.
+/// case [Base(x=_)]: ...
+/// ```
 pub(crate) fn definite_match_pattern_type_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
@@ -284,30 +383,68 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
             if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
-                subject_ty
-            } else {
-                definite_match_pattern_type(db, kind)
+                return subject_ty;
+            }
+        }
+        PatternPredicateKind::Class(kind) => {
+            let class_ty = infer_same_file_expression_type(db, kind.class, TypeContext::default());
+            match class_ty {
+                Type::ClassLiteral(class) => {
+                    if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
+                        return subject_ty;
+                    }
+                }
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless()
+                        && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
+                {
+                    return callable_pattern_type(db);
+                }
+                _ => {}
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
+            return if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
                 subject_ty
             } else {
-                definite_sequence_pattern_type(db, kind)
-            }
+                // A nested subject-dependent pattern rejected the context-free approximation.
+                // Reusing that approximation for the surrounding sequence would reintroduce the
+                // values that the recursive analysis deliberately excluded.
+                Type::Never
+            };
         }
-        PatternPredicateKind::Or(patterns) => UnionType::from_elements(
-            db,
-            patterns
-                .iter()
-                .map(|pattern| definite_match_pattern_type_for_subject(db, pattern, subject_ty)),
-        ),
+        PatternPredicateKind::Mapping(kind) => {
+            return if mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
+                subject_ty
+            } else {
+                Type::Never
+            };
+        }
+        PatternPredicateKind::Or(patterns) => {
+            return UnionType::from_elements(
+                db,
+                patterns.iter().map(|pattern| {
+                    definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+                }),
+            );
+        }
         PatternPredicateKind::As(Some(pattern), _) => {
-            definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+            return definite_match_pattern_type_for_subject(db, pattern, subject_ty);
         }
-        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => subject_ty,
-        _ => definite_match_pattern_type(db, kind),
+        _ => return Type::Never,
     }
+
+    let subject_independent_ty = definite_match_pattern_type(db, kind);
+    // The subject-aware checks above can reject an otherwise exhaustive-looking pattern. Do not
+    // let the less precise fallback reintroduce that conclusion.
+    if subject_ty.is_subtype_of(db, subject_independent_ty) {
+        return Type::Never;
+    }
+
+    IntersectionBuilder::new(db)
+        .add_positive(subject_ty)
+        .add_positive(subject_independent_ty)
+        .build()
 }
 
 /// Return the part of `subject_ty` that can reach a later alternative after `kind` fails.
@@ -455,6 +592,182 @@ fn is_same_enum_pattern_domain<'db>(
     }
 }
 
+/// Return the definite-match type when it does not depend on the current subject type.
+///
+/// `None` means that callers must use subject-aware analysis instead of falling back to the
+/// context-free approximation. In particular, protocol and attribute class patterns are not
+/// guaranteed to match a non-final subclass even when static subtyping says otherwise.
+fn subject_independent_definite_match_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+) -> Option<Type<'db>> {
+    match kind {
+        PatternPredicateKind::Class(kind) => {
+            match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                Type::ClassLiteral(class)
+                    if kind.is_argumentless()
+                        && !class.is_protocol(db)
+                        && !typed_dict_matches_class_pattern(db, class) =>
+                {
+                    Some(Type::instance(db, class.top_materialization(db)))
+                }
+                Type::ClassLiteral(_) => None,
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless() =>
+                {
+                    Some(callable_pattern_type(db))
+                }
+                _ => Some(Type::Never),
+            }
+        }
+        PatternPredicateKind::Sequence(kind) => {
+            build_definite_sequence_pattern_type(db, kind, |pattern| {
+                subject_independent_definite_match_pattern_type(db, pattern)
+            })
+        }
+        PatternPredicateKind::Mapping(kind) => {
+            if kind.is_irrefutable() {
+                Some(mapping_pattern_type(db))
+            } else {
+                None
+            }
+        }
+        PatternPredicateKind::Or(patterns) => patterns
+            .iter()
+            .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
+            .collect::<Option<Vec<_>>>()
+            .map(|types| UnionType::from_elements(db, types)),
+        PatternPredicateKind::As(Some(pattern), _) => {
+            subject_independent_definite_match_pattern_type(db, pattern)
+        }
+        PatternPredicateKind::Value(_) => None,
+        _ => Some(definite_match_pattern_type(db, kind)),
+    }
+}
+
+fn sequence_pattern_getitem_method<'db>(
+    db: &'db dyn Db,
+    indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
+    fallback_return_type: Option<Type<'db>>,
+) -> CallableType<'db> {
+    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
+
+    let overloads = indexed_element_types
+        .into_iter()
+        .map(|(index, element_type)| {
+            Signature::new(
+                Parameters::new(
+                    db,
+                    [
+                        self_parameter(),
+                        Parameter::positional_only(Some(Name::new_static("index")))
+                            .with_annotated_type(Type::int_literal(index)),
+                    ],
+                ),
+                element_type,
+            )
+        });
+    let fallback_overload = fallback_return_type.map(|fallback_return_type| {
+        Signature::new(
+            Parameters::new(
+                db,
+                [
+                    self_parameter(),
+                    Parameter::positional_only(Some(Name::new_static("index")))
+                        .with_annotated_type(KnownClass::Int.to_instance(db)),
+                ],
+            ),
+            fallback_return_type,
+        )
+    });
+
+    CallableType::new(
+        db,
+        CallableSignature::from_overloads(overloads.chain(fallback_overload)),
+        CallableTypeKind::FunctionLike,
+        CallableFunctionProvenance::None,
+    )
+}
+
+/// Build the structural type used for a fixed-length sequence pattern.
+///
+/// For a pattern like:
+///
+/// ```python
+/// match value:
+///     case [int(), str()]:
+///         ...
+/// ```
+///
+/// this returns the sequence-pattern runtime type plus a synthesized protocol
+/// whose `__len__` and indexed `__getitem__` methods encode the fixed length
+/// and element types.
+pub(crate) fn exact_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    element_types: impl ExactSizeIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    let Ok(length) = i64::try_from(element_types.len()) else {
+        return sequence_pattern_type_builder(db).build();
+    };
+
+    // `False == 0` and `True == 1`, so the protocol must accept both literals.
+    let length_type = match length {
+        0 => UnionType::from_two_elements(db, Type::int_literal(0), Type::bool_literal(false)),
+        1 => UnionType::from_two_elements(db, Type::int_literal(1), Type::bool_literal(true)),
+        _ => Type::int_literal(length),
+    };
+
+    let self_parameter = || Parameter::positional_only(Some(Name::new_static("self")));
+
+    let len_signature = Signature::new(Parameters::new(db, [self_parameter()]), length_type);
+    let len_method = CallableType::function_like(db, len_signature);
+
+    let getitem_method = (element_types.len() > 0).then(|| {
+        (
+            "__getitem__",
+            sequence_pattern_getitem_method(db, (0..length).zip(element_types), None),
+        )
+    });
+
+    let protocol = Type::protocol_with_methods(
+        db,
+        std::iter::once(("__len__", len_method)).chain(getitem_method),
+    );
+
+    sequence_pattern_type_builder(db)
+        .add_positive(protocol)
+        .build()
+}
+
+/// Build the structural type used for a sequence pattern containing `*rest`.
+///
+/// Fixed prefix elements use non-negative indices and fixed suffix elements use
+/// negative indices. Other integer indices retain the sequence's element type.
+pub(crate) fn starred_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    prefix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
+    suffix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
+) -> Type<'db> {
+    if prefix_element_types.len() == 0 && suffix_element_types.len() == 0 {
+        return sequence_pattern_type_builder(db).build();
+    }
+
+    let Ok(suffix_length) = i64::try_from(suffix_element_types.len()) else {
+        return sequence_pattern_type_builder(db).build();
+    };
+
+    let indexed_element_types = (0_i64..)
+        .zip(prefix_element_types)
+        .chain((-suffix_length..0).zip(suffix_element_types));
+    let getitem_method =
+        sequence_pattern_getitem_method(db, indexed_element_types, Some(Type::object()));
+    let protocol = Type::protocol_with_methods(db, [("__getitem__", getitem_method)]);
+
+    sequence_pattern_type_builder(db)
+        .add_positive(protocol)
+        .build()
+}
+
 /// Return the values that are guaranteed to match `kind`.
 ///
 /// Reachability and negative narrowing can only subtract this under-approximation.
@@ -475,17 +788,17 @@ pub(crate) fn definite_match_pattern_type<'db>(
                 Type::Never
             }
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
-            if kind.is_irrefutable() {
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(db)
-                    }
-                    _ => Type::Never,
+        PatternPredicateKind::Class(kind) => {
+            match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                Type::ClassLiteral(class) if kind.is_argumentless() => {
+                    Type::instance(db, class.top_materialization(db))
                 }
-            } else {
-                Type::Never
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless() =>
+                {
+                    callable_pattern_type(db)
+                }
+                _ => Type::Never,
             }
         }
         PatternPredicateKind::Mapping(kind) => {
@@ -511,36 +824,51 @@ pub(crate) fn definite_match_pattern_type<'db>(
 }
 
 /// Return the values that are guaranteed to match a sequence pattern.
-pub(crate) fn definite_sequence_pattern_type<'db>(
+fn definite_sequence_pattern_type<'db>(
     db: &'db dyn Db,
     kind: &SequencePatternPredicateKind<'db>,
 ) -> Type<'db> {
+    build_definite_sequence_pattern_type(db, kind, |pattern| {
+        Some(definite_match_pattern_type(db, pattern))
+    })
+    .unwrap_or(Type::Never)
+}
+
+fn build_definite_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    mut element_type: impl FnMut(&PatternPredicateKind<'db>) -> Option<Type<'db>>,
+) -> Option<Type<'db>> {
     if kind.is_irrefutable() {
-        return sequence_pattern_type_builder(db).build();
+        return Some(sequence_pattern_type_builder(db).build());
     }
 
     if let Some((prefix, suffix)) = kind.split_around_star() {
-        return Type::tuple(TupleType::mixed(
+        let prefix_types = prefix
+            .iter()
+            .map(&mut element_type)
+            .collect::<Option<Vec<_>>>()?;
+        let suffix_types = suffix
+            .iter()
+            .map(&mut element_type)
+            .collect::<Option<Vec<_>>>()?;
+        return Some(Type::tuple(TupleType::mixed(
             db,
-            prefix
-                .iter()
-                .map(|pattern| definite_match_pattern_type(db, pattern)),
+            prefix_types,
             Type::object(),
-            suffix
-                .iter()
-                .map(|pattern| definite_match_pattern_type(db, pattern)),
-        ));
+            suffix_types,
+        )));
     }
 
     let element_types: Vec<_> = kind
         .patterns
         .iter()
-        .map(|pattern| definite_match_pattern_type(db, pattern))
-        .collect();
+        .map(element_type)
+        .collect::<Option<_>>()?;
 
     if element_types.iter().any(Type::is_never) {
-        Type::Never
+        Some(Type::Never)
     } else {
-        exact_sequence_pattern_type(db, element_types.into_iter())
+        Some(exact_sequence_pattern_type(db, element_types.into_iter()))
     }
 }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,16 +15,17 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, exact_sequence_pattern_type, infer_expression_types,
-    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_match_pattern_type_for_subject,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    pattern_binding_fallthrough_type, pattern_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
+    CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
+    SequencePatternPredicateKind, SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -1060,9 +1061,9 @@ fn necessary_match_pattern_type<'db>(
 ) -> Type<'db> {
     match pattern {
         PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
-        PatternPredicateKind::Class(cls, _) => positive_class_pattern_type(
+        PatternPredicateKind::Class(kind) => positive_class_pattern_type(
             db,
-            infer_same_file_expression_type(db, *cls, TypeContext::default()),
+            infer_same_file_expression_type(db, kind.class, TypeContext::default()),
         )
         .unwrap_or_else(Type::object),
         PatternPredicateKind::Mapping(_) => mapping_pattern_type(db),
@@ -1270,15 +1271,23 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
             ),
-            PatternPredicateKind::Class(cls, kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive),
-            ),
-            PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
-            ),
-            PatternPredicateKind::Sequence(kind) => {
-                self.evaluate_match_pattern_sequence(subject, kind, is_positive)
+            PatternPredicateKind::Class(kind) => {
+                PatternNarrowingResult::Possible(self.evaluate_match_pattern_class(
+                    subject,
+                    kind.class,
+                    pattern_predicate_kind,
+                    is_positive,
+                ))
             }
+            PatternPredicateKind::Mapping(_) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_mapping(subject, pattern_predicate_kind, is_positive),
+            ),
+            PatternPredicateKind::Sequence(kind) => self.evaluate_match_pattern_sequence(
+                subject,
+                kind,
+                pattern_predicate_kind,
+                is_positive,
+            ),
             PatternPredicateKind::Value(expr) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_value(subject, *expr, is_positive),
             ),
@@ -1412,10 +1421,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     bindings: BTreeMap::new(),
                 }
             }
-            PatternPredicateKind::Class(class_expr, _) => {
+            PatternPredicateKind::Class(kind) => {
                 let class_ty = necessary_match_pattern_type(self.db, pattern);
                 let class =
-                    infer_same_file_expression_type(self.db, *class_expr, TypeContext::default())
+                    infer_same_file_expression_type(self.db, kind.class, TypeContext::default())
                         .as_class_literal();
                 let matched_subject_ty =
                     self.match_class_pattern_subject_type(class, class_ty, subject_ty, false);
@@ -1459,18 +1468,6 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         evaluate_type_equality(self.db, subject_ty, value_ty, true)
             .map(|constraint| self.intersect_types(subject_ty, constraint))
             .unwrap_or(subject_ty)
-    }
-
-    fn contains_class_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
-        match pattern {
-            PatternPredicateKind::Class(..) => true,
-            PatternPredicateKind::Sequence(kind) => {
-                kind.patterns.iter().any(Self::contains_class_pattern)
-            }
-            PatternPredicateKind::Or(patterns) => patterns.iter().any(Self::contains_class_pattern),
-            PatternPredicateKind::As(Some(pattern), _) => Self::contains_class_pattern(pattern),
-            _ => false,
-        }
     }
 
     fn contains_unsupported_binding_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
@@ -1536,13 +1533,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let mut previous_pattern = first_pattern;
 
         for pattern in patterns {
-            remaining_subject_ty = if Self::contains_class_pattern(previous_pattern) {
-                // Attribute extraction can still fail after the runtime class check. The next PR
-                // refines this with subject-aware class-pattern exhaustiveness.
-                remaining_subject_ty
-            } else {
-                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty)
-            };
+            remaining_subject_ty =
+                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty);
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
             binding_subject_types.add_in_place(alternative.binding_subject_ty);
@@ -2954,35 +2946,29 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         subject: Expression<'db>,
         cls: Expression<'db>,
-        kind: ClassPatternKind,
+        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
-            // A class pattern like `case Point(x=0, y=0)` is not irrefutable. In the positive case,
-            // we can still narrow the type of the match subject to `Point`. But in the negative case,
-            // we cannot exclude `Point` as a possibility.
-            return None;
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
+
+        if !is_positive {
+            let subject_ty =
+                infer_same_file_expression_type(self.db, subject, TypeContext::default());
+            let definitely_matched =
+                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+            if definitely_matched.is_never() {
+                return None;
+            }
+
+            return Some(NarrowingConstraints::from_iter([(
+                place,
+                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+            )]));
         }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject);
-
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
-
-        let narrowed_type = if is_positive {
-            positive_class_pattern_type(self.db, class_type)?
-        } else {
-            match class_type {
-                Type::ClassLiteral(class) => {
-                    Type::instance(self.db, class.top_materialization(self.db)).negate(self.db)
-                }
-                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                    callable_pattern_type(self.db).negate(self.db)
-                }
-                dynamic @ Type::Dynamic(_) => dynamic,
-                _ => return None,
-            }
-        };
+        let narrowed_type = positive_class_pattern_type(self.db, class_type)?;
 
         Some(NarrowingConstraints::from_iter([(
             place,
@@ -2993,15 +2979,26 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_match_pattern_mapping(
         &mut self,
         subject: Expression<'db>,
-        kind: ClassPatternKind,
+        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
-            return None;
-        }
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject);
+        if !is_positive {
+            let subject_ty =
+                infer_same_file_expression_type(self.db, subject, TypeContext::default());
+            let definitely_matched =
+                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+            if definitely_matched.is_never() {
+                return None;
+            }
+
+            return Some(NarrowingConstraints::from_iter([(
+                place,
+                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+            )]));
+        }
 
         let mapping_type = ClassInfoConstraintFunction::IsInstance
             .generate_constraint(
@@ -3021,6 +3018,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         subject: Expression<'db>,
         kind: &SequencePatternPredicateKind<'db>,
+        _pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> PatternNarrowingResult<'db> {
         let subject_node = subject.node_ref(self.db).node(self.module);
@@ -3041,7 +3039,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
 
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
-        let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
+        let Some(subject_place) = PlaceExpr::try_from_expr(subject_node) else {
             return PatternNarrowingResult::Possible(None);
         };
 
@@ -3058,7 +3056,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return PatternNarrowingResult::Possible(None);
         }
 
-        let place = self.expect_place(&subject);
+        let place = self.expect_place(&subject_place);
 
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             place,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1282,12 +1282,9 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Mapping(_) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_mapping(subject, pattern_predicate_kind, is_positive),
             ),
-            PatternPredicateKind::Sequence(kind) => self.evaluate_match_pattern_sequence(
-                subject,
-                kind,
-                pattern_predicate_kind,
-                is_positive,
-            ),
+            PatternPredicateKind::Sequence(kind) => {
+                self.evaluate_match_pattern_sequence(subject, kind, is_positive)
+            }
             PatternPredicateKind::Value(expr) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_value(subject, *expr, is_positive),
             ),
@@ -2949,24 +2946,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject_place);
-
         if !is_positive {
-            let subject_ty =
-                infer_same_file_expression_type(self.db, subject, TypeContext::default());
-            let definitely_matched =
-                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
-            if definitely_matched.is_never() {
-                return None;
-            }
-
-            return Some(NarrowingConstraints::from_iter([(
-                place,
-                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
-            )]));
+            return self.evaluate_negative_match_pattern(subject, pattern);
         }
 
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
         let narrowed_type = positive_class_pattern_type(self.db, class_type)?;
 
@@ -2982,24 +2967,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject_place);
-
         if !is_positive {
-            let subject_ty =
-                infer_same_file_expression_type(self.db, subject, TypeContext::default());
-            let definitely_matched =
-                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
-            if definitely_matched.is_never() {
-                return None;
-            }
-
-            return Some(NarrowingConstraints::from_iter([(
-                place,
-                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
-            )]));
+            return self.evaluate_negative_match_pattern(subject, pattern);
         }
 
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
         let mapping_type = ClassInfoConstraintFunction::IsInstance
             .generate_constraint(
                 self.db,
@@ -3014,11 +2987,30 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         )]))
     }
 
+    fn evaluate_negative_match_pattern(
+        &self,
+        subject: Expression<'db>,
+        pattern: &PatternPredicateKind<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
+        let definitely_matched =
+            definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+        if definitely_matched.is_never() {
+            return None;
+        }
+
+        Some(NarrowingConstraints::from_iter([(
+            place,
+            NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+        )]))
+    }
+
     fn evaluate_match_pattern_sequence(
         &mut self,
         subject: Expression<'db>,
         kind: &SequencePatternPredicateKind<'db>,
-        _pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> PatternNarrowingResult<'db> {
         let subject_node = subject.node_ref(self.db).node(self.module);


### PR DESCRIPTION
## Summary

Successful-pattern analysis tells us which values can reach a `case` body. But exhaustiveness and narrowing after a _failed_ case need a stricter answer: which values were guaranteed to match that `case`?

```python
from typing import Literal, TypedDict

class Event(TypedDict):
    kind: Literal["event"]

def handle(event: Event) -> int:
    match event:
        case {"kind": "event"}:
            return 1
```

The mapping pattern is exhaustive because `kind` is required and its declared type is fully covered by the nested literal pattern. An optional or absent key would leave a path where the pattern can fail.

This PR makes definite-match analysis use the actual subject type and recurse through the complete pattern. A class pattern is definite only when its class check always succeeds, every requested member is definitely present, and every nested pattern covers that member's type. Mapping patterns apply the same rule to required `TypedDict` keys, and sequence patterns can prove a match for known fixed tuple shapes.

The same subject-aware rule is used through `or` and `as` patterns, subclasses, and `__match_args__`. Value patterns use Python equality rather than nominal type identity, including when nested inside a structural pattern, so negative narrowing removes only values that are guaranteed to have matched.
