### PR TITLE
[ty] Avoid cross-TypeVar leakage in generic inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -343,6 +343,19 @@ def i[T](x: T, cond: bool) -> T | list[T]:
     return x if cond else [x]
 ```
 
+The return type context should preserve the independent key and value types of a generic `dict`
+constructor:
+
+```py
+from collections.abc import Iterable, Mapping
+
+def dict_with_numeric_promotion(
+    keys: Iterable[float],
+    values: Iterable[int],
+) -> Mapping[float, int]:
+    return dict(zip(keys, values))
+```
+
 ## Type context sources
 
 Type context is sourced from various places, including annotated assignments:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -4933,13 +4933,18 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // Filter out inferable typevars (cross-typevar references from
                         // SequentMap transitivity) and unspecialized typevars (from partially
                         // specialized contexts).
-                        let inferred_ty = binding.solution.filter_union(self.db, |ty| {
-                            if ty.has_unspecialized_type_var(self.db) {
-                                partially_specialized_declared_type.insert(identity);
-                                return false;
-                            }
-                            true
-                        });
+                        let inferred_ty = builder
+                            .remove_inferable_typevar_artifacts_from_solution(
+                                binding.bound_typevar,
+                                binding.solution,
+                            )
+                            .filter_union(self.db, |ty| {
+                                if ty.has_unspecialized_type_var(self.db) {
+                                    partially_specialized_declared_type.insert(identity);
+                                    return false;
+                                }
+                                true
+                            });
                         if inferred_ty.has_unspecialized_type_var(self.db) {
                             continue;
                         }

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1999,12 +1999,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // TODO: This is a solution-level projection. A more principled version would live in the
         // constraint-set solution extraction layer, taking an explicit domain of typevars to solve
         // for and existentially quantifying away the other typevars in that domain.
-        if self.can_remove_inferable_typevar_artifacts(generic_context) {
-            for identity in generic_context.variables_inner(self.db).keys() {
-                if let Some(ty) = types.get_mut(identity) {
-                    *ty =
-                        self.remove_inferable_typevar_artifacts_from_solution(generic_context, *ty);
-                }
+        for (identity, variable) in generic_context.variables_inner(self.db) {
+            if let Some(ty) = types.get_mut(identity) {
+                *ty = self.remove_inferable_typevar_artifacts_from_solution(*variable, *ty);
             }
         }
 
@@ -2096,54 +2093,47 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         })
     }
 
-    fn can_remove_inferable_typevar_artifacts(&self, generic_context: GenericContext<'db>) -> bool {
-        // Mixed contexts can intentionally use one context's typevars to solve another (for
-        // example, constructor calls whose `__init__` self annotation remaps class typevars).
-        // Only remove artifacts for ordinary generic calls whose typevars all come from one
-        // source-level binding context.
-        let mut binding_contexts = generic_context
-            .variables_inner(self.db)
-            .values()
-            .map(|typevar| typevar.binding_context(self.db));
-        let Some(first) = binding_contexts.next() else {
-            return false;
-        };
-        first != BindingContext::Synthetic && binding_contexts.all(|context| context == first)
-    }
-
     fn is_inferable_typevar_artifact(
         &self,
-        generic_context: GenericContext<'db>,
+        target: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
     ) -> bool {
+        let target_context = target.binding_context(self.db);
         ty.as_typevar().is_some_and(|typevar| {
-            typevar.is_inferable(self.db, self.inferable)
-                && generic_context.contains(self.db, typevar.identity(self.db))
+            // Relationships across binding contexts can intentionally remap one generic context
+            // onto another, as with constructor `self` annotations. Synthetic contexts do not
+            // identify a single source-level binding, so they are not safe to project either.
+            target_context != BindingContext::Synthetic
+                && typevar.is_inferable(self.db, self.inferable)
+                && typevar.binding_context(self.db) == target_context
         })
     }
 
-    fn remove_inferable_typevar_artifacts_from_solution(
+    /// Remove inferable type variables introduced by transitivity within the target's binding
+    /// context while preserving intentional relationships to other generic contexts.
+    pub(crate) fn remove_inferable_typevar_artifacts_from_solution(
         &self,
-        generic_context: GenericContext<'db>,
+        target: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
-        let ty = self.remove_inferable_typevar_artifacts_from_lower_bound(generic_context, ty);
-        self.remove_inferable_typevar_artifacts_from_upper_bound(generic_context, ty)
+        let ty = self.remove_inferable_typevar_artifacts_from_lower_bound(target, ty);
+        self.remove_inferable_typevar_artifacts_from_upper_bound(target, ty)
     }
 
     fn remove_inferable_typevar_artifacts_from_lower_bound(
         &self,
-        generic_context: GenericContext<'db>,
+        target: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
         match ty {
             Type::Union(union)
-                if union.elements(self.db).iter().any(|element| {
-                    !self.is_inferable_typevar_artifact(generic_context, *element)
-                }) =>
+                if union
+                    .elements(self.db)
+                    .iter()
+                    .any(|element| !self.is_inferable_typevar_artifact(target, *element)) =>
             {
                 union.filter(self.db, |element| {
-                    !self.is_inferable_typevar_artifact(generic_context, *element)
+                    !self.is_inferable_typevar_artifact(target, *element)
                 })
             }
             _ => ty,
@@ -2152,17 +2142,17 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
     fn remove_inferable_typevar_artifacts_from_upper_bound(
         &self,
-        generic_context: GenericContext<'db>,
+        target: BoundTypeVarInstance<'db>,
         ty: Type<'db>,
     ) -> Type<'db> {
         match ty {
             Type::Intersection(intersection)
-                if intersection.iter_positive(self.db).any(|element| {
-                    !self.is_inferable_typevar_artifact(generic_context, element)
-                }) =>
+                if intersection
+                    .iter_positive(self.db)
+                    .any(|element| !self.is_inferable_typevar_artifact(target, element)) =>
             {
                 intersection.map_positive(self.db, |element| {
-                    if self.is_inferable_typevar_artifact(generic_context, *element) {
+                    if self.is_inferable_typevar_artifact(target, *element) {
                         Type::object()
                     } else {
                         *element


### PR DESCRIPTION
## Summary

Generic return-type context can introduce relationships between type variables while solving a call. We need those relationships during constraint solving, but we previously reused them as concrete preferred types during argument inference.

For example, inferring `dict(zip(keys, values))` against `Mapping[float, int]` can derive a key solution containing the value TypeVar and a value solution containing the key TypeVar. Treating those intermediate relationships as final solutions causes both `dict` parameters to widen to `int | float`. This fails on `main`:

```python
from collections.abc import Iterable, Mapping

def build(
    keys: Iterable[float],
    values: Iterable[int],
) -> Mapping[float, int]:
    return dict(zip(keys, values))
```

This projects inferable TypeVar artifacts within each source binding context before using solutions as preferred types. Relationships across separate generic contexts remain intact, preserving constructor `self` remapping and similar inference.
