### PR TITLE
[ty] Short-circuit identical protocol method comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -3627,6 +3627,27 @@ def g(x: B2[int]):
     pass
 ```
 
+## Identical inherited protocol members after specialization
+
+Identical protocol members can be short-circuited after specialization, but members whose
+specialized types differ must still be compared.
+
+```py
+from ty_extensions import is_assignable_to, is_subtype_of, static_assert
+from typing import Protocol, TypeVar
+
+T = TypeVar("T")
+
+class A(Protocol[T]):
+    def close(self) -> None: ...
+    def get(self) -> T: ...
+
+class B(A[T], Protocol[T]): ...
+
+static_assert(not is_subtype_of(B[int], A[str]))
+static_assert(not is_assignable_to(B[int], A[str]))
+```
+
 ## The `Generator` protocol's `_ReturnT_co` needs special casing
 
 The `_ReturnT_co` type parameter in the `Generator` protocol is the value of a `yield from` over

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -861,6 +861,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         (
                             ProtocolMemberKind::Method(source_method),
                             ProtocolMemberKind::Method(target_method),
+                        ) if source_method == target_method
+                            && self
+                                .relation
+                                .can_safely_assume_reflexivity(Type::Callable(source_method)) =>
+                        {
+                            self.always()
+                        }
+
+                        (
+                            ProtocolMemberKind::Method(source_method),
+                            ProtocolMemberKind::Method(target_method),
                         ) => self.check_callable_pair(
                             db,
                             source_method.bind_self(db, None),

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -817,6 +817,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
 
                 let result = source_member.when_some_and(db, self.constraints, |source_member| {
+                    if source_member == target_member
+                        && self
+                            .relation
+                            .can_safely_assume_reflexivity(source_member.ty())
+                    {
+                        return self.always();
+                    }
+
                     match (source_member.kind, target_member.kind) {
                         // Method members are always immutable;
                         // they can never be subtypes of/assignable to mutable attribute members.
@@ -857,17 +865,6 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 Type::Callable(protocol_bind_self(db, target_callable, None)),
                             )
                         }),
-
-                        (
-                            ProtocolMemberKind::Method(source_method),
-                            ProtocolMemberKind::Method(target_method),
-                        ) if source_method == target_method
-                            && self
-                                .relation
-                                .can_safely_assume_reflexivity(Type::Callable(source_method)) =>
-                        {
-                            self.always()
-                        }
 
                         (
                             ProtocolMemberKind::Method(source_method),


### PR DESCRIPTION
## Summary

Skip rebinding and comparing identical protocol method callables when the active relation is safely reflexive. This reduces DateType benchmark instructions by 15.9% while leaving broader project benchmarks neutral.

Disclaimer: This was entirely written by codex and I don't claim to understand this in full, but it looks reasonable? But I'm sure there are reasons why we shouldn't do this or why it's unsound.

## Test Plan

Testing: Passed the ty test suite, Clippy, repository hooks, and CodSpeed project benchmarks.
