### PR TITLE
[flake8-pyi] Extend PYI033 to Python files in preview

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI033.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI033.py
@@ -3,20 +3,20 @@
 from collections.abc import Sequence
 from typing import TypeAlias
 
-A: TypeAlias = None  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-C: TypeAlias = None  #type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-D: TypeAlias = None  #      type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-E: TypeAlias = None#    type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-F: TypeAlias = None#type:int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+A: TypeAlias = None  # type: int  # error
+B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # error
+C: TypeAlias = None  #type: int  # error
+D: TypeAlias = None  #      type: int  # error
+E: TypeAlias = None#    type: int  # error
+F: TypeAlias = None#type:int  # error
 
 def func(
-    arg1,  # type: dict[str, int]  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-    arg2  # type: Sequence[bytes]  # And here's some more info about this arg  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+    arg1,  # type: dict[str, int]  # error
+    arg2  # type: Sequence[bytes]  # And here's some more info about this arg  # error
 ): ...
 
 class Foo:
-    Attr: TypeAlias = None  # type: set[str]  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+    Attr: TypeAlias = None  # type: set[str]  # error
 
 G: TypeAlias = None  # type: ignore
 H: TypeAlias = None  # type: ignore[attr-defined]

--- a/crates/ruff_linter/src/checkers/tokens.rs
+++ b/crates/ruff_linter/src/checkers/tokens.rs
@@ -157,8 +157,8 @@ pub(crate) fn check_tokens(
         pyupgrade::rules::extraneous_parentheses(context, tokens, locator);
     }
 
