### PR TITLE
[ty] Migrate type property tests to new intersection syntax

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/constraints.md
@@ -124,9 +124,9 @@ A _negated range_ constraint is the opposite of a range constraint: it requires 
 be within a particular lower and upper bound. The typevar can only specialize to a type that is a
 strict subtype of the lower bound, a strict supertype of the upper bound, or incomparable to either.
 
-```py
+```pyi
 from typing import Any, final, Never, Sequence
-from ty_extensions import ConstraintSet, Not, static_assert
+from ty_extensions import ConstraintSet, static_assert
 
 class Super: ...
 class Base(Super): ...
@@ -143,7 +143,7 @@ def _[T]() -> None:
 Every type is a supertype of `Never`, so a lower bound of `Never` is the same as having no lower
 bound.
 
-```py
+```pyi
 def _[T]() -> None:
     # ¬(T@_ ≤ Base)
     ~ConstraintSet.range(Never, T, Base)
@@ -152,7 +152,7 @@ def _[T]() -> None:
 Similarly, every type is a subtype of `object`, so an upper bound of `object` is the same as having
 no upper bound.
 
-```py
+```pyi
 def _[T]() -> None:
     # ¬(Base ≤ T@_)
     ~ConstraintSet.range(Base, T, object)
@@ -161,7 +161,7 @@ def _[T]() -> None:
 And a negated range constraint with _both_ a lower bound of `Never` and an upper bound of `object`
 cannot be satisfied at all.
 
-```py
+```pyi
 def _[T]() -> None:
     # (T@_ ≠ *)
     ~ConstraintSet.range(Never, T, object)
@@ -170,7 +170,7 @@ def _[T]() -> None:
 If the lower bound and upper bounds are "inverted" (the upper bound is a subtype of the lower bound)
 or incomparable, then the negated range constraint can always be satisfied.
 
-```py
+```pyi
 def _[T]() -> None:
     static_assert(~ConstraintSet.range(Super, T, Sub))
     static_assert(~ConstraintSet.range(Base, T, Unrelated))
@@ -179,7 +179,7 @@ def _[T]() -> None:
 The lower and upper bound can be the same type, in which case the typevar can be specialized to any
 type other than that specific type.
 
-```py
+```pyi
 def _[T]() -> None:
     # (T@_ ≠ Base)
     ~ConstraintSet.range(Base, T, Base)
@@ -188,7 +188,7 @@ def _[T]() -> None:
 Constraints can only refer to fully static types, so the lower and upper bounds are transformed into
 their bottom and top materializations, respectively.
 
-```py
+```pyi
 def _[T]() -> None:
     constraints = ~ConstraintSet.range(Base, T, Any)
     expected = ~ConstraintSet.range(Base, T, object)
@@ -209,9 +209,9 @@ def _[T]() -> None:
 
 A negated _type_ is not the same thing as a negated _range_.
 
-```py
+```pyi
 def _[T]() -> None:
-    negated_type = ConstraintSet.range(Never, T, Not[int])
+    negated_type = ConstraintSet.range(Never, T, ~int)
     negated_constraint = ~ConstraintSet.range(Never, T, int)
     static_assert(negated_type != negated_constraint)
 ```
@@ -245,7 +245,7 @@ def _[T, U]() -> None:
 
 The intersection of two ranges is where the ranges "overlap".
 
-```py
+```pyi
 from typing import final
 from ty_extensions import ConstraintSet, static_assert
 
@@ -277,7 +277,7 @@ def _[T]() -> None:
 
 If they don't overlap, the intersection is empty.
 
-```py
+```pyi
 def _[T]() -> None:
     static_assert(not ConstraintSet.range(SubSub, T, Sub) & ConstraintSet.range(Base, T, Super))
     static_assert(not ConstraintSet.range(SubSub, T, Sub) & ConstraintSet.range(Unrelated, T, object))
@@ -287,16 +287,15 @@ Expanding on this, when intersecting two upper bounds constraints (`(T ≤ Base)
 intersect the upper bounds. Any type that satisfies both `T ≤ Base` and `T ≤ Other` must necessarily
 satisfy their intersection `T ≤ Base & Other`, and vice versa.
 
-```py
+```pyi
 from typing import Never
-from ty_extensions import Intersection
 
 # This is not final, so it's possible for a subclass to inherit from both Base and Other.
 class Other: ...
 
 def upper_bounds[T]():
     # (T@upper_bounds ≤ Base & Other)
-    intersection_type = ConstraintSet.range(Never, T, Intersection[Base, Other])
+    intersection_type = ConstraintSet.range(Never, T, Base & Other)
     # (T@upper_bounds ≤ Base) ∧ (T@upper_bounds ≤ Other)
     intersection_constraint = ConstraintSet.range(Never, T, Base) & ConstraintSet.range(Never, T, Other)
     static_assert(intersection_type == intersection_constraint)
