### PR TITLE
Update fix availability for always-fixable rules

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/ellipsis_in_non_empty_class_body.rs
@@ -32,7 +32,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 pub(crate) struct EllipsisInNonEmptyClassBody;
 
 impl Violation for EllipsisInNonEmptyClassBody {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unnecessary_literal_union.rs
@@ -53,7 +53,7 @@ pub(crate) struct UnnecessaryLiteralUnion {
 }
 
 impl Violation for UnnecessaryLiteralUnion {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/unused_private_type_definition.rs
@@ -37,7 +37,7 @@ pub(crate) struct UnusedPrivateTypeVar {
 }
 
 impl Violation for UnusedPrivateTypeVar {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
+++ b/crates/ruff_linter/src/rules/flake8_pytest_style/rules/parametrize.rs
@@ -208,7 +208,7 @@ pub(crate) struct PytestParametrizeValuesWrongType {
 }
 
 impl Violation for PytestParametrizeValuesWrongType {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
+++ b/crates/ruff_linter/src/rules/flake8_type_checking/rules/type_alias_quotes.rs
@@ -53,7 +53,7 @@ use ruff_python_ast::token::parenthesized_range;
 pub(crate) struct UnquotedTypeAlias;
 
 impl Violation for UnquotedTypeAlias {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
+++ b/crates/ruff_linter/src/rules/pycodestyle/rules/multiple_imports_on_one_line.rs
@@ -35,7 +35,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 pub(crate) struct MultipleImportsOnOneLine;
 
 impl Violation for MultipleImportsOnOneLine {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/if_exp_instead_of_or_operator.rs
@@ -46,7 +46,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 pub(crate) struct IfExpInsteadOfOrOperator;
 
 impl Violation for IfExpInsteadOfOrOperator {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/isinstance_type_none.rs
@@ -36,7 +36,7 @@ use crate::{FixAvailability, Violation};
 pub(crate) struct IsinstanceTypeNone;
 
 impl Violation for IsinstanceTypeNone {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/print_empty_string.rs
@@ -55,7 +55,7 @@ enum Reason {
 }
 
 impl Violation for PrintEmptyString {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/single_item_membership_test.rs
@@ -48,7 +48,7 @@ pub(crate) struct SingleItemMembershipTest {
 }
 
 impl Violation for SingleItemMembershipTest {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/slice_copy.rs
@@ -45,7 +45,7 @@ use crate::rules::refurb::helpers::generate_method_call;
 pub(crate) struct SliceCopy;
 
 impl Violation for SliceCopy {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/mutable_fromkeys_value.rs
@@ -53,7 +53,7 @@ use crate::{Edit, Fix, FixAvailability, Violation};
 pub(crate) struct MutableFromkeysValue;
 
 impl Violation for MutableFromkeysValue {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {

--- a/crates/ruff_linter/src/rules/ruff/rules/unnecessary_nested_literal.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unnecessary_nested_literal.rs
@@ -63,7 +63,7 @@ use crate::{Applicability, Edit, Fix, FixAvailability, Violation};
 pub(crate) struct UnnecessaryNestedLiteral;
 
 impl Violation for UnnecessaryNestedLiteral {
-    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Sometimes;
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
 
     #[derive_message_formats]
     fn message(&self) -> String {


### PR DESCRIPTION
## Summary

Marks rules that attach a fix on every diagnostic path as always fixable.