### PR TITLE
[ty] Use diagnostic tags in the playground

### DIFF
--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -938,6 +938,16 @@ impl Diagnostic {
         Severity::from(self.inner.severity())
     }
 
+    #[wasm_bindgen]
+    pub fn tags(&self) -> Vec<DiagnosticTag> {
+        self.inner
+            .primary_tags()
+            .unwrap_or_default()
+            .iter()
+            .map(DiagnosticTag::from)
+            .collect()
+    }
+
     #[wasm_bindgen(js_name = "textRange")]
     pub fn text_range(&self) -> Option<TextRange> {
         self.inner
@@ -1202,6 +1212,22 @@ impl From<diagnostic::Severity> for Severity {
             diagnostic::Severity::Warning => Self::Warning,
             diagnostic::Severity::Error => Self::Error,
             diagnostic::Severity::Fatal => Self::Fatal,
+        }
+    }
+}
+
+#[wasm_bindgen]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum DiagnosticTag {
+    Unnecessary,
+    Deprecated,
+}
+
+impl From<&diagnostic::DiagnosticTag> for DiagnosticTag {
+    fn from(value: &diagnostic::DiagnosticTag) -> Self {
+        match value {
+            diagnostic::DiagnosticTag::Unnecessary => Self::Unnecessary,
+            diagnostic::DiagnosticTag::Deprecated => Self::Deprecated,
         }
     }
 }

--- a/crates/ty_wasm/tests/api.rs
+++ b/crates/ty_wasm/tests/api.rs
@@ -1,6 +1,6 @@
 #![cfg(target_arch = "wasm32")]
 
-use ty_wasm::{Position, PositionEncoding, SubDiagnosticSeverity, Workspace};
+use ty_wasm::{DiagnosticTag, Position, PositionEncoding, SubDiagnosticSeverity, Workspace};
 use wasm_bindgen_test::wasm_bindgen_test;
 
 #[wasm_bindgen_test]
@@ -59,6 +59,43 @@ fn check() {
         sub_diagnostics
             .iter()
             .all(|sub_diagnostic| sub_diagnostic.annotations.is_empty())
+    );
+}
+
+#[wasm_bindgen_test]
+fn diagnostic_tags() {
+    ty_wasm::before_main();
+
+    let mut workspace = Workspace::new(
+        "/",
+        PositionEncoding::Utf32,
+        js_sys::JSON::parse("{}").unwrap(),
+    )
+    .expect("Workspace to be created");
+
+    workspace
+        .open_file(
+            "test.py",
+            "from typing_extensions import deprecated\n\n\
+             @deprecated(\"use replacement\")\n\
+             def old() -> None: ...\n\n\
+             old()\n\
+             value = 1  # ty: ignore\n",
+        )
+        .expect("File to be opened");
+
+    let result = workspace.check().expect("Check to succeed");
+    let tags = |id| {
+        result
+            .iter()
+            .find(|diagnostic| diagnostic.id() == id)
+            .map(ty_wasm::Diagnostic::tags)
+    };
+
+    assert_eq!(tags("deprecated"), Some(vec![DiagnosticTag::Deprecated]));
+    assert_eq!(
+        tags("unused-ignore-comment"),
+        Some(vec![DiagnosticTag::Unnecessary])
     );
 }
 

--- a/playground/ty/src/Editor/Chrome.tsx
+++ b/playground/ty/src/Editor/Chrome.tsx
@@ -14,7 +14,7 @@ import {
   Theme,
   VerticalResizeHandle,
 } from "shared";
-import { FileHandle, Hint, Workspace } from "ty_wasm";
+import { type DiagnosticTag, FileHandle, Hint, Workspace } from "ty_wasm";
 import {
   Panel,
   Group as PanelGroup,
@@ -333,6 +333,7 @@ function useCheckResult(
         annotations: diagnostic.annotations(workspace),
         subDiagnostics: diagnostic.subDiagnostics(workspace),
         severity: diagnostic.severity(),
+        tags: diagnostic.tags() as DiagnosticTag[],
         range: diagnostic.toRange(workspace) ?? null,
         textRange: diagnostic.textRange() ?? null,
         raw: diagnostic,

--- a/playground/ty/src/Editor/Diagnostics.tsx
+++ b/playground/ty/src/Editor/Diagnostics.tsx
@@ -1,6 +1,7 @@
 import { SubDiagnosticSeverity } from "ty_wasm";
 import type {
   DiagnosticAnnotation,
+  DiagnosticTag,
   Severity,
   Range,
   SubDiagnostic,
@@ -178,6 +179,7 @@ export interface Diagnostic {
   annotations: DiagnosticAnnotation[];
   subDiagnostics: SubDiagnostic[];
   severity: Severity;
+  tags: DiagnosticTag[];
   range: Range | null;
   textRange: TextRange | null;
   raw: TyDiagnostic;

--- a/playground/ty/src/Editor/Editor.tsx
+++ b/playground/ty/src/Editor/Editor.tsx
@@ -34,6 +34,7 @@ import {
   type FileHandle,
   DocumentHighlight,
   DocumentHighlightKind,
+  DiagnosticTag,
   InlayHintKind,
   LocationLink,
   TextEdit,
@@ -47,6 +48,11 @@ import {
 } from "./Diagnostics";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
 import CompletionItemKind = languages.CompletionItemKind;
+
+const markerTagByDiagnosticTag = {
+  [DiagnosticTag.Unnecessary]: MarkerTag.Unnecessary,
+  [DiagnosticTag.Deprecated]: MarkerTag.Deprecated,
+} satisfies Record<DiagnosticTag, MarkerTag>;
 
 type Props = {
   visible: boolean;
@@ -603,7 +609,7 @@ class PlaygroundServer
           message: diagnosticDisplayMessage(diagnostic),
           relatedInformation: this.diagnosticRelatedInformation(diagnostic),
           severity: mapSeverity(diagnostic.severity),
-          tags: [],
+          tags: diagnostic.tags.map((tag) => markerTagByDiagnosticTag[tag]),
         };
       }),
       ...hints.map((hint) => ({


### PR DESCRIPTION
Summary
--

The ty version of #26105

Test Plan
--

A new ty_wasm test and a manual run in the local playground:

<img width="608" height="317" alt="Screenshot 2026-06-17 at 12 21 38" src="https://github.com/user-attachments/assets/b576b884-befa-4a31-a4a6-091bc5c394d7" />
