### PR TITLE
Fix Pyodide playground asset check

### DIFF
--- a/.github/workflows/publish-ty-playground.yml
+++ b/.github/workflows/publish-ty-playground.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: playground
       - name: "Verify Pyodide assets"
         run: |
-          test -f ty/dist/assets/pyodide.asm.js
+          test -f ty/dist/assets/pyodide.asm.mjs
           test -f ty/dist/assets/pyodide.asm.wasm
           test -f ty/dist/assets/pyodide-lock.json
           test -f ty/dist/assets/python_stdlib.zip


### PR DESCRIPTION
Pyodide 314 renamed its runtime module from `pyodide.asm.js` to `pyodide.asm.mjs`. Update the deployment verification to check the asset produced by the upgraded package.

Testing: Built the ty playground and ran the repository hooks.