### PR TITLE
[ty] Implement unified generic call inference

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -7538,6 +7538,31 @@ func("<CURSOR>")
     }
 
     #[test]
+    fn string_literal_completions_overloaded_generic_function_argument() {
+        let builder = completion_test_builder(
+            r#"
+from typing import Literal, overload
+
+@overload
+def func[T](value: T, mode: Literal["r"]) -> T: ...
+@overload
+def func[T](value: T, mode: Literal["w"]) -> T: ...
+def func(value: object, mode: str) -> object: ...
+
+func(1, "<CURSOR>")
+"#,
+        );
+
+        assert_snapshot!(
+            builder.skip_keywords().skip_builtins().skip_auto_import().type_signatures().build().snapshot(),
+            @r#"
+        r :: Literal["r"]
+        w :: Literal["w"]
+        "#,
+        );
+    }
+
+    #[test]
     fn string_literal_completions_annotated_assignment() {
         let builder = completion_test_builder(
             r#"

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -592,7 +592,7 @@ x5: ObjectCallback | IntCallback = make_callback(lambda value: consume(value.bit
 But not in a way that leads to assignability errors:
 
 ```py
-from typing import TypedDict, Any
+from typing import Any, Sequence, TypedDict
 
 class TD2(TypedDict):
     x: str
@@ -621,6 +621,15 @@ def _(dt: dict[str, Any], key: str):
 
     x8: TD2 | None = dt.get(key, {"x": 0})
     reveal_type(x8)  # revealed: TD2 | None
+
+def as_sequence[T](x: T, y: list[T], z: list[T]) -> Sequence[T]:
+    return [x]
+
+def _(x: int, z: list[int]):
+    x1: Sequence[int] = as_sequence(x, [x], z)
+
+    # TODO: A covariant type context should not cause us to unnecessarily widen call arguments.
+    x2: Sequence[int | str] = as_sequence(x, [x], z)  # error: [invalid-argument-type]
 ```
 
 Partially specialized type context is not ignored:
@@ -651,43 +660,43 @@ def two_dicts_default(x: dict[U | int, Any], y: dict[U | str, Any]) -> U:
     raise NotImplementedError
 
 def _():
-    # revealed: list[int | X]
-    # revealed: list[str | X]
+    # revealed: list[X | int]
+    # revealed: list[X | str]
     x1 = two_lists(reveal_type(lst(X())), reveal_type(lst(X())))
     reveal_type(x1)  # revealed: X
 
-    # revealed: list[int | X]
-    # revealed: list[str | X]
+    # revealed: list[X | int]
+    # revealed: list[X | str]
     x2 = two_lists(reveal_type([X()]), reveal_type([X()]))
     reveal_type(x2)  # revealed: X
 
-    # revealed: list[int | X]
-    # revealed: list[str | X]
+    # revealed: list[X | int]
+    # revealed: list[X | str]
     x3 = two_lists_default(reveal_type(lst(X())), reveal_type(lst(X())))
     reveal_type(x3)  # revealed: X
 
-    # revealed: list[int | X]
-    # revealed: list[str | X]
+    # revealed: list[X | int]
+    # revealed: list[X | str]
     x4 = two_lists_default(reveal_type([X()]), reveal_type([X()]))
     reveal_type(x4)  # revealed: X
 
-    # revealed: dict[int | X, Any]
-    # revealed: dict[str | X, Any]
+    # revealed: dict[X | int, Any]
+    # revealed: dict[X | str, Any]
     x5 = two_dicts(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
     reveal_type(x5)  # revealed: X
 
-    # revealed: dict[int | X, Any]
-    # revealed: dict[str | X, Any]
+    # revealed: dict[X | int, Any]
+    # revealed: dict[X | str, Any]
     x6 = two_dicts(reveal_type({X(): X()}), reveal_type({X(): X()}))
     reveal_type(x6)  # revealed: X
 
-    # revealed: dict[int | X, Any]
-    # revealed: dict[str | X, Any]
+    # revealed: dict[X | int, Any]
+    # revealed: dict[X | str, Any]
     x7 = two_dicts_default(reveal_type(dct(X(), X())), reveal_type(dct(X(), X())))
     reveal_type(x7)  # revealed: X
 
-    # revealed: dict[int | X, Any]
-    # revealed: dict[str | X, Any]
+    # revealed: dict[X | int, Any]
+    # revealed: dict[X | str, Any]
     x8 = two_dicts_default(reveal_type({X(): X()}), reveal_type({X(): X()}))
     reveal_type(x8)  # revealed: X
 ```
@@ -1265,8 +1274,7 @@ def f1(x: list[int | str], y: str) -> str: ...
 def f1(x, y) -> int | str:
     raise NotImplementedError
 
-# TODO: We should reveal `list[int]` here.
-x1 = f1(reveal_type([1]), 1)  # revealed: list[int]
+x1 = f1(reveal_type([1]), 1)  # revealed: list[int | None]
 reveal_type(x1)  # revealed: int
 
 x2 = f1(reveal_type([1]), int_or_str())  # revealed: list[int]
@@ -1293,8 +1301,7 @@ def f3(x: TD, y: int) -> int: ...
 def f3(x: TD2, y: str) -> str: ...
 def f3(x, y) -> object: ...
 
-# TODO: We should reveal `TD2` here.
-x4 = f3(reveal_type({"x": [1]}), "1")  # revealed: dict[str, list[int]]
+x4 = f3(reveal_type({"x": [1]}), "1")  # revealed: TD2
 reveal_type(x4)  # revealed: str
 
 x5 = f3(reveal_type({"x": [1]}), int_or_str())  # revealed: dict[str, list[int]]
@@ -1335,7 +1342,7 @@ def list_or_set2[T, U](x: T, y: U) -> list[T] | set[U]:
 
 # TODO: We should not error here.
 # error: [no-matching-overload]
-x8 = f6(reveal_type(list_or_set2(1, 1)))  # revealed: list[int] | set[int]
+x8 = f6(reveal_type(list_or_set2(1, 1)))  # revealed: list[int | None] | set[int]
 reveal_type(x8)  # revealed: Unknown
 
 @overload
@@ -1345,8 +1352,7 @@ def f7[T](y: list[T]) -> list[T]: ...
 def f7(y: object) -> object:
     raise NotImplementedError
 
-# TODO: We should reveal `list[int | str]` here.
-x9 = f7(reveal_type(["Sheet1"]))  # revealed: list[str]
+x9 = f7(reveal_type(["Sheet1"]))  # revealed: list[int | str]
 reveal_type(x9)  # revealed: list[int | str]
 
 def f8(xs: tuple[str, ...]) -> tuple[str, ...]:
@@ -1570,10 +1576,9 @@ reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]
 f11: Callable[[*tuple[int, ...]], tuple[int, ...]] = lambda *args: reveal_type(args)  # revealed: tuple[Unknown, ...]
 reveal_type(f11)  # revealed: (*args) -> tuple[Unknown, ...]
 
-# TODO: Better generic call inference.
 def _(x: list[int]):
-    f12 = list(map(lambda y: y + 1, x))
-    reveal_type(f12)  # revealed: list[Unknown]
+    f12 = list(map(lambda y: reveal_type(y) + 1, x))  # revealed: int
+    reveal_type(f12)  # revealed: list[int]
 
 def _() -> Callable[[int], int]:
     return id(lambda x: reveal_type(x))  # revealed: int
@@ -1602,6 +1607,285 @@ f12 = lambda: [1]
 # TODO: This should not error.
 _: list[int | str] = f12()  # error: [invalid-assignment]
 reveal_type(f12)  # revealed: () -> list[int]
+```
+
+## Unified call inference
+
+Generic call arguments are inferred under fixpoint iteration, allowing constraints from call
+arguments to contribute type context to sibling arguments within a given generic call, until
+convergence.
+
+```py
+from typing import Any, Callable, Literal, Sequence, TypedDict, TypeVar, overload
+
+def combine[T](x: T, y: list[T], z: list[T]) -> T:
+    return x
+
+def combine_reversed[T](x: T, z: list[T], y: list[T]) -> T:
+    return x
+
+def _(x: int, y: int | str, z: int | str | None):
+    x1: int | str | None = combine(y, [x], [z])
+    reveal_type(x1)  # revealed: int | str | None
+
+    x2 = combine(y, [x], [z])
+    reveal_type(x2)  # revealed: int | str | None
+
+    x3 = combine_reversed(y, [z], [x])
+    reveal_type(x3)  # revealed: int | str | None
+
+def collection_pair[T](pair: tuple[T, list[T]]) -> T:
+    return pair[0]
+
+x = collection_pair((1, [True]))
+reveal_type(x)  # revealed: int
+
+def callable_pair[T](pair: tuple[Callable[[T], int], list[T]]) -> None:
+    function, values = pair
+    function(values[0])
+
+callable_pair((lambda value: reveal_type(value) + 1, [1]))  # revealed: int
+
+def nested_pair[T](pair: tuple[T, list[T]]) -> T:
+    return pair[0]
+
+x = nested_pair(("value", [None]))
+reveal_type(x)  # revealed: str | None
+```
+
+```py
+class A(TypedDict):
+    a: int
+    b: int
+
+def pair_with_list[T](x: T, y: list[T]) -> T:
+    return x
+
+def pair_with_sequence[T](x: T, y: Sequence[T]) -> T:
+    return x
+
+def list_pair[T](x: list[T], y: list[T]) -> T:
+    return x[0]
+
+def pair[T](x: T, y: T) -> T:
+    return x
+
+def _(a: A, b: list[A]):
+    x1: A = pair_with_list(a, [{"a": 1, "b": 2}])
+    reveal_type(x1)  # revealed: A
+
+    # TODO: This should solve to `A`.
+    x2 = pair_with_list(a, [{"a": 1, "b": 2}])
+    reveal_type(x2)  # revealed: A | dict[str, int]
+
+    x3 = pair_with_sequence(a, [{"a": 1, "b": 2}])
+    reveal_type(x3)  # revealed: A
+
+    # TODO: This should solve to `A`.
+    x4 = list_pair(b, [{"a": 1, "b": 2}])  # error: [invalid-argument-type]
+    reveal_type(x4)  # revealed: A | dict[str, int]
+
+    x5 = pair({"a": 1, "b": 2}, a)
+    reveal_type(x5)  # revealed: A
+
+    x6 = pair(a, {"a": 1, "b": 2})
+    reveal_type(x6)  # revealed: A
+```
+
+```py
+from typing import TypedDict, reveal_type
+
+class TD(TypedDict):
+    x: int
+
+def f[T](x: T, y: T) -> T:
+    return x
+
+def _(td: TD):
+    # revealed: TD
+    x = reveal_type(f(td, reveal_type({"x": 1})))  # revealed: TD
+
+    # TODO: Generic call narrowing on `reveal_type` happens to choose
+    # the `dict` constraint here instead of `TD`, failing to narrow the
+    # dictionary literal.
+    x = f(td, reveal_type({"x": 1}))  # revealed: dict[str, int]
+    reveal_type(x)  # revealed: TD | dict[str, int]
+```
+
+```py
+class ActiveInitializer[T]:
+    def __new__(cls, *args: object) -> "ActiveInitializer[T]":
+        return super().__new__(cls)
+
+    def __init__(self, value: T, values: list[T]) -> None:
+        pass
+
+x = ActiveInitializer(1, [True])
+reveal_type(x)  # revealed: ActiveInitializer[int]
+
+class InactiveInitializer:
+    def __new__[T](cls, value: T, values: list[T]) -> T:
+        return value
+
+    def __init__(self) -> None:
+        pass
+
+x = InactiveInitializer(1, [True])
+reveal_type(x)  # revealed: int
+```
+
+```py
+def consume_and_produce[T, R](
+    consumer: Callable[[T], R],
+    producer: Callable[[], T],
+    value: T,
+) -> T:
+    produced = producer()
+    consumer(produced)
+    consumer(value)
+    return produced
+
+x = consume_and_produce(
+    lambda x: reveal_type(x),  # revealed: str | int
+    lambda: "s",
+    1,
+)
+
+reveal_type(x)  # revealed: Literal["s", 1]
+```
+
+```py
+def nested_callable[T](
+    value: T,
+    callbacks: Sequence[Callable[[Callable[[T], None]], None]],
+) -> None:
+    pass
+
+nested_callable(
+    1,
+    [lambda callable: print(reveal_type(callable))],  # revealed: (int, /) -> None
+)
+```
+
+```py
+class Base: ...
+class Dog(Base): ...
+class Cat(Base): ...
+
+BaseType = TypeVar("BaseType", bound=Base)
+
+def register_handlers(handlers: dict[str, type[BaseType]]) -> None: ...
+
+register_handlers({"dog": Dog, "cat": Cat})
+
+class X: ...
+
+def accept_classes[T: X](classes: list[type[T]]) -> None: ...
+
+accept_classes([X])
+```
+
+```py
+FloatDtype = type[float] | Literal["float"]
+
+@overload
+def overloaded_call(data: Sequence[str], dtype: object) -> str: ...
+@overload
+def overloaded_call(data: list[Any], dtype: FloatDtype) -> float: ...
+@overload
+def overloaded_call[T](data: Sequence[T], dtype: Literal["generic"]) -> T: ...
+def overloaded_call(data: object, dtype: object) -> object:
+    return data
+
+def _(dtype: FloatDtype):
+    x = overloaded_call([1.0], dtype)
+    reveal_type(x)  # revealed: int | float
+```
+
+Note that long chains of callables with constraint dependencies in reverse source-order may require
+multiple fixpoint iterations.
+
+```py
+from typing import Callable
+
+def chain[A, B, C, D](
+    first: Callable[[C], D],
+    second: Callable[[B], C],
+    third: Callable[[A], B],
+    source: list[A],
+) -> D:
+    return first(second(third(source[0])))
+
+x = chain(
+    lambda c: c + 1,
+    lambda b: b + 1,
+    lambda a: a + 1,
+    [1, 2, 3],
+)
+reveal_type(x)  # revealed: int
+```
+
+The upper bound on iterations is calculated based on the number of independent occurences of
+inferable type variables, not the number of arguments.
+
+```py
+from typing import Callable
+
+def list_to_callable[T](values: list[T]) -> Callable[[T], T]:
+    raise NotImplementedError
+
+def propagate[A, B, C, D](
+    first: Callable[[C], D],
+    second: Callable[[B], C],
+    third: Callable[[A], B],
+    source: list[A],
+) -> D:
+    return first(second(third(source[0])))
+
+def propagate_tuple[A, B, C, D](
+    arguments: tuple[
+        Callable[[C], D],
+        Callable[[B], C],
+        Callable[[A], B],
+        list[A],
+    ],
+) -> D:
+    raise NotImplementedError
+
+def _(seed: int):
+    x = propagate(
+        list_to_callable([]),
+        list_to_callable([]),
+        list_to_callable([]),
+        [seed],
+    )
+    reveal_type(x)  # revealed: int
+
+    x = propagate_tuple((
+        list_to_callable([]),
+        list_to_callable([]),
+        list_to_callable([]),
+        [seed],
+    ))
+    reveal_type(x)  # revealed: int
+```
+
+Only diagnostics from the final round of iteration are preserved:
+
+```py
+def diagnostic_pair[T](value: T, values: list[T]) -> T:
+    return value
+
+# error: [unresolved-reference]
+diagnostic_pair(missing_name, [1])
+diagnostic_pair(suppressed_missing, [1])  # ty: ignore[unresolved-reference]
+
+def non_generic(value: int) -> int:
+    return value
+
+# error: [unresolved-reference]
+diagnostic_pair(non_generic(missing_argument), [1])
+diagnostic_pair(non_generic(suppressed_argument), [1])  # ty: ignore[unresolved-reference]
 ```
 
 ## Dunder Calls

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1802,6 +1802,38 @@ def _(dtype: FloatDtype):
     reveal_type(x)  # revealed: int | float
 ```
 
+```py
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class TakesInt(Protocol):
+    def __call__(
+        self,
+        tag: Literal["int"],
+        callback: Callable[[int], int],
+    ) -> int: ...
+
+@runtime_checkable
+class TakesStr(Protocol):
+    def __call__(
+        self,
+        tag: Literal["str"],
+        callback: Callable[[str], str],
+    ) -> str: ...
+
+def _(callback: TakesInt) -> None:
+    if isinstance(callback, TakesStr):
+        reveal_type(callback)  # revealed: TakesInt & TakesStr
+
+        # TODO: Perform fixpoint iteration when evaluating callable intersections.
+        x1 = callback("int", lambda value: reveal_type(value) + 1)  # revealed: Unknown
+        reveal_type(x1)  # revealed: int
+
+        # TODO: Perform fixpoint iteration when evaluating callable intersections.
+        x2 = callback("str", lambda value: reveal_type(value) + "!")  # revealed: Unknown
+        reveal_type(x2)  # revealed: str
+```
+
 Note that long chains of callables with constraint dependencies in reverse source-order may require
 multiple fixpoint iterations.
 

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -2143,6 +2143,81 @@ x = f({"y": 1}, "a")
 reveal_type(x)  # revealed: str
 ```
 
+Only the types and diagnostics produced by inference against matching overloads are preserved:
+
+```py
+from collections.abc import Callable
+from typing import TypedDict, overload
+
+@overload
+def transform(value: str, callback: Callable[[int], str], /) -> str: ...
+@overload
+def transform(value: bytes, callback: Callable[[int], bytes], /) -> bytes: ...
+def transform(value: str | bytes, callback: Callable[..., str | bytes], /) -> str | bytes:
+    return value
+
+string_result = transform(
+    "",
+    reveal_type(lambda x: str(x) * x),  # revealed: (x: int) -> str
+)
+reveal_type(string_result)  # revealed: str
+bytes_result = transform(
+    b"",
+    reveal_type(lambda x: x.to_bytes(1)),  # revealed: (x: int) -> bytes
+)
+reveal_type(bytes_result)  # revealed: bytes
+
+class Payload(TypedDict):
+    name: str
+    count: int
+
+@overload
+def select_payload(payload: Payload, discriminator: int, /) -> int: ...
+@overload
+def select_payload(payload: dict[str, object], discriminator: str, /) -> str: ...
+def select_payload(payload: Payload | dict[str, object], discriminator: int | str, /) -> int | str:
+    return discriminator
+
+# error: [missing-typed-dict-key] "Missing required key 'count' in TypedDict `Payload` constructor"
+# error: [no-matching-overload]
+select_payload({"name": "missing count"}, 1)
+
+# error: [invalid-argument-type]
+# error: [no-matching-overload]
+select_payload({"name": "bad count", "count": "not an int"}, 1)
+
+# error: [invalid-key]
+# error: [no-matching-overload]
+select_payload({"name": "extra key", "count": 1, "extra": None}, 1)
+
+select_payload({"extra": None}, "plain dictionary")
+
+@overload
+def select_generic_payload[T](value: T, payload: Payload, discriminator: int, /) -> T: ...
+@overload
+def select_generic_payload[T](value: T, payload: dict[str, object], discriminator: str, /) -> T: ...
+def select_generic_payload[T](
+    value: T,
+    payload: Payload | dict[str, object],
+    discriminator: int | str,
+    /,
+) -> T:
+    return value
+
+selected_generic_payload = select_generic_payload(
+    1,
+    reveal_type({"name": "generic", "count": 1}),  # revealed: Payload
+    1,
+)
+reveal_type(selected_generic_payload)  # revealed: Literal[1]
+
+# error: [missing-typed-dict-key] "Missing required key 'count' in TypedDict `Payload` constructor"
+# error: [no-matching-overload]
+select_generic_payload(1, {"name": "generic"}, 1)
+
+select_generic_payload(1, {"extra": None}, "plain dictionary")
+```
+
 ```py
 from typing import SupportsRound, overload
 

--- a/crates/ty_python_semantic/resources/mdtest/call/overloads.md
+++ b/crates/ty_python_semantic/resources/mdtest/call/overloads.md
@@ -1166,6 +1166,22 @@ def _(t: tuple[int, str] | tuple[int, str, int]) -> None:
     reveal_type(m(*t))  # revealed: Literal[1, 2]
 ```
 
+### Retry from parameter matching with type context
+
+When retrying, arguments are inferred with the correct type context:
+
+```py
+from typing import Callable, overload
+
+@overload
+def n(callback: Callable[[int], int], value: int, /) -> int: ...
+@overload
+def n(callback: Callable[[str], str], first: str, second: str, /) -> str: ...
+def n(*args: object) -> object: ...
+def _(values: tuple[int] | tuple[str, str]):
+    reveal_type(n(lambda value: value, *values))  # revealed: int | str
+```
+
 ## Filtering based on variadic arguments
 
 This is step 4 of the overload call evaluation algorithm which specifies that:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/paramspec.md
@@ -827,9 +827,8 @@ def overloaded_put_object(*, TagSet: object, func: object = None) -> None: ...
 to_thread_like_keyword(TagSet=reveal_type([{"Key": "k", "Value": "v"}]), func=overloaded_put_object)  # revealed: list[Tag]
 ```
 
-ParamSpec forwarding should not use raw unspecialized parameter types from a wrapped generic
-callable as argument context. The forwarded list literals should be inferred the same way as in the
-equivalent direct generic call, not with a raw `list[T]` context from the wrapped callable.
+Generic callable arguments participate in fixpoint inference, allowing the inferred type of sibling
+`ParamSpec` arguments to constrain the type of the callable.
 
 ```py
 from typing import Callable
@@ -845,14 +844,22 @@ def to_thread_like[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.k
 # TODO: This should not error once the call-expression type context specializes the generic
 # wrapped callable before we infer forwarded `ParamSpec` arguments.
 # error: [invalid-assignment]
-union_list_result: list[int | str] = to_thread_like(generic_identity_list, reveal_type([1]))  # revealed: list[int]
+union_list_result: list[int | str] = to_thread_like(
+    generic_identity_list,
+    reveal_type([1]),  # revealed: list[int]
+)
 
-# error: [invalid-argument-type]
-# error: [invalid-argument-type]
-to_thread_like(generic_pair, [1], reveal_type([""]))  # revealed: list[str]
+to_thread_like(
+    generic_pair,
+    reveal_type([1]),  # revealed: list[str | int]
+    reveal_type([""]),  # revealed: list[int | str]
+)
 
-# error: [invalid-argument-type]
-to_thread_like(generic_pair_with_container, 1, reveal_type([""]))  # revealed: list[str]
+to_thread_like(
+    generic_pair_with_container,
+    1,
+    reveal_type([""]),  # revealed: list[Literal[1] | str]
+)
 ```
 
 ### Specializing `ParamSpec` with another `ParamSpec`

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -49,7 +49,7 @@ struct CallArgument<'a, 'db> {
 ///
 /// Note that a single argument may produce multiple distinct inferred types when inferred
 /// with type context across multiple bindings.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct CallArgumentTypes<'db> {
     fallback_type: Option<Type<'db>>,
     types: FxHashMap<Type<'db>, Type<'db>>,
@@ -195,6 +195,12 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         self.items.len()
     }
 
+    pub(crate) fn is_variadic(&self, index: usize) -> bool {
+        self.items.get(index).is_some_and(|argument| {
+            matches!(argument.argument, Argument::Variadic | Argument::Keywords)
+        })
+    }
+
     pub(crate) fn argument_types(&self, index: usize) -> Option<&CallArgumentTypes<'db>> {
         self.items.get(index).map(|item| &item.types)
     }
@@ -212,8 +218,23 @@ impl<'a, 'db> CallArguments<'a, 'db> {
             .insert(tcx, ty);
     }
 
+    pub(crate) fn clear_types(&mut self, index: usize) {
+        self.items
+            .get_mut(index)
+            .expect("argument index should be valid")
+            .types = CallArgumentTypes::default();
+    }
+
     pub(crate) fn iter_types(&self) -> impl Iterator<Item = &CallArgumentTypes<'db>> + '_ {
         self.items.iter().map(|item| &item.types)
+    }
+
+    /// Returns `true` if the inferred types are equal for the given set of argument indices.
+    pub(crate) fn inferred_types_equal_at(&self, other: &Self, argument_indices: &[usize]) -> bool {
+        argument_indices.iter().all(|&index| {
+            self.items.get(index).map(|item| &item.types)
+                == other.items.get(index).map(|item| &item.types)
+        })
     }
 
     /// Prepend an optional extra synthetic argument (for a `self` or `cls` parameter) to the front

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -224,19 +224,15 @@ impl<'db> CallableItem<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-        discard_downstream_constructors: bool,
+        mode: CheckTypesMode,
     ) {
         match self {
             CallableItem::Regular(binding) => {
                 binding.check_types(db, constraints, argument_types, call_expression_tcx);
             }
-            CallableItem::Constructor(binding) => binding.check_types(
-                db,
-                constraints,
-                argument_types,
-                call_expression_tcx,
-                discard_downstream_constructors,
-            ),
+            CallableItem::Constructor(binding) => {
+                binding.check_types(db, constraints, argument_types, call_expression_tcx, mode);
+            }
         }
     }
 
@@ -407,16 +403,10 @@ impl<'db> BindingsElement<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-        discard_downstream_constructors: bool,
+        mode: CheckTypesMode,
     ) {
         for item in &mut self.items {
-            item.check_types(
-                db,
-                constraints,
-                call_arguments,
-                call_expression_tcx,
-                discard_downstream_constructors,
-            );
+            item.check_types(db, constraints, call_arguments, call_expression_tcx, mode);
         }
     }
 
@@ -506,15 +496,39 @@ pub(crate) struct Bindings<'db> {
     enclosing_binding_contexts: Option<Box<[BindingContext<'db>]>>,
 }
 
-/// The set of overloads that matched the arguments at a given call-site, before argument type
-/// inference.
+/// The set of overload candidates at a given call-site, before argument type inference.
 ///
 /// This set is kept stable across fixpoint iterations during generic call inference, ensuring
 /// that all inferred argument types are available during overload evaluation.
-pub(crate) type MatchingOverloadSet = SmallVec<[SmallVec<[usize; 1]>; 1]>;
+pub(crate) type OverloadSet = SmallVec<[SmallVec<[usize; 1]>; 1]>;
 
-pub(crate) fn requires_overload_evaluation(matching_overloads: &MatchingOverloadSet) -> bool {
-    matching_overloads.iter().any(|indices| indices.len() > 1)
+/// Returns whether overload evaluation is required for the given set of overload candidates.
+pub(crate) fn requires_overload_evaluation(candidates: &OverloadSet) -> bool {
+    // TODO: This only recognizes overloads within the same callable binding, ignoring intersections
+    // that may need to be evaluated. `OverloadSet` should preserve the union-of-intersections
+    // representation of callables.
+    candidates.iter().any(|indices| indices.len() > 1)
+}
+
+/// Controls the behavior of a given call to [`Bindings::check_types`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CheckTypesMode {
+    /// After checking, retain only the callable bindings that contribute to the call
+    /// evaluation.
+    Finalize,
+
+    /// Preserve all callable bindings, regardless of whether they evaluate successfully.
+    ///
+    /// Generic call inference may perform fixpoint iteration in order to unify
+    /// type context across call arguments, and so all callable bindings should
+    /// remain candidates until the final round is finalized.
+    Provisional,
+}
+
+impl CheckTypesMode {
+    pub(crate) fn is_provisional(self) -> bool {
+        matches!(self, Self::Provisional)
+    }
 }
 
 impl<'db> Bindings<'db> {
@@ -842,14 +856,14 @@ impl<'db> Bindings<'db> {
 
     /// Visits the given set of overload candidates, invoking the provided callback for each
     /// binding.
-    pub(crate) fn visit_matching_overload_set<'a>(
+    pub(crate) fn visit_overload_set<'a>(
         &'a self,
-        candidates: &'a MatchingOverloadSet,
+        candidates: &'a OverloadSet,
         visit: &mut impl FnMut(&'a Binding<'db>, &'a CallableBinding<'db>),
     ) {
-        let mut matching_overloads = candidates.iter();
+        let mut candidate_overloads = candidates.iter();
         self.visit_type_context_callables(&mut |binding| {
-            let overloads = matching_overloads
+            let overloads = candidate_overloads
                 .next()
                 .expect("checked bindings are stable across fixpoint iterations");
 
@@ -1093,7 +1107,7 @@ impl<'db> Bindings<'db> {
             call_arguments,
             call_expression_tcx,
             dataclass_field_specifiers,
-            true,
+            CheckTypesMode::Finalize,
         ) {
             Ok(()) => Ok(self),
             Err(err) => Err(CallError(err, Box::new(self))),
@@ -1107,22 +1121,16 @@ impl<'db> Bindings<'db> {
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
-        discard_downstream_constructors: bool,
+        mode: CheckTypesMode,
     ) -> Result<(), CallErrorKind> {
         // Check types for each element (union variant)
         for element in &mut self.elements {
-            element.check_types(
-                db,
-                constraints,
-                call_arguments,
-                call_expression_tcx,
-                discard_downstream_constructors,
-            );
+            element.check_types(db, constraints, call_arguments, call_expression_tcx, mode);
         }
 
         // Generic call inference must maintain a stable set of overloads until the final round
         // of fixpoint iteration.
-        if !discard_downstream_constructors {
+        if mode.is_provisional() {
             return Ok(());
         }
 
@@ -1149,7 +1157,9 @@ impl<'db> Bindings<'db> {
         self.as_result(db)
     }
 
-    pub(crate) fn discard_downstream_constructors(
+    /// Finalize the bindings after a provisional check, retaining only those that contribute
+    /// to the final call evaluation.
+    pub(crate) fn finalize_argument_inference(
         &mut self,
         db: &'db dyn Db,
         call_arguments: &CallArguments<'_, 'db>,
@@ -1161,7 +1171,7 @@ impl<'db> Bindings<'db> {
             if constructor.discard_downstream_constructor(db)
                 && let Some(downstream) = constructor.downstream_constructor_mut()
             {
-                let _ = downstream.discard_downstream_constructors(
+                let _ = downstream.finalize_argument_inference(
                     db,
                     call_arguments,
                     dataclass_field_specifiers,
@@ -3366,15 +3376,7 @@ impl<'db> CallableBinding<'db> {
         // `*arg` where `arg` is a union of a 2-tuple and a 3-tuple, we shouldn't eliminate any
         // overload for arity reasons before trying argument expansion.
         let (should_retry_after_provisional_arity, overloads_for_expansion) =
-            if self.overloads.len() > 1
-                && self.matching_overloads().count() < self.overloads.len()
-                && call_arguments.iter().any(|(argument, argument_types)| {
-                    matches!(argument, Argument::Variadic)
-                        && argument_types
-                            .get_default()
-                            .is_some_and(|argument_type| is_expandable_type(db, argument_type))
-                })
-            {
+            if self.should_retry_after_provisional_arity(db, call_arguments.as_ref()) {
                 // We will retry all overloads after argument expansion.
                 (true, (0..self.overloads.len()).collect())
             } else {
@@ -3686,6 +3688,38 @@ impl<'db> CallableBinding<'db> {
         // argument types. This is necessary because we restore the state to the pre-evaluation
         // snapshot when processing the expanded argument lists.
         snapshotter.restore(self, post_evaluation_snapshot);
+    }
+
+    /// Returns the set of overload candidates that may contribute to the call evaluation.
+    ///
+    /// Overloads removed by provisional arity matching are typically ignored. However, they remain
+    /// candidates in the presence of an expandable `*args` argument, that may lead to overload
+    /// evaluation retrying with the expanded argument.
+    pub(crate) fn candidate_overload_indices(
+        &self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'_, 'db>,
+    ) -> SmallVec<[usize; 1]> {
+        if self.should_retry_after_provisional_arity(db, call_arguments) {
+            (0..self.overloads.len()).collect()
+        } else {
+            self.matching_overloads().map(|(index, _)| index).collect()
+        }
+    }
+
+    fn should_retry_after_provisional_arity(
+        &self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'_, 'db>,
+    ) -> bool {
+        self.overloads.len() > 1
+            && self.matching_overloads().count() < self.overloads.len()
+            && call_arguments.iter().any(|(argument, argument_types)| {
+                matches!(argument, Argument::Variadic)
+                    && argument_types
+                        .get_default()
+                        .is_some_and(|argument_type| is_expandable_type(db, argument_type))
+            })
     }
 
     /// Filter overloads based on variadic argument to variadic parameter match.
@@ -6152,7 +6186,7 @@ impl<'db> Binding<'db> {
             &sub_arguments,
             call_expression_tcx,
             &[],
-            true,
+            CheckTypesMode::Finalize,
         );
 
         let specialized_binding = specialized_bindings.single_element()?;

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -12,7 +12,7 @@ mod constructor;
 mod enum_property;
 
 use std::borrow::Cow;
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::fmt;
 
@@ -59,7 +59,9 @@ use crate::types::signatures::{
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
 use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
-use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
+use crate::types::visitor::{
+    TypeCollector, TypeKind, TypeVisitor, walk_non_atomic_type, walk_type_with_recursion_guard,
+};
 use crate::types::{
     BindingContext, BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes,
     ClassLiteral, DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType, GenericAlias,
@@ -222,14 +224,19 @@ impl<'db> CallableItem<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        discard_downstream_constructors: bool,
     ) {
         match self {
             CallableItem::Regular(binding) => {
                 binding.check_types(db, constraints, argument_types, call_expression_tcx);
             }
-            CallableItem::Constructor(binding) => {
-                binding.check_types(db, constraints, argument_types, call_expression_tcx);
-            }
+            CallableItem::Constructor(binding) => binding.check_types(
+                db,
+                constraints,
+                argument_types,
+                call_expression_tcx,
+                discard_downstream_constructors,
+            ),
         }
     }
 
@@ -400,9 +407,16 @@ impl<'db> BindingsElement<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        discard_downstream_constructors: bool,
     ) {
         for item in &mut self.items {
-            item.check_types(db, constraints, call_arguments, call_expression_tcx);
+            item.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                discard_downstream_constructors,
+            );
         }
     }
 
@@ -490,6 +504,17 @@ pub(crate) struct Bindings<'db> {
     /// `None` means the caller did not provide lexical collision information. `Some([])` means the
     /// caller knows there are no enclosing binding contexts.
     enclosing_binding_contexts: Option<Box<[BindingContext<'db>]>>,
+}
+
+/// The set of overloads that matched the arguments at a given call-site, before argument type
+/// inference.
+///
+/// This set is kept stable across fixpoint iterations during generic call inference, ensuring
+/// that all inferred argument types are available during overload evaluation.
+pub(crate) type MatchingOverloadSet = SmallVec<[SmallVec<[usize; 1]>; 1]>;
+
+pub(crate) fn requires_overload_evaluation(matching_overloads: &MatchingOverloadSet) -> bool {
+    matching_overloads.iter().any(|indices| indices.len() > 1)
 }
 
 impl<'db> Bindings<'db> {
@@ -815,6 +840,33 @@ impl<'db> Bindings<'db> {
         }
     }
 
+    /// Visits the given set of overload candidates, invoking the provided callback for each
+    /// binding.
+    pub(crate) fn visit_matching_overload_set<'a>(
+        &'a self,
+        candidates: &'a MatchingOverloadSet,
+        visit: &mut impl FnMut(&'a Binding<'db>, &'a CallableBinding<'db>),
+    ) {
+        let mut matching_overloads = candidates.iter();
+        self.visit_type_context_callables(&mut |binding| {
+            let overloads = matching_overloads
+                .next()
+                .expect("checked bindings are stable across fixpoint iterations");
+
+            if overloads.is_empty() {
+                // If there is a single non-matching overload, we infer against it for better
+                // diagnostics.
+                if let [overload] = binding.overloads() {
+                    visit(overload, binding);
+                }
+            } else {
+                for &overload in overloads {
+                    visit(&binding.overloads()[overload], binding);
+                }
+            }
+        });
+    }
+
     /// Returns `true` if every element of the union contains an intersection element with a matching
     /// overload that satisfies the provided closure, or `false` otherwise.
     pub(crate) fn satisfies(&self, f: impl Fn(&Binding<'db>) -> bool) -> bool {
@@ -1041,6 +1093,7 @@ impl<'db> Bindings<'db> {
             call_arguments,
             call_expression_tcx,
             dataclass_field_specifiers,
+            true,
         ) {
             Ok(()) => Ok(self),
             Err(err) => Err(CallError(err, Box::new(self))),
@@ -1054,10 +1107,23 @@ impl<'db> Bindings<'db> {
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
+        discard_downstream_constructors: bool,
     ) -> Result<(), CallErrorKind> {
         // Check types for each element (union variant)
         for element in &mut self.elements {
-            element.check_types(db, constraints, call_arguments, call_expression_tcx);
+            element.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                discard_downstream_constructors,
+            );
+        }
+
+        // Generic call inference must maintain a stable set of overloads until the final round
+        // of fixpoint iteration.
+        if !discard_downstream_constructors {
+            return Ok(());
         }
 
         self.evaluate_known_cases(db, call_arguments, dataclass_field_specifiers);
@@ -1076,6 +1142,33 @@ impl<'db> Bindings<'db> {
 
         // For intersection elements with at least one successful binding,
         // filter out the failing bindings after deferred constructor checks.
+        for element in &mut self.elements {
+            element.retain_successful(db);
+        }
+
+        self.as_result(db)
+    }
+
+    pub(crate) fn discard_downstream_constructors(
+        &mut self,
+        db: &'db dyn Db,
+        call_arguments: &CallArguments<'_, 'db>,
+        dataclass_field_specifiers: &[Type<'db>],
+    ) -> Result<(), CallErrorKind> {
+        self.evaluate_known_cases(db, call_arguments, dataclass_field_specifiers);
+
+        for constructor in self.iter_constructor_items_mut() {
+            if constructor.discard_downstream_constructor(db)
+                && let Some(downstream) = constructor.downstream_constructor_mut()
+            {
+                let _ = downstream.discard_downstream_constructors(
+                    db,
+                    call_arguments,
+                    dataclass_field_specifiers,
+                );
+            }
+        }
+
         for element in &mut self.elements {
             element.retain_successful(db);
         }
@@ -3274,7 +3367,7 @@ impl<'db> CallableBinding<'db> {
         // overload for arity reasons before trying argument expansion.
         let (should_retry_after_provisional_arity, overloads_for_expansion) =
             if self.overloads.len() > 1
-                && self.matching_overload_index().len() < self.overloads.len()
+                && self.matching_overloads().count() < self.overloads.len()
                 && call_arguments.iter().any(|(argument, argument_types)| {
                     matches!(argument, Argument::Variadic)
                         && argument_types
@@ -3908,6 +4001,13 @@ impl<'db> CallableBinding<'db> {
             .filter(|(_, overload)| !overload.has_errors_affecting_overload_resolution())
     }
 
+    /// Returns the overload which call arguments should be inferred against, if every overload is
+    /// non-matching.
+    pub(crate) fn best_failing_overload(&self) -> Option<&Binding<'db>> {
+        self.best_failing_overload_index(FailingOverloadSelection::AffectsOverloadResolution)
+            .and_then(|index| self.overloads.get(index))
+    }
+
     /// Returns an iterator over all the mutable overloads that matched for this call binding.
     pub(crate) fn matching_overloads_mut(
         &mut self,
@@ -4040,9 +4140,7 @@ impl<'db> CallableBinding<'db> {
                 // If multiple overloads passed arity check but only one matched types
                 // (possibly with semantic errors), report its errors directly instead
                 // of the generic "no matching overload" message.
-                if let MatchingOverloadIndex::Single(matching_overload_index) =
-                    self.matching_overload_index()
-                {
+                if let Ok((matching_overload_index, _)) = self.matching_overloads().exactly_one() {
                     let callable_description =
                         CallableDescription::new(context.db(), self.signature_type);
                     let matching_overload =
@@ -4199,16 +4297,6 @@ pub(crate) enum MatchingOverloadIndex {
 
     /// Multiple matching overloads found at the given indexes.
     Multiple(Vec<usize>),
-}
-
-impl MatchingOverloadIndex {
-    pub(crate) fn len(&self) -> usize {
-        match self {
-            MatchingOverloadIndex::None => 0,
-            MatchingOverloadIndex::Single(_) => 1,
-            MatchingOverloadIndex::Multiple(indexes) => indexes.len(),
-        }
-    }
 }
 
 #[derive(Default, Clone, Copy)]
@@ -5502,8 +5590,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             );
         };
 
-        match callable_binding.matching_overload_index() {
-            MatchingOverloadIndex::None => {
+        let mut matching_overloads = callable_binding.matching_overloads();
+        match (matching_overloads.next(), matching_overloads.next()) {
+            (None, _) => {
                 if let [binding] = callable_binding.overloads() {
                     // This is not an overloaded function, so we can propagate its errors to the
                     // outer bindings.
@@ -5519,12 +5608,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     extend_errors(&callable_binding.overloads()[index].errors);
                 }
             }
-            MatchingOverloadIndex::Single(index) => {
+            (Some((_, binding)), None) => {
                 // TODO: We should also update the specialization for the `ParamSpec` to reflect the
                 // matching overload here.
-                extend_errors(&callable_binding.overloads()[index].errors);
+                extend_errors(&binding.errors);
             }
-            MatchingOverloadIndex::Multiple(_) => {
+            (Some(_), Some(_)) => {
                 if !matches!(
                     callable_binding.overload_call_return_type,
                     Some(OverloadCallReturnType::ArgumentTypeExpansion(_))
@@ -5693,8 +5782,8 @@ impl<'db> MatchedArgument<'db> {
     }
 }
 
-/// The type context to use when inferring a call-site argument.
-#[derive(Clone, Copy, Debug)]
+/// The type context to use when inferring a call-site argument, for a given binding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ArgumentTypeContext<'db> {
     Standard {
         /// The raw parameter type from the overload signature.
@@ -5703,6 +5792,7 @@ pub(crate) enum ArgumentTypeContext<'db> {
         /// declared type.
         parameter_type: Type<'db>,
     },
+
     ParamSpec {
         /// The `P.args` or `P.kwargs` parameter that this argument is bound to.
         paramspec_parameter_type: Type<'db>,
@@ -5766,7 +5856,7 @@ impl<'db> ArgumentTypeContext<'db> {
     /// For a forwarded `ParamSpec` argument, the expression is inferred against the specialized
     /// wrapped parameter but may still be looked up through the original `P.args` or `P.kwargs`
     /// annotation during the outer wrapper call check.
-    pub(crate) fn insert_inferred_type(
+    pub(crate) fn insert_inferred_type_into(
         self,
         arguments_types: &mut CallArguments<'_, 'db>,
         argument_index: usize,
@@ -5808,6 +5898,58 @@ struct ParamSpecArgumentContext<'a, 'call, 'db> {
     arguments_types: &'a CallArguments<'call, 'db>,
     argument_index: usize,
     call_expression_tcx: TypeContext<'db>,
+}
+
+/// Returns the number of occurrences of inferable type variables in the provided type.
+fn inferable_typevar_occurrences<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    inferable: InferableTypeVars<'db>,
+) -> usize {
+    struct InferableTypeVarVisitor<'db> {
+        inferable: InferableTypeVars<'db>,
+        count: Cell<usize>,
+        stack: RefCell<SmallVec<[Type<'db>; 8]>>,
+    }
+
+    impl<'db> TypeVisitor<'db> for InferableTypeVarVisitor<'db> {
+        fn should_visit_lazy_type_attributes(&self) -> bool {
+            false
+        }
+
+        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+            if let Type::TypeVar(typevar) = ty {
+                let identity = if typevar.is_paramspec(db) {
+                    typevar.without_paramspec_attr(db).identity(db)
+                } else {
+                    typevar.identity(db)
+                };
+                if identity.is_inferable(db, self.inferable) {
+                    self.count.set(self.count.get() + 1);
+                }
+                return;
+            }
+
+            let TypeKind::NonAtomic(non_atomic_type) = TypeKind::from(ty) else {
+                return;
+            };
+            if self.stack.borrow().contains(&ty) {
+                return;
+            }
+
+            self.stack.borrow_mut().push(ty);
+            walk_non_atomic_type(db, non_atomic_type, self);
+            self.stack.borrow_mut().pop();
+        }
+    }
+
+    let visitor = InferableTypeVarVisitor {
+        inferable,
+        count: Cell::new(0),
+        stack: RefCell::default(),
+    };
+    visitor.visit_type(db, ty);
+    visitor.count.get()
 }
 
 /// Binding information for one of the overloads of a callable.
@@ -5897,6 +6039,36 @@ impl<'db> Binding<'db> {
             .get(argument_index + usize::from(binding.bound_type.is_some()))
     }
 
+    /// Returns the number of occurrences of inferable type variables in the parameter(s) matching the
+    /// provided argument index.
+    pub(crate) fn typevar_occurrences_for_parameter(
+        &self,
+        db: &'db dyn Db,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+    ) -> usize {
+        let Some(generic_context) = self.signature.generic_context else {
+            return 0;
+        };
+        let Some(argument) = self.matched_argument_for_call_argument(binding, argument_index)
+        else {
+            return 0;
+        };
+
+        let inferable_typevars = generic_context.inferable_typevars(db);
+        argument
+            .parameters
+            .iter()
+            .map(|parameter| {
+                inferable_typevar_occurrences(
+                    db,
+                    self.signature.parameters()[parameter.index].annotated_type(),
+                    inferable_typevars,
+                )
+            })
+            .sum()
+    }
+
     /// Returns source argument indices matched to the `ParamSpec` component.
     ///
     /// The returned indices are relative to the original call site, excluding any synthetic bound
@@ -5929,57 +6101,6 @@ impl<'db> Binding<'db> {
                     .then_some(matched_argument_index - bound_argument_offset)
             })
             .collect()
-    }
-
-    /// Infers the callable value that a `ParamSpec` maps to for this overload.
-    ///
-    /// The wrapper's current arguments are rechecked against this single overload so that a binder
-    /// argument such as `func: Callable[P, R]` can specialize `P` before forwarded arguments are
-    /// inferred.
-    ///
-    /// ```py
-    /// def put_tags(tags: list[Tag], /) -> None: ...
-    /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
-    /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # infers `P` from `put_tags`
-    /// ```
-    fn inferred_paramspec_callable(
-        &self,
-        db: &'db dyn Db,
-        constraints: &ConstraintSetBuilder<'db>,
-        binding: &CallableBinding<'db>,
-        paramspec: BoundTypeVarInstance<'db>,
-        arguments_types: &CallArguments<'_, 'db>,
-        call_expression_tcx: TypeContext<'db>,
-    ) -> Option<CallableType<'db>> {
-        let mut specialized_binding =
-            CallableBinding::from_overloads(self.signature_type, [self.signature.clone()]);
-        if let Some(bound_type) = binding.bound_type {
-            specialized_binding = specialized_binding.with_bound_type(bound_type);
-        }
-
-        // Reuse the normal binding checker to infer `P` from the arguments that have already
-        // been inferred. This avoids duplicating specialization logic here; the current
-        // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
-        let mut specialized_bindings =
-            Bindings::from(specialized_binding).match_parameters(db, arguments_types);
-        let _ = specialized_bindings.check_types_impl(
-            db,
-            constraints,
-            arguments_types,
-            call_expression_tcx,
-            &[],
-        );
-
-        let Type::Callable(callable) = specialized_bindings
-            .single_element()
-            .and_then(|binding| binding.matching_overloads().exactly_one().ok())
-            .and_then(|(_, overload)| overload.specialization(db))
-            .and_then(|specialization| specialization.get(db, paramspec))?
-        else {
-            return None;
-        };
-
-        (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
     }
 
     /// Returns the specialized wrapped-call parameter type for a forwarded argument.
@@ -6017,7 +6138,12 @@ impl<'db> Binding<'db> {
             self.signature_type,
             callable.signatures(db).iter().cloned(),
         );
-        let sub_arguments = arguments_types.select(&paramspec_argument_indices);
+
+        let mut sub_arguments = arguments_types.select(&paramspec_argument_indices);
+        // Clear the previously inferred type for this argument, if it was inferred in the previous
+        // fixpoint iteration.
+        sub_arguments.clear_types(sub_argument_index);
+
         let mut specialized_bindings =
             Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
         let _ = specialized_bindings.check_types_impl(
@@ -6026,6 +6152,7 @@ impl<'db> Binding<'db> {
             &sub_arguments,
             call_expression_tcx,
             &[],
+            true,
         );
 
         let specialized_binding = specialized_bindings.single_element()?;
@@ -6045,14 +6172,6 @@ impl<'db> Binding<'db> {
         let parameter_type = specialized_overload.signature.parameters()
             [specialized_parameter.index]
             .annotated_type();
-        // A context like `list[Unknown]` or `list[T@g]` is worse than no context here:
-        // it can erase the concrete literal type that should later specialize the wrapped
-        // callable. Check the parameter before applying the sub-call specialization so an
-        // earlier forwarded argument cannot turn `list[T@g]` into apparently-safe `list[int]`.
-        if parameter_type.has_dynamic(db) || parameter_type.has_typevar_or_typevar_instance(db) {
-            return None;
-        }
-
         let parameter_type = specialized_overload
             .specialization(db)
             .map_or(parameter_type, |specialization| {
@@ -6063,52 +6182,18 @@ impl<'db> Binding<'db> {
             .then_some(parameter_type)
     }
 
-    /// Returns the wrapper parameter type that can bind the `ParamSpec` used by forwarded arguments.
+    /// Returns the type context to use for bidirectional inference of a source call argument,
+    /// using the provided argument specialization.
     ///
-    /// This is used before normal source-order inference so a keyword forwarded through `P.kwargs`
-    /// can still use a later binder argument such as `func=put_object`.
-    ///
-    /// ```py
-    /// def put_object(*, TagSet: list[Tag]) -> None: ...
-    /// def wrapper[**P, R](func: Callable[P, R], **kwargs: P.kwargs) -> R: ...
-    /// wrapper(TagSet=[{"Key": "k", "Value": "v"}], func=put_object)
-    /// ```
-    pub(crate) fn paramspec_binder_parameter_type(
-        &self,
-        db: &'db dyn Db,
-        binding: &CallableBinding<'db>,
-        argument_index: usize,
-    ) -> Option<Type<'db>> {
-        let (prefix, paramspec) = self.signature.parameters().as_paramspec_with_prefix()?;
-        let [parameter] = self
-            .matched_argument_for_call_argument(binding, argument_index)?
-            .parameters
-            .as_slice()
-        else {
-            return None;
-        };
-
-        if parameter.index >= prefix.len() {
-            return None;
-        }
-
-        let parameter_type = self.signature.parameters()[parameter.index].annotated_type();
-        parameter_type
-            .references_typevar(db, paramspec.typevar(db).identity(db))
-            .then_some(parameter_type)
-    }
-
-    /// Returns the type context to use for bidirectional inference of a source call argument.
-    ///
-    /// This covers the normal parameter annotation path, generic return-context specialization, and
-    /// the `ParamSpec` forwarding path where a wrapper argument receives context from the wrapped
-    /// callable's parameter.
+    /// This method also handles `ParamSpec` forwarding, where a wrapper argument receives context
+    /// from the wrapped callable's parameter.
     ///
     /// ```py
     /// def put_tags(tags: list[Tag], /) -> None: ...
     /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args) -> R: ...
     /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # forwarded list gets `list[Tag]`
     /// ```
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn argument_type_context(
         &self,
         db: &'db dyn Db,
@@ -6117,6 +6202,7 @@ impl<'db> Binding<'db> {
         arguments_types: &CallArguments<'_, 'db>,
         argument_index: usize,
         call_expression_tcx: TypeContext<'db>,
+        specialization: Option<Specialization<'db>>,
     ) -> Option<ArgumentTypeContext<'db>> {
         let argument_matches = self.matched_argument_for_call_argument(binding, argument_index)?;
         let [parameter] = argument_matches.parameters.as_slice() else {
@@ -6126,6 +6212,19 @@ impl<'db> Binding<'db> {
         let parameter = &self.signature.parameters()[parameter.index];
         let mut parameter_type = parameter.annotated_type();
         let original_parameter_type = parameter_type;
+        let paramspec_callable = |paramspec| {
+            let Type::Callable(callable) = self
+                .specialization(db)
+                .and_then(|specialization| specialization.get(db, paramspec))
+                .or_else(|| {
+                    specialization.and_then(|specialization| specialization.get(db, paramspec))
+                })?
+            else {
+                return None;
+            };
+
+            (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
+        };
 
         // If the parameter is a single non-ParamSpec type variable with an upper bound,
         // e.g., `typing.Self`, use the upper bound as type context. ParamSpec components
@@ -6142,9 +6241,8 @@ impl<'db> Binding<'db> {
             ));
         }
 
-        // If this is a generic call, attempt to specialize the parameter type using the
-        // declared type context, propagating the declared types of any type variables.
-        if let Some(generic_context) = self.signature.generic_context {
+        // If this is a generic call, specialize the parameter type using the computed constraints.
+        if self.signature.generic_context.is_some() {
             let paramspec = if let Type::TypeVar(typevar) = original_parameter_type
                 && typevar.is_paramspec(db)
                 && typevar.paramspec_attr(db).is_some()
@@ -6154,70 +6252,10 @@ impl<'db> Binding<'db> {
                 None
             };
 
-            let mut return_type_solutions: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> =
-                FxHashMap::default();
-            if let Some(declared_return_ty) = call_expression_tcx.annotation {
-                let return_ty = self
-                    .normalized_constructor_return(db)
-                    .unwrap_or(self.signature.return_ty);
-                let path_bounds = return_ty.assignable_solutions_with_inferable(
-                    db,
-                    declared_return_ty,
-                    generic_context.inferable_typevars(db),
-                );
-
-                if let Solutions::Constrained(solutions) = path_bounds.solve(db, constraints) {
-                    for solution in solutions {
-                        for binding in solution {
-                            let identity = binding.bound_typevar.identity(db);
-                            return_type_solutions
-                                .entry(identity)
-                                .and_modify(|existing| {
-                                    *existing = UnionType::from_two_elements(
-                                        db,
-                                        *existing,
-                                        binding.solution,
-                                    );
-                                })
-                                .or_insert(binding.solution);
-                        }
-                    }
-                }
-            }
-
-            // Default specialize any type variables to a marker type, which will be ignored
-            // during argument inference, allowing the concrete subset of the parameter
-            // type to still affect argument inference.
-            //
-            // TODO: Eventually, we want to "tie together" the typevars of the two calls
-            // so that we can infer their specializations at the same time — or at least, for
-            // the specialization of one to influence the specialization of the other. It's
-            // not yet clear how we're going to do that. (We might have to start inferring
-            // constraint sets for each expression, instead of simple types?)
-            let unspecialized = Type::Dynamic(DynamicType::UnspecializedTypeVar);
-            let specialization = generic_context.specialize_recursive(
-                db,
-                generic_context.variables(db).map(|typevar| {
-                    Some(
-                        return_type_solutions
-                            .get(&typevar.identity(db))
-                            .copied()
-                            .unwrap_or(unspecialized),
-                    )
-                }),
-            );
-
-            // A `P.args`/`P.kwargs` parameter has a useful context only after another
-            // argument, usually a `Callable[P, R]`, specializes `P`.
+            // A `P.args`/`P.kwargs` parameter receives context from the `ParamSpec` specialization
+            // checked during the previous fixpoint round.
             if let Some(paramspec) = paramspec
-                && let Some(callable) = self.inferred_paramspec_callable(
-                    db,
-                    constraints,
-                    binding,
-                    paramspec,
-                    arguments_types,
-                    call_expression_tcx,
-                )
+                && let Some(callable) = paramspec_callable(paramspec)
                 && let Some(specialized_parameter_type) =
                     self.paramspec_argument_context(ParamSpecArgumentContext {
                         db,
@@ -6235,12 +6273,88 @@ impl<'db> Binding<'db> {
                 ));
             }
 
-            parameter_type = parameter_type.apply_specialization(db, specialization);
+            parameter_type = parameter_type.apply_optional_specialization(db, specialization);
         }
 
         Some(ArgumentTypeContext::standard(
             original_parameter_type,
             parameter_type,
+        ))
+    }
+
+    /// Returns the specialization that should be applied to the parameters of this overload for
+    /// type context.
+    ///
+    /// Parameter types are specialized based on the constraints from the declared type of the
+    /// call expression, as well as the argument types inferred from the previous round of
+    /// fixpoint iteration.
+    pub(crate) fn argument_type_context_specialization(
+        &self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) -> Option<Specialization<'db>> {
+        let generic_context = self.signature.generic_context?;
+
+        let mut return_type_solutions: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> =
+            FxHashMap::default();
+        if let Some(declared_return_ty) = call_expression_tcx.annotation {
+            let normalized_return_ty = self
+                .normalized_constructor_return(db)
+                .unwrap_or(self.signature.return_ty);
+            let path_bounds = normalized_return_ty.assignable_solutions_with_inferable(
+                db,
+                declared_return_ty,
+                generic_context.inferable_typevars(db),
+            );
+
+            if let Solutions::Constrained(solutions) = path_bounds.solve(db, constraints) {
+                for solution in solutions {
+                    for binding in solution {
+                        let identity = binding.bound_typevar.identity(db);
+                        return_type_solutions
+                            .entry(identity)
+                            .and_modify(|existing| {
+                                *existing =
+                                    UnionType::from_two_elements(db, *existing, binding.solution);
+                            })
+                            .or_insert(binding.solution);
+                    }
+                }
+            }
+        }
+
+        // TODO: Note that specializing parameter types for type context using this specialization is
+        // not strictly correct, as it requires eagerly choosing a solution for a given type variable,
+        // which may conflate upper and lower bounds when applied transitively to parameter types
+        // in which the type variable may be in invariant or contravariant position. A more correct
+        // approach would be to propagate constraint sets as type context, making bidirectional
+        // inference constraint-set-aware, or to infer constraint sets directly for argument types,
+        // and avoid the need to construct type context before call inference has completed.
+        Some(generic_context.specialize_recursive(
+            db,
+            generic_context.variables(db).map(|typevar| {
+                let identity = typevar.identity(db);
+
+                let call_expression_constraints = return_type_solutions.get(&identity).copied();
+                let argument_constraints = self
+                    .specialization(db)
+                    .and_then(|specialization| specialization.get(db, typevar))
+                    .filter(|ty| !ty.has_dynamic(db))
+                    .map(|ty| ty.promote(db));
+
+                // TODO: We should similarly combine both the call expression and argument constraints
+                // here. We currently only rely on argument constraints when there is no explicit declared
+                // type for the call expression.
+                Some(
+                    call_expression_constraints
+                        .or(argument_constraints)
+                        // Default specialize any type variables to a marker type, which will be ignored
+                        // during argument inference, allowing the concrete subset of the parameter
+                        // type to still affect argument inference.
+                        .unwrap_or(Type::Dynamic(DynamicType::UnspecializedTypeVar)),
+                )
+            }),
         ))
     }
 

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -1,4 +1,4 @@
-use super::{Binding, Bindings, CallableBinding, CallableItem};
+use super::{Binding, Bindings, CallableBinding, CallableItem, CheckTypesMode};
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
@@ -76,25 +76,24 @@ impl<'db> ConstructorBinding<'db> {
         }
     }
 
-    /// Checks this constructor and, if requested, discards inactive downstream constructors.
+    /// Check types for all bindings in this constructor.
     ///
-    /// During generic call inference, the candidate overload and constructor set must remain
-    /// stable across fixpoint iterations, and so downstream constructors are not discarded
-    /// until the final round.
+    /// If `CheckTypesMode::Finalize` is provided, inactive downstream constructors will be
+    /// discarded. Otherwise, all constructor bindings are preserved after the check.
     pub(super) fn check_types(
         &mut self,
         db: &'db dyn Db,
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-        discard_downstream_constructors: bool,
+        mode: CheckTypesMode,
     ) {
         self.entry
             .check_types(db, constraints, argument_types, call_expression_tcx);
 
         // Now that we've fully checked our own callable, we can determine whether downstream
         // constructors should be checked or not.
-        if !discard_downstream_constructors {
+        if mode.is_provisional() {
             if let Some(downstream) = self.downstream_constructor_mut() {
                 let _ = downstream.check_types_impl(
                     db,
@@ -102,7 +101,7 @@ impl<'db> ConstructorBinding<'db> {
                     argument_types,
                     call_expression_tcx,
                     &[],
-                    false,
+                    mode,
                 );
             }
         } else if !self.should_check_downstream(db) {
@@ -170,7 +169,7 @@ impl<'db> ConstructorBinding<'db> {
                 argument_types,
                 call_expression_tcx,
                 dataclass_field_specifiers,
-                true,
+                CheckTypesMode::Finalize,
             );
         }
     }

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -76,58 +76,79 @@ impl<'db> ConstructorBinding<'db> {
         }
     }
 
-    /// Check types for this constructor method, and then decide (based on the resolved return
-    /// types) whether we should continue considering downstream constructors or discard them.
+    /// Checks this constructor and, if requested, discards inactive downstream constructors.
+    ///
+    /// During generic call inference, the candidate overload and constructor set must remain
+    /// stable across fixpoint iterations, and so downstream constructors are not discarded
+    /// until the final round.
     pub(super) fn check_types(
         &mut self,
         db: &'db dyn Db,
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        discard_downstream_constructors: bool,
     ) {
-        /// For constructors which may have downstreams (that is, metaclass `__call__` or `__new__`),
-        /// analyze their overloads to determine whether to check downstream constructors.
-        ///
-        /// We analyze overloads individually rather than just relying on the resolved return type of
-        /// the overall callable, because in multiple-matching-overload cases where the overload
-        /// resolution algorithm might just collapse to `Unknown`, we want to make a more informed
-        /// decision based on whether all overloads return instance types, or not.
-        fn should_check_downstream<'db>(
-            binding: &ConstructorBinding<'db>,
-            db: &'db dyn Db,
-        ) -> bool {
-            let constructor_kind = binding.constructor_kind();
-            if constructor_kind.is_init() || binding.downstream_constructor().is_none() {
-                return false;
-            }
-
-            let callable = binding.callable();
-
-            if callable.as_result().is_err() {
-                return false;
-            }
-
-            let constructed_instance_type = binding.constructed_instance_type();
-            let constructor_class_literal = binding.constructed_class_literal(db);
-
-            // If any matching overload returns the constructed instance type itself, or an instance of
-            // the constructed class, we need to check downstream constructors.
-            callable.matching_overloads().any(|(_, overload)| {
-                overload.return_ty == constructed_instance_type
-                    || constructor_class_literal.is_some_and(|class_literal| {
-                        constructor_returns_instance(db, class_literal, overload.return_ty)
-                    })
-            })
-        }
-
         self.entry
             .check_types(db, constraints, argument_types, call_expression_tcx);
 
         // Now that we've fully checked our own callable, we can determine whether downstream
         // constructors should be checked or not.
-        if !should_check_downstream(self, db) {
+        if !discard_downstream_constructors {
+            if let Some(downstream) = self.downstream_constructor_mut() {
+                let _ = downstream.check_types_impl(
+                    db,
+                    constraints,
+                    argument_types,
+                    call_expression_tcx,
+                    &[],
+                    false,
+                );
+            }
+        } else if !self.should_check_downstream(db) {
             // If not, we can discard the downstream constructor bindings entirely.
             self.downstream_constructor = None;
+        }
+    }
+
+    /// For constructors which may have downstreams (that is, metaclass `__call__` or `__new__`),
+    /// analyze their overloads to determine whether to check downstream constructors.
+    ///
+    /// We analyze overloads individually rather than just relying on the resolved return type of
+    /// the overall callable, because in multiple-matching-overload cases where the overload
+    /// resolution algorithm might just collapse to `Unknown`, we want to make a more informed
+    /// decision based on whether all overloads return instance types, or not.
+    fn should_check_downstream(&self, db: &'db dyn Db) -> bool {
+        let constructor_kind = self.constructor_kind();
+        if constructor_kind.is_init() || self.downstream_constructor().is_none() {
+            return false;
+        }
+
+        let callable = self.callable();
+        if callable.as_result().is_err() {
+            return false;
+        }
+
+        let constructed_instance_type = self.constructed_instance_type();
+        let constructor_class_literal = self.constructed_class_literal(db);
+
+        // If any matching overload returns the constructed instance type itself, or an instance of
+        // the constructed class, we need to check downstream constructors.
+        callable.matching_overloads().any(|(_, overload)| {
+            overload.return_ty == constructed_instance_type
+                || constructor_class_literal.is_some_and(|class_literal| {
+                    constructor_returns_instance(db, class_literal, overload.return_ty)
+                })
+        })
+    }
+
+    /// Discards an inactive downstream constructor.
+    pub(super) fn discard_downstream_constructor(&mut self, db: &'db dyn Db) -> bool {
+        if self.should_check_downstream(db) {
+            true
+        } else {
+            self.downstream_constructor = None;
+            false
         }
     }
 
@@ -149,6 +170,7 @@ impl<'db> ConstructorBinding<'db> {
                 argument_types,
                 call_expression_tcx,
                 dataclass_field_specifiers,
+                true,
             );
         }
     }

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -235,6 +235,13 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         diagnostics.shrink_to_fit();
         diagnostics
     }
+
+    /// Consume this context without compacting its diagnostics.
+    #[must_use]
+    pub(crate) fn finish_uncompacted(mut self) -> TypeCheckDiagnostics {
+        self.bomb.defuse();
+        self.diagnostics.into_inner()
+    }
 }
 
 impl fmt::Debug for InferContext<'_, '_> {

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
 use crate::reachability::is_range_reachable;
+use crate::types::call::bind::CheckTypesMode;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
 use crate::types::constraints::ConstraintSetBuilder;
@@ -777,7 +778,7 @@ pub fn call_signature_details<'db>(
             &call_arguments,
             TypeContext::default(),
             &[],
-            true,
+            CheckTypesMode::Finalize,
         );
 
         // Extract signature details from all callable bindings

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -777,6 +777,7 @@ pub fn call_signature_details<'db>(
             &call_arguments,
             TypeContext::default(),
             &[],
+            true,
         );
 
         // Extract signature details from all callable bindings

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -1537,6 +1537,9 @@ struct ExpressionInferenceExtra<'db> {
     /// The diagnostics for this region.
     diagnostics: TypeCheckDiagnostics,
 
+    /// Functions called while inferring this expression.
+    called_functions: Box<[FunctionType<'db>]>,
+
     /// The fallback type for missing expressions/bindings/declarations or recursive type inference.
     cycle_recovery: Option<Type<'db>>,
 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -44,7 +44,7 @@ use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_wit
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
 use crate::types::call::bind::{
-    ArgumentTypeContext, MatchingOverloadSet, requires_overload_evaluation,
+    ArgumentTypeContext, CheckTypesMode, OverloadSet, requires_overload_evaluation,
 };
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
@@ -57,12 +57,11 @@ use crate::types::diagnostic::{
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
     INVALID_DECLARATION, INVALID_ENUM_MEMBER_ANNOTATION, INVALID_LEGACY_TYPE_VARIABLE,
     INVALID_NEWTYPE, INVALID_PARAMSPEC, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM,
-    INVALID_TYPE_GUARD_CALL, INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS,
-    POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE, TypeCheckDiagnostics,
-    UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE,
-    UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE, hint_if_stdlib_attribute_exists_on_other_versions,
-    report_attempted_protocol_instantiation, report_bad_dunder_delattr_call,
-    report_bad_dunder_delete_call, report_call_to_abstract_method,
+    INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS, POSSIBLY_MISSING_IMPLICIT_CALL,
+    POSSIBLY_MISSING_SUBMODULE, TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE,
+    UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE, UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE,
+    hint_if_stdlib_attribute_exists_on_other_versions, report_attempted_protocol_instantiation,
+    report_bad_dunder_delattr_call, report_bad_dunder_delete_call, report_call_to_abstract_method,
     report_cannot_pop_required_field_on_typed_dict, report_invalid_assignment,
     report_invalid_class_match_pattern, report_invalid_exception_caught,
     report_invalid_exception_cause, report_invalid_exception_raised,
@@ -5033,22 +5032,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut max_typevar_occurrences = 0;
         let mut has_generic_context = false;
-        let mut matching_overloads = MatchingOverloadSet::new();
+        let mut overload_candidates = OverloadSet::new();
 
         // Compute the upper bound on fixpoint iteration, based on the maximum number of inferable
-        // typevar occurrences across all matching overloads. Note that the set of matching overloads
+        // typevar occurrences across all overload candidates. Note that the set of overload candidates
         // stays stable across all iterations.
         bindings.visit_type_context_callables(&mut |binding| {
-            has_generic_context |= binding
-                .matching_overloads()
-                .any(|(_, overload)| overload.signature.generic_context.is_some());
+            let candidate_overload_indices = binding.candidate_overload_indices(db, argument_types);
 
-            let matching_overload_indices: SmallVec<[usize; 1]> = binding
-                .matching_overloads()
-                .map(|(index, _)| index)
-                .collect();
+            has_generic_context |= candidate_overload_indices.iter().any(|&overload_index| {
+                binding.overloads()[overload_index]
+                    .signature
+                    .generic_context
+                    .is_some()
+            });
 
-            for overload_index in &matching_overload_indices {
+            for overload_index in &candidate_overload_indices {
                 let overload = &binding.overloads()[*overload_index];
                 if overload.signature.generic_context.is_none() {
                     continue;
@@ -5069,7 +5068,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 max_typevar_occurrences = max_typevar_occurrences.max(overload_typevar_occurrences);
             }
 
-            matching_overloads.push(matching_overload_indices);
+            overload_candidates.push(candidate_overload_indices);
         });
 
         let generic_arguments: SmallVec<_> = generic_arguments
@@ -5079,12 +5078,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .collect();
 
         // Enable the expression cache if we are going to perform multi-inference.
-        let teardown_expression_cache =
-            if !generic_arguments.is_empty() || requires_overload_evaluation(&matching_overloads) {
-                self.setup_expression_cache()
-            } else {
-                false
-            };
+        let teardown_expression_cache = if !generic_arguments.is_empty()
+            || requires_overload_evaluation(&overload_candidates)
+        {
+            self.setup_expression_cache()
+        } else {
+            false
+        };
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = call_expression_tcx
@@ -5132,7 +5132,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     narrowed_tcx,
                     &generic_arguments,
                     max_typevar_occurrences,
-                    &matching_overloads,
+                    &overload_candidates,
                 )
             } else {
                 speculative_builder.infer_and_check_argument_types_simple(
@@ -5143,7 +5143,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     &mut speculative_bindings,
                     &constraints,
                     narrowed_tcx,
-                    &matching_overloads,
+                    &overload_candidates,
                 )
             };
 
@@ -5208,7 +5208,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 call_expression_tcx,
                 &generic_arguments,
                 max_typevar_occurrences,
-                &matching_overloads,
+                &overload_candidates,
             )
         } else {
             self.infer_and_check_argument_types_simple(
@@ -5219,7 +5219,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 bindings,
                 &constraints,
                 call_expression_tcx,
-                &matching_overloads,
+                &overload_candidates,
             )
         };
 
@@ -5240,19 +5240,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         bindings: &mut Bindings<'db>,
         constraints: &ConstraintSetBuilder<'db>,
         call_expression_tcx: TypeContext<'db>,
-        candidates: &MatchingOverloadSet,
+        candidates: &OverloadSet,
     ) -> Result<(), CallErrorKind> {
+        let requires_overload_evaluation = requires_overload_evaluation(candidates);
         let arguments_tcx = self.collect_call_arguments_type_context(
             baseline_argument_types,
             bindings,
-            None,
+            requires_overload_evaluation.then_some(candidates),
             constraints,
             call_expression_tcx,
         );
 
         // If we are not inferring against multiple overloads, we can infer the arguments
         // and check the binding directly.
-        if !requires_overload_evaluation(candidates) {
+        if !requires_overload_evaluation {
             self.infer_all_argument_types(
                 ast_arguments,
                 argument_types,
@@ -5267,7 +5268,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 argument_types,
                 call_expression_tcx,
                 &self.dataclass_field_specifiers,
-                true,
+                CheckTypesMode::Finalize,
             );
         }
 
@@ -5290,7 +5291,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             argument_types,
             call_expression_tcx,
             &self.dataclass_field_specifiers,
-            true,
+            CheckTypesMode::Finalize,
         );
 
         let checked_argument_types = argument_types.clone();
@@ -5330,7 +5331,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression_tcx: TypeContext<'db>,
         generic_arguments: &SmallVec<[usize; 4]>,
         typevar_occurrences: usize,
-        candidates: &MatchingOverloadSet,
+        candidates: &OverloadSet,
     ) -> Result<(), CallErrorKind> {
         let db = self.db();
         let requires_overload_evaluation = requires_overload_evaluation(candidates);
@@ -5384,7 +5385,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 &next_argument_types,
                 call_expression_tcx,
                 &self.dataclass_field_specifiers,
-                false,
+                CheckTypesMode::Provisional,
             );
 
             // The number of occurrences of inferable typevars forms an upper bound for the number
@@ -5418,7 +5419,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         // Discard any non-matching constructors overloads now that the inferred types have converged.
-        let result = next_bindings.discard_downstream_constructors(
+        let result = next_bindings.finalize_argument_inference(
             db,
             &converged_argument_types,
             &self.dataclass_field_specifiers,
@@ -5460,7 +5461,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         &self,
         argument_types: &CallArguments<'_, 'db>,
         bindings: &'bindings Bindings<'db>,
-        candidates: Option<&'bindings MatchingOverloadSet>,
+        candidates: Option<&'bindings OverloadSet>,
         constraints: &ConstraintSetBuilder<'db>,
         call_expression_tcx: TypeContext<'db>,
     ) -> Vec<Option<MatchingArgumentTypeContext<'db>>> {
@@ -5503,10 +5504,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
 
-        // Collect the set of all matching overloads and bindings.
+        // Collect the set of candidate overloads and bindings.
         let mut overloads_with_binding: OverloadsWithBinding = Vec::new();
         if let Some(candidates) = candidates {
-            bindings.visit_matching_overload_set(candidates, &mut |overload, binding| {
+            bindings.visit_overload_set(candidates, &mut |overload, binding| {
                 let specialization = overload.argument_type_context_specialization(
                     db,
                     constraints,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,5 @@
 use std::cell::{OnceCell, RefCell};
+use std::collections::hash_map;
 use std::rc::Rc;
 
 use compact_str::CompactString;
@@ -23,11 +24,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
-    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
-    FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    CollectionUseConstraints, DeferredAndUndecorated, DefinitionInference,
+    DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
+    FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
+    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra, infer_deferred_types,
+    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
+    infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -41,7 +43,9 @@ use crate::place::{
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
 use crate::types::attribute_write::{AssignmentAttributeMembers, assignment_attribute_members};
-use crate::types::call::bind::MatchingOverloadIndex;
+use crate::types::call::bind::{
+    ArgumentTypeContext, MatchingOverloadSet, requires_overload_evaluation,
+};
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
@@ -53,11 +57,12 @@ use crate::types::diagnostic::{
     GeneratorMismatchKind, INEFFECTIVE_FINAL, INVALID_ARGUMENT_TYPE, INVALID_ASSIGNMENT,
     INVALID_DECLARATION, INVALID_ENUM_MEMBER_ANNOTATION, INVALID_LEGACY_TYPE_VARIABLE,
     INVALID_NEWTYPE, INVALID_PARAMSPEC, INVALID_TYPE_ALIAS_TYPE, INVALID_TYPE_FORM,
-    INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS, POSSIBLY_MISSING_IMPLICIT_CALL,
-    POSSIBLY_MISSING_SUBMODULE, UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL,
-    UNRESOLVED_REFERENCE, UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE,
-    hint_if_stdlib_attribute_exists_on_other_versions, report_attempted_protocol_instantiation,
-    report_bad_dunder_delattr_call, report_bad_dunder_delete_call, report_call_to_abstract_method,
+    INVALID_TYPE_GUARD_CALL, INVALID_TYPE_VARIABLE_BOUND, INVALID_TYPE_VARIABLE_CONSTRAINTS,
+    POSSIBLY_MISSING_IMPLICIT_CALL, POSSIBLY_MISSING_SUBMODULE, TypeCheckDiagnostics,
+    UNDEFINED_REVEAL, UNRESOLVED_ATTRIBUTE, UNRESOLVED_GLOBAL, UNRESOLVED_REFERENCE,
+    UNSUPPORTED_OPERATOR, UNUSED_AWAITABLE, hint_if_stdlib_attribute_exists_on_other_versions,
+    report_attempted_protocol_instantiation, report_bad_dunder_delattr_call,
+    report_bad_dunder_delete_call, report_call_to_abstract_method,
     report_cannot_pop_required_field_on_typed_dict, report_invalid_assignment,
     report_invalid_class_match_pattern, report_invalid_exception_caught,
     report_invalid_exception_cause, report_invalid_exception_raised,
@@ -359,9 +364,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     dataclass_field_specifiers: SmallVec<[Type<'db>; NUM_FIELD_SPECIFIERS_INLINE]>,
 }
 
-/// An expression cache shared across builders during multi-inference.
-type ExpressionCache<'db> = FxHashMap<(ExpressionNodeKey, TypeContext<'db>), Type<'db>>;
-
 fn transparent_callable_decorator_result<'db>(
     db: &'db dyn Db,
     bindings: &Bindings<'db>,
@@ -659,6 +661,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
             self.extend_cycle_recovery(extra.cycle_recovery);
+            self.called_functions
+                .extend(extra.called_functions.iter().copied());
             self.string_annotations
                 .extend(extra.string_annotations.iter().copied());
             self.expected_types
@@ -680,6 +684,48 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if !matches!(self.region, InferenceRegion::Scope(..)) {
                 self.bindings.extend(extra.bindings.iter().copied());
             }
+        }
+    }
+
+    fn extend_expression_cache_entry(&mut self, inference: &FullExpressionCacheEntry<'db>) {
+        #[cfg(debug_assertions)]
+        assert_eq!(self.scope, inference.scope);
+
+        self.expressions
+            .extend(inference.expressions.iter().map(|(key, ty)| (*key, *ty)));
+        self.context.extend(&inference.diagnostics);
+        self.extend_cycle_recovery(inference.cycle_recovery);
+        self.called_functions
+            .extend(inference.called_functions.iter().copied());
+        self.string_annotations
+            .extend(inference.string_annotations.iter().copied());
+        self.expected_types
+            .extend(inference.expected_types.iter().map(|(key, ty)| (*key, *ty)));
+        self.type_expression_flags.extend(
+            inference
+                .type_expression_flags
+                .iter()
+                .map(|(key, flags)| (*key, *flags)),
+        );
+
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "constraints for distinct collection definitions are merged independently"
+        )]
+        for (collection_def, constraints) in &inference.collection_use_constraints {
+            self.collection_use_constraints
+                .entry(*collection_def)
+                .and_modify(|this| this.extend(constraints))
+                .or_insert(constraints.clone());
+        }
+
+        if !matches!(self.region, InferenceRegion::Scope(..)) {
+            self.bindings.extend(
+                inference
+                    .bindings
+                    .iter()
+                    .map(|(definition, ty)| (*definition, *ty)),
+            );
         }
     }
 
@@ -787,7 +833,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if self.expression_cache.is_some() {
             false
         } else {
-            self.expression_cache = Some(Rc::new(RefCell::new(FxHashMap::default())));
+            self.expression_cache = Some(Rc::new(RefCell::new(ExpressionCache::default())));
             true
         }
     }
@@ -4979,11 +5025,66 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Result<(), CallErrorKind> {
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
+        let initial_argument_types = argument_types.clone();
 
-        let has_generic_context = bindings
-            .iter_flat()
-            .flat_map(CallableBinding::overloads)
-            .any(|overload| overload.signature.generic_context.is_some());
+        // Keep track of which arguments match generic parameters.
+        let mut generic_arguments = SmallVec::<[bool; 8]>::with_capacity(argument_types.len());
+        generic_arguments.resize(argument_types.len(), false);
+
+        let mut max_typevar_occurrences = 0;
+        let mut has_generic_context = false;
+        let mut matching_overloads = MatchingOverloadSet::new();
+
+        // Compute the upper bound on fixpoint iteration, based on the maximum number of inferable
+        // typevar occurrences across all matching overloads. Note that the set of matching overloads
+        // stays stable across all iterations.
+        bindings.visit_type_context_callables(&mut |binding| {
+            has_generic_context |= binding
+                .matching_overloads()
+                .any(|(_, overload)| overload.signature.generic_context.is_some());
+
+            let matching_overload_indices: SmallVec<[usize; 1]> = binding
+                .matching_overloads()
+                .map(|(index, _)| index)
+                .collect();
+
+            for overload_index in &matching_overload_indices {
+                let overload = &binding.overloads()[*overload_index];
+                if overload.signature.generic_context.is_none() {
+                    continue;
+                }
+
+                let mut overload_typevar_occurrences = 0;
+                for (argument_index, is_generic) in generic_arguments.iter_mut().enumerate() {
+                    if argument_types.is_variadic(argument_index) {
+                        continue;
+                    }
+
+                    let typevar_occurrences =
+                        overload.typevar_occurrences_for_parameter(db, binding, argument_index);
+                    *is_generic |= typevar_occurrences > 0;
+                    overload_typevar_occurrences += typevar_occurrences;
+                }
+
+                max_typevar_occurrences = max_typevar_occurrences.max(overload_typevar_occurrences);
+            }
+
+            matching_overloads.push(matching_overload_indices);
+        });
+
+        let generic_arguments: SmallVec<_> = generic_arguments
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, is_generic)| is_generic.then_some(index))
+            .collect();
+
+        // Enable the expression cache if we are going to perform multi-inference.
+        let teardown_expression_cache =
+            if !generic_arguments.is_empty() || requires_overload_evaluation(&matching_overloads) {
+                self.setup_expression_cache()
+            } else {
+                false
+            };
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = call_expression_tcx
@@ -5014,27 +5115,39 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             let mut speculative_bindings = bindings.clone();
             let mut speculative_builder = self.speculate();
+            let mut speculative_argument_types = initial_argument_types.clone();
 
             // Attempt to infer the argument types using the narrowed type context.
-            speculative_builder.infer_all_argument_types(
-                ast_arguments.clone(),
-                argument_types,
-                infer_argument_ty,
-                bindings,
-                narrowed_tcx,
-            );
-
-            // Ensure the argument types match their annotated types.
-            if speculative_bindings
-                .check_types_impl(
-                    db,
+            //
+            // If there are matching generic parameters on any overload, we perform fixpoint
+            // iteration to allow call arguments to contribute type context constraints to
+            // other siblings.
+            let result = if !generic_arguments.is_empty() {
+                speculative_builder.infer_and_check_argument_types_unified(
+                    &ast_arguments,
+                    &mut speculative_argument_types,
+                    infer_argument_ty,
+                    &mut speculative_bindings,
                     &constraints,
-                    argument_types,
                     narrowed_tcx,
-                    &self.dataclass_field_specifiers,
+                    &generic_arguments,
+                    max_typevar_occurrences,
+                    &matching_overloads,
                 )
-                .is_err()
-            {
+            } else {
+                speculative_builder.infer_and_check_argument_types_simple(
+                    ast_arguments.clone(),
+                    &mut speculative_argument_types,
+                    &initial_argument_types,
+                    infer_argument_ty,
+                    &mut speculative_bindings,
+                    &constraints,
+                    narrowed_tcx,
+                    &matching_overloads,
+                )
+            };
+
+            if result.is_err() {
                 return None;
             }
 
@@ -5051,135 +5164,437 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
 
             // Successfully narrowed to an element of the union.
+            *bindings = speculative_bindings;
+            *argument_types = speculative_argument_types;
             self.extend(speculative_builder);
-            Some(bindings.check_types_impl(
-                db,
-                &constraints,
-                argument_types,
-                narrowed_tcx,
-                &self.dataclass_field_specifiers,
-            ))
+
+            Some(result)
         };
 
         // Prefer the declared type of generic classes or callables when narrowing.
         //
         // Splitting up this loop is not necessary for correctness, but leads to a slight
         // performance improvement.
-        for narrowed_ty in narrow_targets
-            .iter()
-            .filter(|ty| ty.may_prefer_declared_type(db))
-        {
+        for narrowed_ty in std::iter::chain(
+            narrow_targets
+                .iter()
+                .filter(|ty| ty.may_prefer_declared_type(db)),
+            narrow_targets
+                .iter()
+                .filter(|ty| !ty.may_prefer_declared_type(db)),
+        ) {
             if let Some(result) = try_narrow(*narrowed_ty) {
+                if teardown_expression_cache {
+                    self.teardown_expression_cache();
+                }
+
                 return result;
             }
         }
-        for narrowed_ty in narrow_targets
-            .iter()
-            .filter(|ty| !ty.may_prefer_declared_type(db))
-        {
-            if let Some(result) = try_narrow(*narrowed_ty) {
-                return result;
-            }
-        }
+
+        *argument_types = initial_argument_types.clone();
 
         // Infer against the entire union as a fallback.
         //
         // TODO: We could also attempt an inference without type context, but this
         // leads to similar performance issues.
-        self.infer_all_argument_types(
-            ast_arguments,
-            argument_types,
-            infer_argument_ty,
+        let result = if !generic_arguments.is_empty() {
+            self.infer_and_check_argument_types_unified(
+                &ast_arguments,
+                argument_types,
+                infer_argument_ty,
+                bindings,
+                &constraints,
+                call_expression_tcx,
+                &generic_arguments,
+                max_typevar_occurrences,
+                &matching_overloads,
+            )
+        } else {
+            self.infer_and_check_argument_types_simple(
+                ast_arguments,
+                argument_types,
+                &initial_argument_types,
+                infer_argument_ty,
+                bindings,
+                &constraints,
+                call_expression_tcx,
+                &matching_overloads,
+            )
+        };
+
+        if teardown_expression_cache {
+            self.teardown_expression_cache();
+        }
+
+        result
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    fn infer_and_check_argument_types_simple<'call>(
+        &mut self,
+        ast_arguments: ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'call, 'db>,
+        baseline_argument_types: &CallArguments<'call, 'db>,
+        infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
+        bindings: &mut Bindings<'db>,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_expression_tcx: TypeContext<'db>,
+        candidates: &MatchingOverloadSet,
+    ) -> Result<(), CallErrorKind> {
+        let arguments_tcx = self.collect_call_arguments_type_context(
+            baseline_argument_types,
             bindings,
+            None,
+            constraints,
             call_expression_tcx,
         );
 
-        bindings.check_types_impl(
-            db,
-            &constraints,
+        // If we are not inferring against multiple overloads, we can infer the arguments
+        // and check the binding directly.
+        if !requires_overload_evaluation(candidates) {
+            self.infer_all_argument_types(
+                ast_arguments,
+                argument_types,
+                &arguments_tcx,
+                infer_argument_ty,
+                CallArgumentInferenceMode::Commit,
+            );
+
+            return bindings.check_types_impl(
+                self.db(),
+                constraints,
+                argument_types,
+                call_expression_tcx,
+                &self.dataclass_field_specifiers,
+                true,
+            );
+        }
+
+        // Otherwise, we first infer the argument types speculatively.
+        let mut speculative_builder = self.speculate();
+        speculative_builder.infer_all_argument_types(
+            ast_arguments.clone(),
+            argument_types,
+            &arguments_tcx,
+            infer_argument_ty,
+            // If there are multiple matching overloads, we will re-infer with the final set
+            // of matching overloads after overload evaluation, and so can avoid the default
+            // inference here.
+            CallArgumentInferenceMode::Speculate,
+        );
+
+        let result = bindings.check_types_impl(
+            self.db(),
+            constraints,
             argument_types,
             call_expression_tcx,
             &self.dataclass_field_specifiers,
-        )
+            true,
+        );
+
+        let checked_argument_types = argument_types.clone();
+        *argument_types = baseline_argument_types.clone();
+
+        // And re-infer argument types after overload evaluation, ensuring that only
+        // inferred types and diagnostics from matching overloads are preserved.
+        let arguments_tcx = self.collect_call_arguments_type_context(
+            &checked_argument_types,
+            bindings,
+            None,
+            constraints,
+            call_expression_tcx,
+        );
+        self.infer_all_argument_types(
+            ast_arguments,
+            argument_types,
+            &arguments_tcx,
+            infer_argument_ty,
+            CallArgumentInferenceMode::Commit,
+        );
+        self.union_expected_types(&speculative_builder.expected_types);
+
+        result
     }
 
-    /// Infer the argument types for all bindings.
-    ///
-    /// Note that this method may infer the type of a given argument expression multiple times with
-    /// distinct type context. The provided `MultiInferenceState` can be used to dictate multi-inference
-    /// behavior.
-    fn infer_all_argument_types<'bindings>(
+    /// Infer generic call arguments under fixpoint iteration, allowing arguments to contribute
+    /// type context constraints to other siblings.
+    #[expect(clippy::too_many_arguments)]
+    fn infer_and_check_argument_types_unified(
         &mut self,
-        ast_arguments: ArgumentsIter<'_>,
-        arguments_types: &mut CallArguments<'_, 'db>,
+        ast_arguments: &ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'_, 'db>,
         infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
-        bindings: &'bindings Bindings<'db>,
+        bindings: &mut Bindings<'db>,
+        constraints: &ConstraintSetBuilder<'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) {
+        generic_arguments: &SmallVec<[usize; 4]>,
+        typevar_occurrences: usize,
+        candidates: &MatchingOverloadSet,
+    ) -> Result<(), CallErrorKind> {
+        let db = self.db();
+        let requires_overload_evaluation = requires_overload_evaluation(candidates);
+
+        let mut arguments_tcx = self.collect_call_arguments_type_context(
+            argument_types,
+            bindings,
+            Some(candidates),
+            constraints,
+            call_expression_tcx,
+        );
+
+        let mut iteration = 0;
+        let mut next_bindings = bindings.clone();
+        let mut prev_argument_types = argument_types.clone();
+
+        let (converged_builder, converged_argument_types) = loop {
+            let mut next_argument_types = argument_types.clone();
+
+            // Infer the argument types for the current iteration.
+            let mut speculative_builder = self.speculate();
+            speculative_builder.infer_all_argument_types(
+                ast_arguments.clone(),
+                &mut next_argument_types,
+                &arguments_tcx,
+                infer_argument_ty,
+                if requires_overload_evaluation {
+                    // If there are multiple matching overloads, we will re-infer with the final set
+                    // of matching overloads after overload evaluation, and so can avoid the default
+                    // inference here.
+                    CallArgumentInferenceMode::Speculate
+                } else {
+                    CallArgumentInferenceMode::Commit
+                },
+            );
+
+            let inferred_types_converged = next_argument_types
+                .inferred_types_equal_at(&prev_argument_types, generic_arguments);
+
+            // If the inferred types have converged, and already evaluated the bindings from the
+            // previous iteration, we are done.
+            if iteration > 0 && inferred_types_converged {
+                break (speculative_builder, next_argument_types);
+            }
+
+            // Otherwise, we have to evaluate the bindings against the newly inferred types.
+            next_bindings = bindings.clone();
+            let _ = next_bindings.check_types_impl(
+                db,
+                constraints,
+                &next_argument_types,
+                call_expression_tcx,
+                &self.dataclass_field_specifiers,
+                false,
+            );
+
+            // The number of occurrences of inferable typevars forms an upper bound for the number
+            // of fixpoint iterations, and so if the types have converged, or we have reached the
+            // upper bound, we are done.
+            if inferred_types_converged || iteration == typevar_occurrences {
+                break (speculative_builder, next_argument_types);
+            }
+
+            // Collect the argument constraints based on the newly inferred types.
+            let next_arguments_tcx = self.collect_call_arguments_type_context(
+                &next_argument_types,
+                &next_bindings,
+                Some(candidates),
+                constraints,
+                call_expression_tcx,
+            );
+
+            // If the argument constraints have converged, the inferred types will be identical,
+            // and so we can exit early.
+            if generic_arguments
+                .iter()
+                .all(|&index| arguments_tcx.get(index) == next_arguments_tcx.get(index))
+            {
+                break (speculative_builder, next_argument_types);
+            }
+
+            iteration += 1;
+            arguments_tcx = next_arguments_tcx;
+            prev_argument_types = next_argument_types;
+        };
+
+        // Discard any non-matching constructors overloads now that the inferred types have converged.
+        let result = next_bindings.discard_downstream_constructors(
+            db,
+            &converged_argument_types,
+            &self.dataclass_field_specifiers,
+        );
+
+        // If the set of candidate bindings contained multiple matching overloads, re-infer the argument
+        // types against the final set of matching overloads, such that only the relevant diagnostics
+        // and inferred types are preserved.
+        if requires_overload_evaluation {
+            let arguments_tcx = self.collect_call_arguments_type_context(
+                &converged_argument_types,
+                &next_bindings,
+                None,
+                constraints,
+                call_expression_tcx,
+            );
+
+            self.infer_all_argument_types(
+                ast_arguments.clone(),
+                argument_types,
+                &arguments_tcx,
+                infer_argument_ty,
+                CallArgumentInferenceMode::Commit,
+            );
+
+            self.union_expected_types(&converged_builder.expected_types);
+        } else {
+            // Otherwise, we can simply use the newly inferred types.
+            *argument_types = converged_argument_types;
+            self.extend(converged_builder);
+        }
+
+        *bindings = next_bindings;
+        result
+    }
+
+    /// Collects the type contexts used to infer the arguments of a call expression.
+    fn collect_call_arguments_type_context<'bindings>(
+        &self,
+        argument_types: &CallArguments<'_, 'db>,
+        bindings: &'bindings Bindings<'db>,
+        candidates: Option<&'bindings MatchingOverloadSet>,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) -> Vec<Option<MatchingArgumentTypeContext<'db>>> {
+        type OverloadsWithBinding<'a, 'db> = Vec<(
+            &'a Binding<'db>,
+            &'a CallableBinding<'db>,
+            Option<Specialization<'db>>,
+        )>;
+
         fn add_overloads_from_binding<'a, 'db>(
-            overloads_with_binding: &mut Vec<(&'a Binding<'db>, &'a CallableBinding<'db>)>,
+            db: &'db dyn Db,
+            overloads_with_binding: &mut OverloadsWithBinding<'a, 'db>,
             binding: &'a CallableBinding<'db>,
+            constraints: &ConstraintSetBuilder<'db>,
+            call_expression_tcx: TypeContext<'db>,
         ) {
-            match binding.matching_overload_index() {
-                MatchingOverloadIndex::Single(_) | MatchingOverloadIndex::Multiple(_) => {
-                    overloads_with_binding.extend(
-                        binding
-                            .matching_overloads()
-                            .map(|(_, overload)| (overload, binding)),
+            let mut matching_overloads = binding.matching_overloads().peekable();
+            if matching_overloads.peek().is_some() {
+                overloads_with_binding.extend(matching_overloads.map(|(_, overload)| {
+                    let specialization = overload.argument_type_context_specialization(
+                        db,
+                        constraints,
+                        call_expression_tcx,
                     );
-                }
+
+                    (overload, binding, specialization)
+                }));
+            } else if let Some(overload) = binding.best_failing_overload() {
+                let specialization = overload.argument_type_context_specialization(
+                    db,
+                    constraints,
+                    call_expression_tcx,
+                );
 
                 // If there is a single overload that does not match, we still infer the argument
                 // types for better diagnostics.
-                MatchingOverloadIndex::None => {
-                    if let [overload] = binding.overloads() {
-                        overloads_with_binding.push((overload, binding));
-                    }
-                }
+                overloads_with_binding.push((overload, binding, specialization));
             }
         }
 
         let db = self.db();
-        let constraints = ConstraintSetBuilder::new();
 
-        let mut overloads_with_binding: Vec<(&Binding<'db>, &CallableBinding<'db>)> = Vec::new();
+        // Collect the set of all matching overloads and bindings.
+        let mut overloads_with_binding: OverloadsWithBinding = Vec::new();
+        if let Some(candidates) = candidates {
+            bindings.visit_matching_overload_set(candidates, &mut |overload, binding| {
+                let specialization = overload.argument_type_context_specialization(
+                    db,
+                    constraints,
+                    call_expression_tcx,
+                );
 
-        bindings.visit_type_context_callables(&mut |binding| {
-            add_overloads_from_binding(&mut overloads_with_binding, binding);
-        });
+                overloads_with_binding.push((overload, binding, specialization));
+            });
+        } else {
+            bindings.visit_type_context_callables(&mut |binding| {
+                add_overloads_from_binding(
+                    db,
+                    &mut overloads_with_binding,
+                    binding,
+                    constraints,
+                    call_expression_tcx,
+                );
+            });
+        }
 
-        // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
-        // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
-        // types first so the normal ParamSpec context path below is not source-order dependent.
-        for (argument_index, ast_argument) in ast_arguments.clone().enumerate() {
-            if ast_argument.is_variadic() {
-                continue;
-            }
-            let ast_argument = ast_argument.value();
-
-            let mut inferred_declared_types = FxHashSet::default();
-            for declared_type in overloads_with_binding
-                .iter()
-                .filter_map(|(overload, binding)| {
-                    overload.paramspec_binder_parameter_type(db, binding, argument_index)
-                })
-            {
-                if !inferred_declared_types.insert(declared_type) {
-                    continue;
+        // Collect the type context of each argument from each matching overload.
+        (0..argument_types.len())
+            .map(|argument_index| {
+                if argument_types.is_variadic(argument_index) {
+                    return None;
                 }
 
-                let mut speculative_builder = self.speculate_without_diagnostics();
-                let inferred_ty = infer_argument_ty(
-                    &mut speculative_builder,
-                    (
+                let parameter_tcx =
+                    |overload: &Binding<'db>, binding: &CallableBinding<'db>, specialization| {
+                        overload.argument_type_context(
+                            db,
+                            constraints,
+                            binding,
+                            argument_types,
+                            argument_index,
+                            call_expression_tcx,
+                            specialization,
+                        )
+                    };
+
+                let parameter_contexts = if let Ok((overload, binding, specialization)) =
+                    overloads_with_binding.iter().exactly_one()
+                {
+                    MatchingArgumentTypeContext::Unique(parameter_tcx(
+                        overload,
+                        binding,
+                        *specialization,
+                    ))
+                } else {
+                    MatchingArgumentTypeContext::Many(
+                        overloads_with_binding
+                            .iter()
+                            .map(|(overload, binding, specialization)| {
+                                parameter_tcx(overload, binding, *specialization)
+                            })
+                            .collect(),
+                    )
+                };
+
+                Some(parameter_contexts)
+            })
+            .collect()
+    }
+
+    /// Infers every call argument using the provided set of type context.
+    fn infer_all_argument_types(
+        &mut self,
+        ast_arguments: ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'_, 'db>,
+        arguments_tcx: &[Option<MatchingArgumentTypeContext<'db>>],
+        infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
+        mode: CallArgumentInferenceMode,
+    ) {
+        let insert_argument_ty =
+            |argument_index,
+             inferred_ty,
+             argument_tcx: &Option<ArgumentTypeContext<'db>>,
+             argument_types: &mut CallArguments<'_, 'db>| {
+                if let Some(argument_tcx) = argument_tcx {
+                    argument_tcx.insert_inferred_type_into(
+                        argument_types,
                         argument_index,
-                        ast_argument,
-                        TypeContext::new(Some(declared_type)),
-                    ),
-                );
-                arguments_types.insert_type(argument_index, declared_type, inferred_ty);
-            }
-        }
+                        inferred_ty,
+                    );
+                } else {
+                    argument_types.insert_type(argument_index, TypeContext::default(), inferred_ty);
+                }
+            };
 
         for (argument_index, ast_argument) in ast_arguments.enumerate() {
             // Splatted arguments are inferred before parameter matching to
@@ -5191,109 +5606,89 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             let ast_argument = ast_argument.value();
 
-            let parameter_tcx = |overload: &'bindings Binding<'db>,
-                                 binding: &CallableBinding<'db>| {
-                overload.argument_type_context(
-                    db,
-                    &constraints,
-                    binding,
-                    arguments_types,
-                    argument_index,
-                    call_expression_tcx,
-                )
+            let Some(argument_tcx) = &arguments_tcx[argument_index] else {
+                continue;
             };
 
-            // If there is only a single binding and overload, we can infer the argument directly with
-            // the unique parameter type annotation.
-            if let Ok((overload, binding)) = overloads_with_binding.iter().exactly_one() {
-                let parameter_context = parameter_tcx(overload, binding);
-
-                if let Some(parameter_context) = parameter_context {
-                    let inferred_ty = infer_argument_ty(
-                        self,
-                        (
-                            argument_index,
-                            ast_argument,
-                            parameter_context.type_context(),
-                        ),
-                    );
-                    parameter_context.insert_inferred_type(
-                        arguments_types,
-                        argument_index,
-                        inferred_ty,
-                    );
-                } else {
-                    let inferred_ty = infer_argument_ty(
-                        self,
-                        (argument_index, ast_argument, TypeContext::default()),
-                    );
-                    arguments_types.insert_type(
-                        argument_index,
-                        TypeContext::default(),
-                        inferred_ty,
-                    );
+            match argument_tcx {
+                MatchingArgumentTypeContext::Unique(argument_tcx) => {
+                    let tcx = argument_tcx
+                        .map(ArgumentTypeContext::type_context)
+                        .unwrap_or_default();
+                    let inferred_ty = infer_argument_ty(self, (argument_index, ast_argument, tcx));
+                    insert_argument_ty(argument_index, inferred_ty, argument_tcx, argument_types);
                 }
-            } else {
-                // Infer the type of each argument once with each distinct parameter type as type context.
-                let parameter_contexts: Vec<_> = overloads_with_binding
-                    .iter()
-                    .filter_map(|(overload, binding)| parameter_tcx(overload, binding))
-                    .collect();
 
-                // We perform inference once without any type context, emitting any diagnostics that are unrelated
-                // to bidirectional type inference.
-                let default_ty =
-                    infer_argument_ty(self, (argument_index, ast_argument, TypeContext::default()));
-                arguments_types.insert_type(argument_index, TypeContext::default(), default_ty);
+                MatchingArgumentTypeContext::Many(argument_tcx) => {
+                    let mut inferred_by_cache_key = FxHashMap::default();
 
-                let mut inferred_by_cache_key = FxHashMap::default();
+                    // If there are multiple applicable type contexts and we are not in
+                    // speculative mode, infer the argument without type context as the
+                    // default inference.
+                    if mode.requires_default_inference() {
+                        let inferred_ty = infer_argument_ty(
+                            self,
+                            (argument_index, ast_argument, TypeContext::default()),
+                        );
 
-                // Cache expressions inferred across speculative inference attempts.
-                //
-                // This is important to avoid exponential blowup for deeply nested generic calls,
-                // as inner expressions are repeatedly inferred with the same type context.
-                let teardown = self.setup_expression_cache();
-
-                for parameter_context in parameter_contexts {
-                    let inference_cache_key = parameter_context.inference_cache_key();
-                    if let Some(inferred_ty) =
-                        inferred_by_cache_key.get(&inference_cache_key).copied()
-                    {
-                        // Even when the inference cache key is identical, this overload may later
-                        // look up the inferred type through a different original `ParamSpec`
-                        // annotation, so insert through its own context.
-                        parameter_context.insert_inferred_type(
-                            arguments_types,
+                        argument_types.insert_type(
                             argument_index,
+                            TypeContext::default(),
                             inferred_ty,
                         );
-                        continue;
+
+                        inferred_by_cache_key.insert(None, inferred_ty);
                     }
 
-                    // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
-                    // type context is only used as a hint to infer a more assignable argument type, and should not lead
-                    // to diagnostics for non-matching overloads.
-                    let mut speculative_builder = self.speculate_without_diagnostics();
-                    let inferred_ty = infer_argument_ty(
-                        &mut speculative_builder,
-                        (
+                    // Cache expressions inferred across speculative inference attempts.
+                    //
+                    // This is important to avoid exponential blowup for deeply nested generic calls,
+                    // as inner expressions are repeatedly inferred with the same type context.
+                    let teardown_expression_cache = self.setup_expression_cache();
+
+                    for argument_tcx in argument_tcx {
+                        let inference_cache_key =
+                            argument_tcx.map(ArgumentTypeContext::inference_cache_key);
+                        if let Some(inferred_ty) =
+                            inferred_by_cache_key.get(&inference_cache_key).copied()
+                        {
+                            // Even when the inference cache key is identical, this overload may later
+                            // look up the inferred type through a different original `ParamSpec`
+                            // annotation, so insert through its own context.
+                            insert_argument_ty(
+                                argument_index,
+                                inferred_ty,
+                                argument_tcx,
+                                argument_types,
+                            );
+
+                            continue;
+                        }
+
+                        let tcx = argument_tcx
+                            .map(ArgumentTypeContext::type_context)
+                            .unwrap_or_default();
+
+                        let mut speculative_builder = self.speculate();
+                        let inferred_ty = infer_argument_ty(
+                            &mut speculative_builder,
+                            (argument_index, ast_argument, tcx),
+                        );
+
+                        insert_argument_ty(
                             argument_index,
-                            ast_argument,
-                            parameter_context.type_context(),
-                        ),
-                    );
+                            inferred_ty,
+                            argument_tcx,
+                            argument_types,
+                        );
 
-                    inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
-                    self.union_expected_types(&speculative_builder.expected_types);
-                    parameter_context.insert_inferred_type(
-                        arguments_types,
-                        argument_index,
-                        inferred_ty,
-                    );
-                }
+                        inferred_by_cache_key.insert(inference_cache_key, inferred_ty);
+                        self.union_expected_types(&speculative_builder.expected_types);
+                    }
 
-                if teardown {
-                    self.teardown_expression_cache();
+                    if teardown_expression_cache {
+                        self.teardown_expression_cache();
+                    }
                 }
             }
         }
@@ -5383,7 +5778,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         peer_ty: Option<Type<'db>>,
         mut infer_expression: impl FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        let peer_tcx = if allows_collection_literal_peer_context(tcx)
+        let peer_tcx = if is_empty_collection_type_context(tcx)
             && is_collection_literal(expression)
             && let Some(peer_ty) = peer_ty
         {
@@ -5421,31 +5816,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         standalone_expression: Expression<'db>,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        // `infer_expression_types` cache inference results for a given expression and type
-        // context. For expressions that are not directly affected by type context, we defer
-        // applying the type context until after the Salsa query runs, allowing us to reuse
-        // the memoized query result during multi-inference.
-        let inference_tcx = if can_defer_type_context(expression) {
-            TypeContext::default()
-        } else {
-            tcx
-        };
-
-        let types = infer_expression_types(self.db(), standalone_expression, inference_tcx);
+        let types = infer_expression_types(self.db(), standalone_expression, tcx);
         self.extend_expression(types);
 
         // Instead of calling `self.expression_type(expr)` after extending here, we get
         // the result from `types` directly because we might be in cycle recovery where
         // `types.cycle_fallback_type` is `Some(fallback_ty)`, which we can retrieve by
         // using `expression_type` on `types`:
-        let ty = types.expression_type(expression);
-        if inference_tcx == tcx {
-            ty
-        } else {
-            let ty = self.apply_type_context(expression, ty, tcx);
-            self.expressions.insert(expression.into(), ty);
-            ty
-        }
+        types.expression_type(expression)
     }
 
     /// Infer the type of an expression.
@@ -5454,27 +5832,60 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if let Some(ty) = self.expression_cache.as_ref().and_then(|expression_cache| {
-            expression_cache
-                .borrow()
-                .get(&(expression.into(), tcx))
-                .copied()
-        }) {
-            self.store_expression_type(expression, ty);
-            return ty;
-        }
+        let Some(expression_cache) = &self.expression_cache else {
+            return self.infer_expression_uncached(expression, tcx);
+        };
 
+        // See if we already have a cached entry for this expression.
+        let expression_key = expression.into();
+        let cache_entry = expression_cache.borrow().get(expression_key, tcx).cloned();
+
+        match cache_entry {
+            Some(ExpressionCacheEntry::Small(ty)) => {
+                self.store_expression_type(expression, ty);
+                ty
+            }
+
+            Some(ExpressionCacheEntry::Full(inference)) => {
+                let ty = inference.expression_type(expression_key);
+                self.extend_expression_cache_entry(&inference);
+                ty
+            }
+
+            _ => {
+                // The expression is uncached, infer it independently and cache the inference results.
+                let mut speculative_builder = self.speculate();
+                let ty = speculative_builder.infer_expression_uncached(expression, tcx);
+                let inference = speculative_builder.into_expression_cache_entry();
+
+                let cached = if inference.is_single_expression(expression_key, ty) {
+                    self.store_expression_type(expression, ty);
+                    ExpressionCacheEntry::Small(ty)
+                } else {
+                    self.extend_expression_cache_entry(&inference);
+                    ExpressionCacheEntry::Full(Rc::new(inference))
+                };
+
+                if let Some(expression_cache) = &self.expression_cache {
+                    expression_cache
+                        .borrow_mut()
+                        .insert(expression_key, tcx, cached);
+                }
+
+                ty
+            }
+        }
+    }
+
+    fn infer_expression_uncached(
+        &mut self,
+        expression: &ast::Expr,
+        tcx: TypeContext<'db>,
+    ) -> Type<'db> {
         if let Some(target) = tcx.annotation
             && let Some(ty) = self.infer_type_form_contextual_expression(expression, target)
         {
             self.store_expression_type(expression, ty);
-
-            if let Some(expression_cache) = &self.expression_cache {
-                expression_cache
-                    .borrow_mut()
-                    .insert((expression.into(), tcx), ty);
-            }
-
             return ty;
         }
 
@@ -5490,7 +5901,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        let mut ty = match expression {
+        let ty = match expression {
             ast::Expr::NoneLiteral(ast::ExprNoneLiteral {
                 range: _,
                 node_index: _,
@@ -5516,8 +5927,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.infer_dict_comprehension_expression(dictcomp, tcx)
             }
             ast::Expr::SetComp(setcomp) => self.infer_set_comprehension_expression(setcomp, tcx),
-            ast::Expr::Name(name) => self.infer_name_expression(name),
-            ast::Expr::Attribute(attribute) => self.infer_attribute_expression(attribute),
+            ast::Expr::Name(name) => {
+                let ty = self.infer_name_expression(name);
+                tcx.annotation.map_or(ty, |target| {
+                    self.specialize_generic_class_from_context(ty, target)
+                })
+            }
+            ast::Expr::Attribute(attribute) => {
+                let ty = self.infer_attribute_expression(attribute);
+                tcx.annotation.map_or(ty, |target| {
+                    self.specialize_generic_class_from_context(ty, target)
+                })
+            }
             ast::Expr::UnaryOp(unary_op) => self.infer_unary_expression(unary_op),
             ast::Expr::BinOp(binary) => self.infer_binary_expression(binary, tcx),
             ast::Expr::BoolOp(bool_op) => self.infer_boolean_expression(bool_op, tcx),
@@ -5541,15 +5962,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        ty = self.apply_type_context(expression, ty, tcx);
+        let ty = self.apply_type_context(expression, ty, tcx);
         self.store_expression_type(expression, ty);
-
-        if let Some(expression_cache) = &self.expression_cache {
-            expression_cache
-                .borrow_mut()
-                .insert((expression.into(), tcx), ty);
-        }
-
         ty
     }
 
@@ -5560,12 +5974,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         mut ty: Type<'db>,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if matches!(expression, ast::Expr::Name(_) | ast::Expr::Attribute(_))
-            && let Some(target) = tcx.annotation
-        {
-            ty = self.specialize_generic_class_from_context(ty, target);
-        }
-
         // Avoid promoting explicitly annotated literal values.
         if let Type::LiteralValue(literal) = ty
             && let Some(tcx) = tcx.annotation
@@ -6238,7 +6646,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut narrowed_tys = Vec::new();
                     let mut item_types = FxHashMap::default();
                     // Reuse nested expressions that receive the same field context across candidates.
-                    let teardown = self.setup_expression_cache();
+                    let teardown_expression_cache = self.setup_expression_cache();
                     for typed_dict in typed_dicts {
                         // Suppress diagnostics for discarded candidates. A mixed union like
                         // `TypedDict | dict[str, Any]` should remain quiet when the dict arm accepts
@@ -6252,7 +6660,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         item_types.clear();
                     }
-                    if teardown {
+                    if teardown_expression_cache {
                         self.teardown_expression_cache();
                     }
 
@@ -6795,10 +7203,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 builder.build_with(generic_context, |current_typevar, bounds| {
                     let lower = bounds?.lower?;
 
-                    let lower = if tcx.annotation.is_none() {
-                        // Constraints learned from later collection uses should follow the same
-                        // promotion policy as literal elements: promote element literal types in
-                        // invariant position unless an explicit annotation made them unpromotable.
+                    let lower = if is_empty_collection_type_context(tcx) {
+                        // Constraints learned from later collection uses follow the same promotion
+                        // policy as literal elements: promote element literal types in invariant
+                        // position unless an explicit annotation made them unpromotable.
                         lower.promote(self.db())
                     } else {
                         lower
@@ -6812,7 +7220,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         lower
                     };
 
-                    let lower = if elt_tcx_constraints.is_empty() {
+                    let lower = if is_empty_collection_type_context(tcx) {
                         lower
                             // Promote singleton types to `T | Unknown` in inferred type parameters,
                             // so that e.g. `[None]` is inferred as `list[None | Unknown]`.
@@ -7346,7 +7754,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let test_ty = self.infer_maybe_standalone_expression(test, TypeContext::default());
         let (body_ty, orelse_ty) =
-            if allows_collection_literal_peer_context(tcx) && is_collection_literal(body) {
+            if is_empty_collection_type_context(tcx) && is_collection_literal(body) {
                 // Infer the peer branch first so the body can use its type as context.
                 let orelse_ty = self.infer_expression(orelse, tcx);
                 let body_ty = self.infer_expression_with_collection_literal_peer_context(
@@ -9958,7 +10366,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = bool_op;
         // The first operand has no peers. If no later operand is a collection literal,
         // accumulating prior types cannot affect inference.
-        let track_peer_types = allows_collection_literal_peer_context(tcx)
+        let track_peer_types = is_empty_collection_type_context(tcx)
             && values.iter().skip(1).any(is_collection_literal);
         self.infer_chained_boolean_types(
             *op,
@@ -10148,13 +10556,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     pub(super) fn finish_expression(mut self) -> ExpressionInference<'db> {
         self.infer_region();
+        self.into_expression_inference()
+    }
 
+    /// Consume the results already collected by this builder without inferring its region.
+    fn into_expression_inference(self) -> ExpressionInference<'db> {
+        let region = self.region;
+        self.into_expression_cache_entry()
+            .into_expression_inference(region)
+    }
+
+    /// Consume the results already collected by this builder without compacting them.
+    fn into_expression_cache_entry(self) -> FullExpressionCacheEntry<'db> {
         let Self {
             context,
             expressions,
             qualifiers: _,
             type_expression_flags,
-            mut collection_use_constraints,
+            collection_use_constraints,
             string_annotations,
             expected_types,
             scope,
@@ -10173,13 +10592,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             reachability_cache: _,
             typevar_binding_context: _,
             deferred_state: _,
-            called_functions: _,
+            called_functions,
             index: _,
             region: _,
             return_types_and_ranges: _,
         } = self;
 
-        let diagnostics = context.finish();
+        let diagnostics = context.finish_uncompacted();
         let _ = scope;
 
         assert!(
@@ -10191,37 +10610,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             "Expression region can't have deferred definitions"
         );
 
-        let extra =
-            (!string_annotations.is_empty()
-                || !type_expression_flags.is_empty()
-                || !collection_use_constraints.is_empty()
-                || !expected_types.is_empty()
-                || cycle_recovery.is_some()
-                || !bindings.is_empty()
-                || !diagnostics.is_empty()).then(|| {
-                if bindings.len() > 20 {
-                    tracing::debug!(
-                        "Inferred expression region `{:?}` contains {} bindings. Lookups by linear scan might be slow.",
-                        self.region,
-                        bindings.len()
-                    );
-                }
-
-                collection_use_constraints.shrink_to_fit();
-                Box::new(ExpressionInferenceExtra {
-                    string_annotations: FrozenSet::from(string_annotations),
-                    expected_types: FrozenMap::from(expected_types),
-                    type_expression_flags: FrozenMap::from(type_expression_flags),
-                    bindings: bindings.into_boxed_slice(),
-                    diagnostics,
-                    cycle_recovery,
-                    collection_use_constraints
-                })
-            });
-
-        ExpressionInference {
-            expressions: FrozenMap::from(expressions),
-            extra,
+        FullExpressionCacheEntry {
+            expressions,
+            type_expression_flags,
+            collection_use_constraints,
+            string_annotations,
+            expected_types,
+            bindings,
+            diagnostics,
+            called_functions,
+            cycle_recovery,
             #[cfg(debug_assertions)]
             scope,
         }
@@ -10644,6 +11042,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Returns a speculative builder that does not construct diagnostics.
+    ///
+    /// Note that this method may lead to lost diagnostics if the expression cache
+    /// is enabled, as future multi-inference attempts may reuse inference results
+    /// in which diagnostics were suppressed.
     fn speculate_without_diagnostics(&self) -> Self {
         let mut builder = self.speculate();
         builder.context.suppress_diagnostics();
@@ -10722,6 +11124,169 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 }
 
+/// An expression cache shared across builders during multi-inference.
+///
+/// This provides a cheap way of reusing inference results without the overhead
+/// of Salsa standalone expressions.
+#[derive(Default)]
+struct ExpressionCache<'db> {
+    entries: FxHashMap<ExpressionNodeKey, ExpressionCacheEntries<'db>>,
+}
+
+impl<'db> ExpressionCache<'db> {
+    fn get(
+        &self,
+        expression: ExpressionNodeKey,
+        tcx: TypeContext<'db>,
+    ) -> Option<&ExpressionCacheEntry<'db>> {
+        self.entries.get(&expression)?.get(tcx)
+    }
+
+    fn insert(
+        &mut self,
+        expression: ExpressionNodeKey,
+        tcx: TypeContext<'db>,
+        value: ExpressionCacheEntry<'db>,
+    ) {
+        match self.entries.entry(expression) {
+            hash_map::Entry::Occupied(mut entry) => {
+                entry.get_mut().insert(tcx, value);
+            }
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(ExpressionCacheEntries::Single(tcx, value));
+            }
+        }
+    }
+}
+
+/// The inferred types of a given expression, keyed by type context.
+enum ExpressionCacheEntries<'db> {
+    Single(TypeContext<'db>, ExpressionCacheEntry<'db>),
+    Many(FxHashMap<TypeContext<'db>, ExpressionCacheEntry<'db>>),
+}
+
+impl<'db> ExpressionCacheEntries<'db> {
+    fn get(&self, tcx: TypeContext<'db>) -> Option<&ExpressionCacheEntry<'db>> {
+        match self {
+            Self::Single(cached_tcx, value) if *cached_tcx == tcx => Some(value),
+            Self::Single(_, _) => None,
+            Self::Many(values) => values.get(&tcx),
+        }
+    }
+
+    fn insert(&mut self, tcx: TypeContext<'db>, value: ExpressionCacheEntry<'db>) {
+        if let Self::Single(cached_tcx, cached_value) = self
+            && *cached_tcx == tcx
+        {
+            *cached_value = value;
+            return;
+        }
+
+        let previous = std::mem::replace(self, Self::Many(FxHashMap::default()));
+        *self = match previous {
+            Self::Single(cached_tcx, cached_value) => Self::Many(FxHashMap::from_iter([
+                (cached_tcx, cached_value),
+                (tcx, value),
+            ])),
+            Self::Many(mut values) => {
+                values.insert(tcx, value);
+                Self::Many(values)
+            }
+        };
+    }
+}
+
+/// The inferred types for an expression region under a given type context.
+#[derive(Clone)]
+enum ExpressionCacheEntry<'db> {
+    Small(Type<'db>),
+    Full(Rc<FullExpressionCacheEntry<'db>>),
+}
+
+/// The full inference results for an expression region.
+///
+/// Unlike [`ExpressionInference`], this type is short-lived, and avoids the cost of compaction
+/// that is otherwise performed for Salsa results.
+struct FullExpressionCacheEntry<'db> {
+    expressions: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    type_expression_flags: FxHashMap<ExpressionNodeKey, TypeExpressionFlags>,
+    collection_use_constraints: CollectionUseConstraints<'db>,
+    string_annotations: FxHashSet<ExpressionNodeKey>,
+    expected_types: FxHashMap<ExpressionNodeKey, Type<'db>>,
+    bindings: VecMap<Definition<'db>, Type<'db>>,
+    diagnostics: TypeCheckDiagnostics,
+    called_functions: FxIndexSet<FunctionType<'db>>,
+    cycle_recovery: Option<Type<'db>>,
+    #[cfg(debug_assertions)]
+    scope: ScopeId<'db>,
+}
+
+impl<'db> FullExpressionCacheEntry<'db> {
+    fn expression_type(&self, expression: ExpressionNodeKey) -> Type<'db> {
+        self.expressions
+            .get(&expression)
+            .copied()
+            .or(self.cycle_recovery)
+            .unwrap_or_else(Type::unknown)
+    }
+
+    fn is_single_expression(&self, expression: ExpressionNodeKey, ty: Type<'db>) -> bool {
+        self.expressions.len() == 1
+            && self.expressions.get(&expression) == Some(&ty)
+            && self.type_expression_flags.is_empty()
+            && self.collection_use_constraints.is_empty()
+            && self.string_annotations.is_empty()
+            && self.expected_types.is_empty()
+            && self.bindings.is_empty()
+            && self.diagnostics.is_empty()
+            && self.called_functions.is_empty()
+            && self.cycle_recovery.is_none()
+    }
+
+    fn into_expression_inference(
+        mut self,
+        region: InferenceRegion<'db>,
+    ) -> ExpressionInference<'db> {
+        let extra = (!self.string_annotations.is_empty()
+            || !self.type_expression_flags.is_empty()
+            || !self.collection_use_constraints.is_empty()
+            || !self.expected_types.is_empty()
+            || self.cycle_recovery.is_some()
+            || !self.bindings.is_empty()
+            || !self.called_functions.is_empty()
+            || !self.diagnostics.is_empty())
+        .then(|| {
+            if self.bindings.len() > 20 {
+                tracing::debug!(
+                    "Inferred expression region `{:?}` contains {} bindings. Lookups by linear scan might be slow.",
+                    region,
+                    self.bindings.len()
+                );
+            }
+
+            self.collection_use_constraints.shrink_to_fit();
+            self.diagnostics.shrink_to_fit();
+            Box::new(ExpressionInferenceExtra {
+                string_annotations: FrozenSet::from(self.string_annotations),
+                expected_types: FrozenMap::from(self.expected_types),
+                type_expression_flags: FrozenMap::from(self.type_expression_flags),
+                bindings: self.bindings.into_boxed_slice(),
+                diagnostics: self.diagnostics,
+                called_functions: self.called_functions.into_iter().collect(),
+                cycle_recovery: self.cycle_recovery,
+                collection_use_constraints: self.collection_use_constraints,
+            })
+        });
+
+        ExpressionInference {
+            expressions: FrozenMap::from(self.expressions),
+            extra,
+            #[cfg(debug_assertions)]
+            scope: self.scope,
+        }
+    }
+}
+
 /// Manages the inference of a given expression.
 struct MultiInferenceGuard<'db, 'ast, 'infer> {
     infer_expr:
@@ -10792,55 +11357,34 @@ impl Drop for MultiInferenceGuard<'_, '_, '_> {
 /// context.
 type ArgExpr<'db, 'ast> = (usize, &'ast ast::Expr, TypeContext<'db>);
 
+#[derive(Clone, Copy)]
+enum CallArgumentInferenceMode {
+    /// Infer against every candidate type context entirely speculatively.
+    Speculate,
+
+    /// Commit a default inference without type context, if there are multiple
+    /// applicable type contexts.
+    Commit,
+}
+
+impl CallArgumentInferenceMode {
+    fn requires_default_inference(self) -> bool {
+        matches!(self, Self::Commit)
+    }
+}
+
+/// The set of type contexts to use when inferring a call-site argument, across all matching overloads.
+#[derive(Debug, PartialEq, Eq)]
+enum MatchingArgumentTypeContext<'db> {
+    Unique(Option<ArgumentTypeContext<'db>>),
+    Many(Vec<Option<ArgumentTypeContext<'db>>>),
+}
+
 fn is_collection_literal(expression: &ast::Expr) -> bool {
     matches!(
         expression,
         ast::Expr::List(_) | ast::Expr::Set(_) | ast::Expr::Dict(_)
     )
-}
-
-/// Returns `true` if applying type context to the given expression may be deferred after inference.
-///
-/// For example, list literals must be inferred with type context directly, as the type context may
-/// influence the type assigned to an invariant generic type parameter. However, bare name expressions
-/// may be inferred without type context, and later specialized after inference.
-fn can_defer_type_context(expression: &ast::Expr) -> bool {
-    match expression {
-        ast::Expr::StringLiteral(_)
-        | ast::Expr::Tuple(_)
-        | ast::Expr::List(_)
-        | ast::Expr::Set(_)
-        | ast::Expr::Dict(_)
-        | ast::Expr::Generator(_)
-        | ast::Expr::ListComp(_)
-        | ast::Expr::DictComp(_)
-        | ast::Expr::SetComp(_)
-        | ast::Expr::BinOp(_)
-        | ast::Expr::BoolOp(_)
-        | ast::Expr::If(_)
-        | ast::Expr::Lambda(_)
-        | ast::Expr::Call(_)
-        | ast::Expr::Starred(_)
-        | ast::Expr::Await(_) => false,
-
-        ast::Expr::NoneLiteral(_)
-        | ast::Expr::NumberLiteral(_)
-        | ast::Expr::BooleanLiteral(_)
-        | ast::Expr::BytesLiteral(_)
-        | ast::Expr::FString(_)
-        | ast::Expr::TString(_)
-        | ast::Expr::EllipsisLiteral(_)
-        | ast::Expr::Name(_)
-        | ast::Expr::Attribute(_)
-        | ast::Expr::UnaryOp(_)
-        | ast::Expr::Compare(_)
-        | ast::Expr::Subscript(_)
-        | ast::Expr::Slice(_)
-        | ast::Expr::Yield(_)
-        | ast::Expr::YieldFrom(_)
-        | ast::Expr::Named(_)
-        | ast::Expr::IpyEscapeCommand(_) => true,
-    }
 }
 
 /// Returns `true` if `tcx` cannot provide useful type context for a collection literal.
@@ -10857,7 +11401,7 @@ fn can_defer_type_context(expression: &ast::Expr) -> bool {
 /// This deliberately matches only the bare marker: a partially specialized context such as
 /// `list[UnspecializedTypeVar | int]` still carries useful collection structure and concrete type
 /// information.
-fn allows_collection_literal_peer_context(tcx: TypeContext<'_>) -> bool {
+fn is_empty_collection_type_context(tcx: TypeContext<'_>) -> bool {
     tcx.annotation
         .is_none_or(|annotation| annotation == Type::Dynamic(DynamicType::UnspecializedTypeVar))
 }


### PR DESCRIPTION
Generic call inference faces the problem of how to provide unspecialized parameter types as type context to call arguments. We currently specialize parameter types based on the annotated type of the call expression. However, for unannotated calls, we fail to account for constraints contributed by sibling arguments, for example:

```py
def f[T](x: T, y: list[T]) -> T:
    return x

def _(x: int | str, y: int):
    f(x, [y]) # error[invalid-argument-type]: Expected `list[int | str]`, found `list[int]`
```

Or a more complex example, which pyright is also unable to solve:
```py
def f[T](x: T, y: list[T], z: list[T]) -> T:
    return x

def _(x: int | str, y: int, z: int | str | None):
    f(x, [y], [z]) # error[invalid-argument-type]: Expected `list[int | str | None]`, found `list[int]`
```

We also fail to provide useful type coverage for lambda expressions in generic signatures:
```py
x = map(lambda x: reveal_type(x) + 2, [1, 2, 3]) # revealed: Unknown
reveal_type(x) # revealed: map[Unknown]
```

This PR extends generic call inference to perform fixpoint iteration, allowing inferred argument types to contribute type context constraints to future iterations, until convergence. This allows us solve all the examples above, as well as handle complex chains of dependencies such as the following, which no other type checker currently supports:
```py
def chain[A, B, C, D](
    first: Callable[[C], D],
    second: Callable[[B], C],
    third: Callable[[A], B],
    source: list[A],
) -> D:
    return first(second(third(source[0])))

reveal_type(chain(  # revealed: int
    lambda c: reveal_type(c) + 1, # revealed: int
    lambda b: reveal_type(b) + 1, # revealed: int
    lambda a: reveal_type(a) + 1, # revealed: int
    [1, 2, 3],
))
```

Resolves https://github.com/astral-sh/ty/issues/2521, which I split into a few sub-issues that remain as limitations of the fixpoint scheme. This also resolves https://github.com/astral-sh/ty/issues/3469.

To avoid the overhead of multi-inference during fixpoint iteration, this PR extends our local expression caching to support caching entire inference region results, including diagnostics. This allows results from speculative inference rounds to be reused during the final round of fixpoint iteration. As a result, this PR is able to resolve https://github.com/astral-sh/ty/issues/3597 with relatively minimal overhead, which accounts for some of the new previously-suppressed ecosystem diagnostics.

This also removes a significant part of the code added in https://github.com/astral-sh/ruff/pull/24934, as the `ParamSpec` re-inference path now naturally falls out of fixpoint iteration. I also ended up reverting https://github.com/astral-sh/ruff/pull/26252 as part of this change, as the performance implications seemed negligible, and I don't think it warrants the extra complexity that it grew into (which accounts for the small memory usage regression). 