### PR TITLE
[ty] Treat TypeVar bounds as assignability constraints

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -9,6 +9,25 @@ python-version = "3.13"
 
 `typing.Self` is only available in Python 3.11 and later.
 
+## Upper-bound relations
+
+Unlike an ordinary type variable, `Self` cannot be explicitly specialized to a dynamic type, so it
+retains subtype and redundancy relationships with its upper bound:
+
+```py
+from typing import Self
+from ty_extensions import is_subtype_of, static_assert
+
+class Base: ...
+
+class Child(Base):
+    def method(self) -> None:
+        static_assert(is_subtype_of(Self, Base))
+
+        def _(value: Self | Base) -> None:
+            reveal_type(value)  # revealed: Base
+```
+
 ## Methods
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -527,7 +527,7 @@ def f[T: bool](x: T) -> T:
             return x
         case _:
             reveal_type(x)  # revealed: T@f & ~Literal[True] & ~Literal[False]
-            assert_never(x)
+            assert_never(x)  # error: [type-assertion-failure]
 
 def g[T: Literal["foo", "bar"]](x: T) -> T:
     match x:
@@ -537,7 +537,7 @@ def g[T: Literal["foo", "bar"]](x: T) -> T:
             return x
         case _:
             reveal_type(x)  # revealed: T@g & ~Literal["foo"] & ~Literal["bar"]
-            assert_never(x)
+            assert_never(x)  # error: [type-assertion-failure]
 
 def h[T: int | str](x: T) -> T:
     if isinstance(x, int):
@@ -555,7 +555,7 @@ def i[T: (int, str)](x: T) -> T:
         case str():
             pass
         case _:
-            assert_never(x)
+            assert_never(x)  # error: [type-assertion-failure]
 
     return x
 
@@ -566,7 +566,7 @@ def eq_narrow_match_constrained[T: (Literal["foo"], Literal["bar"])](x: T) -> T:
         case "bar":
             pass
         case _:
-            assert_never(x)
+            assert_never(x)  # error: [type-assertion-failure]
 
     return x
 
@@ -576,7 +576,7 @@ def eq_narrow_if_bounded[T: Literal["foo", "bar"]](x: T) -> T:
     elif x == "bar":
         pass
     else:
-        assert_never(x)
+        assert_never(x)  # error: [type-assertion-failure]
 
     return x
 
@@ -586,15 +586,16 @@ def eq_narrow_if_constrained[T: (Literal["foo"], Literal["bar"])](x: T) -> T:
     elif x == "bar":
         pass
     else:
-        assert_never(x)
+        assert_never(x)  # error: [type-assertion-failure]
 
     return x
 ```
 
-In these examples, no `invalid-return-type` diagnostics are emitted, despite the fact there are no
-`else` clauses. Note that these examples deliberately also do *not* have any `assert_never` or
+Some of these examples are exhaustive despite having no `else` clause. The match and equality
+examples that rely on a typevar's bound or constraints are not exhaustive because of possible
+dynamic specializations. These examples deliberately do *not* have any `assert_never` or
 `assert_type` calls, since these call expressions can create their own `IsNonTerminalCall`
-predicates in our reachability infrastructure!
+predicates in our reachability infrastructure.
 
 ```py
 class A: ...
@@ -618,21 +619,21 @@ def l[T](x: T) -> bool:
     elif not isinstance(x, int):
         return False
 
-def m[T: A | B](x: T) -> bool:
+def m[T: A | B](x: T) -> bool:  # error: [invalid-return-type]
     match x:
         case A():
             return True
         case B():
             return False
 
-def n[T: (A, B)](x: T) -> bool:
+def n[T: (A, B)](x: T) -> bool:  # error: [invalid-return-type]
     match x:
         case A():
             return True
         case B():
             return False
 
-def o[T: Literal["foo", "bar"]](x: T) -> bool:
+def o[T: Literal["foo", "bar"]](x: T) -> bool:  # error: [invalid-return-type]
     if x == "foo":
         return True
     elif x == "bar":
@@ -645,7 +646,7 @@ def p[T: Literal["foo", "bar"]](x: T) -> bool:  # error: [invalid-return-type]
         case "bar":
             return False
 
