### PR TITLE
docs: document argfile support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -467,6 +467,28 @@ $ ruff check path/to/code/ --select F401 --select F403 --quiet
 All other configuration options can be set via the command line
 using the `--config` flag, detailed below.
 
+### Argument files
+
+Ruff can read command-line arguments from a file by prefixing the file path with `@`.
+Each argument must be written on its own line in the file. For example, given an
+`arguments.txt` file containing:
+
+```text
+--select
+F401
+src/package/__init__.py
+tests/
+```
+
+You can pass those arguments to `ruff check` with:
+
+```console
+$ ruff check @arguments.txt
+```
+
+Argument files are useful when passing a large number of paths or arguments to Ruff, such as from
+generated file lists in CI.
+
 ### The `--config` CLI flag
 
 The `--config` flag has two uses. It is most often used to point to the


### PR DESCRIPTION
Summary
- Document Ruff's existing `@argfile` support in the command-line interface section.
- Include the required one-argument-per-line format and a `ruff check @arguments.txt` example.
- This PR follows the repository AI policy.

Reproduction
- `ruff check @file_containing_arguments` is supported but not currently documented in the user docs.
- Closes #21894.

Root cause
- Ruff has integration test coverage for reading CLI arguments from argfiles, but the docs do not mention the feature.

Changes
- Add an `Argument files` subsection to `docs/configuration.md`.
- Explain that each argument should be written on its own line.

Tests
- `git diff --check`
- `python3 - <<'PY' ...` snippet assertion for the new docs section
- `cargo test -p ruff check_input_from_argfile`

Screenshots/Logs
- Not applicable; documentation-only change.
