### PR TITLE
Support human-readable names when hovering suppression comments and in code actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ dependencies = [
  "jod-thread",
  "libc",
  "lsp-server",
+ "memchr",
  "regex",
  "ruff_db",
  "ruff_diagnostics",

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -336,6 +336,30 @@ fn lex_inline_noqa(
     lexer.lex_inline_noqa()
 }
 
+/// Return the range of the rule identifier at `offset` within `comment_range`, if it exists and is
+/// part of a file-level or line-level `noqa` comment.
+pub(crate) fn rule_identifier_range_at_offset(
+    source: &str,
+    comment_range: TextRange,
+    offset: TextSize,
+) -> Option<TextRange> {
+    let Some(NoqaLexerOutput {
+        directive: Directive::Codes(codes),
+        ..
+    }) = lex_inline_noqa(comment_range, source)
+        .ok()
+        .flatten()
+        .or_else(|| lex_file_exemption(comment_range, source).ok().flatten())
+    else {
+        return None;
+    };
+
+    codes
+        .iter()
+        .map(Ranged::range)
+        .find(|range| range.contains(offset))
+}
+
 /// Lexes file-level exemption comment, e.g. `# ruff: noqa: F401`
 fn lex_file_exemption(
     comment_range: TextRange,

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -1272,6 +1272,21 @@ impl Iterator for SuppressionParser<'_> {
     }
 }
 
