### PR TITLE
[`ruff`] Don't flag assignment in `with` before `yield` outside it (RUF070)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF070.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF070.py
@@ -56,16 +56,18 @@ def foo():
     x = yield 1
     yield x  # RUF070 (yield as assigned value, fix adds parentheses)
 
-# Assignment inside `with`, yield outside
-def foo():
-    with open("foo.txt") as f:
-        x = f.read()
-    yield x  # RUF070
-
 
 ###
 # Non-errors
 ###
+
+# Assignment inside `with`, yield outside: squashing the assignment back into the
+# `yield` would move it inside the `with`, changing when the value is computed and
+# (for async generators) resurfacing ASYNC119 -- an autofix loop. See #25653.
+def foo():
+    with open("foo.txt") as f:
+        x = f.read()
+    yield x
 
 # Variable used after yield
 def foo():

--- a/crates/ruff_linter/src/rules/flake8_return/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_return/mod.rs
@@ -4,8 +4,6 @@ mod helpers;
 pub(crate) mod rules;
 mod visitor;
 
-pub(crate) use visitor::has_conditional_body;
-
 #[cfg(test)]
 mod tests {
     use std::path::Path;

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_assign_before_yield.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_assign_before_yield.rs
@@ -4,13 +4,11 @@ use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::visitor;
 use ruff_python_ast::visitor::Visitor;
 use ruff_python_ast::{self as ast, Expr, Identifier, Stmt};
-use ruff_python_semantic::SemanticModel;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 
 use crate::checkers::ast::Checker;
 use crate::fix::edits;
-use crate::rules::flake8_return::has_conditional_body;
 use crate::{AlwaysFixableViolation, Edit, Fix};
 
 /// ## What it does
@@ -76,7 +74,7 @@ pub(crate) fn unnecessary_assign_before_yield(checker: &Checker, function_stmt: 
     };
 
     let visitor = {
-        let mut visitor = YieldVisitor::new(checker.semantic());
+        let mut visitor = YieldVisitor::new();
         visitor.visit_body(&function_def.body);
         visitor
     };
@@ -156,9 +154,7 @@ pub(crate) fn unnecessary_assign_before_yield(checker: &Checker, function_stmt: 
     }
 }
 
-struct YieldVisitor<'semantic, 'a> {
-    /// The semantic model of the current file.
-    semantic: &'semantic SemanticModel<'a>,
+struct YieldVisitor<'a> {
     /// The non-local variables in the current function.
     non_locals: FxHashSet<&'a str>,
     /// The annotated variables in the current function.
@@ -169,10 +165,9 @@ struct YieldVisitor<'semantic, 'a> {
     sibling: Option<&'a Stmt>,
 }
 
-impl<'semantic, 'a> YieldVisitor<'semantic, 'a> {
-    fn new(semantic: &'semantic SemanticModel<'a>) -> Self {
+impl YieldVisitor<'_> {
+    fn new() -> Self {
         Self {
-            semantic,
             non_locals: FxHashSet::default(),
             annotations: FxHashSet::default(),
             assignment_yield: Vec::new(),
@@ -181,7 +176,7 @@ impl<'semantic, 'a> YieldVisitor<'semantic, 'a> {
     }
 }
 
-impl<'a> Visitor<'a> for YieldVisitor<'_, 'a> {
+impl<'a> Visitor<'a> for YieldVisitor<'a> {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
             Stmt::ClassDef(_) | Stmt::FunctionDef(_) => {
@@ -202,23 +197,17 @@ impl<'a> Visitor<'a> for YieldVisitor<'_, 'a> {
                 }
             }
             Stmt::Expr(ast::StmtExpr { value, .. }) => {
-                if matches!(value.as_ref(), Expr::Yield(_) | Expr::YieldFrom(_)) {
-                    match self.sibling {
-                        Some(Stmt::Assign(stmt_assign)) => {
-                            self.assignment_yield
-                                .push((stmt_assign, value.as_ref(), stmt));
-                        }
-                        Some(Stmt::With(with)) => {
-                            if let Some(stmt_assign) =
-                                with.body.last().and_then(Stmt::as_assign_stmt)
-                                && !has_conditional_body(with, self.semantic)
-                            {
-                                self.assignment_yield
-                                    .push((stmt_assign, value.as_ref(), stmt));
-                            }
-                        }
-                        _ => {}
-                    }
+                if matches!(value.as_ref(), Expr::Yield(_) | Expr::YieldFrom(_))
+                    && let Some(Stmt::Assign(stmt_assign)) = self.sibling
+                {
+                    // Only flag when the assignment and the `yield` are siblings. An assignment
+                    // that is the last statement of a preceding `with` block is intentionally
+                    // skipped: squashing it into the `yield` would move the assignment back inside
+                    // the `with`, changing when the value is computed relative to the context
+                    // manager's cleanup. For async generators this also resurfaces ASYNC119,
+                    // creating an autofix loop (see #25653).
+                    self.assignment_yield
+                        .push((stmt_assign, value.as_ref(), stmt));
                 }
             }
             _ => {}

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF070_RUF070.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__preview__RUF070_RUF070.py.snap
@@ -250,8 +250,6 @@ RUF070 [*] Unnecessary assignment to `x` before `yield` statement
 56 |     x = yield 1
 57 |     yield x  # RUF070 (yield as assigned value, fix adds parentheses)
    |           ^
-58 |
-59 | # Assignment inside `with`, yield outside
    |
 help: Remove unnecessary assignment
 53 |     yield x  # RUF070 (no space after `=`)
@@ -261,26 +259,6 @@ help: Remove unnecessary assignment
    -     yield x  # RUF070 (yield as assigned value, fix adds parentheses)
 56 +     yield (yield 1)
 57 |
-58 | # Assignment inside `with`, yield outside
-59 | def foo():
-note: This is an unsafe fix and may change runtime behavior
-
-RUF070 [*] Unnecessary assignment to `x` before `yield` statement
-  --> RUF070.py:63:11
-   |
-61 |     with open("foo.txt") as f:
-62 |         x = f.read()
-63 |     yield x  # RUF070
-   |           ^
-   |
-help: Remove unnecessary assignment
-59 | # Assignment inside `with`, yield outside
-60 | def foo():
-61 |     with open("foo.txt") as f:
-   -         x = f.read()
-   -     yield x  # RUF070
-62 +         yield f.read()
-63 |
-64 |
-65 | ###
+58 |
+59 | ###
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Fixes #25653.

RUF070 (`unnecessary-assign-before-yield`) paired an assignment that was the last statement of a preceding `with` block with a `yield` of that variable located *outside* the `with`, and its autofix squashed the assignment back into the `yield`. That squash moves the assignment inside the `with` block, changing when the value is computed relative to the context manager's cleanup.

For async generators this also creates an autofix loop with ASYNC119: the ASYNC119-recommended refactor is exactly "assign inside the `with`, yield the result outside it", but RUF070 then rewrites it back to a `yield` inside the `with`, resurfacing the ASYNC119 violation.

## Fix

Restrict RUF070 to the case agreed on in the issue thread: only flag when the assignment and the `yield` are direct siblings. The legitimate in-`with` case (assignment and `yield` both inside the same `with` body) is unaffected and still flagged.

Removing the `with`-specific sibling branch drops the only use of the conditional-body check, so `YieldVisitor` no longer needs the semantic model and the `has_conditional_body` re-export is removed.

## Test

Adds a fixture case covering "assignment inside `with`, yield outside" as a non-error and regenerates the RUF070 snapshot. `cargo test -p ruff_linter` passes (preview_rules: 17 passed).