@@ -306,7 +305,7 @@ For an intersection of two lower bounds constraints (`(Base ≤ T) ∧ (Other �
 bounds. Any type that satisfies both `Base ≤ T` and `Other ≤ T` must necessarily satisfy their union
 `Base | Other ≤ T`, and vice versa.
 
-```py
+```pyi
 def lower_bounds[T]():
     # (Base | Other ≤ T@lower_bounds)
     union_type = ConstraintSet.range(Base | Other, T, object)
@@ -777,17 +776,17 @@ def f[S, T, U]():
 The ordering of elements in a union or intersection do not affect what types satisfy a constraint
 set.
 
-```py
+```pyi
 from typing import Never
-from ty_extensions import ConstraintSet, Intersection, static_assert
+from ty_extensions import ConstraintSet, static_assert
 
 def f[T]():
     c1 = ConstraintSet.range(Never, T, str | int)
     c2 = ConstraintSet.range(Never, T, int | str)
     static_assert(c1 == c2)
 
-    c1 = ConstraintSet.range(Never, T, Intersection[str, int])
-    c2 = ConstraintSet.range(Never, T, Intersection[int, str])
+    c1 = ConstraintSet.range(Never, T, str & int)
+    c2 = ConstraintSet.range(Never, T, int & str)
     static_assert(c1 == c2)
 ```
 
@@ -798,7 +797,7 @@ a typevar with itself as an upper or lower bound. No matter what type the typeva
 that type is always a subtype of itself. (Remember that typevars are only specialized to fully
 static types.)
 
-```py
+```pyi
 from typing import Never
 from ty_extensions import ConstraintSet, static_assert
 
@@ -820,19 +819,17 @@ This is also true when the typevar appears in a union in the upper bound, or in 
 the lower bound. (Note that this lines up with how we simplify the intersection of two constraints,
 as shown above.)
 
-```py
-from ty_extensions import Intersection
-
+```pyi
 def same_typevar[T]():
     constraints = ConstraintSet.range(Never, T, T | None)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(Intersection[T, None], T, object)
+    constraints = ConstraintSet.range(T & None, T, object)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(Intersection[T, None], T, T | None)
+    constraints = ConstraintSet.range(T & None, T, T | None)
     expected = ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 ```
@@ -840,15 +837,13 @@ def same_typevar[T]():
 Similarly, if the lower bound is an intersection containing the _negation_ of the typevar, then the
 constraint set can never be satisfied, since every type is disjoint with its negation.
 
-```py
-from ty_extensions import Not
-
+```pyi
 def same_typevar[T]():
-    constraints = ConstraintSet.range(Intersection[Not[T], None], T, object)
+    constraints = ConstraintSet.range(~T & None, T, object)
     expected = ~ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 
-    constraints = ConstraintSet.range(Not[T], T, object)
+    constraints = ConstraintSet.range(~T, T, object)
     expected = ~ConstraintSet.range(Never, T, object)
     static_assert(constraints == expected)
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_assignable_to.md
@@ -392,9 +392,9 @@ While a homogeneous tuple type is not assignable to any heterogeneous tuple type
 tuple type can be assignable to a homogeneous tuple type, and homogeneous tuple types can be
 assignable to `Sequence`:
 
-```py
+```pyi
 from typing import Literal, Any, Sequence
-from ty_extensions import static_assert, is_assignable_to, Not, AlwaysFalsy
+from ty_extensions import static_assert, is_assignable_to, AlwaysFalsy
 
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Literal[1], *tuple[Literal[2], ...]]))
@@ -405,7 +405,7 @@ static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[*tuple[str, 
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int, ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[int | str, ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
-static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], tuple[~AlwaysFalsy, ...]))
 static_assert(is_assignable_to(tuple[Literal[1], Literal[2]], Sequence[int]))
 static_assert(is_assignable_to(tuple[int, ...], Sequence[int]))
 static_assert(is_assignable_to(tuple[int, ...], Sequence[Any]))
@@ -414,7 +414,7 @@ static_assert(is_assignable_to(tuple[Any, ...], Sequence[int]))
 static_assert(is_assignable_to(tuple[()], tuple[Literal[1, 2], ...]))
 static_assert(is_assignable_to(tuple[()], tuple[int, ...]))
 static_assert(is_assignable_to(tuple[()], tuple[int | str, ...]))
-static_assert(is_assignable_to(tuple[()], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_assignable_to(tuple[()], tuple[~AlwaysFalsy, ...]))
 static_assert(is_assignable_to(tuple[()], Sequence[int]))
 
 static_assert(not is_assignable_to(tuple[int, int], tuple[str, ...]))
@@ -429,7 +429,7 @@ python-version = "3.12"
 
 ```py
 from typing import Literal, Any, Sequence
-from ty_extensions import static_assert, is_assignable_to, Not, AlwaysFalsy
+from ty_extensions import static_assert, is_assignable_to, AlwaysFalsy
 
 static_assert(
     is_assignable_to(
@@ -679,8 +679,8 @@ static_assert(not is_assignable_to(Literal[True] | AlwaysFalsy, Literal[False] |
 
 ## Intersection types
 
-```py
-from ty_extensions import static_assert, is_assignable_to, Intersection, Not, AlwaysTruthy, AlwaysFalsy
+```pyi
+from ty_extensions import static_assert, is_assignable_to, AlwaysTruthy, AlwaysFalsy
 from typing_extensions import Any, Literal, final, LiteralString
 
 class Parent: ...
@@ -689,74 +689,74 @@ class Child2(Parent): ...
 class Grandchild(Child1, Child2): ...
 class Unrelated: ...
 
-static_assert(is_assignable_to(Intersection[Child1, Child2], Child1))
-static_assert(is_assignable_to(Intersection[Child1, Child2], Child2))
-static_assert(is_assignable_to(Intersection[Child1, Child2], Parent))
-static_assert(is_assignable_to(Intersection[Child1, Parent], Parent))
+static_assert(is_assignable_to(Child1 & Child2, Child1))
+static_assert(is_assignable_to(Child1 & Child2, Child2))
+static_assert(is_assignable_to(Child1 & Child2, Parent))
+static_assert(is_assignable_to(Child1 & Parent, Parent))
 
-static_assert(is_assignable_to(Intersection[Parent, Unrelated], Parent))
-static_assert(is_assignable_to(Intersection[Child1, Unrelated], Child1))
-static_assert(is_assignable_to(Intersection[Child1, Unrelated, Child2], Intersection[Child1, Unrelated]))
+static_assert(is_assignable_to(Parent & Unrelated, Parent))
+static_assert(is_assignable_to(Child1 & Unrelated, Child1))
+static_assert(is_assignable_to(Child1 & Unrelated & Child2, Child1 & Unrelated))
 
-static_assert(is_assignable_to(Intersection[Child1, Not[Child2]], Child1))
-static_assert(is_assignable_to(Intersection[Child1, Not[Child2]], Parent))
-static_assert(is_assignable_to(Intersection[Child1, Not[Grandchild]], Parent))
+static_assert(is_assignable_to(Child1 & ~Child2, Child1))
+static_assert(is_assignable_to(Child1 & ~Child2, Parent))
+static_assert(is_assignable_to(Child1 & ~Grandchild, Parent))
 
-static_assert(is_assignable_to(Intersection[Child1, Child2], Intersection[Child1, Child2]))
-static_assert(is_assignable_to(Intersection[Child1, Child2], Intersection[Child2, Child1]))
-static_assert(is_assignable_to(Grandchild, Intersection[Child1, Child2]))
-static_assert(not is_assignable_to(Intersection[Child1, Child2], Intersection[Parent, Unrelated]))
+static_assert(is_assignable_to(Child1 & Child2, Child1 & Child2))
+static_assert(is_assignable_to(Child1 & Child2, Child2 & Child1))
+static_assert(is_assignable_to(Grandchild, Child1 & Child2))
+static_assert(not is_assignable_to(Child1 & Child2, Parent & Unrelated))
 
-static_assert(not is_assignable_to(Parent, Intersection[Parent, Unrelated]))
-static_assert(not is_assignable_to(int, Intersection[int, Not[Literal[1]]]))
+static_assert(not is_assignable_to(Parent, Parent & Unrelated))
+static_assert(not is_assignable_to(int, int & ~Literal[1]))
 # The literal `1` is not assignable to `Parent`, so the intersection of int and Parent is definitely an int that is not `1`
-static_assert(is_assignable_to(Intersection[int, Parent], Intersection[int, Not[Literal[1]]]))
-static_assert(not is_assignable_to(int, Not[int]))
-static_assert(not is_assignable_to(int, Not[Literal[1]]))
+static_assert(is_assignable_to(int & Parent, int & ~Literal[1]))
+static_assert(not is_assignable_to(int, ~int))
+static_assert(not is_assignable_to(int, ~Literal[1]))
 
-static_assert(is_assignable_to(Not[Parent], Not[Child1]))
-static_assert(not is_assignable_to(Not[Parent], Parent))
-static_assert(not is_assignable_to(Intersection[Unrelated, Not[Parent]], Parent))
+static_assert(is_assignable_to(~Parent, ~Child1))
+static_assert(not is_assignable_to(~Parent, Parent))
+static_assert(not is_assignable_to(Unrelated & ~Parent, Parent))
 
 # Intersection with `Any` dominates the left hand side of intersections
-static_assert(is_assignable_to(Intersection[Any, Parent], Parent))
-static_assert(is_assignable_to(Intersection[Any, Child1], Parent))
-static_assert(is_assignable_to(Intersection[Any, Child2, Not[Child1]], Parent))
-static_assert(is_assignable_to(Intersection[Any, Parent], Unrelated))
-static_assert(is_assignable_to(Intersection[Any, Parent], Intersection[Parent, Unrelated]))
-static_assert(is_assignable_to(Intersection[Any, Parent, Unrelated], Parent))
-static_assert(is_assignable_to(Intersection[Any, Parent, Unrelated], Intersection[Parent, Unrelated]))
+static_assert(is_assignable_to(Any & Parent, Parent))
+static_assert(is_assignable_to(Any & Child1, Parent))
+static_assert(is_assignable_to(Any & Child2 & ~Child1, Parent))
+static_assert(is_assignable_to(Any & Parent, Unrelated))
+static_assert(is_assignable_to(Any & Parent, Parent & Unrelated))
+static_assert(is_assignable_to(Any & Parent & Unrelated, Parent))
+static_assert(is_assignable_to(Any & Parent & Unrelated, Parent & Unrelated))
 
-# Even Any & Not[Parent] is assignable to Parent, since it could be Never
-static_assert(is_assignable_to(Intersection[Any, Not[Parent]], Parent))
-static_assert(is_assignable_to(Intersection[Any, Not[Parent]], Not[Parent]))
+# Even Any & ~Parent is assignable to Parent, since it could be Never
+static_assert(is_assignable_to(Any & ~Parent, Parent))
+static_assert(is_assignable_to(Any & ~Parent, ~Parent))
 
 # Intersection with `Any` is effectively ignored on the right hand side for the sake of assignment
-static_assert(is_assignable_to(Parent, Intersection[Any, Parent]))
-static_assert(is_assignable_to(Parent, Parent | Intersection[Any, Unrelated]))
-static_assert(is_assignable_to(Child1, Intersection[Any, Parent]))
-static_assert(not is_assignable_to(Literal[1], Intersection[Any, Parent]))
-static_assert(not is_assignable_to(Unrelated, Intersection[Any, Parent]))
+static_assert(is_assignable_to(Parent, Any & Parent))
+static_assert(is_assignable_to(Parent, Parent | Any & Unrelated))
+static_assert(is_assignable_to(Child1, Any & Parent))
+static_assert(not is_assignable_to(Literal[1], Any & Parent))
+static_assert(not is_assignable_to(Unrelated, Any & Parent))
 
 # Intersections with Any on both sides combine the above logic - the LHS dominates and Any is ignored on the right hand side
-static_assert(is_assignable_to(Intersection[Any, Parent], Intersection[Any, Parent]))
-static_assert(is_assignable_to(Intersection[Any, Unrelated], Intersection[Any, Parent]))
-static_assert(is_assignable_to(Intersection[Any, Parent, Unrelated], Intersection[Any, Parent, Unrelated]))
-static_assert(is_assignable_to(Intersection[Unrelated, Any], Intersection[Unrelated, Not[Any]]))
-static_assert(is_assignable_to(Intersection[Literal[1], Any], Intersection[Unrelated, Not[Any]]))
+static_assert(is_assignable_to(Any & Parent, Any & Parent))
+static_assert(is_assignable_to(Any & Unrelated, Any & Parent))
+static_assert(is_assignable_to(Any & Parent & Unrelated, Any & Parent & Unrelated))
+static_assert(is_assignable_to(Unrelated & Any, Unrelated & ~Any))
+static_assert(is_assignable_to(Literal[1] & Any, Unrelated & ~Any))
 
 # TODO: No errors
 # The condition `is_assignable_to(T & U, U)` should still be satisfied after the following transformations:
 # `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[LiteralString, Not[Literal[""]]], AlwaysTruthy))
+static_assert(is_assignable_to(LiteralString & ~Literal[""], AlwaysTruthy))
 # error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[LiteralString, Not[Literal["", "a"]]], AlwaysTruthy))
+static_assert(is_assignable_to(LiteralString & ~Literal["", "a"], AlwaysTruthy))
 # `LiteralString & ~AlwaysFalsy`  -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[LiteralString, Not[Literal[""]]], Not[AlwaysFalsy]))
+static_assert(is_assignable_to(LiteralString & ~Literal[""], ~AlwaysFalsy))
 # error: [static-assert-error]
-static_assert(is_assignable_to(Intersection[LiteralString, Not[Literal["", "a"]]], Not[AlwaysFalsy]))
+static_assert(is_assignable_to(LiteralString & ~Literal["", "a"], ~AlwaysFalsy))
 ```
 
 ## Callable types with Unknown/missing return type
@@ -768,18 +768,18 @@ of `~type`, the intersection should be assignable to `~type`.
 The root cause was that we failed to properly materialize a `Callable[..., Unknown]` type when the
 `Unknown` return type originated from a missing annotation.
 
-```py
-from ty_extensions import static_assert, is_assignable_to, Intersection, Not, Unknown, RegularCallableTypeOf
+```pyi
+from ty_extensions import static_assert, is_assignable_to, Unknown, RegularCallableTypeOf
 from typing import Callable
 
 # `Callable[..., Unknown]` has explicit Unknown return type
-static_assert(is_assignable_to(Intersection[Not[type], Not[Callable[..., Unknown]]], Not[type]))
+static_assert(is_assignable_to(~type & ~Callable[..., Unknown], ~type))
 
 # Function with no return annotation (has implicit Unknown return type internally)
 def no_return_annotation(*args, **kwargs): ...
 
 # `RegularCallableTypeOf[no_return_annotation]` has `returns: None` internally (no annotation)
-static_assert(is_assignable_to(Intersection[Not[type], Not[RegularCallableTypeOf[no_return_annotation]]], Not[type]))
+static_assert(is_assignable_to(~type & ~RegularCallableTypeOf[no_return_annotation], ~type))
 ```
 
 ## Intersections with non-fully-static negated elements
@@ -789,21 +789,21 @@ materialization of that type is disjoint from the _bottom_ materialization of al
 in the intersection. This differs from subtyping, which should do the disjointness check against the
 _top_ materialization of the negated elements.
 
-```py
+```pyi
 from typing_extensions import Any, Never, Sequence
-from ty_extensions import Not, is_assignable_to, static_assert
+from ty_extensions import is_assignable_to, static_assert
 
 # The bottom materialization of `tuple[Any]` is `tuple[Never]`,
 # which simplifies to `Never`, so `tuple[int]` and `tuple[()]` are
 # both assignable to `~tuple[Any]`
-static_assert(is_assignable_to(tuple[int], Not[tuple[Any]]))
-static_assert(is_assignable_to(tuple[()], Not[tuple[Any]]))
+static_assert(is_assignable_to(tuple[int], ~tuple[Any]))
+static_assert(is_assignable_to(tuple[()], ~tuple[Any]))
 
 # But the bottom materialization of `tuple[Any, ...]` is `tuple[Never, ...]`,
 # which simplifies to `tuple[()]`, so `tuple[int]` is still assignable to
 # `~tuple[Any, ...]`, but `tuple[()]` is not
-static_assert(is_assignable_to(tuple[int], Not[tuple[Any, ...]]))
-static_assert(not is_assignable_to(tuple[()], Not[tuple[Any, ...]]))
+static_assert(is_assignable_to(tuple[int], ~tuple[Any, ...]))
+static_assert(not is_assignable_to(tuple[()], ~tuple[Any, ...]))
 
 # Similarly, the bottom materialization of `Sequence[Any]` is `Sequence[Never]`,
 # so `tuple[()]` is not assignable to `~Sequence[Any]`, and nor is `list[Never]`,
@@ -816,15 +816,15 @@ static_assert(not is_assignable_to(tuple[()], Not[tuple[Any, ...]]))
 # Other `list` and `tuple` specializations *are* assignable to `~Sequence[Any]`,
 # however, since there are many fully static materializations of `Sequence[Any]`
 # that would be disjoint from a given `list` or `tuple` specialization.
-static_assert(not is_assignable_to(tuple[()], Not[Sequence[Any]]))
-static_assert(not is_assignable_to(list[Never], Not[Sequence[Any]]))
-static_assert(not is_assignable_to(tuple[int, ...], Not[Sequence[Any]]))
+static_assert(not is_assignable_to(tuple[()], ~Sequence[Any]))
+static_assert(not is_assignable_to(list[Never], ~Sequence[Any]))
+static_assert(not is_assignable_to(tuple[int, ...], ~Sequence[Any]))
 
 # TODO: should pass (`tuple[int]` should be considered disjoint from `Sequence[Never]`)
-static_assert(is_assignable_to(tuple[int], Not[Sequence[Any]]))  # error: [static-assert-error]
+static_assert(is_assignable_to(tuple[int], ~Sequence[Any]))  # error: [static-assert-error]
 
 # TODO: should pass (`list[int]` should be considered disjoint from `Sequence[Never]`)
-static_assert(is_assignable_to(list[int], Not[Sequence[Any]]))  # error: [static-assert-error]
+static_assert(is_assignable_to(list[int], ~Sequence[Any]))  # error: [static-assert-error]
 
 # If the left-hand side is also not fully static,
 # the left-hand side will be assignable to the right if the bottom materialization
@@ -834,21 +834,21 @@ static_assert(is_assignable_to(list[int], Not[Sequence[Any]]))  # error: [static
 # `tuple[Any, ...]` cannot be assignable to `~tuple[Any, ...]`,
 # because the bottom materialization of `tuple[Any, ...]` is
 # `tuple[()]`, and `tuple[()]` is not disjoint from itself
-static_assert(not is_assignable_to(tuple[Any, ...], Not[tuple[Any, ...]]))
+static_assert(not is_assignable_to(tuple[Any, ...], ~tuple[Any, ...]))
 
 # but `tuple[Any]` is assignable to `~tuple[Any]`,
 # as the bottom materialization of `tuple[Any]` is `Never`,
 # and `Never` *is* disjoint from itself
-static_assert(is_assignable_to(tuple[Any], Not[tuple[Any]]))
+static_assert(is_assignable_to(tuple[Any], ~tuple[Any]))
 
 # The same principle applies for non-fully-static `list` specializations.
 # TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
-static_assert(is_assignable_to(list[Any], Not[list[Any]]))  # error: [static-assert-error]
+static_assert(is_assignable_to(list[Any], ~list[Any]))  # error: [static-assert-error]
 
 # `Bottom[list[Any]]` is `Never`, which is disjoint from `Bottom[Sequence[Any]]`
 # (which is `Sequence[Never]`).
 # TODO: this should pass (`Bottom[list[Any]]` should simplify to `Never`)
-static_assert(is_assignable_to(list[Any], Not[Sequence[Any]]))  # error: [static-assert-error]
+static_assert(is_assignable_to(list[Any], ~Sequence[Any]))  # error: [static-assert-error]
 ```
 
 ## General properties
@@ -929,15 +929,15 @@ static_assert(is_assignable_to(Never, type[Any]))
 `Any` and `Unknown` are gradual types. They could materialize to any given type at runtime,
 including `Never`.
 
-```py
-from ty_extensions import static_assert, is_assignable_to, Unknown, Intersection
+```pyi
+from ty_extensions import static_assert, is_assignable_to, Unknown
 from typing_extensions import Never, Any
 
 static_assert(is_assignable_to(Any, Never))
 static_assert(is_assignable_to(Unknown, Never))
 static_assert(is_assignable_to(Any | Unknown, Never))
-static_assert(is_assignable_to(Intersection[Any, int], Never))
-static_assert(is_assignable_to(Intersection[Unknown, int], Never))
+static_assert(is_assignable_to(Any & int, Never))
+static_assert(is_assignable_to(Unknown & int, Never))
 static_assert(not is_assignable_to(Any | int, Never))
 static_assert(not is_assignable_to(Unknown | int, Never))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -5,9 +5,9 @@ This means that it is known that no possible runtime object inhabits both types 
 
 ## Basic builtin types
 
-```py
+```pyi
 from typing_extensions import Literal, LiteralString, Any
-from ty_extensions import Intersection, Not, TypeOf, is_disjoint_from, static_assert
+from ty_extensions import TypeOf, is_disjoint_from, static_assert
 
 static_assert(is_disjoint_from(bool, str))
 static_assert(not is_disjoint_from(bool, bool))
@@ -16,7 +16,7 @@ static_assert(not is_disjoint_from(bool, object))
 
 static_assert(not is_disjoint_from(Any, bool))
 static_assert(not is_disjoint_from(Any, Any))
-static_assert(not is_disjoint_from(Any, Not[Any]))
+static_assert(not is_disjoint_from(Any, ~Any))
 
 static_assert(not is_disjoint_from(LiteralString, LiteralString))
 static_assert(not is_disjoint_from(str, LiteralString))
@@ -24,10 +24,10 @@ static_assert(not is_disjoint_from(str, LiteralString))
 
 ## Enum complements
 
-```py
+```pyi
 from enum import Enum
 from typing import Literal
-from ty_extensions import Intersection, Not, is_disjoint_from, static_assert
+from ty_extensions import is_disjoint_from, static_assert
 
 class Color(Enum):
     RED = 1
@@ -36,22 +36,22 @@ class Color(Enum):
 
 static_assert(
     is_disjoint_from(
-        Intersection[Color, Not[Literal[Color.RED]]],
-        Intersection[Color, Not[Literal[Color.GREEN, Color.BLUE]]],
+        Color & ~Literal[Color.RED],
+        Color & ~Literal[Color.GREEN, Color.BLUE],
     )
 )
 static_assert(
     is_disjoint_from(
-        Intersection[Color, Not[Literal[Color.GREEN, Color.BLUE]]],
-        Intersection[Color, Not[Literal[Color.RED]]],
+        Color & ~Literal[Color.GREEN, Color.BLUE],
+        Color & ~Literal[Color.RED],
     )
 )
 ```
 
 ## Class hierarchies
 
-```py
-from ty_extensions import is_disjoint_from, static_assert, Intersection, is_subtype_of
+```pyi
+from ty_extensions import is_disjoint_from, static_assert, is_subtype_of
 from typing import final
 
 class A: ...
@@ -69,7 +69,7 @@ static_assert(not is_disjoint_from(B1, B2))
 class C(B1, B2): ...
 
 # ... which lies in their intersection:
-static_assert(is_subtype_of(C, Intersection[B1, B2]))
+static_assert(is_subtype_of(C, B1 & B2))
 
 # However, if a class is marked final, it cannot be subclassed ...
 @final
@@ -146,10 +146,10 @@ static_assert(not is_disjoint_from(Foo[int], Foo[str]))
 Only incompatible invariant generic arguments imply disjointness. Covariant generic arguments do
 not: a covariant container can be inhabited by an empty value.
 
-```py
+```pyi
 from collections.abc import Sequence
 from typing import Any, Generic, TypeVar
-from ty_extensions import Intersection, is_disjoint_from, static_assert
+from ty_extensions import is_disjoint_from, static_assert
 
 T = TypeVar("T")
 U = TypeVar("U")
@@ -183,8 +183,8 @@ static_assert(not is_disjoint_from(Invariant[B], Invariant[Any]))
 # `A | Any` cannot materialize to be equivalent to `B`.
 static_assert(is_disjoint_from(Invariant[A | Any], Invariant[B]))
 static_assert(is_disjoint_from(Invariant[B], Invariant[A | Any]))
-static_assert(is_disjoint_from(Invariant[Intersection[A, Any]], Invariant[B]))
-static_assert(is_disjoint_from(Invariant[B], Invariant[Intersection[A, Any]]))
+static_assert(is_disjoint_from(Invariant[A & Any], Invariant[B]))
+static_assert(is_disjoint_from(Invariant[B], Invariant[A & Any]))
 static_assert(is_disjoint_from(InvariantPair[A, A], InvariantPair[A, B]))
 static_assert(not is_disjoint_from(Covariant[A], Covariant[B]))
 static_assert(not is_disjoint_from(Covariant[A], CoSubB))
@@ -375,7 +375,7 @@ static_assert(is_disjoint_from(tuple[int, int], tuple[None, ...]))  # error: [st
 
 ```py
 from typing_extensions import Literal
-from ty_extensions import Intersection, is_disjoint_from, static_assert
+from ty_extensions import is_disjoint_from, static_assert
 
 static_assert(is_disjoint_from(Literal[1, 2], Literal[3]))
 static_assert(is_disjoint_from(Literal[1, 2], Literal[3, 4]))
@@ -386,9 +386,9 @@ static_assert(not is_disjoint_from(Literal[1, 2], Literal[2, 3]))
 
 ## Intersections
 
-```py
+```pyi
 from typing_extensions import Literal, final, Any, LiteralString
-from ty_extensions import Intersection, is_disjoint_from, static_assert, Not, AlwaysFalsy
+from ty_extensions import is_disjoint_from, static_assert, AlwaysFalsy
 
 @final
 class P: ...
@@ -405,9 +405,9 @@ static_assert(is_disjoint_from(P, R))
 static_assert(is_disjoint_from(Q, R))
 
 # ... their intersections are also disjoint:
-static_assert(is_disjoint_from(Intersection[P, Q], R))
-static_assert(is_disjoint_from(Intersection[P, R], Q))
-static_assert(is_disjoint_from(Intersection[Q, R], P))
+static_assert(is_disjoint_from(P & Q, R))
+static_assert(is_disjoint_from(P & R, Q))
+static_assert(is_disjoint_from(Q & R, P))
 
 # On the other hand, for non-disjoint classes ...
 class X: ...
@@ -419,33 +419,33 @@ static_assert(not is_disjoint_from(X, Z))
 static_assert(not is_disjoint_from(Y, Z))
 
 # ... their intersections are also not disjoint:
-static_assert(not is_disjoint_from(Intersection[X, Y], Z))
-static_assert(not is_disjoint_from(Intersection[X, Z], Y))
-static_assert(not is_disjoint_from(Intersection[Y, Z], X))
+static_assert(not is_disjoint_from(X & Y, Z))
+static_assert(not is_disjoint_from(X & Z, Y))
+static_assert(not is_disjoint_from(Y & Z, X))
 
 # If one side has a positive fully-static element and the other side has a negative of that element, they are disjoint
-static_assert(is_disjoint_from(int, Not[int]))
-static_assert(is_disjoint_from(Intersection[X, Y, Not[Z]], Intersection[X, Z]))
-static_assert(is_disjoint_from(Intersection[X, Not[Literal[1]]], Literal[1]))
+static_assert(is_disjoint_from(int, ~int))
+static_assert(is_disjoint_from(X & Y & ~Z, X & Z))
+static_assert(is_disjoint_from(X & ~Literal[1], Literal[1]))
 
 class Parent: ...
 class Child(Parent): ...
 
 static_assert(not is_disjoint_from(Parent, Child))
-static_assert(not is_disjoint_from(Parent, Not[Child]))
-static_assert(not is_disjoint_from(Not[Parent], Not[Child]))
-static_assert(is_disjoint_from(Not[Parent], Child))
-static_assert(is_disjoint_from(Intersection[X, Not[Parent]], Child))
-static_assert(is_disjoint_from(Intersection[X, Not[Parent]], Intersection[X, Child]))
+static_assert(not is_disjoint_from(Parent, ~Child))
+static_assert(not is_disjoint_from(~Parent, ~Child))
+static_assert(is_disjoint_from(~Parent, Child))
+static_assert(is_disjoint_from(X & ~Parent, Child))
+static_assert(is_disjoint_from(X & ~Parent, X & Child))
 
-static_assert(not is_disjoint_from(Intersection[Any, X], Intersection[Any, Not[Y]]))
-static_assert(not is_disjoint_from(Intersection[Any, Not[Y]], Intersection[Any, X]))
+static_assert(not is_disjoint_from(Any & X, Any & ~Y))
+static_assert(not is_disjoint_from(Any & ~Y, Any & X))
 
-static_assert(is_disjoint_from(Intersection[int, Any], Not[int]))
-static_assert(is_disjoint_from(Not[int], Intersection[int, Any]))
+static_assert(is_disjoint_from(int & Any, ~int))
+static_assert(is_disjoint_from(~int, int & Any))
 
 # TODO https://github.com/astral-sh/ty/issues/216
-static_assert(is_disjoint_from(AlwaysFalsy, Intersection[LiteralString, Not[Literal[""]]]))  # error: [static-assert-error]
+static_assert(is_disjoint_from(AlwaysFalsy, LiteralString & ~Literal[""]))  # error: [static-assert-error]
 ```
 
 ## Special types
@@ -466,9 +466,9 @@ static_assert(is_disjoint_from(Never, object))
 
 ### `None`
 
-```py
+```pyi
 from typing_extensions import Literal, LiteralString
-from ty_extensions import is_disjoint_from, static_assert, Intersection, Not
+from ty_extensions import is_disjoint_from, static_assert
 
 static_assert(is_disjoint_from(None, Literal[True]))
 static_assert(is_disjoint_from(None, Literal[1]))
@@ -482,15 +482,15 @@ static_assert(not is_disjoint_from(None, None))
 static_assert(not is_disjoint_from(None, int | None))
 static_assert(not is_disjoint_from(None, object))
 
-static_assert(is_disjoint_from(Intersection[int, Not[str]], None))
-static_assert(is_disjoint_from(None, Intersection[int, Not[str]]))
+static_assert(is_disjoint_from(int & ~str, None))
+static_assert(is_disjoint_from(None, int & ~str))
 ```
 
 ### Literals
 
-```py
+```pyi
 from typing_extensions import Literal, LiteralString
-from ty_extensions import Intersection, Not, TypeOf, is_disjoint_from, static_assert, AlwaysFalsy, AlwaysTruthy
+from ty_extensions import TypeOf, is_disjoint_from, static_assert, AlwaysFalsy, AlwaysTruthy
 from enum import Enum
 
 class Answer(Enum):
@@ -529,22 +529,22 @@ static_assert(not is_disjoint_from(Literal["a"], str))
 
 # TODO: No errors
 # error: [static-assert-error]
-static_assert(is_disjoint_from(AlwaysFalsy, Intersection[LiteralString, Not[Literal[""]]]))
+static_assert(is_disjoint_from(AlwaysFalsy, LiteralString & ~Literal[""]))
 # error: [static-assert-error]
-static_assert(is_disjoint_from(Intersection[Not[Literal[True]], Not[Literal[False]]], bool))
+static_assert(is_disjoint_from(~Literal[True] & ~Literal[False], bool))
 # error: [static-assert-error]
-static_assert(is_disjoint_from(Intersection[AlwaysFalsy, Not[Literal[False]]], bool))
+static_assert(is_disjoint_from(AlwaysFalsy & ~Literal[False], bool))
 # error: [static-assert-error]
-static_assert(is_disjoint_from(Intersection[AlwaysTruthy, Not[Literal[True]]], bool))
+static_assert(is_disjoint_from(AlwaysTruthy & ~Literal[True], bool))
 
 # TODO: No errors
-# The condition `is_disjoint(T, Not[T])` must still be satisfied after the following transformations:
+# The condition `is_disjoint(T, ~T)` must still be satisfied after the following transformations:
 # `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_disjoint_from(Intersection[LiteralString, AlwaysTruthy], Not[LiteralString] | AlwaysFalsy))
+static_assert(is_disjoint_from(LiteralString & AlwaysTruthy, ~LiteralString | AlwaysFalsy))
 # `LiteralString & ~AlwaysFalsy`  -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_disjoint_from(Intersection[LiteralString, Not[AlwaysFalsy]], Not[LiteralString] | AlwaysFalsy))
+static_assert(is_disjoint_from(LiteralString & ~AlwaysFalsy, ~LiteralString | AlwaysFalsy))
 ```
 
 ### Class, module and function literals

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_equivalent_to.md
@@ -84,22 +84,23 @@ static_assert(not is_equivalent_to(type[object], type[Any]))
 
 ## Unions and intersections
 
-```py
-from typing import Any, Literal
-from ty_extensions import Intersection, Not, Unknown, is_equivalent_to, static_assert
+```pyi
+from typing import Any, Literal, TypeAlias
+from ty_extensions import Unknown, is_equivalent_to, static_assert
 from enum import Enum
 
 static_assert(is_equivalent_to(str | int, str | int))
 static_assert(is_equivalent_to(str | int | Any, str | int | Unknown))
 static_assert(is_equivalent_to(str | int, int | str))
-static_assert(is_equivalent_to(Intersection[str, int, Not[bytes], Not[None]], Intersection[int, str, Not[None], Not[bytes]]))
-static_assert(is_equivalent_to(Intersection[str | int, Not[type[Any]]], Intersection[int | str, Not[type[Unknown]]]))
+static_assert(is_equivalent_to(str & int & ~bytes & ~None, int & str & ~None & ~bytes))
+static_assert(is_equivalent_to((str | int) & ~type[Any], (int | str) & ~type[Unknown]))
 
 static_assert(not is_equivalent_to(str | int, int | str | bytes))
 static_assert(not is_equivalent_to(str | int | bytes, int | str | dict))  # error: [missing-type-argument]
 
 static_assert(is_equivalent_to(Unknown, Unknown | Any))
-static_assert(is_equivalent_to(Unknown, Intersection[Unknown, Any]))
+UnknownAndAny: TypeAlias = Unknown & Any
+static_assert(is_equivalent_to(Unknown, UnknownAndAny))
 
 class P: ...
 class Q: ...
@@ -124,25 +125,25 @@ static_assert(is_equivalent_to(R | P | Q, R | Q | P))  # 15
 
 static_assert(is_equivalent_to(str | None, None | str))
 
-static_assert(is_equivalent_to(Intersection[P, Q], Intersection[Q, P]))
-static_assert(is_equivalent_to(Intersection[Q, Not[P]], Intersection[Not[P], Q]))
-static_assert(is_equivalent_to(Intersection[Q, R, Not[P]], Intersection[Not[P], R, Q]))
-static_assert(is_equivalent_to(Intersection[Q | R, Not[P | S]], Intersection[Not[S | P], R | Q]))
+static_assert(is_equivalent_to(P & Q, Q & P))
+static_assert(is_equivalent_to(Q & ~P, ~P & Q))
+static_assert(is_equivalent_to(Q & R & ~P, ~P & R & Q))
+static_assert(is_equivalent_to((Q | R) & ~(P | S), ~(S | P) & (R | Q)))
 
 class Single(Enum):
     VALUE = 1
 
 static_assert(is_equivalent_to(P | Q | Single, Literal[Single.VALUE] | Q | P))
 
-static_assert(is_equivalent_to(Any, Any | Intersection[Any, str]))
-static_assert(is_equivalent_to(Any, Intersection[str, Any] | Any))
-static_assert(is_equivalent_to(Any, Any | Intersection[Any, Not[None]]))
-static_assert(is_equivalent_to(Any, Intersection[Not[None], Any] | Any))
+static_assert(is_equivalent_to(Any, Any | Any & str))
+static_assert(is_equivalent_to(Any, str & Any | Any))
+static_assert(is_equivalent_to(Any, Any | Any & ~None))
+static_assert(is_equivalent_to(Any, ~None & Any | Any))
 
-static_assert(is_equivalent_to(Any, Unknown | Intersection[Unknown, str]))
-static_assert(is_equivalent_to(Any, Intersection[str, Unknown] | Unknown))
-static_assert(is_equivalent_to(Any, Unknown | Intersection[Unknown, Not[None]]))
-static_assert(is_equivalent_to(Any, Intersection[Not[None], Unknown] | Unknown))
+static_assert(is_equivalent_to(Any, Unknown | Unknown & str))
+static_assert(is_equivalent_to(Any, str & Unknown | Unknown))
+static_assert(is_equivalent_to(Any, Unknown | Unknown & ~None))
+static_assert(is_equivalent_to(Any, ~None & Unknown | Unknown))
 ```
 
 ## Tuples
@@ -159,8 +160,8 @@ static_assert(not is_equivalent_to(tuple[str, int], tuple[int, str]))
 
 ## Tuples containing equivalent but differently ordered unions/intersections are equivalent
 
-```py
-from ty_extensions import is_equivalent_to, TypeOf, static_assert, Intersection, Not
+```pyi
+from ty_extensions import is_equivalent_to, TypeOf, static_assert
 from typing import Literal
 
 class P: ...
@@ -170,15 +171,13 @@ class S: ...
 
 static_assert(is_equivalent_to(tuple[P | Q], tuple[Q | P]))
 static_assert(is_equivalent_to(tuple[P | None], tuple[None | P]))
-static_assert(
-    is_equivalent_to(tuple[Intersection[P, Q] | Intersection[R, Not[S]]], tuple[Intersection[Not[S], R] | Intersection[Q, P]])
-)
+static_assert(is_equivalent_to(tuple[P & Q | R & ~S], tuple[~S & R | Q & P]))
 ```
 
 ## Unions containing tuples containing tuples containing unions (etc.)
 
-```py
-from ty_extensions import is_equivalent_to, static_assert, Intersection
+```pyi
+from ty_extensions import is_equivalent_to, static_assert
 
 class P: ...
 class Q: ...
@@ -191,22 +190,22 @@ static_assert(
 )
 static_assert(
     is_equivalent_to(
-        tuple[tuple[tuple[tuple[tuple[Intersection[P, Q]]]]]],
-        tuple[tuple[tuple[tuple[tuple[Intersection[Q, P]]]]]],
+        tuple[tuple[tuple[tuple[tuple[P & Q]]]]],
+        tuple[tuple[tuple[tuple[tuple[Q & P]]]]],
     )
 )
 ```
 
 ## Intersections containing tuples containing unions
 
-```py
-from ty_extensions import is_equivalent_to, static_assert, Intersection
+```pyi
+from ty_extensions import is_equivalent_to, static_assert
 
 class P: ...
 class Q: ...
 class R: ...
 
-static_assert(is_equivalent_to(Intersection[tuple[P | Q], R], Intersection[tuple[Q | P], R]))
+static_assert(is_equivalent_to(tuple[P | Q] & R, tuple[Q | P] & R))
 ```
 
 ## Unions containing generic instances parameterized by unions

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_single_valued.md
@@ -2,7 +2,7 @@
 
 A type is single-valued iff it is not empty and all inhabitants of it compare equal.
 
-```py
+```pyi
 import types
 from types import UnionType
 from typing_extensions import Any, Literal, LiteralString, Never, Callable, TypeAliasType
@@ -62,8 +62,8 @@ An enum literal is only considered single-valued if it has no custom `__eq__`/`_
 these methods always return `True`/`False`, respectively. Otherwise, the single member of the enum
 literal type might not compare equal to itself.
 
-```py
-from ty_extensions import Intersection, is_single_valued, static_assert, TypeOf
+```pyi
+from ty_extensions import is_single_valued, static_assert, TypeOf
 from enum import Enum
 
 class NormalEnum(Enum):
@@ -111,7 +111,7 @@ def _(value: NormalEnum) -> None:
         return
     static_assert(is_single_valued(TypeOf[value]))
 
-def _(value: Intersection[NormalEnum, Any]) -> None:
+def _(value: NormalEnum & Any) -> None:
     if value is NormalEnum.NO:
         return
     static_assert(not is_single_valued(TypeOf[value]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_singleton.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_singleton.md
@@ -4,10 +4,10 @@ A type is a singleton type iff it has exactly one inhabitant.
 
 ## Basic
 
-```py
+```pyi
 from types import UnionType
 from typing_extensions import Any, Callable, Literal, Never, TypeAliasType
-from ty_extensions import Intersection, TypeOf, is_singleton, static_assert
+from ty_extensions import TypeOf, is_singleton, static_assert
 from enum import Enum
 
 class Answer(Enum):
@@ -30,7 +30,7 @@ def _(answer: Answer) -> None:
         return
     static_assert(is_singleton(TypeOf[answer]))
 
-def _(answer: Intersection[Answer, Any]) -> None:
+def _(answer: Answer & Any) -> None:
     if answer is Answer.NO:
         return
     static_assert(not is_singleton(TypeOf[answer]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_subtype_of.md
@@ -177,9 +177,9 @@ While a homogeneous tuple type is not a subtype of any heterogeneous tuple types
 tuple type can be a subtype of a homogeneous tuple type, and homogeneous tuple types can be subtypes
 of `Sequence`:
 
-```py
+```pyi
 from typing import Literal, Any, Sequence
-from ty_extensions import static_assert, is_subtype_of, Not, AlwaysFalsy
+from ty_extensions import static_assert, is_subtype_of, AlwaysFalsy
 
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Literal[1, 2], ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Literal[1], *tuple[Literal[2], ...]]))
@@ -189,14 +189,14 @@ static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Literal[1], Lit
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[*tuple[str, ...], Literal[1], Literal[2]]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int, ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[int | str, ...]))
-static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], tuple[~AlwaysFalsy, ...]))
 static_assert(is_subtype_of(tuple[Literal[1], Literal[2]], Sequence[int]))
 static_assert(is_subtype_of(tuple[int, ...], Sequence[int]))
 
 static_assert(is_subtype_of(tuple[()], tuple[Literal[1, 2], ...]))
 static_assert(is_subtype_of(tuple[()], tuple[int, ...]))
 static_assert(is_subtype_of(tuple[()], tuple[int | str, ...]))
