### PR TITLE
[ty] Update real-world benchmark pins

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::disallowed_names)]
 use ruff_benchmark::criterion;
 use ruff_benchmark::real_world_projects::{
-    InstalledProject, RealWorldProject, copy_directory_recursive, get_project_cache_dir,
-    install_dependencies_to_cache,
+    InstalledProject, RealWorldProject, TY_ECOSYSTEM_PIN, copy_directory_recursive,
+    get_project_cache_dir, install_dependencies_to_cache,
 };
 
 use std::fmt::Write;
@@ -243,7 +243,7 @@ fn setup_micro_case_inner(code: &str, dependencies: Option<(&str, &[&str])>) -> 
             dependencies,
             &venv_path,
             SupportedPythonVersion::Py312,
-            "2025-06-17",
+            TY_ECOSYSTEM_PIN,
         )
         .expect("Failed to install dependencies");
 
@@ -1438,13 +1438,13 @@ fn hydra(criterion: &mut Criterion) {
         RealWorldProject {
             name: "hydra-zen",
             repository: "https://github.com/mit-ll-responsible-ai/hydra-zen",
-            commit: "dd2b50a9614c6f8c46c5866f283c8f7e7a960aa8",
-            paths: &["src"],
+            commit: "03a01096ea6a7c574fdf0b9990056506e566df2d",
+            paths: &["src", "tests/annotations"],
             dependencies: &["pydantic", "beartype", "hydra-core"],
-            max_dep_date: "2025-06-17",
-            python_version: SupportedPythonVersion::Py313,
+            max_dep_date: TY_ECOSYSTEM_PIN,
+            python_version: SupportedPythonVersion::Py311,
         },
-        100,
+        510,
     );
 
     bench_project(&benchmark, criterion);
@@ -1455,13 +1455,13 @@ fn attrs(criterion: &mut Criterion) {
         RealWorldProject {
             name: "attrs",
             repository: "https://github.com/python-attrs/attrs",
-            commit: "a6ae894aad9bc09edc7cdad8c416898784ceec9b",
-            paths: &["src"],
+            commit: "89fae8300f484544c1b7678cea5efe58c551fbb9",
+            paths: &["src/attrs", "src/attr", "typing-examples"],
             dependencies: &[],
-            max_dep_date: "2025-06-17",
-            python_version: SupportedPythonVersion::Py313,
+            max_dep_date: TY_ECOSYSTEM_PIN,
+            python_version: SupportedPythonVersion::Py311,
         },
-        120,
+        102,
     );
 
     bench_project(&benchmark, criterion);
@@ -1472,13 +1472,13 @@ fn anyio(criterion: &mut Criterion) {
         RealWorldProject {
             name: "anyio",
             repository: "https://github.com/agronholm/anyio",
-            commit: "561d81270a12f7c6bbafb5bc5fad99a2a13f96be",
+            commit: "ffe91331adb912c5d150f5d373f7cd28a0e96a62",
             paths: &["src"],
-            dependencies: &[],
-            max_dep_date: "2025-06-17",
-            python_version: SupportedPythonVersion::Py313,
+            dependencies: &["exceptiongroup", "idna", "pytest"],
+            max_dep_date: TY_ECOSYSTEM_PIN,
+            python_version: SupportedPythonVersion::Py311,
         },
-        150,
+        110,
     );
 
     bench_project(&benchmark, criterion);
@@ -1489,13 +1489,13 @@ fn datetype(criterion: &mut Criterion) {
         RealWorldProject {
             name: "DateType",
             repository: "https://github.com/glyph/DateType",
-            commit: "57c9c93cf2468069f72945fc04bf27b64100dad8",
+            commit: "a6ebb954cd18302a031a29b2f65e077b8e7776d4",
             paths: &["src"],
             dependencies: &[],
-            max_dep_date: "2025-07-04",
-            python_version: SupportedPythonVersion::Py313,
+            max_dep_date: TY_ECOSYSTEM_PIN,
+            python_version: SupportedPythonVersion::Py311,
         },
-        10,
+        17,
     );
 
     bench_project(&benchmark, criterion);

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -2,7 +2,7 @@ use divan::{Bencher, bench};
 use std::fmt::{Display, Formatter};
 
 use rayon::ThreadPoolBuilder;
-use ruff_benchmark::real_world_projects::{InstalledProject, RealWorldProject};
+use ruff_benchmark::real_world_projects::{InstalledProject, RealWorldProject, TY_ECOSYSTEM_PIN};
 use ruff_db::system::{OsSystem, SystemPath, SystemPathBuf};
 
 use ruff_db::testing::setup_logging_with_filter;
@@ -93,8 +93,8 @@ static ALTAIR: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "altair",
         repository: "https://github.com/vega/altair",
-        commit: "d1f4a1ef89006e5f6752ef1f6df4b7a509336fba",
-        paths: &["altair"],
+        commit: "a9765713566095349cb1cfbbe85d6ad258c84245",
+        paths: &["altair", "tests"],
         dependencies: &[
             "jinja2",
             "narwhals",
@@ -106,17 +106,17 @@ static ALTAIR: Benchmark = Benchmark::new(
             "scipy-stubs",
             "types-jsonschema",
         ],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py312,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    950,
+    3,
 );
 
 static COLOUR_SCIENCE: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "colour-science",
         repository: "https://github.com/colour-science/colour",
