### PR TITLE
[ty] Simplify intersections of invariant generic types with `Any` specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/intersection_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/intersection_types.md
@@ -1339,5 +1339,80 @@ class Y(X):
 test(Y())
 ```
 
+## Intersections of invariant generics
+
+For any gradual type `G`, `Invariant[G] & Invariant[Any] = Invariant[G]`.
+
+```py
+from typing import Any
+from ty_extensions import Unknown
+
+class P: ...
+class Q: ...
+
+class Invariant[T]:
+    value: T
+
+type InvariantAny = Invariant[Any]
+
+def _(
+    i1: Invariant[Any] & Invariant[P],
+    i2: Invariant[P] & Invariant[Any],
+    i3: InvariantAny & Invariant[P],
+    i4: Invariant[Unknown] & Invariant[P],
+    i5: Invariant[Any] & Q & Invariant[P],
+    i6: Invariant[P] & Q & Invariant[Any],
+) -> None:
+    reveal_type(i1)  # revealed: Invariant[P]
+    reveal_type(i2)  # revealed: Invariant[P]
+    reveal_type(i3)  # revealed: Invariant[P]
+    reveal_type(i4)  # revealed: Invariant[P]
+    reveal_type(i5)  # revealed: Q & Invariant[P]
+    reveal_type(i6)  # revealed: Invariant[P] & Q
+
+def _(
+    i1: list[Any] & list[int],
+    i2: dict[str, int] & dict[str, Any],
+    i3: dict[Any, str] & dict[int, str],
+    i4: dict[str, int] & dict[Any, Any],
+) -> None:
+    reveal_type(i1)  # revealed: list[int]
+    reveal_type(i2)  # revealed: dict[str, int]
+    reveal_type(i3)  # revealed: dict[int, str]
+    reveal_type(i4)  # revealed: dict[str, int]
+
+def _(
+    i1: list[Any] & list[Any | int],
+    i2: list[Any] & list[Any],
+) -> None:
+    reveal_type(i1)  # revealed: list[Any | int]
+    reveal_type(i2)  # revealed: list[Any]
+```
+
+Intersections with typevars and NewTypes are not affected by this:
+
+```py
+from typing import Any, NewType, TypeVar
+from typing_extensions import TypeIs
+
+T = TypeVar("T", bound=list[Any])
+ListId = NewType("ListId", list[Any])
+
+def is_int_list(value: object) -> TypeIs[list[int]]:
+    return isinstance(value, list) and all(isinstance(item, int) for item in value)
+
+def preserve_id(value: ListId) -> ListId:
+    if is_int_list(value):
+        reveal_type(value)  # revealed: ListId & list[int]
+        return value
+    return value
+
+def preserve_type(value: T) -> T:
+    if is_int_list(value):
+        reveal_type(value)  # revealed: T@preserve_type & list[int]
+        return value
+    return value
+```
+
 [complement laws]: https://en.wikipedia.org/wiki/Complement_(set_theory)
 [de morgan's laws]: https://en.wikipedia.org/wiki/De_Morgan%27s_laws

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/materialization.md
@@ -411,16 +411,41 @@ static_assert(is_equivalent_to(Bottom[(Any | int) & tuple[str, Unknown]], Never)
 class Foo: ...
 
 static_assert(is_equivalent_to(Bottom[(Any | Foo) & tuple[str]], Foo & tuple[str]))
+```
+
+## Intersections of invariant generics
+
+The intersection `list[Any] & list[int]` is eagerly simplified to `list[int]`. Therefore, this is
+just a fully-static type where bottom and top materialization are the same:
+
+```pyi
+from typing import Any
+from ty_extensions import Bottom, Top
 
 def _(
     top: Top[list[Any] & list[int]],
     bottom: Bottom[list[Any] & list[int]],
 ):
-    # Top[list[Any] & list[int]] = Top[list[Any]] & list[int] = list[int]
     reveal_type(top)  # revealed: list[int]
-    # Bottom[list[Any] & list[int]] = Bottom[list[Any]] & list[int] = Bottom[list[Any]]
+    reveal_type(bottom)  # revealed: list[int]
+```
+
+Unfortunately, we get a seemingly different result when we distribute `Top[..]` and `Bottom[..]`
+over the intersection first:
+
+```pyi
+def _(
+    top: Top[list[Any]] & Top[list[int]],
+    bottom: Bottom[list[Any]] & Bottom[list[int]],
+):
+    reveal_type(top)  # revealed: list[int]
     reveal_type(bottom)  # revealed: Bottom[list[Any]]
 ```
