### PR TITLE
Render subdiagnostics and secondary annotations as related information in the Ruff server

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3738,7 +3738,19 @@ impl DiagnosticGuard<'_, '_> {
         range: impl Ranged,
     ) {
         let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let message = message.into_diagnostic_message();
+        debug_assert!(
+            !message.as_str().is_empty(),
+            "use `secondary_annotation_without_message` for annotations without a message"
+        );
         let ann = Annotation::secondary(span).message(message);
+        self.diagnostic.as_mut().unwrap().annotate(ann);
+    }
+
+    /// Add a secondary annotation without a message at the given range.
+    pub(crate) fn secondary_annotation_without_message(&mut self, range: impl Ranged) {
+        let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let ann = Annotation::secondary(span);
         self.diagnostic.as_mut().unwrap().annotate(ann);
     }
 }

--- a/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/dict_index_missing_items.rs
@@ -157,7 +157,7 @@ impl<'a> Visitor<'a> for SubscriptVisitor<'a, '_> {
                 )
             });
 
-            guard.secondary_annotation("", expr);
+            guard.secondary_annotation_without_message(expr);
         } else {
             visitor::walk_expr(self, expr);
         }

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/os_error_alias.rs
@@ -105,7 +105,7 @@ fn tuple_diagnostic(checker: &Checker, tuple: &ast::ExprTuple, aliases: &[&Expr]
     let mut diagnostic = checker.report_diagnostic(OSErrorAlias { name: None }, diagnostic_range);
     if is_up024_precise_highlighting_enabled(checker.settings()) {
         for alias in aliases.iter().skip(1) {
-            diagnostic.secondary_annotation("", alias.range());
+            diagnostic.secondary_annotation_without_message(alias.range());
         }
     }
     let semantic = checker.semantic();

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -537,7 +537,7 @@ impl Suppressions {
                 remove_codes,
                 highlight_only_code,
             );
-            diagnostic.secondary_annotation("", second_range);
+            diagnostic.secondary_annotation_without_message(second_range);
             let applicability = if applicability.is_unsafe()
                 || second_comment.is_nested()
                     && second_edit.range().contains_range(second_comment.range)

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -1,16 +1,19 @@
 //! Access to the Ruff linting API for the LSP
 
+use std::fmt::Write;
+use std::path::Path;
+
 use ruff_python_ast::SourceType;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     DIAGNOSTIC_NAME, PositionEncoding,
-    edit::{NotebookRange, ToRangeExt},
+    edit::{NotebookDocument, NotebookRange, ToRangeExt},
     resolve::is_document_excluded_for_linting,
     session::DocumentQuery,
 };
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic};
 use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_linter::{
     Locator,
@@ -68,6 +71,7 @@ pub(crate) fn check(
     query: &DocumentQuery,
     encoding: PositionEncoding,
     show_syntax_errors: bool,
+    supports_related_information: bool,
 ) -> DiagnosticsMap {
     let settings = query.settings();
     let document_path = query.virtual_file_path();
@@ -76,6 +80,8 @@ pub(crate) fn check(
         return DiagnosticsMap::default();
     };
     let source_kind = query.make_python_source_kind(source_type);
+    let document_uri = query.make_key().into_uri();
+    let notebook = query.as_notebook();
 
     // If the document is excluded, return an empty list of diagnostics.
     if is_document_excluded_for_linting(
@@ -157,6 +163,15 @@ pub(crate) fn check(
         stylist.line_ending(),
         &suppressions,
     );
+    let context = LspDiagnosticContext {
+        source_kind: &source_kind,
+        index: locator.to_index(),
+        encoding,
+        document_path: document_path.as_ref(),
+        document_uri: &document_uri,
+        notebook,
+        supports_related_information,
+    };
 
     let mut diagnostics_map = DiagnosticsMap::default();
 
@@ -180,13 +195,7 @@ pub(crate) fn check(
                 if message.is_invalid_syntax() && !show_syntax_errors {
                     None
                 } else {
-                    Some(to_lsp_diagnostic(
-                        &message,
-                        noqa_edit,
-                        &source_kind,
-                        locator.to_index(),
-                        encoding,
-                    ))
+                    Some(to_lsp_diagnostic(&message, noqa_edit, &context))
                 }
             });
 
@@ -239,18 +248,25 @@ pub(crate) fn fixes_for_diagnostics(
         .collect()
 }
 
+struct LspDiagnosticContext<'a> {
+    source_kind: &'a SourceKind,
+    index: &'a LineIndex,
+    encoding: PositionEncoding,
+    document_path: &'a Path,
+    document_uri: &'a lsp_types::Uri,
+    notebook: Option<&'a NotebookDocument>,
+    supports_related_information: bool,
+}
+
 /// Generates an LSP diagnostic with an associated cell index for the diagnostic to go in.
 /// If the source kind is a text document, the cell index will always be `0`.
 fn to_lsp_diagnostic(
     diagnostic: &Diagnostic,
     noqa_edit: Option<Edit>,
-    source_kind: &SourceKind,
-    index: &LineIndex,
-    encoding: PositionEncoding,
+    context: &LspDiagnosticContext,
 ) -> (usize, lsp_types::Diagnostic) {
     let diagnostic_range = diagnostic.range().unwrap_or_default();
     let name = diagnostic.name();
-    let body = diagnostic.concise_message().to_string();
     let fix = diagnostic.fix();
     let suggestion = diagnostic.first_help_text();
     let code = diagnostic.secondary_code();
@@ -264,12 +280,22 @@ fn to_lsp_diagnostic(
                 .into_iter()
                 .flat_map(Fix::edits)
                 .map(|edit| lsp_types::TextEdit {
-                    range: diagnostic_edit_range(edit.range(), source_kind, index, encoding),
+                    range: diagnostic_edit_range(
+                        edit.range(),
+                        context.source_kind,
+                        context.index,
+                        context.encoding,
+                    ),
                     new_text: edit.content().unwrap_or_default().to_string(),
                 })
                 .collect();
             let noqa_edit = noqa_edit.map(|noqa_edit| lsp_types::TextEdit {
-                range: diagnostic_edit_range(noqa_edit.range(), source_kind, index, encoding),
+                range: diagnostic_edit_range(
+                    noqa_edit.range(),
+                    context.source_kind,
+                    context.index,
+                    context.encoding,
+                ),
                 new_text: noqa_edit.into_content().unwrap_or_default().into_string(),
             });
             serde_json::to_value(AssociatedDiagnosticData {
@@ -285,16 +311,20 @@ fn to_lsp_diagnostic(
     let range: lsp_types::Range;
     let cell: usize;
 
-    if let Some(notebook_index) = source_kind.as_ipy_notebook().map(Notebook::index) {
+    if let Some(notebook_index) = context.source_kind.as_ipy_notebook().map(Notebook::index) {
         NotebookRange { cell, range } = diagnostic_range.to_notebook_range(
-            source_kind.source_code(),
-            index,
+            context.source_kind.source_code(),
+            context.index,
             notebook_index,
-            encoding,
+            context.encoding,
         );
     } else {
         cell = usize::default();
-        range = diagnostic_range.to_range(source_kind.source_code(), index, encoding);
+        range = diagnostic_range.to_range(
+            context.source_kind.source_code(),
+            context.index,
+            context.encoding,
+        );
     }
 
     let (severity, code) = if let Some(code) = code {
@@ -311,6 +341,62 @@ fn to_lsp_diagnostic(
         )
     };
 
+    let related_information =
+        if context.supports_related_information {
+            let mut related_information = Vec::new();
+            related_information.extend(
+                diagnostic.secondary_annotations().filter_map(|annotation| {
+                    annotation_to_related_information(annotation, context)
+                }),
+            );
+
+            for sub_diagnostic in diagnostic.sub_diagnostics() {
+                related_information.extend(sub_diagnostic_to_related_information(
+                    sub_diagnostic,
+                    context,
+                ));
+                related_information.extend(sub_diagnostic.secondary_annotations().filter_map(
+                    |annotation| annotation_to_related_information(annotation, context),
+                ));
+            }
+
+            Some(related_information)
+        } else {
+            None
+        };
+
+    let mut body = if context.supports_related_information {
+        if let Some(annotation_message) = diagnostic
+            .primary_annotation()
+            .and_then(Annotation::get_message)
+        {
+            format!("{}: {annotation_message}", diagnostic.primary_message())
+        } else {
+            diagnostic.primary_message().to_string()
+        }
+    } else {
+        diagnostic.concise_message().to_string()
+    };
+
+    // Append sub-diagnostics that have no location (and thus can't be shown as related
+    // information) to the message.
+    let mut first = true;
+    for sub_diagnostic in diagnostic.sub_diagnostics() {
+        if sub_diagnostic.primary_annotation().is_none() {
+            if first {
+                body.push('\n');
+                first = false;
+            }
+            write!(
+                body,
+                "\n{severity}: {message}",
+                severity = sub_diagnostic.severity(),
+                message = sub_diagnostic.concise_message(),
+            )
+            .ok();
+        }
+    }
+
     (
         cell,
         lsp_types::Diagnostic {
@@ -325,10 +411,61 @@ fn to_lsp_diagnostic(
             }),
             source: Some(DIAGNOSTIC_NAME.into()),
             message: body.into(),
-            related_information: None,
+            related_information,
             data,
         },
     )
+}
+
+fn annotation_to_related_information(
+    annotation: &Annotation,
+    context: &LspDiagnosticContext,
+) -> Option<lsp_types::DiagnosticRelatedInformation> {
+    Some(lsp_types::DiagnosticRelatedInformation {
+        location: span_to_location(annotation.get_span(), context)?,
+        message: annotation.get_message()?.to_string(),
+    })
+}
+
+fn sub_diagnostic_to_related_information(
+    diagnostic: &SubDiagnostic,
+    context: &LspDiagnosticContext,
+) -> Option<lsp_types::DiagnosticRelatedInformation> {
+    Some(lsp_types::DiagnosticRelatedInformation {
+        location: span_to_location(diagnostic.primary_annotation()?.get_span(), context)?,
+        message: diagnostic.concise_message().to_string(),
+    })
+}
+
+fn span_to_location(span: &Span, context: &LspDiagnosticContext) -> Option<lsp_types::Location> {
+    let source_file = span.as_ruff_file()?;
+    if Path::new(source_file.name()) != context.document_path {
+        return None;
+    }
+    let range = span.range()?;
+
+    if let Some(notebook) = context.notebook {
+        let notebook_index = context.source_kind.as_ipy_notebook().map(Notebook::index)?;
+        let NotebookRange { cell, range } = range.to_notebook_range(
+            source_file.source_text(),
+            source_file.index(),
+            notebook_index,
+            context.encoding,
+        );
+        Some(lsp_types::Location {
+            uri: notebook.cell_uri_by_index(cell)?.clone(),
+            range,
+        })
+    } else {
+        Some(lsp_types::Location {
+            uri: context.document_uri.clone(),
+            range: range.to_range(
+                source_file.source_text(),
+                source_file.index(),
+                context.encoding,
+            ),
+        })
+    }
 }
 
 fn diagnostic_edit_range(
@@ -368,4 +505,105 @@ fn tags(diagnostic: &Diagnostic) -> Option<Vec<lsp_types::DiagnosticTag>> {
             })
             .collect()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::diagnostic::{DiagnosticId, Severity, SubDiagnosticSeverity};
+    use ruff_source_file::SourceFileBuilder;
+    use ruff_text_size::{TextRange, TextSize};
+
+    use super::*;
+
+    #[test]
+    fn all_annotations_are_related_information() {
+        let source = "abcdef";
+        let source_file = SourceFileBuilder::new("test.py", source).finish();
+        let span = |offset| {
+            Span::from(source_file.clone())
+                .with_range(TextRange::at(TextSize::new(offset), TextSize::new(1)))
+        };
+
+        let mut diagnostic = Diagnostic::new(
+            DiagnosticId::lint("synthetic"),
+            Severity::Error,
+            "Synthetic diagnostic",
+        );
+        diagnostic.annotate(Annotation::primary(span(0)).message("Primary annotation"));
+        diagnostic.annotate(Annotation::secondary(span(1)).message("Secondary annotation"));
+        diagnostic.annotate(Annotation::primary(span(2)).message("Additional primary annotation"));
+        diagnostic.annotate(Annotation::secondary(span(3)));
+        diagnostic.annotate(
+            Annotation::secondary(
+                Span::from(SourceFileBuilder::new("other.py", "x").finish())
+                    .with_range(TextRange::new(TextSize::new(0), TextSize::new(1))),
+            )
+            .message("Foreign annotation"),
+        );
+
+        let mut sub_diagnostic =
+            SubDiagnostic::new(SubDiagnosticSeverity::Info, "Synthetic subdiagnostic");
+        sub_diagnostic.annotate(Annotation::secondary(span(3)).message("Secondary subannotation"));
+        sub_diagnostic.annotate(Annotation::primary(span(4)).message("Primary subannotation"));
+        sub_diagnostic
+            .annotate(Annotation::primary(span(5)).message("Additional primary subannotation"));
+        diagnostic.sub(sub_diagnostic);
+        diagnostic.sub(SubDiagnostic::new(
+            SubDiagnosticSeverity::Help,
+            "Unlocated subdiagnostic",
+        ));
+
+        let source_kind = SourceKind::Python {
+            code: source.to_string(),
+            is_stub: false,
+        };
+        let index = LineIndex::from_source_text(source);
+        let uri = lsp_types::Uri::parse("file:///test.py").expect("URI to be valid");
+        let context = LspDiagnosticContext {
+            source_kind: &source_kind,
+            index: &index,
+            encoding: PositionEncoding::UTF8,
+            document_path: Path::new("test.py"),
+            document_uri: &uri,
+            notebook: None,
+            supports_related_information: true,
+        };
+        let (_, lsp_diagnostic) = to_lsp_diagnostic(&diagnostic, None, &context);
+
+        assert_eq!(
+            lsp_diagnostic.message,
+            lsp_types::Message::String(
+                "Synthetic diagnostic: Primary annotation\n\nhelp: Unlocated subdiagnostic"
+                    .to_string()
+            )
+        );
+        let related_information = lsp_diagnostic
+            .related_information
+            .expect("client supports diagnostic related information");
+        assert!(
+            related_information
+                .iter()
+                .all(|information| information.location.uri == uri)
+        );
+        assert_eq!(
+            related_information
+                .iter()
+                .map(|information| information.location.range.start.character)
+                .collect::<Vec<_>>(),
+            [1, 2, 4, 3, 5]
+        );
+        assert_eq!(
+            related_information
+                .iter()
+                .map(|information| information.message.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "Secondary annotation",
+                "Additional primary annotation",
+                "Synthetic subdiagnostic: Primary subannotation",
+                "Secondary subannotation",
+                "Additional primary subannotation",
+            ]
+        );
+    }
 }

--- a/crates/ruff_server/src/server/api/diagnostics.rs
+++ b/crates/ruff_server/src/server/api/diagnostics.rs
@@ -12,6 +12,9 @@ pub(super) fn generate_diagnostics(snapshot: &DocumentSnapshot) -> DiagnosticsMa
             document,
             snapshot.encoding(),
             snapshot.client_settings().show_syntax_errors(),
+            snapshot
+                .resolved_client_capabilities()
+                .diagnostic_related_information,
         )
     } else {
         DiagnosticsMap::default()

--- a/crates/ruff_server/src/session/capabilities.rs
+++ b/crates/ruff_server/src/session/capabilities.rs
@@ -9,6 +9,7 @@ pub(crate) struct ResolvedClientCapabilities {
     pub(crate) document_changes: bool,
     pub(crate) workspace_refresh: bool,
     pub(crate) pull_diagnostics: bool,
+    pub(crate) diagnostic_related_information: bool,
 }
 
 impl ResolvedClientCapabilities {
@@ -50,6 +51,17 @@ impl ResolvedClientCapabilities {
             .and_then(|text_document| text_document.diagnostic.as_ref())
             .is_some();
 
+        let diagnostic_related_information = client_capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.publish_diagnostics.as_ref())
+            .and_then(|publish_diagnostics| {
+                publish_diagnostics
+                    .diagnostics_capabilities
+                    .related_information
+            })
+            .unwrap_or_default();
+
         Self {
             code_action_deferred_edit_resolution: code_action_data_support
                 && code_action_edit_resolution,
@@ -57,6 +69,7 @@ impl ResolvedClientCapabilities {
             document_changes,
             workspace_refresh,
             pull_diagnostics,
+            diagnostic_related_information,
         }
     }
 }
@@ -72,6 +85,7 @@ impl std::fmt::Display for ResolvedClientCapabilities {
                 self.document_changes,
                 self.workspace_refresh,
                 self.pull_diagnostics,
+                self.diagnostic_related_information,
             ]
         };
         Ok(())

--- a/crates/ruff_server/tests/e2e/main.rs
+++ b/crates/ruff_server/tests/e2e/main.rs
@@ -1085,7 +1085,6 @@ impl TestServerBuilder {
         self
     }
 
-    #[expect(dead_code)]
     pub(crate) fn enable_diagnostic_related_information(mut self, enabled: bool) -> Self {
         self.client_capabilities
             .text_document

--- a/crates/ruff_server/tests/e2e/notebook.rs
+++ b/crates/ruff_server/tests/e2e/notebook.rs
@@ -25,6 +25,101 @@ struct NotebookChange {
 }
 
 #[test]
+fn related_information() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .with_file(
+            "pyproject.toml",
+            r#"
+[tool.ruff.lint]
+select = ["F811"]
+"#,
+        )?
+        .enable_diagnostic_related_information(true)
+        .build();
+
+    let notebook_path = server.file_path("test.ipynb");
+    let cell_uris = [
+        make_cell_uri(&notebook_path, 0),
+        make_cell_uri(&notebook_path, 1),
+    ];
+    let cells = cell_uris
+        .iter()
+        .cloned()
+        .map(|uri| lsp_types::NotebookCell {
+            kind: lsp_types::NotebookCellKind::Code,
+            document: uri,
+            metadata: None,
+            execution_summary: None,
+        })
+        .collect();
+    let cell_text_documents = cell_uris
+        .iter()
+        .cloned()
+        .zip(["import os\n", "import os\n"])
+        .map(|(uri, source)| {
+            TextDocumentItem::new(uri, lsp_types::LanguageKind::Python, 0, source.to_string())
+        })
+        .collect();
+
+    server.send_notification::<DidOpenNotebookDocumentNotification>(
+        DidOpenNotebookDocumentParams {
+            notebook_document: NotebookDocument {
+                uri: server.file_uri("test.ipynb"),
+                notebook_type: "jupyter-notebook".to_string(),
+                version: 0,
+                metadata: None,
+                cells,
+            },
+            cell_text_documents,
+        },
+    );
+
+    let diagnostics = server.collect_publish_diagnostic_notifications(cell_uris.len());
+    assert!(
+        diagnostics
+            .get(&cell_uris[0])
+            .expect("first cell to have diagnostics published")
+            .is_empty()
+    );
+    let [diagnostic] = diagnostics
+        .get(&cell_uris[1])
+        .expect("second cell to have diagnostics published")
+        .as_slice()
+    else {
+        panic!("second cell to have one diagnostic");
+    };
+    let [related_information] = diagnostic
+        .related_information
+        .as_deref()
+        .expect("client supports diagnostic related information")
+    else {
+        panic!("diagnostic to have one related information entry");
+    };
+
+    assert_eq!(related_information.location.uri, cell_uris[0]);
+    assert_eq!(
+        related_information.location.range,
+        Range {
+            start: Position {
+                line: 0,
+                character: 7,
+            },
+            end: Position {
+                line: 0,
+                character: 9,
+            },
+        }
+    );
+    assert_eq!(
+        related_information.message,
+        "previous definition of `os` here"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn super_resolution_overview() -> Result<()> {
     let fixture_path = fixture_path(NOTEBOOK_FIXTURE_PATH)?;
     let workspace_dir = fixture_path

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__notebook_without_ipynb_extension_open.snap
@@ -21,7 +21,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/missing-required-import"
       },
       "source": "Ruff",
-      "message": "Missing required import: `from __future__ import annotations`",
+      "message": "Missing required import: `from __future__ import annotations`\n\nhelp: Insert required import: `from __future__ import annotations`",
       "tags": [],
       "data": {
         "code": "I002",
@@ -294,7 +294,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/unsorted-imports"
       },
       "source": "Ruff",
-      "message": "Import block is un-sorted or un-formatted",
+      "message": "Import block is un-sorted or un-formatted\n\nhelp: Organize imports",
       "tags": [],
       "data": {
         "code": "I001",
@@ -348,7 +348,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -404,7 +404,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -456,7 +456,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -508,7 +508,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/f-string-missing-placeholders"
       },
       "source": "Ruff",
-      "message": "f-string without any placeholders",
+      "message": "f-string without any placeholders\n\nhelp: Remove extraneous `f` prefix",
       "tags": [],
       "data": {
         "code": "F541",

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_final.snap
@@ -21,7 +21,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/missing-required-import"
       },
       "source": "Ruff",
-      "message": "Missing required import: `from __future__ import annotations`",
+      "message": "Missing required import: `from __future__ import annotations`\n\nhelp: Insert required import: `from __future__ import annotations`",
       "tags": [],
       "data": {
         "code": "I002",
@@ -294,7 +294,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/unsorted-imports"
       },
       "source": "Ruff",
-      "message": "Import block is un-sorted or un-formatted",
+      "message": "Import block is un-sorted or un-formatted\n\nhelp: Organize imports",
       "tags": [],
       "data": {
         "code": "I001",
@@ -348,7 +348,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -404,7 +404,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -456,7 +456,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -508,7 +508,7 @@ expression: "final_diagnostics.expect(\"at least one notebook change\")"
         "href": "https://docs.astral.sh/ruff/rules/f-string-missing-placeholders"
       },
       "source": "Ruff",
-      "message": "f-string without any placeholders",
+      "message": "f-string without any placeholders\n\nhelp: Remove extraneous `f` prefix",
       "tags": [],
       "data": {
         "code": "F541",

--- a/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
+++ b/crates/ruff_server/tests/e2e/snapshots/e2e__notebook__super_resolution_overview_open.snap
@@ -21,7 +21,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/missing-required-import"
       },
       "source": "Ruff",
-      "message": "Missing required import: `from __future__ import annotations`",
+      "message": "Missing required import: `from __future__ import annotations`\n\nhelp: Insert required import: `from __future__ import annotations`",
       "tags": [],
       "data": {
         "code": "I002",
@@ -294,7 +294,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/unsorted-imports"
       },
       "source": "Ruff",
-      "message": "Import block is un-sorted or un-formatted",
+      "message": "Import block is un-sorted or un-formatted\n\nhelp: Organize imports",
       "tags": [],
       "data": {
         "code": "I001",
@@ -348,7 +348,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -404,7 +404,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -456,7 +456,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/useless-semicolon"
       },
       "source": "Ruff",
-      "message": "Statement ends with an unnecessary semicolon",
+      "message": "Statement ends with an unnecessary semicolon\n\nhelp: Remove unnecessary semicolon",
       "tags": [],
       "data": {
         "code": "E703",
@@ -508,7 +508,7 @@ expression: diagnostics
         "href": "https://docs.astral.sh/ruff/rules/f-string-missing-placeholders"
       },
       "source": "Ruff",
-      "message": "f-string without any placeholders",
+      "message": "f-string without any placeholders\n\nhelp: Remove extraneous `f` prefix",
       "tags": [],
       "data": {
         "code": "F541",

--- a/crates/ruff_server/tests/e2e/workspace.rs
+++ b/crates/ruff_server/tests/e2e/workspace.rs
@@ -58,7 +58,7 @@ ignore = ["F401"]
             "href": "https://docs.astral.sh/ruff/rules/unused-import"
           },
           "source": "Ruff",
-          "message": "`os` imported but unused",
+          "message": "`os` imported but unused\n\nhelp: Remove unused import: `os`",
           "tags": [
             1
           ],


### PR DESCRIPTION
## Summary

- Preserve additional primary annotations, secondary annotations, and located subdiagnostics as LSP related information in `ruff_server`.
- Keep unlocated subdiagnostics in the main diagnostic message and translate notebook annotation spans to the correct cell URI and range.
- Add focused conversion, end-to-end, and notebook coverage.

`ruff_server` previously discarded this diagnostic structure during LSP conversion, unlike `ty_server` and the Ruff/ty playgrounds.

## Test plan


https://github.com/user-attachments/assets/3be19a4d-6559-42d8-8673-207bb11406bb

