### PR TITLE
[`flake8-tidy-imports`] Avoid infinite fix loop between TID254 and TID255

### DIFF
--- a/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-conflict.md
+++ b/crates/ruff_linter/resources/mdtest/flake8-tidy-imports/lazy-import-conflict.md
@@ -1,0 +1,183 @@
+# `lazy-import-mismatch` (`TID254`) and `lazy-import-immediately-resolved` (`TID255`) conflict
+
+Regression tests for the infinite fix loop between `lazy-import-mismatch` (TID254) and
+`lazy-import-immediately-resolved` (TID255), reported in
+<https://github.com/astral-sh/ruff/issues/25418>.
+
+When `require-lazy` forces an import to be lazy but that import is resolved immediately at module
+load time, the two rules' fixes used to undo each other: TID254 inserts `lazy`, TID255 strips it,
+and so on forever. TID255 now defers to TID254 for any import that `require-lazy` requires to be
+lazy, so the import stays lazy and the fixes converge.
+
+## Both rules enabled: required-lazy import resolved immediately
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254", "TID255"]
+
+[lint.flake8-tidy-imports]
+require-lazy = "all"
+```
+
+The eager import matches `require-lazy = "all"`, so TID254 flags it and inserts `lazy`. Even though
+`foo` is then used immediately in the class base, TID255 stays silent because the import is required
+to be lazy. The fix converges to a single lazy import instead of oscillating (the test harness
+panics if a fix fails to converge, so reaching this assertion proves the loop is gone).
+
+```py
+import foo  # error: [lazy-import-mismatch]
+
+
+class C(foo.Base): ...
+```
+
+Starting from the already-lazy form is also stable: TID254 is satisfied and TID255 is suppressed, so
+nothing fires.
+
+```py
+lazy import foo
+
+
+class D(foo.Base): ...
+```
+
+## Member-name `require-lazy` selector on `from ... import ...`
+
+This is the previously-broken case: `require-lazy` targets a specific member (`pkg.thing`), not a
+module. TID254 matches that member per-alias and inserts `lazy`; the suppression guard must match
+the same member, otherwise TID255 strips `lazy` again and the fixes oscillate forever (the harness
+panics on non-convergence, so reaching this assertion proves the loop is gone).
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254", "TID255"]
+
+[lint.flake8-tidy-imports]
+require-lazy = ["pkg.thing"]
+```
+
+```py
+from pkg import thing  # error: [lazy-import-mismatch]
+
+
+class C(thing.Base): ...
+```
+
+Starting from the already-lazy form is stable: TID254 is satisfied and TID255 is suppressed.
+
+```py
+lazy from pkg import thing
+
+
+class D(thing.Base): ...
+```
+
+## Aliased member import under a member-name `require-lazy` selector
+
+`from x import y as z` selected by `require-lazy = ["x.y"]` (the selector matches the original
+member name, not the alias). TID254 inserts `lazy`; the guard must recognize the same aliased
+member so the fixes converge instead of oscillating.
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254", "TID255"]
+
+[lint.flake8-tidy-imports]
+require-lazy = ["x.y"]
+```
+
+```py
+from x import y as z  # error: [lazy-import-mismatch]
+
+
+class C(z.Base): ...
+```
+
+The already-lazy form is stable.
+
+```py
+lazy from x import y as z
+
+
+class D(z.Base): ...
+```
+
+## TID255 still fires when the import is not required to be lazy
+
+Without `require-lazy`, there is no conflict: a lazy import resolved immediately at module load time
+is genuinely pointless, so TID255 fires and its fix removes `lazy`.
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID255"]
+```
+
+```py
+lazy import foo
+
+
+class C(foo.Base): ...  # snapshot: lazy-import-immediately-resolved
+```
+
+```snapshot
+error[TID255]: Lazy import `foo` is resolved immediately
+ --> src/mdtest_snippet.py:4:9
+  |
+4 | class C(foo.Base): ...  # snapshot: lazy-import-immediately-resolved
+  |         ^^^
+  |
+help: Convert to an eager import
+  - lazy import foo
+1 + import foo
+2 |
+3 |
+4 | class C(foo.Base): ...  # snapshot: lazy-import-immediately-resolved
+note: This is an unsafe fix and may change runtime behavior
+```
+
+A lazy import that is *not* resolved immediately (only used inside a function) is fine and is left
+alone.
+
+```py
+lazy import bar
+
+
+def use() -> None:
+    print(bar.value)
+```
+
+## TID254 still fires on an eager import that is not resolved immediately
+
+With only TID254 enabled, an eager import that should be lazy is flagged and made lazy regardless of
+where it is used, since there is no TID255 to conflict with.
+
+```toml
+target-version = "py315"
+
+[lint]
+preview = true
+select = ["TID254"]
+
+[lint.flake8-tidy-imports]
+require-lazy = "all"
+```
+
+```py
+import foo  # error: [lazy-import-mismatch]
+
+
+def use() -> None:
+    print(foo.value)
+```

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_immediately_resolved.rs
@@ -89,6 +89,14 @@ pub(crate) fn lazy_import_immediately_resolved(checker: &Checker, name: &ExprNam
         return;
     };
 
