### PR TITLE
[ty] Fix nested capture build on main

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -138,8 +138,19 @@ struct ScopeInfo<'ast> {
 type NestedGlobalOrNonlocalDeclarations = FxHashMap<Name, SmallVec<[NestedDeclaration; 1]>>;
 
 /// Captures cannot be resolved until the enclosing scope is complete because a later binding can
-/// make the name local. Each pending capture remembers the bindings visible when the nested scope
-/// was created and, for lazy scopes, any bindings added afterward.
+/// make the name local. For example, `inner` captures `outer`'s local `value`, even though the
+/// binding appears after `inner` is defined:
+///
+/// ```python
+/// def outer():
+///     def inner():
+///         return value
+///
+///     value = 1
+/// ```
+///
+/// Each pending capture remembers the bindings visible when the nested scope was created and, for
+/// lazy scopes, any bindings added afterward.
 type PendingCaptures = FxHashMap<Name, SmallVec<[PendingCapture; 1]>>;
 
 #[derive(Debug)]

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2063,6 +2063,7 @@ impl<'db> UseDefMapBuilder<'db> {
         symbol: ScopedSymbolId,
     ) -> impl Iterator<Item = ScopedDefinitionId> + '_ {
         self.symbol_states[symbol]
+            .state
             .bindings()
             .iter()
             .map(LiveBinding::binding)


### PR DESCRIPTION
## Summary

PR #26012 changed pending symbol states to wrap the underlying `PlaceState`, but PR #25536 still accessed bindings directly from the wrapper when it merged afterward. This caused `ty_python_core` to fail to compile on `main`.

Access the wrapped state before iterating its bindings. This also restores the expanded `PendingCaptures` documentation that illustrates why capture resolution must account for bindings introduced after a nested function is defined.

The focused `ty_python_core` test suite and file-scoped repository hooks pass.
