### PR TITLE
[ty] Extend test coverage for parsing of reStructuredText literal blocks

### DIFF
--- a/crates/ty_ide/src/docstring/formats/rst.rs
+++ b/crates/ty_ide/src/docstring/formats/rst.rs
@@ -797,7 +797,11 @@ Intro paragraph.
 Intervening prose.
 
 :param second: Second parameter.
-    Continued.
+    Continued::
+
+        literal block
+
+Trailing prose.
 ";
         let parsed = Docstring::parse(docstring);
 
@@ -809,7 +813,7 @@ Intervening prose.
 
         let second = &parsed.field_lists[1];
         assert_eq!(second.start_line, 6);
-        assert_eq!(second.end_line, 8);
+        assert_eq!(second.end_line, 10);
 
         assert_snapshot!(field_list_ranges(docstring, &parsed.field_lists), @r"
         | Intro paragraph.
@@ -821,8 +825,13 @@ Intervening prose.
         |
         | :param second: Second parameter.
         | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        |     Continued.
-        | ^^^^^^^^^^^^^^
+        |     Continued::
+        | ^^^^^^^^^^^^^^^
+        |
+        |         literal block
+        | ^^^^^^^^^^^^^^^^^^^^^
+        |
+        | Trailing prose.
         ");
     }
 
@@ -879,6 +888,39 @@ Intervening prose.
         first: First line.
           :param fake: This is continuation text, not a new field.
         second: Real second parameter.
+        ");
+    }
+
+    #[test]
+    fn parameter_documentation_recovers_sibling_fields_after_missing_literal_block() {
+        let param_docs = parameter_documentation(
+            "\
+:param quoted: Example::
+
+:param sample: This is sample input.
+:returns: This is still sample input.
+
+:param real: Real parameter.",
+        );
+
+        assert_snapshot!(param_docs, @r"
+        quoted: Example::
+        sample: This is sample input.
+        real: Real parameter.
+        ");
+    }
+
+    #[test]
+    fn parameter_documentation_requires_blank_line_before_field_body_literal_block() {
+        let param_docs = parameter_documentation(
+            "\
+:param first: Explanation::
+:param second: Second parameter.",
+        );
+
+        assert_snapshot!(param_docs, @r"
+        first: Explanation::
+        second: Second parameter.
         ");
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This adds some additional test coverage that demonstrates that we parse certain edge cases involving reStructuredText (reST) literal blocks correctly.

In particular, I learned that continuation lines and nest body elements of a reST field body [**must** be indented relative to the field name marker](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists:~:text=The%20field%20body%20may%20contain%20multiple%20body%20elements%2C%20indented%20relative%20to%20the%20field%20marker.%20The%20first%20line%20after%20the%20field%20name%20marker%20determines%20the%20indentation%20of%20the%20field%20body.). So although a [quoted literal block](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#quoted-literal-blocks), does not require additional indentation if it appears on its own, it must have indentation relative to the field name marker if it is part of a field body.

The current parser (incidentally) handles this correctly; this helps to ensure that we don't regress that behaviour.

## Test Plan

Please see included tests.
<!-- How was it tested? -->
