### PR TITLE
[ty] Avoid simplifying unions with type variables

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -171,6 +171,8 @@ def _(x: Union[int]):
 If the type variable has an upper bound, the specialized type must satisfy that bound:
 
 ```py
+from typing import Any
+
 type Bounded[T: int] = list[T]
 type BoundedByUnion[T: int | str] = list[T]
 
@@ -189,6 +191,15 @@ reveal_type(BoundedByUnion[int])  # revealed: <type alias 'BoundedByUnion[int]'>
 reveal_type(BoundedByUnion[IntSubclass])  # revealed: <type alias 'BoundedByUnion[IntSubclass]'>
 reveal_type(BoundedByUnion[str])  # revealed: <type alias 'BoundedByUnion[str]'>
 reveal_type(BoundedByUnion[int | str])  # revealed: <type alias 'BoundedByUnion[int | str]'>
+
+# A type variable can be explicitly specialized to a dynamic type, so it must not be simplified
+# out of a union with its bound. All types, including dynamic types, are still subtypes of object.
+type IntOr[T: int] = int | T
+type ObjectOr[T: int] = object | T
+
+def _(int_or: IntOr[Any], object_or: ObjectOr[Any]):
+    reveal_type(int_or)  # revealed: int | Any
+    reveal_type(object_or)  # revealed: object
 
 type TupleOfIntAndStr[T: int, U: str] = tuple[T, U]
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -672,17 +672,16 @@ def unbounded_unconstrained[T](t: T) -> None:
         reveal_type(x)  # revealed: T@unbounded_unconstrained | Any
 ```
 
-The union of a bounded typevar with its bound is that bound. (The typevar is guaranteed to be
-specialized to a subtype of the bound.) The union of a bounded typevar with a subtype of its bound
-cannot be simplified. (The typevar might be specialized to a different subtype of the bound.)
+The union of a bounded typevar with another type cannot be simplified based on its bound. The
+typevar might be explicitly specialized to a dynamic type.
 
 ```py
 def bounded[T: Base](t: T) -> None:
     def _(x: T | Super) -> None:
-        reveal_type(x)  # revealed: Super
+        reveal_type(x)  # revealed: T@bounded | Super
 
     def _(x: T | Base) -> None:
-        reveal_type(x)  # revealed: Base
+        reveal_type(x)  # revealed: T@bounded | Base
 
     def _(x: T | Sub) -> None:
         reveal_type(x)  # revealed: T@bounded | Sub
@@ -694,21 +693,19 @@ def bounded[T: Base](t: T) -> None:
         reveal_type(x)  # revealed: T@bounded | Any
 ```
 
-The union of a constrained typevar with a type depends on how that type relates to the constraints.
-If all of the constraints are a subtype of that type, the union simplifies to that type. Inversely,
-if the type is a subtype of every constraint, the union simplifies to the typevar. Otherwise, the
-union cannot be simplified.
+The union of a constrained typevar with another type cannot be simplified based on its constraints.
+The typevar might be explicitly specialized to a dynamic type.
 
 ```py
 def constrained[T: (Base, Sub)](t: T) -> None:
     def _(x: T | Super) -> None:
-        reveal_type(x)  # revealed: Super
+        reveal_type(x)  # revealed: T@constrained | Super
 
     def _(x: T | Base) -> None:
-        reveal_type(x)  # revealed: Base
+        reveal_type(x)  # revealed: T@constrained | Base
 
     def _(x: T | Sub) -> None:
-        reveal_type(x)  # revealed: T@constrained
+        reveal_type(x)  # revealed: T@constrained | Sub
 
     def _(x: T | Unrelated) -> None:
         reveal_type(x)  # revealed: T@constrained | Unrelated
@@ -748,19 +745,17 @@ def unbounded_unconstrained[T](t: T) -> None:
         reveal_type(x)  # revealed: T@unbounded_unconstrained & Any
 ```
 
