### PR TITLE
Use human-readable names in LSP and playground diagnostics

### DIFF
--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -22,7 +22,8 @@ use ruff_linter::{
     linter::check_path,
     package::PackageRoot,
     packaging::detect_package_root,
-    settings::flags,
+    preview::is_human_readable_names_enabled,
+    settings::{LinterSettings, flags},
     source_kind::SourceKind,
     suppression::Suppressions,
 };
@@ -171,6 +172,7 @@ pub(crate) fn check(
         document_uri: &document_uri,
         notebook,
         supports_related_information,
+        settings: &settings.linter,
     };
 
     let mut diagnostics_map = DiagnosticsMap::default();
@@ -256,6 +258,7 @@ struct LspDiagnosticContext<'a> {
     document_uri: &'a lsp_types::Uri,
     notebook: Option<&'a NotebookDocument>,
     supports_related_information: bool,
+    settings: &'a LinterSettings,
 }
 
 /// Generates an LSP diagnostic with an associated cell index for the diagnostic to go in.
@@ -328,7 +331,13 @@ fn to_lsp_diagnostic(
     }
 
     let (severity, code) = if let Some(code) = code {
-        (severity(code), code.to_string())
+        let severity = severity(code);
+        let code = if is_human_readable_names_enabled(context.settings.preview) {
+            name.to_string()
+        } else {
+            code.to_string()
+        };
+        (severity, code)
     } else {
         (
             match diagnostic.severity() {
@@ -337,7 +346,7 @@ fn to_lsp_diagnostic(
                 ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::Error,
                 ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::Error,
             },
-            diagnostic.secondary_code_or_id().to_string(),
+            diagnostic.id().to_string(),
         )
     };
 
@@ -559,6 +568,7 @@ mod tests {
         };
         let index = LineIndex::from_source_text(source);
         let uri = lsp_types::Uri::parse("file:///test.py").expect("URI to be valid");
+        let settings = LinterSettings::default();
         let context = LspDiagnosticContext {
             source_kind: &source_kind,
             index: &index,
@@ -567,6 +577,7 @@ mod tests {
             document_uri: &uri,
             notebook: None,
             supports_related_information: true,
+            settings: &settings,
         };
         let (_, lsp_diagnostic) = to_lsp_diagnostic(&diagnostic, None, &context);
 

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -10,7 +10,7 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
         .with_file("pyproject.toml", "tool.ruff.preview = true")?
         .build();
 
-    server.open_text_document("test.py", "import os", 1);
+    server.open_text_document("test.py", "import os\n", 1);
 
     let diagnostics = server.document_diagnostic_request("test.py", None);
 
@@ -47,8 +47,8 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
                 "newText": "",
                 "range": {
                   "end": {
-                    "character": 9,
-                    "line": 0
+                    "character": 0,
+                    "line": 1
                   },
                   "start": {
                     "character": 0,
@@ -61,8 +61,8 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
               "newText": "  # noqa: F401\n",
               "range": {
                 "end": {
-                  "character": 9,
-                  "line": 0
+                  "character": 0,
+                  "line": 1
                 },
                 "start": {
                   "character": 9,

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -1,0 +1,83 @@
+use anyhow::Result;
+use insta::assert_json_snapshot;
+
+use crate::TestServerBuilder;
+
+#[test]
+fn uses_human_readable_names_in_preview() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .with_file("pyproject.toml", "tool.ruff.preview = true")?
+        .build();
+
+    server.open_text_document("test.py", "import os", 1);
+
+    let diagnostics = server.document_diagnostic_request("test.py", None);
+
+    assert_json_snapshot!(
+        diagnostics,
+        @r#"
+    {
+      "items": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 7
+            },
+            "end": {
+              "line": 0,
+              "character": 9
+            }
+          },
+          "severity": 2,
+          "code": "unused-import",
+          "codeDescription": {
+            "href": "https://docs.astral.sh/ruff/rules/unused-import"
+          },
+          "source": "Ruff",
+          "message": "`os` imported but unused\n\nhelp: Remove unused import: `os`",
+          "tags": [
+            1
+          ],
+          "data": {
+            "code": "F401",
+            "edits": [
+              {
+                "newText": "",
+                "range": {
+                  "end": {
+                    "character": 9,
+                    "line": 0
+                  },
+                  "start": {
+                    "character": 0,
+                    "line": 0
+                  }
+                }
+              }
+            ],
+            "noqa_edit": {
+              "newText": "  # noqa: F401\n",
+              "range": {
+                "end": {
+                  "character": 9,
+                  "line": 0
+                },
+                "start": {
+                  "character": 9,
+                  "line": 0
+                }
+              }
+            },
+            "title": "Remove unused import: `os`"
+          }
+        }
+      ],
+      "kind": "full"
+    }
+    "#
+    );
+
+    Ok(())
+}

--- a/crates/ruff_server/tests/e2e/main.rs
+++ b/crates/ruff_server/tests/e2e/main.rs
@@ -27,6 +27,7 @@
 
 mod code_action;
 mod custom_extension;
+mod diagnostics;
 mod hover;
 mod notebook;
 mod workspace;

--- a/crates/ruff_wasm/src/lib.rs
+++ b/crates/ruff_wasm/src/lib.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use js_sys::Error;
 use ruff_db::diagnostic;
+use ruff_linter::preview::is_human_readable_names_enabled;
 use ruff_linter::settings::types::PythonVersion;
 use ruff_linter::suppression::Suppressions;
 use serde::{Deserialize, Serialize};
@@ -398,8 +399,16 @@ impl Workspace {
                     })
                     .collect();
 
