### PR TITLE
[ty] Construct synthetic getattribute method during protocol member checks

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -2284,6 +2284,64 @@ class ThisFails:
 ThisFails().x
 ```
 
+`__getattribute__` is also checked against assignments to protocols, to make sure all fields are
+compatible. In the following `Person.name` can't be an `int` so this should fail:
+
+```py
+from typing import Protocol
+
+class IntName(Protocol):
+    def __getattribute__(self, name: Any, /) -> int: ...
+
+class Person:
+    name: str
+
+def get_name_as_int(person: IntName) -> int:
+    return person.name
+
+# error: [invalid-argument-type]
+get_name_as_int(Person())
+```
+
+This can be used with literal type arguments to construct the necessary fields names later:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from typing import Protocol, Literal
+
+class HasAttr[A: str, T](Protocol):
+    def __getattribute__(self, attribute: A, /) -> T: ...  # ty: ignore[invalid-method-override]
+
+class IntStrPair:
+    left: int
+    right: str
+
+# This errors, `left` is not an str in IntStrPair
+# error: [invalid-assignment]
+a: HasAttr[Literal["left"], str] = IntStrPair()
+
+# This errors, `other` is not in IntStrPair
+# error: [invalid-assignment]
+b: HasAttr[Literal["other"], str] = IntStrPair()
+
+# This doesn't error, `left` is an int in IntStrPair
+c: HasAttr[Literal["left"], int] = IntStrPair()
+```
+
+This allows you to give a type to `getattr`:
+
+```py
+def my_getattr[A: str, T](object: HasAttr[A, T], attr: A) -> T:
+    return getattr(object, attr)
+
+reveal_type(my_getattr(IntStrPair(), "left"))  # revealed: int
+reveal_type(my_getattr(IntStrPair(), "right"))  # revealed: str
+```
+
 ## Metaclasses with custom `__getattr__` methods
 
 A class is an instance of its metaclass. When attribute lookup on a class fails, Python falls back

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -6,9 +6,12 @@ use itertools::Itertools;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashMap;
 
-use crate::types::callable::CallableTypeKind;
+use crate::place::Provenance::SingleDefinition;
+use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
+use crate::types::list_members::all_members;
 use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
-use crate::types::{TypeContext, UpcastPolicy};
+use crate::types::signatures::CallableSignature;
+use crate::types::{KnownClass, TypeContext, UpcastPolicy};
 use crate::{
     Db, FxOrderSet,
     place::{
@@ -702,12 +705,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // 3. Looking up `__call__` on the meta-type of a class-literal, generic-alias or subclass-of type is
                 //    unfortunately not sufficient to obtain the `Callable` supertypes of these types, due to the
                 //    complex interaction between `__new__`, `__init__` and metaclass `__call__`.
-                let attribute_type = if member.name == "__call__" {
-                    ty
+                let (attribute_type, provenance) = if member.name == "__call__" {
+                    (ty, None)
                 } else {
                     let Place::Defined(DefinedPlace {
                         ty: attribute_type,
                         definedness: Definedness::AlwaysDefined,
+                        provenance: attribute_provenance,
                         ..
                     }) = ty
                         .invoke_descriptor_protocol(
@@ -726,8 +730,28 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         });
                         return self.never();
                     };
-                    attribute_type
+                    (attribute_type, Some(attribute_provenance))
                 };
+
+                // `__getattribute__` checks if the type doesn't define an explicit definition of
+                // it own. If it's just using `object`'s default, instead check if the type's fields
+                // would be valid for the protocol's `__getattribute__`'s name parameter's Literal
+                // values and return types for each signature
+                if member.name == "__getattribute__"
+                    && let Some(SingleDefinition(definition)) = provenance
+                    // If the current definition is the same as object.__getattr__, then this hasn't
+                    // overridden it so can use the check-each-field logic
+                    && let Place::Defined(DefinedPlace {
+                                              provenance: SingleDefinition(obj_definition),
+                                              ..
+                                          }) = KnownClass::Object
+                    .to_instance(db)
+                    .member(db, member.name)
+                    .place
+                    && obj_definition == definition
+                {
+                    return self.type_satisfies_protocol_getattribute(db, *method, ty);
+                }
 
                 // TODO: Instances of `typing.Self` in the protocol member should specialize to the
                 // type that we are checking. Without this, we will treat `Self` as an inferable
@@ -795,6 +819,65 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             });
         }
         result
