### PR TITLE
[ty] Support `Annotated[Any, ...]` as a class base

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/annotated.md
@@ -73,7 +73,7 @@ def _(x: Annotated[(int,)]):
 Inheriting from `Annotated[T, ...]` is equivalent to inheriting from `T` itself.
 
 ```py
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Any
 from ty_extensions import reveal_mro
 
 class C(Annotated[int, "foo"]): ...
@@ -90,6 +90,11 @@ class E(Annotated[list["E"], "metadata"]): ...
 
 # error: [revealed-type] "Revealed MRO: (<class 'E'>, <class 'list[E]'>, <class 'MutableSequence[E]'>, <class 'Sequence[E]'>, <class 'Reversible[E]'>, <class 'Collection[E]'>, <class 'Iterable[E]'>, <class 'Container[Any]'>, typing.Protocol, typing.Generic, <class 'object'>)"
 reveal_mro(E)
+
+class F(Annotated[Any, "metadata"]): ...
+
+# revealed: (<class 'F'>, Any, <class 'object'>)
+reveal_mro(F)
 ```
 
 ### Not parameterized

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -204,14 +204,13 @@ impl<'db> ClassBase<'db> {
                     Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
                 }
                 KnownInstanceType::Annotated(ty) => {
-                    // Unions are not supported in this position, so we only need to support
-                    // something like `class C(Annotated[Base, "metadata"]): ...`, which we
-                    // can do by turning the instance type (`Base` in this example) back into
-                    // a class.
-                    let annotated_ty = ty.inner(db);
-                    let instance_ty = annotated_ty.as_nominal_instance()?;
-
-                    Some(Self::Class(instance_ty.class(db)))
+                    match ty.inner(db) {
+                        Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
+                        Type::NominalInstance(instance) => {
+                            Some(Self::Class(instance.class(db)))
+                        }
+                        _ => None,
+                    }
                 }
             },
 


### PR DESCRIPTION
## Summary

`Annotated[T, ...]` is equivalent to `T`, but when it is used as a class base, we currently only convert nominal inner types back to class objects. This causes valid dynamic bases to be rejected:

```python
from typing import Annotated, Any

class F(Annotated[Any, "metadata"]): ...
```

This preserves dynamic inner types as dynamic class bases, so `Annotated[Any, ...]` behaves like `Any` while existing nominal `Annotated` bases continue to work unchanged.