-static_assert(is_subtype_of(tuple[()], tuple[Not[AlwaysFalsy], ...]))
+static_assert(is_subtype_of(tuple[()], tuple[~AlwaysFalsy, ...]))
 static_assert(is_subtype_of(tuple[()], Sequence[int]))
 
 static_assert(not is_subtype_of(tuple[Literal[1], Literal[2]], tuple[Any, ...]))
@@ -209,7 +209,7 @@ static_assert(not is_subtype_of(tuple[Any, ...], Sequence[int]))
 
 ```py
 from typing import Literal, Any, Sequence
-from ty_extensions import static_assert, is_subtype_of, Not, AlwaysFalsy
+from ty_extensions import static_assert, is_subtype_of, AlwaysFalsy
 
 static_assert(
     is_subtype_of(
@@ -471,9 +471,9 @@ static_assert(not is_subtype_of(Literal[1, "two", 3], int))
 
 ## Intersection types
 
-```py
+```pyi
 from typing_extensions import Literal, LiteralString
-from ty_extensions import Intersection, Not, is_subtype_of, static_assert
+from ty_extensions import is_subtype_of, static_assert
 
 class A: ...
 class B1(A): ...
@@ -488,49 +488,49 @@ static_assert(is_subtype_of(C, B1))
 static_assert(is_subtype_of(C, B2))
 
 # For complements, the subtyping relation is reversed:
-static_assert(is_subtype_of(Not[A], Not[B1]))
-static_assert(is_subtype_of(Not[A], Not[B2]))
-static_assert(is_subtype_of(Not[A], Not[C]))
-static_assert(is_subtype_of(Not[B1], Not[C]))
-static_assert(is_subtype_of(Not[B2], Not[C]))
+static_assert(is_subtype_of(~A, ~B1))
+static_assert(is_subtype_of(~A, ~B2))
+static_assert(is_subtype_of(~A, ~C))
+static_assert(is_subtype_of(~B1, ~C))
+static_assert(is_subtype_of(~B2, ~C))
 
 # The intersection of two types is a subtype of both:
-static_assert(is_subtype_of(Intersection[B1, B2], B1))
-static_assert(is_subtype_of(Intersection[B1, B2], B2))
+static_assert(is_subtype_of(B1 & B2, B1))
+static_assert(is_subtype_of(B1 & B2, B2))
 # … and of their common supertype:
-static_assert(is_subtype_of(Intersection[B1, B2], A))
+static_assert(is_subtype_of(B1 & B2, A))
 
 # A common subtype of two types is a subtype of their intersection:
-static_assert(is_subtype_of(C, Intersection[B1, B2]))
+static_assert(is_subtype_of(C, B1 & B2))
 # … but not the other way around:
-static_assert(not is_subtype_of(Intersection[B1, B2], C))
+static_assert(not is_subtype_of(B1 & B2, C))
 
 # "Removing" B1 from A leaves a subtype of A.
-static_assert(is_subtype_of(Intersection[A, Not[B1]], A))
-static_assert(is_subtype_of(Intersection[A, Not[B1]], Not[B1]))
+static_assert(is_subtype_of(A & ~B1, A))
+static_assert(is_subtype_of(A & ~B1, ~B1))
 
 # B1 and B2 are not disjoint, so this is not true:
-static_assert(not is_subtype_of(B2, Intersection[A, Not[B1]]))
+static_assert(not is_subtype_of(B2, A & ~B1))
 # … but for two disjoint subtypes, it is:
-static_assert(is_subtype_of(Literal[2], Intersection[int, Not[Literal[1]]]))
+static_assert(is_subtype_of(Literal[2], int & ~Literal[1]))
 
 # A and Unrelated are not related, so this is not true:
-static_assert(not is_subtype_of(Intersection[A, Not[B1]], Not[Unrelated]))
+static_assert(not is_subtype_of(A & ~B1, ~Unrelated))
 # … but for a disjoint type like `None`, it is:
-static_assert(is_subtype_of(Intersection[A, Not[B1]], Not[None]))
+static_assert(is_subtype_of(A & ~B1, ~None))
 
 # Complements of types are still subtypes of `object`:
-static_assert(is_subtype_of(Not[A], object))
+static_assert(is_subtype_of(~A, object))
 
 # More examples:
-static_assert(is_subtype_of(type[str], Not[None]))
-static_assert(is_subtype_of(Not[LiteralString], object))
+static_assert(is_subtype_of(type[str], ~None))
+static_assert(is_subtype_of(~LiteralString, object))
 
-static_assert(not is_subtype_of(Intersection[int, Not[Literal[2]]], Intersection[int, Not[Literal[3]]]))
-static_assert(not is_subtype_of(Not[Literal[2]], Not[Literal[3]]))
-static_assert(not is_subtype_of(Not[Literal[2]], Not[int]))
-static_assert(not is_subtype_of(int, Not[Literal[3]]))
-static_assert(not is_subtype_of(Literal[1], Intersection[int, Not[Literal[1]]]))
+static_assert(not is_subtype_of(int & ~Literal[2], int & ~Literal[3]))
+static_assert(not is_subtype_of(~Literal[2], ~Literal[3]))
+static_assert(not is_subtype_of(~Literal[2], ~int))
+static_assert(not is_subtype_of(int, ~Literal[3]))
+static_assert(not is_subtype_of(Literal[1], int & ~Literal[1]))
 ```
 
 ## Intersections with non-fully-static negated elements
