### PR TITLE
[ty] Narrow equality across IntEnum classes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -137,6 +137,8 @@ class Bar(IntEnum):
     A = 1
     B = 2
 
+reveal_type(Foo.X.value)  # revealed: Literal[1]
+
 def _(value: Foo | Bar):
     if value == Foo.X:
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
@@ -194,6 +196,8 @@ class Generated(IntEnum):
 
 class Other(IntEnum):
     ONE = 1
+
+reveal_type(Generated.ONE.value)  # revealed: int
 
 def _(value: Generated | Other):
     if value == Generated.ONE:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -151,6 +151,57 @@ def _(value: Foo | Bar):
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
 ```
 
+The same narrowing applies when comparing enum members directly with their inherited integer or
+string values. The negative constraint excludes both the builtin literal and every enum member known
+to compare equal to it:
+
+```py
+from enum import Enum, IntEnum, StrEnum
+
+class IntMember(int, Enum):
+    X = 1
+    Y = 2
+
+class Integer(IntEnum):
+    X = 1
+    Y = 2
+
+class String(StrEnum):
+    X = "X"
+    Y = "Y"
+
+class StrMember(str, Enum):
+    X = "X"
+    Y = "Y"
+
+def _(value: IntMember | Integer | String | StrMember):
+    if value == 1:
+        pass
+    else:
+        reveal_type(value)  # revealed: Literal[IntMember.Y, Integer.Y] | String | StrMember
+
+    if value != 1:
+        reveal_type(value)  # revealed: Literal[IntMember.Y, Integer.Y] | String | StrMember
+
+    if value == "X":
+        pass
+    else:
+        reveal_type(value)  # revealed: IntMember | Integer | Literal[String.Y, StrMember.Y]
+
+    if value != "X":
+        reveal_type(value)  # revealed: IntMember | Integer | Literal[String.Y, StrMember.Y]
+
+def random() -> bool:
+    return False
+
+def loop_back():
+    value = IntMember.X if random() else IntMember.Y
+    if value != 1:
+        while random():
+            reveal_type(value)  # revealed: Literal[IntMember.Y, Integer.Y]
+            value = Integer.Y
+```
+
 A custom `__new__` can replace the value declared in an `IntEnum` class body. We can still narrow
 the members of `Foo`, whose runtime values are known, but must preserve all of `Shifted` because its
 members' runtime values cannot be determined statically:
@@ -280,7 +331,7 @@ def _(generate_next_value: Any):
         if value == "explicit":
             reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT]
         else:
-            reveal_type(value)  # revealed: Literal[OpaqueGenerator.EXPLICIT, "other"]
+            reveal_type(value)  # revealed: Literal["other"]
 ```
 
 This narrowing behavior is only safe if the enum has no custom `__eq__`/`__ne__` method:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,11 +122,12 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
-`IntEnum` members from different classes compare using their integer values:
+Unlike plain `Enum` members, `IntEnum` members inherit integer equality. Members of different
+`IntEnum` classes therefore compare equal when they have the same integer value, so both equality
+and inequality narrowing must account for matching members from every class in the union:
 
 ```py
-from enum import IntEnum, auto
-from typing import Literal
+from enum import IntEnum
 
 class Foo(IntEnum):
     X = 1
@@ -146,6 +147,18 @@ def _(value: Foo | Bar):
         reveal_type(value)  # revealed: Literal[Foo.Y, Bar.B]
     else:
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
+```
+
+A custom `__new__` can replace the value declared in an `IntEnum` class body. We can still narrow
+the members of `Foo`, whose runtime values are known, but must preserve all of `Shifted` because its
+members' runtime values cannot be determined statically:
+
+```py
+from enum import IntEnum
+
+class Foo(IntEnum):
+    X = 1
+    Y = 2
 
 class Shifted(IntEnum):
     def __new__(cls, value: int) -> "Shifted":
@@ -161,8 +174,17 @@ def _(value: Foo | Shifted):
         reveal_type(value)  # revealed: Literal[Foo.X] | Shifted
     else:
         reveal_type(value)  # revealed: Literal[Foo.Y] | Shifted
+```
 