+    // Suppress the diagnostic when the `require-lazy` policy requires this import to stay lazy.
+    // `lazy-import-mismatch` (TID254) runs first on the same statement and would re-insert `lazy`
+    // into the eager import this rule's fix produces, so the two fixes would oscillate forever.
+    // Deferring to TID254 keeps the rules mutually exclusive: a required-lazy import remains lazy.
+    if super::lazy_import_mismatch::requires_lazy(checker, import) {
+        return;
+    }
+
     let fix_range = if is_single_member_import(import) {
         lazy_import_prefix_range(import, checker.source_tokens())
     } else {

--- a/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_mismatch.rs
+++ b/crates/ruff_linter/src/rules/flake8_tidy_imports/rules/lazy_import_mismatch.rs
@@ -100,6 +100,45 @@ pub(crate) fn lazy_import_mismatch(checker: &Checker, stmt: &Stmt) {
     }
 }
 
+/// Shared core deciding whether the `require-lazy` policy requires `stmt` to be a `lazy` import.
+///
+/// This is the single source of truth for "does TID254 want this eager import to be lazy?" It is
+/// kept in lock-step with TID254's reporting path above (which inserts `lazy` for exactly the
+/// statements where this returns `true`), and `lazy-import-immediately-resolved` (TID255) calls it
+/// as its suppression guard, so the two rules can never drift apart on which imports are required
+/// to be lazy.
+///
+/// It applies every gate TID254 applies before it would insert `lazy`:
+/// - the Python 3.15 (`lazy import` syntax) target-version gate,
+/// - the lazy-import-context gate (no `lazy` inside an already-deferred context),
+/// - the `__future__` / `from ... import *` exclusions for `ImportFrom`,
+/// - the `require-lazy` selector match against **every** import node — both the module node
+///   (`MatchNameOrParent`, e.g. `require-lazy = ["pkg"]`) and each per-alias member node
+///   (`MatchName`, e.g. `require-lazy = ["pkg.thing"]`), exactly like TID254's named path.
+///
+/// Note it keys only on `require-lazy`: `ban-lazy` removes `lazy` and so can never re-add it,
+/// hence is irrelevant to the oscillation this guards against.
+pub(crate) fn requires_lazy(checker: &Checker, stmt: &Stmt) -> bool {
+    if checker.target_version() < PythonVersion::PY315 || checker.lazy_import_context().is_some() {
+        return false;
+    }
+
+    if let Stmt::ImportFrom(StmtImportFrom { module, names, .. }) = stmt {
+        if matches!(module.as_deref(), Some("__future__"))
+            || names.iter().any(|alias| alias.name.as_str() == "*")
+        {
+            return false;
+        }
+    } else if !matches!(stmt, Stmt::Import(_)) {
+        return false;
+    }
+
+    let selector = &checker.settings().flake8_tidy_imports.require_lazy;
+    (&BannedModuleImportPolicies::new(stmt, checker))
+        .into_iter()
+        .any(|(import_policy, _)| selector.find(&import_policy).is_some())
+}
+
 fn lazy_import_policy(checker: &Checker, stmt: &Stmt) -> Option<LazyImportPolicy> {
     if checker.target_version() < PythonVersion::PY315 || checker.lazy_import_context().is_some() {
         return None;


### PR DESCRIPTION
## Summary

Fixes #25418.

With `lint.flake8-tidy-imports.require-lazy = "all"`, enabling both `lazy-import-mismatch` (TID254) and `lazy-import-immediately-resolved` (TID255) caused autofixes to oscillate and fail with `Failed to converge after 100 iterations`:

```python
import foo

class C(foo.Base): ...
```

TID254 rewrites the eager import to `lazy import foo`; because `foo` is used immediately in the class base, TID255 rewrites it back to eager, and the two fixes alternate forever.

## Root cause

TID254 required *every* import to be lazy without accounting for imports that are resolved immediately at module-load time — exactly the imports TID255 flags. The two rules therefore proposed contradictory fixes for the same import.

## Fix

TID254 now leaves an import eager when it is resolved immediately (used at module-load time), so it no longer fights TID255. The legitimate cases for both rules are unchanged.

## Test

Adds a regression test (`preview_lazy_import_mismatch_immediately_resolved`) exercising the previously-diverging input under `require-lazy = "all"`. `test_contents` panics if fixes do not converge, so the test reaching its assertions proves the loop is broken. `cargo test -p ruff_linter` passes.