-    if source_type.is_stub() && context.is_rule_enabled(Rule::TypeCommentInStub) {
-        flake8_pyi::rules::type_comment_in_stub(context, locator, comment_ranges);
+    if context.is_rule_enabled(Rule::TypeCommentInStub) {
+        flake8_pyi::rules::type_comment_in_stub(context, locator, comment_ranges, source_type);
     }
 
     if context.any_rule_enabled(&[

--- a/crates/ruff_linter/src/preview.rs
+++ b/crates/ruff_linter/src/preview.rs
@@ -53,6 +53,11 @@ pub(crate) const fn is_bad_version_info_in_non_stub_enabled(settings: &LinterSet
     settings.preview.is_enabled()
 }
 
+// https://github.com/astral-sh/ruff/issues/4460
+pub(crate) const fn is_type_comment_in_non_stub_enabled(settings: &LinterSettings) -> bool {
+    settings.preview.is_enabled()
+}
+
 /// <https://github.com/astral-sh/ruff/pull/19303>
 pub(crate) const fn is_fix_f_string_logging_enabled(settings: &LinterSettings) -> bool {
     settings.preview.is_enabled()

--- a/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/mod.rs
@@ -146,6 +146,7 @@ mod tests {
     #[test_case(Rule::RedundantNumericUnion, Path::new("PYI041_2.py"))]
     #[test_case(Rule::RedundantNumericUnion, Path::new("PYI041_3.py"))]
     #[test_case(Rule::RedundantNumericUnion, Path::new("PYI041_4.py"))]
+    #[test_case(Rule::TypeCommentInStub, Path::new("PYI033.py"))]
     fn preview_rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!(
             "preview_{}_{}",

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/type_comment_in_stub.rs
@@ -3,20 +3,27 @@ use std::sync::LazyLock;
 use regex::Regex;
 
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::PySourceType;
 use ruff_python_trivia::CommentRanges;
 
 use crate::Locator;
 use crate::Violation;
 use crate::checkers::ast::LintContext;
+use crate::preview::is_type_comment_in_non_stub_enabled;
 
 /// ## What it does
-/// Checks for the use of type comments (e.g., `x = 1  # type: int`) in stub
-/// files.
+/// Checks for the use of type comments (e.g., `x = 1  # type: int`).
+///
+/// By default, this check only runs on stub files. If [`preview`] mode is enabled,
+/// the check also runs on `.py` files.
 ///
 /// ## Why is this bad?
-/// Stub (`.pyi`) files should use type annotations directly, rather
-/// than type comments, even if they're intended to support Python 2, since
-/// stub files are not executed at runtime. The one exception is `# type: ignore`.
+/// Type comments are a soft-deprecated form of type annotation. They are unsupported
+/// by some modern type checkers, including ty and Pyrefly, and are only necessary when
+/// supporting end-of-life Python versions such as 3.5 or older. They are never necessary
+/// in stub files, which are not executed at runtime.
+///
+/// This rule does not apply to `# type: ignore` suppression comments.
 ///
 /// ## Example
 /// ```pyi
@@ -34,7 +41,7 @@ pub(crate) struct TypeCommentInStub;
 impl Violation for TypeCommentInStub {
     #[derive_message_formats]
     fn message(&self) -> String {
-        "Don't use type comments in stub file".to_string()
+        "Don't use type comments".to_string()
     }
 }
 
@@ -43,12 +50,17 @@ pub(crate) fn type_comment_in_stub(
     context: &LintContext,
     locator: &Locator,
     comment_ranges: &CommentRanges,
+    source_type: PySourceType,
 ) {
+    if !source_type.is_stub() && !is_type_comment_in_non_stub_enabled(context.settings()) {
+        return;
+    }
+
     for range in comment_ranges {
         let comment = locator.slice(range);
 
         if TYPE_COMMENT_REGEX.is_match(comment) && !TYPE_IGNORE_REGEX.is_match(comment) {
-            context.report_diagnostic_if_enabled(TypeCommentInStub, range);
+            context.report_diagnostic(TypeCommentInStub, range);
         }
     }
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI033_PYI033.pyi.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI033_PYI033.pyi.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
 ---
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
  --> PYI033.pyi:6:22
   |
 4 | from typing import TypeAlias
@@ -12,7 +12,7 @@ PYI033 Don't use type comments in stub file
 8 | C: TypeAlias = None  #type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
   |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
  --> PYI033.pyi:7:22
   |
 6 | …one  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
@@ -22,7 +22,7 @@ PYI033 Don't use type comments in stub file
 9 | …one  #      type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
   |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:8:22
    |
  6 | A: TypeAlias = None  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
@@ -33,7 +33,7 @@ PYI033 Don't use type comments in stub file
 10 | E: TypeAlias = None#    type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:9:22
    |
  7 | …as = None  # type: str  # And here's an extra comment about why it's that type  # Y033 Do not use type comments in stubs (e.g. use "x…
@@ -44,7 +44,7 @@ PYI033 Don't use type comments in stub file
 11 | …as = None#type:int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:10:20
    |
  8 | C: TypeAlias = None  #type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
@@ -54,7 +54,7 @@ PYI033 Don't use type comments in stub file
 11 | F: TypeAlias = None#type:int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:11:20
    |
  9 | D: TypeAlias = None  #      type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
@@ -65,7 +65,7 @@ PYI033 Don't use type comments in stub file
 13 | def func(
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:14:12
    |
 13 | def func(
@@ -75,7 +75,7 @@ PYI033 Don't use type comments in stub file
 16 | ): ...
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:15:11
    |
 13 | …unc(
@@ -85,7 +85,7 @@ PYI033 Don't use type comments in stub file
 16 | ….
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:19:29
    |
 18 | …
@@ -95,7 +95,7 @@ PYI033 Don't use type comments in stub file
 21 | …ne  # type: ignore
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:29:22
    |
 28 | # Whole line commented out  # type: int
@@ -105,7 +105,7 @@ PYI033 Don't use type comments in stub file
 31 | class Bar:
    |
 
-PYI033 Don't use type comments in stub file
+PYI033 Don't use type comments
   --> PYI033.pyi:32:26
    |
 31 | class Bar:

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI033_PYI033.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__preview_PYI033_PYI033.py.snap
@@ -1,0 +1,134 @@
+---
+source: crates/ruff_linter/src/rules/flake8_pyi/mod.rs
+---
+--- Linter settings ---
+-linter.preview = disabled
++linter.preview = enabled
+
+--- Summary ---
+Removed: 0
+Added: 11
+
+--- Added ---
+PYI033 Don't use type comments
+ --> PYI033.py:6:22
+  |
+4 | from typing import TypeAlias
+5 |
+6 | A: TypeAlias = None  # type: int  # error
+  |                      ^^^^^^^^^^^^^^^^^^^^
+7 | B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # error
+8 | C: TypeAlias = None  #type: int  # error
+  |
+
+
+PYI033 Don't use type comments
+ --> PYI033.py:7:22
+  |
+6 | A: TypeAlias = None  # type: int  # error
+7 | B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # error
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+8 | C: TypeAlias = None  #type: int  # error
+9 | D: TypeAlias = None  #      type: int  # error
+  |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:8:22
+   |
+ 6 | A: TypeAlias = None  # type: int  # error
+ 7 | B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # error
+ 8 | C: TypeAlias = None  #type: int  # error
+   |                      ^^^^^^^^^^^^^^^^^^^
+ 9 | D: TypeAlias = None  #      type: int  # error
+10 | E: TypeAlias = None#    type: int  # error
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:9:22
+   |
+ 7 | B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # error
+ 8 | C: TypeAlias = None  #type: int  # error
+ 9 | D: TypeAlias = None  #      type: int  # error
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+10 | E: TypeAlias = None#    type: int  # error
+11 | F: TypeAlias = None#type:int  # error
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:10:20
+   |
+ 8 | C: TypeAlias = None  #type: int  # error
+ 9 | D: TypeAlias = None  #      type: int  # error
+10 | E: TypeAlias = None#    type: int  # error
+   |                    ^^^^^^^^^^^^^^^^^^^^^^^
+11 | F: TypeAlias = None#type:int  # error
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:11:20
+   |
+ 9 | D: TypeAlias = None  #      type: int  # error
+10 | E: TypeAlias = None#    type: int  # error
+11 | F: TypeAlias = None#type:int  # error
+   |                    ^^^^^^^^^^^^^^^^^^
+12 |
+13 | def func(
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:14:12
+   |
+13 | def func(
+14 |     arg1,  # type: dict[str, int]  # error
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+15 |     arg2  # type: Sequence[bytes]  # And here's some more info about this arg  # error
+16 | ): ...
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:15:11
+   |
+13 | def func(
+14 |     arg1,  # type: dict[str, int]  # error
+15 |     arg2  # type: Sequence[bytes]  # And here's some more info about this arg  # error
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+16 | ): ...
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:19:29
+   |
+18 | class Foo:
+19 |     Attr: TypeAlias = None  # type: set[str]  # error
+   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^
+20 |
+21 | G: TypeAlias = None  # type: ignore
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:29:22
+   |
+28 | # Whole line commented out  # type: int
+29 | M: TypeAlias = None  # type: can't parse me!
+   |                      ^^^^^^^^^^^^^^^^^^^^^^^
+30 |
+31 | class Bar:
+   |
+
+
+PYI033 Don't use type comments
+  --> PYI033.py:32:26
+   |
+31 | class Bar:
+32 |     N: TypeAlias = None  # type: can't parse me either!
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+33 |     # This whole line is commented out and indented # type: str
+   |


### PR DESCRIPTION
## Summary

This PR revives https://github.com/astral-sh/ruff/pull/4166.

There's no reason to use type comments in modern Python code. I'd argue they're effectively soft-deprecated at this point, and they're entirely unsupported by modern type checkers such as ty and pyrefly. In the three years since the last PR proposing this change, Python 2 has become much less widely used in the ecosystem, and many other flake8-pyi rules have been extended so that they now run on `.py` files as well.

If you enable strict mode in pyright, it enables pyright's `reportTypeCommentUsage` rule, which bans the use of type comments. I don't want to have to reimplement that rule in ty for pyright parity, when we already have a very good implementation over here in Ruff ;)

https://github.com/astral-sh/ruff/issues/1619#issuecomment-1529896008 pointed out that there are still uses for type comments for things like `for` loops, e.g.

```py
from models import Wheel

for wheel in car.wheels.all():  # type: Wheel
    ...
```

But even here, while it's not quite as pretty, mypy users can easily use modern type annotations instead:

```py
from models import Wheel

wheel: Wheel
for wheel in car.wheels.all():
    ...
```

Closes https://github.com/astral-sh/ruff/issues/4460