### PR TITLE
[`flake8-pyi`] Accept `TypeVar` bound to `BaseException` in `__exit__`/`__aexit__` (`PYI036`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
@@ -187,3 +187,25 @@ class UnacceptableNarrowBoundGeneric:
     def __exit__[T: ValueError](
         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
     ) -> bool: ...  # PYI036 (the TypeVar bound is narrower than `BaseException`)
+
+# A class-scoped type parameter does not make the method generic: the class could be
+# specialized to a type narrower than `BaseException`, so this is not equivalent to
+# annotating with `BaseException` directly.
+class UnacceptablePep695ClassGeneric[T: BaseException]:
+    def __exit__(
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # PYI036 (`T` is a class type parameter, not a method one)
+
+class UnacceptableOldStyleClassGeneric(typing.Generic[_ExcT]):
+    def __exit__(
+        self, exc_type: type[_ExcT] | None, exc: _ExcT | None, tb: TracebackType | None
+    ) -> bool: ...  # PYI036 (`_ExcT` parametrizes the class, not the method)
+
+# A method-scoped PEP 695 type parameter shadows an outer `TypeVar` of the same name,
+# so only its own (here, missing) bound is considered.
+_ExcT2 = typing.TypeVar("_ExcT2", bound=BaseException)
+
+class UnacceptableShadowedTypeVar:
+    def __exit__[_ExcT2](
+        self, exc_type: type[_ExcT2] | None, exc: _ExcT2 | None, tb: TracebackType | None, /
+    ) -> bool: ...  # PYI036 (the method's own `_ExcT2` is unbounded)

--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
@@ -167,3 +167,23 @@ class UnacceptableOverload2:
     @overload
     def __exit__(self, exc_typ: object, exc: Exception, tb: builtins.TracebackType) -> None: ...  # PYI036
     def __exit__(self, exc_typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...
+
+class AcceptablePep695Generic:
+    def __exit__[T: BaseException](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # Okay
+    async def __aexit__[T: BaseException](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # Okay
+
+_ExcT = typing.TypeVar("_ExcT", bound=BaseException)
+
+class AcceptableOldStyleGeneric:
+    def __exit__(
+        self, exc_type: type[_ExcT] | None, exc: _ExcT | None, tb: TracebackType | None
+    ) -> bool: ...  # Okay
+
+class UnacceptableNarrowBoundGeneric:
+    def __exit__[T: ValueError](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # PYI036 (the TypeVar bound is narrower than `BaseException`)

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -1,8 +1,8 @@
 use std::fmt::{Display, Formatter};
 
 use ruff_python_ast::{
-    Expr, ExprBinOp, ExprSubscript, ExprTuple, Operator, ParameterWithDefault, Parameters, Stmt,
-    StmtClassDef, StmtFunctionDef, TypeParam, TypeParams,
+    Expr, ExprBinOp, ExprName, ExprSubscript, ExprTuple, Operator, ParameterWithDefault,
+    Parameters, Stmt, StmtClassDef, StmtFunctionDef, TypeParam, TypeParams,
 };
 use smallvec::SmallVec;
 
@@ -214,6 +214,7 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
         &non_self_positional_args,
         func_kind,
         type_params,
+        parent_class_def,
     );
 }
 
@@ -261,6 +262,7 @@ fn check_positional_args_for_non_overloaded_method(
     non_self_positional_params: &[&ParameterWithDefault],
     kind: FuncKind,
     type_params: Option<&TypeParams>,
+    class_def: &StmtClassDef,
 ) {
     // For each argument, define the predicate against which to check the annotation.
     type AnnotationValidator<'a> = &'a dyn Fn(&Expr) -> bool;
@@ -269,11 +271,11 @@ fn check_positional_args_for_non_overloaded_method(
 
     let validations: [(ErrorKind, AnnotationValidator); 3] = [
         (ErrorKind::FirstArgBadAnnotation, &|expr| {
-            is_base_exception_type(expr, semantic, type_params)
+            is_base_exception_type(expr, semantic, type_params, class_def)
         }),
         (ErrorKind::SecondArgBadAnnotation, &|expr| {
             semantic.match_builtin_expr(expr, "BaseException")
-                || is_base_exception_bound_type_var(expr, semantic, type_params)
+                || is_base_exception_bound_type_var(expr, semantic, type_params, class_def)
         }),
         (ErrorKind::ThirdArgBadAnnotation, &|expr| {
             is_traceback_type(expr, semantic)
@@ -423,13 +425,18 @@ fn check_positional_args_for_overloaded_method(
     // Now check the second:
     if parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[0],
-        |annotation| is_base_exception_type(annotation, semantic, type_params),
+        |annotation| is_base_exception_type(annotation, semantic, type_params, parent_class_def),
         semantic,
     ) && parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[1],
         |annotation| {
             semantic.match_builtin_expr(annotation, "BaseException")
-                || is_base_exception_bound_type_var(annotation, semantic, type_params)
+                || is_base_exception_bound_type_var(
+                    annotation,
+                    semantic,
+                    type_params,
+                    parent_class_def,
+                )
         },
         semantic,
     ) && parameter_annotation_loosely_matches_predicate(
@@ -534,6 +541,7 @@ fn is_base_exception_type(
     expr: &Expr,
     semantic: &SemanticModel,
     type_params: Option<&TypeParams>,
+    class_def: &StmtClassDef,
 ) -> bool {
     let Expr::Subscript(ExprSubscript { value, slice, .. }) = expr else {
         return false;
@@ -541,43 +549,56 @@ fn is_base_exception_type(
 
     if semantic.match_typing_expr(value, "Type") || semantic.match_builtin_expr(value, "type") {
         semantic.match_builtin_expr(slice, "BaseException")
-            || is_base_exception_bound_type_var(slice, semantic, type_params)
+            || is_base_exception_bound_type_var(slice, semantic, type_params, class_def)
     } else {
         false
     }
 }
 
-/// Return `true` if the [`Expr`] is a `TypeVar` that is bound to `BaseException`.
+/// Return `true` if the [`Expr`] is a `TypeVar` that makes the *method* generic and
+/// is bound to `BaseException`.
 ///
 /// Both PEP 695-style type parameters (e.g. `def __exit__[T: BaseException](...)`)
 /// and "old-style" `TypeVar`s (e.g. `T = TypeVar("T", bound=BaseException)`) are
 /// recognized. Annotating an `__exit__`/`__aexit__` argument with such a `TypeVar`
 /// is equivalent to annotating it with `BaseException` directly.
+///
+/// A *class*-scoped type parameter (e.g. `class C(Generic[T])` or `class C[T]`) is
+/// **not** accepted: the class can be specialized to a type narrower than
+/// `BaseException`, which would make the annotation unsound.
 fn is_base_exception_bound_type_var(
     expr: &Expr,
     semantic: &SemanticModel,
     type_params: Option<&TypeParams>,
+    class_def: &StmtClassDef,
 ) -> bool {
     let Expr::Name(name) = expr else {
         return false;
     };
 
-    // PEP 695 type parameter, e.g. `def __exit__[T: BaseException](...)`.
+    // A class-scoped type parameter does not make the method generic, so reject it.
+    if is_class_type_parameter(name, class_def) {
+        return false;
+    }
+
+    // A PEP 695 type parameter declared on the method itself shadows any outer binding
+    // of the same name, so only its own bound is considered.
     //
-    // Names in annotations are resolved lazily, so `resolve_name` is not reliable
-    // here; instead, match the name directly against the enclosing type parameter
-    // list, which is what the runtime binding would resolve to.
-    if let Some(bound) = type_params.and_then(|type_params| {
+    // Names in annotations are resolved lazily, so `resolve_name` is not reliable here;
+    // match the name directly against the enclosing type-parameter list instead.
+    if let Some(type_var) = type_params.and_then(|type_params| {
         type_params
             .iter()
             .filter_map(TypeParam::as_type_var)
             .find(|type_var| type_var.name.id == name.id)
-            .and_then(|type_var| type_var.bound.as_deref())
     }) {
-        return semantic.match_builtin_expr(bound, "BaseException");
+        return type_var
+            .bound
+            .as_deref()
+            .is_some_and(|bound| semantic.match_builtin_expr(bound, "BaseException"));
     }
 
-    // "Old-style" `TypeVar`, e.g. `T = TypeVar("T", bound=BaseException)`.
+    // Otherwise, an "old-style" free `TypeVar`, e.g. `T = TypeVar("T", bound=BaseException)`.
     if !semantic.seen_typing() {
         return false;
     }
@@ -597,4 +618,41 @@ fn is_base_exception_bound_type_var(
         .filter(|call| semantic.match_typing_expr(&call.func, "TypeVar"))
         .and_then(|call| call.arguments.find_keyword("bound"))
         .is_some_and(|keyword| semantic.match_builtin_expr(&keyword.value, "BaseException"))
+}
+
+/// Return `true` if `name` refers to a type parameter of `class_def` itself, i.e. a
+/// PEP 695 class type parameter (`class C[T]`) or an "old-style" generic-class
+/// parameter (`class C(Generic[T])`).
+fn is_class_type_parameter(name: &ExprName, class_def: &StmtClassDef) -> bool {
+    // PEP 695 class type parameters, e.g. `class C[T]: ...`.
+    if let Some(type_params) = &class_def.type_params {
+        if type_params
+            .iter()
+            .filter_map(TypeParam::as_type_var)
+            .any(|type_var| type_var.name.id == name.id)
+        {
+            return true;
+        }
+    }
+
+    // "Old-style" generic classes, e.g. `class C(Generic[T]): ...`.
+    class_def.bases().iter().any(|base| {
+        matches!(
+            base,
+            Expr::Subscript(ExprSubscript { slice, .. }) if subscript_mentions_name(slice, name)
+        )
+    })
+}
+
+/// Return `true` if `slice` is `name` or a tuple of subscript elements containing `name`,
+/// e.g. the `T` in `Generic[T]` or `Generic[T, U]`.
+fn subscript_mentions_name(slice: &Expr, name: &ExprName) -> bool {
+    match slice {
+        Expr::Name(other) => other.id == name.id,
+        Expr::Tuple(tuple) => tuple
+            .elts
+            .iter()
+            .any(|element| matches!(element, Expr::Name(other) if other.id == name.id)),
+        _ => false,
+    }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -2,7 +2,7 @@ use std::fmt::{Display, Formatter};
 
 use ruff_python_ast::{
     Expr, ExprBinOp, ExprSubscript, ExprTuple, Operator, ParameterWithDefault, Parameters, Stmt,
-    StmtClassDef, StmtFunctionDef,
+    StmtClassDef, StmtFunctionDef, TypeParam, TypeParams,
 };
 use smallvec::SmallVec;
 
@@ -137,8 +137,10 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
         decorator_list,
         name,
         parameters,
+        type_params,
         ..
     } = function;
+    let type_params = type_params.as_deref();
 
     let func_kind = match name.as_str() {
         "__exit__" if !is_async => FuncKind::Sync,
@@ -166,6 +168,7 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
             func_kind,
             parent_class_def,
             parameters.range(),
+            type_params,
         );
         return;
     }
@@ -206,7 +209,12 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
         );
     }
 
-    check_positional_args_for_non_overloaded_method(checker, &non_self_positional_args, func_kind);
+    check_positional_args_for_non_overloaded_method(
+        checker,
+        &non_self_positional_args,
+        func_kind,
+        type_params,
+    );
 }
 
 /// Determine whether a "short" argument list (i.e., an argument list with less than four elements)
@@ -252,16 +260,24 @@ fn check_positional_args_for_non_overloaded_method(
     checker: &Checker,
     non_self_positional_params: &[&ParameterWithDefault],
     kind: FuncKind,
+    type_params: Option<&TypeParams>,
 ) {
     // For each argument, define the predicate against which to check the annotation.
-    type AnnotationValidator = fn(&Expr, &SemanticModel) -> bool;
+    type AnnotationValidator<'a> = &'a dyn Fn(&Expr) -> bool;
+
+    let semantic = checker.semantic();
 
     let validations: [(ErrorKind, AnnotationValidator); 3] = [
-        (ErrorKind::FirstArgBadAnnotation, is_base_exception_type),
-        (ErrorKind::SecondArgBadAnnotation, |expr, semantic| {
-            semantic.match_builtin_expr(expr, "BaseException")
+        (ErrorKind::FirstArgBadAnnotation, &|expr| {
+            is_base_exception_type(expr, semantic, type_params)
         }),
-        (ErrorKind::ThirdArgBadAnnotation, is_traceback_type),
+        (ErrorKind::SecondArgBadAnnotation, &|expr| {
+            semantic.match_builtin_expr(expr, "BaseException")
+                || is_base_exception_bound_type_var(expr, semantic, type_params)
+        }),
+        (ErrorKind::ThirdArgBadAnnotation, &|expr| {
+            is_traceback_type(expr, semantic)
+        }),
     ];
 
     for (param, (error_info, predicate)) in
@@ -271,15 +287,13 @@ fn check_positional_args_for_non_overloaded_method(
             continue;
         };
 
-        if is_object_or_unused(annotation, checker.semantic()) {
+        if is_object_or_unused(annotation, semantic) {
             continue;
         }
 
         // If there's an annotation that's not `object` or `Unused`, check that the annotated type
         // matches the predicate.
-        if non_none_annotation_element(annotation, checker.semantic())
-            .is_some_and(|elem| predicate(elem, checker.semantic()))
-        {
+        if non_none_annotation_element(annotation, semantic).is_some_and(predicate) {
             continue;
         }
 
@@ -301,6 +315,7 @@ fn check_positional_args_for_overloaded_method(
     kind: FuncKind,
     parent_class_def: &StmtClassDef,
     parameters_range: TextRange,
+    type_params: Option<&TypeParams>,
 ) {
     fn parameter_annotation_loosely_matches_predicate(
         parameter: &ParameterWithDefault,
@@ -408,11 +423,14 @@ fn check_positional_args_for_overloaded_method(
     // Now check the second:
     if parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[0],
-        |annotation| is_base_exception_type(annotation, semantic),
+        |annotation| is_base_exception_type(annotation, semantic, type_params),
         semantic,
     ) && parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[1],
-        |annotation| semantic.match_builtin_expr(annotation, "BaseException"),
+        |annotation| {
+            semantic.match_builtin_expr(annotation, "BaseException")
+                || is_base_exception_bound_type_var(annotation, semantic, type_params)
+        },
         semantic,
     ) && parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[2],
@@ -510,15 +528,73 @@ fn is_traceback_type(expr: &Expr, semantic: &SemanticModel) -> bool {
         })
 }
 
-/// Return `true` if the [`Expr`] is, e.g., `Type[BaseException]`.
-fn is_base_exception_type(expr: &Expr, semantic: &SemanticModel) -> bool {
+/// Return `true` if the [`Expr`] is, e.g., `Type[BaseException]` or `type[T]`
+/// where `T` is a `TypeVar` bound to `BaseException`.
+fn is_base_exception_type(
+    expr: &Expr,
+    semantic: &SemanticModel,
+    type_params: Option<&TypeParams>,
+) -> bool {
     let Expr::Subscript(ExprSubscript { value, slice, .. }) = expr else {
         return false;
     };
 
     if semantic.match_typing_expr(value, "Type") || semantic.match_builtin_expr(value, "type") {
         semantic.match_builtin_expr(slice, "BaseException")
+            || is_base_exception_bound_type_var(slice, semantic, type_params)
     } else {
         false
     }
+}
+
+/// Return `true` if the [`Expr`] is a `TypeVar` that is bound to `BaseException`.
+///
+/// Both PEP 695-style type parameters (e.g. `def __exit__[T: BaseException](...)`)
+/// and "old-style" `TypeVar`s (e.g. `T = TypeVar("T", bound=BaseException)`) are
+/// recognized. Annotating an `__exit__`/`__aexit__` argument with such a `TypeVar`
+/// is equivalent to annotating it with `BaseException` directly.
+fn is_base_exception_bound_type_var(
+    expr: &Expr,
+    semantic: &SemanticModel,
+    type_params: Option<&TypeParams>,
+) -> bool {
+    let Expr::Name(name) = expr else {
+        return false;
+    };
+
+    // PEP 695 type parameter, e.g. `def __exit__[T: BaseException](...)`.
+    //
+    // Names in annotations are resolved lazily, so `resolve_name` is not reliable
+    // here; instead, match the name directly against the enclosing type parameter
+    // list, which is what the runtime binding would resolve to.
+    if let Some(bound) = type_params.and_then(|type_params| {
+        type_params
+            .iter()
+            .filter_map(TypeParam::as_type_var)
+            .find(|type_var| type_var.name.id == name.id)
+            .and_then(|type_var| type_var.bound.as_deref())
+    }) {
+        return semantic.match_builtin_expr(bound, "BaseException");
+    }
+
+    // "Old-style" `TypeVar`, e.g. `T = TypeVar("T", bound=BaseException)`.
+    if !semantic.seen_typing() {
+        return false;
+    }
+
+    let Some(binding) = semantic
+        .lookup_symbol(name.id.as_str())
+        .map(|id| semantic.binding(id))
+    else {
+        return false;
+    };
+
+    binding
+        .source
+        .map(|node_id| semantic.statement(node_id))
+        .and_then(Stmt::as_assign_stmt)
+        .and_then(|assign| assign.value.as_call_expr())
+        .filter(|call| semantic.match_typing_expr(&call.func, "TypeVar"))
+        .and_then(|call| call.arguments.find_keyword("bound"))
+        .is_some_and(|keyword| semantic.match_builtin_expr(&keyword.value, "BaseException"))
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
@@ -218,3 +218,23 @@ PYI036 Annotations for a three-argument `__exit__` overload (excluding `self`) s
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 169 |     def __exit__(self, exc_typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...
     |
+
+PYI036 The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
+   --> PYI036.py:188:25
+    |
+186 | class UnacceptableNarrowBoundGeneric:
+187 |     def __exit__[T: ValueError](
+188 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                         ^^^^^^^^^^^^^^
+189 |     ) -> bool: ...  # PYI036 (the TypeVar bound is narrower than `BaseException`)
+    |
+
+PYI036 The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
+   --> PYI036.py:188:46
+    |
+186 | class UnacceptableNarrowBoundGeneric:
+187 |     def __exit__[T: ValueError](
+188 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                                              ^^^^^^^^
+189 |     ) -> bool: ...  # PYI036 (the TypeVar bound is narrower than `BaseException`)
+    |

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
@@ -238,3 +238,63 @@ PYI036 The second argument in `__exit__` should be annotated with `object` or `B
     |                                              ^^^^^^^^
 189 |     ) -> bool: ...  # PYI036 (the TypeVar bound is narrower than `BaseException`)
     |
+
+PYI036 The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
+   --> PYI036.py:196:25
+    |
+194 | class UnacceptablePep695ClassGeneric[T: BaseException]:
+195 |     def __exit__(
+196 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                         ^^^^^^^^^^^^^^
+197 |     ) -> bool: ...  # PYI036 (`T` is a class type parameter, not a method one)
+    |
+
+PYI036 The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
+   --> PYI036.py:196:46
+    |
+194 | class UnacceptablePep695ClassGeneric[T: BaseException]:
+195 |     def __exit__(
+196 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                                              ^^^^^^^^
+197 |     ) -> bool: ...  # PYI036 (`T` is a class type parameter, not a method one)
+    |
+
+PYI036 The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
+   --> PYI036.py:201:25
+    |
+199 | class UnacceptableOldStyleClassGeneric(typing.Generic[_ExcT]):
+200 |     def __exit__(
+201 |         self, exc_type: type[_ExcT] | None, exc: _ExcT | None, tb: TracebackType | None
+    |                         ^^^^^^^^^^^^^^^^^^
+202 |     ) -> bool: ...  # PYI036 (`_ExcT` parametrizes the class, not the method)
+    |
+
+PYI036 The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
+   --> PYI036.py:201:50
+    |
+199 | class UnacceptableOldStyleClassGeneric(typing.Generic[_ExcT]):
+200 |     def __exit__(
+201 |         self, exc_type: type[_ExcT] | None, exc: _ExcT | None, tb: TracebackType | None
+    |                                                  ^^^^^^^^^^^^
+202 |     ) -> bool: ...  # PYI036 (`_ExcT` parametrizes the class, not the method)
+    |
+
+PYI036 The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
+   --> PYI036.py:210:25
+    |
+208 | class UnacceptableShadowedTypeVar:
+209 |     def __exit__[_ExcT2](
+210 |         self, exc_type: type[_ExcT2] | None, exc: _ExcT2 | None, tb: TracebackType | None, /
+    |                         ^^^^^^^^^^^^^^^^^^^
+211 |     ) -> bool: ...  # PYI036 (the method's own `_ExcT2` is unbounded)
+    |
+
+PYI036 The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
+   --> PYI036.py:210:51
+    |
+208 | class UnacceptableShadowedTypeVar:
+209 |     def __exit__[_ExcT2](
+210 |         self, exc_type: type[_ExcT2] | None, exc: _ExcT2 | None, tb: TracebackType | None, /
+    |                                                   ^^^^^^^^^^^^^
+211 |     ) -> bool: ...  # PYI036 (the method's own `_ExcT2` is unbounded)
+    |


### PR DESCRIPTION
## Summary

Fixes #25905.

`PYI036` (`bad-exit-annotation`) raised a false positive when an `__exit__`/`__aexit__` method used a generic exception type:

```python
from types import TracebackType


class Foo:
    def __exit__[T: BaseException](
        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
    ) -> bool: ...
```

Annotating the first two arguments with a `TypeVar` bound to `BaseException` is equivalent to annotating them with `type[BaseException] | None` / `BaseException | None`, so this should be accepted.

This PR makes the first- and second-argument checks (both the non-overloaded and overloaded paths) additionally accept a `TypeVar` that is bound to `BaseException`. Both forms are recognized:

- PEP 695 type parameters — `def __exit__[T: BaseException](...)`
- "old-style" `TypeVar`s — `T = TypeVar("T", bound=BaseException)`

A `TypeVar` whose bound is *narrower* than `BaseException` (e.g. `[T: ValueError]`) is still flagged, since that annotation would be unsound.

Note: because names inside annotations are resolved lazily, `resolve_name` is not reliable inside this rule; PEP 695 type parameters are matched directly against the enclosing type-parameter list, and old-style `TypeVar`s are resolved via `lookup_symbol`.

## Test Plan

Added fixtures to `PYI036.py` covering PEP 695 and old-style `TypeVar`s bound to `BaseException` (accepted), plus a too-narrow bound (still flagged). `cargo test -p ruff_linter` passes; `cargo clippy` is clean.