-        commit: "a17e2335c29e7b6f08080aa4c93cfa9b61f84757",
+        commit: "4ee3b72a2c6205c1d0cd964075621ec19290d571",
         paths: &["colour"],
         dependencies: &[
             "matplotlib",
@@ -125,18 +125,18 @@ static COLOUR_SCIENCE: Benchmark = Benchmark::new(
             "pytest",
             "scipy-stubs",
         ],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py310,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    350,
+    425,
 );
 
 static FREQTRADE: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "freqtrade",
         repository: "https://github.com/freqtrade/freqtrade",
-        commit: "2d842ea129e56575852ee0c45383c8c3f706be19",
-        paths: &["freqtrade"],
+        commit: "9fca9c818529c51ba19a1e76bc9428cf3ad56e4b",
+        paths: &["freqtrade", "scripts"],
         dependencies: &[
             "numpy",
             "pandas-stubs",
@@ -145,20 +145,20 @@ static FREQTRADE: Benchmark = Benchmark::new(
             "types-cachetools",
             "types-filelock",
             "types-python-dateutil",
-            "types-requests",
+            "requests",
             "types-tabulate",
         ],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py312,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    650,
+    717,
 );
 
 static PANDAS: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "pandas",
         repository: "https://github.com/pandas-dev/pandas",
-        commit: "5909621e2267eb67943a95ef5e895e8484c53432",
+        commit: "19b0ecf5d5b7fa0b8391a6d2cc1e2a7d1ea5f660",
         paths: &["pandas"],
         dependencies: &[
             "numpy",
@@ -168,70 +168,65 @@ static PANDAS: Benchmark = Benchmark::new(
             "types-setuptools",
             "pytest",
         ],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py312,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    5500,
+    6700,
 );
 
 static PYDANTIC: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "pydantic",
         repository: "https://github.com/pydantic/pydantic",
-        commit: "0c4a22b64b23dfad27387750cf07487efc45eb05",
+        commit: "7974d591c7d22d6667ea9d09831ba9caddcbb373",
         paths: &["pydantic"],
-        dependencies: &[
-            "annotated-types",
-            "pydantic-core",
-            "typing-extensions",
-            "typing-inspection",
-        ],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py39,
+        dependencies: &["annotated-types", "pydantic-core", "typing-inspection"],
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    3200,
+    1600,
 );
 
 static SYMPY: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "sympy",
         repository: "https://github.com/sympy/sympy",
-        commit: "22fc107a94eaabc4f6eb31470b39db65abb7a394",
+        commit: "8381f0c42956f60caed72aedb2ca4e82420b9992",
         paths: &["sympy"],
         dependencies: &["mpmath"],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py312,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    14250,
+    16000,
 );
 
 static TANJUN: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "tanjun",
         repository: "https://github.com/FasterSpeeding/Tanjun",
-        commit: "69f40db188196bc59516b6c69849c2d85fbc2f4a",
+        commit: "88d43a267a5bcd995d4929f62b14fbe5c18e59de",
         paths: &["tanjun"],
         dependencies: &["hikari", "alluka"],
-        max_dep_date: "2025-06-17",
-        python_version: SupportedPythonVersion::Py312,
+        max_dep_date: TY_ECOSYSTEM_PIN,
+        python_version: SupportedPythonVersion::Py311,
     },
-    120,
+    110,
 );
 
 static STATIC_FRAME: Benchmark = Benchmark::new(
     RealWorldProject {
         name: "static-frame",
         repository: "https://github.com/static-frame/static-frame",
-        commit: "34962b41baca5e7f98f5a758d530bff02748a421",
+        commit: "0b1e2fc2e819cde1b9b99be7cc57be08ee43d8de",
         paths: &["static_frame"],
         // N.B. `arraykit` is installed as a dependency during ecosystem runs,
         // but it takes much longer to be installed in a Codspeed run
         // (seems to be built from source on the Codspeed CI runners for some reason).
         dependencies: &["numpy"],
-        max_dep_date: "2025-08-09",
+        max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    1810,
+    1950,
 );
 
 #[track_caller]

--- a/crates/ruff_benchmark/benches/ty_walltime.rs
+++ b/crates/ruff_benchmark/benches/ty_walltime.rs
@@ -128,7 +128,7 @@ static COLOUR_SCIENCE: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    425,
+    450,
 );
 
 static FREQTRADE: Benchmark = Benchmark::new(
@@ -197,7 +197,7 @@ static SYMPY: Benchmark = Benchmark::new(
         max_dep_date: TY_ECOSYSTEM_PIN,
         python_version: SupportedPythonVersion::Py311,
     },
-    16000,
+    16500,
 );
 
 static TANJUN: Benchmark = Benchmark::new(

--- a/crates/ruff_benchmark/src/real_world_projects.rs
+++ b/crates/ruff_benchmark/src/real_world_projects.rs
@@ -20,6 +20,8 @@ use anyhow::{Context, Result};
 use ruff_db::system::{MemoryFileSystem, SystemPath, SystemPathBuf};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 
+pub const TY_ECOSYSTEM_PIN: &str = "2026-06-17T06:46:32Z";
+
 /// Configuration for a real-world project to benchmark
 #[derive(Debug, Clone)]
 pub struct RealWorldProject<'a> {


### PR DESCRIPTION
## Summary

Update the real-world ty benchmarks to the current ecosystem project revisions, paths, dependencies, Python version, and dependency cutoff.

## Test Plan

Testing: Ran one-shot real-world benchmark validation and repository hooks.