### PR TITLE
[ty] Preserve metaclasses when inheriting from intersection-typed bases

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/metaclass.md
+++ b/crates/ty_python_semantic/resources/mdtest/metaclass.md
@@ -597,6 +597,31 @@ reveal_type(B.__class__)  # revealed: <class 'M'>
 reveal_type(C.__class__)  # revealed: <class 'M'>
 ```
 
+## Inheritance from an intersection type
+
+Narrowing can cause a class object to have an intersection type. A class that inherits from this
+intersection should still inherit the class object's metaclass.
+
+```py
+from typing import Any
+
+class Meta(type):
+    meta_attr: int = 1
+
+class Base(metaclass=Meta):
+    base_attr: str = ""
+
+def f(other: Any):
+    if Base is other:
+        reveal_type(Base)  # revealed: <class 'Base'> & Any
+
+        class Child(Base): ...
+
+        reveal_type(Child.base_attr)  # revealed: str
+        reveal_type(Child.__class__)  # revealed: <class 'Meta'>
+        reveal_type(Child.meta_attr)  # revealed: int
+```
+
 ## Conflict (1)
 
 The metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -529,13 +529,16 @@ impl<'db> StaticClassLiteral<'db> {
         }
     }
 
-    /// Iterate over this class's explicit bases, filtering out any bases that are not class
-    /// objects, and applying default specialization to any unspecialized generic class literals.
+    /// Iterate over this class's explicit bases, resolving them in the same way as MRO
+    /// construction, filtering out any bases that are not fully static class objects.
     fn fully_static_explicit_bases(self, db: &'db dyn Db) -> impl Iterator<Item = ClassType<'db>> {
         self.explicit_bases(db)
             .iter()
             .copied()
-            .filter_map(|ty| ty.to_class_type(db))
+            .filter_map(move |ty| {
+                ClassBase::try_from_type(db, ty, Some(ClassLiteral::Static(self)))
+                    .and_then(ClassBase::into_class)
+            })
     }
 
     /// Determine if this class is a protocol.


### PR DESCRIPTION
## Summary

Resolve bases for metaclass finding using the same rules as MRO construction. This avoids dropping inherited metaclasses when inheriting from an intersection.

Closes https://github.com/astral-sh/ty/issues/3282

## Testing

Added semantic regression coverage in `metaclass.md`.