### PR TITLE
[ty] Suggest keyword-only arguments between variadic parameters

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -5130,15 +5130,34 @@ bar(o<CURSOR>
     // Regression test for https://github.com/astral-sh/ty/issues/3803
     #[test]
     fn call_keyword_only_argument_between_variadic_parameters() {
-        for parameters in ["arg1, *arg2, special, **kw", "*args, special, **kw"] {
-            let source = format!("def func({parameters}): ...\n\nfunc(sp<CURSOR>\n");
-            completion_test_builder(&source)
-                .skip_keywords()
-                .skip_builtins()
-                .skip_auto_import()
-                .build()
-                .contains("special");
-        }
+        completion_test_builder(
+            "\
+def func(*args, special, **kw): ...
+
+func(sp<CURSOR>
+",
+        )
+        .skip_keywords()
+        .skip_builtins()
+        .skip_auto_import()
+        .build()
+        .contains("special");
+    }
+
+    #[test]
+    fn call_keyword_only_argument_between_variadic_parameters_after_positional_argument() {
+        completion_test_builder(
+            "\
+def func(arg1, *arg2, special, **kw): ...
+
+func(sp<CURSOR>
+",
+        )
+        .skip_keywords()
+        .skip_builtins()
+        .skip_auto_import()
+        .build()
+        .contains("special");
     }
 
     #[test]

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -5127,6 +5127,20 @@ bar(o<CURSOR>
         );
     }
 
+    // Regression test for https://github.com/astral-sh/ty/issues/3803
+    #[test]
+    fn call_keyword_only_argument_between_variadic_parameters() {
+        for parameters in ["arg1, *arg2, special, **kw", "*args, special, **kw"] {
+            let source = format!("def func({parameters}): ...\n\nfunc(sp<CURSOR>\n");
+            completion_test_builder(&source)
+                .skip_keywords()
+                .skip_builtins()
+                .skip_auto_import()
+                .build()
+                .contains("special");
+        }
+    }
+
     #[test]
     fn call_multiple_keyword_arguments() {
         let builder = completion_test_builder(

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -647,7 +647,7 @@ fn displayed_parameters_for_signature<'db>(
     let parameters = signature.parameters();
 
     match parameters.kind() {
-        ParametersKind::Standard | ParametersKind::Concatenate(_) => {
+        ParametersKind::Standard | ParametersKind::Gradual | ParametersKind::Concatenate(_) => {
             let mut displayed_parameters = Vec::new();
             let mut parameter_to_displayed_parameter_mapping = vec![None; parameters.len()];
 
@@ -721,7 +721,7 @@ fn displayed_parameters_for_signature<'db>(
                 vec![Some(0); parameters.len()],
             )
         }
-        ParametersKind::Gradual | ParametersKind::Top => (Vec::new(), vec![None; parameters.len()]),
+        ParametersKind::Top => (Vec::new(), vec![None; parameters.len()]),
     }
 }
 


### PR DESCRIPTION
## Summary

Functions with unannotated `*args` and `**kwargs` use a gradual parameter list. Prior to this change, we omitted all structured parameters for gradual signatures when building signature help, including explicit keyword-only parameters retained between the variadics:

```python
def func(*args, special, **kwargs): ...

func(sp<CURSOR>)
```

This extracts displayed parameters from gradual signatures the same way we do for standard and `Concatenate` signatures. Pure `(*args, **kwargs)` signatures still render their parameters as `...` and expose no concrete parameters, while retained parameters such as `special` are now available to keyword-argument completion.

The regression test covers both reported shapes, with and without a positional parameter before `*args`.

Closes https://github.com/astral-sh/ty/issues/3803.
