### PR TITLE
[ty] Preserve exact class objects during identity narrowing

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -416,10 +416,10 @@ reveal_type(Derived.f(1))  # revealed: str
 reveal_type(Derived().f(1))  # revealed: str
 ```
 
-### Implicit receivers in final classes
+### Implicit receivers in generic final classes
 
-For a final class, an implicit `type[Self]` receiver is compatible with the exact class object. For
-a generic final class, that exact class object is a generic alias:
+For a generic final class, an implicit `type[Self]` receiver is compatible with the exact generic
+class object:
 
 ```toml
 [environment]
@@ -427,24 +427,13 @@ python-version = "3.12"
 ```
 
 ```py
-from __future__ import annotations
-
 from typing import final
 from ty_extensions import TypeOf
 
 @final
-class Final:
-    @classmethod
-    def call_method(cls) -> None:
-        cls.method()
-
-    @classmethod
-    def method(cls) -> None: ...
-
-@final
 class GenericFinal[T]:
     @classmethod
-    def class_object(cls) -> TypeOf[GenericFinal[T]]:
+    def class_object(cls) -> "TypeOf[GenericFinal[T]]":
         return cls
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -418,17 +418,36 @@ reveal_type(Derived().f(1))  # revealed: str
 
 ### Implicit receivers in final classes
 
-For a final class, an implicit `type[Self]` receiver refers to the exact class object and can bind
-to another classmethod on that class:
+For a final class, including a generic final class, an implicit `type[Self]` receiver refers to the
+exact class object and can bind to another classmethod on that class:
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 from typing import final
+from ty_extensions import TypeOf
 
 @final
 class Final:
     @classmethod
     def call_from_classmethod(cls) -> None:
         cls.method()
+
+    def call_from_instance(self) -> None:
+        self.method()
+
+    @classmethod
+    def method(cls) -> None: ...
+
+@final
+class GenericFinal[T]:
+    @classmethod
+    def call_from_classmethod(cls) -> None:
+        cls.method()
+        exact: TypeOf[GenericFinal[T]] = cls
 
     def call_from_instance(self) -> None:
         self.method()

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -416,6 +416,27 @@ reveal_type(Derived.f(1))  # revealed: str
 reveal_type(Derived().f(1))  # revealed: str
 ```
 
+### Implicit receivers in final classes
+
+For a final class, an implicit `type[Self]` receiver refers to the exact class object and can bind
+to another classmethod on that class:
+
+```py
+from typing import final
+
+@final
+class Final:
+    @classmethod
+    def call_from_classmethod(cls) -> None:
+        cls.method()
+
+    def call_from_instance(self) -> None:
+        self.method()
+
+    @classmethod
+    def method(cls) -> None: ...
+```
+
 ### Accessing the classmethod as a static member
 
 Accessing a `@classmethod`-decorated function at runtime returns a `classmethod` object. We

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -418,8 +418,8 @@ reveal_type(Derived().f(1))  # revealed: str
 
 ### Implicit receivers in final classes
 
-For a final class, including a generic final class, an implicit `type[Self]` receiver refers to the
-exact class object and can bind to another classmethod on that class:
+For a final class, an implicit `type[Self]` receiver is compatible with the exact class object. For
+a generic final class, that exact class object is a generic alias:
 
 ```toml
 [environment]
@@ -427,17 +427,16 @@ python-version = "3.12"
 ```
 
 ```py
+from __future__ import annotations
+
 from typing import final
 from ty_extensions import TypeOf
 
 @final
 class Final:
     @classmethod
-    def call_from_classmethod(cls) -> None:
+    def call_method(cls) -> None:
         cls.method()
-
-    def call_from_instance(self) -> None:
-        self.method()
 
     @classmethod
     def method(cls) -> None: ...
@@ -445,15 +444,8 @@ class Final:
 @final
 class GenericFinal[T]:
     @classmethod