@@ -540,36 +540,36 @@ materialization of that type is disjoint from the _top_ materialization of all n
 the intersection. This differs from assignability, which should do the disjointness check against
 the _bottom_ materialization of the negated elements.
 
-```py
+```pyi
 from typing_extensions import Any, Never, Sequence
-from ty_extensions import Not, is_subtype_of, static_assert
+from ty_extensions import is_subtype_of, static_assert
 
 # The top materialization of `tuple[Any]` is `tuple[object]`,
 # which is disjoint from `tuple[()]` but not `tuple[int]`,
 # so `tuple[()]` is a subtype of `~tuple[Any]` but `tuple[int]`
 # is not.
-static_assert(is_subtype_of(tuple[()], Not[tuple[Any]]))
-static_assert(not is_subtype_of(tuple[int], Not[tuple[Any]]))
-static_assert(not is_subtype_of(tuple[Any], Not[tuple[Any]]))
+static_assert(is_subtype_of(tuple[()], ~tuple[Any]))
+static_assert(not is_subtype_of(tuple[int], ~tuple[Any]))
+static_assert(not is_subtype_of(tuple[Any], ~tuple[Any]))
 
 # The top materialization of `tuple[Any, ...]` is `tuple[object, ...]`,
 # so no tuple type can be considered a subtype of `~tuple[Any, ...]`