-The intersection of a bounded typevar with its bound or a supertype of its bound is the typevar
-itself. (The typevar might be specialized to a subtype of the bound.) The intersection of a bounded
-typevar with a subtype of its bound cannot be simplified. (The typevar might be specialized to a
-different subtype of the bound.) The intersection of a bounded typevar with a type that is disjoint
+The intersection of a bounded typevar with another type cannot be simplified based on subtyping
+relationships with its bound. The intersection of a bounded typevar with a type that is disjoint
 from its bound is `Never`.
 
 ```py
 def bounded[T: Base](t: T) -> None:
     def _(x: Intersection[T, Super]) -> None:
-        reveal_type(x)  # revealed: T@bounded
+        reveal_type(x)  # revealed: T@bounded & Super
 
     def _(x: Intersection[T, Base]) -> None:
-        reveal_type(x)  # revealed: T@bounded
+        reveal_type(x)  # revealed: T@bounded & Base
 
     def _(x: Intersection[T, Sub]) -> None:
         reveal_type(x)  # revealed: T@bounded & Sub

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -649,6 +649,7 @@ there is no guarantee what type the typevar will be specialized to.
 
 ```py
 from typing import Any
+from ty_extensions import is_equivalent_to, is_subtype_of, static_assert
 
 class Super: ...
 class Base(Super): ...
@@ -691,6 +692,10 @@ def bounded[T: Base](t: T) -> None:
 
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@bounded | Any
+
+    static_assert(is_subtype_of(T | Base, Base))
+    static_assert(is_subtype_of(Base, T | Base))
+    static_assert(is_equivalent_to(T | Base, Base))
 ```
 
 The union of a constrained typevar with another type cannot be simplified based on its constraints.
@@ -712,6 +717,10 @@ def constrained[T: (Base, Sub)](t: T) -> None:
 
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@constrained | Any
+
+    static_assert(is_subtype_of(T | Sub, T))
+    static_assert(is_subtype_of(T, T | Sub))
+    static_assert(is_equivalent_to(T | Sub, T))
 ```
 
 ## Intersections involving typevars

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -194,8 +194,9 @@ mapping_segments = {**get_segments_by_name(), "start": (1, 2), "end": (3, 4, 5)}
 reveal_type(mapping_segments)  # revealed: dict[str, tuple[int, int] | tuple[int, int, int]]
 ```
 
-This also applies when the non-literal tuple type is hidden behind a type alias or a type variable,
-or when it is subsumed by one of the literal tuple types while building the union.
+This also applies when the non-literal tuple type is hidden behind a type alias or `NewType`, or
+when it is subsumed by one of the literal tuple types while building the union. Type variables
+remain in the union because they can be explicitly specialized to a dynamic type.
 
 ```toml
 [environment]
@@ -230,7 +231,8 @@ reveal_type(newtype_segments)  # revealed: list[tuple[int, int] | tuple[int, int
 
 def check_bound_typevar_segment(segment: BoundSegment) -> None:
     bound_typevar_segments = [segment, (1, 2), (3, 4, 5)]
