### PR TITLE
[ty] Preserve narrowing after qualified TYPE_CHECKING

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -1825,7 +1825,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         fn resolve_to_literal(node: &ast::Expr) -> Option<bool> {
             match node {
                 ast::Expr::BooleanLiteral(ast::ExprBooleanLiteral { value, .. }) => Some(*value),
-                ast::Expr::Name(ast::ExprName { id, .. }) if id == "TYPE_CHECKING" => Some(true),
+                node if is_if_type_checking(node) => Some(true),
                 ast::Expr::NumberLiteral(ast::ExprNumberLiteral {
                     value: ast::Number::Int(n),
                     ..

--- a/crates/ty_python_semantic/resources/mdtest/known_constants.md
+++ b/crates/ty_python_semantic/resources/mdtest/known_constants.md
@@ -26,6 +26,26 @@ from typing import TYPE_CHECKING as TC
 reveal_type(TC)  # revealed: Literal[True]
 ```
 
+### Qualified conditions
+
+Qualified references to `TYPE_CHECKING` are evaluated eagerly, allowing narrowing from the
+statically reachable branch to be preserved after the condition:
+
+```py
+import typing
+import typing as t
+
+def typing_qualified(value: int | None) -> None:
+    if typing.TYPE_CHECKING:
+        assert isinstance(value, int)
+    reveal_type(value)  # revealed: int
+
+def typing_alias_qualified(value: int | None) -> None:
+    if t.TYPE_CHECKING:
+        assert isinstance(value, int)
+    reveal_type(value)  # revealed: int
+```
+
 ### `typing_extensions` re-export
 
 This should behave in the same way as `typing.TYPE_CHECKING`:


### PR DESCRIPTION
## Summary

Teach semantic-index predicate construction to recognize qualified `TYPE_CHECKING` conditions using the same detector already used for identifying type-checking blocks. This preserves narrowing established in the statically reachable branch for both `typing.TYPE_CHECKING` and qualified module aliases such as `t.TYPE_CHECKING`.

Add regression coverage for both qualified forms to the existing known-constants mdtest.

## Root cause

Only the bare name `TYPE_CHECKING` was eagerly evaluated while building the semantic index. Qualified forms were resolved as true later during type inference, after the branch flow states had already been merged and branch-local narrowing had been discarded.

Fixes https://github.com/astral-sh/ty/issues/3779