-def q[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:
+def q[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:  # error: [invalid-return-type]
     if x == "foo":
         return True
     elif x == "bar":

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -512,6 +512,10 @@ class Answer(Enum):
 python-version = "3.12"
 ```
 
+A type variable can be specialized to a dynamic type regardless of its bound or constraints, so
+eliminating every inhabitant of the declared bound or constraints does not necessarily make the
+remaining branch unreachable.
+
 ```py
 from typing import assert_never, Literal
 
@@ -522,7 +526,7 @@ def f[T: bool](x: T) -> T:
         case False:
             return x
         case _:
-            reveal_type(x)  # revealed: Never
+            reveal_type(x)  # revealed: T@f & ~Literal[True] & ~Literal[False]
             assert_never(x)
 
 def g[T: Literal["foo", "bar"]](x: T) -> T:
@@ -532,7 +536,7 @@ def g[T: Literal["foo", "bar"]](x: T) -> T:
         case "bar":
             return x
         case _:
-            reveal_type(x)  # revealed: Never
+            reveal_type(x)  # revealed: T@g & ~Literal["foo"] & ~Literal["bar"]
             assert_never(x)
 
 def h[T: int | str](x: T) -> T:
@@ -634,7 +638,7 @@ def o[T: Literal["foo", "bar"]](x: T) -> bool:
     elif x == "bar":
         return False
 
-def p[T: Literal["foo", "bar"]](x: T) -> bool:
+def p[T: Literal["foo", "bar"]](x: T) -> bool:  # error: [invalid-return-type]
     match x:
         case "foo":
             return True
@@ -647,7 +651,7 @@ def q[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:
     elif x == "bar":
         return False
 
-def r[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:
+def r[T: (Literal["foo"], Literal["bar"])](x: T) -> bool:  # error: [invalid-return-type]
     match x:
         case "foo":
             return True

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -171,6 +171,8 @@ def _(x: Union[int]):
 If the type variable has an upper bound, the specialized type must satisfy that bound:
 
 ```py
+from typing import Any
+
 type Bounded[T: int] = list[T]
 type BoundedByUnion[T: int | str] = list[T]
 
@@ -189,6 +191,15 @@ reveal_type(BoundedByUnion[int])  # revealed: <type alias 'BoundedByUnion[int]'>
 reveal_type(BoundedByUnion[IntSubclass])  # revealed: <type alias 'BoundedByUnion[IntSubclass]'>
 reveal_type(BoundedByUnion[str])  # revealed: <type alias 'BoundedByUnion[str]'>
 reveal_type(BoundedByUnion[int | str])  # revealed: <type alias 'BoundedByUnion[int | str]'>
+
+# A type variable can be explicitly specialized to a dynamic type, so it must not be simplified
+# out of a union with its bound. All types, including dynamic types, are still subtypes of object.
+type IntOr[T: int] = int | T
+type ObjectOr[T: int] = object | T
+
+def _(int_or: IntOr[Any], object_or: ObjectOr[Any]):
+    reveal_type(int_or)  # revealed: int | Any
+    reveal_type(object_or)  # revealed: object
 
 type TupleOfIntAndStr[T: int, U: str] = tuple[T, U]
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -672,17 +672,16 @@ def unbounded_unconstrained[T](t: T) -> None:
         reveal_type(x)  # revealed: T@unbounded_unconstrained | Any
 ```
 
-The union of a bounded typevar with its bound is that bound. (The typevar is guaranteed to be
-specialized to a subtype of the bound.) The union of a bounded typevar with a subtype of its bound
-cannot be simplified. (The typevar might be specialized to a different subtype of the bound.)
+The union of a bounded typevar with another type cannot be simplified based on its bound. The
+typevar might be explicitly specialized to a dynamic type.
 
 ```py
 def bounded[T: Base](t: T) -> None:
     def _(x: T | Super) -> None:
-        reveal_type(x)  # revealed: Super
+        reveal_type(x)  # revealed: T@bounded | Super
 
     def _(x: T | Base) -> None:
-        reveal_type(x)  # revealed: Base
+        reveal_type(x)  # revealed: T@bounded | Base
 
     def _(x: T | Sub) -> None:
         reveal_type(x)  # revealed: T@bounded | Sub
@@ -694,21 +693,19 @@ def bounded[T: Base](t: T) -> None:
         reveal_type(x)  # revealed: T@bounded | Any
 ```
 
-The union of a constrained typevar with a type depends on how that type relates to the constraints.
-If all of the constraints are a subtype of that type, the union simplifies to that type. Inversely,
-if the type is a subtype of every constraint, the union simplifies to the typevar. Otherwise, the
-union cannot be simplified.
+The union of a constrained typevar with another type cannot be simplified based on its constraints.
+The typevar might be explicitly specialized to a dynamic type.
 
 ```py
 def constrained[T: (Base, Sub)](t: T) -> None:
     def _(x: T | Super) -> None:
-        reveal_type(x)  # revealed: Super
+        reveal_type(x)  # revealed: T@constrained | Super
 
     def _(x: T | Base) -> None:
-        reveal_type(x)  # revealed: Base
+        reveal_type(x)  # revealed: T@constrained | Base
 
     def _(x: T | Sub) -> None:
-        reveal_type(x)  # revealed: T@constrained
+        reveal_type(x)  # revealed: T@constrained | Sub
 
     def _(x: T | Unrelated) -> None:
         reveal_type(x)  # revealed: T@constrained | Unrelated
@@ -748,19 +745,17 @@ def unbounded_unconstrained[T](t: T) -> None:
         reveal_type(x)  # revealed: T@unbounded_unconstrained & Any
 ```
 
-The intersection of a bounded typevar with its bound or a supertype of its bound is the typevar
-itself. (The typevar might be specialized to a subtype of the bound.) The intersection of a bounded
-typevar with a subtype of its bound cannot be simplified. (The typevar might be specialized to a
-different subtype of the bound.) The intersection of a bounded typevar with a type that is disjoint
+The intersection of a bounded typevar with another type cannot be simplified based on subtyping
+relationships with its bound. The intersection of a bounded typevar with a type that is disjoint
 from its bound is `Never`.
 
 ```py
 def bounded[T: Base](t: T) -> None:
     def _(x: Intersection[T, Super]) -> None:
-        reveal_type(x)  # revealed: T@bounded
+        reveal_type(x)  # revealed: T@bounded & Super
 
     def _(x: Intersection[T, Base]) -> None:
-        reveal_type(x)  # revealed: T@bounded
+        reveal_type(x)  # revealed: T@bounded & Base
 
     def _(x: Intersection[T, Sub]) -> None:
         reveal_type(x)  # revealed: T@bounded & Sub

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -335,11 +335,11 @@ def unbounded_unconstrained[T, U](t: T, u: U) -> None:
     static_assert(not is_subtype_of(U, T))
 ```
 
-A bounded typevar is assignable to its bound, and a bounded, fully static typevar is a subtype of
-its bound. (A typevar with a non-fully-static bound is itself non-fully-static, and therefore does
-not participate in subtyping.) A fully static bound is not assignable to, nor a subtype of, the
-typevar, since the typevar might be specialized to a smaller type. (This is true even if the bound
-is a final class, since the typevar can still be specialized to `Never`.)
+A bounded typevar is assignable to its bound, but it is not a subtype of the bound because it can be
+explicitly specialized to a dynamic type. All typevars remain subtypes of `object`, since all types,
+including dynamic types, are subtypes of `object`. A fully static bound is not assignable to, nor a
+subtype of, the typevar, since the typevar might be specialized to a smaller type. (This is true
+even if the bound is a final class, since the typevar can still be specialized to `Never`.)
 
 ```py
 from typing import Any
@@ -349,13 +349,15 @@ def bounded[T: Super](t: T) -> None:
     static_assert(is_assignable_to(T, Any))
     static_assert(is_assignable_to(Any, T))
     static_assert(is_assignable_to(T, Super))
+    static_assert(is_assignable_to(T, object))
     static_assert(not is_assignable_to(T, Sub))
     static_assert(not is_assignable_to(Super, T))
     static_assert(not is_assignable_to(Sub, T))
 
     static_assert(not is_subtype_of(T, Any))
     static_assert(not is_subtype_of(Any, T))
-    static_assert(is_subtype_of(T, Super))
+    static_assert(not is_subtype_of(T, Super))
+    static_assert(is_subtype_of(T, object))
     static_assert(not is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Sub, T))
@@ -386,7 +388,7 @@ def bounded_final[T: FinalClass](t: T) -> None:
 
     static_assert(not is_subtype_of(T, Any))
     static_assert(not is_subtype_of(Any, T))
-    static_assert(is_subtype_of(T, FinalClass))
+    static_assert(not is_subtype_of(T, FinalClass))
     static_assert(not is_subtype_of(FinalClass, T))
 ```
 
@@ -411,9 +413,10 @@ def two_final_bounded[T: FinalClass, U: FinalClass](t: T, u: U) -> None:
     static_assert(not is_subtype_of(U, T))
 ```
 
-A constrained fully static typevar is assignable to the union of its constraints, but not to any of
-the constraints individually. None of the constraints are subtypes of the typevar, though the
-intersection of all of its constraints is a subtype of the typevar.
+A constrained fully static typevar is assignable to the union of its constraints, but it is not a
+subtype of that union because it can be explicitly specialized to a dynamic type. None of the
+constraints are subtypes of the typevar. The intersection of all constraints is assignable to the
+typevar, but it is not a subtype of the typevar.
 
 ```py
 from ty_extensions import Intersection
@@ -438,14 +441,14 @@ def constrained[T: (Base, Unrelated)](t: T) -> None:
     static_assert(not is_subtype_of(T, Sub))
     static_assert(not is_subtype_of(T, Unrelated))
     static_assert(not is_subtype_of(T, Any))
-    static_assert(is_subtype_of(T, Super | Unrelated))
-    static_assert(is_subtype_of(T, Base | Unrelated))
+    static_assert(not is_subtype_of(T, Super | Unrelated))
+    static_assert(not is_subtype_of(T, Base | Unrelated))
     static_assert(not is_subtype_of(T, Sub | Unrelated))
     static_assert(not is_subtype_of(Any, T))
     static_assert(not is_subtype_of(Super, T))
     static_assert(not is_subtype_of(Unrelated, T))
     static_assert(not is_subtype_of(Super | Unrelated, T))
-    static_assert(is_subtype_of(Intersection[Base, Unrelated], T))
+    static_assert(not is_subtype_of(Intersection[Base, Unrelated], T))
 
 def constrained_by_gradual[T: (Base, Any)](t: T) -> None:
     static_assert(is_assignable_to(T, Super))
@@ -693,9 +696,13 @@ def bounded[T: Base](t: T) -> None:
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@bounded | Any
 
-    static_assert(is_subtype_of(T | Base, Base))
+    def _(x: T | object) -> None:
+        reveal_type(x)  # revealed: object
+
+    static_assert(not is_subtype_of(T | Base, Base))
     static_assert(is_subtype_of(Base, T | Base))
-    static_assert(is_equivalent_to(T | Base, Base))
+    static_assert(not is_equivalent_to(T | Base, Base))
+    static_assert(is_equivalent_to(T | object, object))
 ```
 
 The union of a constrained typevar with another type cannot be simplified based on its constraints.
@@ -718,9 +725,9 @@ def constrained[T: (Base, Sub)](t: T) -> None:
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@constrained | Any
 
-    static_assert(is_subtype_of(T | Sub, T))
+    static_assert(not is_subtype_of(T | Sub, T))
     static_assert(is_subtype_of(T, T | Sub))
-    static_assert(is_equivalent_to(T | Sub, T))
+    static_assert(not is_equivalent_to(T | Sub, T))
 ```
 
 ## Intersections involving typevars

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -761,9 +761,9 @@ def unbounded_unconstrained[T](t: T) -> None:
         reveal_type(x)  # revealed: T@unbounded_unconstrained & Any
 ```
 
-The intersection of a bounded typevar with another type cannot be simplified based on subtyping
-relationships with its bound. The intersection of a bounded typevar with a type that is disjoint
-from its bound is `Never`.
+The intersection of a bounded typevar with another type cannot be simplified based on subtyping or
+disjointness relationships with its bound. The typevar can be explicitly specialized to a dynamic
+type, which may overlap with a type that is disjoint from the bound.
 
 ```py
 def bounded[T: Base](t: T) -> None:
@@ -777,10 +777,21 @@ def bounded[T: Base](t: T) -> None:
         reveal_type(x)  # revealed: T@bounded & Sub
 
     def _(x: Intersection[T, None]) -> None:
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: T@bounded & None
 
     def _(x: Intersection[T, Any]) -> None:
         reveal_type(x)  # revealed: T@bounded & Any
+```
+
+This also means that we must preserve the typevar until a generic alias is specialized:
+
+```py
+type StrPart[T: int] = Intersection[T, str]
+
+def accept_str_part(value: StrPart[Any]) -> None:
+    reveal_type(value)  # revealed: Any & str
+
+accept_str_part("")
 ```
 
 Constrained typevars can be modeled using a hypothetical `OneOf` connector, where the typevar must
@@ -792,11 +803,10 @@ runtime objects. This is one reason we have not actually added this connector to
 Nevertheless, describing constrained typevars this way helps explain how we simplify intersections
 involving them.
 
-This means that when intersecting a constrained typevar with a type `T`, constraints that are
-supertypes of `T` can be simplified to `T`, since intersection distributes over `OneOf`. Moreover,
-constraints that are disjoint from `T` are no longer valid specializations of the typevar, since
-`Never` is an identity for `OneOf`. Even if only one compatible constraint remains, we preserve the
-typevar itself in the intersection so other occurrences of the same typevar stay correlated.
+Without dynamic specializations, intersecting a constrained typevar with a type `T` could eliminate
+constraints that are disjoint from `T`. However, the typevar can be explicitly specialized to a
+dynamic type, so the intersection must preserve both the typevar and `T` even when all declared
+constraints are disjoint from `T`.
 
 ```py
 def constrained[T: (Base, Sub, Unrelated)](t: T) -> None:
@@ -811,21 +821,21 @@ def constrained[T: (Base, Sub, Unrelated)](t: T) -> None:
         reveal_type(x)  # revealed: T@constrained & Sub
 
     def _(x: Intersection[T, None]) -> None:
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: T@constrained & None
 
     def _(x: Intersection[T, Any]) -> None:
         reveal_type(x)  # revealed: T@constrained & Any
 ```
 
-We can simplify the intersection similarly when removing a type from a constrained typevar, since
-this is modeled internally as an intersection with a negation.
+For the same reason, removing a type from a constrained typevar cannot be simplified based only on
+the declared constraints.
 
 ```py
 from ty_extensions import Not
 
 def remove_constraint[T: (int, str, bool)](t: T) -> None:
     def _(x: Intersection[T, Not[int]]) -> None:
-        reveal_type(x)  # revealed: T@remove_constraint & str
+        reveal_type(x)  # revealed: T@remove_constraint & ~int
 
     def _(x: Intersection[T, Not[str]]) -> None:
         # With OneOf this would be OneOf[int, bool]
@@ -835,10 +845,10 @@ def remove_constraint[T: (int, str, bool)](t: T) -> None:
         reveal_type(x)  # revealed: T@remove_constraint & ~bool
 
     def _(x: Intersection[T, Not[int], Not[str]]) -> None:
-        reveal_type(x)  # revealed: Never
+        reveal_type(x)  # revealed: T@remove_constraint & ~int & ~str
 
     def _(x: Intersection[T, Not[None]]) -> None:
-        reveal_type(x)  # revealed: T@remove_constraint
+        reveal_type(x)  # revealed: T@remove_constraint & ~None
 
     def _(x: Intersection[T, Not[Any]]) -> None:
         reveal_type(x)  # revealed: T@remove_constraint & Any
@@ -930,7 +940,7 @@ class SomeClass[T: (int, str)]:
     def narrowed1(self) -> None:
         narrowed: int | str
         assert not isinstance(self.field, int)
-        reveal_type(self.field)  # revealed: T@SomeClass & str
+        reveal_type(self.field)  # revealed: T@SomeClass & ~int
         narrowed = self.field
 
     def narrowed2(self) -> None:
@@ -954,14 +964,14 @@ def f[T: (P, Q)](t: T) -> None:
         reveal_type(t)  # revealed: T@f & P
         p: P = t
     else:
-        reveal_type(t)  # revealed: T@f & Q & ~P
+        reveal_type(t)  # revealed: T@f & ~P
         q: Q = t
 
     if isinstance(t, Q):
         reveal_type(t)  # revealed: T@f & Q
         q: Q = t
     else:
-        reveal_type(t)  # revealed: T@f & P & ~Q
+        reveal_type(t)  # revealed: T@f & ~Q
         p: P = t
 
 def g[T: (P, Q, R)](t: T) -> None:
@@ -972,7 +982,7 @@ def g[T: (P, Q, R)](t: T) -> None:
         reveal_type(t)  # revealed: T@g & Q & ~P
         q: Q = t
     else:
-        reveal_type(t)  # revealed: T@g & R & ~P & ~Q
+        reveal_type(t)  # revealed: T@g & ~P & ~Q
         r: R = t
 
     if isinstance(t, P):
@@ -988,7 +998,8 @@ def g[T: (P, Q, R)](t: T) -> None:
         reveal_type(t)  # revealed: Never
 ```
 
-If the constraints are disjoint, simplification does eliminate the redundant negative:
+Even if the constraints are disjoint, we preserve the negative element because the typevar may be
+explicitly specialized to a dynamic type:
 
 ```py
 def h[T: (P, None)](t: T) -> None:
@@ -996,7 +1007,7 @@ def h[T: (P, None)](t: T) -> None:
         reveal_type(t)  # revealed: T@h & None
         p: None = t
     else:
-        reveal_type(t)  # revealed: T@h & P
+        reveal_type(t)  # revealed: T@h & ~None
         p: P = t
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -736,7 +736,7 @@ The intersection of an unbounded unconstrained typevar with any other type canno
 since there is no guarantee what type the typevar will be specialized to.
 
 ```py
-from ty_extensions import Intersection
+from ty_extensions import Intersection, is_subtype_of, static_assert
 from typing import Any
 
 class Super: ...
@@ -792,6 +792,10 @@ def accept_str_part(value: StrPart[Any]) -> None:
     reveal_type(value)  # revealed: Any & str
 
 accept_str_part("")
+
+def downstream_relations[T: int](value: Intersection[T, str]) -> None:
+    static_assert(not is_subtype_of(Intersection[T, str], bytes))
+    reveal_type(value == "")  # revealed: bool
 ```
 
 Constrained typevars can be modeled using a hypothetical `OneOf` connector, where the typevar must

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/variables.md
@@ -649,6 +649,7 @@ there is no guarantee what type the typevar will be specialized to.
 
 ```py
 from typing import Any
+from ty_extensions import is_equivalent_to, is_subtype_of, static_assert
 
 class Super: ...
 class Base(Super): ...
@@ -691,6 +692,10 @@ def bounded[T: Base](t: T) -> None:
 
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@bounded | Any
+
+    static_assert(is_subtype_of(T | Base, Base))
+    static_assert(is_subtype_of(Base, T | Base))
+    static_assert(is_equivalent_to(T | Base, Base))
 ```
 
 The union of a constrained typevar with another type cannot be simplified based on its constraints.
@@ -712,6 +717,10 @@ def constrained[T: (Base, Sub)](t: T) -> None:
 
     def _(x: T | Any) -> None:
         reveal_type(x)  # revealed: T@constrained | Any
+
+    static_assert(is_subtype_of(T | Sub, T))
+    static_assert(is_subtype_of(T, T | Sub))
+    static_assert(is_equivalent_to(T | Sub, T))
 ```
 
 ## Intersections involving typevars

--- a/crates/ty_python_semantic/resources/mdtest/promotion.md
+++ b/crates/ty_python_semantic/resources/mdtest/promotion.md
@@ -194,8 +194,9 @@ mapping_segments = {**get_segments_by_name(), "start": (1, 2), "end": (3, 4, 5)}
 reveal_type(mapping_segments)  # revealed: dict[str, tuple[int, int] | tuple[int, int, int]]
 ```
 
-This also applies when the non-literal tuple type is hidden behind a type alias or a type variable,
-or when it is subsumed by one of the literal tuple types while building the union.
+This also applies when the non-literal tuple type is hidden behind a type alias or `NewType`, or
+when it is subsumed by one of the literal tuple types while building the union. Type variables
+remain in the union because they can be explicitly specialized to a dynamic type.
 
 ```toml
 [environment]
@@ -230,7 +231,8 @@ reveal_type(newtype_segments)  # revealed: list[tuple[int, int] | tuple[int, int
 
 def check_bound_typevar_segment(segment: BoundSegment) -> None:
     bound_typevar_segments = [segment, (1, 2), (3, 4, 5)]
-    reveal_type(bound_typevar_segments)  # revealed: list[tuple[int, int] | tuple[int, int, int]]
+    # revealed: list[BoundSegment@check_bound_typevar_segment | tuple[int, int] | tuple[int, int, int]]
+    reveal_type(bound_typevar_segments)
 
 def check_constrained_typevar_segment(segment: ConstrainedSegment) -> None:
     constrained_typevar_segments = [segment, (1, 2), (3, 4, 5)]

--- a/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_compendium/never.md
@@ -10,7 +10,8 @@ python-version = "3.14"
 ## `Never` is a subtype of every type
 
 The `Never` type is the bottom type of Python's type system. It is a subtype of every type, but no
-type is a subtype of `Never`, except for `Never` itself or type variables with upper bound `Never`.
+type is a subtype of `Never` except for `Never` itself. A typevar with upper bound `Never` can still
+be explicitly specialized to a dynamic type, so it is assignable to but not a subtype of `Never`.
 
 ```py
 from ty_extensions import static_assert, is_subtype_of
@@ -28,7 +29,7 @@ static_assert(not is_subtype_of(int, Never))
 T = TypeVar("T", bound=Never)
 
 def _(t: T):
-    static_assert(is_subtype_of(T, Never))
+    static_assert(not is_subtype_of(T, Never))
 ```
 
 ## `Never` is assignable to every type

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -177,7 +177,9 @@ class B:
 
 ## Subtyping
 
-A class `A` is a subtype of `type[T]` if any instance of `A` is a subtype of `T`.
+A class `A` is a subtype of `type[T]` if any instance of `A` is a subtype of `T`. Bounds and
+constraints make `type[T]` assignable to the corresponding class-object types, but do not make it a
+subtype because `T` can be explicitly specialized to a dynamic type.
 
 ```py
 from typing import Any, Callable, Protocol
@@ -214,10 +216,11 @@ def _[T: int](_: T):
     static_assert(is_disjoint_from(type[T], int))
 
     static_assert(not is_subtype_of(type[int], type[T]))
-    static_assert(is_subtype_of(type[T], type[int]))
+    static_assert(not is_subtype_of(type[T], type[int]))
+    static_assert(is_assignable_to(type[T], type[int]))
     static_assert(not is_disjoint_from(type[T], type[int]))
 
-    static_assert(is_subtype_of(type[T], type[int] | None))
+    static_assert(not is_subtype_of(type[T], type[int] | None))
     static_assert(not is_disjoint_from(type[T], type[int] | None))
 
     static_assert(is_subtype_of(type[T], type[T]))
@@ -274,13 +277,13 @@ def _[T: (int, str)](_: T):
     static_assert(not is_disjoint_from(type[T], type[int]))
     static_assert(not is_disjoint_from(type[T], type[str]))
 
-    static_assert(is_subtype_of(type[T], type[int] | type[str]))
-    static_assert(is_subtype_of(type[T], type[int | str]))
+    static_assert(not is_subtype_of(type[T], type[int] | type[str]))
+    static_assert(not is_subtype_of(type[T], type[int | str]))
     static_assert(not is_disjoint_from(type[T], type[int | str]))
     static_assert(not is_disjoint_from(type[T], type[int] | type[str]))
 
 def _[T: (int | str, int)](_: T):
-    static_assert(is_subtype_of(type[int], type[T]))
+    static_assert(not is_subtype_of(type[int], type[T]))
     static_assert(not is_disjoint_from(type[int], type[T]))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -179,7 +179,7 @@ class B:
 
 A class `A` is a subtype of `type[T]` if any instance of `A` is a subtype of `T`. Bounds and
 constraints make `type[T]` assignable to the corresponding class-object types, but do not make it a
-subtype because `T` can be explicitly specialized to a dynamic type.
+subtype or disjoint from `T` because `T` can be explicitly specialized to a dynamic type.
 
 ```py
 from typing import Any, Callable, Protocol
@@ -209,7 +209,7 @@ def _[T](_: T):
 def _[T: int](_: T):
     static_assert(not is_subtype_of(type[T], T))
     static_assert(not is_subtype_of(T, type[T]))
-    static_assert(is_disjoint_from(type[T], T))
+    static_assert(not is_disjoint_from(type[T], T))
 
     static_assert(not is_subtype_of(type[T], int))
     static_assert(not is_subtype_of(int, type[T]))
@@ -247,7 +247,7 @@ def _[T: int](_: T):
 def _[T: (int, str)](_: T):
     static_assert(not is_subtype_of(type[T], T))
     static_assert(not is_subtype_of(T, type[T]))
-    static_assert(is_disjoint_from(type[T], T))
+    static_assert(not is_disjoint_from(type[T], T))
 
     static_assert(is_subtype_of(type[T], type[T]))
     static_assert(not is_disjoint_from(type[T], type[T]))

--- a/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_of/generics.md
@@ -103,7 +103,7 @@ def _[T: int](x: type | type[T]):
     reveal_type(x())  # revealed: Any
 
 def _[T: int](x: type[int] | type[T]):
-    reveal_type(x())  # revealed: int
+    reveal_type(x())  # revealed: int | T@_
 
 def _[T](x: type[int] | type[T]):
     reveal_type(x())  # revealed: int | T@_
@@ -123,10 +123,10 @@ def narrow_a[B: A](a: A, b: B):
     reveal_type(type_of_a)  # revealed: type[A]
 
     if isinstance(a, type(b)):
-        reveal_type(a)  # revealed: B@narrow_a
+        reveal_type(a)  # revealed: A & B@narrow_a
 
     if issubclass(type_of_a, type(b)):
-        reveal_type(type_of_a)  # revealed: type[B@narrow_a]
+        reveal_type(type_of_a)  # revealed: type[A] & type[B@narrow_a]
 ```
 
 Narrowing through `type[T]` or `Type[T]` should preserve the type variable identity, so the narrowed

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -477,19 +477,21 @@ python-version = "3.12"
 
 ```py
 from typing import Any, Never, TypeVar
-from ty_extensions import Unknown, Bottom, Top, static_assert, is_subtype_of
+from ty_extensions import Unknown, Bottom, Top, static_assert, is_assignable_to, is_subtype_of
 
 def bounded_by_gradual[T: Any](t: T) -> None:
     # Top materialization of `T: Any` is `T: object`
 
     # Bottom materialization of `T: Any` is `T: Never`
-    static_assert(is_subtype_of(Bottom[T], Never))
+    static_assert(is_assignable_to(Bottom[T], Never))
+    static_assert(not is_subtype_of(Bottom[T], Never))
 
 def constrained_by_gradual[T: (int, Any)](t: T) -> None:
     # Top materialization of `T: (int, Any)` is `T: (int, object)`
 
     # Bottom materialization of `T: (int, Any)` is `T: (int, Never)`
-    static_assert(is_subtype_of(Bottom[T], int))
+    static_assert(is_assignable_to(Bottom[T], int))
+    static_assert(not is_subtype_of(Bottom[T], int))
 ```
 
 ## Generics

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -207,11 +207,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
 
         (Type::Intersection(intersection), right)
-            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+            if intersection.positive(db).iter().any(
+                |ty| matches!(ty, Type::TypeVar(tvar) if tvar.typevar(db).is_self(db)),
+            ) =>
         {
             Some(infer_binary_type_comparison(
                 context,
-                intersection.with_expanded_typevars_and_newtypes(db),
+                intersection.with_expanded_newtypes_and_self_typevars(db),
                 op,
                 right,
                 range,
@@ -219,13 +221,15 @@ pub(super) fn infer_binary_type_comparison<'db>(
             ))
         }
         (left, Type::Intersection(intersection))
-            if intersection.positive(db).iter().copied().any(Type::is_type_var) =>
+            if intersection.positive(db).iter().any(
+                |ty| matches!(ty, Type::TypeVar(tvar) if tvar.typevar(db).is_self(db)),
+            ) =>
         {
             Some(infer_binary_type_comparison(
                 context,
                 left,
                 op,
-                intersection.with_expanded_typevars_and_newtypes(db),
+                intersection.with_expanded_newtypes_and_self_typevars(db),
                 range,
                 visitor
             ))

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1377,12 +1377,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // Except for impure redundancy used to simplify unions and intersections, a fully
-            // static typevar is a subtype of its upper bound, and to something similar to the union
-            // of its constraints. An unbound, unconstrained, fully static typevar has an implicit
-            // upper bound of `object` (which is handled above).
+            // A typevar is assignable to its upper bound, or to something similar to the union of
+            // its constraints. It is not generally a subtype of or redundant with those types,
+            // because it can be explicitly specialized to a dynamic type. `object` is the one
+            // exception and is handled above.
             (Type::TypeVar(bound_typevar), _)
-                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                if self.is_eager_assignability()
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1403,9 +1403,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // If the typevar is constrained, there must be multiple constraints, and the typevar
             // might be specialized to any one of them. However, the constraints do not have to be
-            // disjoint, which means an lhs type might be a subtype of all of the constraints.
+            // disjoint, which means an lhs type might be assignable to all of the constraints.
             (_, Type::TypeVar(bound_typevar))
-                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
+                if self.is_eager_assignability()
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1070,10 +1070,21 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .positive(db)
                 .iter()
                 .any(|element| match element {
-                    Type::TypeVar(tvar) => !tvar.is_inferable(db, self.inferable),
+                    Type::TypeVar(tvar) => {
+                        !tvar.is_inferable(db, self.inferable)
+                            && (self.relation.is_assignability() || tvar.typevar(db).is_self(db))
+                    }
                     Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_union(),
                     _ => false,
                 })
+        };
+
+        let expand_intersection = |intersection: IntersectionType<'db>| {
+            if self.relation.is_assignability() {
+                intersection.with_expanded_typevars_and_newtypes_for_assignability(db)
+            } else {
+                intersection.with_expanded_newtypes_and_self_typevars(db)
+            }
         };
 
         match (source, target) {
@@ -1379,10 +1390,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // A typevar is assignable to its upper bound, or to something similar to the union of
             // its constraints. It is not generally a subtype of or redundant with those types,
-            // because it can be explicitly specialized to a dynamic type. `object` is the one
-            // exception and is handled above.
+            // because it can be explicitly specialized to a dynamic type. `Self` cannot be
+            // explicitly specialized, so it retains those relations with its upper bound.
+            // `object` is the other exception and is handled above.
             (Type::TypeVar(bound_typevar), _)
-                if self.is_eager_assignability()
+                if (self.is_eager_assignability() || bound_typevar.typevar(db).is_self(db))
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1492,17 +1504,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     // Normally non-unions cannot directly contain unions in our model due to the fact that we
                     // enforce a DNF structure on our set-theoretic types. However, it *is* possible for there
                     // to be a newtype of a union, for an intersection to contain a newtype of a union, or for
-                    // a non-inferable typevar (possibly inside an intersection) to widen to a bound or set of
-                    // constraints that exposes a union; this requires special handling.
+                    // `Self` (possibly inside an intersection) to widen to a bound that exposes a
+                    // union. Ordinary typevars can also widen under assignability. These cases
+                    // require special handling.
                     match source {
                         Type::Intersection(intersection)
                             if should_expand_intersection(intersection) =>
                         {
-                            self.check_type_pair(
-                                db,
-                                intersection.with_expanded_typevars_and_newtypes(db),
-                                target,
-                            )
+                            self.check_type_pair(db, expand_intersection(intersection), target)
                         }
                         Type::NewTypeInstance(newtype) => {
                             let concrete_base = newtype.concrete_base_type(db);
@@ -1640,11 +1649,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
                     .or(db, self.constraints, || {
                         if should_expand_intersection(intersection) {
-                            self.check_type_pair(
-                                db,
-                                intersection.with_expanded_typevars_and_newtypes(db),
-                                target,
-                            )
+                            self.check_type_pair(db, expand_intersection(intersection), target)
                         } else {
                             self.never()
                         }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1294,13 +1294,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 },
             ),
 
-            // In general, a TypeVar `T` is not redundant with a type `S` unless one of the two conditions is satisfied:
-            // 1. `T` is a bound TypeVar and `T`'s upper bound is a subtype of `S`.
-            //    TypeVars without an explicit upper bound are treated as having an implicit upper bound of `object`.
-            // 2. `T` is a constrained TypeVar and all of `T`'s constraints are subtypes of `S`.
-            //
-            // However, there is one exception to this general rule: for any given typevar `T`,
-            // `T` will always be a subtype of any union containing `T`.
+            // A typevar can be explicitly specialized to a dynamic type, regardless of its bound
+            // or constraints. It is therefore not generally redundant with its bound or the union
+            // of its constraints. However, a typevar `T` is always redundant with a union that
+            // already contains `T`.
             (_, Type::Union(union))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
@@ -1380,11 +1377,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // A fully static typevar is a subtype of its upper bound, and to something similar to
-            // the union of its constraints. An unbound, unconstrained, fully static typevar has an
-            // implicit upper bound of `object` (which is handled above).
+            // Except for redundancy, a fully static typevar is a subtype of its upper bound, and
+            // to something similar to the union of its constraints. An unbound, unconstrained,
+            // fully static typevar has an implicit upper bound of `object` (which is handled
+            // above).
             (Type::TypeVar(bound_typevar), _)
-                if !bound_typevar.is_inferable(db, self.inferable)
+                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                    && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
@@ -1406,7 +1405,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
             (_, Type::TypeVar(bound_typevar))
-                if !bound_typevar.is_inferable(db, self.inferable)
+                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                    && !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)
                         .constraints(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1296,8 +1296,8 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // A typevar can be explicitly specialized to a dynamic type, regardless of its bound
             // or constraints. It is therefore not generally redundant with its bound or the union
-            // of its constraints. However, a typevar `T` is always redundant with a union that
-            // already contains `T`.
+            // of its constraints when simplifying unions and intersections. However, a typevar `T`
+            // is always redundant with a union that already contains `T`.
             (_, Type::Union(union))
                 if self.relation.can_safely_assume_reflexivity(source)
                     && union.elements(db).contains(&source) =>
@@ -1377,12 +1377,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // Except for redundancy, a fully static typevar is a subtype of its upper bound, and
-            // to something similar to the union of its constraints. An unbound, unconstrained,
-            // fully static typevar has an implicit upper bound of `object` (which is handled
-            // above).
+            // Except for impure redundancy used to simplify unions and intersections, a fully
+            // static typevar is a subtype of its upper bound, and to something similar to the union
+            // of its constraints. An unbound, unconstrained, fully static typevar has an implicit
+            // upper bound of `object` (which is handled above).
             (Type::TypeVar(bound_typevar), _)
-                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && bound_typevar.typevar(db).bound_or_constraints(db).is_some() =>
             {
@@ -1405,7 +1405,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // might be specialized to any one of them. However, the constraints do not have to be
             // disjoint, which means an lhs type might be a subtype of all of the constraints.
             (_, Type::TypeVar(bound_typevar))
-                if !matches!(self.relation, TypeRelation::Redundancy { .. })
+                if !matches!(self.relation, TypeRelation::Redundancy { pure: false })
                     && !bound_typevar.is_inferable(db, self.inferable)
                     && !bound_typevar
                         .typevar(db)

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2543,8 +2543,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
             // A typevar is never disjoint from itself, since all occurrences of the typevar must
             // be specialized to the same type. (This is an important difference between typevars
-            // and `Any`!) Different typevars might be disjoint, depending on their bounds and
-            // constraints, which are handled below.
+            // and `Any`!)
             (Type::TypeVar(left_tvar), Type::TypeVar(right_tvar))
                 if !left_tvar.is_inferable(db, self.inferable)
                     && left_tvar.is_same_typevar_as(db, right_tvar) =>
@@ -2560,25 +2559,20 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 self.always()
             }
 
-            // An unbounded typevar is never disjoint from any other type, since it might be
-            // specialized to any type. A bounded typevar is not disjoint from its bound, and is
-            // only disjoint from other types if its bound is. A constrained typevar is disjoint
-            // from a type if all of its constraints are.
+            // A typevar is never disjoint from another type based only on its bound or
+            // constraints, because it can be explicitly specialized to a dynamic type. `Self` is
+            // the exception: it cannot be explicitly specialized, so its bound remains usable.
             (Type::TypeVar(tvar), other) | (other, Type::TypeVar(tvar))
                 if !tvar.is_inferable(db, self.inferable) =>
             {
-                match tvar.typevar(db).bound_or_constraints(db) {
-                    None => self.never(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        self.check_type_pair(db, bound, other)
-                    }
-                    Some(TypeVarBoundOrConstraints::Constraints(typevar_constraints)) => {
-                        typevar_constraints.elements(db).iter().when_all(
-                            db,
-                            self.constraints,
-                            |constraint| self.check_type_pair(db, *constraint, other),
-                        )
-                    }
+                if tvar.typevar(db).is_self(db) {
+                    tvar.typevar(db)
+                        .upper_bound(db)
+                        .when_none_or(db, self.constraints, |bound| {
+                            self.check_type_pair(db, bound, other)
+                        })
+                } else {
+                    self.never()
                 }
             }
 

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -930,11 +930,21 @@ impl<'db> IntersectionType<'db> {
         }
     }
 
-    /// Return a version of this intersection type where any type variables in the positive elements
-    /// have been replaced by their bounds or constraints, and where any newtypes in the positive elements
+    /// Return a version of this intersection type where any `Self` type variables in the positive
+    /// elements have been replaced by their bounds, and where any newtypes in the positive elements
     /// have been replaced by their concrete base types.
-    pub(crate) fn with_expanded_typevars_and_newtypes(self, db: &'db dyn Db) -> Type<'db> {
-        expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db))
+    pub(crate) fn with_expanded_newtypes_and_self_typevars(self, db: &'db dyn Db) -> Type<'db> {
+        expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db), false)
+    }
+
+    /// Return a version that also replaces ordinary type variables with their bounds or
+    /// constraints. This is only valid for assignability relations, since a dynamic
+    /// specialization is assignable to the type variable's bound.
+    pub(crate) fn with_expanded_typevars_and_newtypes_for_assignability(
+        self,
+        db: &'db dyn Db,
+    ) -> Type<'db> {
+        expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db), true)
     }
 
     pub fn iter_positive(self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
@@ -955,22 +965,6 @@ impl<'db> IntersectionType<'db> {
 }
 
 fn expand_intersection_typevars_and_newtypes<'db>(
-    db: &'db dyn Db,
-    positive: &FxOrderSet<Type<'db>>,
-    negative: &NegativeIntersectionElements<'db>,
-) -> Type<'db> {
-    expand_intersection(db, positive, negative, true)
-}
-
-fn expand_intersection_newtypes_and_self_typevars<'db>(
-    db: &'db dyn Db,
-    positive: &FxOrderSet<Type<'db>>,
-    negative: &NegativeIntersectionElements<'db>,
-) -> Type<'db> {
-    expand_intersection(db, positive, negative, false)
-}
-
-fn expand_intersection<'db>(
     db: &'db dyn Db,
     positive: &FxOrderSet<Type<'db>>,
     negative: &NegativeIntersectionElements<'db>,

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -959,10 +959,27 @@ fn expand_intersection_typevars_and_newtypes<'db>(
     positive: &FxOrderSet<Type<'db>>,
     negative: &NegativeIntersectionElements<'db>,
 ) -> Type<'db> {
