### PR TITLE
[ty] Avoid assuming classes with `Any` or `Unknown` bases are descriptors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -328,7 +328,8 @@ reveal_type(HigherDynamicBaseWrapper().attribute)  # revealed: Literal["concrete
 
 Requiring concrete descriptor methods when inspecting a nominal type's MRO does not mean that a
 value whose own type is dynamic is definitely not a descriptor. It could be a data descriptor and
-take precedence over a class attribute:
+take precedence over a class attribute. The same uncertainty applies when a dynamic type is one arm
+of a union:
 
 ```py
 from typing import Any, Literal
@@ -347,6 +348,14 @@ class C(metaclass=Meta):
     attribute: int = 1
 
 reveal_type(C.attribute)  # revealed: Any
+
+class UnionMeta(type):
+    attribute: Any | DataDescriptor = DataDescriptor()
+
+class UnionC(metaclass=UnionMeta):
+    attribute: int = 1
+
+reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 ```
 
 ### Descriptors only work when used as class variables

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -243,6 +243,59 @@ reveal_type(C2().attr)  # revealed: Literal["non-data"] | bytes
 C2().attr = 1
 ```
 
+### Descriptor methods must be concrete
+
+An unknown class base can provide any attribute, but that does not make every subclass a descriptor.
+We only apply the descriptor protocol when a concrete `__get__` method is visible:
+
+```py
+import random
+
+class A: ...
+class B: ...
+
+Base = A if random.random() > 0.5 else B
+
+class ClassWithUnknownBase(Base):  # error: [unsupported-base]
+    def known_method(self) -> None: ...
+
+class Wrapper:
+    value: ClassWithUnknownBase
+
+reveal_type(Wrapper.value)  # revealed: ClassWithUnknownBase
+reveal_type(Wrapper().value)  # revealed: ClassWithUnknownBase
+```
+
+The same applies to `Any`. A concrete `__get__` is still recognized, but an unknown `__set__` or
+`__delete__` method inherited from `Any` does not make it a data descriptor:
+
+```py
+from typing import Any, Literal
+
+class NotADescriptor(Any):
+    def known_method(self) -> None: ...
+
+class NonDataDescriptorWithAnyBase(Any):
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["non-data"]:
+        return "non-data"
+
+class DataDescriptorWithAnyBase(Any):
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
+        return "data"
+
+    def __set__(self, instance: object, value: object) -> None:
+        pass
+
+class AnyWrapper:
+    plain: NotADescriptor
+    non_data: NonDataDescriptorWithAnyBase
+    data: DataDescriptorWithAnyBase
+
+reveal_type(AnyWrapper().plain)  # revealed: NotADescriptor
+reveal_type(AnyWrapper().non_data)  # revealed: Literal["non-data"] | NonDataDescriptorWithAnyBase
+reveal_type(AnyWrapper().data)  # revealed: Literal["data"]
+```
+
 ### Descriptors only work when used as class variables
 
 Descriptors only work when used as class variables. When put in instances, they have no effect.

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -245,24 +245,35 @@ C2().attr = 1
 
 ### Classes with unknown bases are not automatically descriptors
 
-When we cannot determine a class's base, we treat that base as `Unknown`. We should not assume the
-class is a descriptor just because the unknown base could define `__get__`:
+When we cannot determine a class's base, we treat that base as `Unknown`. A `__get__` method written
+on the class still makes it a descriptor, but we do not assume that `Unknown` supplies `__set__` or
+`__delete__`. A `__set__` method written on the class still makes it a data descriptor:
 
 ```py
-import random
+from typing import Literal
+from unknown_module import UnknownBase  # error: [unresolved-import]
 
-class A: ...
-class B: ...
+class NotADescriptor(UnknownBase): ...
 
-Base = A if random.random() > 0.5 else B
+class NonDataDescriptor(UnknownBase):
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["non-data"]:
+        return "non-data"
 
-class ClassWithUnknownBase(Base):  # error: [unsupported-base]
-    ...
+class DataDescriptor(UnknownBase):
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
+        return "data"
 
-class Wrapper:
-    value: ClassWithUnknownBase
+    def __set__(self, instance: object, value: object) -> None:
+        pass
 
-reveal_type(Wrapper().value)  # revealed: ClassWithUnknownBase
+class C:
+    plain: NotADescriptor
+    non_data: NonDataDescriptor
+    data: DataDescriptor
+
+reveal_type(C().plain)  # revealed: NotADescriptor
+reveal_type(C().non_data)  # revealed: Literal["non-data"] | NonDataDescriptor
+reveal_type(C().data)  # revealed: Literal["data"]
 ```
 
 An `Any` base follows the same rule. A `__get__` method written on the class still makes it a
@@ -293,6 +304,16 @@ class C:
 reveal_type(C().plain)  # revealed: NotADescriptor
 reveal_type(C().non_data)  # revealed: Literal["non-data"] | NonDataDescriptor
 reveal_type(C().data)  # revealed: Literal["data"]
+
+class OptionalAttribute:
+    value: NotADescriptor | None
+
+optional_attribute = OptionalAttribute()
+optional_attribute.value = NotADescriptor()
+
+# The assignment can narrow because `NotADescriptor` has no concrete `__set__` or `__delete__`
+# method.
+reveal_type(optional_attribute.value)  # revealed: NotADescriptor
 ```
 
 An `Any` base that appears before another base class may override that class's `__get__` method at
