### PR TITLE
[ruff] Document async context caveat for RUF029

### DIFF
--- a/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
+++ b/crates/ruff_linter/src/rules/ruff/rules/unused_async.rs
@@ -18,7 +18,12 @@ use crate::rules::fastapi::rules::is_fastapi_route;
 /// ## Why is this bad?
 /// Declaring a function `async` when it's not is usually a mistake, and will artificially limit the
 /// contexts where that function may be called. In some cases, labeling a function `async` is
-/// semantically meaningful (e.g. with the trio library).
+/// semantically meaningful (e.g. with the trio library, or when a function relies on async execution
+/// context such as `ContextVar` state).
+///
+/// If a function must remain `async` for semantic reasons, but has no other `async` features, you
+/// can add an explicit checkpoint like `await asyncio.sleep(0)` or disable this rule for that
+/// function.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
## Summary

- Clarify that `async` can be semantically meaningful for RUF029 when a function relies on async execution context, such as `ContextVar` state.
- Document `await asyncio.sleep(0)` as an explicit checkpoint option when a function must remain async but otherwise has no async features.
- Fixes #23196.

## Reproduction

- The issue example keeps `ContextVar` state isolated when the function remains async.
- Removing `async`, as a user might infer from RUF029, changes when and where the function body executes and can change runtime behavior.

## Root cause

- The RUF029 docs already said `async` can be semantically meaningful, but only gave Trio as an example.
- The docs did not mention async execution context or an explicit checkpoint workaround.

## Changes

- Expanded the RUF029 rule documentation in `unused_async.rs`.
- Regenerated docs to verify the generated RUF029 output includes the new text; no tracked generated files changed.

## Tests

- `git diff --check upstream/main..HEAD`
- `rustfmt --check crates/ruff_linter/src/rules/ruff/rules/unused_async.rs`
- `cargo run -p ruff_dev -- generate-docs`
- `cargo run -p ruff_dev -- generate-docs --dry-run >/tmp/ruff-23196-generate-docs.txt && rg -n "async execution|ContextVar|asyncio\.sleep\(0\)" /tmp/ruff-23196-generate-docs.txt`
- `printf 'async def func():\n    print("x")\n' | cargo run -p ruff -- check --isolated --preview --select RUF029 -` (expected RUF029 diagnostic)
- Not run: `uvx prek run --files crates/ruff_linter/src/rules/ruff/rules/unused_async.rs` because `uvx` is not installed in this environment.

## Screenshots/Logs

- Not applicable; documentation-only change.

This PR follows the repository AI policy.