### PR TITLE
[ty] Preserve unpacking diagnostics for nested assignment targets

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -231,6 +231,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     scopes_by_expression: ExpressionsScopeMapBuilder,
     definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>,
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
+    unpacks_by_target: FxHashMap<ExpressionNodeKey, Unpack<'db>>,
     condition_flow_snapshots_by_node: FxHashMap<ExpressionNodeKey, ConditionFlowSnapshots>,
     statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
     imported_modules: FxHashSet<ModuleName>,
@@ -285,6 +286,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes_by_node: FxHashMap::default(),
             definitions_by_node: FxHashMap::default(),
             expressions_by_node: FxHashMap::default(),
+            unpacks_by_target: FxHashMap::default(),
             condition_flow_snapshots_by_node: FxHashMap::default(),
             statements_by_node: FxHashMap::default(),
             enclosing_lambda_statements: FxHashMap::default(),
@@ -2430,7 +2432,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     } else {
                         self.current_scope()
                     };
-                let unpack = Some(Unpack::new(
+                let unpack = Unpack::new(
                     self.db,
                     self.file,
                     value_file_scope,
@@ -2438,8 +2440,9 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     // Note `target` belongs to the `self.module` tree
                     AstNodeRef::new(self.module, target),
                     UnpackValue::new(unpackable.kind(), value),
-                ));
-                Some(unpackable.as_current_assignment(unpack))
+                );
+                self.unpacks_by_target.insert(target.into(), unpack);
+                Some(unpackable.as_current_assignment(Some(unpack)))
             }
             ast::Expr::Name(_)
             | ast::Expr::Starred(_)
@@ -2503,6 +2506,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scopes: self.scopes.into(),
             definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
             expressions_by_node: self.expressions_by_node,
