### PR TITLE
[ty] Fix bound TypeVar default cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -278,15 +278,13 @@ type A[T = A] = A[int]
 An explicit alias specialization overrides the alias type parameter's default:
 
 ```py
-from typing import Generic
-from typing_extensions import TypeVar
+type ExplicitAlias[
+    FirstT = ExplicitAlias[int, str],
+    SecondT = FirstT,
+] = list[SecondT]
 
-ExplicitT = TypeVar("ExplicitT", default="ExplicitAlias[int]")
-type ExplicitAlias[AliasT = ExplicitT] = list[AliasT]
-
-class ExplicitContainer(Generic[ExplicitT]): ...
-
-reveal_type(ExplicitContainer())  # revealed: ExplicitContainer[ExplicitAlias[int]]
+def explicit_alias_default(x: ExplicitAlias):
+    reveal_type(x)  # revealed: list[ExplicitAlias[int, str]]
 ```
 
 A self-referential default that does not reference itself in the alias body should also not crash,

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/aliases.md
@@ -275,6 +275,20 @@ Self-referential defaults should not crash type inference:
 type A[T = A] = A[int]
 ```
 
+An explicit alias specialization overrides the alias type parameter's default:
+
+```py
+from typing import Generic
+from typing_extensions import TypeVar
+
+ExplicitT = TypeVar("ExplicitT", default="ExplicitAlias[int]")
+type ExplicitAlias[AliasT = ExplicitT] = list[AliasT]
+
+class ExplicitContainer(Generic[ExplicitT]): ...
+
+reveal_type(ExplicitContainer())  # revealed: ExplicitContainer[ExplicitAlias[int]]
+```
+
 A self-referential default that does not reference itself in the alias body should also not crash,
 even when the default is evaluated (e.g., by omitting the type argument):
 

--- a/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
@@ -1,0 +1,31 @@
+# Regression test for #3804
+
+Regression test for [this issue](https://github.com/astral-sh/ty/issues/3804).
+
+`cog.py`:
+
+```py
+from commands import GroupMixin
+
+class Group(GroupMixin): ...
+class Bot(GroupMixin): ...
+```
+
+`commands.py`:
+
+```py
+from typing import TYPE_CHECKING, Generic
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from cog import Bot
+
+CogT = TypeVar("CogT", bound="Bot", default="Bot", covariant=True)
+
+class GroupMixin(Generic[CogT]):
+    def method(self): ...
+
+def call_method(value: object):
+    if isinstance(value, GroupMixin):
+        value.method()
+```

--- a/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
@@ -2,13 +2,6 @@
 
 Regression test for [this issue](https://github.com/astral-sh/ty/issues/3804).
 
-```toml
-[environment]
-python-version = "3.13"
-```
-
-## Nominal default
-
 `cog.py`:
 
 ```py
@@ -30,41 +23,6 @@ if TYPE_CHECKING:
 CogT = TypeVar("CogT", bound="Bot", default="Bot", covariant=True)
 
 class GroupMixin(Generic[CogT]):
-    def method(self): ...
-
-def call_method(value: object):
-    if isinstance(value, GroupMixin):
-        value.method()
-```
-
-## Type alias default
-
-A valid type alias default must not be discarded just because its value is inferred as part of a
-cycle.
-
-`cog.py`:
-
-```py
-from commands import GroupMixin
-
-class Group(GroupMixin): ...
-class Bot(GroupMixin): ...
-```
-
-`commands.py`:
-
-```py
-from typing import TYPE_CHECKING, Generic
-from typing_extensions import TypeVar
-
-if TYPE_CHECKING:
-    from cog import Bot
-
-type BotAlias = Bot
-
-T = TypeVar("T", bound="Bot", default=BotAlias, covariant=True)
-
-class GroupMixin(Generic[T]):
     def method(self): ...
 
 def call_method(value: object):