-static_assert(not is_subtype_of(tuple[()], Not[tuple[Any, ...]]))
-static_assert(not is_subtype_of(tuple[int], Not[tuple[Any, ...]]))
-static_assert(not is_subtype_of(tuple[int, ...], Not[tuple[Any, ...]]))
-static_assert(not is_subtype_of(tuple[object, ...], Not[tuple[Any, ...]]))
-static_assert(not is_subtype_of(tuple[Any, ...], Not[tuple[Any, ...]]))
+static_assert(not is_subtype_of(tuple[()], ~tuple[Any, ...]))
+static_assert(not is_subtype_of(tuple[int], ~tuple[Any, ...]))
+static_assert(not is_subtype_of(tuple[int, ...], ~tuple[Any, ...]))
+static_assert(not is_subtype_of(tuple[object, ...], ~tuple[Any, ...]))
+static_assert(not is_subtype_of(tuple[Any, ...], ~tuple[Any, ...]))
 
 # Similarly, the top materialization of `Sequence[Any]` is `Sequence[object]`,
 # so no sequence type can be considered a subtype of `~Sequence[Any]`.
-static_assert(not is_subtype_of(tuple[()], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(tuple[int], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(tuple[int, ...], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(tuple[object, ...], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(tuple[Any, ...], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(list[Never], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(list[Any], Not[Sequence[Any]]))
-static_assert(not is_subtype_of(list[int], Not[Sequence[Any]]))
+static_assert(not is_subtype_of(tuple[()], ~Sequence[Any]))
+static_assert(not is_subtype_of(tuple[int], ~Sequence[Any]))
+static_assert(not is_subtype_of(tuple[int, ...], ~Sequence[Any]))
+static_assert(not is_subtype_of(tuple[object, ...], ~Sequence[Any]))
+static_assert(not is_subtype_of(tuple[Any, ...], ~Sequence[Any]))
+static_assert(not is_subtype_of(list[Never], ~Sequence[Any]))
+static_assert(not is_subtype_of(list[Any], ~Sequence[Any]))
+static_assert(not is_subtype_of(list[int], ~Sequence[Any]))
 ```
 
 ## Special types
@@ -599,8 +599,8 @@ static_assert(is_subtype_of(Never, AlwaysFalsy))
 python-version = "3.11"
 ```
 
-```py
-from ty_extensions import AlwaysTruthy, AlwaysFalsy, Intersection, Not, is_subtype_of, static_assert
+```pyi
+from ty_extensions import AlwaysTruthy, AlwaysFalsy, is_subtype_of, static_assert
 from typing_extensions import Literal, LiteralString
 
 static_assert(is_subtype_of(Literal[1], AlwaysTruthy))
@@ -628,14 +628,14 @@ static_assert(not is_subtype_of(Literal[True] | AlwaysFalsy, Literal[False] | Al
 # The condition `is_subtype_of(T & U, U)` must still be satisfied after the following transformations:
 # `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal[""]]], AlwaysTruthy))
+static_assert(is_subtype_of(LiteralString & ~Literal[""], AlwaysTruthy))
 # error: [static-assert-error]
-static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal["", "a"]]], AlwaysTruthy))
+static_assert(is_subtype_of(LiteralString & ~Literal["", "a"], AlwaysTruthy))
 # `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
 # error: [static-assert-error]
-static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal[""]]], Not[AlwaysFalsy]))
+static_assert(is_subtype_of(LiteralString & ~Literal[""], ~AlwaysFalsy))
 # error: [static-assert-error]
