### PR TITLE
[ty] Validate deprecated warning categories

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/deprecated.md
+++ b/crates/ty_python_semantic/resources/mdtest/deprecated.md
@@ -222,6 +222,19 @@ def valid_deco(): ...
 valid_deco()  # error: [deprecated] "some message"
 ```
 
+## Category
+
+The category must be a `Warning` subclass or `None`.
+
+```py
+from typing_extensions import deprecated
+
+@deprecated("some message", category=42)  # error: [invalid-argument-type] "type[Warning] | None"
+def invalid_category(): ...
+@deprecated("some message", category=None)
+def no_category(): ...
+```
+
 ## Different Versions
 
 There are 2 different sources of `@deprecated`: `warnings` and `typing_extensions`. The version in

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4603,6 +4603,8 @@ impl<'db> Type<'db> {
                 //         stacklevel: int = 1
                 //     ) -> Self: ...
                 // ```
+                let warning_class_type = KnownClass::Warning.to_subclass_of(db);
+
                 Some(
                     Binding::single(
                         self,
@@ -4615,12 +4617,10 @@ impl<'db> Type<'db> {
                                     Parameter::keyword_only(Name::new_static("category"))
                                         .with_annotated_type(UnionType::from_two_elements(
                                             db,
-                                            // TODO: should be `type[Warning]`
-                                            Type::any(),
+                                            warning_class_type,
                                             KnownClass::NoneType.to_instance(db),
                                         ))
-                                        // TODO: should be `type[Warning]`
-                                        .with_default_type(Type::any()),
+                                        .with_default_type(warning_class_type),
                                     Parameter::keyword_only(Name::new_static("stacklevel"))
                                         .with_annotated_type(KnownClass::Int.to_instance(db))
                                         .with_default_type(Type::int_literal(1)),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4618,7 +4618,7 @@ impl<'db> Type<'db> {
                                         .with_annotated_type(UnionType::from_two_elements(
                                             db,
                                             warning_class_type,
-                                            KnownClass::NoneType.to_instance(db),
+                                            Type::none(db),
                                         ))
                                         .with_default_type(warning_class_type),
                                     Parameter::keyword_only(Name::new_static("stacklevel"))

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -57,6 +57,7 @@ pub enum KnownClass {
     Property,
     BaseException,
     Exception,
+    Warning,
     BaseExceptionGroup,
     ExceptionGroup,
     Staticmethod,
@@ -204,6 +205,7 @@ impl KnownClass {
 
             Self::BaseException
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::Object
@@ -304,6 +306,7 @@ impl KnownClass {
             | KnownClass::BaseException
             | KnownClass::NotImplementedError
             | KnownClass::Exception
+            | KnownClass::Warning
             | KnownClass::BaseExceptionGroup
             | KnownClass::ExceptionGroup
             | KnownClass::Staticmethod
@@ -405,6 +408,7 @@ impl KnownClass {
             | KnownClass::Property
             | KnownClass::BaseException
             | KnownClass::Exception
+            | KnownClass::Warning
             | KnownClass::NotImplementedError
             | KnownClass::BaseExceptionGroup
             | KnownClass::ExceptionGroup
@@ -507,6 +511,7 @@ impl KnownClass {
             | KnownClass::Property
             | KnownClass::BaseException
             | KnownClass::Exception
+            | KnownClass::Warning
             | KnownClass::NotImplementedError
             | KnownClass::BaseExceptionGroup
             | KnownClass::ExceptionGroup
@@ -633,6 +638,7 @@ impl KnownClass {
             | Self::BaseException
             | Self::BaseExceptionGroup
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::Staticmethod
@@ -726,6 +732,7 @@ impl KnownClass {
             | KnownClass::Property
             | KnownClass::BaseException
             | KnownClass::Exception
+            | KnownClass::Warning
             | KnownClass::NotImplementedError
             | KnownClass::BaseExceptionGroup
             | KnownClass::ExceptionGroup
@@ -827,6 +834,7 @@ impl KnownClass {
             Self::BaseException => "BaseException",
             Self::BaseExceptionGroup => "BaseExceptionGroup",
             Self::Exception => "Exception",
+            Self::Warning => "Warning",
             Self::NotImplementedError => "NotImplementedError",
             Self::ExceptionGroup => "ExceptionGroup",
             Self::Staticmethod => "staticmethod",
@@ -1189,6 +1197,7 @@ impl KnownClass {
             | Self::BaseException
             | Self::BaseExceptionGroup
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::Staticmethod
@@ -1308,6 +1317,7 @@ impl KnownClass {
             | Self::BaseException
             | Self::BaseExceptionGroup
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::Staticmethod
@@ -1433,6 +1443,7 @@ impl KnownClass {
             | Self::BaseException
             | Self::BaseExceptionGroup
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::Staticmethod
@@ -1518,6 +1529,7 @@ impl KnownClass {
             "BaseException" => &[Self::BaseException],
             "BaseExceptionGroup" => &[Self::BaseExceptionGroup],
             "Exception" => &[Self::Exception],
+            "Warning" => &[Self::Warning],
             "NotImplementedError" => &[Self::NotImplementedError],
             "ExceptionGroup" => &[Self::ExceptionGroup],
             "staticmethod" => &[Self::Staticmethod],
@@ -1635,6 +1647,7 @@ impl KnownClass {
             | Self::VersionInfo
             | Self::BaseException
             | Self::Exception
+            | Self::Warning
             | Self::NotImplementedError
             | Self::ExceptionGroup
             | Self::EllipsisType


### PR DESCRIPTION
## Summary

Validate the `category` argument to `warnings.deprecated` and `typing_extensions.deprecated` against their declared `type[Warning] | None` signature.

The synthesized signature previously modeled this argument as `Any`, so invalid values such as `category=42` were silently accepted. Warning subclasses and `None` remain valid, and invalid values now receive the standard argument-type diagnostic.
