### PR TITLE
[ty] Ignore declared type context for failed collection literals

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
+++ b/crates/ty_python_semantic/resources/mdtest/assignment/annotations.md
@@ -244,11 +244,14 @@ reveal_type(r)  # revealed: dict[int | str, int | str]
 ## Incorrect collection literal assignments are complained about
 
 ```py
-# error: [invalid-assignment] "Object of type `list[str | int]` is not assignable to `list[str]`"
-a: list[str] = [1, 2, 3]
+# error: [invalid-assignment] "Object of type `list[str]` is not assignable to `list[int]`"
+a: list[int] = reveal_type(["a"])  # revealed: list[str]
 
 # error: [invalid-assignment] "Object of type `set[int | str]` is not assignable to `set[int]`"
 b: set[int] = {1, 2, "3"}
+
+# error: [invalid-assignment] "Object of type `dict[str, str]` is not assignable to `dict[int, int]`"
+c: dict[int, int] = reveal_type({**{"a": "b"}})  # revealed: dict[str, str]
 ```
 
 ## Mutually assignable annotated assignments use the declared type

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -382,7 +382,7 @@ r2: RecursiveList[int] = [1, [1, 2, 3]]
 r3: RecursiveList[int] = "a"
 # error: [invalid-assignment]
 r4: RecursiveList[int] = ["a"]
-# error: [invalid-assignment] "Object of type `list[int | list[RecursiveList[int]] | list[int | list[RecursiveList[int]] | str]]` is not assignable to `RecursiveList[int]`"
+# error: [invalid-assignment] "Object of type `list[int | list[RecursiveList[int]] | list[str]]` is not assignable to `RecursiveList[int]`"
 r5: RecursiveList[int] = [1, ["a"]]
 
 def _(x: RecursiveList[int]):
@@ -422,7 +422,7 @@ d1: DivergentList[int] = []
 d2: DivergentList[int] = [1]
 # error: [invalid-assignment]
 d3: DivergentList[int] = ["a"]
