### PR TITLE
[ty] Bump tainted cycles constant

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -128,16 +128,16 @@ class C:
         self.c = lambda positional_only=self.c, /: positional_only
         self.d = lambda *, kw_only=self.d: kw_only
 
-        # revealed: (positional: Unknown = ...) -> Unknown | ((positional=...) -> Divergent) | ((positional=...) -> Divergent)
+        # revealed: (positional: Unknown = ...) -> Unknown | ((positional=...) -> Divergent)
         reveal_type(self.a)
 
-        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Divergent) | ((*, kw_only=...) -> Divergent)
+        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Divergent)
         reveal_type(self.b)
 
-        # revealed: (positional_only: Unknown = ..., /) -> Unknown | ((positional_only=..., /) -> Divergent) | ((positional_only=..., /) -> Divergent)
+        # revealed: (positional_only: Unknown = ..., /) -> Unknown | ((positional_only=..., /) -> Divergent)
         reveal_type(self.c)
 
-        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Divergent) | ((*, kw_only=...) -> Divergent)
+        # revealed: (*, kw_only=...) -> Unknown | ((*, kw_only=...) -> Divergent)
         reveal_type(self.d)
 ```
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -227,4 +227,4 @@ impl IOErrorDiagnostic {
 /// values that will soon converge, but where unioning in the early value causes an
 /// unrecoverable loss of precision. This constant controls how many iterations
 /// are considered likely to produce "tainted" results that should be discarded.
-pub(crate) const TAINTED_CYCLES: u32 = 1;
+pub(crate) const TAINTED_CYCLES: u32 = 3;


### PR DESCRIPTION
Our cycle handling union type inference results across cycle iterations to force monotonicity, but currently avoid doing so for the first N cycle iterations, as earlier iterations are likely to produce "tainted" results that pollute the final converged type. This PR bumps N from 1 to 3, which allows us to produce nicer results for more complex cycles, e.g.,
```py
class C:
    def _(self):
        self.f = lambda x=self.f: x
        
        # before: (x: Unknown = ...) -> Unknown | ((x=...) -> Divergent) | ((x=...) -> Divergent)
        # after:  (x: Unknown = ...) -> Unknown | ((x=...) -> Divergent)
        reveal_type(self.f)
```

This seems to show up with lambdas specifically because our lambda inference is inherently cyclic, as the value of the parameter `x` above depends on the declared `Callable` type of the lambda, contributing additional iterations to any other outer cycles (on `self.f` in the above example) involving the lambda expression, which means that there is more than one "tainted" cycle iteration in which we have little information about the type of the lambda.