-# `int.__new__` converts the generated string to `1` at runtime.
+The return value of `_generate_next_value_` is not necessarily the final value of an `IntEnum`
+member. Here, the inherited `int.__new__` converts the generated string `"1"` to the integer `1`.
+Because the generated value's exact conversion is not modeled, we cannot use it to decide whether
+members of `Generated` and `Other` compare equal:
+
+```py
+from enum import IntEnum, auto
+from typing import Literal
+
 class Generated(IntEnum):
     # error: [invalid-method-override]
     def _generate_next_value_(name, start, count, last_values) -> Literal["1"]:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,46 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+`IntEnum` members from different classes compare using their integer values:
+
+```py
+from enum import IntEnum
+
+class Foo(IntEnum):
+    X = 1
+    Y = 2
+
+class Bar(IntEnum):
+    A = 1
+    B = 2
+
+def _(value: Foo | Bar):
+    if value == Foo.X:
+        reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
+    else:
+        reveal_type(value)  # revealed: Literal[Foo.Y, Bar.B]
+
+    if value != Foo.X:
+        reveal_type(value)  # revealed: Literal[Foo.Y, Bar.B]
+    else:
+        reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
+
+class Shifted(IntEnum):
+    def __new__(cls, value: int) -> "Shifted":
+        member = int.__new__(cls, value + 1)
+        member._value_ = value + 1
+        return member
+
+    A = 1
+    B = 2
+
+def _(value: Foo | Shifted):
+    if value == Foo.X:
+        reveal_type(value)  # revealed: Literal[Foo.X] | Shifted
+    else:
+        reveal_type(value)  # revealed: Literal[Foo.Y] | Shifted
+```
+
 An assignment to `__new__`, `__init__`, or other methods can replace the value declared in the class
 body. In that case, we cannot compare an enum member with its declared value statically:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -125,7 +125,8 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
 `IntEnum` members from different classes compare using their integer values:
 
 ```py
-from enum import IntEnum
+from enum import IntEnum, auto
+from typing import Literal
 
 class Foo(IntEnum):
     X = 1
@@ -160,6 +161,21 @@ def _(value: Foo | Shifted):
         reveal_type(value)  # revealed: Literal[Foo.X] | Shifted
     else:
         reveal_type(value)  # revealed: Literal[Foo.Y] | Shifted
