### PR TITLE
[ty] Show bare `Final` as a special form on hover

### DIFF
--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -6089,6 +6089,95 @@ def function():
     }
 
     #[test]
+    fn hover_bare_final_annotation() {
+        let test = hover_test(
+            r#"
+            from typing import Final
+
+            x: Final<CURSOR> = 1
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        <special-form 'typing.Final'>
+        ---------------------------------------------
+        Special typing construct to indicate final names to type checkers.
+
+        A final name cannot be re-assigned or overridden in a subclass.
+
+        For example::
+
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        There is no runtime checking of these properties.
+
+        ---------------------------------------------
+        ```xml
+        <special-form 'typing.Final'>
+        ```
+        ---
+        Special typing construct to indicate final names to type checkers.<HB>
+        <HB>
+        A final name cannot be re-assigned or overridden in a subclass.<HB>
+        <HB>
+        For example:  <HB>
+        ```````````python
+            MAX_SIZE: Final = 9000
+            MAX_SIZE += 1  # Error reported by type checker
+
+            class Connection:
+                TIMEOUT: Final[int] = 10
+
+            class FastConnector(Connection):
+                TIMEOUT = 1  # Error reported by type checker
+
+        ```````````
+        There is no runtime checking of these properties.
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:4:4
+          |
+        4 | x: Final = 1
+          |    ^^^^^- Cursor offset
+          |    |
+          |    source
+          |
+        ");
+
+        let test = hover_test(
+            r#"
+            from typing import Final
+
+            x<CURSOR>: Final = 1
+        "#,
+        );
+
+        assert_snapshot!(test.hover(), @"
+        Literal[1] (Final)
+        ---------------------------------------------
+        ```python
+        Literal[1] (Final)
+        ```
+        ---------------------------------------------
+        info[hover]: Hovered content is
+         --> main.py:4:1
+          |
+        4 | x: Final = 1
+          | ^- Cursor offset
+          | |
+          | source
+          |
+        ");
+    }
+
+    #[test]
     fn hover_comprehension_type_context() {
         let test = hover_test(
             r#"

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -18,6 +18,33 @@ pub(super) enum PEP613Policy {
     Disallowed,
 }
 
+/// The semantic result of inferring an annotation and the type stored for its expression node.
+struct AnnotationExpressionInference<'db> {
+    /// The type and qualifiers that the annotation contributes to the declaration.
+    annotation_ty: TypeAndQualifiers<'db>,
+    /// The type exposed for the annotation expression itself, including to IDE features.
+    expression_ty: Type<'db>,
+}
+
+impl<'db> AnnotationExpressionInference<'db> {
+    fn new(annotation_ty: TypeAndQualifiers<'db>) -> Self {
+        Self {
+            expression_ty: annotation_ty.inner_type(),
+            annotation_ty,
+        }
+    }
+
+    fn with_expression_type(
+        annotation_ty: TypeAndQualifiers<'db>,
+        expression_ty: Type<'db>,
+    ) -> Self {
+        Self {
+            annotation_ty,
+            expression_ty,
+        }
+    }
+}
+
 /// Annotation expressions.
 impl<'db> TypeInferenceBuilder<'db, '_> {
     /// Infer the type of an annotation expression with the given [`DeferredExpressionState`].
@@ -83,7 +110,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             annotation: &ast::Expr,
             builder: &TypeInferenceBuilder<'db, '_>,
             pep_613_policy: PEP613Policy,
-        ) -> TypeAndQualifiers<'db> {
+        ) -> AnnotationExpressionInference<'db> {
             let special_case = match ty {
                 Type::SpecialForm(special_form) => match special_form {
                     SpecialFormType::TypeQualifier(qualifier) => {
@@ -133,17 +160,28 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 _ => None,
             };
 
-            special_case.unwrap_or_else(|| {
+            let annotation_ty = special_case.unwrap_or_else(|| {
                 TypeAndQualifiers::declared(
                     builder.infer_name_or_attribute_type_expression(ty, annotation),
                 )
-            })
+            });
+
+            if matches!(
+                ty,
+                Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::Final))
+            ) {
+                AnnotationExpressionInference::with_expression_type(annotation_ty, ty)
+            } else {
+                AnnotationExpressionInference::new(annotation_ty)
+            }
         }
 
         // https://typing.python.org/en/latest/spec/annotations.html#grammar-token-expression-grammar-annotation_expression
