### PR TITLE
[ty] Speed up large-union narrowing

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6936,17 +6936,6 @@ impl<'db> Type<'db> {
         }
     }
 
-    /// Return whether the negation of this type is a subtype of `target`.
-    ///
-    /// This avoids materializing expensive negations when the subtype check can be performed
-    /// directly on the original type shape.
-    pub(crate) fn negation_is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
-        match self {
-            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, target),
-            _ => self.negate(db).is_subtype_of(db, target),
-        }
-    }
-
     /// Return whether the negation of this type is a subtype of `target`, reusing `negated_cache`
     /// for type shapes whose negation must still be materialized.
     pub(crate) fn negation_is_subtype_of_cached(
@@ -6956,7 +6945,7 @@ impl<'db> Type<'db> {
         negated_cache: &mut Option<Type<'db>>,
     ) -> bool {
         match self {
-            Type::Intersection(_) => self.negation_is_subtype_of(db, target),
+            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, target),
             _ => {
                 let negated = negated_cache.get_or_insert_with(|| self.negate(db));
                 negated.is_subtype_of(db, target)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6938,6 +6938,21 @@ impl<'db> Type<'db> {
 }
 
 impl<'db> IntersectionType<'db> {
+    /// Return whether the negation of this intersection is a subtype of `target`.
+    ///
+    /// Applying De Morgan's law to an intersection produces a union. Checking each branch
+    /// directly avoids constructing and simplifying that temporary union, which can be costly
+    /// for the large intersections produced by repeated narrowing.
+    pub(crate) fn negation_is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        self.positive(db)
+            .iter()
+            .all(|positive| positive.negate(db).is_subtype_of(db, target))
+            && self
+                .negative(db)
+                .iter()
+                .all(|negative| negative.is_subtype_of(db, target))
+    }
+
     // Calls the dunder on each element separately and combines the results.
     // This avoids intersecting bound methods (which often collapses to Never)
     // and instead intersects the return types.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6935,6 +6935,34 @@ impl<'db> Type<'db> {
             Truthiness::Ambiguous => KnownClass::Bool.to_instance(db),
         }
     }
+
+    /// Return whether the negation of this type is a subtype of `target`.
+    ///
+    /// This avoids materializing expensive negations when the subtype check can be performed
+    /// directly on the original type shape.
+    pub(crate) fn negation_is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        match self {
+            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, target),
+            _ => self.negate(db).is_subtype_of(db, target),
+        }
+    }
+
+    /// Return whether the negation of this type is a subtype of `target`, reusing `negated_cache`
+    /// for type shapes whose negation must still be materialized.
+    pub(crate) fn negation_is_subtype_of_cached(
+        self,
+        db: &'db dyn Db,
+        target: Type<'db>,
+        negated_cache: &mut Option<Type<'db>>,
+    ) -> bool {
+        match self {
+            Type::Intersection(_) => self.negation_is_subtype_of(db, target),
+            _ => {
+                let negated = negated_cache.get_or_insert_with(|| self.negate(db));
+                negated.is_subtype_of(db, target)
+            }
+        }
+    }
 }
 
 impl<'db> IntersectionType<'db> {

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -113,6 +113,14 @@ mod stable {
         forall types s, t. s.is_subtype_of(db, t) && t.is_subtype_of(db, s) => s.is_equivalent_to(db, t)
     );
 
+    type_property_test!(
+        structural_negation_subtyping_matches_materialized_negation, db,
+        forall types s, t. match s {
+            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, t) == s.negate(db).is_subtype_of(db, t),
+            _ => true,
+        }
+    );
+
     // `T` is not disjoint from itself, unless `T` is `Never`.
     type_property_test!(
         disjoint_from_is_irreflexive, db,

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -115,7 +115,10 @@ mod stable {
 
     type_property_test!(
         structural_negation_subtyping_matches_materialized_negation, db,
-        forall types s, t. s.negation_is_subtype_of(db, t) == s.negate(db).is_subtype_of(db, t)
+        forall types s, t. {
+            let mut cache = None;
+            s.negation_is_subtype_of_cached(db, t, &mut cache) == s.negate(db).is_subtype_of(db, t)
+        }
     );
 
     // `T` is not disjoint from itself, unless `T` is `Never`.

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -115,10 +115,7 @@ mod stable {
 
     type_property_test!(
         structural_negation_subtyping_matches_materialized_negation, db,
-        forall types s, t. match s {
-            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, t) == s.negate(db).is_subtype_of(db, t),
-            _ => true,
-        }
+        forall types s, t. s.negation_is_subtype_of(db, t) == s.negate(db).is_subtype_of(db, t)
     );
 
     // `T` is not disjoint from itself, unless `T` is `Never`.

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -957,8 +957,13 @@ impl<'db> UnionBuilder<'db> {
                     continue;
                 }
 
-                let negated = ty_negated.get_or_insert_with(|| ty.negate(self.db));
-                if negated.is_subtype_of(self.db, element_type) {
+                let negation_is_subtype = if let Type::Intersection(intersection) = ty {
+                    intersection.negation_is_subtype_of(self.db, element_type)
+                } else {
+                    let negated = ty_negated.get_or_insert_with(|| ty.negate(self.db));
+                    negated.is_subtype_of(self.db, element_type)
+                };
+                if negation_is_subtype {
                     // We add `ty` to the union. We just checked that `~ty` is a subtype of an
                     // existing `element`. This also means that `~ty | ty` is a subtype of
                     // `element | ty`, because both elements in the first union are subtypes of

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -304,8 +304,6 @@ impl<'db> UnionElement<'db> {
     /// Try reducing this `UnionElement` given the presence in the same union of `other_type`.
     fn try_reduce(&mut self, db: &'db dyn Db, other_type: Type<'db>) -> ReduceResult<'db> {
         let mut other_type_negated_cache = None;
-        let mut other_type_negated =
-            || *other_type_negated_cache.get_or_insert_with(|| other_type.negate(db));
 
         let mut collapse = false;
         let mut ignore = false;
@@ -333,7 +331,9 @@ impl<'db> UnionElement<'db> {
                 ignore = true;
                 return true;
             }
-            if collapse || other_type_negated().is_subtype_of(db, ty) {
+            if collapse
+                || other_type.negation_is_subtype_of_cached(db, ty, &mut other_type_negated_cache)
+            {
                 collapse = true;
                 return true;
             }
@@ -957,13 +957,7 @@ impl<'db> UnionBuilder<'db> {
                     continue;
                 }
 
-                let negation_is_subtype = if let Type::Intersection(intersection) = ty {
-                    intersection.negation_is_subtype_of(self.db, element_type)
-                } else {
-                    let negated = ty_negated.get_or_insert_with(|| ty.negate(self.db));
-                    negated.is_subtype_of(self.db, element_type)
-                };
-                if negation_is_subtype {
+                if ty.negation_is_subtype_of_cached(self.db, element_type, &mut ty_negated) {
                     // We add `ty` to the union. We just checked that `~ty` is a subtype of an
                     // existing `element`. This also means that `~ty | ty` is a subtype of
                     // `element | ty`, because both elements in the first union are subtypes of


### PR DESCRIPTION
## Summary

Supersedes #23555 with a semantics-preserving optimization for large-union narrowing. Apply De Morgan's law structurally when checking an intersection's negation, avoiding construction and simplification of a temporary union.

This reduces simulated instructions for `large_union_narrowing` by 22.85% (662,828,371 to 511,360,788).

## Test Plan

Testing: Passed ty's semantic test suite, 10,000 property-test cases, Clippy, repository hooks, and CodSpeed.
