### PR TITLE
Fix misleading SIM107 "Use instead" example

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
+++ b/crates/ruff_linter/src/rules/flake8_simplify/rules/return_in_try_except_finally.rs
@@ -34,7 +34,7 @@ use crate::checkers::ast::Checker;
 ///     except Exception:
 ///         return_value = "An exception occurred"
 ///     finally:
-///         return_value = -1
+///         print("Done")  # Cleanup runs without overwriting the return value.
 ///     return return_value
 /// ```
 ///


### PR DESCRIPTION
The "Use instead" example for SIM107 (return-in-try-except-finally) assigned `return_value = -1` in the `finally` block, which overwrites the value from the `try`/`except` arms. The function therefore always returned `-1` — the same footgun the rule is meant to warn against.

This updates the `finally` block to perform a genuine cleanup side effect instead, so the example returns the computed value while still showing a valid use of `finally` (matching the rule's cited "Defining Clean-up Actions" reference).

Closes #22325