### PR TITLE
[ty] Add context-sensitive keyword completions

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -772,12 +772,23 @@ struct ContextCursor<'m> {
 
 /// The cursor position relative to an AST range and its surrounding parentheses.
 enum RangeEndPosition {
+    /// The cursor follows the complete range, including any surrounding parentheses.
     After,
+    /// The cursor follows the AST range but precedes a surrounding closing parenthesis.
     InsideParentheses,
 }
 
 impl RangeEndPosition {
-    fn keywords(
+    /// Selects the keywords valid at this position.
+    ///
+    /// `after` applies after the complete, possibly parenthesized range, while
+    /// `inside_parentheses` applies before its closing parenthesis. For example:
+    ///
+    /// ```python
+    /// case (400 <CURSOR>)  # `as`
+    /// case (400) <CURSOR>  # `as` or `if`
+    /// ```
+    fn select_keywords(
         self,
         after: &'static [&'static str],
         inside_parentheses: &'static [&'static str],
@@ -1130,10 +1141,10 @@ impl<'m> ContextCursor<'m> {
                 .find_map(|node| match node {
                     ast::AnyNodeRef::StmtFor(stmt) => self
                         .range_end_position(stmt.target.range(), node, token)
-                        .map(|position| position.keywords(IN, NONE)),
+                        .map(|position| position.select_keywords(IN, NONE)),
                     ast::AnyNodeRef::Comprehension(comprehension) => self
                         .range_end_position(comprehension.target.range(), node, token)
-                        .map(|position| position.keywords(IN, NONE)),
+                        .map(|position| position.select_keywords(IN, NONE)),
                     _ => None,
                 })
         {
@@ -1148,14 +1159,14 @@ impl<'m> ContextCursor<'m> {
                     ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
                         let range = item.context_expr.range();
                         self.range_end_position(range, item.into(), token)
-                            .map(|position| position.keywords(AS, NONE))
+                            .map(|position| position.select_keywords(AS, NONE))
                             .or_else(|| self.range_end_position(range, node, token).map(|_| AS))
                     }),
                     ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => handler
                         .type_
                         .as_deref()
                         .and_then(|type_| self.range_end_position(type_.range(), node, token))
-                        .map(|position| position.keywords(AS, NONE)),
+                        .map(|position| position.select_keywords(AS, NONE)),
                     _ => None,
                 })
         {
@@ -1180,15 +1191,15 @@ impl<'m> ContextCursor<'m> {
                                 && let Some(position) =
                                     self.range_end_position(case.pattern.range(), node, token)
                             {
-                                Some(position.keywords(IF, NONE))
+                                Some(position.select_keywords(IF, NONE))
                             } else {
                                 self.range_end_position(pattern.range(), node, token)
-                                    .map(|position| position.keywords(MATCH, AS))
+                                    .map(|position| position.select_keywords(MATCH, AS))
                             }
                         }
                         pattern => self
                             .range_end_position(pattern.range(), node, token)
-                            .map(|position| position.keywords(MATCH, AS)),
+                            .map(|position| position.select_keywords(MATCH, AS)),
                     }
                 })
         {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -770,6 +770,25 @@ struct ContextCursor<'m> {
     covering_node: CoveringNode<'m>,
 }
 
+/// The cursor position relative to an AST range and its surrounding parentheses.
+enum RangeEndPosition {
+    After,
+    InsideParentheses,
+}
+
+impl RangeEndPosition {
+    fn keywords(
+        self,
+        after: &'static [&'static str],
+        inside_parentheses: &'static [&'static str],
+    ) -> &'static [&'static str] {
+        match self {
+            RangeEndPosition::After => after,
+            RangeEndPosition::InsideParentheses => inside_parentheses,
+        }
+    }
+}
+
 impl<'m> ContextCursor<'m> {
     /// Returns information about the context of the cursor.
     fn new(
@@ -1026,20 +1045,18 @@ impl<'m> ContextCursor<'m> {
             .map(|(right, _)| right)
     }
 
-    /// Returns the keywords that can follow `range` at the cursor position.
-    fn keywords_after_range(
+    /// Returns the cursor position after `range`, accounting for surrounding parentheses.
+    fn range_end_position(
         &self,
         range: TextRange,
         parent: AnyNodeRef,
         token: &Token,
-        keywords: &'static [&'static str],
-        parenthesized_keywords: &'static [&'static str],
-    ) -> Option<&'static [&'static str]> {
+    ) -> Option<RangeEndPosition> {
         let range_ends_at_token = range.contains_range(token.range()) && range.end() == token.end();
         match self.closing_parenthesis(range, parent) {
-            Some(right) if right.range() == token.range() => Some(keywords),
-            Some(_) if range_ends_at_token => Some(parenthesized_keywords),
-            None if range_ends_at_token => Some(keywords),
+            Some(right) if right.range() == token.range() => Some(RangeEndPosition::After),
+            Some(_) if range_ends_at_token => Some(RangeEndPosition::InsideParentheses),
+            None if range_ends_at_token => Some(RangeEndPosition::After),
             _ => None,
         }
     }