+                let code = if !is_human_readable_names_enabled(self.settings.linter.preview)
+                    && let Some(code) = msg.secondary_code()
+                {
+                    code.as_str()
+                } else {
+                    msg.id().as_str()
+                };
+
                 ExpandedMessage {
-                    code: msg.secondary_code_or_id().to_string(),
+                    code: code.to_string(),
                     message: msg.concise_message().to_string(),
                     annotations,
                     sub_diagnostics,

--- a/playground/ruff/src/Editor/SourceEditor.tsx
+++ b/playground/ruff/src/Editor/SourceEditor.tsx
@@ -197,7 +197,10 @@ function updateMarkers(monaco: Monaco, diagnostics: Array<Diagnostic>) {
         relatedInformation: diagnosticRelatedInformation(diagnostic, model.uri),
         severity: MarkerSeverity.Error,
         tags:
-          diagnostic.code === "F401" || diagnostic.code === "F841"
+          diagnostic.code === "F401" ||
+          diagnostic.code === "F841" ||
+          diagnostic.code === "unused-import" ||
+          diagnostic.code === "unused-variable"
             ? [MarkerTag.Unnecessary]
             : [],
       };


### PR DESCRIPTION
## Summary

This PR follows up on #25937 to display human-readable names in the LSP and playground too, when preview is enabled.

## Test Plan

In VS Code with `preview = true` in my `ruff.toml`:

<img width="788" height="352" alt="Screenshot 2026-06-16 at 16 28 50" src="https://github.com/user-attachments/assets/9352d76c-a87a-4721-9ca0-c9b130c98452" />

with `preview = false`:

<img width="794" height="318" alt="Screenshot 2026-06-16 at 16 29 13" src="https://github.com/user-attachments/assets/88a3346e-63a2-4e51-8d3b-fa71b36388b2" />

In the playground with preview enabled:

<img width="730" height="333" alt="Screenshot 2026-06-16 at 16 58 15" src="https://github.com/user-attachments/assets/3df5e40b-6b7e-4832-b0ba-6b3cb3b685b0" />

and with preview disabled:

<img width="769" height="323" alt="Screenshot 2026-06-16 at 16 51 30" src="https://github.com/user-attachments/assets/b7261c3b-512d-43bb-9dd7-ddf825773734" />

