### PR TITLE
[ty] Cache expanded intersection typevars and newtypes

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -933,6 +933,13 @@ impl<'db> IntersectionType<'db> {
     /// Return a version of this intersection type where any type variables in the positive elements
     /// have been replaced by their bounds or constraints, and where any newtypes in the positive elements
     /// have been replaced by their concrete base types.
+    #[salsa::tracked(
+        cycle_initial=|_, id, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _| {
+            result.cycle_normalized(db, *previous, cycle)
+        },
+        heap_size=ruff_memory_usage::heap_size
+    )]
     pub(crate) fn with_expanded_typevars_and_newtypes(self, db: &'db dyn Db) -> Type<'db> {
         expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db))
     }


### PR DESCRIPTION
## Summary

Cache expanded intersection typevars and newtypes as a Salsa query so repeated relation checks can reuse the expansion.

For pandas-stubs:
* Walltime (ty_walltime, 5 samples): 16.01s median before -> 15.34s median after, about 4.2% faster.
* Memory (TY_MEMORY_REPORT=json): 385,589,101 bytes before -> 365,928,165 bytes after, about 5.1% lower.

The new tracked query adds about 1.00 MB for 334 cached expansions, but total Salsa memory still drops because `is_redundant_with_impl` memo metadata shrinks substantially.

## Test Plan

Testing: Ran focused ty semantic tests and repository hooks.