+    expand_intersection(db, positive, negative, true)
+}
+
+fn expand_intersection_newtypes_and_self_typevars<'db>(
+    db: &'db dyn Db,
+    positive: &FxOrderSet<Type<'db>>,
+    negative: &NegativeIntersectionElements<'db>,
+) -> Type<'db> {
+    expand_intersection(db, positive, negative, false)
+}
+
+fn expand_intersection<'db>(
+    db: &'db dyn Db,
+    positive: &FxOrderSet<Type<'db>>,
+    negative: &NegativeIntersectionElements<'db>,
+    expand_non_self_typevars: bool,
+) -> Type<'db> {
     let mut builder = IntersectionBuilder::new(db);
     for &element in positive {
         match element {
-            Type::TypeVar(tvar) => {
+            Type::TypeVar(tvar) if expand_non_self_typevars || tvar.typevar(db).is_self(db) => {
                 match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         builder = builder.add_positive(bound);

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -38,7 +38,7 @@
 
 use super::RecursivelyDefined;
 use crate::types::enums::{EnumComplement, enum_metadata};
-use crate::types::set_theoretic::expand_intersection_newtypes_and_self_typevars;
+use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType,
@@ -1703,8 +1703,12 @@ impl<'db> InnerIntersectionBuilder<'db> {
             Type::TypeVar(tvar) => tvar.typevar(db).is_self(db),
             _ => false,
         }) {
-            let speculative =
-                expand_intersection_newtypes_and_self_typevars(db, &self.positive, &self.negative);
+            let speculative = expand_intersection_typevars_and_newtypes(
+                db,
+                &self.positive,
+                &self.negative,
+                false,
+            );
             if speculative.is_never() {
                 return Type::Never;
             }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -38,11 +38,11 @@
 
 use super::RecursivelyDefined;
 use crate::types::enums::{EnumComplement, enum_metadata};
-use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
+use crate::types::set_theoretic::expand_intersection_newtypes_and_self_typevars;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType,
-    SubclassOfType, Type, TypeVarBoundOrConstraints, UnionType,
+    SubclassOfType, Type, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
@@ -1689,89 +1689,22 @@ impl<'db> InnerIntersectionBuilder<'db> {
         }
     }
 
-    /// Tries to simplify any constrained typevars in the intersection.
-    ///
-    /// We must preserve the constrained `TypeVar` itself in the result, even if only a single
-    /// compatible constraint remains, because other occurrences of the same `TypeVar` still need
-    /// to correlate with it (for example, when returning a narrowed value as `T`).
-    ///
-    /// - If the intersection contains negative entries for all but one of the constraints, we can
-    ///   add that remaining constraint as a positive entry.
-    ///
-    /// - If the intersection contains negative entries for all of the constraints, the overall
-    ///   intersection is `Never`.
-    fn simplify_constrained_typevars(&mut self, db: &'db dyn Db) {
-        let mut to_add = SmallVec::<[Type<'db>; 1]>::new();
-
-        for ty in &self.positive {
-            let Type::TypeVar(bound_typevar) = ty else {
-                continue;
-            };
-            let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
-                bound_typevar.typevar(db).bound_or_constraints(db)
-            else {
-                continue;
-            };
-
-            // Determine which constraints appear as negative entries in the intersection.
-            let constraints = constraints.elements(db);
-            let mut remaining_constraints: Vec<_> = constraints.iter().copied().map(Some).collect();
-            for negative in &self.negative {
-                // This linear search should be fine as long as we don't encounter typevars with
-                // thousands of constraints.
-                let matching_constraints = constraints
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, c)| c.is_subtype_of(db, *negative));
-                for (constraint_index, _) in matching_constraints {
-                    remaining_constraints[constraint_index] = None;
-                }
-            }
-
-            let mut iter = remaining_constraints.into_iter().flatten();
-            let Some(remaining_constraint) = iter.next() else {
-                // All of the typevar constraints have been removed, so the entire intersection is
-                // `Never`.
-                *self = Self::default();
-                self.positive.insert(Type::Never);
-                return;
-            };
-
-            let more_than_one_remaining_constraint = iter.next().is_some();
-            if more_than_one_remaining_constraint {
-                // This typevar cannot be simplified.
-                continue;
-            }
-
-            // Only one typevar constraint remains. Adding it as a positive element lets the normal
-            // intersection simplification remove any incompatible negatives, while keeping the
-            // original typevar in the result.
-            to_add.push(remaining_constraint);
-        }
-
-        for remaining_constraint in to_add {
-            self.add_positive(db, remaining_constraint);
-        }
-    }
-
     fn build(mut self, db: &'db dyn Db) -> Type<'db> {
         if self.has_empty_enum_complement(db) {
             return Type::Never;
         }
 
-        self.simplify_constrained_typevars(db);
-
-        // If any typevars are in `self.positive`, speculatively solve all bounded type variables
-        // to their upper bound and all constrained type variables to the union of their constraints.
-        // If that speculative intersection simplifies to `Never`, this intersection must also simplify
-        // to `Never`.
-        if self
-            .positive
-            .iter()
-            .any(|ty| matches!(ty, Type::TypeVar(_) | Type::NewTypeInstance(_)))
-        {
+        // A `NewType` instance has the same inhabitants as its concrete base type, and `Self`
+        // cannot be explicitly specialized to a dynamic type. If replacing those types with their
+        // bases or bounds makes the intersection uninhabited, the original intersection is also
+        // uninhabited.
+        if self.positive.iter().any(|ty| match ty {
+            Type::NewTypeInstance(_) => true,
+            Type::TypeVar(tvar) => tvar.typevar(db).is_self(db),
+            _ => false,
+        }) {
             let speculative =
-                expand_intersection_typevars_and_newtypes(db, &self.positive, &self.negative);
+                expand_intersection_newtypes_and_self_typevars(db, &self.positive, &self.negative);
             if speculative.is_never() {
                 return Type::Never;
             }


### PR DESCRIPTION
## Summary

A TypeVar may be explicitly specialized to a dynamic type even when it declares an upper bound or constraints. We should therefore use those declarations to establish assignability, but not subtyping or redundancy. `object` remains the exception because every type, including `Any`, is a subtype of and redundant with `object`.

```python
from ty_extensions import is_assignable_to, is_equivalent_to, is_subtype_of, static_assert

def f[T: int]() -> None:
    static_assert(is_assignable_to(T, int))
    static_assert(not is_subtype_of(T, int))
    static_assert(not is_equivalent_to(T | int, int))
    static_assert(is_subtype_of(T, object))
    static_assert(is_equivalent_to(T | object, object))
```

[PR #26118](https://github.com/astral-sh/ruff/pull/26118) only disabled bound- and constraint-based shortcuts for the redundancy checks used by union and intersection builders. That preserved `T | int` structurally while continuing to consider it equivalent to `int`. This change instead limits bound and constraint expansion to eager assignability, so subtype queries, equivalence checks, and set-theoretic builders all follow the dynamic-specialization model.

The same rule applies to constrained TypeVars, `type[T]`, and materialized TypeVars. For example, a bottom-materialized TypeVar is assignable to its materialized bound but is not considered a subtype of it, because it remains a TypeVar that can be explicitly specialized to a dynamic type.

This implements the broader relation semantics described in [the follow-up discussion](https://github.com/astral-sh/ty/issues/1666#issuecomment-3639107147). The full `ty_python_semantic` suite and stable type-relation property tests pass.

Closes https://github.com/astral-sh/ty/issues/1666.
