### PR TITLE
[ty] Chunk indexed AST node storage

### DIFF
--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -745,18 +745,33 @@ class C[T](Base, metaclass=Meta):
             )
             .expect("test source should parse");
             let indexed = IndexedModule::new(parsed);
+            let mut visitor = Visitor {
+                nodes: Some(CollectedNodes::default()),
+                index: 0,
+                max_index: MAX_REAL_INDEX,
+                overflowed: false,
+            };
+            AnyNodeRef::from(indexed.parsed.syntax()).visit_source_order(&mut visitor);
+            let CollectedNodes { addresses, kinds } = visitor
+                .nodes
+                .expect("test visitor should collect indexed nodes");
 
-            let node_count = u32::try_from(indexed.index.len())
-                .expect("number of indexed nodes should fit in u32");
+            assert_eq!(indexed.index.len(), addresses.len());
             let mut seen_kinds = [false; 1 << IndexedNodes::KIND_BITS];
 
-            for raw_index in 0..node_count {
-                let index = NodeIndex::from(raw_index);
-                let (_, kind) = indexed.index.get(raw_index as usize);
+            for (raw_index, (address, kind)) in addresses.into_iter().zip(kinds).enumerate() {
+                let index = NodeIndex::from(
+                    u32::try_from(raw_index).expect("node index should fit in u32"),
+                );
                 seen_kinds[usize::from(kind as u8)] = true;
-                assert_eq!(indexed.get_by_index(index).node_index().load(), index);
-            }
+                assert_eq!(indexed.index.get(raw_index), (address, kind));
 
+                let node = indexed.get_by_index(index);
+                let (actual_kind, actual_pointer) = node.into_raw_parts();
+                assert_eq!(actual_kind, kind);
+                assert_eq!(actual_pointer.as_ptr().expose_provenance(), address);
+                assert_eq!(node.node_index().load(), index);
+            }
             for kind in RootNodeKind::ALL {
                 let is_indexed = !matches!(
                     kind,
@@ -764,51 +779,6 @@ class C[T](Base, metaclass=Meta):
                 );
                 assert_eq!(seen_kinds[usize::from(*kind as u8)], is_indexed);
             }
