### PR TITLE
[ty] Handle callable classes in solver

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1054,6 +1054,25 @@ reveal_type(result)  # revealed: Derived
 print(result.attr)  # No error
 ```
 
+## Callable instances
+
+Generic parameters can be inferred from the `__call__` method of a class instance.
+
+```py
+from typing import Callable, TypeVar
+
+R = TypeVar("R")
+
+def call(callable: Callable[[], R]) -> R:
+    return callable()
+
+class MyCallable:
+    def __call__(self) -> int:
+        return 1
+
+reveal_type(call(MyCallable()))  # revealed: int
+```
+
 ## Passing a constrained TypeVar to a function expecting a compatible constrained TypeVar
 
 A constrained TypeVar should be assignable to a different constrained TypeVar if each constraint of

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -1147,6 +1147,23 @@ def _(x: list[str]):
     reveal_type(accepts_callable(GenericClass)(x, x))
 ```
 
+### Callable instances
+
+Generic parameters can be inferred from the `__call__` method of a class instance.
+
+```py
+from typing import Callable
+
+def call[R](callable: Callable[[], R]) -> R:
+    return callable()
+
+class MyCallable:
+    def __call__(self) -> int:
+        return 1
+
+reveal_type(call(MyCallable()))  # revealed: int
+```
+
 ### `Callable`s that return union types
 
 ```py


### PR DESCRIPTION
In the legacy solver, when a nominal instance is matched against a (formal) `Callable`, use the `(Type::Callable(formal_callable), _)` match arm which handles the transformation of a nominal instance into a callable object. This allows us to solve cases like

```py
from typing import Callable

def call[R](callable: Callable[[], R]) -> R:
    return callable()

class MyCallable:
    def __call__(self) -> int:
        return 1

my_callable = MyCallable()
reveal_type(call(my_callable))  # previously: Unknown, now: int
```

closes https://github.com/astral-sh/ty/issues/3763

The ecosystem impact here shows the downstream fallout of type inference becoming more precise. I didn't spot anything that would indicate a problem with this particular change.