+/// Returns the range of the rule identifier at `offset` within a `noqa` or Ruff suppression
+/// comment.
+pub fn rule_identifier_range_at_offset(
+    source: &str,
+    comment_range: TextRange,
+    offset: TextSize,
+) -> Option<TextRange> {
+    crate::noqa::rule_identifier_range_at_offset(source, comment_range, offset).or_else(|| {
+        SuppressionParser::new(source, comment_range)
+            .filter_map(Result::ok)
+            .flat_map(|comment| comment.codes)
+            .find(|range| range.contains(offset))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::fmt::{self, Formatter};

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -32,7 +32,6 @@ ignore = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
-regex = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ruff_server/Cargo.toml
+++ b/crates/ruff_server/Cargo.toml
@@ -32,6 +32,7 @@ ignore = { workspace = true }
 jod-thread = { workspace = true }
 lsp-server = { workspace = true }
 lsp-types = { workspace = true }
+memchr = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -1,7 +1,11 @@
+use std::sync::{Arc, OnceLock};
+
 use lsp_types::{
     LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
     TextDocumentContentChangeWholeDocument,
 };
+use ruff_python_ast::{ModModule, PySourceType};
+use ruff_python_parser::{Parsed, parse_unchecked_source};
 use ruff_source_file::LineIndex;
 
 use crate::PositionEncoding;
@@ -25,6 +29,22 @@ pub struct TextDocument {
     version: DocumentVersion,
     /// The language ID of the document as provided by the client.
     language_id: Option<LanguageId>,
+    /// A lazily parsed module for hover requests.
+    parsed_module: OnceLock<Arc<ParsedModule>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedModule {
+    source_type: PySourceType,
+    parsed: Parsed<ModModule>,
+}
+
+impl std::ops::Deref for ParsedModule {
+    type Target = Parsed<ModModule>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.parsed
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -52,6 +72,7 @@ impl TextDocument {
             index,
             version,
             language_id: None,
+            parsed_module: OnceLock::new(),
         }
     }
 
@@ -81,12 +102,33 @@ impl TextDocument {
         self.language_id
     }
 
+    pub(crate) fn parsed_module(&self, source_type: PySourceType) -> Arc<ParsedModule> {
+        fn parse(contents: &str, source_type: PySourceType) -> Arc<ParsedModule> {
+            Arc::new(ParsedModule {
+                source_type,
+                parsed: parse_unchecked_source(contents, source_type),
+            })
+        }
+
+        let parsed = self
+            .parsed_module
+            .get_or_init(|| parse(self.contents(), source_type));
+
+        if parsed.source_type == source_type {
+            Arc::clone(parsed)
+        } else {
+            parse(self.contents(), source_type)
+        }
+    }
+
     pub fn apply_changes(
         &mut self,
         changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
     ) {
+        self.parsed_module.take();
+
         if let [
             TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
                 TextDocumentContentChangeWholeDocument { text },
@@ -159,7 +201,11 @@ impl TextDocument {
 #[cfg(test)]
 mod tests {
     use crate::{PositionEncoding, TextDocument};
-    use lsp_types::{Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial};
+    use lsp_types::{
+        Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
+        TextDocumentContentChangeWholeDocument,
+    };
+    use ruff_python_ast::PySourceType;
 
     #[test]
     fn redo_edit() {
@@ -222,5 +268,28 @@ def interface():
     pass
 "#
         );
+    }
+
+    #[test]
+    fn parsed_module_cache_invalidation() {
+        let mut document = TextDocument::new("x = 1\n".to_string(), 1);
+
+        let parsed = document.parsed_module(PySourceType::Python);
+        assert_eq!(parsed.syntax().body.len(), 1);
+
+        document.apply_changes(
+            vec![
+                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                    TextDocumentContentChangeWholeDocument {
+                        text: "x = 1\ny = 2\n".to_string(),
+                    },
+                ),
+            ],
+            2,
+            PositionEncoding::UTF16,
+        );
+
+        let updated = document.parsed_module(PySourceType::Python);
+        assert_eq!(updated.syntax().body.len(), 2);
     }
 }

--- a/crates/ruff_server/src/edit/text_document.rs
+++ b/crates/ruff_server/src/edit/text_document.rs
@@ -1,11 +1,7 @@
-use std::sync::{Arc, OnceLock};
-
 use lsp_types::{
     LanguageKind, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
     TextDocumentContentChangeWholeDocument,
 };
-use ruff_python_ast::{ModModule, PySourceType};
-use ruff_python_parser::{Parsed, parse_unchecked_source};
 use ruff_source_file::LineIndex;
 
 use crate::PositionEncoding;
@@ -29,22 +25,6 @@ pub struct TextDocument {
     version: DocumentVersion,
     /// The language ID of the document as provided by the client.
     language_id: Option<LanguageId>,
-    /// A lazily parsed module for hover requests.
-    parsed_module: OnceLock<Arc<ParsedModule>>,
-}
-
-#[derive(Debug)]
-pub(crate) struct ParsedModule {
-    source_type: PySourceType,
-    parsed: Parsed<ModModule>,
-}
-
-impl std::ops::Deref for ParsedModule {
-    type Target = Parsed<ModModule>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.parsed
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -72,7 +52,6 @@ impl TextDocument {
             index,
             version,
             language_id: None,
-            parsed_module: OnceLock::new(),
         }
     }
 
@@ -102,33 +81,12 @@ impl TextDocument {
         self.language_id
     }
 
-    pub(crate) fn parsed_module(&self, source_type: PySourceType) -> Arc<ParsedModule> {
-        fn parse(contents: &str, source_type: PySourceType) -> Arc<ParsedModule> {
-            Arc::new(ParsedModule {
-                source_type,
-                parsed: parse_unchecked_source(contents, source_type),
-            })
-        }
-
-        let parsed = self
-            .parsed_module
-            .get_or_init(|| parse(self.contents(), source_type));
-
-        if parsed.source_type == source_type {
-            Arc::clone(parsed)
-        } else {
-            parse(self.contents(), source_type)
-        }
-    }
-
     pub fn apply_changes(
         &mut self,
         changes: Vec<lsp_types::TextDocumentContentChangeEvent>,
         new_version: DocumentVersion,
         encoding: PositionEncoding,
     ) {
-        self.parsed_module.take();
-
         if let [
             TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
                 TextDocumentContentChangeWholeDocument { text },
@@ -201,11 +159,7 @@ impl TextDocument {
 #[cfg(test)]
 mod tests {
     use crate::{PositionEncoding, TextDocument};
-    use lsp_types::{
-        Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial,
-        TextDocumentContentChangeWholeDocument,
-    };
-    use ruff_python_ast::PySourceType;
+    use lsp_types::{Position, TextDocumentContentChangeEvent, TextDocumentContentChangePartial};
 
     #[test]
     fn redo_edit() {
@@ -268,28 +222,5 @@ def interface():
     pass
 "#
         );
-    }
-
-    #[test]
-    fn parsed_module_cache_invalidation() {
-        let mut document = TextDocument::new("x = 1\n".to_string(), 1);
-
-        let parsed = document.parsed_module(PySourceType::Python);
-        assert_eq!(parsed.syntax().body.len(), 1);
-
-        document.apply_changes(
-            vec![
-                TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
-                    TextDocumentContentChangeWholeDocument {
-                        text: "x = 1\ny = 2\n".to_string(),
-                    },
-                ),
-            ],
-            2,
-            PositionEncoding::UTF16,
-        );
-
-        let updated = document.parsed_module(PySourceType::Python);
-        assert_eq!(updated.syntax().body.len(), 2);
     }
 }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -42,7 +42,7 @@ pub(crate) struct AssociatedDiagnosticData {
     /// Edits to fix the diagnostic. If this is empty, a fix
     /// does not exist.
     pub(crate) edits: Vec<lsp_types::TextEdit>,
-    /// The NOQA code for the diagnostic.
+    /// The identifier displayed for the diagnostic.
     pub(crate) code: String,
     /// Possible edit to add a `noqa` comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
@@ -56,7 +56,7 @@ pub(crate) struct DiagnosticFix {
     pub(crate) fixed_diagnostic: lsp_types::Diagnostic,
     /// The message describing what the fix does.
     pub(crate) title: String,
-    /// The NOQA code for the diagnostic.
+    /// The identifier displayed for the diagnostic.
     pub(crate) code: String,
     /// Edits to fix the diagnostic. If this is empty, a fix
     /// does not exist.
@@ -272,13 +272,30 @@ fn to_lsp_diagnostic(
     let name = diagnostic.name();
     let fix = diagnostic.fix();
     let suggestion = diagnostic.first_help_text();
-    let code = diagnostic.secondary_code();
-
     let fix = fix.and_then(|fix| fix.applies(Applicability::Unsafe).then_some(fix));
+
+    let (severity, code) = if let Some(code) = diagnostic.secondary_code() {
+        let severity = severity(code);
+        let code = if is_human_readable_names_enabled(context.settings.preview) {
+            name.to_string()
+        } else {
+            code.to_string()
+        };
+        (severity, code)
+    } else {
+        (
+            match diagnostic.severity() {
+                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::Information,
+                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::Warning,
+                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::Error,
+                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::Error,
+            },
+            diagnostic.id().to_string(),
+        )
+    };
 
     let data = (fix.is_some() || noqa_edit.is_some())
         .then(|| {
-            let code = code?.to_string();
             let edits = fix
                 .into_iter()
                 .flat_map(Fix::edits)
@@ -305,7 +322,7 @@ fn to_lsp_diagnostic(
                 title: suggestion.unwrap_or(name).to_string(),
                 noqa_edit,
                 edits,
-                code,
+                code: code.clone(),
             })
             .ok()
         })
@@ -329,26 +346,6 @@ fn to_lsp_diagnostic(
             context.encoding,
         );
     }
-
-    let (severity, code) = if let Some(code) = code {
-        let severity = severity(code);
-        let code = if is_human_readable_names_enabled(context.settings.preview) {
-            name.to_string()
-        } else {
-            code.to_string()
-        };
-        (severity, code)
-    } else {
-        (
-            match diagnostic.severity() {
-                ruff_db::diagnostic::Severity::Info => lsp_types::DiagnosticSeverity::Information,
-                ruff_db::diagnostic::Severity::Warning => lsp_types::DiagnosticSeverity::Warning,
-                ruff_db::diagnostic::Severity::Error => lsp_types::DiagnosticSeverity::Error,
-                ruff_db::diagnostic::Severity::Fatal => lsp_types::DiagnosticSeverity::Error,
-            },
-            diagnostic.id().to_string(),
-        )
-    };
 
     let related_information =
         if context.supports_related_information {

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -102,7 +102,7 @@ pub(crate) fn hover(
         })?;
     let identifier_range = TextRange::at(
         line_range.start() + TextSize::try_from(identifiers_start + identifier.start()).ok()?,
-        TextSize::try_from(identifier.end) - identifiers_start).ok()?,
+        TextSize::try_from(identifier.len()).ok()?,
     );
 
     // Get the rule for the identifier under the cursor.

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -10,6 +10,7 @@ use ruff_python_ast::SourceType;
 use ruff_source_file::OneIndexed;
 use ruff_text_size::{TextRange, TextSize};
 use std::fmt::Write;
+use std::sync::LazyLock;
 
 pub(crate) struct Hover;
 
@@ -68,32 +69,38 @@ pub(crate) fn hover(
     let line = &document.contents()[line_range];
 
     // Get the list of rule identifiers from a `noqa` or Ruff suppression comment.
-    let noqa_regex = Regex::new(r"(?i:# (?:(?:ruff|flake8): )?(?P<noqa>noqa))(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?").unwrap();
-    let suppression_regex = Regex::new(
-        r"(?x)
+    static NOQA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i:# (?:(?:ruff|flake8): )?(?P<noqa>noqa))(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?").unwrap()
+    });
+    static SUPPRESSION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"(?x)
         \#\s*ruff\s*:\s*(?:disable|enable|file-ignore|ignore)\s*\[\s*
         (?P<codes>(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*)(?:\s*,\s*(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*))*\s*,?)
         \s*\]",
-    )
-    .unwrap();
+        )
+        .unwrap()
+    });
+    static IDENTIFIER_REGEX: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[A-Z]+[0-9]+|[a-z][a-z0-9-]*").unwrap());
+
     let cursor: usize = position
         .position
         .character
         .try_into()
         .expect("column number should fit within a usize");
-    let identifiers_match = noqa_regex
+    let identifiers_match = NOQA_REGEX
         .captures(line)
         .and_then(|captures| captures.name("codes"))
         .into_iter()
         .chain(
-            suppression_regex
+            SUPPRESSION_REGEX
                 .captures_iter(line)
                 .filter_map(|captures| captures.name("codes")),
         )
         .find(|identifiers| cursor >= identifiers.start() && cursor < identifiers.end())?;
     let identifiers_start = identifiers_match.start();
-    let identifier_regex = Regex::new(r"[A-Z]+[0-9]+|[a-z][a-z0-9-]*").unwrap();
-    let identifier = identifier_regex
+    let identifier = IDENTIFIER_REGEX
         .find_iter(identifiers_match.as_str())
         .find(|identifier| {
             cursor >= (identifier.start() + identifiers_start)

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -1,16 +1,16 @@
-use crate::edit::ToRangeExt;
+use crate::edit::{RangeExt, ToRangeExt};
 use crate::server::Result;
 use crate::session::{Client, DocumentSnapshot};
 use anyhow::Context;
 use lsp_types::{self as types, HoverRequest};
-use regex::Regex;
 use ruff_linter::FixAvailability;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
+use ruff_linter::suppression::rule_identifier_range_at_offset;
 use ruff_python_ast::SourceType;
-use ruff_source_file::OneIndexed;
-use ruff_text_size::{TextRange, TextSize};
+use ruff_python_ast::token::TokenKind;
+use ruff_python_parser::parse_unchecked_source;
+use ruff_text_size::Ranged;
 use std::fmt::Write;
-use std::sync::LazyLock;
 
 pub(crate) struct Hover;
 
@@ -47,7 +47,7 @@ pub(crate) fn hover(
     position: &types::TextDocumentPositionParams,
 ) -> Option<types::Hover> {
     // Don't show noqa hover for non-Python documents (e.g., markdown files).
-    let SourceType::Python(_) = snapshot.query().source_type_for_lint() else {
+    let SourceType::Python(source_type) = snapshot.query().source_type_for_lint() else {
         return None;
     };
 
@@ -56,63 +56,19 @@ pub(crate) fn hover(
         .as_single_document()
         .context("Failed to get text document for the hover request")
         .unwrap();
-    let line_number: usize = position
-        .position
-        .line
-        .try_into()
-        .expect("line number should fit within a usize");
-    let line_range = document.index().line_range(
-        OneIndexed::from_zero_indexed(line_number),
-        document.contents(),
-    );
-
-    let line = &document.contents()[line_range];
-
-    // Get the list of rule identifiers from a `noqa` or Ruff suppression comment.
-    static NOQA_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i:# (?:(?:ruff|flake8): )?(?P<noqa>noqa))(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?").unwrap()
-    });
-    static SUPPRESSION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(
-            r"(?x)
-        \#\s*ruff\s*:\s*(?:disable|enable|file-ignore|ignore)\s*\[\s*
-        (?P<codes>(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*)(?:\s*,\s*(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*))*\s*,?)
-        \s*\]",
-        )
-        .unwrap()
-    });
-    static IDENTIFIER_REGEX: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"[A-Z]+[0-9]+|[a-z][a-z0-9-]*").unwrap());
-
-    let cursor: usize = position
-        .position
-        .character
-        .try_into()
-        .expect("column number should fit within a usize");
-    let identifiers_match = NOQA_REGEX
-        .captures(line)
-        .and_then(|captures| captures.name("codes"))
-        .into_iter()
-        .chain(
-            SUPPRESSION_REGEX
-                .captures_iter(line)
-                .filter_map(|captures| captures.name("codes")),
-        )
-        .find(|identifiers| cursor >= identifiers.start() && cursor < identifiers.end())?;
-    let identifiers_start = identifiers_match.start();
-    let identifier = IDENTIFIER_REGEX
-        .find_iter(identifiers_match.as_str())
-        .find(|identifier| {
-            cursor >= (identifier.start() + identifiers_start)
-                && cursor < (identifier.end() + identifiers_start)
-        })?;
-    let identifier_range = TextRange::at(
-        line_range.start() + TextSize::try_from(identifiers_start + identifier.start()).ok()?,
-        TextSize::try_from(identifier.len()).ok()?,
-    );
+    let cursor = types::Range::new(position.position, position.position)
+        .to_text_range(document.contents(), document.index(), snapshot.encoding())
+        .start();
+    let parsed = parse_unchecked_source(document.contents(), source_type);
+    let comment = parsed
+        .tokens()
+        .at_offset(cursor)
+        .find(|token| token.kind() == TokenKind::Comment)?;
+    let identifier_range =
+        rule_identifier_range_at_offset(document.contents(), comment.range(), cursor)?;
 
     // Get the rule for the identifier under the cursor.