-        }
-
-        #[test]
-        fn indexed_node_storage_layouts() {
-            let alignment = IndexedNodes::ALIGNMENT;
-            let chunk_distance = 1usize << (usize::BITS - 3);
-            let addresses: Vec<_> = (0..130)
-                .map(|index| {
-                    0x1000
-                        + (index / IndexedNodes::CHUNK_LEN) * chunk_distance
-                        + (index % IndexedNodes::CHUNK_LEN) * alignment
-                })
-                .collect();
-            let kinds: Vec<_> = (0..addresses.len())
-                .map(|index| {
-                    if index.is_multiple_of(2) {
-                        RootNodeKind::Stmt
-                    } else {
-                        RootNodeKind::Identifier
-                    }
-                })
-                .collect();
-            let chunked = IndexedNodes::from_collected(CollectedNodes {
-                addresses: addresses.clone(),
-                kinds: kinds.clone(),
-            });
-
-            assert_eq!(chunked.chunks.len(), 3);
-            assert!(
-                chunked
-                    .chunks
-                    .iter()
-                    .all(|chunk| matches!(chunk.layout, IndexChunkLayout::Relative))
-            );
-            for (index, (&address, &kind)) in addresses.iter().zip(&kinds).enumerate() {
-                assert_eq!(chunked.get(index), (address, kind));
-            }
-
-            let wide = IndexedNodes::from_collected(CollectedNodes {
-                addresses: vec![0x1000, 0x1001],
-                kinds: vec![RootNodeKind::Stmt, RootNodeKind::Identifier],
-            });
-            assert!(matches!(wide.chunks[0].layout, IndexChunkLayout::Wide));
-            assert_eq!(wide.get(0), (0x1000, RootNodeKind::Stmt));
-            assert_eq!(wide.get(1), (0x1001, RootNodeKind::Identifier));
         }
     }
 }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -224,6 +224,15 @@ mod indexed {
     /// a fat pointer per node. Entries are divided into fixed-size chunks so that unrelated AST
     /// allocations do not force every node into a wider representation. Each chunk starts on a
     /// word boundary in `words`.
+    ///
+    /// # Safety invariant
+    ///
+    /// Every entry preserves the exact exposed address and [`RootNodeKind`] obtained from the same
+    /// [`AnyRootNodeRef`]. Relative entries use lossless address arithmetic and wide entries store
+    /// the full address. The parsed AST is placed in its final [`Arc`] before those addresses are
+    /// collected. Installing the completed index does not move or mutate the parsed AST, and no
+    /// API moves, replaces, or mutably exposes it while the index exists. Lookups pair each stored
+    /// address with `NonNull::with_exposed_provenance` and its original kind.
     #[derive(Debug, Default, get_size2::GetSize)]
     struct IndexedNodes {
         chunks: Box<[IndexChunk]>,
@@ -474,9 +483,10 @@ mod indexed {
             let nodes = visitor
                 .nodes
                 .expect("top-level AST visitor should collect indexed nodes");
+            let index = IndexedNodes::from_collected(nodes);
             Arc::get_mut(&mut inner)
                 .expect("newly created indexed module should have a unique Arc")
-                .index = IndexedNodes::from_collected(nodes);
+                .index = index;
 
             inner
         }
@@ -490,8 +500,9 @@ mod indexed {
             let index = index as usize;
             let (address, kind) = self.index.get(index);
 
-            // SAFETY: `kind` and `address` were recorded from the same node, and the node is owned
-            // by `self.parsed`, so it lives for as long as this borrow of `self`.
+            // SAFETY: By the `IndexedNodes` safety invariant, this is the exact exposed address and
+            // root-node kind recorded from the same node after `parsed` reached its stable address.
+            // `self` keeps the AST alive and immutable for the returned reference's lifetime.
             unsafe {
                 AnyRootNodeRef::from_raw_parts(
                     kind,

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -218,124 +218,182 @@ mod indexed {
         pub parsed: Parsed<ModModule>,
     }
 
+    #[derive(Debug, Default, get_size2::GetSize)]
+    struct IndexedNodes {
+        /// Fixed-size chunks make lookup O(1) while allowing each region of the AST to use the
+        /// smallest entry width that can represent its addresses.
+        chunks: Box<[IndexChunk]>,
+        words: Box<[u64]>,
+    }
+
     #[derive(Debug, get_size2::GetSize)]
-    enum IndexedNodes {
-        /// The node kind is stored in the low bits and the scaled address offset in the high bits.
-        Packed { base: usize, entries: Box<[u32]> },
-        Split {
-            base: usize,
-            offsets: Box<[u32]>,
-            kinds: Box<[RootNodeKind]>,
-        },
-        Wide {
-            addresses: Box<[usize]>,
-            kinds: Box<[RootNodeKind]>,
-        },
+    struct IndexChunk {
+        base: usize,
+        word_start: u32,
+        entry_bits: u8,
+        entry_count: u8,
+        layout: IndexChunkLayout,
+    }
+
+    #[derive(Copy, Clone, Debug, get_size2::GetSize)]
+    #[repr(u8)]
+    enum IndexChunkLayout {
+        Relative,
+        Wide,
     }
 
     impl IndexedNodes {
         const ALIGNMENT: usize = std::mem::align_of::<AtomicNodeIndex>();
-        const KIND_BITS: u32 = 5;
-        const KIND_MASK: u32 = (1 << Self::KIND_BITS) - 1;
-        const MAX_PACKED_OFFSET: usize = (u32::MAX >> Self::KIND_BITS) as usize;
+        const CHUNK_LEN: usize = 64;
+        const KIND_BITS: u8 = 5;
+        const KIND_MASK: u64 = (1 << Self::KIND_BITS) - 1;
 
         fn from_collected(nodes: CollectedNodes) -> Self {
             let CollectedNodes { addresses, kinds } = nodes;
             debug_assert_eq!(addresses.len(), kinds.len());
 
-            let mut address_iter = addresses.iter().copied();
-            let Some(first) = address_iter.next() else {
-                return Self::default();
-            };
-            let (base, max, aligned) = address_iter.fold(
-                (first, first, first.is_multiple_of(Self::ALIGNMENT)),
-                |(base, max, aligned), address| {
-                    (
-                        base.min(address),
-                        max.max(address),
-                        aligned && address.is_multiple_of(Self::ALIGNMENT),
-                    )
-                },
-            );
+            let mut chunks = Vec::with_capacity(addresses.len().div_ceil(Self::CHUNK_LEN));
+            let mut words = Vec::new();
 
-            if !aligned {
-                return Self::Wide {
-                    addresses: addresses.into_boxed_slice(),
-                    kinds: kinds.into_boxed_slice(),
-                };
+            for (address_chunk, kind_chunk) in addresses
+                .chunks(Self::CHUNK_LEN)
+                .zip(kinds.chunks(Self::CHUNK_LEN))
+            {
+                let base = address_chunk.iter().copied().min().unwrap_or_default();
+                let max = address_chunk.iter().copied().max().unwrap_or_default();
+                let aligned = address_chunk
+                    .iter()
+                    .all(|address| address.is_multiple_of(Self::ALIGNMENT));
+                let offset_bits = usize::BITS - ((max - base) / Self::ALIGNMENT).leading_zeros();
+                let relative_bits = u8::try_from(offset_bits)
+                    .expect("an address offset cannot require more than u8::MAX bits")
+                    + Self::KIND_BITS;
+                let word_start = u32::try_from(words.len())
+                    .expect("indexed AST bitstream should fit in u32 words");
+
+                if aligned && relative_bits <= 64 {
+                    let entry_count = u8::try_from(address_chunk.len())
+                        .expect("an index chunk contains at most 64 entries");
+                    chunks.push(IndexChunk {
+                        base,
+                        word_start,
+                        entry_bits: relative_bits,
+                        entry_count,
+                        layout: IndexChunkLayout::Relative,
+                    });
+                    for (entry, (&address, &kind)) in
+                        address_chunk.iter().zip(kind_chunk).enumerate()
+                    {
+                        let offset = (address - base) / Self::ALIGNMENT;
+                        let offset = u64::try_from(offset)
+                            .expect("relative address offset was checked to fit in 64 bits");
+                        Self::write_bits(
+                            &mut words,
+                            word_start as usize * 64 + entry * usize::from(relative_bits),
+                            (offset << Self::KIND_BITS) | u64::from(kind as u8),
+                            relative_bits,
+                        );
+                    }
+                } else {
+                    // Wide chunks store one address word per entry followed by packed node kinds.
+                    let entry_count = u8::try_from(address_chunk.len())
+                        .expect("an index chunk contains at most 64 entries");
+                    chunks.push(IndexChunk {
+                        base: 0,
+                        word_start,
+                        entry_bits: Self::KIND_BITS,
+                        entry_count,
+                        layout: IndexChunkLayout::Wide,
+                    });
+                    words.extend(address_chunk.iter().map(|address| {
+                        u64::try_from(*address)
+                            .expect("AST node addresses should fit in a bitstream word")
+                    }));
+                    for (entry, &kind) in kind_chunk.iter().enumerate() {
+                        Self::write_bits(
+                            &mut words,
+                            (word_start as usize + address_chunk.len()) * 64
+                                + entry * usize::from(Self::KIND_BITS),
+                            u64::from(kind as u8),
+                            Self::KIND_BITS,
+                        );
+                    }
+                }
             }
 
-            let max_offset = (max - base) / Self::ALIGNMENT;
+            Self {
+                chunks: chunks.into_boxed_slice(),
+                words: words.into_boxed_slice(),
+            }
+        }
 
-            if max_offset <= Self::MAX_PACKED_OFFSET {
-                Self::Packed {
-                    base,
-                    entries: addresses
-                        .into_iter()
-                        .zip(kinds)
-                        .map(|(address, kind)| {
-                            let offset = u32::try_from((address - base) / Self::ALIGNMENT)
-                                .expect("node offset was checked to fit in packed entry");
-                            (offset << Self::KIND_BITS) | u32::from(kind as u8)
-                        })
-                        .collect(),
-                }
-            } else if u32::try_from(max_offset).is_ok() {
-                Self::Split {
-                    base,
-                    offsets: addresses
-                        .into_iter()
-                        .map(|address| {
-                            u32::try_from((address - base) / Self::ALIGNMENT)
-                                .expect("aligned address span was checked to fit in u32")
-                        })
-                        .collect(),
-                    kinds: kinds.into_boxed_slice(),
-                }
+        fn write_bits(words: &mut Vec<u64>, bit: usize, value: u64, bits: u8) {
+            debug_assert!((1..=64).contains(&bits));
+            let word = bit / 64;
+            let shift = bit % 64;
+            let end = bit + usize::from(bits);
+            words.resize(words.len().max(end.div_ceil(64)), 0);
+            words[word] |= value << shift;
+            if end > (word + 1) * 64 {
+                words[word + 1] |= value >> (64 - shift);
+            }
+        }
+
+        fn read_bits(words: &[u64], bit: usize, bits: u8) -> u64 {
+            debug_assert!((1..=64).contains(&bits));
+            let word = bit / 64;
+            let shift = bit % 64;
+            let low = words[word] >> shift;
+            let value = if shift + usize::from(bits) <= 64 {
+                low
             } else {
-                Self::Wide {
-                    addresses: addresses.into_boxed_slice(),
-                    kinds: kinds.into_boxed_slice(),
-                }
+                low | (words[word + 1] << (64 - shift))
+            };
+            if bits == 64 {
+                value
+            } else {
+                value & ((1 << bits) - 1)
             }
         }
 
         #[cfg(test)]
         fn len(&self) -> usize {
-            match self {
-                Self::Packed { entries, .. } => entries.len(),
-                Self::Split { offsets, .. } => offsets.len(),
-                Self::Wide { addresses, .. } => addresses.len(),
-            }
+            self.chunks
+                .iter()
+                .map(|chunk| usize::from(chunk.entry_count))
+                .sum()
         }
 
         fn get(&self, index: usize) -> (usize, RootNodeKind) {
-            match self {
-                Self::Packed { base, entries } => {
-                    let entry = entries[index];
+            let chunk_index = index / Self::CHUNK_LEN;
+            let entry_index = index % Self::CHUNK_LEN;
+            let chunk = &self.chunks[chunk_index];
+            let words = &self.words[chunk.word_start as usize..];
+
+            match chunk.layout {
+                IndexChunkLayout::Relative => {
+                    let entry = Self::read_bits(
+                        words,
+                        entry_index * usize::from(chunk.entry_bits),
+                        chunk.entry_bits,
+                    );
                     let offset = (entry >> Self::KIND_BITS) as usize;
                     let kind = RootNodeKind::from_u8((entry & Self::KIND_MASK) as u8)
                         .expect("packed node kind should be valid");
-                    (*base + offset * Self::ALIGNMENT, kind)
+                    (chunk.base + offset * Self::ALIGNMENT, kind)
                 }
-                Self::Split {
-                    base,
-                    offsets,
-                    kinds,
-                } => {
-                    let offset = offsets[index] as usize;
-                    (*base + offset * Self::ALIGNMENT, kinds[index])
+                IndexChunkLayout::Wide => {
+                    let address = usize::try_from(words[entry_index])
+                        .expect("stored AST node address should fit in usize");
+                    let kind_bit = usize::from(chunk.entry_count) * 64
+                        + entry_index * usize::from(Self::KIND_BITS);
+                    let kind =
+                        RootNodeKind::from_u8(
+                            Self::read_bits(words, kind_bit, Self::KIND_BITS) as u8
+                        )
+                        .expect("packed node kind should be valid");
+                    (address, kind)
                 }
-                Self::Wide { addresses, kinds } => (addresses[index], kinds[index]),
-            }
-        }
-    }
-
-    impl Default for IndexedNodes {
-        fn default() -> Self {
-            Self::Packed {
-                base: 0,
-                entries: Box::default(),
             }
         }
     }
@@ -667,39 +725,46 @@ class C[T](Base, metaclass=Meta):
         }
 
         #[test]
-        fn indexed_node_storage_variants() {
+        fn indexed_node_storage_layouts() {
             let alignment = IndexedNodes::ALIGNMENT;
-            let compact_max = IndexedNodes::MAX_PACKED_OFFSET;
-            let nodes = |addresses| CollectedNodes {
+            let chunk_distance = 1usize << (usize::BITS - 3);
+            let addresses: Vec<_> = (0..130)
+                .map(|index| {
+                    0x1000
+                        + (index / IndexedNodes::CHUNK_LEN) * chunk_distance
+                        + (index % IndexedNodes::CHUNK_LEN) * alignment
+                })
+                .collect();
+            let kinds: Vec<_> = (0..addresses.len())
+                .map(|index| {
+                    if index.is_multiple_of(2) {
+                        RootNodeKind::Stmt
+                    } else {
+                        RootNodeKind::Identifier
+                    }
+                })
+                .collect();
+            let chunked = IndexedNodes::from_collected(CollectedNodes {
+                addresses: addresses.clone(),
+                kinds: kinds.clone(),
+            });
+
+            assert_eq!(chunked.chunks.len(), 3);
+            assert!(
+                chunked
+                    .chunks
+                    .iter()
+                    .all(|chunk| matches!(chunk.layout, IndexChunkLayout::Relative))
+            );
+            for (index, (&address, &kind)) in addresses.iter().zip(&kinds).enumerate() {
+                assert_eq!(chunked.get(index), (address, kind));
+            }
+
+            let wide = IndexedNodes::from_collected(CollectedNodes {
+                addresses: vec![0x1000, 0x1001],
                 kinds: vec![RootNodeKind::Stmt, RootNodeKind::Identifier],
-                addresses,
-            };
-
-            let packed =
-                IndexedNodes::from_collected(nodes(vec![0x1000, 0x1000 + compact_max * alignment]));
-            assert!(matches!(packed, IndexedNodes::Packed { .. }));
-            assert_eq!(packed.get(0), (0x1000, RootNodeKind::Stmt));
-            assert_eq!(
-                packed.get(1),
-                (0x1000 + compact_max * alignment, RootNodeKind::Identifier)
-            );
-
-            let split = IndexedNodes::from_collected(nodes(vec![
-                0x1000,
-                0x1000 + (compact_max + 1) * alignment,
-            ]));
-            assert!(matches!(split, IndexedNodes::Split { .. }));
-            assert_eq!(split.get(0), (0x1000, RootNodeKind::Stmt));
-            assert_eq!(
-                split.get(1),
-                (
-                    0x1000 + (compact_max + 1) * alignment,
-                    RootNodeKind::Identifier
-                )
-            );
-
-            let wide = IndexedNodes::from_collected(nodes(vec![0x1000, 0x1001]));
-            assert!(matches!(wide, IndexedNodes::Wide { .. }));
+            });
+            assert!(matches!(wide.chunks[0].layout, IndexChunkLayout::Wide));
             assert_eq!(wide.get(0), (0x1000, RootNodeKind::Stmt));
             assert_eq!(wide.get(1), (0x1001, RootNodeKind::Identifier));
         }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -282,22 +282,24 @@ mod indexed {
         const KIND_BITS: u8 = 5;
         const KIND_MASK: u64 = (1 << Self::KIND_BITS) - 1;
 
-        fn from_collected(nodes: CollectedNodes) -> Self {
-            let CollectedNodes { addresses, kinds } = nodes;
-            debug_assert_eq!(addresses.len(), kinds.len());
-
-            let mut chunks = Vec::with_capacity(addresses.len().div_ceil(Self::CHUNK_LEN));
+        fn from_collected(nodes: CollectedNodes<'_>) -> Self {
+            let CollectedNodes { nodes } = nodes;
+            let mut chunks = Vec::with_capacity(nodes.len().div_ceil(Self::CHUNK_LEN));
             let mut words = Vec::new();
 
-            for (address_chunk, kind_chunk) in addresses
-                .chunks(Self::CHUNK_LEN)
-                .zip(kinds.chunks(Self::CHUNK_LEN))
-            {
-                let base = address_chunk.iter().copied().min().unwrap_or_default();
-                let max = address_chunk.iter().copied().max().unwrap_or_default();
-                let aligned = address_chunk
-                    .iter()
-                    .all(|address| address.is_multiple_of(Self::ALIGNMENT));
+            for node_chunk in nodes.chunks(Self::CHUNK_LEN) {
+                let (base, max, aligned) =
+                    node_chunk
+                        .iter()
+                        .fold((usize::MAX, 0, true), |(base, max, aligned), node| {
+                            let (_, pointer) = node.into_raw_parts();
+                            let address = pointer.as_ptr().expose_provenance();
+                            (
+                                base.min(address),
+                                max.max(address),
+                                aligned && address.is_multiple_of(Self::ALIGNMENT),
+                            )
+                        });
                 let offset_bits = usize::BITS - ((max - base) / Self::ALIGNMENT).leading_zeros();
                 let relative_bits = u8::try_from(offset_bits)
                     .expect("an address offset cannot require more than u8::MAX bits")
@@ -306,7 +308,7 @@ mod indexed {
                     .expect("indexed AST bitstream should fit in u32 words");
 
                 if aligned && relative_bits <= 64 {
-                    let entry_count = u8::try_from(address_chunk.len())
+                    let entry_count = u8::try_from(node_chunk.len())
                         .expect("an index chunk contains at most 64 entries");
                     chunks.push(IndexChunk {
                         base,
@@ -315,9 +317,9 @@ mod indexed {
                         entry_count,
                         layout: IndexChunkLayout::Relative,
                     });
-                    for (entry, (&address, &kind)) in
-                        address_chunk.iter().zip(kind_chunk).enumerate()
-                    {
+                    for (entry, node) in node_chunk.iter().enumerate() {
+                        let (kind, pointer) = node.into_raw_parts();
+                        let address = pointer.as_ptr().expose_provenance();
                         let offset = (address - base) / Self::ALIGNMENT;
                         let offset = u64::try_from(offset)
                             .expect("relative address offset was checked to fit in 64 bits");
@@ -330,7 +332,7 @@ mod indexed {
                     }
                 } else {
                     // Wide chunks store one address word per entry followed by packed node kinds.
-                    let entry_count = u8::try_from(address_chunk.len())
+                    let entry_count = u8::try_from(node_chunk.len())
                         .expect("an index chunk contains at most 64 entries");
                     chunks.push(IndexChunk {
                         base: 0,
@@ -339,14 +341,16 @@ mod indexed {
                         entry_count,
                         layout: IndexChunkLayout::Wide,
                     });
-                    words.extend(address_chunk.iter().map(|address| {
-                        u64::try_from(*address)
+                    words.extend(node_chunk.iter().map(|node| {
+                        let (_, pointer) = node.into_raw_parts();
+                        u64::try_from(pointer.as_ptr().expose_provenance())
                             .expect("AST node addresses should fit in a bitstream word")
                     }));
-                    for (entry, &kind) in kind_chunk.iter().enumerate() {
+                    for (entry, node) in node_chunk.iter().enumerate() {
+                        let (kind, _) = node.into_raw_parts();
                         Self::write_bits(
                             &mut words,
-                            (word_start as usize + address_chunk.len()) * 64
+                            (word_start as usize + node_chunk.len()) * 64
                                 + entry * usize::from(Self::KIND_BITS),
                             u64::from(kind as u8),
                             Self::KIND_BITS,
@@ -516,24 +520,23 @@ mod indexed {
     }
 
     #[derive(Default)]
-    struct CollectedNodes {
-        addresses: Vec<usize>,
-        kinds: Vec<RootNodeKind>,
+    struct CollectedNodes<'ast> {
+        nodes: Vec<AnyRootNodeRef<'ast>>,
     }
 
     /// A visitor that collects nodes in source order.
-    struct Visitor {
+    struct Visitor<'ast> {
         index: u32,
         max_index: u32,
-        nodes: Option<CollectedNodes>,
+        nodes: Option<CollectedNodes<'ast>>,
         overflowed: bool,
     }
 
-    impl Visitor {
-        fn visit_node<'a, T>(&mut self, node: &'a T)
+    impl<'ast> Visitor<'ast> {
+        fn visit_node<T>(&mut self, node: &'ast T)
         where
             T: HasNodeIndex,
-            AnyRootNodeRef<'a>: From<&'a T>,
+            AnyRootNodeRef<'ast>: From<&'ast T>,
         {
             // Only check on write (the maximum is orders of magnitude less than u32::MAX)
             if self.index > self.max_index {
@@ -543,15 +546,13 @@ mod indexed {
             }
 
             if let Some(nodes) = &mut self.nodes {
-                let (kind, pointer) = AnyRootNodeRef::from(node).into_raw_parts();
-                nodes.addresses.push(pointer.as_ptr().expose_provenance());
-                nodes.kinds.push(kind);
+                nodes.nodes.push(AnyRootNodeRef::from(node));
             }
             self.index += 1;
         }
     }
 
-    impl<'a> SourceOrderVisitor<'a> for Visitor {
+    impl<'a> SourceOrderVisitor<'a> for Visitor<'a> {
         #[inline]
         fn visit_stmt(&mut self, stmt: &'a Stmt) {
             self.visit_node(stmt);
@@ -752,14 +753,16 @@ class C[T](Base, metaclass=Meta):
                 overflowed: false,
             };
             AnyNodeRef::from(indexed.parsed.syntax()).visit_source_order(&mut visitor);
-            let CollectedNodes { addresses, kinds } = visitor
+            let CollectedNodes { nodes } = visitor
                 .nodes
                 .expect("test visitor should collect indexed nodes");
 
-            assert_eq!(indexed.index.len(), addresses.len());
+            assert_eq!(indexed.index.len(), nodes.len());
             let mut seen_kinds = [false; 1 << IndexedNodes::KIND_BITS];
 
-            for (raw_index, (address, kind)) in addresses.into_iter().zip(kinds).enumerate() {
+            for (raw_index, expected_node) in nodes.into_iter().enumerate() {
+                let (kind, pointer) = expected_node.into_raw_parts();
+                let address = pointer.as_ptr().expose_provenance();
                 let index = NodeIndex::from(
                     u32::try_from(raw_index).expect("node index should fit in u32"),
                 );

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -214,9 +214,207 @@ mod indexed {
     /// A wrapper around the AST that allows access to AST nodes by index.
     #[derive(Debug, get_size2::GetSize)]
     pub struct IndexedModule {
-        index: Box<[AnyRootNodeRef<'static>]>,
+        index: IndexedNodes,
         pub parsed: Parsed<ModModule>,
     }
+
+    #[derive(Debug, get_size2::GetSize)]
+    enum IndexedNodes {
+        /// The node kind is stored in the low bits and the scaled address offset in the high bits.
+        Packed { base: usize, entries: Box<[u32]> },
+        Split {
+            base: usize,
+            offsets: Box<[u32]>,
+            kinds: Box<[IndexedNodeKind]>,
+        },
+        Wide {
+            addresses: Box<[usize]>,
+            kinds: Box<[IndexedNodeKind]>,
+        },
+    }
+
+    impl IndexedNodes {
+        const ALIGNMENT: usize = std::mem::align_of::<AtomicNodeIndex>();
+        const KIND_BITS: u32 = 5;
+        const KIND_MASK: u32 = (1 << Self::KIND_BITS) - 1;
+        const MAX_PACKED_OFFSET: usize = (u32::MAX >> Self::KIND_BITS) as usize;
+
+        fn from_collected(nodes: CollectedNodes) -> Self {
+            let CollectedNodes { addresses, kinds } = nodes;
+            debug_assert_eq!(addresses.len(), kinds.len());
+
+            let mut address_iter = addresses.iter().copied();
+            let Some(first) = address_iter.next() else {
+                return Self::default();
+            };
+            let (base, max, aligned) = address_iter.fold(
+                (first, first, first.is_multiple_of(Self::ALIGNMENT)),
+                |(base, max, aligned), address| {
+                    (
+                        base.min(address),
+                        max.max(address),
+                        aligned && address.is_multiple_of(Self::ALIGNMENT),
+                    )
+                },
+            );
+
+            if !aligned {
+                return Self::Wide {
+                    addresses: addresses.into_boxed_slice(),
+                    kinds: kinds.into_boxed_slice(),
+                };
+            }
+
+            let max_offset = (max - base) / Self::ALIGNMENT;
+
+            if max_offset <= Self::MAX_PACKED_OFFSET {
+                Self::Packed {
+                    base,
+                    entries: addresses
+                        .into_iter()
+                        .zip(kinds)
+                        .map(|(address, kind)| {
+                            let offset = u32::try_from((address - base) / Self::ALIGNMENT)
+                                .expect("node offset was checked to fit in packed entry");
+                            (offset << Self::KIND_BITS) | u32::from(kind as u8)
+                        })
+                        .collect(),
+                }
+            } else if u32::try_from(max_offset).is_ok() {
+                Self::Split {
+                    base,
+                    offsets: addresses
+                        .into_iter()
+                        .map(|address| {
+                            u32::try_from((address - base) / Self::ALIGNMENT)
+                                .expect("aligned address span was checked to fit in u32")
+                        })
+                        .collect(),
+                    kinds: kinds.into_boxed_slice(),
+                }
+            } else {
+                Self::Wide {
+                    addresses: addresses.into_boxed_slice(),
+                    kinds: kinds.into_boxed_slice(),
+                }
+            }
+        }
+
+        #[cfg(test)]
+        fn len(&self) -> usize {
+            match self {
+                Self::Packed { entries, .. } => entries.len(),
+                Self::Split { offsets, .. } => offsets.len(),
+                Self::Wide { addresses, .. } => addresses.len(),
+            }
+        }
+
+        fn get(&self, index: usize) -> (usize, IndexedNodeKind) {
+            match self {
+                Self::Packed { base, entries } => {
+                    let entry = entries[index];
+                    let offset = (entry >> Self::KIND_BITS) as usize;
+                    let kind = IndexedNodeKind::from_bits(entry & Self::KIND_MASK);
+                    (*base + offset * Self::ALIGNMENT, kind)
+                }
+                Self::Split {
+                    base,
+                    offsets,
+                    kinds,
+                } => {
+                    let offset = offsets[index] as usize;
+                    (*base + offset * Self::ALIGNMENT, kinds[index])
+                }
+                Self::Wide { addresses, kinds } => (addresses[index], kinds[index]),
+            }
+        }
+    }
+
+    impl Default for IndexedNodes {
+        fn default() -> Self {
+            Self::Packed {
+                base: 0,
+                entries: Box::default(),
+            }
+        }
+    }
+
+    macro_rules! define_indexed_node_kinds {
+        ($($kind:ident => $node:ty),+ $(,)?) => {
+            #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
+            #[repr(u8)]
+            enum IndexedNodeKind {
+                $($kind),+
+            }
+
+            impl IndexedNodeKind {
+                const ALL: &'static [Self] = &[$(Self::$kind),+];
+
+                fn from_bits(bits: u32) -> Self {
+                    Self::ALL[bits as usize]
+                }
+
+                /// Reconstructs the AST reference stored at `address`.
+                ///
+                /// # Safety
+                ///
+                /// `address` must point to the node type represented by `self`, and that node must
+                /// live for `'ast`.
+                unsafe fn node_ref<'ast>(self, address: usize) -> AnyRootNodeRef<'ast> {
+                    match self {
+                        $(Self::$kind => {
+                            // SAFETY: This macro defines both the type-to-kind mapping used while
+                            // collecting nodes and the inverse mapping used here. The indexed AST
+                            // owns the exposed address and cannot move or be dropped during this
+                            // borrow.
+                            let node = unsafe {
+                                &*std::ptr::with_exposed_provenance::<$node>(address)
+                            };
+                            AnyRootNodeRef::from(node)
+                        }),+
+                    }
+                }
+            }
+
+            trait IndexedNode: HasNodeIndex {
+                const KIND: IndexedNodeKind;
+            }
+
+            $(impl IndexedNode for $node {
+                const KIND: IndexedNodeKind = IndexedNodeKind::$kind;
+            })+
+        };
+    }
+
+    define_indexed_node_kinds! {
+        Stmt => Stmt,
+        Expr => Expr,
+        Decorator => Decorator,
+        Comprehension => Comprehension,
+        ExceptHandler => ExceptHandler,
+        Arguments => Arguments,
+        Parameters => Parameters,
+        Parameter => Parameter,
+        ParameterWithDefault => ParameterWithDefault,
+        Keyword => Keyword,
+        Alias => Alias,
+        WithItem => WithItem,
+        TypeParams => TypeParams,
+        TypeParam => TypeParam,
+        MatchCase => MatchCase,
+        Pattern => Pattern,
+        PatternArguments => PatternArguments,
+        PatternKeyword => PatternKeyword,
+        ElifElseClause => ElifElseClause,
+        FString => FString,
+        InterpolatedStringElement => InterpolatedStringElement,
+        TString => TString,
+        StringLiteral => StringLiteral,
+        BytesLiteral => BytesLiteral,
+        Identifier => Identifier,
+    }
+
+    const _: () = assert!(IndexedNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
 
     /// Ensure the following sub-AST is indexed, using the parent node's index
     /// as a basis for unambiguous AST node indices.
@@ -249,10 +447,9 @@ mod indexed {
 
     impl IndexedModule {
         /// Create a new [`IndexedModule`] from the given AST.
-        #[expect(clippy::unnecessary_cast)]
         pub fn new(parsed: Parsed<ModModule>) -> Arc<Self> {
             let mut visitor = Visitor {
-                nodes: Some(Vec::new()),
+                nodes: Some(CollectedNodes::default()),
                 index: 0,
                 max_index: MAX_REAL_INDEX,
                 overflowed: false,
@@ -260,21 +457,17 @@ mod indexed {
 
             let mut inner = Arc::new(IndexedModule {
                 parsed,
-                index: Box::new([]),
+                index: IndexedNodes::default(),
             });
 
             AnyNodeRef::from(inner.parsed.syntax()).visit_source_order(&mut visitor);
 
-            let index: Box<[AnyRootNodeRef<'_>]> = visitor.nodes.unwrap().into_boxed_slice();
-
-            // SAFETY: We cast from `Box<[AnyRootNodeRef<'_>]>` to `Box<[AnyRootNodeRef<'static>]>`,
-            // faking the 'static lifetime to create the self-referential struct. The node references
-            // are into the `Arc<Parsed<ModModule>>`, so are valid for as long as the `IndexedModule`
-            // is alive. We make sure to restore the correct lifetime in `get_by_index`.
-            //
-            // Note that we can never move the data within the `Arc` after this point.
-            Arc::get_mut(&mut inner).unwrap().index =
-                unsafe { Box::from_raw(Box::into_raw(index) as *mut [AnyRootNodeRef<'static>]) };
+            let nodes = visitor
+                .nodes
+                .expect("top-level AST visitor should collect indexed nodes");
+            Arc::get_mut(&mut inner)
+                .expect("newly created indexed module should have a unique Arc")
+                .index = IndexedNodes::from_collected(nodes);
 
             inner
         }
@@ -285,26 +478,31 @@ mod indexed {
                 .as_u32()
                 .expect("attempted to access uninitialized `NodeIndex`");
 
-            // Note that this method restores the correct lifetime: the nodes are valid for as
-            // long as the reference to `IndexedModule` is alive.
-            self.index[index as usize]
+            let index = index as usize;
+            let (address, kind) = self.index.get(index);
+
+            // SAFETY: `kind` and `address` were recorded from the same node, and the node is owned
+            // by `self.parsed`, so it lives for as long as this borrow of `self`.
+            unsafe { kind.node_ref(address) }
         }
     }
 
-    /// A visitor that collects nodes in source order.
-    pub struct Visitor<'a> {
-        pub index: u32,
-        pub max_index: u32,
-        pub nodes: Option<Vec<AnyRootNodeRef<'a>>>,
-        pub overflowed: bool,
+    #[derive(Default)]
+    struct CollectedNodes {
+        addresses: Vec<usize>,
+        kinds: Vec<IndexedNodeKind>,
     }
 
-    impl<'a> Visitor<'a> {
-        fn visit_node<T>(&mut self, node: &'a T)
-        where
-            T: HasNodeIndex + std::fmt::Debug,
-            AnyRootNodeRef<'a>: From<&'a T>,
-        {
+    /// A visitor that collects nodes in source order.
+    struct Visitor {
+        index: u32,
+        max_index: u32,
+        nodes: Option<CollectedNodes>,
+        overflowed: bool,
+    }
+
+    impl Visitor {
+        fn visit_node<T: IndexedNode>(&mut self, node: &T) {
             // Only check on write (the maximum is orders of magnitude less than u32::MAX)
             if self.index > self.max_index {
                 self.overflowed = true;
@@ -313,19 +511,16 @@ mod indexed {
             }
 
             if let Some(nodes) = &mut self.nodes {
-                nodes.push(AnyRootNodeRef::from(node));
+                nodes
+                    .addresses
+                    .push(std::ptr::from_ref(node).expose_provenance());
+                nodes.kinds.push(T::KIND);
             }
             self.index += 1;
         }
     }
 
-    impl<'a> SourceOrderVisitor<'a> for Visitor<'a> {
-        #[inline]
-        fn visit_mod(&mut self, module: &'a Mod) {
-            self.visit_node(module);
-            walk_module(self, module);
-        }
-
+    impl<'a> SourceOrderVisitor<'a> for Visitor {
         #[inline]
         fn visit_stmt(&mut self, stmt: &'a Stmt) {
             self.visit_node(stmt);
@@ -334,7 +529,7 @@ mod indexed {
 
         #[inline]
         fn visit_annotation(&mut self, expr: &'a Expr) {
-            self.visit_node(expr);
+            // `walk_annotation` delegates to `visit_expr`, which indexes the expression once.
             walk_annotation(self, expr);
         }
 
@@ -485,6 +680,111 @@ mod indexed {
         fn visit_identifier(&mut self, identifier: &'a Identifier) {
             self.visit_node(identifier);
             walk_identifier(self, identifier);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn indexed_nodes_round_trip() {
+            let parsed = ruff_python_parser::parse_module(
+                r#"
+import os as imported_os
+
+@decorator
+class C[T](Base, metaclass=Meta):
+    def method(self, value: int = 1, *args, keyword=2, **kwargs):
+        try:
+            with context() as items:
+                return [item for item in items if item]
+        except Error as error:
+            match error:
+                case Error(code=code):
+                    if code:
+                        return f"{code!r}"
+                    elif code is None:
+                        return t"{code}"
+                    else:
+                        return "string"
+                case _:
+                    return b"bytes"
+"#,
+            )
+            .expect("test source should parse");
+            let indexed = IndexedModule::new(parsed);
+
+            let node_count = u32::try_from(indexed.index.len())
+                .expect("number of indexed nodes should fit in u32");
+            let mut seen_kinds = vec![false; IndexedNodeKind::ALL.len()];
+
+            for raw_index in 0..node_count {
+                let index = NodeIndex::from(raw_index);
+                let (_, kind) = indexed.index.get(raw_index as usize);
+                seen_kinds[usize::from(kind as u8)] = true;
+                let stored_index = indexed
+                    .get_by_index(index)
+                    .node_index()
+                    .load()
+                    .as_u32()
+                    .expect("indexed node should have an initialized index");
+                assert_eq!(Some(stored_index), index.as_u32());
+            }
+
+            for kind in IndexedNodeKind::ALL {
+                assert!(
+                    seen_kinds[usize::from(*kind as u8)],
+                    "fixture does not cover {kind:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn indexed_node_storage_variants() {
+            assert!(IndexedNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
+            for (bits, kind) in IndexedNodeKind::ALL.iter().copied().enumerate() {
+                assert_eq!(usize::from(kind as u8), bits);
+                assert_eq!(IndexedNodeKind::from_bits(bits as u32), kind);
+            }
+
+            let alignment = IndexedNodes::ALIGNMENT;
+            let compact_max = IndexedNodes::MAX_PACKED_OFFSET;
+            let nodes = |addresses| CollectedNodes {
+                kinds: vec![IndexedNodeKind::Stmt, IndexedNodeKind::Identifier],
+                addresses,
+            };
+
+            let packed =
+                IndexedNodes::from_collected(nodes(vec![0x1000, 0x1000 + compact_max * alignment]));
+            assert!(matches!(packed, IndexedNodes::Packed { .. }));
+            assert_eq!(packed.get(0), (0x1000, IndexedNodeKind::Stmt));
+            assert_eq!(
+                packed.get(1),
+                (
+                    0x1000 + compact_max * alignment,
+                    IndexedNodeKind::Identifier
+                )
+            );
+
+            let split = IndexedNodes::from_collected(nodes(vec![
+                0x1000,
+                0x1000 + (compact_max + 1) * alignment,
+            ]));
+            assert!(matches!(split, IndexedNodes::Split { .. }));
+            assert_eq!(split.get(0), (0x1000, IndexedNodeKind::Stmt));
+            assert_eq!(
+                split.get(1),
+                (
+                    0x1000 + (compact_max + 1) * alignment,
+                    IndexedNodeKind::Identifier
+                )
+            );
+
+            let wide = IndexedNodes::from_collected(nodes(vec![0x1000, 0x1001]));
+            assert!(matches!(wide, IndexedNodes::Wide { .. }));
+            assert_eq!(wide.get(0), (0x1000, IndexedNodeKind::Stmt));
+            assert_eq!(wide.get(1), (0x1001, IndexedNodeKind::Identifier));
         }
     }
 }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -645,6 +645,7 @@ class C[T](Base, metaclass=Meta):
             )
             .expect("test source should parse");
             let indexed = IndexedModule::new(parsed);
+            assert!(matches!(&indexed.index, IndexedNodes::Packed { .. }));
 
             let node_count = u32::try_from(indexed.index.len())
                 .expect("number of indexed nodes should fit in u32");
@@ -654,13 +655,7 @@ class C[T](Base, metaclass=Meta):
                 let index = NodeIndex::from(raw_index);
                 let (_, kind) = indexed.index.get(raw_index as usize);
                 seen_kinds[usize::from(kind as u8)] = true;
-                let stored_index = indexed
-                    .get_by_index(index)
-                    .node_index()
-                    .load()
-                    .as_u32()
-                    .expect("indexed node should have an initialized index");
-                assert_eq!(Some(stored_index), index.as_u32());
+                assert_eq!(indexed.get_by_index(index).node_index().load(), index);
             }
 
             for kind in RootNodeKind::ALL {
@@ -674,12 +669,6 @@ class C[T](Base, metaclass=Meta):
 
         #[test]
         fn indexed_node_storage_variants() {
-            assert!(RootNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
-            for (bits, kind) in RootNodeKind::ALL.iter().copied().enumerate() {
-                assert_eq!(usize::from(kind as u8), bits);
-                assert_eq!(RootNodeKind::from_u8(bits as u8), Some(kind));
-            }
-
             let alignment = IndexedNodes::ALIGNMENT;
             let compact_max = IndexedNodes::MAX_PACKED_OFFSET;
             let nodes = |addresses| CollectedNodes {

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -225,11 +225,11 @@ mod indexed {
         Split {
             base: usize,
             offsets: Box<[u32]>,
-            kinds: Box<[IndexedNodeKind]>,
+            kinds: Box<[RootNodeKind]>,
         },
         Wide {
             addresses: Box<[usize]>,
-            kinds: Box<[IndexedNodeKind]>,
+            kinds: Box<[RootNodeKind]>,
         },
     }
 
@@ -309,12 +309,13 @@ mod indexed {
             }
         }
 
-        fn get(&self, index: usize) -> (usize, IndexedNodeKind) {
+        fn get(&self, index: usize) -> (usize, RootNodeKind) {
             match self {
                 Self::Packed { base, entries } => {
                     let entry = entries[index];
                     let offset = (entry >> Self::KIND_BITS) as usize;
-                    let kind = IndexedNodeKind::from_bits(entry & Self::KIND_MASK);
+                    let kind = RootNodeKind::from_u8((entry & Self::KIND_MASK) as u8)
+                        .expect("packed node kind should be valid");
                     (*base + offset * Self::ALIGNMENT, kind)
                 }
                 Self::Split {
@@ -339,82 +340,7 @@ mod indexed {
         }
     }
 
-    macro_rules! define_indexed_node_kinds {
-        ($($kind:ident => $node:ty),+ $(,)?) => {
-            #[derive(Clone, Copy, Debug, Eq, PartialEq, get_size2::GetSize)]
-            #[repr(u8)]
-            enum IndexedNodeKind {
-                $($kind),+
-            }
-
-            impl IndexedNodeKind {
-                const ALL: &'static [Self] = &[$(Self::$kind),+];
-
-                fn from_bits(bits: u32) -> Self {
-                    Self::ALL[bits as usize]
-                }
-
-                /// Reconstructs the AST reference stored at `address`.
-                ///
-                /// # Safety
-                ///
-                /// `address` must point to the node type represented by `self`, and that node must
-                /// live for `'ast`.
-                unsafe fn node_ref<'ast>(self, address: usize) -> AnyRootNodeRef<'ast> {
-                    match self {
-                        $(Self::$kind => {
-                            // SAFETY: This macro defines both the type-to-kind mapping used while
-                            // collecting nodes and the inverse mapping used here. The indexed AST
-                            // owns the exposed address and cannot move or be dropped during this
-                            // borrow.
-                            let node = unsafe {
-                                &*std::ptr::with_exposed_provenance::<$node>(address)
-                            };
-                            AnyRootNodeRef::from(node)
-                        }),+
-                    }
-                }
-            }
-
-            trait IndexedNode: HasNodeIndex {
-                const KIND: IndexedNodeKind;
-            }
-
-            $(impl IndexedNode for $node {
-                const KIND: IndexedNodeKind = IndexedNodeKind::$kind;
-            })+
-        };
-    }
-
-    define_indexed_node_kinds! {
-        Stmt => Stmt,
-        Expr => Expr,
-        Decorator => Decorator,
-        Comprehension => Comprehension,
-        ExceptHandler => ExceptHandler,
-        Arguments => Arguments,
-        Parameters => Parameters,
-        Parameter => Parameter,
-        ParameterWithDefault => ParameterWithDefault,
-        Keyword => Keyword,
-        Alias => Alias,
-        WithItem => WithItem,
-        TypeParams => TypeParams,
-        TypeParam => TypeParam,
-        MatchCase => MatchCase,
-        Pattern => Pattern,
-        PatternArguments => PatternArguments,
-        PatternKeyword => PatternKeyword,
-        ElifElseClause => ElifElseClause,
-        FString => FString,
-        InterpolatedStringElement => InterpolatedStringElement,
-        TString => TString,
-        StringLiteral => StringLiteral,
-        BytesLiteral => BytesLiteral,
-        Identifier => Identifier,
-    }
-
-    const _: () = assert!(IndexedNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
+    const _: () = assert!(RootNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
 
     /// Ensure the following sub-AST is indexed, using the parent node's index
     /// as a basis for unambiguous AST node indices.
@@ -483,14 +409,16 @@ mod indexed {
 
             // SAFETY: `kind` and `address` were recorded from the same node, and the node is owned
             // by `self.parsed`, so it lives for as long as this borrow of `self`.
-            unsafe { kind.node_ref(address) }
+            unsafe {
+                AnyRootNodeRef::from_raw_parts(kind, std::ptr::with_exposed_provenance(address))
+            }
         }
     }
 
     #[derive(Default)]
     struct CollectedNodes {
         addresses: Vec<usize>,
-        kinds: Vec<IndexedNodeKind>,
+        kinds: Vec<RootNodeKind>,
     }
 
     /// A visitor that collects nodes in source order.
@@ -502,7 +430,11 @@ mod indexed {
     }
 
     impl Visitor {
-        fn visit_node<T: IndexedNode>(&mut self, node: &T) {
+        fn visit_node<'a, T>(&mut self, node: &'a T)
+        where
+            T: HasNodeIndex,
+            AnyRootNodeRef<'a>: From<&'a T>,
+        {
             // Only check on write (the maximum is orders of magnitude less than u32::MAX)
             if self.index > self.max_index {
                 self.overflowed = true;
@@ -511,10 +443,9 @@ mod indexed {
             }
 
             if let Some(nodes) = &mut self.nodes {
-                nodes
-                    .addresses
-                    .push(std::ptr::from_ref(node).expose_provenance());
-                nodes.kinds.push(T::KIND);
+                let (kind, pointer) = AnyRootNodeRef::from(node).into_raw_parts();
+                nodes.addresses.push(pointer.expose_provenance());
+                nodes.kinds.push(kind);
             }
             self.index += 1;
         }
@@ -717,7 +648,7 @@ class C[T](Base, metaclass=Meta):
 
             let node_count = u32::try_from(indexed.index.len())
                 .expect("number of indexed nodes should fit in u32");
-            let mut seen_kinds = vec![false; IndexedNodeKind::ALL.len()];
+            let mut seen_kinds = [false; 1 << IndexedNodes::KIND_BITS];
 
             for raw_index in 0..node_count {
                 let index = NodeIndex::from(raw_index);
@@ -732,39 +663,37 @@ class C[T](Base, metaclass=Meta):
                 assert_eq!(Some(stored_index), index.as_u32());
             }
 
-            for kind in IndexedNodeKind::ALL {
-                assert!(
-                    seen_kinds[usize::from(*kind as u8)],
-                    "fixture does not cover {kind:?}"
+            for kind in RootNodeKind::ALL {
+                let is_indexed = !matches!(
+                    kind,
+                    RootNodeKind::Mod | RootNodeKind::InterpolatedStringFormatSpec
                 );
+                assert_eq!(seen_kinds[usize::from(*kind as u8)], is_indexed);
             }
         }
 
         #[test]
         fn indexed_node_storage_variants() {
-            assert!(IndexedNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
-            for (bits, kind) in IndexedNodeKind::ALL.iter().copied().enumerate() {
+            assert!(RootNodeKind::ALL.len() <= 1 << IndexedNodes::KIND_BITS);
+            for (bits, kind) in RootNodeKind::ALL.iter().copied().enumerate() {
                 assert_eq!(usize::from(kind as u8), bits);
-                assert_eq!(IndexedNodeKind::from_bits(bits as u32), kind);
+                assert_eq!(RootNodeKind::from_u8(bits as u8), Some(kind));
             }
 
             let alignment = IndexedNodes::ALIGNMENT;
             let compact_max = IndexedNodes::MAX_PACKED_OFFSET;
             let nodes = |addresses| CollectedNodes {
-                kinds: vec![IndexedNodeKind::Stmt, IndexedNodeKind::Identifier],
+                kinds: vec![RootNodeKind::Stmt, RootNodeKind::Identifier],
                 addresses,
             };
 
             let packed =
                 IndexedNodes::from_collected(nodes(vec![0x1000, 0x1000 + compact_max * alignment]));
             assert!(matches!(packed, IndexedNodes::Packed { .. }));
-            assert_eq!(packed.get(0), (0x1000, IndexedNodeKind::Stmt));
+            assert_eq!(packed.get(0), (0x1000, RootNodeKind::Stmt));
             assert_eq!(
                 packed.get(1),
-                (
-                    0x1000 + compact_max * alignment,
-                    IndexedNodeKind::Identifier
-                )
+                (0x1000 + compact_max * alignment, RootNodeKind::Identifier)
             );
 
             let split = IndexedNodes::from_collected(nodes(vec![
@@ -772,19 +701,19 @@ class C[T](Base, metaclass=Meta):
                 0x1000 + (compact_max + 1) * alignment,
             ]));
             assert!(matches!(split, IndexedNodes::Split { .. }));
-            assert_eq!(split.get(0), (0x1000, IndexedNodeKind::Stmt));
+            assert_eq!(split.get(0), (0x1000, RootNodeKind::Stmt));
             assert_eq!(
                 split.get(1),
                 (
                     0x1000 + (compact_max + 1) * alignment,
-                    IndexedNodeKind::Identifier
+                    RootNodeKind::Identifier
                 )
             );
 
             let wide = IndexedNodes::from_collected(nodes(vec![0x1000, 0x1001]));
             assert!(matches!(wide, IndexedNodes::Wide { .. }));
-            assert_eq!(wide.get(0), (0x1000, IndexedNodeKind::Stmt));
-            assert_eq!(wide.get(1), (0x1001, IndexedNodeKind::Identifier));
+            assert_eq!(wide.get(0), (0x1000, RootNodeKind::Stmt));
+            assert_eq!(wide.get(1), (0x1001, RootNodeKind::Identifier));
         }
     }
 }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -493,7 +493,13 @@ mod indexed {
             // SAFETY: `kind` and `address` were recorded from the same node, and the node is owned
             // by `self.parsed`, so it lives for as long as this borrow of `self`.
             unsafe {
-                AnyRootNodeRef::from_raw_parts(kind, std::ptr::with_exposed_provenance(address))
+                AnyRootNodeRef::from_raw_parts(
+                    kind,
+                    std::ptr::NonNull::with_exposed_provenance(
+                        std::num::NonZeroUsize::new(address)
+                            .expect("recorded AST node address should be non-null"),
+                    ),
+                )
             }
         }
     }
@@ -527,7 +533,7 @@ mod indexed {
 
             if let Some(nodes) = &mut self.nodes {
                 let (kind, pointer) = AnyRootNodeRef::from(node).into_raw_parts();
-                nodes.addresses.push(pointer.expose_provenance());
+                nodes.addresses.push(pointer.as_ptr().expose_provenance());
                 nodes.kinds.push(kind);
             }
             self.index += 1;

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -645,7 +645,6 @@ class C[T](Base, metaclass=Meta):
             )
             .expect("test source should parse");
             let indexed = IndexedModule::new(parsed);
-            assert!(matches!(&indexed.index, IndexedNodes::Packed { .. }));
 
             let node_count = u32::try_from(indexed.index.len())
                 .expect("number of indexed nodes should fit in u32");

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -218,19 +218,29 @@ mod indexed {
         pub parsed: Parsed<ModModule>,
     }
 
+    /// Compact storage for the address and [`RootNodeKind`] of every indexed AST node.
+    ///
+    /// This stores the information needed to reconstruct an [`AnyRootNodeRef`] without retaining
+    /// a fat pointer per node. Entries are divided into fixed-size chunks so that unrelated AST
+    /// allocations do not force every node into a wider representation. Each chunk starts on a
+    /// word boundary in `words`.
     #[derive(Debug, Default, get_size2::GetSize)]
     struct IndexedNodes {
-        /// Fixed-size chunks make lookup O(1) while allowing each region of the AST to use the
-        /// smallest entry width that can represent its addresses.
         chunks: Box<[IndexChunk]>,
         words: Box<[u64]>,
     }
 
+    /// Describes the entries for one consecutive group of node indices.
     #[derive(Debug, get_size2::GetSize)]
     struct IndexChunk {
+        /// Minimum node address in a relative chunk; unused for a wide chunk.
         base: usize,
+        /// Index of this chunk's first word in [`IndexedNodes::words`].
         word_start: u32,
+        /// Number of bits per packed entry.
         entry_bits: u8,
+        /// Number of entries, which is only less than [`IndexedNodes::CHUNK_LEN`] in the last
+        /// chunk.
         entry_count: u8,
         layout: IndexChunkLayout,
     }
@@ -238,7 +248,22 @@ mod indexed {
     #[derive(Copy, Clone, Debug, get_size2::GetSize)]
     #[repr(u8)]
     enum IndexChunkLayout {
+        /// Packs each scaled address offset together with its root-node kind:
+        ///
+        /// ```text
+        /// | address offset | root-node kind |
+        ///   entry_bits - 5       5 bits
+        /// ```
+        ///
+        /// The original address is `base + address_offset * ALIGNMENT`. Entries may cross `u64`
+        /// boundaries and the unused bits at the end of the chunk are padding.
         Relative,
+        /// Stores full addresses followed by a packed stream of root-node kinds:
+        ///
+        /// ```text
+        /// | address 0 | ... | address n - 1 | kind 0 | ... | kind n - 1 |
+        ///     64 bits           64 bits        5 bits          5 bits
+        /// ```
         Wide,
     }
 

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -833,8 +833,15 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
         ];
 
         /// Returns the root node kind with the given discriminant.
+        #[inline]
         pub fn from_u8(value: u8) -> Option<Self> {
-            Self::ALL.get(usize::from(value)).copied()
+            match value {
+    """)
+    for index, (name, _) in enumerate(root_nodes):
+        out.append(f"""{index} => Some(Self::{name}),""")
+    out.append("""
+                _ => None,
+            }
         }
     }
     """)

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -948,19 +948,25 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             ///
             /// # Safety
             ///
-            /// `pointer` must be non-null, properly aligned, and point to the root node type
-            /// represented by `kind`. The pointed-to node must live for `'a`.
+            /// - `pointer` must be properly aligned for and point to the exact root node type
+            ///   represented by `kind`.
+            /// - The pointer's provenance must permit reads of a complete, initialized, and valid
+            ///   value of that type.
+            /// - The pointed-to value must not be moved, dropped, or accessed mutably for `'a`.
             #[inline]
             #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
             pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: std::ptr::NonNull<()>) -> Self {
-                match kind {
+                let pointer = pointer.as_ptr();
+                // SAFETY: The caller guarantees that `pointer` is readable as the exact root node
+                // type selected by `kind` and remains valid and immutable for `'a`.
+                unsafe { match kind {
     """)
     for name, ty in root_nodes:
         out.append(
-            f"""RootNodeKind::{name} => AnyRootNodeRef::{name}(unsafe {{ &*pointer.cast::<{ty}>().as_ptr() }}),"""
+            f"""RootNodeKind::{name} => AnyRootNodeRef::{name}(&*pointer.cast::<{ty}>()),"""
         )
     out.append("""
-                }
+                }}
             }
 
             pub fn visit_source_order<'b, V>(self, visitor: &mut V)

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -933,12 +933,12 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
         impl<'a> AnyRootNodeRef<'a> {
             /// Decomposes this reference into its root node kind and a type-erased pointer.
             #[inline]
-            pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
+            pub fn into_raw_parts(self) -> (RootNodeKind, std::ptr::NonNull<()>) {
                 match self {
     """)
     for name, _ in root_nodes:
         out.append(
-            f"""AnyRootNodeRef::{name}(node) => (RootNodeKind::{name}, std::ptr::from_ref(node).cast()),"""
+            f"""AnyRootNodeRef::{name}(node) => (RootNodeKind::{name}, std::ptr::NonNull::from(node).cast()),"""
         )
     out.append("""
                 }
@@ -952,12 +952,12 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             /// represented by `kind`. The pointed-to node must live for `'a`.
             #[inline]
             #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
-            pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
+            pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: std::ptr::NonNull<()>) -> Self {
                 match kind {
     """)
     for name, ty in root_nodes:
         out.append(
-            f"""RootNodeKind::{name} => AnyRootNodeRef::{name}(unsafe {{ &*pointer.cast::<{ty}>() }}),"""
+            f"""RootNodeKind::{name} => AnyRootNodeRef::{name}(unsafe {{ &*pointer.cast::<{ty}>().as_ptr() }}),"""
         )
     out.append("""
                 }

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -785,6 +785,9 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     - `fn AnyRootNodeRef::visit_source_order(self, visitor &mut impl SourceOrderVisitor)`
     """
 
+    root_nodes = [(group.name, group.owned_enum_ty) for group in ast.groups]
+    root_nodes.extend((node.name, node.ty) for node in ast.ungrouped_nodes)
+
     out.append("""
     /// An enumeration of all AST nodes.
     ///
@@ -799,25 +802,24 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
     pub enum AnyRootNodeRef<'a> {
     """)
-    for group in ast.groups:
-        out.append(f"""{group.name}(&'a {group.owned_enum_ty}),""")
-    for node in ast.ungrouped_nodes:
-        out.append(f"""{node.name}(&'a {node.ty}),""")
+    for name, ty in root_nodes:
+        out.append(f"""{name}(&'a {ty}),""")
     out.append("""
     }
     """)
 
     out.append("""
-    /// The root type of an AST node.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+    /// The unflattened enum or struct type stored by an [`AnyRootNodeRef`].
+    ///
+    /// Unlike [`NodeKind`], this does not distinguish variants of root enums such as [`Stmt`]
+    /// and [`Expr`].
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
     #[repr(u8)]
     pub enum RootNodeKind {
     """)
-    for group in ast.groups:
-        out.append(f"""{group.name},""")
-    for node in ast.ungrouped_nodes:
-        out.append(f"""{node.name},""")
+    for name, _ in root_nodes:
+        out.append(f"""{name},""")
     out.append("""
     }
 
@@ -825,10 +827,8 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
         /// All root node kinds in discriminant order.
         pub const ALL: &'static [Self] = &[
     """)
-    for group in ast.groups:
-        out.append(f"""Self::{group.name},""")
-    for node in ast.ungrouped_nodes:
-        out.append(f"""Self::{node.name},""")
+    for name, _ in root_nodes:
+        out.append(f"""Self::{name},""")
     out.append("""
         ];
 
@@ -842,6 +842,7 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     for group in ast.groups:
         out.append(f"""
             impl<'a> From<&'a {group.owned_enum_ty}> for AnyRootNodeRef<'a> {{
+                #[inline]
                 fn from(node: &'a {group.owned_enum_ty}) -> AnyRootNodeRef<'a> {{
                         AnyRootNodeRef::{group.name}(node)
                 }}
@@ -876,6 +877,7 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     for node in ast.ungrouped_nodes:
         out.append(f"""
             impl<'a> From<&'a {node.ty}> for AnyRootNodeRef<'a> {{
+                #[inline]
                 fn from(node: &'a {node.ty}) -> AnyRootNodeRef<'a> {{
                     AnyRootNodeRef::{node.name}(node)
                 }}
@@ -899,10 +901,8 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             fn range(&self) -> ruff_text_size::TextRange {
                 match self {
     """)
-    for group in ast.groups:
-        out.append(f"""AnyRootNodeRef::{group.name}(node) => node.range(),""")
-    for node in ast.ungrouped_nodes:
-        out.append(f"""AnyRootNodeRef::{node.name}(node) => node.range(),""")
+    for name, _ in root_nodes:
+        out.append(f"""AnyRootNodeRef::{name}(node) => node.range(),""")
     out.append("""
                 }
             }
@@ -914,10 +914,8 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             fn node_index(&self) -> &crate::AtomicNodeIndex {
                 match self {
     """)
-    for group in ast.groups:
-        out.append(f"""AnyRootNodeRef::{group.name}(node) => node.node_index(),""")
-    for node in ast.ungrouped_nodes:
-        out.append(f"""AnyRootNodeRef::{node.name}(node) => node.node_index(),""")
+    for name, _ in root_nodes:
+        out.append(f"""AnyRootNodeRef::{name}(node) => node.node_index(),""")
     out.append("""
                 }
             }
@@ -927,16 +925,13 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     out.append("""
         impl<'a> AnyRootNodeRef<'a> {
             /// Decomposes this reference into its root node kind and a type-erased pointer.
+            #[inline]
             pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
                 match self {
     """)
-    for group in ast.groups:
+    for name, _ in root_nodes:
         out.append(
-            f"""AnyRootNodeRef::{group.name}(node) => (RootNodeKind::{group.name}, std::ptr::from_ref(node).cast()),"""
-        )
-    for node in ast.ungrouped_nodes:
-        out.append(
-            f"""AnyRootNodeRef::{node.name}(node) => (RootNodeKind::{node.name}, std::ptr::from_ref(node).cast()),"""
+            f"""AnyRootNodeRef::{name}(node) => (RootNodeKind::{name}, std::ptr::from_ref(node).cast()),"""
         )
     out.append("""
                 }
@@ -948,17 +943,14 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             ///
             /// `pointer` must be non-null, properly aligned, and point to the root node type
             /// represented by `kind`. The pointed-to node must live for `'a`.
+            #[inline]
             #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
             pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
                 match kind {
     """)
-    for group in ast.groups:
+    for name, ty in root_nodes:
         out.append(
-            f"""RootNodeKind::{group.name} => AnyRootNodeRef::{group.name}(unsafe {{ &*pointer.cast::<{group.owned_enum_ty}>() }}),"""
-        )
-    for node in ast.ungrouped_nodes:
-        out.append(
-            f"""RootNodeKind::{node.name} => AnyRootNodeRef::{node.name}(unsafe {{ &*pointer.cast::<{node.ty}>() }}),"""
+            f"""RootNodeKind::{name} => AnyRootNodeRef::{name}(unsafe {{ &*pointer.cast::<{ty}>() }}),"""
         )
     out.append("""
                 }
@@ -971,13 +963,9 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
             {
                 match self {
     """)
-    for group in ast.groups:
+    for name, _ in root_nodes:
         out.append(
-            f"""AnyRootNodeRef::{group.name}(node) => node.visit_source_order(visitor),"""
-        )
-    for node in ast.ungrouped_nodes:
-        out.append(
-            f"""AnyRootNodeRef::{node.name}(node) => node.visit_source_order(visitor),"""
+            f"""AnyRootNodeRef::{name}(node) => node.visit_source_order(visitor),"""
         )
     out.append("""
                 }

--- a/crates/ruff_python_ast/generate.py
+++ b/crates/ruff_python_ast/generate.py
@@ -807,6 +807,38 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
     }
     """)
 
+    out.append("""
+    /// The root type of an AST node.
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+    #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+    #[repr(u8)]
+    pub enum RootNodeKind {
+    """)
+    for group in ast.groups:
+        out.append(f"""{group.name},""")
+    for node in ast.ungrouped_nodes:
+        out.append(f"""{node.name},""")
+    out.append("""
+    }
+
+    impl RootNodeKind {
+        /// All root node kinds in discriminant order.
+        pub const ALL: &'static [Self] = &[
+    """)
+    for group in ast.groups:
+        out.append(f"""Self::{group.name},""")
+    for node in ast.ungrouped_nodes:
+        out.append(f"""Self::{node.name},""")
+    out.append("""
+        ];
+
+        /// Returns the root node kind with the given discriminant.
+        pub fn from_u8(value: u8) -> Option<Self> {
+            Self::ALL.get(usize::from(value)).copied()
+        }
+    }
+    """)
+
     for group in ast.groups:
         out.append(f"""
             impl<'a> From<&'a {group.owned_enum_ty}> for AnyRootNodeRef<'a> {{
@@ -894,6 +926,44 @@ def write_root_anynoderef(out: list[str], ast: Ast) -> None:
 
     out.append("""
         impl<'a> AnyRootNodeRef<'a> {
+            /// Decomposes this reference into its root node kind and a type-erased pointer.
+            pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
+                match self {
+    """)
+    for group in ast.groups:
+        out.append(
+            f"""AnyRootNodeRef::{group.name}(node) => (RootNodeKind::{group.name}, std::ptr::from_ref(node).cast()),"""
+        )
+    for node in ast.ungrouped_nodes:
+        out.append(
+            f"""AnyRootNodeRef::{node.name}(node) => (RootNodeKind::{node.name}, std::ptr::from_ref(node).cast()),"""
+        )
+    out.append("""
+                }
+            }
+
+            /// Reconstructs an AST reference from its root node kind and type-erased pointer.
+            ///
+            /// # Safety
+            ///
+            /// `pointer` must be non-null, properly aligned, and point to the root node type
+            /// represented by `kind`. The pointed-to node must live for `'a`.
+            #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
+            pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
+                match kind {
+    """)
+    for group in ast.groups:
+        out.append(
+            f"""RootNodeKind::{group.name} => AnyRootNodeRef::{group.name}(unsafe {{ &*pointer.cast::<{group.owned_enum_ty}>() }}),"""
+        )
+    for node in ast.ungrouped_nodes:
+        out.append(
+            f"""RootNodeKind::{node.name} => AnyRootNodeRef::{node.name}(unsafe {{ &*pointer.cast::<{node.ty}>() }}),"""
+        )
+    out.append("""
+                }
+            }
+
             pub fn visit_source_order<'b, V>(self, visitor: &mut V)
             where
                 V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -8846,87 +8846,105 @@ impl crate::HasNodeIndex for AnyRootNodeRef<'_> {
 impl<'a> AnyRootNodeRef<'a> {
     /// Decomposes this reference into its root node kind and a type-erased pointer.
     #[inline]
-    pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
+    pub fn into_raw_parts(self) -> (RootNodeKind, std::ptr::NonNull<()>) {
         match self {
-            AnyRootNodeRef::Mod(node) => (RootNodeKind::Mod, std::ptr::from_ref(node).cast()),
-            AnyRootNodeRef::Stmt(node) => (RootNodeKind::Stmt, std::ptr::from_ref(node).cast()),
-            AnyRootNodeRef::Expr(node) => (RootNodeKind::Expr, std::ptr::from_ref(node).cast()),
-            AnyRootNodeRef::ExceptHandler(node) => {
-                (RootNodeKind::ExceptHandler, std::ptr::from_ref(node).cast())
+            AnyRootNodeRef::Mod(node) => (RootNodeKind::Mod, std::ptr::NonNull::from(node).cast()),
+            AnyRootNodeRef::Stmt(node) => {
+                (RootNodeKind::Stmt, std::ptr::NonNull::from(node).cast())
             }
+            AnyRootNodeRef::Expr(node) => {
+                (RootNodeKind::Expr, std::ptr::NonNull::from(node).cast())
+            }
+            AnyRootNodeRef::ExceptHandler(node) => (
+                RootNodeKind::ExceptHandler,
+                std::ptr::NonNull::from(node).cast(),
+            ),
             AnyRootNodeRef::InterpolatedStringElement(node) => (
                 RootNodeKind::InterpolatedStringElement,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
             AnyRootNodeRef::Pattern(node) => {
-                (RootNodeKind::Pattern, std::ptr::from_ref(node).cast())
+                (RootNodeKind::Pattern, std::ptr::NonNull::from(node).cast())
             }
-            AnyRootNodeRef::TypeParam(node) => {
-                (RootNodeKind::TypeParam, std::ptr::from_ref(node).cast())
-            }
+            AnyRootNodeRef::TypeParam(node) => (
+                RootNodeKind::TypeParam,
+                std::ptr::NonNull::from(node).cast(),
+            ),
             AnyRootNodeRef::InterpolatedStringFormatSpec(node) => (
                 RootNodeKind::InterpolatedStringFormatSpec,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
             AnyRootNodeRef::PatternArguments(node) => (
                 RootNodeKind::PatternArguments,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
             AnyRootNodeRef::PatternKeyword(node) => (
                 RootNodeKind::PatternKeyword,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
-            AnyRootNodeRef::Comprehension(node) => {
-                (RootNodeKind::Comprehension, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::Arguments(node) => {
-                (RootNodeKind::Arguments, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::Parameters(node) => {
-                (RootNodeKind::Parameters, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::Parameter(node) => {
-                (RootNodeKind::Parameter, std::ptr::from_ref(node).cast())
-            }
+            AnyRootNodeRef::Comprehension(node) => (
+                RootNodeKind::Comprehension,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::Arguments(node) => (
+                RootNodeKind::Arguments,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::Parameters(node) => (
+                RootNodeKind::Parameters,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::Parameter(node) => (
+                RootNodeKind::Parameter,
+                std::ptr::NonNull::from(node).cast(),
+            ),
             AnyRootNodeRef::ParameterWithDefault(node) => (
                 RootNodeKind::ParameterWithDefault,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
             AnyRootNodeRef::Keyword(node) => {
-                (RootNodeKind::Keyword, std::ptr::from_ref(node).cast())
+                (RootNodeKind::Keyword, std::ptr::NonNull::from(node).cast())
             }
-            AnyRootNodeRef::Alias(node) => (RootNodeKind::Alias, std::ptr::from_ref(node).cast()),
+            AnyRootNodeRef::Alias(node) => {
+                (RootNodeKind::Alias, std::ptr::NonNull::from(node).cast())
+            }
             AnyRootNodeRef::WithItem(node) => {
-                (RootNodeKind::WithItem, std::ptr::from_ref(node).cast())
+                (RootNodeKind::WithItem, std::ptr::NonNull::from(node).cast())
             }
-            AnyRootNodeRef::MatchCase(node) => {
-                (RootNodeKind::MatchCase, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::Decorator(node) => {
-                (RootNodeKind::Decorator, std::ptr::from_ref(node).cast())
-            }
+            AnyRootNodeRef::MatchCase(node) => (
+                RootNodeKind::MatchCase,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::Decorator(node) => (
+                RootNodeKind::Decorator,
+                std::ptr::NonNull::from(node).cast(),
+            ),
             AnyRootNodeRef::ElifElseClause(node) => (
                 RootNodeKind::ElifElseClause,
-                std::ptr::from_ref(node).cast(),
+                std::ptr::NonNull::from(node).cast(),
             ),
-            AnyRootNodeRef::TypeParams(node) => {
-                (RootNodeKind::TypeParams, std::ptr::from_ref(node).cast())
-            }
+            AnyRootNodeRef::TypeParams(node) => (
+                RootNodeKind::TypeParams,
+                std::ptr::NonNull::from(node).cast(),
+            ),
             AnyRootNodeRef::FString(node) => {
-                (RootNodeKind::FString, std::ptr::from_ref(node).cast())
+                (RootNodeKind::FString, std::ptr::NonNull::from(node).cast())
             }
             AnyRootNodeRef::TString(node) => {
-                (RootNodeKind::TString, std::ptr::from_ref(node).cast())
+                (RootNodeKind::TString, std::ptr::NonNull::from(node).cast())
             }
-            AnyRootNodeRef::StringLiteral(node) => {
-                (RootNodeKind::StringLiteral, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::BytesLiteral(node) => {
-                (RootNodeKind::BytesLiteral, std::ptr::from_ref(node).cast())
-            }
-            AnyRootNodeRef::Identifier(node) => {
-                (RootNodeKind::Identifier, std::ptr::from_ref(node).cast())
-            }
+            AnyRootNodeRef::StringLiteral(node) => (
+                RootNodeKind::StringLiteral,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::BytesLiteral(node) => (
+                RootNodeKind::BytesLiteral,
+                std::ptr::NonNull::from(node).cast(),
+            ),
+            AnyRootNodeRef::Identifier(node) => (
+                RootNodeKind::Identifier,
+                std::ptr::NonNull::from(node).cast(),
+            ),
         }
     }
 
@@ -8938,87 +8956,93 @@ impl<'a> AnyRootNodeRef<'a> {
     /// represented by `kind`. The pointed-to node must live for `'a`.
     #[inline]
     #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
-    pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
+    pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: std::ptr::NonNull<()>) -> Self {
         match kind {
-            RootNodeKind::Mod => AnyRootNodeRef::Mod(unsafe { &*pointer.cast::<Mod>() }),
-            RootNodeKind::Stmt => AnyRootNodeRef::Stmt(unsafe { &*pointer.cast::<Stmt>() }),
-            RootNodeKind::Expr => AnyRootNodeRef::Expr(unsafe { &*pointer.cast::<Expr>() }),
+            RootNodeKind::Mod => AnyRootNodeRef::Mod(unsafe { &*pointer.cast::<Mod>().as_ptr() }),
+            RootNodeKind::Stmt => {
+                AnyRootNodeRef::Stmt(unsafe { &*pointer.cast::<Stmt>().as_ptr() })
+            }
+            RootNodeKind::Expr => {
+                AnyRootNodeRef::Expr(unsafe { &*pointer.cast::<Expr>().as_ptr() })
+            }
             RootNodeKind::ExceptHandler => {
-                AnyRootNodeRef::ExceptHandler(unsafe { &*pointer.cast::<ExceptHandler>() })
+                AnyRootNodeRef::ExceptHandler(unsafe { &*pointer.cast::<ExceptHandler>().as_ptr() })
             }
             RootNodeKind::InterpolatedStringElement => {
                 AnyRootNodeRef::InterpolatedStringElement(unsafe {
-                    &*pointer.cast::<InterpolatedStringElement>()
+                    &*pointer.cast::<InterpolatedStringElement>().as_ptr()
                 })
             }
             RootNodeKind::Pattern => {
-                AnyRootNodeRef::Pattern(unsafe { &*pointer.cast::<Pattern>() })
+                AnyRootNodeRef::Pattern(unsafe { &*pointer.cast::<Pattern>().as_ptr() })
             }
             RootNodeKind::TypeParam => {
-                AnyRootNodeRef::TypeParam(unsafe { &*pointer.cast::<TypeParam>() })
+                AnyRootNodeRef::TypeParam(unsafe { &*pointer.cast::<TypeParam>().as_ptr() })
             }
             RootNodeKind::InterpolatedStringFormatSpec => {
                 AnyRootNodeRef::InterpolatedStringFormatSpec(unsafe {
-                    &*pointer.cast::<crate::InterpolatedStringFormatSpec>()
+                    &*pointer
+                        .cast::<crate::InterpolatedStringFormatSpec>()
+                        .as_ptr()
                 })
             }
             RootNodeKind::PatternArguments => AnyRootNodeRef::PatternArguments(unsafe {
-                &*pointer.cast::<crate::PatternArguments>()
+                &*pointer.cast::<crate::PatternArguments>().as_ptr()
             }),
-            RootNodeKind::PatternKeyword => {
-                AnyRootNodeRef::PatternKeyword(unsafe { &*pointer.cast::<crate::PatternKeyword>() })
-            }
-            RootNodeKind::Comprehension => {
-                AnyRootNodeRef::Comprehension(unsafe { &*pointer.cast::<crate::Comprehension>() })
-            }
+            RootNodeKind::PatternKeyword => AnyRootNodeRef::PatternKeyword(unsafe {
+                &*pointer.cast::<crate::PatternKeyword>().as_ptr()
+            }),
+            RootNodeKind::Comprehension => AnyRootNodeRef::Comprehension(unsafe {
+                &*pointer.cast::<crate::Comprehension>().as_ptr()
+            }),
             RootNodeKind::Arguments => {
-                AnyRootNodeRef::Arguments(unsafe { &*pointer.cast::<crate::Arguments>() })
+                AnyRootNodeRef::Arguments(unsafe { &*pointer.cast::<crate::Arguments>().as_ptr() })
             }
-            RootNodeKind::Parameters => {
-                AnyRootNodeRef::Parameters(unsafe { &*pointer.cast::<crate::Parameters>() })
-            }
+            RootNodeKind::Parameters => AnyRootNodeRef::Parameters(unsafe {
+                &*pointer.cast::<crate::Parameters>().as_ptr()
+            }),
             RootNodeKind::Parameter => {
-                AnyRootNodeRef::Parameter(unsafe { &*pointer.cast::<crate::Parameter>() })
+                AnyRootNodeRef::Parameter(unsafe { &*pointer.cast::<crate::Parameter>().as_ptr() })
             }
             RootNodeKind::ParameterWithDefault => AnyRootNodeRef::ParameterWithDefault(unsafe {
-                &*pointer.cast::<crate::ParameterWithDefault>()
+                &*pointer.cast::<crate::ParameterWithDefault>().as_ptr()
             }),
             RootNodeKind::Keyword => {
-                AnyRootNodeRef::Keyword(unsafe { &*pointer.cast::<crate::Keyword>() })
+                AnyRootNodeRef::Keyword(unsafe { &*pointer.cast::<crate::Keyword>().as_ptr() })
             }
             RootNodeKind::Alias => {
-                AnyRootNodeRef::Alias(unsafe { &*pointer.cast::<crate::Alias>() })
+                AnyRootNodeRef::Alias(unsafe { &*pointer.cast::<crate::Alias>().as_ptr() })
             }
             RootNodeKind::WithItem => {
-                AnyRootNodeRef::WithItem(unsafe { &*pointer.cast::<crate::WithItem>() })
+                AnyRootNodeRef::WithItem(unsafe { &*pointer.cast::<crate::WithItem>().as_ptr() })
             }
             RootNodeKind::MatchCase => {
-                AnyRootNodeRef::MatchCase(unsafe { &*pointer.cast::<crate::MatchCase>() })
+                AnyRootNodeRef::MatchCase(unsafe { &*pointer.cast::<crate::MatchCase>().as_ptr() })
             }
             RootNodeKind::Decorator => {
-                AnyRootNodeRef::Decorator(unsafe { &*pointer.cast::<crate::Decorator>() })
+                AnyRootNodeRef::Decorator(unsafe { &*pointer.cast::<crate::Decorator>().as_ptr() })
             }
-            RootNodeKind::ElifElseClause => {
-                AnyRootNodeRef::ElifElseClause(unsafe { &*pointer.cast::<crate::ElifElseClause>() })
-            }
-            RootNodeKind::TypeParams => {
-                AnyRootNodeRef::TypeParams(unsafe { &*pointer.cast::<crate::TypeParams>() })
-            }
+            RootNodeKind::ElifElseClause => AnyRootNodeRef::ElifElseClause(unsafe {
+                &*pointer.cast::<crate::ElifElseClause>().as_ptr()
+            }),
+            RootNodeKind::TypeParams => AnyRootNodeRef::TypeParams(unsafe {
+                &*pointer.cast::<crate::TypeParams>().as_ptr()
+            }),
             RootNodeKind::FString => {
-                AnyRootNodeRef::FString(unsafe { &*pointer.cast::<crate::FString>() })
+                AnyRootNodeRef::FString(unsafe { &*pointer.cast::<crate::FString>().as_ptr() })
             }
             RootNodeKind::TString => {
-                AnyRootNodeRef::TString(unsafe { &*pointer.cast::<crate::TString>() })
+                AnyRootNodeRef::TString(unsafe { &*pointer.cast::<crate::TString>().as_ptr() })
             }
-            RootNodeKind::StringLiteral => {
-                AnyRootNodeRef::StringLiteral(unsafe { &*pointer.cast::<crate::StringLiteral>() })
-            }
-            RootNodeKind::BytesLiteral => {
-                AnyRootNodeRef::BytesLiteral(unsafe { &*pointer.cast::<crate::BytesLiteral>() })
-            }
-            RootNodeKind::Identifier => {
-                AnyRootNodeRef::Identifier(unsafe { &*pointer.cast::<crate::Identifier>() })
-            }
+            RootNodeKind::StringLiteral => AnyRootNodeRef::StringLiteral(unsafe {
+                &*pointer.cast::<crate::StringLiteral>().as_ptr()
+            }),
+            RootNodeKind::BytesLiteral => AnyRootNodeRef::BytesLiteral(unsafe {
+                &*pointer.cast::<crate::BytesLiteral>().as_ptr()
+            }),
+            RootNodeKind::Identifier => AnyRootNodeRef::Identifier(unsafe {
+                &*pointer.cast::<crate::Identifier>().as_ptr()
+            }),
         }
     }
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -8952,97 +8952,93 @@ impl<'a> AnyRootNodeRef<'a> {
     ///
     /// # Safety
     ///
-    /// `pointer` must be non-null, properly aligned, and point to the root node type
-    /// represented by `kind`. The pointed-to node must live for `'a`.
+    /// - `pointer` must be properly aligned for and point to the exact root node type
+    ///   represented by `kind`.
+    /// - The pointer's provenance must permit reads of a complete, initialized, and valid
+    ///   value of that type.
+    /// - The pointed-to value must not be moved, dropped, or accessed mutably for `'a`.
     #[inline]
     #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
     pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: std::ptr::NonNull<()>) -> Self {
-        match kind {
-            RootNodeKind::Mod => AnyRootNodeRef::Mod(unsafe { &*pointer.cast::<Mod>().as_ptr() }),
-            RootNodeKind::Stmt => {
-                AnyRootNodeRef::Stmt(unsafe { &*pointer.cast::<Stmt>().as_ptr() })
+        let pointer = pointer.as_ptr();
+        // SAFETY: The caller guarantees that `pointer` is readable as the exact root node
+        // type selected by `kind` and remains valid and immutable for `'a`.
+        unsafe {
+            match kind {
+                RootNodeKind::Mod => AnyRootNodeRef::Mod(&*pointer.cast::<Mod>()),
+                RootNodeKind::Stmt => AnyRootNodeRef::Stmt(&*pointer.cast::<Stmt>()),
+                RootNodeKind::Expr => AnyRootNodeRef::Expr(&*pointer.cast::<Expr>()),
+                RootNodeKind::ExceptHandler => {
+                    AnyRootNodeRef::ExceptHandler(&*pointer.cast::<ExceptHandler>())
+                }
+                RootNodeKind::InterpolatedStringElement => {
+                    AnyRootNodeRef::InterpolatedStringElement(
+                        &*pointer.cast::<InterpolatedStringElement>(),
+                    )
+                }
+                RootNodeKind::Pattern => AnyRootNodeRef::Pattern(&*pointer.cast::<Pattern>()),
+                RootNodeKind::TypeParam => AnyRootNodeRef::TypeParam(&*pointer.cast::<TypeParam>()),
+                RootNodeKind::InterpolatedStringFormatSpec => {
+                    AnyRootNodeRef::InterpolatedStringFormatSpec(
+                        &*pointer.cast::<crate::InterpolatedStringFormatSpec>(),
+                    )
+                }
+                RootNodeKind::PatternArguments => {
+                    AnyRootNodeRef::PatternArguments(&*pointer.cast::<crate::PatternArguments>())
+                }
+                RootNodeKind::PatternKeyword => {
+                    AnyRootNodeRef::PatternKeyword(&*pointer.cast::<crate::PatternKeyword>())
+                }
+                RootNodeKind::Comprehension => {
+                    AnyRootNodeRef::Comprehension(&*pointer.cast::<crate::Comprehension>())
+                }
+                RootNodeKind::Arguments => {
+                    AnyRootNodeRef::Arguments(&*pointer.cast::<crate::Arguments>())
+                }
+                RootNodeKind::Parameters => {
+                    AnyRootNodeRef::Parameters(&*pointer.cast::<crate::Parameters>())
+                }
+                RootNodeKind::Parameter => {
+                    AnyRootNodeRef::Parameter(&*pointer.cast::<crate::Parameter>())
+                }
+                RootNodeKind::ParameterWithDefault => AnyRootNodeRef::ParameterWithDefault(
+                    &*pointer.cast::<crate::ParameterWithDefault>(),
+                ),
+                RootNodeKind::Keyword => {
+                    AnyRootNodeRef::Keyword(&*pointer.cast::<crate::Keyword>())
+                }
+                RootNodeKind::Alias => AnyRootNodeRef::Alias(&*pointer.cast::<crate::Alias>()),
+                RootNodeKind::WithItem => {
+                    AnyRootNodeRef::WithItem(&*pointer.cast::<crate::WithItem>())
+                }
+                RootNodeKind::MatchCase => {
+                    AnyRootNodeRef::MatchCase(&*pointer.cast::<crate::MatchCase>())
+                }
+                RootNodeKind::Decorator => {
+                    AnyRootNodeRef::Decorator(&*pointer.cast::<crate::Decorator>())
+                }
+                RootNodeKind::ElifElseClause => {
+                    AnyRootNodeRef::ElifElseClause(&*pointer.cast::<crate::ElifElseClause>())
+                }
+                RootNodeKind::TypeParams => {
+                    AnyRootNodeRef::TypeParams(&*pointer.cast::<crate::TypeParams>())
+                }
+                RootNodeKind::FString => {
+                    AnyRootNodeRef::FString(&*pointer.cast::<crate::FString>())
+                }
+                RootNodeKind::TString => {
+                    AnyRootNodeRef::TString(&*pointer.cast::<crate::TString>())
+                }
+                RootNodeKind::StringLiteral => {
+                    AnyRootNodeRef::StringLiteral(&*pointer.cast::<crate::StringLiteral>())
+                }
+                RootNodeKind::BytesLiteral => {
+                    AnyRootNodeRef::BytesLiteral(&*pointer.cast::<crate::BytesLiteral>())
+                }
+                RootNodeKind::Identifier => {
+                    AnyRootNodeRef::Identifier(&*pointer.cast::<crate::Identifier>())
+                }
             }
-            RootNodeKind::Expr => {
-                AnyRootNodeRef::Expr(unsafe { &*pointer.cast::<Expr>().as_ptr() })
-            }
-            RootNodeKind::ExceptHandler => {
-                AnyRootNodeRef::ExceptHandler(unsafe { &*pointer.cast::<ExceptHandler>().as_ptr() })
-            }
-            RootNodeKind::InterpolatedStringElement => {
-                AnyRootNodeRef::InterpolatedStringElement(unsafe {
-                    &*pointer.cast::<InterpolatedStringElement>().as_ptr()
-                })
-            }
-            RootNodeKind::Pattern => {
-                AnyRootNodeRef::Pattern(unsafe { &*pointer.cast::<Pattern>().as_ptr() })
-            }
-            RootNodeKind::TypeParam => {
-                AnyRootNodeRef::TypeParam(unsafe { &*pointer.cast::<TypeParam>().as_ptr() })
-            }
-            RootNodeKind::InterpolatedStringFormatSpec => {
-                AnyRootNodeRef::InterpolatedStringFormatSpec(unsafe {
-                    &*pointer
-                        .cast::<crate::InterpolatedStringFormatSpec>()
-                        .as_ptr()
-                })
-            }
-            RootNodeKind::PatternArguments => AnyRootNodeRef::PatternArguments(unsafe {
-                &*pointer.cast::<crate::PatternArguments>().as_ptr()
-            }),
-            RootNodeKind::PatternKeyword => AnyRootNodeRef::PatternKeyword(unsafe {
-                &*pointer.cast::<crate::PatternKeyword>().as_ptr()
-            }),
-            RootNodeKind::Comprehension => AnyRootNodeRef::Comprehension(unsafe {
-                &*pointer.cast::<crate::Comprehension>().as_ptr()
-            }),
-            RootNodeKind::Arguments => {
-                AnyRootNodeRef::Arguments(unsafe { &*pointer.cast::<crate::Arguments>().as_ptr() })
-            }
-            RootNodeKind::Parameters => AnyRootNodeRef::Parameters(unsafe {
-                &*pointer.cast::<crate::Parameters>().as_ptr()
-            }),
-            RootNodeKind::Parameter => {
-                AnyRootNodeRef::Parameter(unsafe { &*pointer.cast::<crate::Parameter>().as_ptr() })
-            }
-            RootNodeKind::ParameterWithDefault => AnyRootNodeRef::ParameterWithDefault(unsafe {
-                &*pointer.cast::<crate::ParameterWithDefault>().as_ptr()
-            }),
-            RootNodeKind::Keyword => {
-                AnyRootNodeRef::Keyword(unsafe { &*pointer.cast::<crate::Keyword>().as_ptr() })
-            }
-            RootNodeKind::Alias => {
-                AnyRootNodeRef::Alias(unsafe { &*pointer.cast::<crate::Alias>().as_ptr() })
-            }
-            RootNodeKind::WithItem => {
-                AnyRootNodeRef::WithItem(unsafe { &*pointer.cast::<crate::WithItem>().as_ptr() })
-            }
-            RootNodeKind::MatchCase => {
-                AnyRootNodeRef::MatchCase(unsafe { &*pointer.cast::<crate::MatchCase>().as_ptr() })
-            }
-            RootNodeKind::Decorator => {
-                AnyRootNodeRef::Decorator(unsafe { &*pointer.cast::<crate::Decorator>().as_ptr() })
-            }
-            RootNodeKind::ElifElseClause => AnyRootNodeRef::ElifElseClause(unsafe {
-                &*pointer.cast::<crate::ElifElseClause>().as_ptr()
-            }),
-            RootNodeKind::TypeParams => AnyRootNodeRef::TypeParams(unsafe {
-                &*pointer.cast::<crate::TypeParams>().as_ptr()
-            }),
-            RootNodeKind::FString => {
-                AnyRootNodeRef::FString(unsafe { &*pointer.cast::<crate::FString>().as_ptr() })
-            }
-            RootNodeKind::TString => {
-                AnyRootNodeRef::TString(unsafe { &*pointer.cast::<crate::TString>().as_ptr() })
-            }
-            RootNodeKind::StringLiteral => AnyRootNodeRef::StringLiteral(unsafe {
-                &*pointer.cast::<crate::StringLiteral>().as_ptr()
-            }),
-            RootNodeKind::BytesLiteral => AnyRootNodeRef::BytesLiteral(unsafe {
-                &*pointer.cast::<crate::BytesLiteral>().as_ptr()
-            }),
-            RootNodeKind::Identifier => AnyRootNodeRef::Identifier(unsafe {
-                &*pointer.cast::<crate::Identifier>().as_ptr()
-            }),
         }
     }
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -7534,8 +7534,39 @@ impl RootNodeKind {
     ];
 
     /// Returns the root node kind with the given discriminant.
+    #[inline]
     pub fn from_u8(value: u8) -> Option<Self> {
-        Self::ALL.get(usize::from(value)).copied()
+        match value {
+            0 => Some(Self::Mod),
+            1 => Some(Self::Stmt),
+            2 => Some(Self::Expr),
+            3 => Some(Self::ExceptHandler),
+            4 => Some(Self::InterpolatedStringElement),
+            5 => Some(Self::Pattern),
+            6 => Some(Self::TypeParam),
+            7 => Some(Self::InterpolatedStringFormatSpec),
+            8 => Some(Self::PatternArguments),
+            9 => Some(Self::PatternKeyword),
+            10 => Some(Self::Comprehension),
+            11 => Some(Self::Arguments),
+            12 => Some(Self::Parameters),
+            13 => Some(Self::Parameter),
+            14 => Some(Self::ParameterWithDefault),
+            15 => Some(Self::Keyword),
+            16 => Some(Self::Alias),
+            17 => Some(Self::WithItem),
+            18 => Some(Self::MatchCase),
+            19 => Some(Self::Decorator),
+            20 => Some(Self::ElifElseClause),
+            21 => Some(Self::TypeParams),
+            22 => Some(Self::FString),
+            23 => Some(Self::TString),
+            24 => Some(Self::StringLiteral),
+            25 => Some(Self::BytesLiteral),
+            26 => Some(Self::Identifier),
+
+            _ => None,
+        }
     }
 }
 

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -7464,6 +7464,78 @@ pub enum AnyRootNodeRef<'a> {
     Identifier(&'a crate::Identifier),
 }
 
+/// The root type of an AST node.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
+#[repr(u8)]
+pub enum RootNodeKind {
+    Mod,
+    Stmt,
+    Expr,
+    ExceptHandler,
+    InterpolatedStringElement,
+    Pattern,
+    TypeParam,
+    InterpolatedStringFormatSpec,
+    PatternArguments,
+    PatternKeyword,
+    Comprehension,
+    Arguments,
+    Parameters,
+    Parameter,
+    ParameterWithDefault,
+    Keyword,
+    Alias,
+    WithItem,
+    MatchCase,
+    Decorator,
+    ElifElseClause,
+    TypeParams,
+    FString,
+    TString,
+    StringLiteral,
+    BytesLiteral,
+    Identifier,
+}
+
+impl RootNodeKind {
+    /// All root node kinds in discriminant order.
+    pub const ALL: &'static [Self] = &[
+        Self::Mod,
+        Self::Stmt,
+        Self::Expr,
+        Self::ExceptHandler,
+        Self::InterpolatedStringElement,
+        Self::Pattern,
+        Self::TypeParam,
+        Self::InterpolatedStringFormatSpec,
+        Self::PatternArguments,
+        Self::PatternKeyword,
+        Self::Comprehension,
+        Self::Arguments,
+        Self::Parameters,
+        Self::Parameter,
+        Self::ParameterWithDefault,
+        Self::Keyword,
+        Self::Alias,
+        Self::WithItem,
+        Self::MatchCase,
+        Self::Decorator,
+        Self::ElifElseClause,
+        Self::TypeParams,
+        Self::FString,
+        Self::TString,
+        Self::StringLiteral,
+        Self::BytesLiteral,
+        Self::Identifier,
+    ];
+
+    /// Returns the root node kind with the given discriminant.
+    pub fn from_u8(value: u8) -> Option<Self> {
+        Self::ALL.get(usize::from(value)).copied()
+    }
+}
+
 impl<'a> From<&'a Mod> for AnyRootNodeRef<'a> {
     fn from(node: &'a Mod) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Mod(node)
@@ -8711,6 +8783,182 @@ impl crate::HasNodeIndex for AnyRootNodeRef<'_> {
 }
 
 impl<'a> AnyRootNodeRef<'a> {
+    /// Decomposes this reference into its root node kind and a type-erased pointer.
+    pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
+        match self {
+            AnyRootNodeRef::Mod(node) => (RootNodeKind::Mod, std::ptr::from_ref(node).cast()),
+            AnyRootNodeRef::Stmt(node) => (RootNodeKind::Stmt, std::ptr::from_ref(node).cast()),
+            AnyRootNodeRef::Expr(node) => (RootNodeKind::Expr, std::ptr::from_ref(node).cast()),
+            AnyRootNodeRef::ExceptHandler(node) => {
+                (RootNodeKind::ExceptHandler, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::InterpolatedStringElement(node) => (
+                RootNodeKind::InterpolatedStringElement,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::Pattern(node) => {
+                (RootNodeKind::Pattern, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::TypeParam(node) => {
+                (RootNodeKind::TypeParam, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::InterpolatedStringFormatSpec(node) => (
+                RootNodeKind::InterpolatedStringFormatSpec,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::PatternArguments(node) => (
+                RootNodeKind::PatternArguments,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::PatternKeyword(node) => (
+                RootNodeKind::PatternKeyword,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::Comprehension(node) => {
+                (RootNodeKind::Comprehension, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Arguments(node) => {
+                (RootNodeKind::Arguments, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Parameters(node) => {
+                (RootNodeKind::Parameters, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Parameter(node) => {
+                (RootNodeKind::Parameter, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::ParameterWithDefault(node) => (
+                RootNodeKind::ParameterWithDefault,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::Keyword(node) => {
+                (RootNodeKind::Keyword, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Alias(node) => (RootNodeKind::Alias, std::ptr::from_ref(node).cast()),
+            AnyRootNodeRef::WithItem(node) => {
+                (RootNodeKind::WithItem, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::MatchCase(node) => {
+                (RootNodeKind::MatchCase, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Decorator(node) => {
+                (RootNodeKind::Decorator, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::ElifElseClause(node) => (
+                RootNodeKind::ElifElseClause,
+                std::ptr::from_ref(node).cast(),
+            ),
+            AnyRootNodeRef::TypeParams(node) => {
+                (RootNodeKind::TypeParams, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::FString(node) => {
+                (RootNodeKind::FString, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::TString(node) => {
+                (RootNodeKind::TString, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::StringLiteral(node) => {
+                (RootNodeKind::StringLiteral, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::BytesLiteral(node) => {
+                (RootNodeKind::BytesLiteral, std::ptr::from_ref(node).cast())
+            }
+            AnyRootNodeRef::Identifier(node) => {
+                (RootNodeKind::Identifier, std::ptr::from_ref(node).cast())
+            }
+        }
+    }
+
+    /// Reconstructs an AST reference from its root node kind and type-erased pointer.
+    ///
+    /// # Safety
+    ///
+    /// `pointer` must be non-null, properly aligned, and point to the root node type
+    /// represented by `kind`. The pointed-to node must live for `'a`.
+    #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
+    pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
+        match kind {
+            RootNodeKind::Mod => AnyRootNodeRef::Mod(unsafe { &*pointer.cast::<Mod>() }),
+            RootNodeKind::Stmt => AnyRootNodeRef::Stmt(unsafe { &*pointer.cast::<Stmt>() }),
+            RootNodeKind::Expr => AnyRootNodeRef::Expr(unsafe { &*pointer.cast::<Expr>() }),
+            RootNodeKind::ExceptHandler => {
+                AnyRootNodeRef::ExceptHandler(unsafe { &*pointer.cast::<ExceptHandler>() })
+            }
+            RootNodeKind::InterpolatedStringElement => {
+                AnyRootNodeRef::InterpolatedStringElement(unsafe {
+                    &*pointer.cast::<InterpolatedStringElement>()
+                })
+            }
+            RootNodeKind::Pattern => {
+                AnyRootNodeRef::Pattern(unsafe { &*pointer.cast::<Pattern>() })
+            }
+            RootNodeKind::TypeParam => {
+                AnyRootNodeRef::TypeParam(unsafe { &*pointer.cast::<TypeParam>() })
+            }
+            RootNodeKind::InterpolatedStringFormatSpec => {
+                AnyRootNodeRef::InterpolatedStringFormatSpec(unsafe {
+                    &*pointer.cast::<crate::InterpolatedStringFormatSpec>()
+                })
+            }
+            RootNodeKind::PatternArguments => AnyRootNodeRef::PatternArguments(unsafe {
+                &*pointer.cast::<crate::PatternArguments>()
+            }),
+            RootNodeKind::PatternKeyword => {
+                AnyRootNodeRef::PatternKeyword(unsafe { &*pointer.cast::<crate::PatternKeyword>() })
+            }
+            RootNodeKind::Comprehension => {
+                AnyRootNodeRef::Comprehension(unsafe { &*pointer.cast::<crate::Comprehension>() })
+            }
+            RootNodeKind::Arguments => {
+                AnyRootNodeRef::Arguments(unsafe { &*pointer.cast::<crate::Arguments>() })
+            }
+            RootNodeKind::Parameters => {
+                AnyRootNodeRef::Parameters(unsafe { &*pointer.cast::<crate::Parameters>() })
+            }
+            RootNodeKind::Parameter => {
+                AnyRootNodeRef::Parameter(unsafe { &*pointer.cast::<crate::Parameter>() })
+            }
+            RootNodeKind::ParameterWithDefault => AnyRootNodeRef::ParameterWithDefault(unsafe {
+                &*pointer.cast::<crate::ParameterWithDefault>()
+            }),
+            RootNodeKind::Keyword => {
+                AnyRootNodeRef::Keyword(unsafe { &*pointer.cast::<crate::Keyword>() })
+            }
+            RootNodeKind::Alias => {
+                AnyRootNodeRef::Alias(unsafe { &*pointer.cast::<crate::Alias>() })
+            }
+            RootNodeKind::WithItem => {
+                AnyRootNodeRef::WithItem(unsafe { &*pointer.cast::<crate::WithItem>() })
+            }
+            RootNodeKind::MatchCase => {
+                AnyRootNodeRef::MatchCase(unsafe { &*pointer.cast::<crate::MatchCase>() })
+            }
+            RootNodeKind::Decorator => {
+                AnyRootNodeRef::Decorator(unsafe { &*pointer.cast::<crate::Decorator>() })
+            }
+            RootNodeKind::ElifElseClause => {
+                AnyRootNodeRef::ElifElseClause(unsafe { &*pointer.cast::<crate::ElifElseClause>() })
+            }
+            RootNodeKind::TypeParams => {
+                AnyRootNodeRef::TypeParams(unsafe { &*pointer.cast::<crate::TypeParams>() })
+            }
+            RootNodeKind::FString => {
+                AnyRootNodeRef::FString(unsafe { &*pointer.cast::<crate::FString>() })
+            }
+            RootNodeKind::TString => {
+                AnyRootNodeRef::TString(unsafe { &*pointer.cast::<crate::TString>() })
+            }
+            RootNodeKind::StringLiteral => {
+                AnyRootNodeRef::StringLiteral(unsafe { &*pointer.cast::<crate::StringLiteral>() })
+            }
+            RootNodeKind::BytesLiteral => {
+                AnyRootNodeRef::BytesLiteral(unsafe { &*pointer.cast::<crate::BytesLiteral>() })
+            }
+            RootNodeKind::Identifier => {
+                AnyRootNodeRef::Identifier(unsafe { &*pointer.cast::<crate::Identifier>() })
+            }
+        }
+    }
+
     pub fn visit_source_order<'b, V>(self, visitor: &mut V)
     where
         V: crate::visitor::source_order::SourceOrderVisitor<'b> + ?Sized,

--- a/crates/ruff_python_ast/src/generated.rs
+++ b/crates/ruff_python_ast/src/generated.rs
@@ -7464,8 +7464,11 @@ pub enum AnyRootNodeRef<'a> {
     Identifier(&'a crate::Identifier),
 }
 
-/// The root type of an AST node.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+/// The unflattened enum or struct type stored by an [`AnyRootNodeRef`].
+///
+/// Unlike [`NodeKind`], this does not distinguish variants of root enums such as [`Stmt`]
+/// and [`Expr`].
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "get-size", derive(get_size2::GetSize))]
 #[repr(u8)]
 pub enum RootNodeKind {
@@ -7537,6 +7540,7 @@ impl RootNodeKind {
 }
 
 impl<'a> From<&'a Mod> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a Mod) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Mod(node)
     }
@@ -7573,6 +7577,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::ModExpression {
 }
 
 impl<'a> From<&'a Stmt> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a Stmt) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Stmt(node)
     }
@@ -7839,6 +7844,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::StmtIpyEscapeCommand {
 }
 
 impl<'a> From<&'a Expr> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a Expr) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Expr(node)
     }
@@ -8185,6 +8191,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::ExprIpyEscapeCommand {
 }
 
 impl<'a> From<&'a ExceptHandler> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a ExceptHandler) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::ExceptHandler(node)
     }
@@ -8211,6 +8218,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::ExceptHandlerExceptHandler {
 }
 
 impl<'a> From<&'a InterpolatedStringElement> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a InterpolatedStringElement) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::InterpolatedStringElement(node)
     }
@@ -8253,6 +8261,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::InterpolatedStringLiteralEle
 }
 
 impl<'a> From<&'a Pattern> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a Pattern) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Pattern(node)
     }
@@ -8349,6 +8358,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::PatternMatchOr {
 }
 
 impl<'a> From<&'a TypeParam> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a TypeParam) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::TypeParam(node)
     }
@@ -8395,6 +8405,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::TypeParamParamSpec {
 }
 
 impl<'a> From<&'a crate::InterpolatedStringFormatSpec> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::InterpolatedStringFormatSpec) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::InterpolatedStringFormatSpec(node)
     }
@@ -8411,6 +8422,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::InterpolatedStringFormatSpec
 }
 
 impl<'a> From<&'a crate::PatternArguments> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::PatternArguments) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::PatternArguments(node)
     }
@@ -8427,6 +8439,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::PatternArguments {
 }
 
 impl<'a> From<&'a crate::PatternKeyword> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::PatternKeyword) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::PatternKeyword(node)
     }
@@ -8443,6 +8456,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::PatternKeyword {
 }
 
 impl<'a> From<&'a crate::Comprehension> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Comprehension) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Comprehension(node)
     }
@@ -8459,6 +8473,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Comprehension {
 }
 
 impl<'a> From<&'a crate::Arguments> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Arguments) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Arguments(node)
     }
@@ -8475,6 +8490,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Arguments {
 }
 
 impl<'a> From<&'a crate::Parameters> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Parameters) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Parameters(node)
     }
@@ -8491,6 +8507,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Parameters {
 }
 
 impl<'a> From<&'a crate::Parameter> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Parameter) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Parameter(node)
     }
@@ -8507,6 +8524,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Parameter {
 }
 
 impl<'a> From<&'a crate::ParameterWithDefault> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::ParameterWithDefault) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::ParameterWithDefault(node)
     }
@@ -8523,6 +8541,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::ParameterWithDefault {
 }
 
 impl<'a> From<&'a crate::Keyword> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Keyword) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Keyword(node)
     }
@@ -8539,6 +8558,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Keyword {
 }
 
 impl<'a> From<&'a crate::Alias> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Alias) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Alias(node)
     }
@@ -8555,6 +8575,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Alias {
 }
 
 impl<'a> From<&'a crate::WithItem> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::WithItem) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::WithItem(node)
     }
@@ -8571,6 +8592,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::WithItem {
 }
 
 impl<'a> From<&'a crate::MatchCase> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::MatchCase) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::MatchCase(node)
     }
@@ -8587,6 +8609,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::MatchCase {
 }
 
 impl<'a> From<&'a crate::Decorator> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Decorator) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Decorator(node)
     }
@@ -8603,6 +8626,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::Decorator {
 }
 
 impl<'a> From<&'a crate::ElifElseClause> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::ElifElseClause) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::ElifElseClause(node)
     }
@@ -8619,6 +8643,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::ElifElseClause {
 }
 
 impl<'a> From<&'a crate::TypeParams> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::TypeParams) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::TypeParams(node)
     }
@@ -8635,6 +8660,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::TypeParams {
 }
 
 impl<'a> From<&'a crate::FString> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::FString) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::FString(node)
     }
@@ -8651,6 +8677,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::FString {
 }
 
 impl<'a> From<&'a crate::TString> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::TString) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::TString(node)
     }
@@ -8667,6 +8694,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::TString {
 }
 
 impl<'a> From<&'a crate::StringLiteral> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::StringLiteral) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::StringLiteral(node)
     }
@@ -8683,6 +8711,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::StringLiteral {
 }
 
 impl<'a> From<&'a crate::BytesLiteral> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::BytesLiteral) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::BytesLiteral(node)
     }
@@ -8699,6 +8728,7 @@ impl<'a> TryFrom<AnyRootNodeRef<'a>> for &'a crate::BytesLiteral {
 }
 
 impl<'a> From<&'a crate::Identifier> for AnyRootNodeRef<'a> {
+    #[inline]
     fn from(node: &'a crate::Identifier) -> AnyRootNodeRef<'a> {
         AnyRootNodeRef::Identifier(node)
     }
@@ -8784,6 +8814,7 @@ impl crate::HasNodeIndex for AnyRootNodeRef<'_> {
 
 impl<'a> AnyRootNodeRef<'a> {
     /// Decomposes this reference into its root node kind and a type-erased pointer.
+    #[inline]
     pub fn into_raw_parts(self) -> (RootNodeKind, *const ()) {
         match self {
             AnyRootNodeRef::Mod(node) => (RootNodeKind::Mod, std::ptr::from_ref(node).cast()),
@@ -8874,6 +8905,7 @@ impl<'a> AnyRootNodeRef<'a> {
     ///
     /// `pointer` must be non-null, properly aligned, and point to the root node type
     /// represented by `kind`. The pointed-to node must live for `'a`.
+    #[inline]
     #[expect(unsafe_code, reason = "reconstructs a type-erased AST reference")]
     pub unsafe fn from_raw_parts(kind: RootNodeKind, pointer: *const ()) -> Self {
         match kind {


### PR DESCRIPTION
## Summary

`IndexedModule` retains one lookup entry for every indexed AST node. Previously, each entry was a full `AnyRootNodeRef`, even though resolving a `NodeIndex` only requires the node's address and root AST kind.

This replaces those references with a compact, chunked representation. We divide the index into fixed groups of 64 nodes, allowing each chunk to choose a base address and the minimum bit width needed for its entries. Aligned relative offsets and five-bit node-kind discriminants share a packed `u64` bitstream, while unusually large or unaligned chunks use a local wide fallback. Deriving the chunk directly from the node index keeps lookup constant-time and prevents one distant allocation from forcing a wider representation for the entire AST. This also removes the previous split representation.

On lookup, we reconstruct the borrowed `AnyRootNodeRef` from the stored raw parts, avoiding the previous self-referential `'static` reference slice. The AST generator emits `RootNodeKind` and the raw-parts conversions alongside `AnyRootNodeRef`, keeping the unflattened root-type mapping synchronized as the AST evolves. This is intentionally separate from `NodeKind`, which distinguishes concrete variants such as `StmtFunctionDef` rather than the `Stmt` root type addressed by the index.

The traversal also stops indexing annotation expressions twice, since `walk_annotation` already delegates to `visit_expr`. The coverage round-trips every indexed root-node kind and exercises entries spanning bitstream words, independent relative layouts for distant chunks, and the wide fallback.