-    def call_from_classmethod(cls) -> None:
-        cls.method()
-        exact: TypeOf[GenericFinal[T]] = cls
-
-    def call_from_instance(self) -> None:
-        self.method()
-
-    @classmethod
-    def method(cls) -> None: ...
+    def class_object(cls) -> TypeOf[GenericFinal[T]]:
+        return cls
 ```
 
 ### Accessing the classmethod as a static member

--- a/crates/ty_python_semantic/resources/mdtest/call/methods.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/methods.md
@@ -418,8 +418,8 @@ reveal_type(Derived().f(1))  # revealed: str
 
 ### Implicit receivers in generic final classes
 
-For a generic final class, an implicit `type[Self]` receiver is compatible with the exact generic
-class object:
+For a generic final class, an implicit `type[Self]` receiver can bind to another classmethod on the
+exact generic class object:
 
 ```toml
 [environment]
@@ -428,13 +428,15 @@ python-version = "3.12"
 
 ```py
 from typing import final
-from ty_extensions import TypeOf
 
 @final
 class GenericFinal[T]:
     @classmethod
-    def class_object(cls) -> "TypeOf[GenericFinal[T]]":
-        return cls
+    def call_method(cls) -> None:
+        cls.method()
+
+    @classmethod
+    def method(cls) -> None: ...
 ```
 
 ### Accessing the classmethod as a static member

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -137,6 +137,37 @@ def _(a: Literal[1], b: Literal[1, 2], c: Literal[1, 2, 3]):
         reveal_type(c)  # revealed: Literal[1]
 ```
 
+When a generic class object is compared with an exact class object, the exact class object is not
+widened to the generic type. The intersection is retained because it preserves the relationship
+between the class object and `T`:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Y:
+    def __init__(self) -> None: ...
+
+class Z(Y):
+    def __init__(self, x: int) -> None: ...
+
+def narrow[T: (Y, Z)](klass: type[T]) -> None:
+    if klass is Y:
+        reveal_type(klass)  # revealed: type[T@narrow] & <class 'Y'>
+        reveal_type(Y)  # revealed: <class 'Y'> & type[T@narrow]
+
+    if klass is Z:
+        reveal_type(klass)  # revealed: <class 'Z'>
+        reveal_type(Z)  # revealed: <class 'Z'>
+
+def construct[T: (Y, Z)](klass: type[T]) -> T:
+    if klass is Y:
+        return Y()
+    raise AssertionError
+```
+
 ## `is` where the other operand is a call expression
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -166,6 +166,14 @@ def construct[T: (Y, Z)](klass: type[T]) -> T:
     if klass is Y:
         return Y()
     raise AssertionError
+
+class Generic[T]: ...
+class Specialized(Generic[int]): ...
+
+def narrow_generic_alias[T: (Generic[int], Specialized)](klass: type[T]) -> None:
+    if klass is Generic[int]:
+        reveal_type(klass)  # revealed: type[T@narrow_generic_alias] & <class 'Generic[int]'>
+        reveal_type(Generic[int])  # revealed: <class 'Generic[int]'>
 ```
 
 ## `is` where the other operand is a call expression

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -284,19 +284,26 @@ def _[T: (int | str, int)](_: T):
     static_assert(not is_disjoint_from(type[int], type[T]))
 ```
 
-## Final upper bounds
+## Type aliases in final upper bounds
 
-A type variable with a final upper bound has only one possible class object:
+A type variable whose upper bound resolves to a final class has only one possible class object:
+
+```toml
+[environment]
+python-version = "3.12"
+```
 
 ```py
 from typing import final
 from ty_extensions import TypeOf
 
 @final
-class Final: ...
+class FinalClass: ...
 
-def accepts_exact(cls: TypeOf[Final]) -> None: ...
-def bounded[T: Final](cls: type[T]) -> None:
+type Alias = FinalClass
+
+def accepts_exact(cls: TypeOf[FinalClass]) -> None: ...
+def bounded[T: Alias](cls: type[T]) -> None:
     accepts_exact(cls)
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -284,6 +284,22 @@ def _[T: (int | str, int)](_: T):
     static_assert(not is_disjoint_from(type[int], type[T]))
 ```
 
