### PR TITLE
[ty] Reuse known union recognition in IDE resolution

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1650,6 +1650,7 @@ impl<'db> Type<'db> {
         }
     }
 
+    #[cfg(test)]
     #[track_caller]
     pub(crate) const fn expect_union(self) -> UnionType<'db> {
         self.as_union().expect("Expected a Type::Union variant")

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -9,7 +9,7 @@ use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::signatures::{ParametersKind, Signature};
 use crate::types::{
     CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownFunction,
-    KnownUnion, Type, TypeContext, UnionType,
+    KnownUnion, Type, TypeContext,
 };
 use crate::{Db, DisplaySettings, HasDefinition, HasType, SemanticModel};
 use itertools::Either;
@@ -157,11 +157,13 @@ pub fn definitions_for_name<'db>(
         // a type annotation position and `float` or `complex` otherwise.
         //
         // https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
-        if matches!(name_str, "float" | "complex")
-            && let Some(expr) = node.expr_name()
+        if let Some(expr) = node.expr_name()
             && let Some(ty) = expr.inferred_type(model)
             && let Some(union) = ty.as_union()
-            && is_float_or_complex_annotation(db, union, name_str)
+            && matches!(
+                (name_str, union.known(db)),
+                ("float", Some(KnownUnion::Float)) | ("complex", Some(KnownUnion::Complex))
+            )
         {
             return union
                 .elements(db)
@@ -193,17 +195,6 @@ pub fn definitions_for_name<'db>(
     } else {
         resolved_definitions
     }
-}
-
-fn is_float_or_complex_annotation(db: &dyn Db, ty: UnionType, name: &str) -> bool {
-    let float_or_complex_ty = match name {
-        "float" => KnownUnion::Float.to_type(db),
-        "complex" => KnownUnion::Complex.to_type(db),
-        _ => return false,
-    }
-    .expect_union();
-
-    ty == float_or_complex_ty
 }
 
 /// Returns all resolved definitions for an attribute expression `x.y`.


### PR DESCRIPTION
## Summary

Reuse `UnionType::known` when resolving the special `float` and `complex` annotation unions for IDE features. This removes duplicate construction and equality logic while preserving hover and navigation behavior.

## Test Plan

Testing: Focused ty tests and pre-commit hooks passed.
