### PR TITLE
[ty] Co-locate retained definition usage state

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -628,8 +628,8 @@ static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 enum RetainedDefinitionState<'db> {
-    Defined(Definition<'db>),
-    DefinedUsed(Definition<'db>),
+    Unused(Definition<'db>),
+    Used(Definition<'db>),
     Undefined,
     Deleted,
 }
@@ -637,8 +637,8 @@ enum RetainedDefinitionState<'db> {
 impl<'db> RetainedDefinitionState<'db> {
     fn new(state: DefinitionState<'db>, used: bool) -> Self {
         match state {
-            DefinitionState::Defined(definition) if used => Self::DefinedUsed(definition),
-            DefinitionState::Defined(definition) => Self::Defined(definition),
+            DefinitionState::Defined(definition) if used => Self::Used(definition),
+            DefinitionState::Defined(definition) => Self::Unused(definition),
             DefinitionState::Undefined => {
                 debug_assert!(!used);
                 Self::Undefined
@@ -652,7 +652,7 @@ impl<'db> RetainedDefinitionState<'db> {
 
     fn state(self) -> DefinitionState<'db> {
         match self {
-            Self::Defined(definition) | Self::DefinedUsed(definition) => {
+            Self::Unused(definition) | Self::Used(definition) => {
                 DefinitionState::Defined(definition)
             }
             Self::Undefined => DefinitionState::Undefined,
@@ -661,7 +661,7 @@ impl<'db> RetainedDefinitionState<'db> {
     }
 
     fn is_used(self) -> bool {
-        matches!(self, Self::DefinedUsed(_))
+        matches!(self, Self::Used(_))
     }
 }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -631,20 +631,22 @@ enum RetainedDefinitionState<'db> {
     Defined(Definition<'db>),
     DefinedUsed(Definition<'db>),
     Undefined,
-    UndefinedUsed,
     Deleted,
-    DeletedUsed,
 }
 
 impl<'db> RetainedDefinitionState<'db> {
     fn new(state: DefinitionState<'db>, used: bool) -> Self {
-        match (state, used) {
-            (DefinitionState::Defined(definition), false) => Self::Defined(definition),
-            (DefinitionState::Defined(definition), true) => Self::DefinedUsed(definition),
-            (DefinitionState::Undefined, false) => Self::Undefined,
-            (DefinitionState::Undefined, true) => Self::UndefinedUsed,
-            (DefinitionState::Deleted, false) => Self::Deleted,
-            (DefinitionState::Deleted, true) => Self::DeletedUsed,
+        match state {
+            DefinitionState::Defined(definition) if used => Self::DefinedUsed(definition),
+            DefinitionState::Defined(definition) => Self::Defined(definition),
+            DefinitionState::Undefined => {
+                debug_assert!(!used);
+                Self::Undefined
+            }
+            DefinitionState::Deleted => {
+                debug_assert!(!used);
+                Self::Deleted
+            }
         }
     }
 
@@ -653,16 +655,13 @@ impl<'db> RetainedDefinitionState<'db> {
             Self::Defined(definition) | Self::DefinedUsed(definition) => {
                 DefinitionState::Defined(definition)
             }
-            Self::Undefined | Self::UndefinedUsed => DefinitionState::Undefined,
-            Self::Deleted | Self::DeletedUsed => DefinitionState::Deleted,
+            Self::Undefined => DefinitionState::Undefined,
+            Self::Deleted => DefinitionState::Deleted,
         }
     }
 
     fn is_used(self) -> bool {
-        matches!(
-            self,
-            Self::DefinedUsed(_) | Self::UndefinedUsed | Self::DeletedUsed
-        )
+        matches!(self, Self::DefinedUsed(_))
     }
 }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -626,17 +626,54 @@ static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
         narrowing_constraints: NarrowingConstraintsBuilder::default().build(),
     });
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+enum RetainedDefinitionState<'db> {
+    Defined(Definition<'db>),
+    DefinedUsed(Definition<'db>),
+    Undefined,
+    UndefinedUsed,
+    Deleted,
+    DeletedUsed,
+}
+
+impl<'db> RetainedDefinitionState<'db> {
+    fn new(state: DefinitionState<'db>, used: bool) -> Self {
+        match (state, used) {
+            (DefinitionState::Defined(definition), false) => Self::Defined(definition),
+            (DefinitionState::Defined(definition), true) => Self::DefinedUsed(definition),
+            (DefinitionState::Undefined, false) => Self::Undefined,
+            (DefinitionState::Undefined, true) => Self::UndefinedUsed,
+            (DefinitionState::Deleted, false) => Self::Deleted,
+            (DefinitionState::Deleted, true) => Self::DeletedUsed,
+        }
+    }
+
+    fn state(self) -> DefinitionState<'db> {
+        match self {
+            Self::Defined(definition) | Self::DefinedUsed(definition) => {
+                DefinitionState::Defined(definition)
+            }
+            Self::Undefined | Self::UndefinedUsed => DefinitionState::Undefined,
+            Self::Deleted | Self::DeletedUsed => DefinitionState::Deleted,
+        }
+    }
+
+    fn is_used(self) -> bool {
+        matches!(
+            self,
+            Self::DefinedUsed(_) | Self::UndefinedUsed | Self::DeletedUsed
+        )
+    }
+}
+
+static_assertions::assert_eq_size!(RetainedDefinitionState<'static>, DefinitionState<'static>);
+
 /// Applicable definitions and constraints for every use of a name.
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 pub struct UseDefMap<'db> {
     /// Array of [`Definition`] in this scope. Only the first entry should be [`DefinitionState::Undefined`];
     /// this represents the implicit "unbound"/"undeclared" definition of every place.
-    all_definitions: FrozenIndexVec<ScopedDefinitionId, DefinitionState<'db>>,
-
-    /// A bitset-like map indicating whether each binding definition has at least one use.
-    ///
-    /// This uses the same index as `all_definitions`.
-    used_bindings: FrozenIndexVec<ScopedDefinitionId, bool>,
+    all_definitions: FrozenIndexVec<ScopedDefinitionId, RetainedDefinitionState<'db>>,
 
     /// Constraint lookup tables, absent when all retained constraints are built-in terminal
     /// values that require no table lookup.
@@ -775,7 +812,7 @@ impl<'db> UseDefMap<'db> {
     ) -> impl Iterator<Item = (ScopedDefinitionId, DefinitionState<'db>, bool)> + '_ {
         self.all_definitions
             .iter_enumerated()
-            .map(|(id, &state)| (id, state, self.used_bindings[id]))
+            .map(|(id, &state)| (id, state.state(), state.is_used()))
     }
 
     pub fn bindings_at_use(&self, use_id: ScopedUseId) -> BindingWithConstraintsIterator<'_, 'db> {
@@ -836,7 +873,7 @@ impl<'db> UseDefMap<'db> {
     }
 
     pub fn definition(&self, id: ScopedDefinitionId) -> DefinitionState<'db> {
-        self.all_definitions[id]
+        self.all_definitions[id].state()
     }
 
     pub fn narrowing_evaluator(
@@ -1126,7 +1163,7 @@ type EnclosingSnapshots = IndexVec<ScopedEnclosingSnapshotId, EnclosingSnapshot>
 
 #[derive(Clone, Debug)]
 pub struct BindingWithConstraintsIterator<'map, 'db> {
-    all_definitions: &'map IndexSlice<ScopedDefinitionId, DefinitionState<'db>>,
+    all_definitions: &'map IndexSlice<ScopedDefinitionId, RetainedDefinitionState<'db>>,
     constraint_tables: &'map ConstraintTables<'db>,
     boundness_analysis: BoundnessAnalysis,
     inner: LiveBindingsIterator<'map>,
@@ -1153,7 +1190,7 @@ impl<'map, 'db> Iterator for BindingWithConstraintsIterator<'map, 'db> {
         self.inner
             .next()
             .map(|live_binding| BindingWithConstraints {
-                binding: self.all_definitions[live_binding.binding()],
+                binding: self.all_definitions[live_binding.binding()].state(),
                 binding_order: live_binding.binding(),
                 narrowing_constraint: NarrowingEvaluator {
                     constraint: live_binding.narrowing_constraint(),
@@ -1195,7 +1232,7 @@ impl<'map, 'db> NarrowingEvaluator<'map, 'db> {
 
 #[derive(Clone)]
 pub struct DeclarationsIterator<'map, 'db> {
-    all_definitions: &'map IndexSlice<ScopedDefinitionId, DefinitionState<'db>>,
+    all_definitions: &'map IndexSlice<ScopedDefinitionId, RetainedDefinitionState<'db>>,
     constraint_tables: &'map ConstraintTables<'db>,
     boundness_analysis: BoundnessAnalysis,
     inner: LiveDeclarationsIterator<'map>,
@@ -1233,7 +1270,7 @@ impl<'db> Iterator for DeclarationsIterator<'_, 'db> {
                  reachability_constraint,
              }| {
                 DeclarationWithConstraint {
-                    declaration: self.all_definitions[*declaration],
+                    declaration: self.all_definitions[*declaration].state(),
                     declaration_order: *declaration,
                     reachability_constraint: *reachability_constraint,
                 }
@@ -2535,10 +2572,15 @@ impl<'db> UseDefMapBuilder<'db> {
                 narrowing_constraints,
             })
         });
+        let all_definitions = self
+            .all_definitions
+            .into_iter()
+            .zip(self.used_bindings)
+            .map(|(state, used)| RetainedDefinitionState::new(state, used))
+            .collect();
 
         UseDefMap {
-            all_definitions: self.all_definitions.into(),
-            used_bindings: self.used_bindings.into(),
+            all_definitions,
             constraint_tables,
             interned_bindings,
             interned_declarations,


### PR DESCRIPTION
## Summary

We now encode whether each retained definition is used directly in `RetainedDefinitionState`, instead of retaining a separate parallel boolean vector in `UseDefMap`.

The mutable builder continues to keep `all_definitions` and `used_bindings` separate, then combines them only when freezing the immutable map. This keeps mutation straightforward while removing one allocation and one byte per definition from the retained representation. A compile-time size assertion guarantees that the combined enum remains the same size as `DefinitionState`.