+
+# `int.__new__` converts the generated string to `1` at runtime.
+class Generated(IntEnum):
+    # error: [invalid-method-override]
+    def _generate_next_value_(name, start, count, last_values) -> Literal["1"]:
+        return "1"
+
+    ONE = auto()
+
+class Other(IntEnum):
+    ONE = 1
+
+def _(value: Generated | Other):
+    if value == Generated.ONE:
+        reveal_type(value)  # revealed: Generated | Other
 ```
 
 An assignment to `__new__`, `__init__`, or other methods can replace the value declared in the class

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -724,6 +724,21 @@ def exact_int_enum_member_is_exhaustive(status: Literal[Status.READY]) -> int:
         case Status.READY:
             return 1
 
+class First(IntEnum):
+    ONE = 1
+    TWO = 2
+
+class Second(IntEnum):
+    ONE = 1
+    TWO = 2
+
+def cross_int_enum_members(value: First | Second) -> None:
+    match value:
+        case First.ONE:
+            reveal_type(value)  # revealed: Literal[First.ONE, Second.ONE]
+        case _:
+            reveal_type(value)  # revealed: Literal[First.TWO, Second.TWO]
+
 class Automatic(StrEnum):
     GENERATED = auto()
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -104,6 +104,18 @@ impl<'db> EnumValueConstruction<'db> {
         self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
     }
 
+    /// Returns whether the declared or generated value is unsafe to use as equality evidence.
+    ///
+    /// Unlike `.value` inference, this trusts standard-library constructor methods whose
+    /// comparison behavior is modeled. User-defined or opaque constructors and custom metaclasses
+    /// may change that behavior arbitrarily.
+    const fn comparison_value_may_be_transformed(self, is_auto: bool) -> bool {
+        self.init.is_user_defined()
+            || self.new.is_user_defined()
+            || self.metaclass_may_transform_values
+            || (is_auto && self.generate_next_value.is_opaque())
+    }
+
     /// Returns the value to use when checking whether an enum member is an alias.
     ///
     /// For an `auto()` member with a resolvable `_generate_next_value_`, this uses the generator's
@@ -323,6 +335,32 @@ impl<'db> EnumMetadata<'db> {
             Some(annotation)
         } else {
             Some(value)
+        }
+    }
+
+    /// Return a statically known value with the same equality behavior as an enum member.
+    pub(crate) fn comparison_value_type(
+        &self,
+        db: &'db dyn Db,
+        member_name: &Name,
+    ) -> Option<Type<'db>> {
+        let member_name = self.resolve_member(member_name)?;
+        let declared_value = self.members.get(member_name).copied()?;
+
+        let is_auto = self.auto_members.contains(member_name);
+        if self
+            .value_construction
+            .comparison_value_may_be_transformed(is_auto)
+        {
+            None
+        } else if is_auto
+            && let Some(function) = self.value_construction.generate_next_value.function()
+        {
+            Some(function.signature(db).overload_return_type_or_unknown(db))
+        } else {
+            // TODO: `IntEnum` normalizes boolean member values to `int`. The declared boolean has
+            // the same equality behavior, but we do not model the exact runtime `.value` here.
+            Some(declared_value)
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -104,18 +104,6 @@ impl<'db> EnumValueConstruction<'db> {
         self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
     }
 
-    /// Returns whether the declared or generated value is unsafe to use as equality evidence.
-    ///
-    /// Unlike `.value` inference, this trusts standard-library constructor methods whose
-    /// comparison behavior is modeled. User-defined or opaque constructors and custom metaclasses
-    /// may change that behavior arbitrarily.
-    const fn comparison_value_may_be_transformed(self, is_auto: bool) -> bool {
-        self.init.is_user_defined()
-            || self.new.is_user_defined()
-            || self.metaclass_may_transform_values
-            || (is_auto && self.generate_next_value.is_opaque())
-    }
-
     /// Returns the value to use when checking whether an enum member is an alias.
     ///
     /// For an `auto()` member with a resolvable `_generate_next_value_`, this uses the generator's
@@ -335,42 +323,6 @@ impl<'db> EnumMetadata<'db> {
             Some(annotation)
         } else {
             Some(value)
-        }
-    }
-
-    /// Return a statically known value with the same equality behavior as an enum member.
-    pub(crate) fn comparison_value_type(
-        &self,
-        db: &'db dyn Db,
-        member_name: &Name,
-    ) -> Option<Type<'db>> {
-        let member_name = self.resolve_member(member_name)?;
-        let declared_value = self.members.get(member_name).copied()?;
-
-        let is_auto = self.auto_members.contains(member_name);
-        if self
-            .value_construction
-            .comparison_value_may_be_transformed(is_auto)
-        {
-            None
-        } else if is_auto
-            && let Some(function) = self.value_construction.generate_next_value.function()
-        {
-            let generated = function.signature(db).overload_return_type_or_unknown(db);
-            if self
-                .value_annotation
-                .is_some_and(|annotation| !generated.is_assignable_to(db, annotation))
-            {
-                // The inherited value constructor can normalize the generated value. For
-                // example, `IntEnum` converts `"1"` to `1` through `int.__new__`.
-                None
-            } else {
-                Some(generated)
-            }
-        } else {
-            // TODO: `IntEnum` normalizes boolean member values to `int`. The declared boolean has
-            // the same equality behavior, but we do not model the exact runtime `.value` here.
-            Some(declared_value)
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -356,7 +356,17 @@ impl<'db> EnumMetadata<'db> {
         } else if is_auto
             && let Some(function) = self.value_construction.generate_next_value.function()
         {
-            Some(function.signature(db).overload_return_type_or_unknown(db))
+            let generated = function.signature(db).overload_return_type_or_unknown(db);
+            if self
+                .value_annotation
+                .is_some_and(|annotation| !generated.is_assignable_to(db, annotation))
+            {
+                // The inherited value constructor can normalize the generated value. For
+                // example, `IntEnum` converts `"1"` to `1` through `int.__new__`.
+                None
+            } else {
+                Some(generated)
+            }
         } else {
             // TODO: `IntEnum` normalizes boolean member values to `int`. The declared boolean has
             // the same equality behavior, but we do not model the exact runtime `.value` here.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -11,7 +11,7 @@ use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
     EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueTypeKind,
-    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder, UnionType,
+    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -135,7 +135,15 @@ pub(super) fn evaluate_type_equality<'db>(
         ComparisonOperator::Equality,
         condition_expects_equality,
     )
-    .or_else(|| builtin_literal_constraint(db, left, right, condition_expects_equality))
+    .or_else(|| {
+        builtin_literal_constraint(
+            db,
+            left,
+            right,
+            ComparisonOperator::Equality,
+            condition_expects_equality,
+        )
+    })
     .or_else(|| {
         if comparison_domain(db, left, right, ComparisonOperator::Equality)
             == ComparisonDomain::Known
@@ -185,7 +193,15 @@ pub(super) fn evaluate_type_inequality<'db>(
         ComparisonOperator::Inequality,
         condition_expects_equality,
     )
-    .or_else(|| builtin_literal_constraint(db, left, right, condition_expects_equality))
+    .or_else(|| {
+        builtin_literal_constraint(
+            db,
+            left,
+            right,
+            ComparisonOperator::Inequality,
+            condition_expects_equality,
+        )
+    })
     .or_else(|| {
         ComparisonEvaluator::new(db)
             .evaluate(left, right, branch, ComparisonOperator::Inequality)
@@ -526,34 +542,36 @@ fn builtin_literal_constraint<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
+    operator: ComparisonOperator,
     condition_expects_equality: bool,
 ) -> Option<Type<'db>> {
     let Type::LiteralValue(right) = right.resolve_type_alias(db) else {
         return None;
     };
 
-    let equal_to_right = match right.kind() {
+    let mut equal_to_right = match right.kind() {
         LiteralValueTypeKind::Int(value) => {
             let mut builder = UnionBuilder::new(db).add(Type::LiteralValue(right));
             if matches!(value.as_i64(), 0 | 1) {
                 builder = builder.add(Type::bool_literal(value.as_i64() == 1));
             }
-            builder.build()
+            builder
         }
-        LiteralValueTypeKind::Bool(value) => UnionType::from_two_elements(
-            db,
-            Type::LiteralValue(right),
-            Type::int_literal(i64::from(value)),
-        ),
+        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db)
+            .add(Type::LiteralValue(right))
+            .add(Type::int_literal(i64::from(value))),
         LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_) => {
-            Type::LiteralValue(right)
+            UnionBuilder::new(db).add(Type::LiteralValue(right))
         }
         LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
     };
 
     if !condition_expects_equality {
-        return Some(equal_to_right.negate(db));
+        equal_to_right = add_equal_enum_literals(db, left, right.kind(), operator, equal_to_right);
+        return Some(equal_to_right.build().negate(db));
     }
+
+    let equal_to_right = equal_to_right.build();
 
     match left.resolve_type_alias(db) {
         Type::Union(union) => union
@@ -564,6 +582,38 @@ fn builtin_literal_constraint<'db>(
         left => is_builtin_literal_type(db, left),
     }
     .then_some(equal_to_right)
+}
+
+/// Add finite enum members in `ty` that are known to compare equal to `right`.
+fn add_equal_enum_literals<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    right: LiteralValueTypeKind<'db>,
+    operator: ComparisonOperator,
+    mut builder: UnionBuilder<'db>,
+) -> UnionBuilder<'db> {
+    match ty.resolve_type_alias(db) {
+        Type::Union(union) => {
+            for element in union.elements(db) {
+                builder = add_equal_enum_literals(db, *element, right, operator, builder);
+            }
+        }
+        Type::LiteralValue(literal) => {
+            if matches!(literal.kind(), LiteralValueTypeKind::Enum(_))
+                && known_literal_equality(db, literal.kind(), right, operator) == Some(true)
+            {
+                builder = builder.add(Type::LiteralValue(literal));
+            }
+        }
+        ty => {
+            if let Some(alternatives) = finite_alternatives(db, ty, operator) {
+                for alternative in alternatives {
+                    builder = add_equal_enum_literals(db, alternative, right, operator, builder);
+                }
+            }
+        }
+    }
+    builder
 }
 
 /// Return a constraint when every possible value of `left` is a member of the same enum as `right`.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1319,20 +1319,12 @@ fn known_literal_equality<'db>(
     }
 }
 
-/// Return the statically known runtime value of an enum member.
+/// Return a statically known value with the same equality behavior as an enum member.
 ///
 /// Custom enum construction can replace the declared value, so members of such enums return `None`.
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
     let metadata = enum_metadata(db, literal.enum_class(db))?;
-    let name = metadata.resolve_member(literal.name(db))?;
-    if metadata.member_value_may_be_transformed(name) {
-        return None;
-    }
-    if metadata.auto_members.contains(name) {
-        metadata.value_type(db, name)
-    } else {
-        metadata.members.get(name).copied()
-    }
+    metadata.comparison_value_type(db, literal.name(db))
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1319,12 +1319,20 @@ fn known_literal_equality<'db>(
     }
 }
 
-/// Return a statically known value with the same equality behavior as an enum member.
+/// Return the statically known runtime value of an enum member.
 ///
 /// Custom enum construction can replace the declared value, so members of such enums return `None`.
 fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
     let metadata = enum_metadata(db, literal.enum_class(db))?;
-    metadata.comparison_value_type(db, literal.name(db))
+    let name = metadata.resolve_member(literal.name(db))?;
+    if metadata.member_value_may_be_transformed(name) {
+        return None;
+    }
+    if metadata.auto_members.contains(name) {
+        metadata.value_type(db, name)
+    } else {
+        metadata.members.get(name).copied()
+    }
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.


### PR DESCRIPTION
## Summary

`IntEnum` members from different classes compare using their integer values, but we previously treated those members as unequal because they belonged to different enum classes:

```python
from enum import IntEnum

class First(IntEnum):
    ONE = 1

class Second(IntEnum):
    ONE = 1

def handle(value: First | Second) -> None:
    if value == First.ONE:
        reveal_type(value)  # Literal[First.ONE, Second.ONE]
```

Using the precise member values now modeled for standard-library enums, this narrows comparisons across integer- and string-valued enum classes, including `==`, `!=`, and `match` patterns. Negative comparisons against builtin literals also exclude enum members known to compare equal to that literal; for example, `value != 1` removes every finite enum member whose value is `1`.