-        let annotation_ty = match annotation {
+        let inferred = match annotation {
             // String annotations: https://typing.python.org/en/latest/spec/annotations.html#string-annotations
-            ast::Expr::StringLiteral(string) => self.infer_string_annotation_expression(string),
+            ast::Expr::StringLiteral(string) => {
+                AnnotationExpressionInference::new(self.infer_string_annotation_expression(string))
+            }
 
             ast::Expr::Attribute(attribute) => {
                 if !is_dotted_name(annotation) {
@@ -156,10 +194,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         self,
                         pep_613_policy,
                     ),
-                    ast::ExprContext::Invalid => TypeAndQualifiers::declared(Type::unknown()),
-                    ast::ExprContext::Store | ast::ExprContext::Del => TypeAndQualifiers::declared(
-                        todo_type!("Attribute expression annotation in Store/Del context"),
+                    ast::ExprContext::Invalid => AnnotationExpressionInference::new(
+                        TypeAndQualifiers::declared(Type::unknown()),
                     ),
+                    ast::ExprContext::Store | ast::ExprContext::Del => {
+                        AnnotationExpressionInference::new(TypeAndQualifiers::declared(todo_type!(
+                            "Attribute expression annotation in Store/Del context"
+                        )))
+                    }
                 }
             }
 
@@ -170,10 +212,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     self,
                     pep_613_policy,
                 ),
-                ast::ExprContext::Invalid => TypeAndQualifiers::declared(Type::unknown()),
-                ast::ExprContext::Store | ast::ExprContext::Del => TypeAndQualifiers::declared(
-                    todo_type!("Name expression annotation in Store/Del context"),
-                ),
+                ast::ExprContext::Invalid => {
+                    AnnotationExpressionInference::new(TypeAndQualifiers::declared(Type::unknown()))
+                }
+                ast::ExprContext::Store | ast::ExprContext::Del => {
+                    AnnotationExpressionInference::new(TypeAndQualifiers::declared(todo_type!(
+                        "Name expression annotation in Store/Del context"
+                    )))
+                }
             },
 
             ast::Expr::Subscript(subscript @ ast::ExprSubscript { value, slice, .. }) => {
@@ -184,7 +230,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let slice = &**slice;
                 let value_ty = self.infer_expression(value, TypeContext::default());
 
-                match value_ty {
+                let annotation_ty = match value_ty {
                     Type::SpecialForm(special_form) => match special_form {
                         SpecialFormType::Annotated => {
                             let inferred = self.parse_subscription_of_annotated_special_form(
@@ -305,25 +351,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     _ => TypeAndQualifiers::declared(
                         self.infer_subscript_type_expression_no_store(subscript, slice, value_ty),
                     ),
-                }
+                };
+
+                AnnotationExpressionInference::new(annotation_ty)
             }
 
             // Fallback to `infer_type_expression_no_store` for everything else
-            type_expr => {
-                TypeAndQualifiers::declared(self.infer_type_expression_no_store(type_expr))
-            }
+            type_expr => AnnotationExpressionInference::new(TypeAndQualifiers::declared(
+                self.infer_type_expression_no_store(type_expr),
+            )),
         };
 
-        // Keep bare `Final` as a special form for IDE features. The annotation's inner type
-        // remains `Unknown`, allowing a declaration such as `x: Final = 1` to infer its type
-        // from the assigned value.
-        let expression_ty = if annotation_ty.qualifiers == TypeQualifiers::FINAL
-            && matches!(annotation, ast::Expr::Attribute(_) | ast::Expr::Name(_))
-        {
-            Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::Final))
-        } else {
-            annotation_ty.inner_type()
-        };
+        let AnnotationExpressionInference {
+            annotation_ty,
+            expression_ty,
+        } = inferred;
         self.store_expression_type(annotation, expression_ty);
         self.store_qualifiers(annotation, annotation_ty.qualifiers());
 

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -314,7 +314,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        self.store_expression_type(annotation, annotation_ty.inner_type());
+        // Keep bare `Final` as a special form for IDE features. The annotation's inner type
+        // remains `Unknown`, allowing a declaration such as `x: Final = 1` to infer its type
+        // from the assigned value.
+        let expression_ty = if annotation_ty.qualifiers == TypeQualifiers::FINAL
+            && matches!(annotation, ast::Expr::Attribute(_) | ast::Expr::Name(_))
+        {
+            Type::SpecialForm(SpecialFormType::TypeQualifier(TypeQualifier::Final))
+        } else {
+            annotation_ty.inner_type()
+        };
+        self.store_expression_type(annotation, expression_ty);
         self.store_qualifiers(annotation, annotation_ty.qualifiers());
 
         annotation_ty


### PR DESCRIPTION
## Summary

A bare `Final` annotation previously stored `Unknown` as the annotation expression type, so hovering over `Final` reported `Unknown`:

```python
from typing import Final

x: Final = 1
```

Annotation inference needs to represent two distinct results in this case: the type and qualifiers contributed to the declaration, and the type stored for the annotation expression itself. This introduces an explicit inference result containing both values. They are identical for ordinary annotations, while a bare `Final` keeps `Unknown` as its semantic inner type and preserves the resolved `typing.Final` special form as its expression type.

We therefore continue to infer `x` as `Literal[1]`, while hovering over `Final` now reports `<special-form 'typing.Final'>`.

Closes https://github.com/astral-sh/ty/issues/1593.
