### PR TITLE
[ty] Revert equality intersection optimization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -570,6 +570,7 @@ from enum import Enum, IntEnum
 from typing import Any, Literal, TypeVar
 
 T = TypeVar("T", bound=object)
+U = TypeVar("U")
 EQUAL_VALUES = TypeVar("EQUAL_VALUES", Literal[0], Literal[False])
 RUNTIME_TYPE_VAR = TypeVar("RUNTIME_TYPE_VAR")
 
@@ -627,6 +628,11 @@ def _(x: Any):
 def _(x: T):
     if x != Color.RED:
         reveal_type(x)  # revealed: T@_ & ~Literal[Color.RED]
+
+def _(x: U | Literal[Color.RED]):
+    if x == Color.RED:
+        return
+    reveal_type(x)  # revealed: U@_ & ~Literal[Color.RED]
 
 def _(x: Any, y: EQUAL_VALUES):
     if x != y:

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -710,18 +710,11 @@ fn evaluate_target_union<'db>(
 
     let removed = removed_any.then(|| removed.build());
     let mut builder = UnionBuilder::new(db);
-    for (original, narrowed) in elements.iter().zip(narrowed) {
+    for narrowed in narrowed {
         let Some(mut narrowed) = narrowed else {
             continue;
         };
-        // This is a performance optimization that keeps repeated comparisons from building
-        // progressively larger types. For example, if `value == "a"` is false for
-        // `Literal["a", "b"] | Any`, the `"a"` case is gone and the `"b"` case can stay as-is.
-        // Only the `Any` case needs to remember that the value is not `"a"`; adding the same
-        // exclusion to `"b"` would not narrow it further.
-        if original.is_dynamic()
-            && let Some(removed) = removed
-        {
+        if let Some(removed) = removed {
             narrowed = IntersectionBuilder::new(db)
                 .add_positive(narrowed)
                 .add_negative(removed)


### PR DESCRIPTION
## Summary

This reverts the dynamic-only guard added in #26057. Non-dynamic union arms can still overlap alternatives removed by equality narrowing when their individual comparison result is ambiguous. For example, after excluding `Color.RED` from `T | Literal[Color.RED]`, an unconstrained `T` must remain `T & ~Literal[Color.RED]`; dropping that negative constraint incorrectly widens the result to `T`.

The regression test covers that fallthrough behavior. This restores the previous narrowing while we develop a narrower optimization that only skips constraints for arms proven to take the selected branch.

The focused equality mdtest and file-scoped hooks pass.