-static_assert(is_subtype_of(Intersection[LiteralString, Not[Literal["", "a"]]], Not[AlwaysFalsy]))
+static_assert(is_subtype_of(LiteralString & ~Literal["", "a"], ~AlwaysFalsy))
 
 class Length2TupleSubclass(tuple[int, str]): ...
 
@@ -855,8 +855,8 @@ A non-fully-static type can be considered a subtype of another type if all possi
 of the first type represent sets of values that are a subset of every possible set of values
 represented by a materialization of the second type.
 
-```py
-from ty_extensions import Unknown, is_subtype_of, static_assert, Intersection
+```pyi
+from ty_extensions import Unknown, is_subtype_of, static_assert
 from typing_extensions import Any
 
 static_assert(not is_subtype_of(Any, Any))
@@ -866,7 +866,7 @@ static_assert(is_subtype_of(Any, object))
 static_assert(not is_subtype_of(object, Any))
 
 static_assert(is_subtype_of(int, Any | int))
-static_assert(is_subtype_of(Intersection[Any, int], int))
+static_assert(is_subtype_of(Any & int, int))
 static_assert(not is_subtype_of(tuple[int, int], tuple[int, Any]))
 
 class Covariant[T]:
@@ -908,7 +908,7 @@ static_assert(is_subtype_of(Bivariant[object], Bivariant[Any]))
 
 The same for `Unknown`:
 
