### PR TITLE
[ty] Avoid redundant equality intersections

### DIFF
--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -672,11 +672,18 @@ fn evaluate_target_union<'db>(
 
     let removed = removed_any.then(|| removed.build());
     let mut builder = UnionBuilder::new(db);
-    for narrowed in narrowed {
+    for (original, narrowed) in elements.iter().zip(narrowed) {
         let Some(mut narrowed) = narrowed else {
             continue;
         };
-        if let Some(removed) = removed {
+        // This is a performance optimization that keeps repeated comparisons from building
+        // progressively larger types. For example, if `value == "a"` is false for
+        // `Literal["a", "b"] | Any`, the `"a"` case is gone and the `"b"` case can stay as-is.
+        // Only the `Any` case needs to remember that the value is not `"a"`; adding the same
+        // exclusion to `"b"` would not narrow it further.
+        if original.is_dynamic()
+            && let Some(removed) = removed
+        {
             narrowed = IntersectionBuilder::new(db)
                 .add_positive(narrowed)
                 .add_negative(removed)


### PR DESCRIPTION
## Summary

This restores the dynamic-only guard when applying removed union arms as negative constraints during equality narrowing. Static alternatives have already been narrowed individually, so intersecting every surviving arm with the removed set creates redundant intersection types that compound across repeated fallthrough narrowing.

Dynamic alternatives still need those negative constraints to preserve the branch predicate. Keeping that distinction avoids the guarded-`Any` equality benchmark regression introduced by `4e7ab3ac6c` without changing narrowing behavior. The targeted benchmark showed that removing the guard increased runtime by about 33% locally.

The full `ty_python_semantic` suite, Clippy with warnings denied, and file-scoped hooks pass.
