### PR TITLE
[flake8-datetimez] Clarify DTZ002 docs

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
+++ b/crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs
@@ -22,6 +22,10 @@ use crate::rules::flake8_datetimez::helpers;
 /// `datetime.datetime.today()` creates a "naive" object; instead, use
 /// `datetime.datetime.now(tz=...)` to create a timezone-aware object.
 ///
+/// Additionally, the name `today()` can be misleading, as it returns the current
+/// date and time, not just the current date. `now(tz=...)` makes this intent
+/// explicit while also allowing a timezone to be specified.
+///
 /// ## Example
 /// ```python
 /// import datetime


### PR DESCRIPTION
Summary
- Clarify that DTZ002 is not only about timezone awareness.
- Mention that `datetime.datetime.today()` can be misleading because it returns both the current date and time.

Reproduction
- See #23392. `datetime.datetime.today()` behaves like `datetime.datetime.now()` without a timezone, even though the name can suggest a date-only value.
- A maintainer suggested extending the existing DTZ002 documentation with this motivation.

Root cause
- The existing DTZ002 docs explained the timezone issue, but did not mention the naming/intent issue that can make `today()` confusing for users reading the code.

Changes
- Add a short paragraph to the DTZ002 rule docs explaining that `today()` returns the current date and time, and that `now(tz=...)` states the intent more clearly while allowing a timezone.

Tests
- `cargo dev generate-all`
- `cargo test -p ruff_linter rule_calldatetimetoday_path_new_dtz002_py_expects`
- `cargo test -p ruff_linter registry::tests::documentation`
- `git diff --check`
- `cargo fmt --check`
- Not run: `uvx prek run --files crates/ruff_linter/src/rules/flake8_datetimez/rules/call_datetime_today.rs` (`uvx` is not installed in this environment).

Screenshots/Logs
- Not applicable; docs-only change.

This PR follows the repository AI policy.

Fixes #23392.