+    }
+
+    fn type_satisfies_protocol_getattribute(
+        &self,
+        db: &'db dyn Db,
+        method: CallableType<'db>,
+        ty: Type<'db>,
+    ) -> ConstraintSet<'db, 'c> {
+        // `__getattr__` can also be used by `__getattribute__`, so we need to copy the overloads
+        // from these definitions to append to our synthetic getattribute
+        let getattr_signatures = if let Place::Defined(DefinedPlace { ty: getattr_ty, .. }) =
+            ty.member(db, "__getattr__").place
+        {
+            match getattr_ty {
+                Type::FunctionLiteral(func) => Some(func.signature(db)),
+                Type::Callable(callable) => Some(callable.signatures(db)),
+                _ => None,
+            }
+        } else {
+            None
+        }
+        .into_iter()
+        .flat_map(|s| s.overloads.iter().cloned());
+
+        // Construct an overload per field mapping each field to what resultant value is expected
+        let signature = CallableSignature::from_overloads(
+            all_members(db, ty)
+                .into_iter()
+                .map(|m| {
+                    Signature::new(
+                        Parameters::new(
+                            db,
+                            [
+                                Parameter::positional_only(Some(Name::new_static("self")))
+                                    .with_annotated_type(ty),
+                                Parameter::positional_only(Some(Name::new_static("name")))
+                                    .with_annotated_type(Type::string_literal(db, m.name.as_str())),
+                            ],
+                        ),
+                        m.ty,
+                    )
+                })
+                // We add the `__getattr__` overloads at the end since they are a fallback
+                .chain(getattr_signatures),
+        );
+
+        let synthetic_getattr = CallableType::new(
+            db,
+            signature,
+            CallableTypeKind::FunctionLike,
+            CallableFunctionProvenance::ExplicitReturn,
+        );
+        let constraints = self.check_callable_pair(db, synthetic_getattr, method);
+        if constraints.is_never_satisfied(db) {
+            self.provide_context(|| ErrorContext::ProtocolMemberIncompatible {
+                member_name: "__getattribute__".into(),
+            });
+        }
+        constraints
     }
 
     pub(super) fn check_protocol_interface_pair(

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -749,6 +749,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     .member(db, member.name)
                     .place
                     && obj_definition == definition
+                    // Don't run this logic if there's a `__getattr__` fallback. Supporting this would
+                    // require adding the getattr's signatures to the synthetic getattribute, which
+                    // currently makes the syntheticly generated getattrbute subtype check to fail
+                    && let Place::Undefined = ty.member(db, "__getattr__").place
                 {
                     return self.type_satisfies_protocol_getattribute(db, *method, ty);
                 }
@@ -827,43 +831,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         method: CallableType<'db>,
         ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // `__getattr__` can also be used by `__getattribute__`, so we need to copy the overloads
-        // from these definitions to append to our synthetic getattribute
-        let getattr_signatures = if let Place::Defined(DefinedPlace { ty: getattr_ty, .. }) =
-            ty.member(db, "__getattr__").place
-        {
-            match getattr_ty {
-                Type::FunctionLiteral(func) => Some(func.signature(db)),
-                Type::Callable(callable) => Some(callable.signatures(db)),
-                _ => None,
-            }
-        } else {
-            None
-        }
-        .into_iter()
-        .flat_map(|s| s.overloads.iter().cloned());
-
         // Construct an overload per field mapping each field to what resultant value is expected
-        let signature = CallableSignature::from_overloads(
-            all_members(db, ty)
-                .into_iter()
-                .map(|m| {
-                    Signature::new(
-                        Parameters::new(
-                            db,
-                            [
-                                Parameter::positional_only(Some(Name::new_static("self")))
-                                    .with_annotated_type(ty),
-                                Parameter::positional_only(Some(Name::new_static("name")))
-                                    .with_annotated_type(Type::string_literal(db, m.name.as_str())),
-                            ],
-                        ),
-                        m.ty,
-                    )
-                })
-                // We add the `__getattr__` overloads at the end since they are a fallback
-                .chain(getattr_signatures),
-        );
+        let signature =
+            CallableSignature::from_overloads(all_members(db, ty).into_iter().map(|m| {
+                Signature::new(
+                    Parameters::new(
+                        db,
+                        [
+                            Parameter::positional_only(Some(Name::new_static("self")))
+                                .with_annotated_type(ty),
+                            Parameter::positional_only(Some(Name::new_static("name")))
+                                .with_annotated_type(Type::string_literal(db, m.name.as_str())),
+                        ],
+                    ),
+                    m.ty,
+                )
+            }));
 
         let synthetic_getattr = CallableType::new(
             db,


### PR DESCRIPTION
## Summary

As a fix for astral-sh/ty#3786, when checking protocol members, if the member to check is `__getattribute__`, and the prospective subclass's `__getattribute__` is still `object`'s default implementation, this constructs a synthetic `__getattribute__` from the class's members to see if they would be compatible with the `__getattribute__`. This is to close the somewhat niche unsoundness of code like this:

```py
from typing import Protocol

class IntName(Protocol):
    def __getattribute__(self, name: str, /) -> int: ...

class Person:
    name: str

def get_name_as_int(person: IntName) -> int:
    return person.name

get_name_as_int(Person())  # would expect invalid argument type diagnostic, since person.name can't be an int
```

This doesn't change the logic if a user has defined a custom `__getattribute__`, nor does it change the type of `__getattribute__` itself. Instead, this change is limited to protocol satisfiability checking to reduce the impact of it to just closing this particular problem and reduce causing other issues.

This is my first contribution to ty so I'd really appreciate any feedback on if there are cleaner ways to implement any part of this, and would also appreciate any feedback on concerns with this approach, solution, or problem.

---

Additionally, this naturally allows for using `Literal` types as the getattribute name parameter type, allowing for structurally decomposing types into field/type combinations, allowing for typing of `getattr`-like functions:

```py
from typing import Protocol, Literal

class HasAttr[A: str, T](Protocol):
    def __getattribute__(self, attribute: A, /) -> T: ...  # ty: ignore[invalid-method-override]

class IntStrPair:
    left: int
    right: str

def my_getattr[A: str, T](object: HasAttr[A, T], attr: A) -> T:
    return getattr(object, attr)

reveal_type(my_getattr(IntStrPair(), "left"))  # revealed: int
reveal_type(my_getattr(IntStrPair(), "right"))  # revealed: str
```

## Test Plan

I've tested it against some sample code, and added some examples to `mdtest/attributes.md` alongside the other Protocol tests that check that `x: MyProtocol; x.my_attr` uses `__getattribute__` if the protocol defines it, which is closely related.