### PR TITLE
[ty] Use simulation runners for module resolution benchmarks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1111,7 +1111,7 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -m simulation -m memory --features "codspeed,ty_instrumented" --profile profiling --no-default-features -p ruff_benchmark --bench ty
+        run: cargo codspeed build -m simulation -m memory --features "codspeed,module_resolution,ty_instrumented" --profile profiling --no-default-features -p ruff_benchmark --bench module_resolution --bench ty
 
       - name: "Upload benchmark binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1123,7 +1123,7 @@ jobs:
           retention-days: 1
 
   benchmarks-instrumented-ty-run:
-    name: "benchmarks instrumented ty (${{matrix.mode}}: ${{ matrix.benchmark }})"
+    name: "benchmarks instrumented ty (${{ matrix.mode }}: ${{ matrix.name }})"
     runs-on: ubuntu-24.04
     needs: benchmarks-instrumented-ty-build
     timeout-minutes: 20
@@ -1133,12 +1133,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        benchmark:
-          - micro
-          - "check_file|anyio|attrs|hydra|datetype"
-        mode:
-          - simulation
-          - memory
+        include:
+          - name: micro
+            target: ty
+            filter: micro
+            mode: simulation
+          - name: micro
+            target: ty
+            filter: micro
+            mode: memory
+          - name: projects
+            target: ty
+            filter: "check_file|anyio|attrs|hydra|datetype"
+            mode: simulation
+          - name: projects
+            target: ty
+            filter: "check_file|anyio|attrs|hydra|datetype"
+            mode: memory
+          - name: module_resolution
+            target: module_resolution
+            filter: ty_module_resolver
+            mode: simulation
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1167,7 +1182,7 @@ jobs:
         uses: CodSpeedHQ/action@9d332c4d90b43981c3e55ae8e38e68709996240f # v4.17.0
         with:
           mode: ${{ matrix.mode }}
-          run: cargo codspeed run --bench ty "${{ matrix.benchmark }}"
+          run: cargo codspeed run --bench "${{ matrix.target }}" "${{ matrix.filter }}"
 
   benchmarks-walltime-build:
     name: "benchmarks walltime (build)"
@@ -1208,7 +1223,7 @@ jobs:
           tool: cargo-codspeed
 
       - name: "Build benchmarks"
-        run: cargo codspeed build -m walltime --features "codspeed,module_resolution,ty_walltime" --profile profiling --no-default-features -p ruff_benchmark --bench module_resolution --bench ty_walltime
+        run: cargo codspeed build -m walltime --features "codspeed,ty_walltime" --profile profiling --no-default-features -p ruff_benchmark --bench ty_walltime
 
       - name: "Upload benchmark binary"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1242,9 +1257,6 @@ jobs:
           - name: "pydantic|freqtrade|multithreaded|altair"
             target: ty_walltime
             filter: "pydantic|freqtrade|multithreaded|altair"
-          - name: module_resolution
-            target: module_resolution
-            filter: ty_module_resolver
     steps:
       - name: "Checkout Branch"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -90,14 +90,9 @@ fn setup_case(n: usize) -> Case {
 fn ty_module_resolver<const PATHS: usize>(bencher: Bencher) {
     bencher
         .with_inputs(|| setup_case(PATHS))
-        .bench_local_values(|case| {
-            let Case {
-                db,
-                importing_file,
-                resolves,
-            } = case;
-            for name in &resolves {
-                black_box(resolve_module(&db, importing_file, name));
+        .bench_local_refs(|case| {
+            for name in &case.resolves {
+                black_box(resolve_module(&case.db, case.importing_file, name));
             }
         });
 }


### PR DESCRIPTION
## Summary

...and ensure that `Db` teardown is not part of the benchmark. 

We can use simulation runners because the benchmark uses the `TestSystem`, we don't perform any real IO.

Hopefully, this will help to reduce the flakiness.

