### PR TITLE
[ty] Reduce contextual call argument inference overhead

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_form.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_form.md
@@ -425,6 +425,17 @@ def foo(form: TypeForm[int] | TypeForm[str]) -> int | str:
 reveal_type(foo(int))  # revealed: int
 reveal_type(foo(str))  # revealed: str
 foo(float)  # error: [no-matching-overload]
+
+type RecursiveForm = RecursiveForm | TypeForm[int]
+
+@overload
+def consume(value: RecursiveForm, discriminator: int) -> None: ...
+@overload
+def consume(value: RecursiveForm, discriminator: str) -> None: ...
+def consume(value: RecursiveForm, discriminator: int | str) -> None: ...
+
+value: object = object()
+consume(value, 1)
 ```
 
 ## Narrowing to runtime classes

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5858,6 +5858,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        fn contains_type_form<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+            match ty.resolve_type_alias(db) {
+                Type::TypeForm(_) => true,
+                Type::Union(union) => union
+                    .elements(db)
+                    .iter()
+                    .any(|element| matches!(element.resolve_type_alias(db), Type::TypeForm(_))),
+                _ => false,
+            }
+        }
+
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
 
@@ -5964,6 +5975,34 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let default_ty =
                     infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
                 arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
+
+                if parameter_contexts.is_empty() {
+                    continue;
+                }
+
+                if can_defer_type_context(ast_argument)
+                    && parameter_contexts.iter().all(|parameter_context| {
+                        let context = parameter_context.type_context();
+                        !context.is_typealias()
+                            && context
+                                .annotation
+                                .is_none_or(|annotation| !contains_type_form(db, annotation))
+                    })
+                {
+                    for parameter_context in parameter_contexts {
+                        let inferred_ty = self.apply_type_context(
+                            ast_argument,
+                            default_ty,
+                            parameter_context.type_context(),
+                        );
+                        parameter_context.insert_inferred_type(
+                            arguments_types,
+                            argument_index,
+                            inferred_ty,
+                        );
+                    }
+                    continue;
+                }
 
                 let mut inferred_by_cache_key = FxHashMap::default();
 


### PR DESCRIPTION
## Summary

When a call argument is checked against multiple overload contexts, we currently infer it speculatively for every distinct context, even when the expression's type context can be applied after inference. This repeats inference setup and expression-cache work.

This reuses the default inference result for argument expressions that our existing `can_defer_type_context` classification already identifies as safe, then applies each overload context to that result. Type-alias and `TypeForm` contexts retain the existing contextual inference path, including when `TypeForm` appears through a recursive alias.
