### PR TITLE
[ty] Disable LRU tracking for one-shot checks

### DIFF
--- a/crates/ruff_db/src/lib.rs
+++ b/crates/ruff_db/src/lib.rs
@@ -49,6 +49,14 @@ pub fn set_program_version(version: String) -> Result<(), String> {
     VERSION.set(version)
 }
 
+/// Disables LRU bookkeeping for all queries defined by this crate.
+///
+/// This is useful for short-lived database users that don't need to evict query results across
+/// revisions.
+pub fn disable_lru(db: &mut dyn Db) {
+    parsed::disable_lru(db);
+}
+
 /// Most basic database that gives access to files, the host system, source code, and parsed AST.
 #[salsa::db]
 pub trait Db: salsa::Database {

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -39,6 +39,10 @@ pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
     ParsedModule::new(file, parsed)
 }
 
+pub(super) fn disable_lru(db: &mut dyn Db) {
+    parsed_module::set_lru_capacity(db, 0);
+}
+
 pub fn parsed_module_impl(db: &dyn Db, file: File) -> Parsed<ModModule> {
     let source = source_text(db, file);
     let ty = file.source_type(db);

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -165,6 +165,9 @@ fn run_check(args: CheckCommand) -> anyhow::Result<ExitStatus> {
     project_metadata.apply_overrides(&project_options_overrides);
 
     let mut db = ProjectDatabase::fallible(project_metadata, system)?;
+    if !watch {
+        ruff_db::disable_lru(&mut db);
+    }
     let project = db.project();
 
     project.set_verbose(&mut db, verbosity >= VerbosityLevel::Verbose);


### PR DESCRIPTION
## Summary

The `parsed_module` query uses an LRU eviction policy to bound retained query values across Salsa revisions. This bookkeeping is useful for the long-lived server and watch mode, but a one-shot CLI check exits after its first analysis and does not benefit from tracking recently used modules.

This adds a database-level `disable_lru` hook and uses it for non-watch CLI checks. Query memoization within the check remains unchanged, while the server and `ty check --watch` keep the existing LRU behavior.
