### PR TITLE
[ty] Discard dead DNF branches in intersection building

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -739,6 +739,44 @@ def cross_int_enum_members(value: First | Second) -> None:
         case _:
             reveal_type(value)  # revealed: Literal[First.TWO, Second.TWO]
 
+class Warning(Enum):
+    W1 = auto()
+
+class Verdict(Enum):
+    V0 = auto()
+    V1 = auto()
+    V2 = auto()
+    V3 = auto()
+    V4 = auto()
+    V5 = auto()
+    V6 = auto()
+    V7 = auto()
+    V8 = auto()
+    V9 = auto()
+    V10 = auto()
+    V11 = auto()
+
+def many_cross_enum_cases(value: Warning | Verdict) -> None:
+    match value:
+        case Verdict.V0:
+            return
+        case Verdict.V1:
+            return
+        case Verdict.V2:
+            return
+        case Verdict.V3:
+            return
+        case Verdict.V4:
+            return
+        case Verdict.V5:
+            return
+        case Verdict.V6:
+            return
+        case Verdict.V7:
+            return
+        case _:
+            reveal_type(value)  # revealed: Warning | Literal[Verdict.V8, Verdict.V9, Verdict.V10, Verdict.V11]
+
 class Automatic(StrEnum):
     GENERATED = auto()
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1108,6 +1108,17 @@ impl<'db> IntersectionBuilder<'db> {
         }
     }
 
+    /// Add DNF branches, dropping those that have already collapsed to `Never` so that later
+    /// union distribution does not multiply dead branches.
+    fn extend(&mut self, other: Self) {
+        self.intersections.extend(
+            other
+                .intersections
+                .into_iter()
+                .filter(|intersection| !intersection.contains_never()),
+        );
+    }
+
     pub(crate) fn add_positive(self, ty: Type<'db>) -> Self {
         self.add_positive_impl(ty, &mut vec![])
     }
@@ -1144,7 +1155,7 @@ impl<'db> IntersectionBuilder<'db> {
                     .iter()
                     .map(|elem| self.clone().add_positive_impl(*elem, seen_aliases))
                     .fold(IntersectionBuilder::empty(self.db), |mut builder, sub| {
-                        builder.intersections.extend(sub.intersections);
+                        builder.extend(sub);
                         builder
                     })
             }
@@ -1232,7 +1243,7 @@ impl<'db> IntersectionBuilder<'db> {
                 positive_side.chain(negative_side).fold(
                     IntersectionBuilder::empty(self.db),
                     |mut builder, sub| {
-                        builder.intersections.extend(sub.intersections);
+                        builder.extend(sub);
                         builder
                     },
                 )
@@ -1278,6 +1289,10 @@ struct InnerIntersectionBuilder<'db> {
 }
 
 impl<'db> InnerIntersectionBuilder<'db> {
+    fn contains_never(&self) -> bool {
+        self.positive.contains(&Type::Never)
+    }
+
     /// Return `true` when an intersection excludes every member of an enum class.
     ///
     /// This recognizes enum complements that have become empty, such as
@@ -1900,6 +1915,23 @@ mod tests {
 
         let intersection = IntersectionBuilder::new(&db).build();
         assert_eq!(intersection, Type::object());
+    }
+
+    #[test]
+    fn build_intersection_discards_never_dnf_branches() {
+        let db = setup_db();
+        let int = KnownClass::Int.to_instance(&db);
+        let str = KnownClass::Str.to_instance(&db);
+        let bytes = KnownClass::Bytes.to_instance(&db);
+
+        let int_or_str = UnionType::from_elements(&db, [int, str]);
+        let int_or_bytes = UnionType::from_elements(&db, [int, bytes]);
+        let intersection = IntersectionBuilder::new(&db)
+            .add_positive(int_or_str)
+            .add_positive(int_or_bytes);
+
+        assert_eq!(intersection.intersections.len(), 1);
+        assert_eq!(intersection.build(), int);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Drop `Never` DNF branches while building intersections so union distribution does not retain dead paths; this can dramatically reduce the size of the builder in some common cases, including match narrowing across multiple enums.

Added test OOMs before completing on main; completes quickly with this PR.

Closes https://github.com/astral-sh/ty/issues/3808

## Testing

Added test coverage.