-    reveal_type(bound_typevar_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
+    # revealed: list[BoundSegment@check_bound_typevar_segment | tuple[int, int] | tuple[int, int, int]]
+    reveal_type(bound_typevar_segments)
 
 def check_constrained_typevar_segment(segment: ConstrainedSegment) -> None:
     constrained_typevar_segments = [segment, (1, 2), (3, 4, 5)]

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -103,7 +103,7 @@ def _[T: int](x: type | type[T]):
     reveal_type(x())  # revealed: Any
 
 def _[T: int](x: type[int] | type[T]):
-    reveal_type(x())  # revealed: int
+    reveal_type(x())  # revealed: int | T@_
 
 def _[T](x: type[int] | type[T]):
     reveal_type(x())  # revealed: int | T@_
@@ -123,10 +123,10 @@ def narrow_a[B: A](a: A, b: B):
     reveal_type(type_of_a)  # revealed: type[A]
 
     if isinstance(a, type(b)):
-        reveal_type(a)  # revealed: B@narrow_a
+        reveal_type(a)  # revealed: A & B@narrow_a
 
     if issubclass(type_of_a, type(b)):
-        reveal_type(type_of_a)  # revealed: type[B@narrow_a]
+        reveal_type(type_of_a)  # revealed: type[A] & type[B@narrow_a]
 ```
 
 Narrowing through `type[T]` or `Type[T]` should preserve the type variable identity, so the narrowed

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1294,13 +1294,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 },
             ),
 
-            // In general, a TypeVar `T` is not redundant with a type `S` unless one of the two conditions is satisfied:
-            // 1. `T` is a bound TypeVar and `T`'s upper bound is a subtype of `S`.
-            //    TypeVars without an explicit upper bound are treated as having an implicit upper bound of `object`.
-            // 2. `T` is a constrained TypeVar and all of `T`'s constraints are subtypes of `S`.
-            //
-            // However, there is one exception to this general rule: for any given typevar `T`,
-            // `T` will always be a subtype of any union containing `T`.
+            // A typevar can be explicitly specialized to a dynamic type, regardless of its bound
+            // or constraints. It is therefore not generally redundant with its bound or the union
+            // of its constraints. However, a typevar `T` is always redundant with a union that
+            // already contains `T`.
             (_, Type::Union(union))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
@@ -1380,11 +1377,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // A fully static typevar is a subtype of its upper bound, and to something similar to
-            // the union of its constraints. An unbound, unconstrained, fully static typevar has an
-            // implicit upper bound of `object` (which is handled above).
+            // Except for redundancy, a fully static typevar is a subtype of its upper bound, and
+            // to something similar to the union of its constraints. An unbound, unconstrained,
+            // fully static typevar has an implicit upper bound of `object` (which is handled
+            // above).
             (Type::TypeVar(bound_typevar), _)
-                if !bound_typevar.is_inferable(db, self.inferable)
+                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                    && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
@@ -1406,7 +1405,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
             (_, Type::TypeVar(bound_typevar))
-                if !bound_typevar.is_inferable(db, self.inferable)
+                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                    && !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)
                         .constraints(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1296,8 +1296,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // A typevar can be explicitly specialized to a dynamic type, regardless of its bound
             // or constraints. It is therefore not generally redundant with its bound or the union
-            // of its constraints. However, a typevar `T` is always redundant with a union that
-            // already contains `T`.
+            // of its constraints when simplifying unions and intersections. However, a typevar `T`
+            // is always redundant with a union that already contains `T`.
             (_, Type::Union(union))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
@@ -1377,12 +1377,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // Except for redundancy, a fully static typevar is a subtype of its upper bound, and
-            // to something similar to the union of its constraints. An unbound, unconstrained,
-            // fully static typevar has an implicit upper bound of `object` (which is handled
-            // above).
+            // Except for impure redundancy used to simplify unions and intersections, a fully
+            // static typevar is a subtype of its upper bound, and to something similar to the union
+            // of its constraints. An unbound, unconstrained, fully static typevar has an implicit
+            // upper bound of `object` (which is handled above).
             (Type::TypeVar(bound_typevar), _)
-                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1405,7 +1405,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
             (_, Type::TypeVar(bound_typevar))
-                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)


### PR DESCRIPTION
## Summary

We currently use a TypeVar's bound or constraints when removing redundant union arms. This is safe for fully static specializations, but a TypeVar can be explicitly specialized to a dynamic type:

```python
from typing import Any

type IntOr[T: int] = int | T

def f(value: IntOr[Any]) -> None:
    reveal_type(value)  # int | Any
```

Previously, we simplified `int | T` to `int` before specialization, so `IntOr[Any]` incorrectly revealed `int`.

This skips bound- and constraint-based shortcuts only for impure redundancy used by union and intersection builders. Pure redundancy continues to follow ordinary subtyping, preserving equivalence and antisymmetry, while `object` unions retain their existing simplification.

Closes https://github.com/astral-sh/ty/issues/1666.