-    let identifier = identifier.as_str();
+    let identifier = &document.contents()[identifier_range];
     let rule = Rule::from_code(identifier)
         .ok()
         .or_else(|| Rule::from_name(identifier).ok());

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -5,7 +5,6 @@ use anyhow::Context;
 use lsp_types::{self as types, HoverRequest};
 use regex::Regex;
 use ruff_linter::FixAvailability;
-use ruff_linter::preview::is_human_readable_names_enabled;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_python_ast::SourceType;
 use ruff_source_file::OneIndexed;
@@ -107,13 +106,9 @@ pub(crate) fn hover(
 
     // Get the rule for the identifier under the cursor.
     let identifier = identifier.as_str();
-    let rule = Rule::from_code(identifier).ok().or_else(|| {
-        if is_human_readable_names_enabled(snapshot.query().settings().linter.preview) {
-            Rule::from_name(identifier).ok()
-        } else {
-            None
-        }
-    });
+    let rule = Rule::from_code(identifier)
+        .ok()
+        .or_else(|| Rule::from_name(identifier).ok());
     let output = if let Some(rule) = rule {
         format_rule_text(rule)
     } else {

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -1,3 +1,4 @@
+use crate::edit::ToRangeExt;
 use crate::server::Result;
 use crate::session::{Client, DocumentSnapshot};
 use anyhow::Context;
@@ -8,6 +9,7 @@ use ruff_linter::preview::is_human_readable_names_enabled;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_python_ast::SourceType;
 use ruff_source_file::OneIndexed;
+use ruff_text_size::{TextRange, TextSize};
 use std::fmt::Write;
 
 pub(crate) struct Hover;
@@ -98,6 +100,10 @@ pub(crate) fn hover(
             cursor >= (identifier.start() + identifiers_start)
                 && cursor < (identifier.end() + identifiers_start)
         })?;
+    let identifier_range = TextRange::new(
+        line_range.start() + TextSize::try_from(identifiers_start + identifier.start()).ok()?,
+        line_range.start() + TextSize::try_from(identifiers_start + identifier.end()).ok()?,
+    );
 
     // Get the rule for the identifier under the cursor.
     let identifier = identifier.as_str();
@@ -120,7 +126,11 @@ pub(crate) fn hover(
             value: output,
         }
         .into(),
-        range: None,
+        range: Some(identifier_range.to_range(
+            document.contents(),
+            document.index(),
+            snapshot.encoding(),
+        )),
     };
 
     Some(hover)

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -70,9 +70,7 @@ pub(crate) fn hover(
     let line = &document.contents()[line_range];
 
     // Avoid parsing the document if the hovered line doesn't contain a comment.
-    if memchr::memchr(b'#', line.as_bytes()).is_none() {
-        return None;
-    }
+    memchr::memchr(b'#', line.as_bytes())?;
 
     let cursor = types::Range::new(position.position, position.position)
         .to_text_range(document.contents(), document.index(), snapshot.encoding())

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -9,6 +9,7 @@ use ruff_linter::suppression::rule_identifier_range_at_offset;
 use ruff_python_ast::SourceType;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_parser::parse_unchecked_source;
+use ruff_source_file::OneIndexed;
 use ruff_text_size::Ranged;
 use std::fmt::Write;
 
@@ -56,6 +57,23 @@ pub(crate) fn hover(
         .as_single_document()
         .context("Failed to get text document for the hover request")
         .unwrap();
+    let line_number: usize = position
+        .position
+        .line
+        .try_into()
+        .expect("line number should fit within a usize");
+    let line_range = document.index().line_range(
+        OneIndexed::from_zero_indexed(line_number),
+        document.contents(),
+    );
+
+    let line = &document.contents()[line_range];
+
+    // Avoid parsing the document if the hovered line doesn't contain a comment.
+    if memchr::memchr(b'#', line.as_bytes()).is_none() {
+        return None;
+    }
+
     let cursor = types::Range::new(position.position, position.position)
         .to_text_range(document.contents(), document.index(), snapshot.encoding())
         .start();

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -8,6 +8,7 @@ use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_linter::suppression::rule_identifier_range_at_offset;
 use ruff_python_ast::SourceType;
 use ruff_python_ast::token::TokenKind;
+use ruff_python_parser::parse_unchecked_source;
 use ruff_text_size::Ranged;
 use std::fmt::Write;
 
@@ -58,7 +59,7 @@ pub(crate) fn hover(
     let cursor = types::Range::new(position.position, position.position)
         .to_text_range(document.contents(), document.index(), snapshot.encoding())
         .start();
-    let parsed = document.parsed_module(source_type);
+    let parsed = parse_unchecked_source(document.contents(), source_type);
     let comment = parsed
         .tokens()
         .at_offset(cursor)

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -8,7 +8,6 @@ use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_linter::suppression::rule_identifier_range_at_offset;
 use ruff_python_ast::SourceType;
 use ruff_python_ast::token::TokenKind;
-use ruff_python_parser::parse_unchecked_source;
 use ruff_text_size::Ranged;
 use std::fmt::Write;
 
@@ -59,7 +58,7 @@ pub(crate) fn hover(
     let cursor = types::Range::new(position.position, position.position)
         .to_text_range(document.contents(), document.index(), snapshot.encoding())
         .start();
-    let parsed = parse_unchecked_source(document.contents(), source_type);
+    let parsed = document.parsed_module(source_type);
     let comment = parsed
         .tokens()
         .at_offset(cursor)

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -100,9 +100,9 @@ pub(crate) fn hover(
             cursor >= (identifier.start() + identifiers_start)
                 && cursor < (identifier.end() + identifiers_start)
         })?;
-    let identifier_range = TextRange::new(
+    let identifier_range = TextRange::at(
         line_range.start() + TextSize::try_from(identifiers_start + identifier.start()).ok()?,
-        line_range.start() + TextSize::try_from(identifiers_start + identifier.end()).ok()?,
+        TextSize::try_from(identifier.end) - identifiers_start).ok()?,
     );
 
     // Get the rule for the identifier under the cursor.

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -65,17 +65,32 @@ pub(crate) fn hover(
 
     let line = &document.contents()[line_range];
 
-    // Get the list of codes.
+    // Get the list of codes from a `noqa` or Ruff suppression comment.
     let noqa_regex = Regex::new(r"(?i:# (?:(?:ruff|flake8): )?(?P<noqa>noqa))(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?").unwrap();
-    let noqa_captures = noqa_regex.captures(line)?;
-    let codes_match = noqa_captures.name("codes")?;
-    let codes_start = codes_match.start();
-    let code_regex = Regex::new(r"[A-Z]+[0-9]+").unwrap();
+    let suppression_regex = Regex::new(
+        r"(?x)
+        \#\s*ruff\s*:\s*(?:disable|enable|file-ignore|ignore)\s*\[\s*
+        (?P<codes>(?:[A-Z]+[0-9]+)(?:\s*,\s*(?:[A-Z]+[0-9]+))*\s*,?)
+        \s*\]",
+    )
+    .unwrap();
     let cursor: usize = position
         .position
         .character
         .try_into()
         .expect("column number should fit within a usize");
+    let codes_match = noqa_regex
+        .captures(line)
+        .and_then(|captures| captures.name("codes"))
+        .into_iter()
+        .chain(
+            suppression_regex
+                .captures_iter(line)
+                .filter_map(|captures| captures.name("codes")),
+        )
+        .find(|codes| cursor >= codes.start() && cursor < codes.end())?;
+    let codes_start = codes_match.start();
+    let code_regex = Regex::new(r"[A-Z]+[0-9]+").unwrap();
     let word = code_regex.find_iter(codes_match.as_str()).find(|code| {
         cursor >= (code.start() + codes_start) && cursor < (code.end() + codes_start)
     })?;

--- a/crates/ruff_server/src/server/api/requests/hover.rs
+++ b/crates/ruff_server/src/server/api/requests/hover.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use lsp_types::{self as types, HoverRequest};
 use regex::Regex;
 use ruff_linter::FixAvailability;
+use ruff_linter::preview::is_human_readable_names_enabled;
 use ruff_linter::registry::{Linter, Rule, RuleNamespace};
 use ruff_python_ast::SourceType;
 use ruff_source_file::OneIndexed;
@@ -65,12 +66,12 @@ pub(crate) fn hover(
 
     let line = &document.contents()[line_range];
 
-    // Get the list of codes from a `noqa` or Ruff suppression comment.
+    // Get the list of rule identifiers from a `noqa` or Ruff suppression comment.
     let noqa_regex = Regex::new(r"(?i:# (?:(?:ruff|flake8): )?(?P<noqa>noqa))(?::\s?(?P<codes>([A-Z]+[0-9]+(?:[,\s]+)?)+))?").unwrap();
     let suppression_regex = Regex::new(
         r"(?x)
         \#\s*ruff\s*:\s*(?:disable|enable|file-ignore|ignore)\s*\[\s*
-        (?P<codes>(?:[A-Z]+[0-9]+)(?:\s*,\s*(?:[A-Z]+[0-9]+))*\s*,?)
+        (?P<codes>(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*)(?:\s*,\s*(?:[A-Z]+[0-9]+|[a-z][a-z0-9-]*))*\s*,?)
         \s*\]",
     )
     .unwrap();
@@ -79,7 +80,7 @@ pub(crate) fn hover(
         .character
         .try_into()
         .expect("column number should fit within a usize");
-    let codes_match = noqa_regex
+    let identifiers_match = noqa_regex
         .captures(line)
         .and_then(|captures| captures.name("codes"))
         .into_iter()
@@ -88,19 +89,29 @@ pub(crate) fn hover(
                 .captures_iter(line)
                 .filter_map(|captures| captures.name("codes")),
         )
-        .find(|codes| cursor >= codes.start() && cursor < codes.end())?;
-    let codes_start = codes_match.start();
-    let code_regex = Regex::new(r"[A-Z]+[0-9]+").unwrap();
-    let word = code_regex.find_iter(codes_match.as_str()).find(|code| {
-        cursor >= (code.start() + codes_start) && cursor < (code.end() + codes_start)
-    })?;
+        .find(|identifiers| cursor >= identifiers.start() && cursor < identifiers.end())?;
+    let identifiers_start = identifiers_match.start();
+    let identifier_regex = Regex::new(r"[A-Z]+[0-9]+|[a-z][a-z0-9-]*").unwrap();
+    let identifier = identifier_regex
+        .find_iter(identifiers_match.as_str())
+        .find(|identifier| {
+            cursor >= (identifier.start() + identifiers_start)
+                && cursor < (identifier.end() + identifiers_start)
+        })?;
 
-    // Get rule for the code under the cursor.
-    let rule = Rule::from_code(word.as_str());
-    let output = if let Ok(rule) = rule {
+    // Get the rule for the identifier under the cursor.
+    let identifier = identifier.as_str();
+    let rule = Rule::from_code(identifier).ok().or_else(|| {
+        if is_human_readable_names_enabled(snapshot.query().settings().linter.preview) {
+            Rule::from_name(identifier).ok()
+        } else {
+            None
+        }
+    });
+    let output = if let Some(rule) = rule {
         format_rule_text(rule)
     } else {
-        format!("{}: Rule not found", word.as_str())
+        format!("{identifier}: Rule not found")
     };
 
     let hover = types::Hover {

--- a/crates/ruff_server/tests/e2e/code_action.rs
+++ b/crates/ruff_server/tests/e2e/code_action.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use insta::assert_json_snapshot;
-use lsp_types::{CodeAction, CodeActionKind, CodeActionResolveRequest};
+use lsp_types::{
+    Code, CodeAction, CodeActionKind, CodeActionResolveRequest, CodeActionResponse,
+    DocumentDiagnosticReport,
+};
 
 use crate::TestServerBuilder;
 
@@ -74,6 +77,51 @@ fn code_actions_for_python() -> Result<()> {
     ]
     "#
     );
+
+    Ok(())
+}
+
+#[test]
+fn human_readable_rule_names() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .with_file(
+            "pyproject.toml",
+            r#"
+[tool.ruff]
+preview = true
+"#,
+        )?
+        .build();
+
+    server.open_text_document("test.py", "import os\n", 1);
+
+    let diagnostics = match server.document_diagnostic_request("test.py", None) {
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => {
+            report.full_document_diagnostic_report.items
+        }
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+            panic!("Expected a full diagnostic report");
+        }
+    };
+    assert_eq!(
+        diagnostics[0].code,
+        Some(Code::String("unused-import".to_string()))
+    );
+
+    let actions = server
+        .code_action_request("test.py", diagnostics)
+        .expect("Expected code actions");
+    let titles: Vec<_> = actions
+        .iter()
+        .filter_map(|action| match action {
+            CodeActionResponse::CodeAction(action) => Some(action.title.as_str()),
+            CodeActionResponse::Command(_) => None,
+        })
+        .collect();
+
+    assert!(titles.contains(&"Ruff (unused-import): Remove unused import: `os`"));
+    assert!(titles.contains(&"Ruff (unused-import): Disable for this line"));
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -41,7 +41,7 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
             1
           ],
           "data": {
-            "code": "F401",
+            "code": "unused-import",
             "edits": [
               {
                 "newText": "",

--- a/crates/ruff_server/tests/e2e/hover.rs
+++ b/crates/ruff_server/tests/e2e/hover.rs
@@ -102,6 +102,39 @@ fn hover_for_ruff_suppression_comments() -> Result<()> {
 }
 
 #[test]
+fn hover_for_human_readable_rule_name() -> Result<()> {
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(".")?
+        .with_file(
+            "pyproject.toml",
+            r#"
+[tool.ruff]
+preview = true
+"#,
+        )?
+        .build();
+
+    server.open_text_document("test.py", "import os  # ruff: ignore[unused-import]\n", 1);
+
+    let result = server
+        .hover_request(
+            "test.py",
+            Position {
+                line: 0,
+                character: 29,
+            },
+        )
+        .expect("Expected hover information for a human-readable rule name");
+
+    let lsp_types::Contents::MarkupContent(markup) = result.contents else {
+        panic!("Expected Markdown hover contents");
+    };
+    assert!(markup.value.starts_with("# unused-import (F401)"));
+
+    Ok(())
+}
+
+#[test]
 fn unavailable_document_returns_empty_response() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 

--- a/crates/ruff_server/tests/e2e/hover.rs
+++ b/crates/ruff_server/tests/e2e/hover.rs
@@ -63,6 +63,30 @@ fn hover_for_python_noqa() -> Result<()> {
 }
 
 #[test]
+fn hover_for_file_level_noqa() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    server.open_text_document("test.py", "# ruff: noqa: F401\n", 1);
+
+    let result = server
+        .hover_request(
+            "test.py",
+            Position {
+                line: 0,
+                character: 15,
+            },
+        )
+        .expect("Expected hover information for a file-level `noqa` directive");
+
+    let lsp_types::Contents::MarkupContent(markup) = result.contents else {
+        panic!("Expected Markdown hover contents");
+    };
+    assert!(markup.value.starts_with("# unused-import (F401)"));
+
+    Ok(())
+}
+
+#[test]
 fn hover_for_ruff_suppression_comments() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 
@@ -124,14 +148,14 @@ preview = true
         )?
         .build();
 
-    server.open_text_document("test.py", "import os  # ruff: ignore[unused-import]\n", 1);
+    server.open_text_document("test.py", "éééé = 1  # ruff: ignore[unused-import]\n", 1);
 
     let result = server
         .hover_request(
             "test.py",
             Position {
                 line: 0,
-                character: 29,
+                character: 26,
             },
         )
         .expect("Expected hover information for a human-readable rule name");
@@ -145,14 +169,37 @@ preview = true
         Some(Range {
             start: Position {
                 line: 0,
-                character: 26,
+                character: 25,
             },
             end: Position {
                 line: 0,
-                character: 39,
+                character: 38,
             },
         })
     );
+
+    Ok(())
+}
+
+#[test]
+fn no_hover_for_suppression_text_in_string() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    server.open_text_document(
+        "test.py",
+        "\"\"\"\nnot a comment # ruff:ignore[unused-import]\n\"\"\"\n",
+        1,
+    );
+
+    let result = server.hover_request(
+        "test.py",
+        Position {
+            line: 1,
+            character: 31,
+        },
+    );
+
+    assert!(result.is_none());
 
     Ok(())
 }

