### PR TITLE
Reject __debug__ lambda parameters

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/debug_shadow_function.py
+++ b/crates/ruff_python_parser/resources/inline/err/debug_shadow_function.py
@@ -1,3 +1,4 @@
 def __debug__(): ...  # function name
 def f[__debug__](): ...  # type parameter name
 def f(__debug__): ...  # parameter name
+lambda __debug__: 0  # lambda parameter name

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -586,6 +586,7 @@ impl SemanticSyntaxChecker {
                 // def __debug__(): ...  # function name
                 // def f[__debug__](): ...  # type parameter name
                 // def f(__debug__): ...  # parameter name
+                // lambda __debug__: 0  # lambda parameter name
                 Self::check_identifier(name, ctx);
                 if let Some(type_params) = type_params {
                     for type_param in type_params.iter() {
@@ -1012,6 +1013,9 @@ impl SemanticSyntaxChecker {
                 parameters: Some(parameters),
                 ..
             }) => {
+                for parameter in parameters {
+                    Self::check_identifier(parameter.name(), ctx);
+                }
                 Self::duplicate_parameter_name(parameters, ctx);
             }
             _ => {}

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@debug_shadow_function.py.snap
@@ -8,7 +8,7 @@ input_file: crates/ruff_python_parser/resources/inline/err/debug_shadow_function
 Module(
     ModModule {
         node_index: NodeIndex(None),
-        range: 0..125,
+        range: 0..170,
         body: [
             FunctionDef(
                 StmtFunctionDef {
@@ -160,6 +160,54 @@ Module(
                     ],
                 },
             ),
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 125..144,
+                    value: Lambda(
+                        ExprLambda {
+                            node_index: NodeIndex(None),
+                            range: 125..144,
+                            parameters: Some(
+                                Parameters {
+                                    range: 132..141,
+                                    node_index: NodeIndex(None),
+                                    posonlyargs: [],
+                                    args: [
+                                        ParameterWithDefault {
+                                            range: 132..141,
+                                            node_index: NodeIndex(None),
+                                            parameter: Parameter {
+                                                range: 132..141,
+                                                node_index: NodeIndex(None),
+                                                name: Identifier {
+                                                    id: Name("__debug__"),
+                                                    range: 132..141,
+                                                    node_index: NodeIndex(None),
+                                                },
+                                                annotation: None,
+                                            },
+                                            default: None,
+                                        },
+                                    ],
+                                    vararg: None,
+                                    kwonlyargs: [],
+                                    kwarg: None,
+                                },
+                            ),
+                            body: NumberLiteral(
+                                ExprNumberLiteral {
+                                    node_index: NodeIndex(None),
+                                    range: 143..144,
+                                    value: Int(
+                                        0,
+                                    ),
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ),
         ],
     },
 )
@@ -179,6 +227,7 @@ Module(
 2 | def f[__debug__](): ...  # type parameter name
   |       ^^^^^^^^^ Syntax Error: cannot assign to `__debug__`
 3 | def f(__debug__): ...  # parameter name
+4 | lambda __debug__: 0  # lambda parameter name
   |
 
 
@@ -187,4 +236,13 @@ Module(
 2 | def f[__debug__](): ...  # type parameter name
 3 | def f(__debug__): ...  # parameter name
   |       ^^^^^^^^^ Syntax Error: cannot assign to `__debug__`
+4 | lambda __debug__: 0  # lambda parameter name
+  |
+
+
+  |
+2 | def f[__debug__](): ...  # type parameter name
+3 | def f(__debug__): ...  # parameter name
+4 | lambda __debug__: 0  # lambda parameter name
+  |        ^^^^^^^^^ Syntax Error: cannot assign to `__debug__`
   |


### PR DESCRIPTION
## Summary

Reject `__debug__` as a lambda parameter name:

```python
lambda __debug__: 0
```

Function parameters already use the semantic syntax check that prevents assignments to `__debug__`, but lambda parameters only checked for duplicate names. This applies the existing identifier validation consistently to both forms.