-```py
+```pyi
 static_assert(not is_subtype_of(Unknown, Unknown))
 static_assert(not is_subtype_of(Unknown, int))
 static_assert(not is_subtype_of(int, Unknown))
@@ -916,7 +916,7 @@ static_assert(is_subtype_of(Unknown, object))
 static_assert(not is_subtype_of(object, Unknown))
 
 static_assert(is_subtype_of(int, Unknown | int))
-static_assert(is_subtype_of(Intersection[Unknown, int], int))
+static_assert(is_subtype_of(Unknown & int, int))
 static_assert(not is_subtype_of(tuple[int, int], tuple[int, Unknown]))
 ```
 
@@ -929,7 +929,7 @@ would not satisfy the subtype relation.
 
 They are subtypes of `object`.
 
-```py
+```pyi
 class InheritsAny(Any):
     pass
 
@@ -943,7 +943,7 @@ static_assert(is_subtype_of(InheritsAny, object))
 
 Similar for subclass-of types:
 
-```py
+```pyi
 static_assert(not is_subtype_of(type[Any], type[Any]))
 static_assert(not is_subtype_of(type[object], type[Any]))
 static_assert(not is_subtype_of(type[Any], type[Arbitrary]))

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -396,25 +396,25 @@ def _(
 
 All positions in an intersection are covariant.
 
-```py
+```pyi
 from typing import Any
 from typing_extensions import Never
-from ty_extensions import Intersection, Unknown, Bottom, Top, static_assert, is_equivalent_to
+from ty_extensions import Unknown, Bottom, Top, static_assert, is_equivalent_to
 
-static_assert(is_equivalent_to(Top[Intersection[Any, int]], int))
-static_assert(is_equivalent_to(Bottom[Intersection[Any, int]], Never))
+static_assert(is_equivalent_to(Top[Any & int], int))
+static_assert(is_equivalent_to(Bottom[Any & int], Never))
 
 # Here, the top materialization of `Any | int` is `object` and the intersection of it with tuple
-static_assert(is_equivalent_to(Top[Intersection[Any | int, tuple[str, Unknown]]], tuple[str, object]))
-static_assert(is_equivalent_to(Bottom[Intersection[Any | int, tuple[str, Unknown]]], Never))
+static_assert(is_equivalent_to(Top[(Any | int) & tuple[str, Unknown]], tuple[str, object]))
+static_assert(is_equivalent_to(Bottom[(Any | int) & tuple[str, Unknown]], Never))
 
 class Foo: ...
 
-static_assert(is_equivalent_to(Bottom[Intersection[Any | Foo, tuple[str]]], Intersection[Foo, tuple[str]]))
+static_assert(is_equivalent_to(Bottom[(Any | Foo) & tuple[str]], Foo & tuple[str]))
 
 def _(
-    top: Top[Intersection[list[Any], list[int]]],
-    bottom: Bottom[Intersection[list[Any], list[int]]],
+    top: Top[list[Any] & list[int]],
+    bottom: Bottom[list[Any] & list[int]],
 ):
     # Top[list[Any] & list[int]] = Top[list[Any]] & list[int] = list[int]
     reveal_type(top)  # revealed: list[int]
@@ -422,23 +422,23 @@ def _(
     reveal_type(bottom)  # revealed: Bottom[list[Any]]
 ```
 
-## Negation (via `Not`)
+## Negation
 
 All positions in a negation are contravariant.
 
-```py
+```pyi
 from typing import Any
 from typing_extensions import Never
-from ty_extensions import Not, Unknown, Bottom, Top, static_assert, is_equivalent_to
+from ty_extensions import Unknown, Bottom, Top, static_assert, is_equivalent_to
 
 # ~Any is still Any, so the top materialization is object
-static_assert(is_equivalent_to(Top[Not[Any]], object))
-static_assert(is_equivalent_to(Bottom[Not[Any]], Never))
+static_assert(is_equivalent_to(Top[~Any], object))
+static_assert(is_equivalent_to(Bottom[~Any], Never))
 
 # tuple[Any, int] is in a contravariant position, so the
 # top materialization is Never and the negation of it
