### PR TITLE
Reject starred comprehension targets

### DIFF
--- a/crates/ruff_python_parser/resources/inline/err/starred_comprehension_target.py
+++ b/crates/ruff_python_parser/resources/inline/err/starred_comprehension_target.py
@@ -1,0 +1,1 @@
+[item for *items in source]

--- a/crates/ruff_python_parser/resources/inline/ok/starred_comprehension_target.py
+++ b/crates/ruff_python_parser/resources/inline/ok/starred_comprehension_target.py
@@ -1,0 +1,1 @@
+[item for (*items,) in source]

--- a/crates/ruff_python_parser/src/semantic_errors.rs
+++ b/crates/ruff_python_parser/src/semantic_errors.rs
@@ -1113,7 +1113,14 @@ impl SemanticSyntaxChecker {
         generators: &[ast::Comprehension],
         ctx: &Ctx,
     ) {
+        // test_ok starred_comprehension_target
+        // [item for (*items,) in source]
+
+        // test_err starred_comprehension_target
+        // [item for *items in source]
         for (index, generator) in generators.iter().enumerate() {
+            Self::invalid_star_expression(&generator.target, ctx);
+
             for if_expr in &generator.ifs {
                 Self::check_rebound_variables(
                     if_expr,

--- a/crates/ruff_python_parser/tests/snapshots/invalid_syntax@starred_comprehension_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/invalid_syntax@starred_comprehension_target.py.snap
@@ -1,0 +1,73 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/err/starred_comprehension_target.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..28,
+        body: [
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 0..27,
+                    value: ListComp(
+                        ExprListComp {
+                            node_index: NodeIndex(None),
+                            range: 0..27,
+                            elt: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 1..5,
+                                    id: Name("item"),
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 6..26,
+                                    node_index: NodeIndex(None),
+                                    target: Starred(
+                                        ExprStarred {
+                                            node_index: NodeIndex(None),
+                                            range: 10..16,
+                                            value: Name(
+                                                ExprName {
+                                                    node_index: NodeIndex(None),
+                                                    range: 11..16,
+                                                    id: Name("items"),
+                                                    ctx: Store,
+                                                },
+                                            ),
+                                            ctx: Store,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 20..26,
+                                            id: Name("source"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```
+## Semantic Syntax Errors
+
+  |
+1 | [item for *items in source]
+  |           ^^^^^^ Syntax Error: Starred expression cannot be used here
+  |

--- a/crates/ruff_python_parser/tests/snapshots/valid_syntax@starred_comprehension_target.py.snap
+++ b/crates/ruff_python_parser/tests/snapshots/valid_syntax@starred_comprehension_target.py.snap
@@ -1,0 +1,77 @@
+---
+source: crates/ruff_python_parser/tests/fixtures.rs
+input_file: crates/ruff_python_parser/resources/inline/ok/starred_comprehension_target.py
+---
+## AST
+
+```
+Module(
+    ModModule {
+        node_index: NodeIndex(None),
+        range: 0..31,
+        body: [
+            Expr(
+                StmtExpr {
+                    node_index: NodeIndex(None),
+                    range: 0..30,
+                    value: ListComp(
+                        ExprListComp {
+                            node_index: NodeIndex(None),
+                            range: 0..30,
+                            elt: Name(
+                                ExprName {
+                                    node_index: NodeIndex(None),
+                                    range: 1..5,
+                                    id: Name("item"),
+                                    ctx: Load,
+                                },
+                            ),
+                            generators: [
+                                Comprehension {
+                                    range: 6..29,
+                                    node_index: NodeIndex(None),
+                                    target: Tuple(
+                                        ExprTuple {
+                                            node_index: NodeIndex(None),
+                                            range: 10..19,
+                                            elts: [
+                                                Starred(
+                                                    ExprStarred {
+                                                        node_index: NodeIndex(None),
+                                                        range: 11..17,
+                                                        value: Name(
+                                                            ExprName {
+                                                                node_index: NodeIndex(None),
+                                                                range: 12..17,
+                                                                id: Name("items"),
+                                                                ctx: Store,
+                                                            },
+                                                        ),
+                                                        ctx: Store,
+                                                    },
+                                                ),
+                                            ],
+                                            ctx: Store,
+                                            parenthesized: true,
+                                        },
+                                    ),
+                                    iter: Name(
+                                        ExprName {
+                                            node_index: NodeIndex(None),
+                                            range: 23..29,
+                                            id: Name("source"),
+                                            ctx: Load,
+                                        },
+                                    ),
+                                    ifs: [],
+                                    is_async: false,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ),
+        ],
+    },
+)
+```


### PR DESCRIPTION
## Summary

Reject bare starred targets in comprehensions:

```python
[item for *items in source]
```

The semantic syntax checker already rejects a bare starred target in an ordinary `for` statement. This applies the same validation to comprehension clauses while preserving valid tuple and list unpacking targets such as `for *items, in source`.