@@ -321,11 +342,11 @@ class DescriptorOwner:
 reveal_type(DescriptorOwner().attribute)  # revealed: Literal["concrete"] & Any
 ```
 
-### Dynamically typed descriptor values
+### Dynamically typed metaclass attributes
 
-An attribute value typed as `Any` could itself be a data descriptor. It therefore takes precedence
-over an attribute with the same name on the class. The same applies when `Any` is one arm of a
-union:
+A metaclass attribute typed as `Any` could itself be a data descriptor. When the attribute is read
+on a class, it therefore takes precedence over a class attribute with the same name. The same
+applies when `Any` is one arm of a union:
 
 ```py
 from typing import Any, Literal

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -243,10 +243,10 @@ reveal_type(C2().attr)  # revealed: Literal["non-data"] | bytes
 C2().attr = 1
 ```
 
-### Descriptor methods must be concrete
+### Classes with unknown bases are not automatically descriptors
 
-An unknown class base can provide any attribute, but that does not make every subclass a descriptor.
-We only apply the descriptor protocol when a concrete `__get__` method is visible:
+When we cannot determine a class's base, we treat that base as `Unknown`. We should not assume the
+class is a descriptor just because the unknown base could define `__get__`:
 
 ```py
 import random
@@ -257,52 +257,49 @@ class B: ...
 Base = A if random.random() > 0.5 else B
 
 class ClassWithUnknownBase(Base):  # error: [unsupported-base]
-    def known_method(self) -> None: ...
+    ...
 
 class Wrapper:
     value: ClassWithUnknownBase
 
-reveal_type(Wrapper.value)  # revealed: ClassWithUnknownBase
 reveal_type(Wrapper().value)  # revealed: ClassWithUnknownBase
 ```
 
-The same applies to `Any`. A concrete `__get__` is still recognized, but an unknown `__set__` or
-`__delete__` method inherited from `Any` does not make it a data descriptor:
+An `Any` base follows the same rule. A `__get__` method written on the class still makes it a
+descriptor, but we do not assume that `Any` supplies `__set__` or `__delete__`. A `__set__` method
+written on the class still makes it a data descriptor:
 
 ```py
 from typing import Any, Literal
 
-class NotADescriptor(Any):
-    def known_method(self) -> None: ...
+class NotADescriptor(Any): ...
 
-class NonDataDescriptorWithAnyBase(Any):
+class NonDataDescriptor(Any):
     def __get__(self, instance: object, owner: type | None = None) -> Literal["non-data"]:
         return "non-data"
 
-class DataDescriptorWithAnyBase(Any):
+class DataDescriptor(Any):
     def __get__(self, instance: object, owner: type | None = None) -> Literal["data"]:
         return "data"
 
     def __set__(self, instance: object, value: object) -> None:
         pass
 
-class AnyWrapper:
+class C:
     plain: NotADescriptor
-    non_data: NonDataDescriptorWithAnyBase
-    data: DataDescriptorWithAnyBase
+    non_data: NonDataDescriptor
+    data: DataDescriptor
 
-reveal_type(AnyWrapper().plain)  # revealed: NotADescriptor
-reveal_type(AnyWrapper().non_data)  # revealed: Literal["non-data"] | NonDataDescriptorWithAnyBase
-reveal_type(AnyWrapper().data)  # revealed: Literal["data"]
+reveal_type(C().plain)  # revealed: NotADescriptor
+reveal_type(C().non_data)  # revealed: Literal["non-data"] | NonDataDescriptor
+reveal_type(C().data)  # revealed: Literal["data"]
 ```
 
-If a dynamic base appears before a concrete descriptor base, the concrete method establishes that
-the type is a descriptor but does not erase the possibility that the higher dynamic base overrides
-that method:
+An `Any` base that appears before another base class may override that class's `__get__` method at
+runtime. We still use the later method to determine that the class is a descriptor, but its return
+type must account for the earlier `Any` base:
 
 ```py
-from typing import Any, Literal
-
 class DynamicBase:
     def __get__(self, instance: object, owner: type | None = None) -> Literal["dynamic"]:
         return "dynamic"
@@ -314,22 +311,21 @@ class ConcreteBase:
     def __set__(self, instance: object, value: object) -> None:
         pass
 
-Base: Any = DynamicBase
+AnyBase: Any = DynamicBase
 
-class Descriptor(Base, ConcreteBase): ...
+class Descriptor(AnyBase, ConcreteBase): ...
 
-class HigherDynamicBaseWrapper:
+class DescriptorOwner:
     attribute: Descriptor = Descriptor()
 
