### PR TITLE
[flake8-pyi] Clarify PYI051 docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -23,6 +23,11 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// `Literal[1] | int` is equivalent to `int`, as `str` and `int` are the
 /// supertypes of `"A"` and `1` respectively.
 ///
+/// This is an opinionated rule that may not suit all projects. For example, a
+/// stub may use `Literal["A", "B"] | str` to preserve editor completions for
+/// common values while still allowing arbitrary strings. In such cases, consider
+/// disabling this rule or adding a `noqa` comment for the affected annotation.
+///
 /// ## Example
 /// ```pyi
 /// from typing import Literal


### PR DESCRIPTION
Summary
- Clarify that PYI051 is an opinionated lint rule that may not fit every project.
- Mention a common case where `Literal[...] | str` preserves editor completions while still allowing arbitrary strings.

Reproduction
- See #23134. The rule currently treats `Literal["A", "B"] | str` as redundant because `str` is a supertype of the literal values.
- The issue notes that some projects intentionally keep those literals to improve completion hints while still accepting arbitrary strings.

Root cause
- The existing rule docs explained the type-theoretic redundancy, but did not mention that this can be an intentional usability tradeoff for stubs or APIs with common suggested values.

Changes
- Add a short note to the PYI051 docs explaining that the rule is opinionated.
- Suggest disabling the rule or using `noqa` when a project intentionally keeps redundant literals for editor completions.

Tests
- `cargo dev generate-all`
- `cargo test -p ruff_linter rule_redundantliteralunion_path_new_pyi051`
- `cargo test -p ruff_linter registry::tests::documentation`
- `git diff --check`
- `cargo fmt --check`
- Not run: `uvx prek run --files crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs` (`uvx` is not installed in this environment).

Screenshots/Logs
- Not applicable; docs-only change.

This PR follows the repository AI policy.

Fixes #23134.