@@ -1077,6 +1094,7 @@ impl<'m> ContextCursor<'m> {
         const AS: &[&str] = &["as"];
         const IF: &[&str] = &["if"];
         const MATCH: &[&str] = &["as", "if"];
+        const NONE: &[&str] = &[];
 
         let preceding_token = |keyword: &str| {
             let (tokens, start) = match self.typed {
@@ -1110,16 +1128,12 @@ impl<'m> ContextCursor<'m> {
                 .covering_node(token.range())
                 .ancestors()
                 .find_map(|node| match node {
-                    ast::AnyNodeRef::StmtFor(stmt) => {
-                        self.keywords_after_range(stmt.target.range(), node, token, IN, &[])
-                    }
-                    ast::AnyNodeRef::Comprehension(comprehension) => self.keywords_after_range(
-                        comprehension.target.range(),
-                        node,
-                        token,
-                        IN,
-                        &[],
-                    ),
+                    ast::AnyNodeRef::StmtFor(stmt) => self
+                        .range_end_position(stmt.target.range(), node, token)
+                        .map(|position| position.keywords(IN, NONE)),
+                    ast::AnyNodeRef::Comprehension(comprehension) => self
+                        .range_end_position(comprehension.target.range(), node, token)
+                        .map(|position| position.keywords(IN, NONE)),
                     _ => None,
                 })
         {
@@ -1133,14 +1147,15 @@ impl<'m> ContextCursor<'m> {
                 .find_map(|node| match node {
                     ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
                         let range = item.context_expr.range();
-                        self.keywords_after_range(range, item.into(), token, AS, &[])
-                            .or_else(|| self.keywords_after_range(range, node, token, AS, AS))
+                        self.range_end_position(range, item.into(), token)
+                            .map(|position| position.keywords(AS, NONE))
+                            .or_else(|| self.range_end_position(range, node, token).map(|_| AS))
                     }),
-                    ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
-                        handler.type_.as_deref().and_then(|type_| {
-                            self.keywords_after_range(type_.range(), node, token, AS, &[])
-                        })
-                    }
+                    ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => handler
+                        .type_
+                        .as_deref()
+                        .and_then(|type_| self.range_end_position(type_.range(), node, token))
+                        .map(|position| position.keywords(AS, NONE)),
                     _ => None,
                 })
         {
@@ -1162,22 +1177,18 @@ impl<'m> ContextCursor<'m> {
                             ..
                         }) => {
                             if name.is_valid()
-                                && let Some(keywords) = self.keywords_after_range(
-                                    case.pattern.range(),
-                                    node,
-                                    token,
-                                    IF,
-                                    &[],
-                                )
+                                && let Some(position) =
+                                    self.range_end_position(case.pattern.range(), node, token)
                             {
-                                Some(keywords)
+                                Some(position.keywords(IF, NONE))
                             } else {
-                                self.keywords_after_range(pattern.range(), node, token, MATCH, AS)
+                                self.range_end_position(pattern.range(), node, token)
+                                    .map(|position| position.keywords(MATCH, AS))
                             }
                         }
-                        pattern => {
-                            self.keywords_after_range(pattern.range(), node, token, MATCH, AS)
-                        }
+                        pattern => self
+                            .range_end_position(pattern.range(), node, token)
+                            .map(|position| position.keywords(MATCH, AS)),
                     }
                 })
         {

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -69,7 +69,7 @@ pub fn completion<'db>(
     );
     match context.kind {
         ContextKind::Keywords(keywords) => {
-            for &keyword in keywords {
+            for keyword in keywords.iter() {
                 completions
                     .add(CompletionBuilder::keyword(keyword.as_str()).context_specific(true));
             }
@@ -660,9 +660,24 @@ struct Context<'m> {
 
 #[derive(Debug)]
 enum ContextKind<'m> {
-    Keywords(&'static [ContextualKeyword]),
+    Keywords(ContextualKeywords),
     Import(ImportStatement<'m>),
     NonImport(ContextNonImport<'m>),
+}
+
+#[derive(Debug)]
+struct ContextualKeywords {
+    candidates: &'static [ContextualKeyword],
+    following_token: Option<TokenKind>,
+}
+
+impl ContextualKeywords {
+    fn iter(&self) -> impl Iterator<Item = ContextualKeyword> + '_ {
+        self.candidates
+            .iter()
+            .copied()
+            .filter(|keyword| Some(keyword.token_kind()) != self.following_token)
+    }
 }
 
 /// A Python keyword offered only when it is valid in the incomplete syntax at the cursor.
@@ -1123,47 +1138,44 @@ impl<'m> ContextCursor<'m> {
         None
     }
 
-    /// Returns no keywords if one of `keywords` is already the next non-trivia token.
-    fn unless_already_present(
+    /// Excludes a candidate if it is already the next non-trivia token.
+    fn without_already_present(
         &self,
-        keywords: &'static [ContextualKeyword],
-    ) -> &'static [ContextualKeyword] {
-        if self
+        candidates: &'static [ContextualKeyword],
+    ) -> ContextualKeywords {
+        let following_token = if self
             .tokens_before
             .last()
             .is_some_and(|token| token.end() > self.offset)
         {
-            return keywords;
-        }
-
-        let Some(next) = self
-            .parsed
-            .tokens()
-            .after(self.offset)
-            .iter()
-            .find(|token| !token.kind().is_trivia())
-        else {
-            return keywords;
-        };
-        if keywords
-            .iter()
-            .any(|keyword| keyword.token_kind() == next.kind())
-        {
-            &[]
+            None
         } else {
-            keywords
+            self.parsed
+                .tokens()
+                .after(self.offset)
+                .iter()
+                .find(|token| !token.kind().is_trivia())
+                .map(Token::kind)
+        };
+        ContextualKeywords {
+            candidates,
+            following_token,
         }
     }
 
     /// Returns keywords when the cursor follows syntax that can only be
     /// continued by those keywords.
-    fn incomplete_keywords(&self) -> Option<&'static [ContextualKeyword]> {
+    ///
+    /// This first identifies keywords compatible with the typed prefix, then finds the
+    /// complete token immediately before the cursor, and finally checks its enclosing syntax.
+    fn incomplete_keywords(&self) -> Option<ContextualKeywords> {
         const IN: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::In);
         const AS: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::As);
         const IF: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::If);
         const MATCH: &[ContextualKeyword] = &[ContextualKeyword::As, ContextualKeyword::If];
         const NONE: &[ContextualKeyword] = &[];
 
+        // Phase 1: Identify the keyword groups compatible with the typed prefix.
         let typed_matches = |keywords: &[ContextualKeyword]| {
             self.typed.is_none_or(|typed| {
                 keywords
@@ -1178,6 +1190,7 @@ impl<'m> ContextCursor<'m> {
             return None;
         }
 
+        // Phase 2: Find the complete token immediately preceding the completion target.
         let (tokens, start) = match self.typed {
             Some(_) => (
                 self.tokens_before.get(..self.tokens_before.len() - 1)?,
@@ -1202,6 +1215,10 @@ impl<'m> ContextCursor<'m> {
         }
         let covering_node = self.covering_node(token.range());
 
+        // Phase 3: Determine which contextual keywords can follow that token from its
+        // enclosing syntax.
+
+        // Loop and comprehension targets can only be followed by `in`.
         if matches_in
             && let Some(keywords) = covering_node.ancestors().find_map(|node| match node {
                 ast::AnyNodeRef::StmtFor(stmt) => self
@@ -1213,9 +1230,10 @@ impl<'m> ContextCursor<'m> {
                 _ => None,
             })
         {
-            return Some(self.unless_already_present(keywords));
+            return Some(self.without_already_present(keywords));
         }
 
+        // Context managers and exception types can be followed by `as`.
         if matches_as
             && let Some(keywords) = covering_node.ancestors().find_map(|node| match node {
                 ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
@@ -1232,9 +1250,11 @@ impl<'m> ContextCursor<'m> {
                 _ => None,
             })
         {
-            return Some(self.unless_already_present(keywords));
+            return Some(self.without_already_present(keywords));
         }
 
+        // Match patterns can be followed by `as` or `if`; an existing alias can only be
+        // followed by `if`.
         if (matches_as || matches_if)
             && let Some(keywords) = covering_node.ancestors().find_map(|node| {
                 let ast::AnyNodeRef::MatchCase(case) = node else {
@@ -1262,7 +1282,7 @@ impl<'m> ContextCursor<'m> {
                 }
             })
         {
-            return Some(self.unless_already_present(keywords));
+            return Some(self.without_already_present(keywords));
         }
 
         None
@@ -8311,6 +8331,18 @@ match status:
             (
                 "\
 match status:
+    case 400 <CURSOR> if guard",
+                "as",
+            ),
+            (
+                "\
+match status:
+    case 400 <CURSOR> as value",
+                "if",
+            ),
+            (
+                "\
+match status:
     case (400) <CURSOR>",
                 "as\nif",
             ),
@@ -8432,8 +8464,6 @@ for foo<CURSOR>
             "[foo for foo <CURSOR>in items]",
             "with open('bar') <CURSOR>as file: pass",
             "try:\n    pass\nexcept ValueError <CURSOR>as error: pass",
-            "match status:\n    case 400 <CURSOR>as value: pass",
-            "match status:\n    case 400 <CURSOR>if condition: pass",
         ] {
             assert_eq!(
                 completion_test_builder(source).build().snapshot(),

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -43,7 +43,7 @@ pub fn completion<'db>(
     };
     let model = SemanticModel::new(db, file);
 
-    if context.cursor.is_in_string() {
+    if !matches!(context.kind, ContextKind::Keywords(_)) && context.cursor.is_in_string() {
         let Some(string_expr) = context.cursor.enclosing_string_literal_expr() else {
             return vec![];
         };
@@ -68,6 +68,11 @@ pub fn completion<'db>(
         query,
     );
     match context.kind {
+        ContextKind::Keywords(keywords) => {
+            for &keyword in keywords {
+                completions.add(CompletionBuilder::keyword(keyword).context_specific(true));
+            }
+        }
         ContextKind::Import(ref import) => {
             import.add_completions(db, file, &mut completions);
         }
@@ -654,6 +659,7 @@ struct Context<'m> {
 
 #[derive(Debug)]
 enum ContextKind<'m> {
+    Keywords(&'static [&'static str]),
     Import(ImportStatement<'m>),
     NonImport(ContextNonImport<'m>),
 }
@@ -675,11 +681,15 @@ impl<'m> Context<'m> {
         offset: TextSize,
     ) -> Option<Context<'m>> {
         let cursor = ContextCursor::new(parsed, source, offset);
-        if cursor.is_in_no_completions_place() {
+        if cursor.is_in_comment() {
             return None;
         }
 
-        let kind = if let Some(import) = ImportStatement::detect(db, file, &cursor) {
+        let kind = if let Some(keywords) = cursor.incomplete_keywords() {
+            ContextKind::Keywords(keywords)
+        } else if cursor.is_in_definition_place() {
+            return None;
+        } else if let Some(import) = ImportStatement::detect(db, file, &cursor) {
             ContextKind::Import(import)
         } else {
             let target_token = CompletionTargetTokens::find(&cursor)?;
@@ -699,7 +709,7 @@ impl<'m> Context<'m> {
         capabilities: CompletionCapabilities,
     ) -> CollectionContext<'db> {
         match self.kind {
-            ContextKind::Import(_) => CollectionContext::none(),
+            ContextKind::Keywords(_) | ContextKind::Import(_) => CollectionContext::none(),
             ContextKind::NonImport(_) => {
                 let exception_ty = self.cursor.exception_ty(db);
                 let complete_callable_parentheses = settings.complete_function_parentheses
@@ -832,11 +842,6 @@ impl<'m> ContextCursor<'m> {
     /// Convenience method for `covering_node(cursor.parsed.syntax().into(), ...)`.
     fn covering_node(&self, range: TextRange) -> CoveringNode<'m> {
         covering_node(self.parsed.syntax().into(), range)
-    }
-
-    /// Whether the last token is in a place where we should not provide completions.
-    fn is_in_no_completions_place(&self) -> bool {
-        self.is_in_comment() || self.is_in_definition_place()
     }
 
     /// Whether the last token is within a comment or not.
@@ -995,6 +1000,130 @@ impl<'m> ContextCursor<'m> {
             }
             _ => false,
         })
+    }
+
+    /// Returns the last closing parenthesis surrounding `range`, if any.
+    fn closing_parenthesis(&self, range: TextRange, parent: AnyNodeRef) -> Option<&Token> {
+        let right_parentheses = self
+            .parsed
+            .tokens()
+            .in_range(TextRange::new(range.end(), parent.end()))
+            .iter()
+            .filter(|token| !token.kind().is_trivia())
+            .take_while(|token| token.kind() == TokenKind::Rpar);
+        let left_parentheses = self
+            .parsed
+            .tokens()
+            .before(range.start())
+            .iter()
+            .rev()
+            .filter(|token| !token.kind().is_trivia())
+            .take_while(|token| token.kind() == TokenKind::Lpar);
+
+        right_parentheses
+            .zip(left_parentheses)
+            .last()
+            .map(|(right, _)| right)
+    }
+
+    /// Returns the keywords that can follow `range` at the cursor position.
+    fn keywords_after_range(
+        &self,
+        range: TextRange,
+        parent: AnyNodeRef,
+        token: &Token,
+        keywords: &'static [&'static str],
+        parenthesized_keywords: &'static [&'static str],
+    ) -> Option<&'static [&'static str]> {
+        let range_ends_at_token = range.contains_range(token.range()) && range.end() == token.end();
+        match self.closing_parenthesis(range, parent) {
+            Some(right) if right.range() == token.range() => Some(keywords),
+            Some(_) if range_ends_at_token => Some(parenthesized_keywords),
+            None if range_ends_at_token => Some(keywords),
+            _ => None,
+        }
+    }
+
+    /// Returns no keywords if one of `keywords` is already the next non-trivia token.
+    fn unless_already_present(&self, keywords: &'static [&'static str]) -> &'static [&'static str] {
+        if self
+            .tokens_before
+            .last()
+            .is_some_and(|token| token.end() > self.offset)
+        {
+            return keywords;
+        }
+
+        let Some(next) = self
+            .parsed
+            .tokens()
+            .after(self.offset)
+            .iter()
+            .find(|token| !token.kind().is_trivia())
+        else {
+            return keywords;
+        };
+        if keywords.contains(&&self.source[next.range()]) {
+            &[]
+        } else {
+            keywords
+        }
+    }
+
+    /// Returns keywords when the cursor follows syntax that can only be
+    /// continued by those keywords.
+    fn incomplete_keywords(&self) -> Option<&'static [&'static str]> {
+        const IN: &[&str] = &["in"];
+
+        let preceding_token = |keyword: &str| {
+            let (tokens, start) = match self.typed {
+                Some(typed) if keyword.starts_with(typed) => (
+                    self.tokens_before.get(..self.tokens_before.len() - 1)?,
+                    self.range.start(),
+                ),
+                Some(_) => return None,
+                None => (self.tokens_before, self.offset),
+            };
+            let token = tokens
+                .iter()
+                .rev()
+                .find(|token| !token.kind().is_trivia())?;
+            if token.kind() == TokenKind::Newline
+                || token.end() >= start
+                || self
+                    .parsed
+                    .tokens()
+                    .in_range(TextRange::new(token.end(), start))
+                    .iter()
+                    .any(|token| !token.kind().is_trivia())
+            {
+                return None;
+            }
+            Some(token)
+        };
+
+        if let Some(token) = preceding_token("in")
+            && let Some(keywords) = self
+                .covering_node(token.range())
+                .ancestors()
+                .find_map(|node| match node {
+                    ast::AnyNodeRef::StmtFor(stmt) => {
+                        self.keywords_after_range(stmt.target.range(), node, token, IN, &[])
+                    }
+                    ast::AnyNodeRef::Comprehension(comprehension) => self.keywords_after_range(
+                        comprehension.target.range(),
+                        node,
+                        token,
+                        IN,
+                        &[],
+                    ),
+                    _ => None,
+                })
+        {
+            return Some(self.unless_already_present(keywords));
+        }
+
+        None
     }
 
     /// Returns the expected type when the cursor sits inside
@@ -7978,6 +8107,21 @@ match status:
     }
 
     #[test]
+    fn no_contextual_keywords_inside_parentheses() {
+        for (source, unexpected) in [("for (foo <CURSOR>) in items: pass", "in")] {
+            let builder = completion_test_builder(source);
+            assert!(
+                builder
+                    .build()
+                    .completions()
+                    .iter()
+                    .all(|completion| completion.name != unexpected),
+                "Expected completions for `{source}` to not include `{unexpected}`",
+            );
+        }
+    }
+
+    #[test]
     fn no_completions_in_empty_for_variable_binding() {
         let builder = completion_test_builder(
             "\
@@ -8001,6 +8145,45 @@ for foo<CURSOR>
             builder.build().snapshot(),
             @"<No completions found>",
         );
+    }
+
+    #[test]
+    fn for_target_suggests_in() {
+        for source in [
+            "for foo <CURSOR>",
+            "for foo i<CURSOR>",
+            "for foo in<CURSOR>",
+            "for (foo) <CURSOR>",
+            "for foo \\\n    <CURSOR>",
+        ] {
+            assert_eq!(completion_test_builder(source).build().snapshot(), "in");
+        }
+    }
+
+    #[test]
+    fn comprehension_target_suggests_in() {
+        for source in [
+            "[x for x <CURSOR>]",
+            "(x for x <CURSOR>)",
+            "{x for x <CURSOR>}",
+            "{x: x for x <CURSOR>}",
+            "[x async for x <CURSOR>]",
+        ] {
+            assert_eq!(completion_test_builder(source).build().snapshot(), "in");
+        }
+    }
+
+    #[test]
+    fn no_completions_before_existing_contextual_keyword() {
+        for source in [
+            "for foo <CURSOR>in items: pass",
+            "[foo for foo <CURSOR>in items]",
+        ] {
+            assert_eq!(
+                completion_test_builder(source).build().snapshot(),
+                "<No completions found>"
+            );
+        }
     }
 
     #[test]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1075,6 +1075,8 @@ impl<'m> ContextCursor<'m> {
     fn incomplete_keywords(&self) -> Option<&'static [&'static str]> {
         const IN: &[&str] = &["in"];
         const AS: &[&str] = &["as"];
+        const IF: &[&str] = &["if"];
+        const MATCH: &[&str] = &["as", "if"];
 
         let preceding_token = |keyword: &str| {
             let (tokens, start) = match self.typed {
@@ -1140,6 +1142,43 @@ impl<'m> ContextCursor<'m> {
                         })
                     }
                     _ => None,
+                })
+        {
+            return Some(self.unless_already_present(keywords));
+        }
+
+        if let Some(token) = preceding_token("as").or_else(|| preceding_token("if"))
+            && let Some(keywords) = self
+                .covering_node(token.range())
+                .ancestors()
+                .find_map(|node| {
+                    let ast::AnyNodeRef::MatchCase(case) = node else {
+                        return None;
+                    };
+                    match &case.pattern {
+                        ast::Pattern::MatchAs(ast::PatternMatchAs {
+                            pattern: Some(pattern),
+                            name: Some(name),
+                            ..
+                        }) => {
+                            if name.is_valid()
+                                && let Some(keywords) = self.keywords_after_range(
+                                    case.pattern.range(),
+                                    node,
+                                    token,
+                                    IF,
+                                    &[],
+                                )
+                            {
+                                Some(keywords)
+                            } else {
+                                self.keywords_after_range(pattern.range(), node, token, MATCH, AS)
+                            }
+                        }
+                        pattern => {
+                            self.keywords_after_range(pattern.range(), node, token, MATCH, AS)
+                        }
+                    }
                 })
         {
             return Some(self.unless_already_present(keywords));
@@ -8168,6 +8207,59 @@ match status:
     }
 
     #[test]
+    fn match_pattern_suggests_keywords() {
+        for (source, expected) in [
+            (
+                "\
+match status:
+    case 400 <CURSOR>",
+                "as\nif",
+            ),
+            (
+                "\
+match status:
+    case 400 a<CURSOR>",
+                "as",
+            ),
+            (
+                "\
+match status:
+    case 400 i<CURSOR>",
+                "if",
+            ),
+            (
+                "\
+match status:
+    case (400) <CURSOR>",
+                "as\nif",
+            ),
+            (
+                "\
+match status:
+    case (400 <CURSOR>)",
+                "as",
+            ),
+            (
+                "\
+match status:
+    case (
+        400  # comment
+        <CURSOR>
+    )",
+                "as",
+            ),
+            (
+                "\
+match status:
+    case 400 as value <CURSOR>",
+                "if",
+            ),
+        ] {
+            assert_eq!(completion_test_builder(source).build().snapshot(), expected);
+        }
+    }
+
+    #[test]
     fn no_contextual_keywords_inside_parentheses() {
         for (source, unexpected) in [
             ("for (foo <CURSOR>) in items: pass", "in"),
@@ -8175,6 +8267,11 @@ match status:
             (
                 "try:\n    pass\nexcept (ValueError <CURSOR>) as error: pass",
                 "as",
+            ),
+            ("match status:\n    case (400 <CURSOR>): pass", "if"),
+            (
+                "match status:\n    case (400 as value <CURSOR>): pass",
+                "if",
             ),
         ] {
             let builder = completion_test_builder(source);
@@ -8248,6 +8345,8 @@ for foo<CURSOR>
             "[foo for foo <CURSOR>in items]",
             "with open('bar') <CURSOR>as file: pass",
             "try:\n    pass\nexcept ValueError <CURSOR>as error: pass",
+            "match status:\n    case 400 <CURSOR>as value: pass",
+            "match status:\n    case 400 <CURSOR>if condition: pass",
         ] {
             assert_eq!(
                 completion_test_builder(source).build().snapshot(),

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -69,7 +69,7 @@ pub fn completion<'db>(
     );
     match context.kind {
         ContextKind::Keywords(keywords) => {
-            for keyword in keywords.iter() {
+            for &keyword in keywords {
                 completions
                     .add(CompletionBuilder::keyword(keyword.as_str()).context_specific(true));
             }
@@ -660,24 +660,9 @@ struct Context<'m> {
 
 #[derive(Debug)]
 enum ContextKind<'m> {
-    Keywords(ContextualKeywords),
+    Keywords(&'static [ContextualKeyword]),
     Import(ImportStatement<'m>),
     NonImport(ContextNonImport<'m>),
-}
-
-#[derive(Debug)]
-struct ContextualKeywords {
-    candidates: &'static [ContextualKeyword],
-    following_token: Option<TokenKind>,
-}
-
-impl ContextualKeywords {
-    fn iter(&self) -> impl Iterator<Item = ContextualKeyword> + '_ {
-        self.candidates
-            .iter()
-            .copied()
-            .filter(|keyword| Some(keyword.token_kind()) != self.following_token)
-    }
 }
 
 /// A Python keyword offered only when it is valid in the incomplete syntax at the cursor.
@@ -1138,29 +1123,34 @@ impl<'m> ContextCursor<'m> {
         None
     }
 
-    /// Excludes a candidate if it is already the next non-trivia token.
-    fn without_already_present(
+    /// Returns only the candidates that can precede an already present contextual keyword.
+    ///
+    /// `candidates` must be ordered as the keywords can appear in source.
+    fn before_already_present(
         &self,
         candidates: &'static [ContextualKeyword],
-    ) -> ContextualKeywords {
-        let following_token = if self
+    ) -> &'static [ContextualKeyword] {
+        if self
             .tokens_before
             .last()
             .is_some_and(|token| token.end() > self.offset)
         {
-            None
-        } else {
-            self.parsed
-                .tokens()
-                .after(self.offset)
-                .iter()
-                .find(|token| !token.kind().is_trivia())
-                .map(Token::kind)
-        };
-        ContextualKeywords {
-            candidates,
-            following_token,
+            return candidates;
         }
+
+        let Some(next) = self
+            .parsed
+            .tokens()
+            .after(self.offset)
+            .iter()
+            .find(|token| !token.kind().is_trivia())
+        else {
+            return candidates;
+        };
+        candidates
+            .iter()
+            .position(|keyword| keyword.token_kind() == next.kind())
+            .map_or(candidates, |position| &candidates[..position])
     }
 
     /// Returns keywords when the cursor follows syntax that can only be
@@ -1168,7 +1158,7 @@ impl<'m> ContextCursor<'m> {
     ///
     /// This first identifies keywords compatible with the typed prefix, then finds the
     /// complete token immediately before the cursor, and finally checks its enclosing syntax.
-    fn incomplete_keywords(&self) -> Option<ContextualKeywords> {
+    fn incomplete_keywords(&self) -> Option<&'static [ContextualKeyword]> {
         const IN: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::In);
         const AS: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::As);
         const IF: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::If);
@@ -1230,7 +1220,7 @@ impl<'m> ContextCursor<'m> {
                 _ => None,
             })
         {
-            return Some(self.without_already_present(keywords));
+            return Some(self.before_already_present(keywords));
         }
 
         // Context managers and exception types can be followed by `as`.
@@ -1250,7 +1240,7 @@ impl<'m> ContextCursor<'m> {
                 _ => None,
             })
         {
-            return Some(self.without_already_present(keywords));
+            return Some(self.before_already_present(keywords));
         }
 
         // Match patterns can be followed by `as` or `if`; an existing alias can only be
@@ -1282,7 +1272,7 @@ impl<'m> ContextCursor<'m> {
                 }
             })
         {
-            return Some(self.without_already_present(keywords));
+            return Some(self.before_already_present(keywords));
         }
 
         None
@@ -8337,12 +8327,6 @@ match status:
             (
                 "\
 match status:
-    case 400 <CURSOR> as value",
-                "if",
-            ),
-            (
-                "\
-match status:
     case (400) <CURSOR>",
                 "as\nif",
             ),
@@ -8464,6 +8448,7 @@ for foo<CURSOR>
             "[foo for foo <CURSOR>in items]",
             "with open('bar') <CURSOR>as file: pass",
             "try:\n    pass\nexcept ValueError <CURSOR>as error: pass",
+            "match status:\n    case 400 <CURSOR>as value: pass",
         ] {
             assert_eq!(
                 completion_test_builder(source).build().snapshot(),

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1032,8 +1032,12 @@ impl<'m> ContextCursor<'m> {
         })
     }
 
-    /// Returns the last closing parenthesis surrounding `range`, if any.
-    fn closing_parenthesis(&self, range: TextRange, parent: AnyNodeRef) -> Option<&Token> {
+    /// Returns the paired closing parentheses surrounding `range`.
+    fn closing_parentheses(
+        &self,
+        range: TextRange,
+        parent: AnyNodeRef,
+    ) -> impl Iterator<Item = &Token> {
         let right_parentheses = self
             .parsed
             .tokens()
@@ -1052,7 +1056,6 @@ impl<'m> ContextCursor<'m> {
 
         right_parentheses
             .zip(left_parentheses)
-            .last()
             .map(|(right, _)| right)
     }
 
@@ -1064,12 +1067,26 @@ impl<'m> ContextCursor<'m> {
         token: &Token,
     ) -> Option<RangeEndPosition> {
         let range_ends_at_token = range.contains_range(token.range()) && range.end() == token.end();
-        match self.closing_parenthesis(range, parent) {
-            Some(right) if right.range() == token.range() => Some(RangeEndPosition::After),
-            Some(_) if range_ends_at_token => Some(RangeEndPosition::InsideParentheses),
-            None if range_ends_at_token => Some(RangeEndPosition::After),
-            _ => None,
+        let mut closing_parentheses = self.closing_parentheses(range, parent).peekable();
+        let position = |inside_parentheses| {
+            if inside_parentheses {
+                RangeEndPosition::InsideParentheses
+            } else {
+                RangeEndPosition::After
+            }
+        };
+
+        if range_ends_at_token {
+            return Some(position(closing_parentheses.peek().is_some()));
         }
+
+        while let Some(right) = closing_parentheses.next() {
+            if right.range() == token.range() {
+                return Some(position(closing_parentheses.peek().is_some()));
+            }
+        }
+
+        None
     }
 
     /// Returns no keywords if one of `keywords` is already the next non-trivia token.
@@ -8258,6 +8275,12 @@ match status:
                 "\
 match status:
     case (400 <CURSOR>)",
+                "as",
+            ),
+            (
+                "\
+match status:
+    case ((400) <CURSOR>)",
                 "as",
             ),
             (

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1101,107 +1101,106 @@ impl<'m> ContextCursor<'m> {
     /// Returns keywords when the cursor follows syntax that can only be
     /// continued by those keywords.
     fn incomplete_keywords(&self) -> Option<&'static [&'static str]> {
-        const IN: &[&str] = &["in"];
-        const AS: &[&str] = &["as"];
-        const IF: &[&str] = &["if"];
+        const IN: &[&str] = std::slice::from_ref(&"in");
+        const AS: &[&str] = std::slice::from_ref(&"as");
+        const IF: &[&str] = std::slice::from_ref(&"if");
         const MATCH: &[&str] = &["as", "if"];
         const NONE: &[&str] = &[];
 
-        let preceding_token = |keyword: &str| {
-            let (tokens, start) = match self.typed {
-                Some(typed) if keyword.starts_with(typed) => (
-                    self.tokens_before.get(..self.tokens_before.len() - 1)?,
-                    self.range.start(),
-                ),
-                Some(_) => return None,
-                None => (self.tokens_before, self.offset),
-            };
-            let token = tokens
-                .iter()
-                .rev()
-                .find(|token| !token.kind().is_trivia())?;
-            if token.kind() == TokenKind::Newline
-                || token.end() >= start
-                || self
-                    .parsed
-                    .tokens()
-                    .in_range(TextRange::new(token.end(), start))
-                    .iter()
-                    .any(|token| !token.kind().is_trivia())
-            {
-                return None;
-            }
-            Some(token)
+        let typed_matches = |keywords: &[&str]| {
+            self.typed
+                .is_none_or(|typed| keywords.iter().any(|keyword| keyword.starts_with(typed)))
         };
+        let matches_in = typed_matches(IN);
+        let matches_as = typed_matches(AS);
+        let matches_if = typed_matches(IF);
+        if !matches_in && !matches_as && !matches_if {
+            return None;
+        }
 
-        if let Some(token) = preceding_token("in")
-            && let Some(keywords) = self
-                .covering_node(token.range())
-                .ancestors()
-                .find_map(|node| match node {
-                    ast::AnyNodeRef::StmtFor(stmt) => self
-                        .range_end_position(stmt.target.range(), node, token)
-                        .map(|position| position.select_keywords(IN, NONE)),
-                    ast::AnyNodeRef::Comprehension(comprehension) => self
-                        .range_end_position(comprehension.target.range(), node, token)
-                        .map(|position| position.select_keywords(IN, NONE)),
-                    _ => None,
-                })
+        let (tokens, start) = match self.typed {
+            Some(_) => (
+                self.tokens_before.get(..self.tokens_before.len() - 1)?,
+                self.range.start(),
+            ),
+            None => (self.tokens_before, self.offset),
+        };
+        let token = tokens
+            .iter()
+            .rev()
+            .find(|token| !token.kind().is_trivia())?;
+        if token.kind() == TokenKind::Newline
+            || token.end() >= start
+            || self
+                .parsed
+                .tokens()
+                .in_range(TextRange::new(token.end(), start))
+                .iter()
+                .any(|token| !token.kind().is_trivia())
+        {
+            return None;
+        }
+        let covering_node = self.covering_node(token.range());
+
+        if matches_in
+            && let Some(keywords) = covering_node.ancestors().find_map(|node| match node {
+                ast::AnyNodeRef::StmtFor(stmt) => self
+                    .range_end_position(stmt.target.range(), node, token)
+                    .map(|position| position.select_keywords(IN, NONE)),
+                ast::AnyNodeRef::Comprehension(comprehension) => self
+                    .range_end_position(comprehension.target.range(), node, token)
+                    .map(|position| position.select_keywords(IN, NONE)),
+                _ => None,
+            })
         {
             return Some(self.unless_already_present(keywords));
         }
 
-        if let Some(token) = preceding_token("as")
-            && let Some(keywords) = self
-                .covering_node(token.range())
-                .ancestors()
-                .find_map(|node| match node {
-                    ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
-                        let range = item.context_expr.range();
-                        self.range_end_position(range, item.into(), token)
-                            .map(|position| position.select_keywords(AS, NONE))
-                            .or_else(|| self.range_end_position(range, node, token).map(|_| AS))
-                    }),
-                    ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => handler
-                        .type_
-                        .as_deref()
-                        .and_then(|type_| self.range_end_position(type_.range(), node, token))
-                        .map(|position| position.select_keywords(AS, NONE)),
-                    _ => None,
-                })
+        if matches_as
+            && let Some(keywords) = covering_node.ancestors().find_map(|node| match node {
+                ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
+                    let range = item.context_expr.range();
+                    self.range_end_position(range, item.into(), token)
+                        .map(|position| position.select_keywords(AS, NONE))
+                        .or_else(|| self.range_end_position(range, node, token).map(|_| AS))
+                }),
+                ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => handler
+                    .type_
+                    .as_deref()
+                    .and_then(|type_| self.range_end_position(type_.range(), node, token))
+                    .map(|position| position.select_keywords(AS, NONE)),
+                _ => None,
+            })
         {
             return Some(self.unless_already_present(keywords));
         }
 
-        if let Some(token) = preceding_token("as").or_else(|| preceding_token("if"))
-            && let Some(keywords) = self
-                .covering_node(token.range())
-                .ancestors()
-                .find_map(|node| {
-                    let ast::AnyNodeRef::MatchCase(case) = node else {
-                        return None;
-                    };
-                    match &case.pattern {
-                        ast::Pattern::MatchAs(ast::PatternMatchAs {
-                            pattern: Some(pattern),
-                            name: Some(name),
-                            ..
-                        }) => {
-                            if name.is_valid()
-                                && let Some(position) =
-                                    self.range_end_position(case.pattern.range(), node, token)
-                            {
-                                Some(position.select_keywords(IF, NONE))
-                            } else {
-                                self.range_end_position(pattern.range(), node, token)
-                                    .map(|position| position.select_keywords(MATCH, AS))
-                            }
+        if (matches_as || matches_if)
+            && let Some(keywords) = covering_node.ancestors().find_map(|node| {
+                let ast::AnyNodeRef::MatchCase(case) = node else {
+                    return None;
+                };
+                match &case.pattern {
+                    ast::Pattern::MatchAs(ast::PatternMatchAs {
+                        pattern: Some(pattern),
+                        name: Some(name),
+                        ..
+                    }) => {
+                        if name.is_valid()
+                            && let Some(position) =
+                                self.range_end_position(case.pattern.range(), node, token)
+                        {
+                            Some(position.select_keywords(IF, NONE))
+                        } else {
+                            self.range_end_position(pattern.range(), node, token)
+                                .map(|position| position.select_keywords(MATCH, AS))
                         }
-                        pattern => self
-                            .range_end_position(pattern.range(), node, token)
-                            .map(|position| position.select_keywords(MATCH, AS)),
                     }
-                })
+                    pattern => self
+                        .range_end_position(pattern.range(), node, token)
+                        .map(|position| position.select_keywords(MATCH, AS)),
+                }
+            })
         {
             return Some(self.unless_already_present(keywords));
         }

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -70,7 +70,8 @@ pub fn completion<'db>(
     match context.kind {
         ContextKind::Keywords(keywords) => {
             for &keyword in keywords {
-                completions.add(CompletionBuilder::keyword(keyword).context_specific(true));
+                completions
+                    .add(CompletionBuilder::keyword(keyword.as_str()).context_specific(true));
             }
         }
         ContextKind::Import(ref import) => {
@@ -659,9 +660,42 @@ struct Context<'m> {
 
 #[derive(Debug)]
 enum ContextKind<'m> {
-    Keywords(&'static [&'static str]),
+    Keywords(&'static [ContextualKeyword]),
     Import(ImportStatement<'m>),
     NonImport(ContextNonImport<'m>),
+}
+
+/// A Python keyword offered only when it is valid in the incomplete syntax at the cursor.
+///
+/// ```python
+/// for item <CURSOR>          # `in`
+/// with resource <CURSOR>     # `as`
+/// match value:
+///     case pattern <CURSOR>  # `as` or `if`
+/// ```
+#[derive(Clone, Copy, Debug)]
+enum ContextualKeyword {
+    As,
+    If,
+    In,
+}
+
+impl ContextualKeyword {
+    const fn as_str(self) -> &'static str {
+        match self {
+            ContextualKeyword::As => "as",
+            ContextualKeyword::If => "if",
+            ContextualKeyword::In => "in",
+        }
+    }
+
+    const fn token_kind(self) -> TokenKind {
+        match self {
+            ContextualKeyword::As => TokenKind::As,
+            ContextualKeyword::If => TokenKind::If,
+            ContextualKeyword::In => TokenKind::In,
+        }
+    }
 }
 
 /// Context for non-import completions.
@@ -790,9 +824,9 @@ impl RangeEndPosition {
     /// ```
     fn select_keywords(
         self,
-        after: &'static [&'static str],
-        inside_parentheses: &'static [&'static str],
-    ) -> &'static [&'static str] {
+        after: &'static [ContextualKeyword],
+        inside_parentheses: &'static [ContextualKeyword],
+    ) -> &'static [ContextualKeyword] {
         match self {
             RangeEndPosition::After => after,
             RangeEndPosition::InsideParentheses => inside_parentheses,
@@ -1032,7 +1066,7 @@ impl<'m> ContextCursor<'m> {
         })
     }
 
-    /// Returns the paired closing parentheses surrounding `range`.
+    /// Returns the paired closing parentheses surrounding `range`, from innermost to outermost.
     fn closing_parentheses(
         &self,
         range: TextRange,
@@ -1090,7 +1124,10 @@ impl<'m> ContextCursor<'m> {
     }
 
     /// Returns no keywords if one of `keywords` is already the next non-trivia token.
-    fn unless_already_present(&self, keywords: &'static [&'static str]) -> &'static [&'static str] {
+    fn unless_already_present(
+        &self,
+        keywords: &'static [ContextualKeyword],
+    ) -> &'static [ContextualKeyword] {
         if self
             .tokens_before
             .last()
@@ -1108,7 +1145,10 @@ impl<'m> ContextCursor<'m> {
         else {
             return keywords;
         };
-        if keywords.contains(&&self.source[next.range()]) {
+        if keywords
+            .iter()
+            .any(|keyword| keyword.token_kind() == next.kind())
+        {
             &[]
         } else {
             keywords
@@ -1117,16 +1157,19 @@ impl<'m> ContextCursor<'m> {
 
     /// Returns keywords when the cursor follows syntax that can only be
     /// continued by those keywords.
-    fn incomplete_keywords(&self) -> Option<&'static [&'static str]> {
-        const IN: &[&str] = std::slice::from_ref(&"in");
-        const AS: &[&str] = std::slice::from_ref(&"as");
-        const IF: &[&str] = std::slice::from_ref(&"if");
-        const MATCH: &[&str] = &["as", "if"];
-        const NONE: &[&str] = &[];
+    fn incomplete_keywords(&self) -> Option<&'static [ContextualKeyword]> {
+        const IN: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::In);
+        const AS: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::As);
+        const IF: &[ContextualKeyword] = std::slice::from_ref(&ContextualKeyword::If);
+        const MATCH: &[ContextualKeyword] = &[ContextualKeyword::As, ContextualKeyword::If];
+        const NONE: &[ContextualKeyword] = &[];
 
-        let typed_matches = |keywords: &[&str]| {
-            self.typed
-                .is_none_or(|typed| keywords.iter().any(|keyword| keyword.starts_with(typed)))
+        let typed_matches = |keywords: &[ContextualKeyword]| {
+            self.typed.is_none_or(|typed| {
+                keywords
+                    .iter()
+                    .any(|keyword| keyword.as_str().starts_with(typed))
+            })
         };
         let matches_in = typed_matches(IN);
         let matches_as = typed_matches(AS);

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -1074,6 +1074,7 @@ impl<'m> ContextCursor<'m> {
     /// continued by those keywords.
     fn incomplete_keywords(&self) -> Option<&'static [&'static str]> {
         const IN: &[&str] = &["in"];
+        const AS: &[&str] = &["as"];
 
         let preceding_token = |keyword: &str| {
             let (tokens, start) = match self.typed {
@@ -1117,6 +1118,27 @@ impl<'m> ContextCursor<'m> {
                         IN,
                         &[],
                     ),
+                    _ => None,
+                })
+        {
+            return Some(self.unless_already_present(keywords));
+        }
+
+        if let Some(token) = preceding_token("as")
+            && let Some(keywords) = self
+                .covering_node(token.range())
+                .ancestors()
+                .find_map(|node| match node {
+                    ast::AnyNodeRef::StmtWith(stmt) => stmt.items.iter().find_map(|item| {
+                        let range = item.context_expr.range();
+                        self.keywords_after_range(range, item.into(), token, AS, &[])
+                            .or_else(|| self.keywords_after_range(range, node, token, AS, AS))
+                    }),
+                    ast::AnyNodeRef::ExceptHandlerExceptHandler(handler) => {
+                        handler.type_.as_deref().and_then(|type_| {
+                            self.keywords_after_range(type_.range(), node, token, AS, &[])
+                        })
+                    }
                     _ => None,
                 })
         {
@@ -8058,6 +8080,20 @@ with open('bar') as f<CURSOR>
     }
 
     #[test]
+    fn with_item_suggests_as() {
+        for source in [
+            "with open('bar') <CURSOR>",
+            "with open('bar') a<CURSOR>",
+            "with (open('bar')) <CURSOR>",
+            "with (open('bar') <CURSOR>)",
+            "with (\n    open('bar')  # comment\n    <CURSOR>\n)",
+            "with open('bar') \\\n    <CURSOR>",
+        ] {
+            assert_eq!(completion_test_builder(source).build().snapshot(), "as");
+        }
+    }
+
+    #[test]
     fn no_completions_in_except_alias() {
         let builder = completion_test_builder(
             "\
@@ -8071,6 +8107,31 @@ except IndexError as f<CURSOR>
             builder.build().snapshot(),
             @"<No completions found>",
         );
+    }
+
+    #[test]
+    fn except_handler_suggests_as() {
+        for source in [
+            "\
+try:
+    pass
+except ValueError <CURSOR>",
+            "\
+try:
+    pass
+except ValueError a<CURSOR>",
+            "\
+try:
+    pass
+except (ValueError) <CURSOR>",
+            "\
+try:
+    pass
+except ValueError \\
+    <CURSOR>",
+        ] {
+            assert_eq!(completion_test_builder(source).build().snapshot(), "as");
+        }
     }
 
     #[test]
@@ -8108,7 +8169,14 @@ match status:
 
     #[test]
     fn no_contextual_keywords_inside_parentheses() {
-        for (source, unexpected) in [("for (foo <CURSOR>) in items: pass", "in")] {
+        for (source, unexpected) in [
+            ("for (foo <CURSOR>) in items: pass", "in"),
+            ("with ((open() <CURSOR>)): pass", "as"),
+            (
+                "try:\n    pass\nexcept (ValueError <CURSOR>) as error: pass",
+                "as",
+            ),
+        ] {
             let builder = completion_test_builder(source);
             assert!(
                 builder
@@ -8178,6 +8246,8 @@ for foo<CURSOR>
         for source in [
             "for foo <CURSOR>in items: pass",
             "[foo for foo <CURSOR>in items]",
+            "with open('bar') <CURSOR>as file: pass",
+            "try:\n    pass\nexcept ValueError <CURSOR>as error: pass",
         ] {
             assert_eq!(
                 completion_test_builder(source).build().snapshot(),


### PR DESCRIPTION
## Summary

When a statement or pattern is missing a contextual keyword, completion currently falls back to the broad scoped list. For example:

```python
for item <CURSOR>
with open(path) <CURSOR>
match status:
    case 400 <CURSOR>
```

This adds an exclusive contextual-keyword completion path. We now suggest `in` after `for` and comprehension targets, `as` after `with` items and exception types, and `as` or `if` after match patterns. Partial prefixes such as `i<CURSOR>` and `a<CURSOR>` receive the same focused results.

The detector combines recovered AST ranges with token trivia so parenthesized operands, explicit and implicit continuations, comments, existing keywords, grouped `with` items, and aliased match patterns follow Python's keyword-placement rules without broad or duplicate completions.

Closes https://github.com/astral-sh/ty/issues/1568.