-reveal_type(HigherDynamicBaseWrapper().attribute)  # revealed: Literal["concrete"] & Any
+reveal_type(DescriptorOwner().attribute)  # revealed: Literal["concrete"] & Any
 ```
 
-### Directly dynamic descriptor values
+### Dynamically typed descriptor values
 
-Requiring concrete descriptor methods when inspecting a nominal type's MRO does not mean that a
-value whose own type is dynamic is definitely not a descriptor. It could be a data descriptor and
-take precedence over a class attribute. The same uncertainty applies when a dynamic type is one arm
-of a union:
+An attribute value typed as `Any` could itself be a data descriptor. It therefore takes precedence
+over an attribute with the same name on the class. The same applies when `Any` is one arm of a
+union:
 
 ```py
 from typing import Any, Literal
@@ -358,10 +354,11 @@ class UnionC(metaclass=UnionMeta):
 reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 ```
 
-### Gradual class-object descriptor values
+### Class objects with unknown metaclasses
 
-A `type[Any]` value has an unknown metaclass, which could make the class object itself a data
-descriptor. Accessing an attribute with this type preserves that descriptor uncertainty:
+A `type[Any]` value could contain a class whose metaclass implements the descriptor protocol. We
+therefore preserve the possibility that an attribute typed as `type[Any]` is a data descriptor, both
+when reading the attribute and after assigning to it:
 
 ```py
 from typing import Any
@@ -375,17 +372,14 @@ class DescriptorMeta(type):
 
 class Descriptor(metaclass=DescriptorMeta): ...
 
-descriptor: type[Any] = Descriptor
+class C:
+    attribute: type[Any] = Descriptor
 
-class ClassObjectWrapper:
-    attribute: type[Any] = descriptor
+c = C()
+reveal_type(c.attribute)  # revealed: Any
 
-reveal_type(ClassObjectWrapper().attribute)  # revealed: Any
-value: str = ClassObjectWrapper().attribute
-
-wrapper = ClassObjectWrapper()
-wrapper.attribute = int
-reveal_type(wrapper.attribute)  # revealed: Any
+c.attribute = int
+reveal_type(c.attribute)  # revealed: Any
 ```
 
 ### Descriptors only work when used as class variables

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -382,6 +382,10 @@ class ClassObjectWrapper:
 
 reveal_type(ClassObjectWrapper().attribute)  # revealed: Any
 value: str = ClassObjectWrapper().attribute
+
+wrapper = ClassObjectWrapper()
+wrapper.attribute = int
+reveal_type(wrapper.attribute)  # revealed: Any
 ```
 
 ### Descriptors only work when used as class variables

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -296,6 +296,31 @@ reveal_type(AnyWrapper().non_data)  # revealed: Literal["non-data"] | NonDataDes
 reveal_type(AnyWrapper().data)  # revealed: Literal["data"]
 ```
 
+### Directly dynamic descriptor values
+
+Requiring concrete descriptor methods when inspecting a nominal type's MRO does not mean that a
+value whose own type is dynamic is definitely not a descriptor. It could be a data descriptor and
+take precedence over a class attribute:
+
+```py
+from typing import Any, Literal
+
+class DataDescriptor:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["descriptor"]:
+        return "descriptor"
+
+    def __set__(self, instance: object, value: object) -> None:
+        pass
+
+class Meta(type):
+    attribute: Any = DataDescriptor()
+
+class C(metaclass=Meta):
+    attribute: int = 1
+
+reveal_type(C.attribute)  # revealed: Any
+```
+
 ### Descriptors only work when used as class variables
 
 Descriptors only work when used as class variables. When put in instances, they have no effect.

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -296,6 +296,34 @@ reveal_type(AnyWrapper().non_data)  # revealed: Literal["non-data"] | NonDataDes
 reveal_type(AnyWrapper().data)  # revealed: Literal["data"]
 ```
 
+If a dynamic base appears before a concrete descriptor base, the concrete method establishes that
+the type is a descriptor but does not erase the possibility that the higher dynamic base overrides
+that method:
+
+```py
+from typing import Any, Literal
+
+class DynamicBase:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["dynamic"]:
+        return "dynamic"
+
+class ConcreteBase:
+    def __get__(self, instance: object, owner: type | None = None) -> Literal["concrete"]:
+        return "concrete"
+
+    def __set__(self, instance: object, value: object) -> None:
+        pass
+
+Base: Any = DynamicBase
+
+class Descriptor(Base, ConcreteBase): ...
+
+class HigherDynamicBaseWrapper:
+    attribute: Descriptor = Descriptor()
+
+reveal_type(HigherDynamicBaseWrapper().attribute)  # revealed: Literal["concrete"] & Any
+```
+
 ### Directly dynamic descriptor values
 
 Requiring concrete descriptor methods when inspecting a nominal type's MRO does not mean that a