--- a/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3804_bound_typevar_default_cycle.md
@@ -2,6 +2,13 @@
 
 Regression test for [this issue](https://github.com/astral-sh/ty/issues/3804).
 
+```toml
+[environment]
+python-version = "3.13"
+```
+
+## Nominal default
+
 `cog.py`:
 
 ```py
@@ -23,6 +30,41 @@ if TYPE_CHECKING:
 CogT = TypeVar("CogT", bound="Bot", default="Bot", covariant=True)
 
 class GroupMixin(Generic[CogT]):
+    def method(self): ...
+
+def call_method(value: object):
+    if isinstance(value, GroupMixin):
+        value.method()
+```
+
+## Type alias default
+
+A valid type alias default must not be discarded just because its value is inferred as part of a
+cycle.
+
+`cog.py`:
+
+```py
+from commands import GroupMixin
+
+class Group(GroupMixin): ...
+class Bot(GroupMixin): ...
+```
+
+`commands.py`:
+
+```py
+from typing import TYPE_CHECKING, Generic
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from cog import Bot
+
+type BotAlias = Bot
+
+T = TypeVar("T", bound="Bot", default=BotAlias, covariant=True)
+
+class GroupMixin(Generic[T]):
     def method(self): ...
 
 def call_method(value: object):

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1433,13 +1433,18 @@ fn bound_typevar_default_type<'db>(
 
 #[expect(clippy::ref_option)]
 fn bound_typevar_default_type_cycle_recover<'db>(
-    _db: &'db dyn Db,
-    _cycle: &salsa::Cycle,
-    _previous_default: &Option<Type<'db>>,
-    _default: Option<Type<'db>>,
+    db: &'db dyn Db,
+    cycle: &salsa::Cycle,
+    previous_default: &Option<Type<'db>>,
+    default: Option<Type<'db>>,
     _bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
-    None
+    // Normalize the default to ensure cycle convergence.
+    match (previous_default, default) {
+        (Some(prev), Some(default)) => Some(default.cycle_normalized(db, *prev, cycle)),
+        (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
+        (_, None) => None,
+    }
 }
 
 /// Whether a typevar default is eagerly specified or lazily evaluated.

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -391,7 +391,7 @@ impl<'db> TypeVarInstance<'db> {
                 return false;
             }
 
-            if let Some(specialization) = type_alias.specialization(state.db) {
+            let value_type = if let Some(specialization) = type_alias.specialization(state.db) {
                 if specialization
                     .types(state.db)
                     .iter()
@@ -399,6 +399,7 @@ impl<'db> TypeVarInstance<'db> {
                 {
                     return true;
                 }
+                type_alias.value_type(state.db)
             } else if let Some(generic_context) = type_alias.generic_context(state.db)
                 && generic_context.variables(state.db).any(|typevar| {
                     typevar_default_is_self_referential(
@@ -409,9 +410,11 @@ impl<'db> TypeVarInstance<'db> {
                 })
             {
                 return true;
-            }
+            } else {
+                type_alias.raw_value_type(state.db)
+            };
 
-            type_is_self_referential_impl(state, type_alias.raw_value_type(state.db), self_identity)
+            type_is_self_referential_impl(state, value_type, self_identity)
         }
 
         fn type_is_self_referential_impl<'db>(

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1413,7 +1413,7 @@ impl<'db> BoundTypeVarIdentity<'db> {
 }
 
 #[salsa::tracked(
-    cycle_initial=|_, _, _| None,
+    cycle_initial=|_, id, _| Some(Type::divergent(id)),
     cycle_fn=bound_typevar_default_type_cycle_recover,
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -1439,9 +1439,11 @@ fn bound_typevar_default_type_cycle_recover<'db>(
     default: Option<Type<'db>>,
     _bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
-    // Normalize the default to ensure cycle convergence.
     match (previous_default, default) {
-        (Some(prev), Some(default)) => Some(default.cycle_normalized(db, *prev, cycle)),
+        // A type alias is opaque to recursive type normalization. Keep the cycle marker until
+        // alias inference either resolves or rejects a self-referential default.
+        (Some(previous), Some(Type::TypeAlias(_))) if previous.is_divergent() => Some(*previous),
+        (Some(previous), Some(default)) => Some(default.cycle_normalized(db, *previous, cycle)),
         (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
         (_, None) => None,
     }

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1440,9 +1440,17 @@ fn bound_typevar_default_type_cycle_recover<'db>(
     _bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
     match (previous_default, default) {
-        // A type alias is opaque to recursive type normalization. Keep the cycle marker until
-        // alias inference either resolves or rejects a self-referential default.
-        (Some(previous), Some(Type::TypeAlias(_))) if previous.is_divergent() => Some(*previous),
+        // A type alias is opaque to recursive type normalization. If its provisional raw value
+        // depends on the active cycle, keep the previous approximation until alias inference
+        // resolves that dependency.
+        (Some(previous), Some(Type::TypeAlias(alias)))
+            if any_over_type(db, alias.raw_value_type(db), false, |ty| {
+                ty == Type::divergent(cycle.id())
+                    || cycle.head_ids().any(|id| ty == Type::divergent(id))
+            }) =>
+        {
+            Some(*previous)
+        }
         (Some(previous), Some(default)) => Some(default.cycle_normalized(db, *previous, cycle)),
         (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
         (_, None) => None,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -391,6 +391,26 @@ impl<'db> TypeVarInstance<'db> {
                 return false;
             }
 
+            if let Some(specialization) = type_alias.specialization(state.db) {
+                if specialization
+                    .types(state.db)
+                    .iter()
+                    .any(|ty| type_is_self_referential_impl(state, *ty, self_identity))
+                {
+                    return true;
+                }
+            } else if let Some(generic_context) = type_alias.generic_context(state.db)
+                && generic_context.variables(state.db).any(|typevar| {
+                    typevar_default_is_self_referential(
+                        state,
+                        typevar.typevar(state.db),
+                        self_identity,
+                    )
+                })
+            {
+                return true;
+            }
+
             type_is_self_referential_impl(state, type_alias.raw_value_type(state.db), self_identity)
         }
 
@@ -1440,17 +1460,6 @@ fn bound_typevar_default_type_cycle_recover<'db>(
     _bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
     match (previous_default, default) {
-        // A type alias is opaque to recursive type normalization. If its provisional raw value
-        // depends on the active cycle, keep the previous approximation until alias inference
-        // resolves that dependency.
-        (Some(previous), Some(Type::TypeAlias(alias)))
-            if any_over_type(db, alias.raw_value_type(db), false, |ty| {
-                ty == Type::divergent(cycle.id())
-                    || cycle.head_ids().any(|id| ty == Type::divergent(id))
-            }) =>
-        {
-            Some(*previous)
-        }
         (Some(previous), Some(default)) => Some(default.cycle_normalized(db, *previous, cycle)),
         (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
         (_, None) => None,


### PR DESCRIPTION
## Summary

Preserve bound TypeVar defaults during Salsa fixed-point cycle recovery instead of replacing provisional values with None. This prevents query-order-dependent diagnostics in cyclic generic definitions and fixes astral-sh/ty#3804.

## Test Plan

Testing: added regression coverage and ran focused semantic tests, Clippy, and repository hooks.