+## Final upper bounds
+
+A type variable with a final upper bound has only one possible class object:
+
+```py
+from typing import final
+from ty_extensions import TypeOf
+
+@final
+class Final: ...
+
+def accepts_exact(cls: TypeOf[Final]) -> None: ...
+def bounded[T: Final](cls: type[T]) -> None:
+    accepts_exact(cls)
+```
+
 ## Metaclass instances
 
 ```py

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -957,25 +957,23 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// `Y`, doing so would incorrectly simplify `type[T] & <class 'Y'>` to `type[T]`: both `Y` and
     /// `Z` instances are subtypes of `Y`, but only the class object `Y` satisfies `klass is Y`.
     ///
-    /// The exception is `type[Self]` for a final class. In that case, the class cannot be
-    /// subclassed, so its exact class object is the only possible specialization of `Self`.
+    /// The exception is a type variable whose upper bound normalizes to this exact class object.
+    /// That can only happen for a final class, so the exact object is the only valid
+    /// specialization of the type variable.
     fn can_check_typevar_subclass_relation_to_target(
         db: &'db dyn Db,
         source_subclass: SubclassOfType<'db>,
         target: Type<'db>,
     ) -> bool {
-        let is_final_self_class_object = matches!(target, Type::ClassLiteral(_))
-            && source_subclass.into_type_var().is_some_and(|source_i| {
-                let source_typevar = source_i.typevar(db);
-                source_typevar.is_self(db)
-                    && source_typevar
-                        .upper_bound(db)
-                        .and_then(|bound| SubclassOfType::try_from_instance(db, bound))
-                        == Some(target)
-            });
+        let is_exact_upper_bound = source_subclass.into_type_var().is_some_and(|source_i| {
+            source_i
+                .typevar(db)
+                .upper_bound(db)
+                .and_then(|bound| SubclassOfType::try_from_instance(db, bound))
+                == Some(target)
+        });
 
-        (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_))
-            || is_final_self_class_object)
+        (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_)) || is_exact_upper_bound)
             && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())
     }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -966,11 +966,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         target: Type<'db>,
     ) -> bool {
         let is_exact_upper_bound = source_subclass.into_type_var().is_some_and(|source_i| {
-            source_i
-                .typevar(db)
-                .upper_bound(db)
-                .and_then(|bound| SubclassOfType::try_from_instance(db, bound))
-                == Some(target)
+            source_i.typevar(db).upper_bound(db).and_then(|bound| {
+                SubclassOfType::try_from_instance(db, bound.resolve_type_alias(db))
+            }) == Some(target)
         });
 
         (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_)) || is_exact_upper_bound)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -953,9 +953,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// must pass `is_metaclass_instance`) or the regular instance domain (it must have Some
     /// `.to_instance()`)?
     ///
-    /// An exact class object cannot be projected into the instance domain for this check. Doing so
-    /// would incorrectly treat `type[T]` as a subtype of that single class object merely because
-    /// every possible specialization of `T` is a subtype of an instance of that class.
+    /// Do not use instance subtyping for an exact class object. For `T: (Y, Z)` where `Z` extends
+    /// `Y`, doing so would incorrectly simplify `type[T] & <class 'Y'>` to `type[T]`: both `Y` and
+    /// `Z` instances are subtypes of `Y`, but only the class object `Y` satisfies `klass is Y`.
     fn can_check_typevar_subclass_relation_to_target(db: &'db dyn Db, target: Type<'db>) -> bool {
         !matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_))
             && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -956,8 +956,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// Do not use instance subtyping for an exact class object. For `T: (Y, Z)` where `Z` extends
     /// `Y`, doing so would incorrectly simplify `type[T] & <class 'Y'>` to `type[T]`: both `Y` and
     /// `Z` instances are subtypes of `Y`, but only the class object `Y` satisfies `klass is Y`.
-    fn can_check_typevar_subclass_relation_to_target(db: &'db dyn Db, target: Type<'db>) -> bool {
-        !matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_))
+    ///
+    /// The exception is `type[Self]` for a final class. In that case, the class cannot be
+    /// subclassed, so its exact class object is the only possible specialization of `Self`.
+    fn can_check_typevar_subclass_relation_to_target(
+        db: &'db dyn Db,
+        source_subclass: SubclassOfType<'db>,
+        target: Type<'db>,
+    ) -> bool {
+        let is_final_self_class_object = matches!(target, Type::ClassLiteral(_))
+            && source_subclass.into_type_var().is_some_and(|source_i| {
+                let source_typevar = source_i.typevar(db);
+                source_typevar.is_self(db)
+                    && source_typevar
+                        .upper_bound(db)
+                        .and_then(|bound| SubclassOfType::try_from_instance(db, bound))
+                        == Some(target)
+            });
+
+        (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_))
+            || is_final_self_class_object)
             && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())
     }
 
@@ -1343,7 +1361,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // precise representation for "all instances of any classes with a given metaclass").
             (Type::SubclassOf(subclass_of), _)
                 if subclass_of.is_type_var()
-                    && Self::can_check_typevar_subclass_relation_to_target(db, target) =>
+                    && Self::can_check_typevar_subclass_relation_to_target(
+                        db,
+                        subclass_of,
+                        target,
+                    ) =>
             {
                 self.check_typevar_subclass_relation_to_target(db, subclass_of, target)
             }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -952,8 +952,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// Can we check `target`s relation to a `type[T]` in either the metaclass-instance domain (it
     /// must pass `is_metaclass_instance`) or the regular instance domain (it must have Some
     /// `.to_instance()`)?
+    ///
+    /// An exact class object cannot be projected into the instance domain for this check. Doing so
+    /// would incorrectly treat `type[T]` as a subtype of that single class object merely because
+    /// every possible specialization of `T` is a subtype of an instance of that class.
     fn can_check_typevar_subclass_relation_to_target(db: &'db dyn Db, target: Type<'db>) -> bool {
-        Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some()
+        !matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_))
+            && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())
     }
 
     /// Check the relation between a `type[T]` and a target type `A` when `A` can either be
@@ -972,9 +977,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// the metaclass of the upper bound of `T`, and compare in the metaclass-instance domain
     /// directly.
     ///
-    /// If `A` has no `.to_instance()` projection and is not a metaclass instance type, it won't
-    /// pass the `can_check_typevar_subclass_relation_to_target` guard, and this helper does not
-    /// decide the relation; it will fall through to other type-pair branches.
+    /// Exact class objects, and types that have no `.to_instance()` projection and are not
+    /// metaclass instances, do not pass the `can_check_typevar_subclass_relation_to_target` guard.
+    /// This helper does not decide their relation; they fall through to other type-pair branches.
     fn check_typevar_subclass_relation_to_target(
         &self,
         db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Prior to this change, when narrowing `klass is Y` for `T: (Y, Z)`, where `Z` extends `Y`, we incorrectly simplified `type[T] & <class 'Y'>` to `type[T]`.

Both `Y` and `Z` instances are subtypes of `Y`, but only the class object `Y` satisfies `klass is Y`. Using instance subtyping for the exact class object discarded that information, causing `Y` itself to widen to `type[T]` and `Y()` to be checked against `Z`'s constructor. We now exclude exact class literals and specialized generic aliases from that check.

We still retain this behavior when a type variable’s upper bound normalizes to the exact target class object. This can only happen for a final class, so that class object is the type variable’s only possible specialization. (This removed ~10 ecosystem false-positives.)

Closes https://github.com/astral-sh/ty/issues/3074.