--- a/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
+++ b/crates/ty_python_semantic/resources/mdtest/descriptor_protocol.md
@@ -358,6 +358,32 @@ class UnionC(metaclass=UnionMeta):
 reveal_type(UnionC.attribute)  # revealed: Any | Literal["descriptor"]
 ```
 
+### Gradual class-object descriptor values
+
+A `type[Any]` value has an unknown metaclass, which could make the class object itself a data
+descriptor. Accessing an attribute with this type preserves that descriptor uncertainty:
+
+```py
+from typing import Any
+
+class DescriptorMeta(type):
+    def __get__(self, instance: object, owner: type | None = None) -> str:
+        return "descriptor"
+
+    def __set__(self, instance: object, value: object) -> None:
+        pass
+
+class Descriptor(metaclass=DescriptorMeta): ...
+
+descriptor: type[Any] = Descriptor
+
+class ClassObjectWrapper:
+    attribute: type[Any] = descriptor
+
+reveal_type(ClassObjectWrapper().attribute)  # revealed: Any
+value: str = ClassObjectWrapper().attribute
+```
+
 ### Descriptors only work when used as class variables
 
 Descriptors only work when used as class variables. When put in instances, they have no effect.

--- a/crates/ty_python_semantic/resources/mdtest/mro.md
+++ b/crates/ty_python_semantic/resources/mdtest/mro.md
@@ -784,7 +784,7 @@ class C(C.a): ...
 reveal_type(C.__class__)  # revealed: <class 'type'>
 reveal_mro(C)  # revealed: (<class 'C'>, Unknown, <class 'object'>)
 
-class D(D.a):
+class D(D.a):  # error: [unsupported-base]
     a: D
 
 reveal_type(D.__class__)  # revealed: <class 'type'>

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -698,8 +698,8 @@ class FooSubclassOfAny:
 
 static_assert(not is_subtype_of(FooSubclassOfAny, HasX))
 
-# `SubclassOfAny` does not declare `__get__`, so `x` keeps its declared type instead of being read
-# as `Any`.
+# `FooSubclassOfAny` does not declare `__get__`, so `x` keeps its declared type instead of being
+# read as `Any`.
 static_assert(not is_assignable_to(FooSubclassOfAny, HasX))
 
 class FooWithY(Foo):
@@ -3256,7 +3256,7 @@ def _(r: Recursive):
     reveal_type(r.t)  # revealed: tuple[int, tuple[str, Recursive]]
     reveal_type(r.callable1)  # revealed: (int, /) -> Recursive
     reveal_type(r.callable2)  # revealed: (Recursive, /) -> int
-    reveal_type(r.subtype_of)  # revealed: type[@Todo(type[T] for protocols)]
+    reveal_type(r.subtype_of)  # revealed: @Todo(type[T] for protocols)
     reveal_type(r.generic)  # revealed: GenericC[Recursive]
     reveal_type(r.method(r))  # revealed: Recursive
     reveal_type(r.nested)  # revealed: Recursive | ((Recursive, tuple[Recursive, Recursive], /) -> Recursive)

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -698,12 +698,9 @@ class FooSubclassOfAny:
 
 static_assert(not is_subtype_of(FooSubclassOfAny, HasX))
 
-# `FooSubclassOfAny` is assignable to `HasX` for the following reason. The `x` attribute on `FooSubclassOfAny`
-# is accessible on the class itself. When accessing `x` on an instance, the descriptor protocol is invoked, and
-# `__get__` is looked up on `SubclassOfAny`. Every member access on `SubclassOfAny` yields `Any`, so `__get__` is
-# also available, and calling `Any` also yields `Any`. Thus, accessing `x` on an instance of `FooSubclassOfAny`
-# yields `Any`, which is assignable to `int` and vice versa.
-static_assert(is_assignable_to(FooSubclassOfAny, HasX))
+# An `Any` base could provide `__get__`, but that does not make `SubclassOfAny` a descriptor. We
+# preserve the declared type of `x`, which is not assignable to `int`.
+static_assert(not is_assignable_to(FooSubclassOfAny, HasX))
 
 class FooWithY(Foo):
     y: int
@@ -3259,7 +3256,7 @@ def _(r: Recursive):
     reveal_type(r.t)  # revealed: tuple[int, tuple[str, Recursive]]
     reveal_type(r.callable1)  # revealed: (int, /) -> Recursive
     reveal_type(r.callable2)  # revealed: (Recursive, /) -> int
-    reveal_type(r.subtype_of)  # revealed: @Todo(type[T] for protocols)
+    reveal_type(r.subtype_of)  # revealed: type[@Todo(type[T] for protocols)]
     reveal_type(r.generic)  # revealed: GenericC[Recursive]
     reveal_type(r.method(r))  # revealed: Recursive
     reveal_type(r.nested)  # revealed: Recursive | ((Recursive, tuple[Recursive, Recursive], /) -> Recursive)

--- a/crates/ty_python_semantic/resources/mdtest/protocols.md
+++ b/crates/ty_python_semantic/resources/mdtest/protocols.md
@@ -698,8 +698,8 @@ class FooSubclassOfAny:
 
 static_assert(not is_subtype_of(FooSubclassOfAny, HasX))
 
-# An `Any` base could provide `__get__`, but that does not make `SubclassOfAny` a descriptor. We
-# preserve the declared type of `x`, which is not assignable to `int`.
+# `SubclassOfAny` does not declare `__get__`, so `x` keeps its declared type instead of being read
+# as `Any`.
 static_assert(not is_assignable_to(FooSubclassOfAny, HasX))
 
 class FooWithY(Foo):

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3006,6 +3006,10 @@ impl<'db> Type<'db> {
             }
 
             match ty {
+                // A directly dynamic value could be a data descriptor. This differs from a
+                // nominal type with a dynamic base, for which we require a concrete descriptor
+                // method before invoking the protocol.
+                Type::Dynamic(_) => return Some((ty, AttributeKind::DataDescriptor)),
                 Type::Callable(callable) if callable.is_staticmethod_like(db) => {
                     // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
                     // The underlying function is returned as-is, without binding self.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2985,11 +2985,9 @@ impl<'db> Type<'db> {
     fn dynamic_descriptor_type(self) -> Option<Type<'db>> {
         match self {
             Type::Dynamic(_) => Some(self),
-            Type::SubclassOf(subclass_of) => subclass_of
-                .subclass_of()
-                .into_dynamic()
-                .filter(|dynamic| dynamic.is_gradual())
-                .map(Type::Dynamic),
+            Type::SubclassOf(subclass_of) => {
+                subclass_of.subclass_of().into_dynamic().map(Type::Dynamic)
+            }
             _ => None,
         }
     }
@@ -7610,17 +7608,6 @@ pub enum DynamicType<'db> {
 }
 
 impl DynamicType<'_> {
-    pub(crate) const fn is_gradual(self) -> bool {
-        matches!(
-            self,
-            Self::Any
-                | Self::Unknown
-                | Self::UnknownGeneric(_)
-                | Self::InvalidConcatenateUnknown
-                | Self::AmbiguousOverload
-        )
-    }
-
     fn recursive_type_normalized(self) -> Self {
         self
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3149,12 +3149,13 @@ impl<'db> Type<'db> {
         }
 
         match attribute {
-            // Preserve the existing bottom and cycle behavior without performing descriptor
-            // member lookups that cannot provide any additional information.
+            // A directly dynamic attribute could be a data descriptor even though we cannot see
+            // its methods. Preserve that uncertainty, along with the existing bottom and cycle
+            // behavior, without performing member lookups that cannot add information.
             PlaceAndQualifiers {
                 place:
                     Place::Defined(DefinedPlace {
-                        ty: Type::Divergent(_) | Type::Never,
+                        ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
                         ..
                     }),
                 qualifiers: _,
@@ -3265,6 +3266,7 @@ impl<'db> Type<'db> {
 
     /// Returns whether this type is a data descriptor, i.e. defines `__set__` or `__delete__`.
     /// If this type is a union, requires all elements of union to be data descriptors.
+    /// A directly dynamic type is treated as a data descriptor because it could inhabit one.
     pub(crate) fn is_data_descriptor(self, d: &'db dyn Db) -> bool {
         self.is_data_descriptor_impl(d, false)
     }
@@ -3272,15 +3274,15 @@ impl<'db> Type<'db> {
     /// Returns whether this type should be considered a possible data descriptor.
     /// If this type is a union, returns true if _any_ element is a data descriptor.
     /// This is used to determine whether an attribute assignment is valid for narrowing.
-    /// Dynamic types are not considered data descriptors because no concrete `__set__` or
-    /// `__delete__` method is visible on them.
+    /// For practical convenience, dynamic union elements are not considered possible data
+    /// descriptors here, because doing so would disable narrowing too frequently.
     pub(crate) fn may_be_data_descriptor(self, d: &'db dyn Db) -> bool {
         self.is_data_descriptor_impl(d, true)
     }
 
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
-            Type::Dynamic(_) => false,
+            Type::Dynamic(_) => !any_of_union,
             Type::Never | Type::PropertyInstance(_) => true,
             Type::Union(union) if any_of_union => union
                 .elements(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -469,6 +469,12 @@ bitflags! {
 
         /// Do not call `__getattr__` during member lookup.
         const NO_GETATTR_LOOKUP = 1 << 4;
+
+        /// Ignore members that are only available through a dynamic type.
+        ///
+        /// This is used when detecting descriptors. An `Any` or `Unknown` base can provide any
+        /// member, but that does not mean that every subclass should be treated as a descriptor.
+        const REQUIRE_CONCRETE = 1 << 5;
     }
 }
 
@@ -500,6 +506,11 @@ impl MemberLookupPolicy {
     /// Do not call `__getattr__` during member lookup.
     pub(crate) const fn no_getattr_lookup(self) -> bool {
         self.contains(Self::NO_GETATTR_LOOKUP)
+    }
+
+    /// Ignore members that are only available through a dynamic type.
+    pub(crate) const fn require_concrete(self) -> bool {
+        self.contains(Self::REQUIRE_CONCRETE)
     }
 }
 
@@ -2557,6 +2568,8 @@ impl<'db> Type<'db> {
                 }))
             }
 
+            Type::Dynamic(_) if policy.require_concrete() => Some(Place::Undefined.into()),
+
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(Place::bound(self).into()),
 
             Type::ClassLiteral(class) if class.is_typed_dict(db) => {
@@ -3026,7 +3039,13 @@ impl<'db> Type<'db> {
                 _ => {}
             }
 
-            let descr_get = ty.class_member(db, "__get__".into()).place;
+            let descr_get = ty
+                .class_member_with_policy(
+                    db,
+                    "__get__".into(),
+                    MemberLookupPolicy::REQUIRE_CONCRETE,
+                )
+                .place;
 
             if let Place::Defined(DefinedPlace {
                 ty: descr_get,
@@ -3034,6 +3053,12 @@ impl<'db> Type<'db> {
                 ..
             }) = descr_get
             {
+                // A recursive member lookup can yield the internal cycle marker. It does not
+                // represent a concrete descriptor method and must not escape through the access.
+                if descr_get.is_divergent() {
+                    return None;
+                }
+
                 let instance_ty = instance.unwrap_or_else(|| Type::none(db));
                 let return_ty = descr_get
                     .try_call(db, &CallArguments::positional([ty, instance_ty, owner]))
@@ -3124,18 +3149,12 @@ impl<'db> Type<'db> {
         }
 
         match attribute {
-            // This branch is not strictly needed, but it short-circuits the lookup of various dunder
-            // methods and calls that would otherwise be made.
-            //
-            // Note that attribute accesses on dynamic types always succeed. For this reason, they also
-            // have `__get__`, `__set__`, and `__delete__` methods and are therefore considered to be
-            // data descriptors.
-            //
-            // The same is true for `Never`.
+            // Preserve the existing bottom and cycle behavior without performing descriptor
+            // member lookups that cannot provide any additional information.
             PlaceAndQualifiers {
                 place:
                     Place::Defined(DefinedPlace {
-                        ty: Type::Dynamic(_) | Type::Divergent(_) | Type::Never,
+                        ty: Type::Divergent(_) | Type::Never,
                         ..
                     }),
                 qualifiers: _,
@@ -3253,17 +3272,15 @@ impl<'db> Type<'db> {
     /// Returns whether this type should be considered a possible data descriptor.
     /// If this type is a union, returns true if _any_ element is a data descriptor.
     /// This is used to determine whether an attribute assignment is valid for narrowing.
-    /// In theory, dynamic types might be data descriptor types, so it is unsafe to use
-    /// attribute assignment for narrowing if the inferred type of an attribute contains a dynamic type.
-    /// However, strictly applying this rule would disable narrowing too frequently.
-    /// Therefore, for practical convenience, we don't consider dynamic types as data descriptors.
+    /// Dynamic types are not considered data descriptors because no concrete `__set__` or
+    /// `__delete__` method is visible on them.
     pub(crate) fn may_be_data_descriptor(self, d: &'db dyn Db) -> bool {
         self.is_data_descriptor_impl(d, true)
     }
 
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
-            Type::Dynamic(_) => !any_of_union,
+            Type::Dynamic(_) => false,
             Type::Never | Type::PropertyInstance(_) => true,
             Type::Union(union) if any_of_union => union
                 .elements(db)
@@ -3277,9 +3294,20 @@ impl<'db> Type<'db> {
                 .iter_positive(db)
                 .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
             _ => {
-                !self.class_member(db, "__set__".into()).place.is_undefined()
+                !self
+                    .class_member_with_policy(
+                        db,
+                        "__set__".into(),
+                        MemberLookupPolicy::REQUIRE_CONCRETE,
+                    )
+                    .place
+                    .is_undefined()
                     || !self
-                        .class_member(db, "__delete__".into())
+                        .class_member_with_policy(
+                            db,
+                            "__delete__".into(),
+                            MemberLookupPolicy::REQUIRE_CONCRETE,
+                        )
                         .place
                         .is_undefined()
             }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2980,6 +2980,20 @@ impl<'db> Type<'db> {
         }
     }
 
+    /// Returns the descriptor result type for directly dynamic values and gradual class-object
+    /// values.
+    fn dynamic_descriptor_type(self) -> Option<Type<'db>> {
+        match self {
+            Type::Dynamic(_) => Some(self),
+            Type::SubclassOf(subclass_of) => subclass_of
+                .subclass_of()
+                .into_dynamic()
+                .filter(|dynamic| dynamic.is_gradual())
+                .map(Type::Dynamic),
+            _ => None,
+        }
+    }
+
     /// Look up `__get__` on the meta-type of self, and call it with the arguments `self`, `instance`,
     /// and `owner`. `__get__` is different than other dunder methods in that it is not looked up using
     /// the descriptor protocol itself.
@@ -3005,19 +3019,11 @@ impl<'db> Type<'db> {
                 return fallback.try_call_dunder_get(db, instance, owner);
             }
 
+            if let Some(dynamic) = ty.dynamic_descriptor_type() {
+                return Some((dynamic, AttributeKind::DataDescriptor));
+            }
+
             match ty {
-                // A directly dynamic value could be a data descriptor. This differs from a
-                // nominal type with a dynamic base, for which we require a concrete descriptor
-                // method before invoking the protocol.
-                Type::Dynamic(_) => return Some((ty, AttributeKind::DataDescriptor)),
-                Type::SubclassOf(subclass_of)
-                    if let Some(dynamic) = subclass_of.subclass_of().into_dynamic()
-                        && dynamic.is_gradual() =>
-                {
-                    // `type[Any]` and `type[Unknown]` have unknown metaclasses, which could make
-                    // their class-object inhabitants data descriptors.
-                    return Some((Type::Dynamic(dynamic), AttributeKind::DataDescriptor));
-                }
                 Type::Callable(callable) if callable.is_staticmethod_like(db) => {
                     // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
                     // The underlying function is returned as-is, without binding self.
@@ -3051,58 +3057,56 @@ impl<'db> Type<'db> {
                 _ => {}
             }
 
-            let concrete_descr_get = ty
+            let Place::Defined(DefinedPlace {
+                ty: concrete_descr_get,
+                ..
+            }) = ty
                 .class_member_with_policy(
                     db,
                     "__get__".into(),
                     MemberLookupPolicy::REQUIRE_CONCRETE,
                 )
-                .place;
+                .place
+            else {
+                return None;
+            };
 
-            if let Place::Defined(DefinedPlace {
-                ty: concrete_descr_get,
-                ..
-            }) = concrete_descr_get
-            {
-                // A recursive member lookup can yield the internal cycle marker. It does not
-                // represent a concrete descriptor method and must not escape through the access.
-                if concrete_descr_get.is_divergent() {
-                    return None;
-                }
-
-                let Place::Defined(DefinedPlace {
-                    ty: descr_get,
-                    definedness: descr_get_boundness,
-                    ..
-                }) = ty.class_member(db, "__get__".into()).place
-                else {
-                    return None;
-                };
-
-                let instance_ty = instance.unwrap_or_else(|| Type::none(db));
-                let return_ty = descr_get
-                    .try_call(db, &CallArguments::positional([ty, instance_ty, owner]))
-                    .map(|bindings| {
-                        if descr_get_boundness == Definedness::AlwaysDefined {
-                            bindings.return_type(db)
-                        } else {
-                            UnionType::from_two_elements(db, bindings.return_type(db), ty)
-                        }
-                    })
-                    // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
-                    // we should emit a diagnostic here instead of silently ignoring the error.
-                    .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
-
-                let descriptor_kind = if ty.is_data_descriptor(db) {
-                    AttributeKind::DataDescriptor
-                } else {
-                    AttributeKind::NormalOrNonDataDescriptor
-                };
-
-                Some((return_ty, descriptor_kind))
-            } else {
-                None
+            // A recursive member lookup can yield the internal cycle marker. It does not
+            // represent a concrete descriptor method and must not escape through the access.
+            if concrete_descr_get.is_divergent() {
+                return None;
             }
+
+            let Place::Defined(DefinedPlace {
+                ty: descr_get,
+                definedness: descr_get_boundness,
+                ..
+            }) = ty.class_member(db, "__get__".into()).place
+            else {
+                return None;
+            };
+
+            let instance_ty = instance.unwrap_or_else(|| Type::none(db));
+            let return_ty = descr_get
+                .try_call(db, &CallArguments::positional([ty, instance_ty, owner]))
+                .map(|bindings| {
+                    if descr_get_boundness == Definedness::AlwaysDefined {
+                        bindings.return_type(db)
+                    } else {
+                        UnionType::from_two_elements(db, bindings.return_type(db), ty)
+                    }
+                })
+                // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
+                // we should emit a diagnostic here instead of silently ignoring the error.
+                .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
+
+            let descriptor_kind = if ty.is_data_descriptor(db) {
+                AttributeKind::DataDescriptor
+            } else {
+                AttributeKind::NormalOrNonDataDescriptor
+            };
+
+            Some((return_ty, descriptor_kind))
         }
 
         tracing::trace!(
@@ -3303,14 +3307,7 @@ impl<'db> Type<'db> {
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
             Type::Dynamic(_) => !any_of_union,
-            Type::SubclassOf(subclass_of)
-                if subclass_of
-                    .subclass_of()
-                    .into_dynamic()
-                    .is_some_and(DynamicType::is_gradual) =>
-            {
-                true
-            }
+            Type::SubclassOf(_) if self.dynamic_descriptor_type().is_some() => true,
             Type::Never | Type::PropertyInstance(_) => true,
             Type::Union(union) if any_of_union => union
                 .elements(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3010,6 +3010,19 @@ impl<'db> Type<'db> {
                 // nominal type with a dynamic base, for which we require a concrete descriptor
                 // method before invoking the protocol.
                 Type::Dynamic(_) => return Some((ty, AttributeKind::DataDescriptor)),
+                Type::SubclassOf(subclass_of)
+                    if let Some(
+                        dynamic @ (DynamicType::Any
+                        | DynamicType::Unknown
+                        | DynamicType::UnknownGeneric(_)
+                        | DynamicType::InvalidConcatenateUnknown
+                        | DynamicType::AmbiguousOverload),
+                    ) = subclass_of.subclass_of().into_dynamic() =>
+                {
+                    // `type[Any]` and `type[Unknown]` have unknown metaclasses, which could make
+                    // their class-object inhabitants data descriptors.
+                    return Some((Type::Dynamic(dynamic), AttributeKind::DataDescriptor));
+                }
                 Type::Callable(callable) if callable.is_staticmethod_like(db) => {
                     // For "staticmethod-like" callables, model the behavior of `staticmethod.__get__`.
                     // The underlying function is returned as-is, without binding self.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3039,7 +3039,7 @@ impl<'db> Type<'db> {
                 _ => {}
             }
 
-            let descr_get = ty
+            let concrete_descr_get = ty
                 .class_member_with_policy(
                     db,
                     "__get__".into(),
@@ -3048,16 +3048,24 @@ impl<'db> Type<'db> {
                 .place;
 
             if let Place::Defined(DefinedPlace {
-                ty: descr_get,
-                definedness: descr_get_boundness,
+                ty: concrete_descr_get,
                 ..
-            }) = descr_get
+            }) = concrete_descr_get
             {
                 // A recursive member lookup can yield the internal cycle marker. It does not
                 // represent a concrete descriptor method and must not escape through the access.
-                if descr_get.is_divergent() {
+                if concrete_descr_get.is_divergent() {
                     return None;
                 }
+
+                let Place::Defined(DefinedPlace {
+                    ty: descr_get,
+                    definedness: descr_get_boundness,
+                    ..
+                }) = ty.class_member(db, "__get__".into()).place
+                else {
+                    return None;
+                };
 
                 let instance_ty = instance.unwrap_or_else(|| Type::none(db));
                 let return_ty = descr_get

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3011,13 +3011,8 @@ impl<'db> Type<'db> {
                 // method before invoking the protocol.
                 Type::Dynamic(_) => return Some((ty, AttributeKind::DataDescriptor)),
                 Type::SubclassOf(subclass_of)
-                    if let Some(
-                        dynamic @ (DynamicType::Any
-                        | DynamicType::Unknown
-                        | DynamicType::UnknownGeneric(_)
-                        | DynamicType::InvalidConcatenateUnknown
-                        | DynamicType::AmbiguousOverload),
-                    ) = subclass_of.subclass_of().into_dynamic() =>
+                    if let Some(dynamic) = subclass_of.subclass_of().into_dynamic()
+                        && dynamic.is_gradual() =>
                 {
                     // `type[Any]` and `type[Unknown]` have unknown metaclasses, which could make
                     // their class-object inhabitants data descriptors.
@@ -3308,6 +3303,14 @@ impl<'db> Type<'db> {
     fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
         match self {
             Type::Dynamic(_) => !any_of_union,
+            Type::SubclassOf(subclass_of)
+                if subclass_of
+                    .subclass_of()
+                    .into_dynamic()
+                    .is_some_and(DynamicType::is_gradual) =>
+            {
+                true
+            }
             Type::Never | Type::PropertyInstance(_) => true,
             Type::Union(union) if any_of_union => union
                 .elements(db)
@@ -7610,6 +7613,17 @@ pub enum DynamicType<'db> {
 }
 
 impl DynamicType<'_> {
+    pub(crate) const fn is_gradual(self) -> bool {
+        matches!(
+            self,
+            Self::Any
+                | Self::Unknown
+                | Self::UnknownGeneric(_)
+                | Self::InvalidConcatenateUnknown
+                | Self::AmbiguousOverload
+        )
+    }
+
     fn recursive_type_normalized(self) -> Self {
         self
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2390,6 +2390,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                 ClassBase::Generic | ClassBase::Protocol => {
                     // Skip over these very special class bases that aren't really classes.
                 }
+                ClassBase::Dynamic(_) if policy.require_concrete() => {}
                 ClassBase::Dynamic(_) => {
                     // Note: calling `Type::from(superclass).member()` would be incorrect here.
                     // What we'd really want is a `Type::Any.own_class_member()` method,


### PR DESCRIPTION
## Summary

Classes with `Any` or `Unknown` bases currently appear to define every descriptor method, so using an instance of one as a class attribute invokes descriptor handling and can collapse the declared attribute type to `Unknown`:

```python
class Wrapper:
    value: ClassWithUnknownBase


# On main: Unknown
# On this branch: ClassWithUnknownBase
reveal_type(Wrapper().value)
```

This adds a concrete-only member lookup policy for descriptor detection. We now require a visible `__get__`, `__set__`, or `__delete__` method before treating a nominal type with a dynamic MRO entry as a descriptor.

The concrete-only lookup is _only_ used to determine whether the descriptor protocol applies. Once a concrete method is found, the actual call still uses normal lookup so a higher dynamic base can override it. Direct dynamic values, dynamic union arms, and gradual class objects such as `type[Any]` also retain descriptor uncertainty, including during assignment narrowing.

Closes https://github.com/astral-sh/ty/issues/3319.