-# error: [invalid-assignment] "Object of type `list[list[DivergentList[int]] | list[list[DivergentList[int]] | int]]` is not assignable to `DivergentList[int]`"
+# error: [invalid-assignment] "Object of type `list[list[int]]` is not assignable to `DivergentList[int]`"
 d4: DivergentList[int] = [[1]]
 
 def _(x: DivergentList[int]):

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1732,6 +1732,9 @@ bitflags::bitflags! {
         /// Whether we're in a context where `Unpack` can be legal.
         const IN_VALID_UNPACK_CONTEXT = 1 << 10;
 
+        /// Whether a collection literal is being inferred from the type of a peer expression.
+        const IN_COLLECTION_LITERAL_PEER_CONTEXT = 1 << 11;
+
         /// Whether the visitor is currently visiting a type expression.
         const IN_TYPE_EXPRESSION = 1 << 12;
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7133,22 +7133,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // The contextual mappings are still added first below to preserve union ordering.
         let mut inferred_constraints = SmallVec::<[(Type<'db>, Type<'db>); 4]>::new();
         let mut tuple_size_promotion_constraints = TupleSizePromotionConstraints::default();
-        let should_prune_context = !self
+        let mut context_compatibility = (!self
             .inference_flags()
             .contains(InferenceFlags::IN_COLLECTION_LITERAL_PEER_CONTEXT)
             && tcx
                 .annotation
-                .is_some_and(|ty| !ty.has_unspecialized_type_var(self.db()));
-        let mut context_compatibility =
-            should_prune_context.then(FxHashMap::<BoundTypeVarIdentity<'db>, bool>::default);
+                .is_some_and(|ty| !ty.has_unspecialized_type_var(self.db()))
+            && !elt_tcx_constraints.is_empty())
+        .then(FxHashMap::default);
 
         for (elts_index, elts) in elts.iter().enumerate() {
             // An unpacking expression for a dictionary.
             if let &[None, Some(value_expr)] = elts.as_slice() {
-                let unpack_ty = pre_inferred_elt_tys
-                    .as_ref()
-                    .and_then(|inferred_elts| inferred_elts[elts_index][1])
-                    .unwrap_or_else(|| infer_elt_expression(self, (1, value_expr, tcx)));
+                let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
 
                 let Some((unpacked_key_ty, unpacked_value_ty)) =
                     unpack_ty.unpack_keys_and_items(self.db())
@@ -7177,10 +7174,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             let identity = elt_ty.identity(self.db());
                             if let Some(elt_tcx) = elt_tcx_constraints.get(&identity) {
                                 let compatible = inferred_ty.is_assignable_to(self.db(), *elt_tcx);
-                                context_compatibility
-                                    .entry(identity)
-                                    .and_modify(|previous| *previous |= compatible)
-                                    .or_insert(compatible);
+                                *context_compatibility.entry(identity).or_default() |= compatible;
                             }
                         }
                     }
@@ -7238,10 +7232,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some(context_compatibility) = &mut context_compatibility
                     && let Some(compatible) = assignable_to_context
                 {
-                    context_compatibility
-                        .entry(elt_ty_identity)
-                        .and_modify(|previous| *previous |= compatible)
-                        .or_insert(compatible);
+                    *context_compatibility.entry(elt_ty_identity).or_default() |= compatible;
                 }
 
                 // Simplify the inference based on a non-covariant declared type.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7065,11 +7065,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut pre_inferred_elt_tys = None;
 
-        // When contextual inference provides a complete specialization, infer each element once
-        // against that context. Ordinary literals can return the specialization directly when all
-        // elements are compatible. Dictionary unpacking still uses the general solver so that it
-        // preserves gradual types, but reuses these inferred types for compatibility and inference.
-        if tcx.annotation.is_some()
+        // Avoid projecting and solving a constraint set when contextual inference has already
+        // provided the complete specialization and every literal element is compatible with it.
+        if !has_dict_unpack
+            && tcx.annotation.is_some()
             && let Some(specialization) = generic_context
                 .variables(self.db())
                 .map(|typevar| {
@@ -7093,44 +7092,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Infer the elements once here and retain their types so that a failed fast-path check
             // does not recursively re-infer nested collection literals on the slow path.
             let mut inferred_elts = Vec::with_capacity(elts.len());
-            let mut compatible_typevars = FxHashSet::default();
             let mut compatible = true;
 
             for elts in elts {
                 let mut inferred_elt_tys = [None; N];
-
-                if let &[None, Some(value_expr)] = elts.as_slice() {
-                    let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
-                    inferred_elt_tys[1] = Some(unpack_ty);
-
-                    if let Some((unpacked_key_ty, unpacked_value_ty)) =
-                        unpack_ty.unpack_keys_and_items(self.db())
-                    {
-                        for (inferred_ty, elt_tcx, typevar) in itertools::izip!(
-                            [unpacked_key_ty, unpacked_value_ty],
-                            specialization.iter().copied(),
-                            generic_context.variables(self.db())
-                        ) {
-                            if inferred_ty.is_assignable_to(self.db(), elt_tcx) {
-                                compatible_typevars.insert(typevar.identity(self.db()));
-                            } else {
-                                compatible = false;
-                            }
-                        }
-                    } else {
-                        compatible = false;
-                    }
-
-                    inferred_elts.push(inferred_elt_tys);
-                    continue;
-                }
-
-                for (i, elt, elt_tcx, typevar) in itertools::izip!(
-                    0..,
-                    elts,
-                    specialization.iter().copied(),
-                    generic_context.variables(self.db())
-                ) {
+                for (i, elt, elt_tcx) in itertools::izip!(0.., elts, specialization.iter().copied())
+                {
                     let Some(elt) = elt else { continue };
                     let elt_tcx = if elt.is_starred_expr() && collection_class != KnownClass::Dict {
                         Type::homogeneous_tuple(self.db(), elt_tcx)
@@ -7141,16 +7108,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         infer_elt_expression(self, (i, elt, TypeContext::new(Some(elt_tcx))));
                     inferred_elt_tys[i] = Some(inferred_elt_ty);
 
-                    if inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
-                        compatible_typevars.insert(typevar.identity(self.db()));
-                    } else {
+                    if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
                         compatible = false;
                     }
                 }
                 inferred_elts.push(inferred_elt_tys);
             }
 
-            if compatible && !has_dict_unpack {
+            if compatible {
                 let class_type = collection_alias.origin(self.db()).apply_specialization(
                     self.db(),
                     |generic_context| {
@@ -7161,30 +7126,165 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Type::from(class_type).to_instance(self.db());
             }
 
-            if !self
-                .inference_flags()
-                .contains(InferenceFlags::IN_COLLECTION_LITERAL_PEER_CONTEXT)
-                && tcx
-                    .annotation
-                    .is_some_and(|ty| !ty.has_unspecialized_type_var(self.db()))
-            {
-                // If none of the expressions corresponding to a type parameter satisfy a concrete
-                // context, that context cannot contribute to the inferred collection type.
-                // Retaining it would produce types that the literal cannot have, such as
-                // `list[int | str]` for `["a"]` in a `list[int]` context. Keep context for
-                // parameters with compatible expressions so that it can still preserve literal
-                // types and `TypedDict` inference in mixed literals. Partial contexts retain all
-                // constraints because the literal elements may provide their unspecialized parts.
-                elt_tcx_constraints.retain(|identity, _| compatible_typevars.contains(identity));
-                elt_tcx_variance.retain(|identity, _| compatible_typevars.contains(identity));
-            }
             pre_inferred_elt_tys = Some(inferred_elts);
+        }
+
+        // Delay applying element constraints until stale contextual mappings have been removed.
+        // The contextual mappings are still added first below to preserve union ordering.
+        let mut inferred_constraints = SmallVec::<[(Type<'db>, Type<'db>); 4]>::new();
+        let mut tuple_size_promotion_constraints = TupleSizePromotionConstraints::default();
+        let should_prune_context = !self
+            .inference_flags()
+            .contains(InferenceFlags::IN_COLLECTION_LITERAL_PEER_CONTEXT)
+            && tcx
+                .annotation
+                .is_some_and(|ty| !ty.has_unspecialized_type_var(self.db()));
+        let mut context_compatibility =
+            should_prune_context.then(FxHashMap::<BoundTypeVarIdentity<'db>, bool>::default);
+
+        for (elts_index, elts) in elts.iter().enumerate() {
+            // An unpacking expression for a dictionary.
+            if let &[None, Some(value_expr)] = elts.as_slice() {
+                let unpack_ty = pre_inferred_elt_tys
+                    .as_ref()
+                    .and_then(|inferred_elts| inferred_elts[elts_index][1])
+                    .unwrap_or_else(|| infer_elt_expression(self, (1, value_expr, tcx)));
+
+                let Some((unpacked_key_ty, unpacked_value_ty)) =
+                    unpack_ty.unpack_keys_and_items(self.db())
+                else {
+                    if let Some(builder) =
+                        self.context.report_lint(&INVALID_ARGUMENT_TYPE, value_expr)
+                    {
+                        let mut diag = builder
+                            .into_diagnostic("Argument expression after ** must be a mapping type");
+
+                        diag.set_primary_message(format_args!(
+                            "Found `{}`",
+                            unpack_ty.display(self.db())
+                        ));
+                    }
+
+                    continue;
+                };
+
+                let mut elt_tys = elt_tys.clone();
+                if let Some((key_ty, value_ty)) = elt_tys.next_tuple() {
+                    if let Some(context_compatibility) = &mut context_compatibility {
+                        for (elt_ty, inferred_ty) in
+                            [(key_ty, unpacked_key_ty), (value_ty, unpacked_value_ty)]
+                        {
+                            let identity = elt_ty.identity(self.db());
+                            if let Some(elt_tcx) = elt_tcx_constraints.get(&identity) {
+                                let compatible = inferred_ty.is_assignable_to(self.db(), *elt_tcx);
+                                context_compatibility
+                                    .entry(identity)
+                                    .and_modify(|previous| *previous |= compatible)
+                                    .or_insert(compatible);
+                            }
+                        }
+                    }
+
+                    tuple_size_promotion_constraints.record_unpromotable_type(
+                        self.db(),
+                        key_ty.identity(self.db()),
+                        unpacked_key_ty.promote(self.db()),
+                    );
+                    tuple_size_promotion_constraints.record_unpromotable_type(
+                        self.db(),
+                        value_ty.identity(self.db()),
+                        unpacked_value_ty.promote(self.db()),
+                    );
+
+                    inferred_constraints.push((Type::TypeVar(key_ty), unpacked_key_ty));
+                    inferred_constraints.push((Type::TypeVar(value_ty), unpacked_value_ty));
+                }
+
+                continue;
+            }
+
+            // The inferred type of each element acts as an additional constraint on `T`.
+            for (i, elt, elt_ty) in itertools::izip!(0.., elts, elt_tys.clone()) {
+                let Some(elt) = elt else { continue };
+
+                // Note that unlike when preferring the declared type, we use covariant type
+                // assignments from the type context to potentially _narrow_ the inferred type,
+                // by avoiding promotion.
+                let elt_ty_identity = elt_ty.identity(self.db());
+
+                // If the element is a starred expression, we want to apply the type context to each element
+                // in the unpacked expression (which we will store as a tuple when inferring it). We
+                // therefore wrap the type context in an `tuple[T, ...]` specialization.
+                let elt_tcx = elt_tcx_constraints
+                    .get(&elt_ty_identity)
+                    .copied()
+                    .map(|tcx| {
+                        if elt.is_starred_expr() && collection_class != KnownClass::Dict {
+                            Type::homogeneous_tuple(self.db(), tcx)
+                        } else {
+                            tcx
+                        }
+                    });
+
+                let inferred_elt_ty = pre_inferred_elt_tys
+                    .as_ref()
+                    .and_then(|inferred_elts| inferred_elts[elts_index][i])
+                    .unwrap_or_else(|| {
+                        infer_elt_expression(self, (i, elt, TypeContext::new(elt_tcx)))
+                    });
+
+                let assignable_to_context =
+                    elt_tcx.map(|elt_tcx| inferred_elt_ty.is_assignable_to(self.db(), elt_tcx));
+                if let Some(context_compatibility) = &mut context_compatibility
+                    && let Some(compatible) = assignable_to_context
+                {
+                    context_compatibility
+                        .entry(elt_ty_identity)
+                        .and_modify(|previous| *previous |= compatible)
+                        .or_insert(compatible);
+                }
+
+                // Simplify the inference based on a non-covariant declared type.
+                if assignable_to_context.is_some_and(|assignable| {
+                    assignable && !elt_tcx_variance[&elt_ty_identity].is_covariant()
+                }) {
+                    continue;
+                }
+
+                // We promote element literal types in invariant position by default, unless they were
+                // inferred with an explicit literal annotation.
+                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
+
+                let inferred_type_for_typevar = if elt.is_starred_expr() {
+                    inferred_elt_ty
+                        .iterate(self.db())
+                        .homogeneous_element_type(self.db())
+                } else {
+                    inferred_elt_ty
+                };
+
+                tuple_size_promotion_constraints.record_inferred_expression_type(
+                    self.db(),
+                    elt_ty_identity,
+                    elt,
+                    inferred_type_for_typevar,
+                );
+
+                inferred_constraints.push((Type::TypeVar(elt_ty), inferred_type_for_typevar));
+            }
+        }
+
+        if let Some(context_compatibility) = context_compatibility {
+            elt_tcx_constraints.retain(|identity, _| {
+                context_compatibility
+                    .get(identity)
+                    .is_none_or(|compatible| *compatible)
+            });
+            elt_tcx_variance.retain(|identity, _| elt_tcx_constraints.contains_key(identity));
         }
 
         // Create a set of constraints to infer a precise type for `T`.
         let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
-
-        let mut tuple_size_promotion_constraints = TupleSizePromotionConstraints::default();
 
         for elt_ty in elt_tys.clone() {
             let elt_ty_identity = elt_ty.identity(self.db());
@@ -7271,116 +7371,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        for (elts_index, elts) in elts.iter().enumerate() {
-            // An unpacking expression for a dictionary.
-            if let &[None, Some(value_expr)] = elts.as_slice() {
-                let unpack_ty = pre_inferred_elt_tys
-                    .as_ref()
-                    .and_then(|inferred_elts| inferred_elts[elts_index][1])
-                    .unwrap_or_else(|| infer_elt_expression(self, (1, value_expr, tcx)));
-
-                let Some((unpacked_key_ty, unpacked_value_ty)) =
-                    unpack_ty.unpack_keys_and_items(self.db())
-                else {
-                    if let Some(builder) =
-                        self.context.report_lint(&INVALID_ARGUMENT_TYPE, value_expr)
-                    {
-                        let mut diag = builder
-                            .into_diagnostic("Argument expression after ** must be a mapping type");
-
-                        diag.set_primary_message(format_args!(
-                            "Found `{}`",
-                            unpack_ty.display(self.db())
-                        ));
-                    }
-
-                    continue;
-                };
-
-                let mut elt_tys = elt_tys.clone();
-                if let Some((key_ty, value_ty)) = elt_tys.next_tuple() {
-                    tuple_size_promotion_constraints.record_unpromotable_type(
-                        self.db(),
-                        key_ty.identity(self.db()),
-                        unpacked_key_ty.promote(self.db()),
-                    );
-                    tuple_size_promotion_constraints.record_unpromotable_type(
-                        self.db(),
-                        value_ty.identity(self.db()),
-                        unpacked_value_ty.promote(self.db()),
-                    );
-
-                    builder.infer(Type::TypeVar(key_ty), unpacked_key_ty).ok()?;
-
-                    builder
-                        .infer(Type::TypeVar(value_ty), unpacked_value_ty)
-                        .ok()?;
-                }
-
-                continue;
-            }
-
-            // The inferred type of each element acts as an additional constraint on `T`.
-            for (i, elt, elt_ty) in itertools::izip!(0.., elts, elt_tys.clone()) {
-                let Some(elt) = elt else { continue };
-
-                // Note that unlike when preferring the declared type, we use covariant type
-                // assignments from the type context to potentially _narrow_ the inferred type,
-                // by avoiding promotion.
-                let elt_ty_identity = elt_ty.identity(self.db());
-
-                // If the element is a starred expression, we want to apply the type context to each element
-                // in the unpacked expression (which we will store as a tuple when inferring it). We
-                // therefore wrap the type context in an `tuple[T, ...]` specialization.
-                let elt_tcx = elt_tcx_constraints
-                    .get(&elt_ty_identity)
-                    .copied()
-                    .map(|tcx| {
-                        if elt.is_starred_expr() && collection_class != KnownClass::Dict {
-                            Type::homogeneous_tuple(self.db(), tcx)
-                        } else {
-                            tcx
-                        }
-                    });
-
-                let inferred_elt_ty = pre_inferred_elt_tys
-                    .as_ref()
-                    .and_then(|inferred_elts| inferred_elts[elts_index][i])
-                    .unwrap_or_else(|| {
-                        infer_elt_expression(self, (i, elt, TypeContext::new(elt_tcx)))
-                    });
-
-                // Simplify the inference based on a non-covariant declared type.
-                if let Some(elt_tcx) =
-                    elt_tcx.filter(|_| !elt_tcx_variance[&elt_ty_identity].is_covariant())
-                    && inferred_elt_ty.is_assignable_to(self.db(), elt_tcx)
-                {
-                    continue;
-                }
-
-                // We promote element literal types in invariant position by default, unless they were
-                // inferred with an explicit literal annotation.
-                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
-
-                let inferred_type_for_typevar = if elt.is_starred_expr() {
-                    inferred_elt_ty
-                        .iterate(self.db())
-                        .homogeneous_element_type(self.db())
-                } else {
-                    inferred_elt_ty
-                };
-
-                tuple_size_promotion_constraints.record_inferred_expression_type(
-                    self.db(),
-                    elt_ty_identity,
-                    elt,
-                    inferred_type_for_typevar,
-                );
-
-                builder
-                    .infer(Type::TypeVar(elt_ty), inferred_type_for_typevar)
-                    .ok()?;
-            }
+        for (source, target) in inferred_constraints {
+            builder.infer(source, target).ok()?;
         }
 
         let class_type = collection_alias

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5952,6 +5952,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let mut speculative_builder = self.speculate();
+        speculative_builder.context.inference_flags |=
+            InferenceFlags::IN_COLLECTION_LITERAL_PEER_CONTEXT;
         let ty = infer_expression(&mut speculative_builder, peer_tcx);
 
         // Peer context is only an inference hint. If it introduces diagnostics, discard it and
@@ -6939,7 +6941,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // We use a forward assignability check (`identity_instance ≤ tcx`) to infer what each
         // typevar maps to in the type context. For example, if the type context is `list[int]` and
         // `collection_instance` is `list[T]`, the check produces `T = int`.
-        let (elt_tcx_constraints, elt_tcx_variance) = {
+        let (mut elt_tcx_constraints, mut elt_tcx_variance) = {
             let mut elt_tcx_constraints: FxHashMap<
                 BoundTypeVarIdentity<'db>,
                 UnionAccumulator<'db>,
@@ -7063,10 +7065,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut pre_inferred_elt_tys = None;
 
-        // Avoid projecting and solving a constraint set when contextual inference has already
-        // provided the complete specialization and every literal element is compatible with it.
-        if !has_dict_unpack
-            && tcx.annotation.is_some()
+        // When contextual inference provides a complete specialization, infer each element once
+        // against that context. Ordinary literals can return the specialization directly when all
+        // elements are compatible. Dictionary unpacking still uses the general solver so that it
+        // preserves gradual types, but reuses these inferred types for compatibility and inference.
+        if tcx.annotation.is_some()
             && let Some(specialization) = generic_context
                 .variables(self.db())
                 .map(|typevar| {
@@ -7090,12 +7093,44 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Infer the elements once here and retain their types so that a failed fast-path check
             // does not recursively re-infer nested collection literals on the slow path.
             let mut inferred_elts = Vec::with_capacity(elts.len());
+            let mut compatible_typevars = FxHashSet::default();
             let mut compatible = true;
 
             for elts in elts {
                 let mut inferred_elt_tys = [None; N];
-                for (i, elt, elt_tcx) in itertools::izip!(0.., elts, specialization.iter().copied())
-                {
+
+                if let &[None, Some(value_expr)] = elts.as_slice() {
+                    let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
+                    inferred_elt_tys[1] = Some(unpack_ty);
+
+                    if let Some((unpacked_key_ty, unpacked_value_ty)) =
+                        unpack_ty.unpack_keys_and_items(self.db())
+                    {
+                        for (inferred_ty, elt_tcx, typevar) in itertools::izip!(
+                            [unpacked_key_ty, unpacked_value_ty],
+                            specialization.iter().copied(),
+                            generic_context.variables(self.db())
+                        ) {
+                            if inferred_ty.is_assignable_to(self.db(), elt_tcx) {
+                                compatible_typevars.insert(typevar.identity(self.db()));
+                            } else {
+                                compatible = false;
+                            }
+                        }
+                    } else {
+                        compatible = false;
+                    }
+
+                    inferred_elts.push(inferred_elt_tys);
+                    continue;
+                }
+
+                for (i, elt, elt_tcx, typevar) in itertools::izip!(
+                    0..,
+                    elts,
+                    specialization.iter().copied(),
+                    generic_context.variables(self.db())
+                ) {
                     let Some(elt) = elt else { continue };
                     let elt_tcx = if elt.is_starred_expr() && collection_class != KnownClass::Dict {
                         Type::homogeneous_tuple(self.db(), elt_tcx)
@@ -7106,14 +7141,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         infer_elt_expression(self, (i, elt, TypeContext::new(Some(elt_tcx))));
                     inferred_elt_tys[i] = Some(inferred_elt_ty);
 
-                    if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
+                    if inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
+                        compatible_typevars.insert(typevar.identity(self.db()));
+                    } else {
                         compatible = false;
                     }
                 }
                 inferred_elts.push(inferred_elt_tys);
             }
 
-            if compatible {
+            if compatible && !has_dict_unpack {
                 let class_type = collection_alias.origin(self.db()).apply_specialization(
                     self.db(),
                     |generic_context| {
@@ -7124,6 +7161,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Type::from(class_type).to_instance(self.db());
             }
 
+            if !self
+                .inference_flags()
+                .contains(InferenceFlags::IN_COLLECTION_LITERAL_PEER_CONTEXT)
+                && tcx
+                    .annotation
+                    .is_some_and(|ty| !ty.has_unspecialized_type_var(self.db()))
+            {
+                // If none of the expressions corresponding to a type parameter satisfy a concrete
+                // context, that context cannot contribute to the inferred collection type.
+                // Retaining it would produce types that the literal cannot have, such as
+                // `list[int | str]` for `["a"]` in a `list[int]` context. Keep context for
+                // parameters with compatible expressions so that it can still preserve literal
+                // types and `TypedDict` inference in mixed literals. Partial contexts retain all
+                // constraints because the literal elements may provide their unspecialized parts.
+                elt_tcx_constraints.retain(|identity, _| compatible_typevars.contains(identity));
+                elt_tcx_variance.retain(|identity, _| compatible_typevars.contains(identity));
+            }
             pre_inferred_elt_tys = Some(inferred_elts);
         }
 
@@ -7220,7 +7274,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for (elts_index, elts) in elts.iter().enumerate() {
             // An unpacking expression for a dictionary.
             if let &[None, Some(value_expr)] = elts.as_slice() {
-                let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
+                let unpack_ty = pre_inferred_elt_tys
+                    .as_ref()
+                    .and_then(|inferred_elts| inferred_elts[elts_index][1])
+                    .unwrap_or_else(|| infer_elt_expression(self, (1, value_expr, tcx)));
 
                 let Some((unpacked_key_ty, unpacked_value_ty)) =
                     unpack_ty.unpack_keys_and_items(self.db())


### PR DESCRIPTION
## Summary

When a collection literal is inferred under a declared type context,  we currently retain element, key, or value types from the surrounding annotation even when the collection literal cannot produce them -- e.g., here, we reveal `int` on the RHS due to the `int` in `list[int]`:

```python
x: list[int] = reveal_type(["a"])
# revealed: list[int | str]
```

This makes failed-assignment diagnostics describe a type that the right-hand side would never have. We now collect element constraints before constructing the collection specialization and discard the contextual mapping when it has incompatible evidence (and no compatible evidence).

This also handles dictionary keys and values independently, including values introduced through `**` unpacking:

```python
d: dict[int, int] = reveal_type({**{"a": "b"}})
# revealed: dict[str, str]
```

Closes https://github.com/astral-sh/ty/issues/3777.
