### PR TITLE
[ty] Improve `duplicate-base` diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -527,8 +527,8 @@ class VeryEggyOmelette(
 # fmt: off
 ```
 
-A `type: ignore` comment can suppress `duplicate-bases` errors if it is on the first or last line of
-the class "header":
+A `type: ignore` comment can only suppress `duplicate-bases` errors if it is on the same line as the
+class name:
 
 ```py
 # fmt: off
@@ -540,39 +540,18 @@ class B(  # type: ignore[ty:duplicate-base]
     A,
 ): ...
 
-class C(
+class C(  # error: [duplicate-base]
     A,
     A
+# error: [unused-type-ignore-comment]
 ):  # type: ignore[ty:duplicate-base]
     x: int
 
 # fmt: on
 ```
 
-But it will not suppress the error if it occurs in the class body, or on the duplicate base itself.
-The justification for this is that it is the class definition as a whole that will raise an
-exception at runtime, not a sub-expression in the class's bases list.
-
-```py
-# fmt: off
-
-# error: [duplicate-base]
-class D(
-    A,
-    # error: [unused-type-ignore-comment]
-    A,  # type: ignore[ty:duplicate-base]
-): ...
-
-# error: [duplicate-base]
-class E(
-    A,
-    A
-):
-    # error: [unused-type-ignore-comment]
-    x: int  # type: ignore[ty:duplicate-base]
-
-# fmt: on
-```
+This is a limitation that we live with for now, since it seems anyway highly unlikely that anybody
+would want to suppress a `duplicate-base` diagnostic.
 
 ## `__bases__` lists with duplicate `Unknown` bases
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Inline_tuple-literal…_(4ee237f49e7ac736).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Inline_tuple-literal…_(4ee237f49e7ac736).snap
@@ -27,9 +27,8 @@ error[duplicate-base]: Duplicate base class `int`
  --> src/mdtest_snippet.py:2:7
   |
 2 | class InlineTupleDuplicateBases(*(int, int)): ...
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^---^^
-  |                                   |    |
-  |                                   |    Class `int` later repeated here
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^   ---  ^^^ Class `int` later repeated here
+  |                                   |
   |                                   Class `int` first included in bases list here
   |
 info: Definition of class `InlineTupleDuplicateBases` will raise `TypeError` at runtime

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Inline_tuple-literal…_(4ee237f49e7ac736).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_Inline_tuple-literal…_(4ee237f49e7ac736).snap
@@ -27,16 +27,12 @@ error[duplicate-base]: Duplicate base class `int`
  --> src/mdtest_snippet.py:2:7
   |
 2 | class InlineTupleDuplicateBases(*(int, int)): ...
-  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-info: The definition of class `InlineTupleDuplicateBases` will raise `TypeError` at runtime
- --> src/mdtest_snippet.py:2:35
-  |
-2 | class InlineTupleDuplicateBases(*(int, int)): ...
-  |                                   ---  ^^^ Class `int` later repeated here
-  |                                   |
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^---^^---^^
+  |                                   |    |
+  |                                   |    Class `int` later repeated here
   |                                   Class `int` first included in bases list here
   |
+info: Definition of class `InlineTupleDuplicateBases` will raise `TypeError` at runtime
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -105,16 +105,12 @@ error[duplicate-base]: Duplicate base class `str`
  --> src/mdtest_snippet.py:3:7
   |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
-  |       ^^^^^^^^^^^^^
-  |
-info: The definition of class `Foo` will raise `TypeError` at runtime
- --> src/mdtest_snippet.py:3:11
-  |
-3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
-  |           ---  ^^^ Class `str` later repeated here
-  |           |
+  |       ^^^^---^^---^
+  |           |    |
+  |           |    Class `str` later repeated here
   |           Class `str` first included in bases list here
   |
+info: Definition of class `Foo` will raise `TypeError` at runtime
 
 ```
 
@@ -126,24 +122,16 @@ error[duplicate-base]: Duplicate base class `Eggs`
    |  _______^
 17 | |     Spam,
 18 | |     Eggs,
+   | |     ---- Class `Eggs` first included in bases list here
 19 | |     Bar,
 20 | |     Baz,
 21 | |     Spam,
 22 | |     Eggs,
+   | |     ---- Class `Eggs` later repeated here
 23 | | ): ...
    | |_^
    |
-info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:18:5
-   |
-18 |     Eggs,
-   |     ---- Class `Eggs` first included in bases list here
-19 |     Bar,
-20 |     Baz,
-21 |     Spam,
-22 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
+info: Definition of class `Ham` will raise `TypeError` at runtime
 
 ```
 
@@ -154,25 +142,17 @@ error[duplicate-base]: Duplicate base class `Spam`
 16 |   class Ham(
    |  _______^
 17 | |     Spam,
+   | |     ---- Class `Spam` first included in bases list here
 18 | |     Eggs,
 19 | |     Bar,
 20 | |     Baz,
 21 | |     Spam,
+   | |     ---- Class `Spam` later repeated here
 22 | |     Eggs,
 23 | | ): ...
    | |_^
    |
-info: The definition of class `Ham` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:17:5
-   |
-17 |     Spam,
-   |     ---- Class `Spam` first included in bases list here
-18 |     Eggs,
-19 |     Bar,
-20 |     Baz,
-21 |     Spam,
-   |     ^^^^ Class `Spam` later repeated here
-   |
+info: Definition of class `Ham` will raise `TypeError` at runtime
 
 ```
 
@@ -181,16 +161,12 @@ error[duplicate-base]: Duplicate base class `Mushrooms`
   --> src/mdtest_snippet.py:30:7
    |
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
-   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-info: The definition of class `Omelette` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:30:28
-   |
-30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
-   |                            ---------  ^^^^^^^^^ Class `Mushrooms` later repeated here
-   |                            |
+   |       ^^^^^^^^^^^^^^^^^^^^^---------^^---------^
+   |                            |          |
+   |                            |          Class `Mushrooms` later repeated here
    |                            Class `Mushrooms` first included in bases list here
    |
+info: Definition of class `Omelette` will raise `TypeError` at runtime
 
 ```
 
@@ -201,34 +177,22 @@ error[duplicate-base]: Duplicate base class `Eggs`
 37 |   class VeryEggyOmelette(
    |  _______^
 38 | |     Eggs,
+   | |     ---- Class `Eggs` first included in bases list here
 39 | |     Ham,
 40 | |     Spam,
 41 | |     Eggs,
+   | |     ---- Class `Eggs` later repeated here
 42 | |     Mushrooms,
 43 | |     Bar,
 44 | |     Eggs,
+   | |     ---- Class `Eggs` later repeated here
 45 | |     Baz,
 46 | |     Eggs,
+   | |     ---- Class `Eggs` later repeated here
 47 | | ): ...
    | |_^
    |
-info: The definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:38:5
-   |
-38 |     Eggs,
-   |     ---- Class `Eggs` first included in bases list here
-39 |     Ham,
-40 |     Spam,
-41 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-42 |     Mushrooms,
-43 |     Bar,
-44 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-45 |     Baz,
-46 |     Eggs,
-   |     ^^^^ Class `Eggs` later repeated here
-   |
+info: Definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
 
 ```
 
@@ -239,20 +203,14 @@ error[duplicate-base]: Duplicate base class `A`
 69 |   class D(
    |  _______^
 70 | |     A,
+   | |     - Class `A` first included in bases list here
 71 | |     # error: [unused-type-ignore-comment]
 72 | |     A,  # type: ignore[ty:duplicate-base]
+   | |     - Class `A` later repeated here
 73 | | ): ...
    | |_^
    |
-info: The definition of class `D` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:70:5
-   |
-70 |     A,
-   |     - Class `A` first included in bases list here
-71 |     # error: [unused-type-ignore-comment]
-72 |     A,  # type: ignore[ty:duplicate-base]
-   |     ^ Class `A` later repeated here
-   |
+info: Definition of class `D` will raise `TypeError` at runtime
 
 ```
 
@@ -282,18 +240,13 @@ error[duplicate-base]: Duplicate base class `A`
 76 |   class E(
    |  _______^
 77 | |     A,
+   | |     - Class `A` first included in bases list here
 78 | |     A
+   | |     - Class `A` later repeated here
 79 | | ):
    | |_^
    |
-info: The definition of class `E` will raise `TypeError` at runtime
-  --> src/mdtest_snippet.py:77:5
-   |
-77 |     A,
-   |     - Class `A` first included in bases list here
-78 |     A
-   |     ^ Class `A` later repeated here
-   |
+info: Definition of class `E` will raise `TypeError` at runtime
 
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/mro.md_-_Method_Resolution_Or…_-_`__bases__`_lists_wi…_(ea7ebc83ec359b54).snap
@@ -71,31 +71,14 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/mro.md
 56 |     A,
 57 | ): ...
 58 | 
-59 | class C(
+59 | class C(  # error: [duplicate-base]
 60 |     A,
 61 |     A
-62 | ):  # type: ignore[ty:duplicate-base]
-63 |     x: int
-64 | 
-65 | # fmt: on
-66 | # fmt: off
-67 | 
-68 | # error: [duplicate-base]
-69 | class D(
-70 |     A,
-71 |     # error: [unused-type-ignore-comment]
-72 |     A,  # type: ignore[ty:duplicate-base]
-73 | ): ...
-74 | 
-75 | # error: [duplicate-base]
-76 | class E(
-77 |     A,
-78 |     A
-79 | ):
-80 |     # error: [unused-type-ignore-comment]
-81 |     x: int  # type: ignore[ty:duplicate-base]
-82 | 
-83 | # fmt: on
+62 | # error: [unused-type-ignore-comment]
+63 | ):  # type: ignore[ty:duplicate-base]
+64 |     x: int
+65 | 
+66 | # fmt: on
 ```
 
 # Diagnostics
@@ -105,9 +88,8 @@ error[duplicate-base]: Duplicate base class `str`
  --> src/mdtest_snippet.py:3:7
   |
 3 | class Foo(str, str): ...  # error: [duplicate-base] "Duplicate base class `str`"
-  |       ^^^^---^^---^
-  |           |    |
-  |           |    Class `str` later repeated here
+  |       ^^^ ---  ^^^ Class `str` later repeated here
+  |           |
   |           Class `str` first included in bases list here
   |
 info: Definition of class `Foo` will raise `TypeError` at runtime
@@ -118,18 +100,16 @@ info: Definition of class `Foo` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:16:7
    |
-16 |   class Ham(
-   |  _______^
-17 | |     Spam,
-18 | |     Eggs,
-   | |     ---- Class `Eggs` first included in bases list here
-19 | |     Bar,
-20 | |     Baz,
-21 | |     Spam,
-22 | |     Eggs,
-   | |     ---- Class `Eggs` later repeated here
-23 | | ): ...
-   | |_^
+16 | class Ham(
+   |       ^^^
+17 |     Spam,
+18 |     Eggs,
+   |     ---- Class `Eggs` first included in bases list here
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+22 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
    |
 info: Definition of class `Ham` will raise `TypeError` at runtime
 
@@ -139,18 +119,15 @@ info: Definition of class `Ham` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Spam`
   --> src/mdtest_snippet.py:16:7
    |
-16 |   class Ham(
-   |  _______^
-17 | |     Spam,
-   | |     ---- Class `Spam` first included in bases list here
-18 | |     Eggs,
-19 | |     Bar,
-20 | |     Baz,
-21 | |     Spam,
-   | |     ---- Class `Spam` later repeated here
-22 | |     Eggs,
-23 | | ): ...
-   | |_^
+16 | class Ham(
+   |       ^^^
+17 |     Spam,
+   |     ---- Class `Spam` first included in bases list here
+18 |     Eggs,
+19 |     Bar,
+20 |     Baz,
+21 |     Spam,
+   |     ^^^^ Class `Spam` later repeated here
    |
 info: Definition of class `Ham` will raise `TypeError` at runtime
 
@@ -161,9 +138,8 @@ error[duplicate-base]: Duplicate base class `Mushrooms`
   --> src/mdtest_snippet.py:30:7
    |
 30 | class Omelette(Spam, Eggs, Mushrooms, Mushrooms): ...  # error: [duplicate-base]
-   |       ^^^^^^^^^^^^^^^^^^^^^---------^^---------^
-   |                            |          |
-   |                            |          Class `Mushrooms` later repeated here
+   |       ^^^^^^^^             ---------  ^^^^^^^^^ Class `Mushrooms` later repeated here
+   |                            |
    |                            Class `Mushrooms` first included in bases list here
    |
 info: Definition of class `Omelette` will raise `TypeError` at runtime
@@ -174,23 +150,21 @@ info: Definition of class `Omelette` will raise `TypeError` at runtime
 error[duplicate-base]: Duplicate base class `Eggs`
   --> src/mdtest_snippet.py:37:7
    |
-37 |   class VeryEggyOmelette(
-   |  _______^
-38 | |     Eggs,
-   | |     ---- Class `Eggs` first included in bases list here
-39 | |     Ham,
-40 | |     Spam,
-41 | |     Eggs,
-   | |     ---- Class `Eggs` later repeated here
-42 | |     Mushrooms,
-43 | |     Bar,
-44 | |     Eggs,
-   | |     ---- Class `Eggs` later repeated here
-45 | |     Baz,
-46 | |     Eggs,
-   | |     ---- Class `Eggs` later repeated here
-47 | | ): ...
-   | |_^
+37 | class VeryEggyOmelette(
+   |       ^^^^^^^^^^^^^^^^
+38 |     Eggs,
+   |     ---- Class `Eggs` first included in bases list here
+39 |     Ham,
+40 |     Spam,
+41 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
+42 |     Mushrooms,
+43 |     Bar,
+44 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
+45 |     Baz,
+46 |     Eggs,
+   |     ^^^^ Class `Eggs` later repeated here
    |
 info: Definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
 
@@ -198,72 +172,34 @@ info: Definition of class `VeryEggyOmelette` will raise `TypeError` at runtime
 
 ```
 error[duplicate-base]: Duplicate base class `A`
-  --> src/mdtest_snippet.py:69:7
+  --> src/mdtest_snippet.py:59:7
    |
-69 |   class D(
-   |  _______^
-70 | |     A,
-   | |     - Class `A` first included in bases list here
-71 | |     # error: [unused-type-ignore-comment]
-72 | |     A,  # type: ignore[ty:duplicate-base]
-   | |     - Class `A` later repeated here
-73 | | ): ...
-   | |_^
+59 | class C(  # error: [duplicate-base]
+   |       ^
+60 |     A,
+   |     - Class `A` first included in bases list here
+61 |     A
+   |     ^ Class `A` later repeated here
    |
-info: Definition of class `D` will raise `TypeError` at runtime
+info: Definition of class `C` will raise `TypeError` at runtime
 
 ```
 
 ```
 warning[unused-type-ignore-comment]: Unused `type: ignore` directive
-  --> src/mdtest_snippet.py:72:9
+  --> src/mdtest_snippet.py:63:5
    |
-72 |     A,  # type: ignore[ty:duplicate-base]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-help: Remove the unused suppression comment
-69 | class D(
-70 |     A,
-71 |     # error: [unused-type-ignore-comment]
-   -     A,  # type: ignore[ty:duplicate-base]
-72 +     A,
-73 | ): ...
-74 |
-75 | # error: [duplicate-base]
-
-```
-
-```
-error[duplicate-base]: Duplicate base class `A`
-  --> src/mdtest_snippet.py:76:7
-   |
-76 |   class E(
-   |  _______^
-77 | |     A,
-   | |     - Class `A` first included in bases list here
-78 | |     A
-   | |     - Class `A` later repeated here
-79 | | ):
-   | |_^
-   |
-info: Definition of class `E` will raise `TypeError` at runtime
-
-```
-
-```
-warning[unused-type-ignore-comment]: Unused `type: ignore` directive
-  --> src/mdtest_snippet.py:81:13
-   |
-81 |     x: int  # type: ignore[ty:duplicate-base]
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+63 | ):  # type: ignore[ty:duplicate-base]
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 help: Remove the unused suppression comment
-78 |     A
-79 | ):
-80 |     # error: [unused-type-ignore-comment]
-   -     x: int  # type: ignore[ty:duplicate-base]
-81 +     x: int
-82 |
-83 | # fmt: on
+60 |     A,
+61 |     A
+62 | # error: [unused-type-ignore-comment]
+   - ):  # type: ignore[ty:duplicate-base]
+63 + ):
+64 |     x: int
+65 |
+66 | # fmt: on
 
 ```

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -397,8 +397,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// Only call this function from queries in the same file or your
     /// query depends on the AST of another file (bad!).
     fn node<'ast>(self, db: &'db dyn Db, module: &'ast ParsedModuleRef) -> &'ast ast::StmtClassDef {
-        let scope = self.body_scope(db);
-        scope.node(db).expect_class().node(module)
+        self.body_scope(db).node(db).expect_class().node(module)
     }
 
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
@@ -2841,7 +2840,7 @@ impl<'db> StaticClassLiteral<'db> {
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let class_scope = self.body_scope(db);
         let module = parsed_module(db, class_scope.file(db)).load(db);
-        let class_node = class_scope.node(db).expect_class().node(&module);
+        let class_node = self.node(db, &module);
         let class_name = &class_node.name;
         TextRange::new(
             class_name.start(),
@@ -2851,6 +2850,14 @@ impl<'db> StaticClassLiteral<'db> {
                 .map(Ranged::end)
                 .unwrap_or_else(|| class_name.end()),
         )
+    }
+
+    /// Returns the range of the class's name
+    pub(crate) fn focus_range(self, db: &'db dyn Db) -> TextRange {
+        let class_scope = self.body_scope(db);
+        let module = parsed_module(db, class_scope.file(db)).load(db);
+        let class_node = self.node(db, &module);
+        class_node.name.range()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2867,7 +2867,7 @@ pub(crate) fn report_duplicate_bases(
 ) {
     let db = context.db();
 
-    let Some(builder) = context.report_lint(&DUPLICATE_BASE, class.header_range(db)) else {
+    let Some(builder) = context.report_lint(&DUPLICATE_BASE, class.focus_range(db)) else {
         return;
     };
 
@@ -2895,8 +2895,7 @@ pub(crate) fn report_duplicate_bases(
     for index in later_indices {
         let repeated_base = bases_list[*index].source_node();
         diagnostic.annotate(
-            context
-                .secondary(repeated_base)
+            Annotation::primary(context.span(repeated_base))
                 .message(format_args!("Class `{duplicate_name}` later repeated here")),
         );
     }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -2882,28 +2882,24 @@ pub(crate) fn report_duplicate_bases(
     let mut diagnostic =
         builder.into_diagnostic(format_args!("Duplicate base class `{duplicate_name}`"));
 
-    let mut sub_diagnostic = SubDiagnostic::new(
-        SubDiagnosticSeverity::Info,
-        format_args!(
-            "The definition of class `{}` will raise `TypeError` at runtime",
-            class.name(db)
-        ),
-    );
+    diagnostic.info(format_args!(
+        "Definition of class `{}` will raise `TypeError` at runtime",
+        class.name(db)
+    ));
+
     let first_base = bases_list[*first_index].source_node();
-    sub_diagnostic.annotate(
-        Annotation::secondary(context.span(first_base)).message(format_args!(
-            "Class `{duplicate_name}` first included in bases list here"
-        )),
-    );
+    diagnostic.annotate(context.secondary(first_base).message(format_args!(
+        "Class `{duplicate_name}` first included in bases list here"
+    )));
+
     for index in later_indices {
         let repeated_base = bases_list[*index].source_node();
-        sub_diagnostic.annotate(
-            Annotation::primary(context.span(repeated_base))
+        diagnostic.annotate(
+            context
+                .secondary(repeated_base)
                 .message(format_args!("Class `{duplicate_name}` later repeated here")),
         );
     }
-
-    diagnostic.sub(sub_diagnostic);
 }
 
 pub(crate) fn report_invalid_or_unsupported_base(

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -161,7 +161,7 @@ class VeryEggyOmelette(
             .iter()
             .map(|annotation| annotation.primary)
             .collect::<Vec<_>>(),
-        [true, false, false, false]
+        [true, false, true, true]
     );
     assert_eq!(
         annotations

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -123,7 +123,7 @@ f(x=\"foo\")\n",
 }
 
 #[wasm_bindgen_test]
-fn sub_diagnostics_include_multiple_primary_annotations() {
+fn diagnostic_includes_secondary_annotations() {
     ty_wasm::before_main();
 
     let mut workspace = Workspace::new(
@@ -153,35 +153,49 @@ class VeryEggyOmelette(
         .iter()
         .find(|diagnostic| diagnostic.id() == "duplicate-base")
         .expect("Expected a duplicate-base diagnostic");
-    let sub_diagnostics = diagnostic.sub_diagnostics(&workspace);
-    let definition_detail = sub_diagnostics
-        .iter()
-        .find(|sub_diagnostic| {
-            sub_diagnostic.message
-                == "The definition of class `VeryEggyOmelette` will raise `TypeError` at runtime"
-        })
-        .expect("Expected a class definition sub-diagnostic");
+    let annotations = diagnostic.annotations(&workspace);
 
-    assert_eq!(definition_detail.annotations.len(), 3);
+    assert_eq!(annotations.len(), 4);
     assert_eq!(
-        definition_detail
-            .annotations
+        annotations
             .iter()
             .map(|annotation| annotation.primary)
             .collect::<Vec<_>>(),
-        [false, true, true]
+        [true, false, false, false]
     );
     assert_eq!(
-        definition_detail
-            .annotations
+        annotations
             .iter()
             .map(|annotation| annotation.message.as_deref())
             .collect::<Vec<_>>(),
         [
+            None,
             Some("Class `Eggs` first included in bases list here"),
             Some("Class `Eggs` later repeated here"),
             Some("Class `Eggs` later repeated here"),
         ]
+    );
+    assert!(
+        annotations
+            .iter()
+            .all(|annotation| annotation.location.is_some())
+    );
+
+    assert_eq!(
+        diagnostic
+            .sub_diagnostics(&workspace)
+            .iter()
+            .map(|sub_diagnostic| (
+                sub_diagnostic.severity,
+                sub_diagnostic.message.as_str(),
+                sub_diagnostic.annotations.len(),
+            ))
+            .collect::<Vec<_>>(),
+        [(
+            SubDiagnosticSeverity::Info,
+            "Definition of class `VeryEggyOmelette` will raise `TypeError` at runtime",
+            0,
+        )]
     );
 }
 


### PR DESCRIPTION
## Summary

Our `duplicate-base` diagnostics currently render quite poorly in the playground (and, I assume, VSCode) due to a strange concatenation of messages for the subdiagnostic:

<details>
<summary>Screenshot</summary>
<img width="2566" height="1190" alt="image" src="https://github.com/user-attachments/assets/5370f29e-1a01-4d98-a861-dbf46cde3750" />
</details>

They render much better on the CLI, but even on the CLI, they're very verbose, which isn't ideal:

<details>
<summary>Screenshot</summary>
<img width="1602" height="1672" alt="image" src="https://github.com/user-attachments/assets/06b44753-3dba-49d8-839a-fb3cccfbc081" />
</details>

This PR removes the subdiagnostic and just uses secondary annotations on the primary diagnostic. This renders much better in the playground (and, I assume, VSCode):

<details>
<summary>Screenshot</summary>
<img width="1642" height="1550" alt="image" src="https://github.com/user-attachments/assets/cd37478c-8fd2-424a-9957-bfc129b1260b" />
</details>

and is also much more concise on the CLI, albeit with some awkwardly overlapping annotation spans:

<details>
<summary>Screenshot</summary>
<img width="1374" height="1160" alt="image" src="https://github.com/user-attachments/assets/b606808c-a5a8-4c71-93c9-d0920b14be3a" />
</details>

Gist for the code that triggers those diagnostics: https://play.ty.dev/b6b8dd7d-14cc-42f0-8435-6283af761ff4

## Test Plan

mdtests updated