-static_assert(is_equivalent_to(Top[Not[tuple[Any, int]]], object))
-static_assert(is_equivalent_to(Bottom[Not[tuple[Any, int]]], Not[tuple[object, int]]))
+static_assert(is_equivalent_to(Top[~tuple[Any, int]], object))
+static_assert(is_equivalent_to(Bottom[~tuple[Any, int]], ~tuple[object, int]))
 ```
 
 ## `type`
@@ -635,27 +635,27 @@ static_assert(is_equivalent_to(Top[Bottom[list[Any]]], Bottom[list[Any]]))
 Any `list[T]` is a subtype of `Top[list[Any]]`, but with more restrictive gradual types, not all
 other specializations are subtypes.
 
-```py
+```pyi
 from typing import Any, Literal
-from ty_extensions import is_subtype_of, static_assert, Top, Intersection, Bottom
+from ty_extensions import is_subtype_of, static_assert, Top, Bottom
 
 # None and Top
 static_assert(is_subtype_of(list[int], Top[list[Any]]))
 static_assert(not is_subtype_of(Top[list[Any]], list[int]))
-static_assert(is_subtype_of(list[bool], Top[list[Intersection[int, Any]]]))
-static_assert(is_subtype_of(list[int], Top[list[Intersection[int, Any]]]))
-static_assert(not is_subtype_of(list[int | str], Top[list[Intersection[int, Any]]]))
-static_assert(not is_subtype_of(list[object], Top[list[Intersection[int, Any]]]))
-static_assert(not is_subtype_of(list[str], Top[list[Intersection[int, Any]]]))
-static_assert(not is_subtype_of(list[str | bool], Top[list[Intersection[int, Any]]]))
+static_assert(is_subtype_of(list[bool], Top[list[int & Any]]))
+static_assert(is_subtype_of(list[int], Top[list[int & Any]]))
+static_assert(not is_subtype_of(list[int | str], Top[list[int & Any]]))
+static_assert(not is_subtype_of(list[object], Top[list[int & Any]]))
+static_assert(not is_subtype_of(list[str], Top[list[int & Any]]))
+static_assert(not is_subtype_of(list[str | bool], Top[list[int & Any]]))
 
 # Top and Top
 static_assert(is_subtype_of(Top[list[int | Any]], Top[list[Any]]))
 static_assert(not is_subtype_of(Top[list[Any]], Top[list[int | Any]]))
-static_assert(is_subtype_of(Top[list[Intersection[int, Any]]], Top[list[Any]]))
-static_assert(not is_subtype_of(Top[list[Any]], Top[list[Intersection[int, Any]]]))
-static_assert(not is_subtype_of(Top[list[Intersection[int, Any]]], Top[list[int | Any]]))
-static_assert(not is_subtype_of(Top[list[int | Any]], Top[list[Intersection[int, Any]]]))
+static_assert(is_subtype_of(Top[list[int & Any]], Top[list[Any]]))
+static_assert(not is_subtype_of(Top[list[Any]], Top[list[int & Any]]))
+static_assert(not is_subtype_of(Top[list[int & Any]], Top[list[int | Any]]))
+static_assert(not is_subtype_of(Top[list[int | Any]], Top[list[int & Any]]))
 static_assert(not is_subtype_of(Top[list[str | Any]], Top[list[int | Any]]))
 static_assert(is_subtype_of(Top[list[str | int | Any]], Top[list[int | Any]]))
 static_assert(not is_subtype_of(Top[list[int | Any]], Top[list[str | int | Any]]))
@@ -665,8 +665,8 @@ static_assert(is_subtype_of(Bottom[list[Any]], Top[list[Any]]))
 static_assert(is_subtype_of(Bottom[list[Any]], Top[list[int | Any]]))
 static_assert(is_subtype_of(Bottom[list[int | Any]], Top[list[Any]]))
 static_assert(is_subtype_of(Bottom[list[int | Any]], Top[list[int | str]]))
-static_assert(is_subtype_of(Bottom[list[Intersection[int, Any]]], Top[list[Intersection[str, Any]]]))
-static_assert(not is_subtype_of(Bottom[list[Intersection[int, bool | Any]]], Bottom[list[Intersection[str, Literal["x"] | Any]]]))
+static_assert(is_subtype_of(Bottom[list[int & Any]], Top[list[str & Any]]))
+static_assert(not is_subtype_of(Bottom[list[int & (bool | Any)]], Bottom[list[str & (Literal["x"] | Any)]]))
 
 # None and None
 static_assert(not is_subtype_of(list[int], list[Any]))
@@ -683,7 +683,7 @@ static_assert(is_subtype_of(Top[list[int]], list[int]))
 # Bottom and None
 static_assert(is_subtype_of(Bottom[list[Any]], list[object]))
 static_assert(is_subtype_of(Bottom[list[int | Any]], list[str | int]))
-static_assert(not is_subtype_of(Bottom[list[str | Any]], list[Intersection[int, bool | Any]]))
+static_assert(not is_subtype_of(Bottom[list[str | Any]], list[int & (bool | Any)]))
 
 # None and Bottom
 static_assert(not is_subtype_of(list[int], Bottom[list[Any]]))
@@ -710,29 +710,29 @@ static_assert(not is_subtype_of(Bottom[list[int | Any]], Bottom[list[Any]]))
 Assignability is the same as subtyping for top and bottom materializations, because those are fully
 static types, but some gradual types are assignable even if they are not subtypes.
 
-```py
+```pyi
 from typing import Any, Literal
-from ty_extensions import is_assignable_to, static_assert, Top, Intersection, Bottom
+from ty_extensions import is_assignable_to, static_assert, Top, Bottom
 
 # None and Top
 static_assert(is_assignable_to(list[Any], Top[list[Any]]))
 static_assert(is_assignable_to(list[int], Top[list[Any]]))
 static_assert(not is_assignable_to(Top[list[Any]], list[int]))
-static_assert(is_assignable_to(list[bool], Top[list[Intersection[int, Any]]]))
-static_assert(is_assignable_to(list[int], Top[list[Intersection[int, Any]]]))
-static_assert(is_assignable_to(list[Any], Top[list[Intersection[int, Any]]]))
-static_assert(not is_assignable_to(list[int | str], Top[list[Intersection[int, Any]]]))
-static_assert(not is_assignable_to(list[object], Top[list[Intersection[int, Any]]]))
-static_assert(not is_assignable_to(list[str], Top[list[Intersection[int, Any]]]))
-static_assert(not is_assignable_to(list[str | bool], Top[list[Intersection[int, Any]]]))
+static_assert(is_assignable_to(list[bool], Top[list[int & Any]]))
+static_assert(is_assignable_to(list[int], Top[list[int & Any]]))
+static_assert(is_assignable_to(list[Any], Top[list[int & Any]]))
+static_assert(not is_assignable_to(list[int | str], Top[list[int & Any]]))
+static_assert(not is_assignable_to(list[object], Top[list[int & Any]]))
+static_assert(not is_assignable_to(list[str], Top[list[int & Any]]))
+static_assert(not is_assignable_to(list[str | bool], Top[list[int & Any]]))
 
 # Top and Top
 static_assert(is_assignable_to(Top[list[int | Any]], Top[list[Any]]))
 static_assert(not is_assignable_to(Top[list[Any]], Top[list[int | Any]]))
-static_assert(is_assignable_to(Top[list[Intersection[int, Any]]], Top[list[Any]]))
-static_assert(not is_assignable_to(Top[list[Any]], Top[list[Intersection[int, Any]]]))
-static_assert(not is_assignable_to(Top[list[Intersection[int, Any]]], Top[list[int | Any]]))
-static_assert(not is_assignable_to(Top[list[int | Any]], Top[list[Intersection[int, Any]]]))
+static_assert(is_assignable_to(Top[list[int & Any]], Top[list[Any]]))
+static_assert(not is_assignable_to(Top[list[Any]], Top[list[int & Any]]))
+static_assert(not is_assignable_to(Top[list[int & Any]], Top[list[int | Any]]))
+static_assert(not is_assignable_to(Top[list[int | Any]], Top[list[int & Any]]))
 static_assert(not is_assignable_to(Top[list[str | Any]], Top[list[int | Any]]))
 static_assert(is_assignable_to(Top[list[str | int | Any]], Top[list[int | Any]]))
 static_assert(not is_assignable_to(Top[list[int | Any]], Top[list[str | int | Any]]))
@@ -741,10 +741,8 @@ static_assert(not is_assignable_to(Top[list[int | Any]], Top[list[str | int | An
 static_assert(is_assignable_to(Bottom[list[Any]], Top[list[Any]]))
 static_assert(is_assignable_to(Bottom[list[Any]], Top[list[int | Any]]))
 static_assert(is_assignable_to(Bottom[list[int | Any]], Top[list[Any]]))
-static_assert(is_assignable_to(Bottom[list[Intersection[int, Any]]], Top[list[Intersection[str, Any]]]))
-static_assert(
-    not is_assignable_to(Bottom[list[Intersection[int, bool | Any]]], Bottom[list[Intersection[str, Literal["x"] | Any]]])
-)
+static_assert(is_assignable_to(Bottom[list[int & Any]], Top[list[str & Any]]))
+static_assert(not is_assignable_to(Bottom[list[int & (bool | Any)]], Bottom[list[str & (Literal["x"] | Any)]]))
 
 # None and None
 static_assert(is_assignable_to(list[int], list[Any]))
@@ -761,7 +759,7 @@ static_assert(is_assignable_to(Top[list[int]], list[int]))
 # Bottom and None
 static_assert(is_assignable_to(Bottom[list[Any]], list[object]))
 static_assert(is_assignable_to(Bottom[list[int | Any]], Top[list[str | int]]))
-static_assert(not is_assignable_to(Bottom[list[str | Any]], list[Intersection[int, bool | Any]]))
+static_assert(not is_assignable_to(Bottom[list[str | Any]], list[int & (bool | Any)]))
 
 # None and Bottom
 static_assert(is_assignable_to(list[Any], Bottom[list[Any]]))


### PR DESCRIPTION
Migrate the `type_properties` mdtests to the new syntax to make them easier to read.