--- a/crates/ruff_server/tests/e2e/hover.rs
+++ b/crates/ruff_server/tests/e2e/hover.rs
@@ -53,6 +53,55 @@ fn hover_for_python_noqa() -> Result<()> {
 }
 
 #[test]
+fn hover_for_ruff_suppression_comments() -> Result<()> {
+    let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
+
+    server.open_text_document(
+        "test.py",
+        "# ruff: disable[F401]\n# ruff: enable[F401]\n# ruff: file-ignore[F401]\n# ruff: ignore[F401]\n# ruff: disable[F401] # ruff: ignore[F401]\n# ruff: ignore[F401,]\n",
+        1,
+    );
+
+    for position in [
+        Position {
+            line: 0,
+            character: 17,
+        },
+        Position {
+            line: 1,
+            character: 16,
+        },
+        Position {
+            line: 2,
+            character: 21,
+        },
+        Position {
+            line: 3,
+            character: 16,
+        },
+        Position {
+            line: 4,
+            character: 38,
+        },
+        Position {
+            line: 5,
+            character: 16,
+        },
+    ] {
+        let result = server
+            .hover_request("test.py", position)
+            .expect("Expected hover information for a Ruff suppression comment");
+
+        let lsp_types::Contents::MarkupContent(markup) = result.contents else {
+            panic!("Expected Markdown hover contents");
+        };
+        assert!(markup.value.starts_with("# unused-import (F401)"));
+    }
+
+    Ok(())
+}
+
+#[test]
 fn unavailable_document_returns_empty_response() -> Result<()> {
     let mut server = TestServerBuilder::new()?.with_workspace(".")?.build();
 

--- a/crates/ruff_server/tests/e2e/hover.rs
+++ b/crates/ruff_server/tests/e2e/hover.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use insta::assert_json_snapshot;
-use lsp_types::Position;
+use lsp_types::{Position, Range};
 
 use crate::TestServerBuilder;
 
@@ -44,6 +44,16 @@ fn hover_for_python_noqa() -> Result<()> {
       "contents": {
         "kind": "markdown",
         "value": "# unused-noqa (RUF100)\n\nDerived from the **Ruff-specific rules** linter.\n\nFix is always available.\n\n## What it does\nChecks for `noqa` directives that are no longer applicable.\n\n## Why is this bad?\nA `noqa` directive that no longer matches any diagnostic violations is\nlikely included by mistake, and should be removed to avoid confusion.\n\n## Example\n```python\nimport foo  # noqa: F401\n\n\ndef bar():\n    foo.bar()\n```\n\nUse instead:\n```python\nimport foo\n\n\ndef bar():\n    foo.bar()\n```\n\n## Conflict with other linters\nWhen using `RUF100` with the `--fix` option, Ruff may remove trailing comments\nthat follow a `# noqa` directive on the same line, as it interprets the\nremainder of the line as a description for the suppression.\n\nTo prevent Ruff from removing suppressions for other tools (like `pylint`\nor `mypy`), separate them with a second `#` character:\n\n```python\n# Bad: Ruff --fix will remove the pylint comment\ndef visit_ImportFrom(self, node):  # noqa: N802, pylint: disable=invalid-name\n    pass\n\n\n# Good: Ruff will preserve the pylint comment\ndef visit_ImportFrom(self, node):  # noqa: N802 # pylint: disable=invalid-name\n    pass\n```\n\n## Fix safety\n\nThe rule's fix is marked as unsafe when a full suppression comment would be removed and there\nare other nested comments on the same line. Removing such a comment can change the behavior of\nother suppression comments before or after the removed comment.\n\n## See also\n\nThis rule ignores any codes that are unknown to Ruff, as it can't determine\nif the codes are valid or used by other tools. Enable [`invalid-rule-code`][RUF102]\nto flag any unknown rule codes.\n\n## References\n- [Ruff error suppression](https://docs.astral.sh/ruff/linter/#error-suppression)\n\n[RUF102]: https://docs.astral.sh/ruff/rules/invalid-rule-code/"
+      },
+      "range": {
+        "start": {
+          "line": 0,
+          "character": 15
+        },
+        "end": {
+          "line": 0,
+          "character": 21
+        }
       }
     }
     "##
@@ -130,6 +140,19 @@ preview = true
         panic!("Expected Markdown hover contents");
     };
     assert!(markup.value.starts_with("# unused-import (F401)"));
+    assert_eq!(
+        result.range,
+        Some(Range {
+            start: Position {
+                line: 0,
+                character: 26,
+            },
+            end: Position {
+                line: 0,
+                character: 39,
+            },
+        })
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR addresses the hover and code action parts of https://github.com/astral-sh/ruff/pull/26058#pullrequestreview-4513157719, as well as adding hover support for `ruff:ignore`-style comments in general, which previously did not support hovering like `noqa` comments.

I went back and forth on whether to split the two commits into two PRs, but they seemed interrelated enough to leave together.

## Test Plan

New e2e tests and manual testing in VS Code:

https://github.com/user-attachments/assets/d568527f-8e6c-482d-8417-13bd8c0d06b0

You'll probably notice a range issue like I did in this video. I fixed that in the third commit but just recorded a short follow up video instead of trying to redo the full video:

<details><summary>Updated range</summary>
<p>


https://github.com/user-attachments/assets/dfe54181-88d8-42a7-842e-855356ceea6b


</p>
</details> 