+
+This is not a contradiction to what we have above if we view `Bottom[list[Any]]` as an empty
+"marker" type that adds no additional materializations. In other words, the gradual type
+`Bottom[list[Any]] | list[int] & Any` (i.e. the interval that is spanned by the types of the two
+bounds `bottom` and `top`) is equivalent to just `list[int]`.
 
 ## Negation
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -42,7 +42,7 @@ use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements, StringLiteralType,
-    SubclassOfType, Type, TypeVarBoundOrConstraints, UnionType,
+    SubclassOfType, Type, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
@@ -88,6 +88,63 @@ fn split_truthiness_guarded_intersection<'db>(
         core = core.add_negative(*negative);
     }
     Some((core.build(), guard))
+}
+
+/// Return `true` if `general` and `specific` are specializations of the same generic class and
+/// `general` only differs by using dynamic types for invariant type variables. For example,
+/// `list[Any]` is an invariant-dynamic generalization of `list[int]`.
+fn is_invariant_dynamic_generalization_of<'db>(
+    db: &'db dyn Db,
+    general: Type<'db>,
+    specific: Type<'db>,
+) -> bool {
+    // Fast path to avoid performance regressions.
+    if !general.has_dynamic(db) {
+        return false;
+    }
+
+    if matches!(general, Type::TypeVar(_) | Type::NewTypeInstance(_)) {
+        return false;
+    }
+
+    let (
+        Some((general_class, general_specialization)),
+        Some((specific_class, specific_specialization)),
+    ) = (
+        general.class_specialization(db),
+        specific.class_specialization(db),
+    )
+    else {
+        return false;
+    };
+
+    // Top and bottom materializations are not gradual types.
+    if general_class != specific_class
+        || general_specialization.materialization_kind(db).is_some()
+        || specific_specialization.materialization_kind(db).is_some()
+    {
+        return false;
+    }
+
+    let mut has_dynamic_replacement = false;
+    for ((typevar, general_type), specific_type) in general_specialization
+        .generic_context(db)
+        .variables(db)
+        .zip(general_specialization.types(db))
+        .zip(specific_specialization.types(db))
+    {
+        if general_type == specific_type {
+            continue;
+        }
+        if general_type.is_non_divergent_dynamic()
+            && typevar.variance(db) == TypeVarVariance::Invariant
+        {
+            has_dynamic_replacement = true;
+            continue;
+        }
+        return false;
+    }
+    has_dynamic_replacement
 }
 
 /// Try to merge a complementary guarded pair into an unguarded core.
@@ -1501,12 +1558,24 @@ impl<'db> InnerIntersectionBuilder<'db> {
 
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_positive) in self.positive.iter().enumerate() {
-                    // S & T = S    if S <: T
-                    if existing_positive.is_redundant_with(db, new_positive) {
+                    // S & T = S if S <: T or T is an invariant-dynamic generalization of S.
+                    if existing_positive.is_redundant_with(db, new_positive)
+                        || is_invariant_dynamic_generalization_of(
+                            db,
+                            new_positive,
+                            *existing_positive,
+                        )
+                    {
                         return;
                     }
                     // same rule, reverse order
-                    if new_positive.is_redundant_with(db, *existing_positive) {
+                    if new_positive.is_redundant_with(db, *existing_positive)
+                        || is_invariant_dynamic_generalization_of(
+                            db,
+                            *existing_positive,
+                            new_positive,
+                        )
+                    {
                         to_remove.push(index);
                     }
                     // A & B = Never    if A and B are disjoint


### PR DESCRIPTION
## Summary
Implement an intersection simplification for invariant generics, namely

```py
Invariant[G] & Invariant[Any] = Invariant[G]
```
for all gradual types `G`. For the full justification, see https://github.com/astral-sh/ruff/pull/26054 (the result there can be generalized from fully-static types to all gradual types).

## Ecosystem

Both new diagnostic in spark and prefect seems to be true positives.