### PR TITLE
Fix panic when inserting text at a notebook cell boundary

### DIFF
--- a/crates/ruff_diagnostics/src/source_map.rs
+++ b/crates/ruff_diagnostics/src/source_map.rs
@@ -31,12 +31,13 @@ impl SourceMarker {
 /// Sourcemaps are used to map positions in the original source to positions in
 /// the transformed code. Here, only the boundaries of edits are tracked instead
 /// of every single character.
+///
+/// This mapping maintains the invariant that markers are in source order.
 #[derive(Default, PartialEq, Eq)]
 pub struct SourceMap(Vec<SourceMarker>);
 
 impl SourceMap {
-    /// Returns a slice of all the markers in the sourcemap in the order they
-    /// were added.
+    /// Returns a slice of all the markers in the sourcemap in source order.
     pub fn markers(&self) -> &[SourceMarker] {
         &self.0
     }
@@ -45,6 +46,10 @@ impl SourceMap {
     ///
     /// The `output_length` is the length of the transformed string before the
     /// edit is applied.
+    ///
+    /// ## Panics
+    ///
+    /// If the start of `edit` is less than previous markers.
     pub fn push_start_marker(&mut self, edit: &Edit, output_length: TextSize) {
         self.push_marker(edit.start(), output_length);
     }
@@ -53,6 +58,10 @@ impl SourceMap {
     ///
     /// The `output_length` is the length of the transformed string after the
     /// edit has been applied.
+    ///
+    /// ## Panics
+    ///
+    /// If `edit` falls before previous markers.
     pub fn push_end_marker(&mut self, edit: &Edit, output_length: TextSize) {
         if edit.is_insertion() {
             self.push_marker(edit.start(), output_length);
@@ -63,7 +72,16 @@ impl SourceMap {
     }
 
     /// Push a new marker to the sourcemap.
+    ///
+    /// ## Panics
+    ///
+    /// If `offset` is less than previous markers.
     pub fn push_marker(&mut self, offset: TextSize, output_length: TextSize) {
+        assert!(
+            self.0.last().is_none_or(|last| offset >= last.source),
+            "Markers must be pushed in source order",
+        );
+
         self.0.push(SourceMarker {
             source: offset,
             dest: output_length,

--- a/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002_cell_start.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002_cell_start.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.drop(columns=[\"C\"], inplace=True)"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002_cell_start_expected.ipynb
+++ b/crates/ruff_linter/resources/test/fixtures/pandas_vet/PD002_cell_start_expected.ipynb
@@ -1,0 +1,26 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.DataFrame()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.drop(columns=[\"C\"])"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/crates/ruff_linter/src/rules/pandas_vet/mod.rs
+++ b/crates/ruff_linter/src/rules/pandas_vet/mod.rs
@@ -10,7 +10,7 @@ mod tests {
     use test_case::test_case;
 
     use crate::registry::{Linter, Rule};
-    use crate::test::{test_path, test_snippet};
+    use crate::test::{assert_notebook_path, test_path, test_resource_path, test_snippet};
     use crate::{assert_diagnostics, settings};
 
     #[test_case(
@@ -386,6 +386,21 @@ mod tests {
             &settings::LinterSettings::for_rule(rule_code),
         )?;
         assert_diagnostics!(snapshot, diagnostics);
+        Ok(())
+    }
+
+    #[test]
+    fn pd002_fix_at_notebook_cell_start() -> Result<()> {
+        let actual = test_resource_path("fixtures").join("pandas_vet/PD002_cell_start.ipynb");
+        let expected =
+            test_resource_path("fixtures").join("pandas_vet/PD002_cell_start_expected.ipynb");
+
+        assert_notebook_path(
+            actual,
+            expected,
+            &settings::LinterSettings::for_rule(Rule::PandasUseOfInplaceArgument),
+        )?;
+
         Ok(())
     }
 }

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -255,17 +255,24 @@ impl Notebook {
         // the last marker used to update the offsets and check if it's still
         // the closest marker to the current offset.
         let mut last_marker: Option<&SourceMarker> = None;
+        let markers = source_map.markers();
+        debug_assert!(markers.is_sorted_by_key(SourceMarker::source));
 
         // The first offset is always going to be at 0, so skip it.
-        for offset in self.cell_offsets.iter_mut().skip(1).rev() {
+        for (index, offset) in self.cell_offsets.iter_mut().skip(1).rev().enumerate() {
             let closest_marker = match last_marker {
-                Some(marker) if marker.source() <= *offset => marker,
+                Some(marker) if marker.source() < *offset => marker,
                 _ => {
-                    let Some(marker) = source_map
-                        .markers()
-                        .iter()
-                        .rev()
-                        .find(|marker| marker.source() <= *offset)
+                    // An internal offset is also the start of the following cell, so prefer the
+                    // marker before an insertion. The final offset is only a cell end.
+                    let marker_index = markers.partition_point(|marker| {
+                        marker.source() < *offset || (index == 0 && marker.source() == *offset)
+                    });
+                    let (before, after) = markers.split_at(marker_index);
+                    let Some(marker) = after
+                        .first()
+                        .filter(|marker| marker.source() == *offset)
+                        .or_else(|| before.last())
                     else {
                         // There are no markers above the current offset, so we can
                         // stop here.
@@ -488,6 +495,7 @@ mod tests {
 
     use ruff_diagnostics::SourceMap;
     use ruff_source_file::OneIndexed;
+    use ruff_text_size::TextSize;
 
     use crate::{Cell, CellStart, Notebook, NotebookError, NotebookIndex};
 
@@ -730,6 +738,71 @@ print("after empty cells")
         );
 
         Ok(())
+    }
+
+    #[test]
+    fn update_keeps_insertion_at_cell_start_in_that_cell() -> Result<(), NotebookError> {
+        let mut notebook = Notebook::from_source_code(
+            r##"{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["x = 1"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["x.method(inplace=True)"]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 4
+}"##,
+        )?;
+
+        let mut source_map = SourceMap::default();
+        source_map.push_marker(6.into(), 6.into());
+        source_map.push_marker(6.into(), 10.into());
+        notebook.update(
+            &source_map,
+            "x = 1\nx = x.method(inplace=True)\n".to_string(),
+        );
+
+        assert_eq!(
+            notebook.source_code(),
+            "x = 1\nx = x.method(inplace=True)\n"
+        );
+        assert_eq!(
+            notebook.cell_offsets().as_ref(),
+            &[0.into(), 6.into(), 33.into()]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_keeps_insertion_at_end_in_last_cell() {
+        let mut notebook = Notebook::empty();
+        let end = TextSize::of(notebook.source_code());
+        let insertion = "# comment\n";
+        let transformed = format!("{}{insertion}", notebook.source_code());
+
+        let mut source_map = SourceMap::default();
+        source_map.push_marker(end, end);
+        source_map.push_marker(end, end + TextSize::of(insertion));
+        notebook.update(&source_map, transformed.clone());
+
+        assert_eq!(
+            notebook.cell_offsets().last().copied(),
+            Some(TextSize::of(&transformed))
+        );
+        assert_eq!(notebook.cells()[0].source().to_string(), "\n# comment");
     }
 
     #[test_case("vscode_language_id.ipynb")]

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -256,7 +256,6 @@ impl Notebook {
         // the closest marker to the current offset.
         let mut last_marker: Option<&SourceMarker> = None;
         let markers = source_map.markers();
-        debug_assert!(markers.is_sorted_by_key(SourceMarker::source));
 
         // The first offset is always going to be at 0, so skip it.
         for (index, offset) in self.cell_offsets.iter_mut().skip(1).rev().enumerate() {

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -255,27 +255,27 @@ impl Notebook {
         // the last marker used to update the offsets and check if it's still
         // the closest marker to the current offset.
         let mut last_marker: Option<&SourceMarker> = None;
-        let markers = source_map.markers();
 
         // The first offset is always going to be at 0, so skip it.
         for (index, offset) in self.cell_offsets.iter_mut().skip(1).rev().enumerate() {
             let closest_marker = match last_marker {
                 Some(marker) if marker.source() < *offset => marker,
                 _ => {
-                    // An internal offset is also the start of the following cell, so prefer the
-                    // marker before an insertion. The final offset is only a cell end.
-                    let marker_index = markers.partition_point(|marker| {
-                        marker.source() < *offset || (index == 0 && marker.source() == *offset)
-                    });
-                    let (before, after) = markers.split_at(marker_index);
-                    let Some(marker) = after
-                        .first()
-                        .filter(|marker| marker.source() == *offset)
-                        .or_else(|| before.last())
-                    else {
+                    let mut markers = source_map.markers().iter().rev();
+                    let Some(marker) = markers.find(|marker| marker.source() <= *offset) else {
                         // There are no markers above the current offset, so we can
                         // stop here.
                         break;
+                    };
+                    // An internal offset is also the start of the following cell, so prefer the
+                    // first marker at that offset. The final offset is only a cell end.
+                    let marker = if index > 0 && marker.source() == *offset {
+                        markers
+                            .take_while(|marker| marker.source() == *offset)
+                            .last()
+                            .unwrap_or(marker)
+                    } else {
+                        marker
                     };
                     last_marker = Some(marker);
                     marker

--- a/crates/ruff_notebook/src/notebook.rs
+++ b/crates/ruff_notebook/src/notebook.rs
@@ -739,9 +739,8 @@ print("after empty cells")
         Ok(())
     }
 
-    #[test]
-    fn update_keeps_insertion_at_cell_start_in_that_cell() -> Result<(), NotebookError> {
-        let mut notebook = Notebook::from_source_code(
+    fn two_cell_notebook() -> Result<Notebook, NotebookError> {
+        Notebook::from_source_code(
             r##"{
  "cells": [
   {
@@ -763,7 +762,12 @@ print("after empty cells")
  "nbformat": 4,
  "nbformat_minor": 4
 }"##,
-        )?;
+        )
+    }
+
+    #[test]
+    fn update_keeps_insertion_at_cell_start_in_that_cell() -> Result<(), NotebookError> {
+        let mut notebook = two_cell_notebook()?;
 
         let mut source_map = SourceMap::default();
         source_map.push_marker(6.into(), 6.into());
@@ -780,6 +784,30 @@ print("after empty cells")
         assert_eq!(
             notebook.cell_offsets().as_ref(),
             &[0.into(), 6.into(), 33.into()]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_keeps_insertion_at_end_in_non_final_cell() -> Result<(), NotebookError> {
+        let mut notebook = two_cell_notebook()?;
+
+        let mut source_map = SourceMap::default();
+        source_map.push_marker(5.into(), 5.into());
+        source_map.push_marker(5.into(), 16.into());
+        notebook.update(
+            &source_map,
+            "x = 1  # comment\nx.method(inplace=True)\n".to_string(),
+        );
+
+        assert_eq!(
+            notebook.source_code(),
+            "x = 1  # comment\nx.method(inplace=True)\n"
+        );
+        assert_eq!(
+            notebook.cell_offsets().as_ref(),
+            &[0.into(), 17.into(), 40.into()]
         );
 
         Ok(())


### PR DESCRIPTION
Summary
--

Fixes #26100 by preferring the cell boundary marker before the inserted text rather than after it.
The code in question looks like this:

```py
import pandas as pd
df = pd.DataFrame(columns=["A", "B", "C"])
df.drop(columns=["C"], inplace=True)
```

where each line is in its own cell. The `PD002` fix removes the `inplace` kwarg and tries to rewrite
the code to:

```py
import pandas as pd
df = pd.DataFrame(columns=["A", "B", "C"])
df = df.drop(columns=["C"])
```

but the `df = ` was being added before the cell boundary, producing:

```py
import pandas as pd
df = pd.DataFrame(columns=["A", "B", "C"])
df =
df.drop(columns=["C"])
```

Test Plan
--

New ruff_notebook tests, as well as a ruff_linter test with a notebook based on the issue