+            unpacks_by_target: FrozenMap::from(self.unpacks_by_target),
             statements_by_node: self.statements_by_node,
             scope_ids_by_scope: self.scope_ids_by_scope.into(),
             ast_ids,

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4554,7 +4554,7 @@ impl SemanticSyntaxContext for SemanticIndexBuilder<'_, '_> {
 enum CurrentAssignment<'ast, 'db> {
     Assign {
         node: &'ast ast::StmtAssign,
-        unpack: Option<(UnpackPosition, Unpack<'db>)>,
+        unpack: Option<Unpack<'db>>,
     },
     AnnAssign(&'ast ast::StmtAnnAssign),
     AugAssign(&'ast ast::StmtAugAssign),
@@ -4578,11 +4578,10 @@ enum CurrentAssignment<'ast, 'db> {
 impl CurrentAssignment<'_, '_> {
     fn unpack_position_mut(&mut self) -> Option<&mut UnpackPosition> {
         match self {
-            Self::Assign { unpack, .. }
-            | Self::For { unpack, .. }
+            Self::For { unpack, .. }
             | Self::WithItem { unpack, .. }
             | Self::Comprehension { unpack, .. } => unpack.as_mut().map(|(position, _)| position),
-            Self::AnnAssign(_) | Self::AugAssign(_) | Self::Named(_) => None,
+            Self::Assign { .. } | Self::AnnAssign(_) | Self::AugAssign(_) | Self::Named(_) => None,
         }
     }
 }
@@ -4674,19 +4673,22 @@ impl<'ast> Unpackable<'ast> {
         &self,
         unpack: Option<Unpack<'db>>,
     ) -> CurrentAssignment<'ast, 'db> {
-        let unpack = unpack.map(|unpack| (UnpackPosition::First, unpack));
+        let positioned = unpack.map(|unpack| (UnpackPosition::First, unpack));
         match self {
             Unpackable::Assign(stmt) => CurrentAssignment::Assign { node: stmt, unpack },
-            Unpackable::For(stmt) => CurrentAssignment::For { node: stmt, unpack },
+            Unpackable::For(stmt) => CurrentAssignment::For {
+                node: stmt,
+                unpack: positioned,
+            },
             Unpackable::WithItem { item, is_async } => CurrentAssignment::WithItem {
                 item,
                 is_async: *is_async,
-                unpack,
+                unpack: positioned,
             },
             Unpackable::Comprehension { node, first } => CurrentAssignment::Comprehension {
                 node,
                 first: *first,
-                unpack,
+                unpack: positioned,
             },
         }
     }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -515,7 +515,7 @@ pub(crate) struct ImportFromSubmoduleDefinitionNodeRef<'ast> {
 
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct AssignmentDefinitionNodeRef<'ast, 'db> {
-    pub(crate) unpack: Option<(UnpackPosition, Unpack<'db>)>,
+    pub(crate) unpack: Option<Unpack<'db>>,
     pub(crate) value: &'ast ast::Expr,
     pub(crate) target: &'ast ast::Expr,
 }
@@ -685,7 +685,7 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
                 value,
                 target,
             }) => DefinitionKind::Assignment(AssignmentDefinitionKind {
-                target_kind: TargetKind::from(unpack),
+                unpack,
                 value: AstNodeRef::new(parsed, value),
                 target: AstNodeRef::new(parsed, target),
             }),
@@ -1175,15 +1175,6 @@ pub enum TargetKind<'db> {
     Single,
 }
 
-impl<'db> From<Option<(UnpackPosition, Unpack<'db>)>> for TargetKind<'db> {
-    fn from(value: Option<(UnpackPosition, Unpack<'db>)>) -> Self {
-        match value {
-            Some((unpack_position, unpack)) => TargetKind::Sequence(unpack_position, unpack),
-            None => TargetKind::Single,
-        }
-    }
-}
-
 impl<'db> TargetKind<'db> {
     fn from_unpack(unpack: Option<Unpack<'db>>, unpack_position: UnpackPosition) -> Self {
         match unpack {
@@ -1423,14 +1414,14 @@ impl ImportFromSubmoduleDefinitionKind {
 
 #[derive(Clone, Debug, get_size2::GetSize)]
 pub struct AssignmentDefinitionKind<'db> {
-    target_kind: TargetKind<'db>,
+    unpack: Option<Unpack<'db>>,
     value: AstNodeRef<ast::Expr>,
     target: AstNodeRef<ast::Expr>,
 }
 
 impl<'db> AssignmentDefinitionKind<'db> {
-    pub fn target_kind(&self) -> TargetKind<'db> {
-        self.target_kind
+    pub fn unpack(&self) -> Option<Unpack<'db>> {
+        self.unpack
     }
 
     pub fn value<'ast>(&self, module: &'ast ParsedModuleRef) -> &'ast ast::Expr {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -681,13 +681,9 @@ impl<'db> SemanticIndex<'db> {
             .copied()
     }
 
-    /// Returns the [`unpack::Unpack`] ingredient for a list or tuple assignment target.
-    #[track_caller]
-    pub fn expect_unpack(&self, target: impl Into<ExpressionNodeKey>) -> unpack::Unpack<'db> {
-        self.unpacks_by_target
-            .get(&target.into())
-            .copied()
-            .expect("unpacking target should be present in the semantic index")
+    /// Returns the [`unpack::Unpack`] ingredient for an unpacking target, if any.
+    pub fn try_unpack(&self, target: impl Into<ExpressionNodeKey>) -> Option<unpack::Unpack<'db>> {
+        self.unpacks_by_target.get(&target.into()).copied()
     }
 
     pub fn is_standalone_expression(&self, expression_key: impl Into<ExpressionNodeKey>) -> bool {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -317,6 +317,9 @@ pub struct SemanticIndex<'db> {
     /// Map from a standalone expression to its [`Expression`] ingredient.
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
 
+    /// Map from an unpacking target to its [`unpack::Unpack`] ingredient.
+    unpacks_by_target: FrozenMap<ExpressionNodeKey, unpack::Unpack<'db>>,
+
     /// Map from a standalone statement to its [`Statement`] ingredient.
     statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
 
@@ -676,6 +679,15 @@ impl<'db> SemanticIndex<'db> {
         self.expressions_by_node
             .get(&expression_key.into())
             .copied()
+    }
+
+    /// Returns the [`unpack::Unpack`] ingredient for a list or tuple assignment target.
+    #[track_caller]
+    pub fn expect_unpack(&self, target: impl Into<ExpressionNodeKey>) -> unpack::Unpack<'db> {
+        self.unpacks_by_target
+            .get(&target.into())
+            .copied()
+            .expect("unpacking target should be present in the semantic index")
     }
 
     pub fn is_standalone_expression(&self, expression_key: impl Into<ExpressionNodeKey>) -> bool {

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -335,7 +335,6 @@ reveal_type(c_instance.d2)  # revealed: str
 ```py
 class C:
     def __init__(self) -> None:
-        # error: [invalid-assignment] "Object of type `Literal[2]` is not assignable to attribute `b` of type `list[Literal[2, 3]]`"
         self.a, *self.b = (1, 2, 3)
 
 c_instance = C()
@@ -2617,8 +2616,11 @@ mod.global_symbol = 1
 # error: [invalid-assignment] "Object of type `Literal[1]` is not assignable to attribute `global_symbol` of type `str`"
 _, mod.global_symbol = (..., 1)
 
-# TODO: this should be an error, but we do not understand list unpackings yet.
-[_, mod.global_symbol] = [1, 2]
+# error: [invalid-assignment] "Object of type `Literal[2]` is not assignable to attribute `global_symbol` of type `str`"
+[_, mod.global_symbol] = [
+    1,
+    2,
+]
 
 # error: [invalid-assignment] "Object of type `int` is not assignable to attribute `global_symbol` of type `str`"
 for mod.global_symbol in range(3):

--- a/crates/ty_python_semantic/resources/mdtest/unpacking.md
+++ b/crates/ty_python_semantic/resources/mdtest/unpacking.md
@@ -173,6 +173,14 @@ reveal_type(a)  # revealed: Unknown
 reveal_type(b)  # revealed: Unknown
 ```
 
+### Non-name unpacking target
+
+```py
+# error: [not-iterable] "Object of type `Literal[1]` is not iterable"
+# error: [invalid-assignment] "Cannot assign to a subscript on an object of type `Literal[1]`"
+(1[0],) = 1
+```
+
 ### Custom iterator unpacking
 
 ```py

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2365,8 +2365,8 @@ impl<'db> StaticClassLiteral<'db> {
                         // nothing to do here.
                         None
                     }
-                    DefinitionKind::Assignment(assign) => match assign.target_kind() {
-                        TargetKind::Sequence(_, unpack) => {
+                    DefinitionKind::Assignment(assign) => match assign.unpack() {
+                        Some(unpack) => {
                             // We found an unpacking assignment like:
                             //
                             //     .., self.name, .. = <value>
@@ -2376,7 +2376,7 @@ impl<'db> StaticClassLiteral<'db> {
                             let unpacked = infer_unpack_types(db, unpack);
                             Some(unpacked.expression_type(assign.target(&module)))
                         }
-                        TargetKind::Single => {
+                        None => {
                             // We found an un-annotated attribute assignment of the form:
                             //
                             //     self.name = <value>

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -95,6 +95,7 @@ use crate::types::tuple::{Tuple, TupleLength, TupleSpecBuilder, TupleType};
 use crate::types::type_alias::{ManualPEP695TypeAliasType, PEP695TypeAliasType};
 use crate::types::typed_dict::{TypedDictAssignmentKind, TypedDictKeyAssignment};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarConstraints, TypeVarIdentity};
+use crate::types::unpacker::UnpackResult;
 use crate::types::{
     BoundTypeVarInstance, CallDunderError, CallableBinding, CallableType, CallableTypes, ClassType,
     DynamicType, InferenceFlags, InternedConstraintSet, InternedType, IntersectionBuilder,
@@ -2470,9 +2471,41 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = assignment;
 
         for target in targets {
-            self.infer_target(target, value, &|builder, tcx| {
-                builder.infer_standalone_expression(value, tcx)
-            });
+            if matches!(target, ast::Expr::List(_) | ast::Expr::Tuple(_)) {
+                // Infer the standalone expression here to include its diagnostics in this region.
+                self.infer_standalone_expression(value, TypeContext::default());
+
+                let unpacked = infer_unpack_types(self.db(), self.index.expect_unpack(target));
+                self.context.extend(unpacked.diagnostics());
+                self.infer_unpacked_assignment_target(target, value, unpacked);
+            } else {
+                self.infer_target(target, value, &|builder, tcx| {
+                    builder.infer_standalone_expression(value, tcx)
+                });
+            }
+        }
+    }
+
+    fn infer_unpacked_assignment_target(
+        &mut self,
+        target: &ast::Expr,
+        value: &ast::Expr,
+        unpacked: &UnpackResult<'db>,
+    ) {
+        match target {
+            ast::Expr::Starred(ast::ExprStarred { value: target, .. }) => {
+                self.infer_unpacked_assignment_target(target, value, unpacked);
+            }
+            ast::Expr::List(ast::ExprList { elts, .. })
+            | ast::Expr::Tuple(ast::ExprTuple { elts, .. }) => {
+                for target in elts {
+                    self.infer_unpacked_assignment_target(target, value, unpacked);
+                }
+            }
+            _ => {
+                let assigned_ty = unpacked.expression_type(target);
+                self.infer_target_impl(target, value, Some(&|_, _| assigned_ty));
+            }
         }
     }
 
@@ -3653,14 +3686,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let target = assignment.target(self.module());
 
         let mut target_ty = match assignment.target_kind() {
-            TargetKind::Sequence(unpack_position, unpack) => {
+            TargetKind::Sequence(_, unpack) => {
+                // The assignment statement owns unpacking diagnostics so that targets without a
+                // name definition are still checked, and each diagnostic is reported only once.
                 let unpacked = infer_unpack_types(self.db(), unpack);
-                // Only copy the diagnostics if this is the first assignment to avoid duplicating the
-                // unpack assignments.
-                if unpack_position == UnpackPosition::First {
-                    self.context.extend(unpacked.diagnostics());
-                }
-
                 unpacked.expression_type(target)
             }
             TargetKind::Single => {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -3685,14 +3685,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let value = assignment.value(self.module());
         let target = assignment.target(self.module());
 
-        let mut target_ty = match assignment.target_kind() {
-            TargetKind::Sequence(_, unpack) => {
+        let mut target_ty = match assignment.unpack() {
+            Some(unpack) => {
                 // The assignment statement owns unpacking diagnostics so that targets without a
                 // name definition are still checked, and each diagnostic is reported only once.
                 let unpacked = infer_unpack_types(self.db(), unpack);
                 unpacked.expression_type(target)
             }
-            TargetKind::Single => {
+            None => {
                 // This could be an implicit type alias (OptionalList = list[T] | None). Use the definition
                 // of `OptionalList` as the binding context while inferring the RHS (`list[T] | None`), in
                 // order to bind `T` to `OptionalList`.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2471,11 +2471,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = assignment;
 
         for target in targets {
-            if matches!(target, ast::Expr::List(_) | ast::Expr::Tuple(_)) {
+            if let Some(unpack) = self.index.try_unpack(target) {
                 // Infer the standalone expression here to include its diagnostics in this region.
                 self.infer_standalone_expression(value, TypeContext::default());
 
-                let unpacked = infer_unpack_types(self.db(), self.index.expect_unpack(target));
+                let unpacked = infer_unpack_types(self.db(), unpack);
                 self.context.extend(unpacked.diagnostics());
                 self.infer_unpacked_assignment_target(target, value, unpacked);
             } else {


### PR DESCRIPTION
## Summary

Now that we have a statement-level inference query, we can simplify the handling of assignment unpacking and close some diagnostic gaps. We no longer need an `UnpackPosition` to avoid duplicate diagnostics, since the statement-level query always owns the assignment unpacking. We do need to track unpacking expressions by assignment target in the semantic index, and reuse that unpacking metadata during type inference so nested targets still emit unpacking diagnostics.

Closes https://github.com/astral-sh/ty/issues/3801

## Testing

Added mdtest and updated some expectations.