### PR TITLE
[ty] Handle TypeVar bounds over type[...] in attribute lookup

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/self.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/self.md
@@ -473,6 +473,21 @@ class Child(Parent):
 reveal_type(Child.create())  # revealed: Child
 ```
 
+An inherited classmethod should also preserve the method's `Self` type when accessed through `self`.
+
+```py
+from typing import Self, assert_type
+
+class Parent:
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+class Child(Parent):
+    def method(self) -> None:
+        assert_type(self.create(), Self)
+```
+
 ## Attributes
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -727,6 +727,38 @@ def specialized(box: Box[Callable[..., Any]]) -> None:
     box.cls.whatever
 ```
 
+## Attribute access on TypeVars bounded by `type[...]`
+
+Regression test for <https://github.com/astral-sh/ty/issues/3782>.
+
+```py
+from typing import ClassVar, TypeVar
+from typing_extensions import Self
+
+class A:
+    attr: ClassVar[str]
+    current: ClassVar[Self]
+
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+class B:
+    attr: ClassVar[int]
+
+T = TypeVar("T", bound=type[A])
+
+def single_bound(cls: T) -> None:
+    reveal_type(cls.attr)  # revealed: str
+    reveal_type(cls.current)  # revealed: T'instance@single_bound
+    reveal_type(cls.create())  # revealed: T'instance@single_bound
+
+U = TypeVar("U", bound=type[A] | type[B])
+
+def union_bound(cls: U) -> None:
+    reveal_type(cls.attr)  # revealed: str | int
+```
+
 ## Solving TypeVars with upper bounds in unions
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/functions.md
@@ -800,6 +800,33 @@ def specialized(box: Box[Callable[..., Any]]) -> None:
     box.cls.whatever
 ```
 
+## Attribute access on TypeVars bounded by `type[...]`
+
+Regression test for <https://github.com/astral-sh/ty/issues/3782>.
+
+```py
+from typing import ClassVar, Self
+
+class A:
+    attr: ClassVar[str]
+    current: ClassVar[Self]
+
+    @classmethod
+    def create(cls) -> Self:
+        return cls()
+
+class B:
+    attr: ClassVar[int]
+
+def single_bound[T: type[A]](cls: T) -> None:
+    reveal_type(cls.attr)  # revealed: str
+    reveal_type(cls.current)  # revealed: T'instance@single_bound
+    reveal_type(cls.create())  # revealed: T'instance@single_bound
+
+def union_bound[T: type[A] | type[B]](cls: T) -> None:
+    reveal_type(cls.attr)  # revealed: str | int
+```
+
 ## Solving TypeVars with upper bounds in unions
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3691,6 +3691,57 @@ impl<'db> Type<'db> {
             policy: MemberLookupPolicy,
             receiver: Option<Type<'db>>,
         ) -> PlaceAndQualifiers<'db> {
+            fn instance_like_member_lookup<'db>(
+                db: &'db dyn Db,
+                this: Type<'db>,
+                name: &Name,
+                policy: MemberLookupPolicy,
+                receiver: Type<'db>,
+            ) -> PlaceAndQualifiers<'db> {
+                let name_str = name.as_str();
+
+                // Enum members can be accessed through enum instances and other enum members,
+                // e.g. `answer.YES` or `Answer.YES.NO`.
+                if let Some(enum_class) = match this {
+                    Type::LiteralValue(literal) => literal
+                        .as_enum()
+                        .map(|enum_literal| enum_literal.enum_class_literal(db)),
+                    _ => this
+                        .nominal_class(db)
+                        .map(|class| class.class_literal(db))
+                        .and_then(|class| class.into_enum_class(db)),
+                } && let Some(resolved_name) = enum_class.resolve_member(db, name)
+                {
+                    return Place::bound(Type::enum_literal(EnumLiteralType::new(
+                        db,
+                        enum_class,
+                        resolved_name,
+                    )))
+                    .into();
+                }
+
+                let fallback = this.instance_member(db, name_str);
+
+                let result = this.invoke_descriptor_protocol(
+                    db,
+                    receiver,
+                    name_str,
+                    fallback,
+                    InstanceFallbackShadowsNonDataDescriptor::No,
+                    policy,
+                );
+
+                if result.is_class_var() && this.is_typed_dict() {
+                    // `ClassVar`s on `TypedDictFallback` cannot be accessed on inhabitants of `SomeTypedDict`.
+                    // They can only be accessed on `SomeTypedDict` directly.
+                    return Place::Undefined.into();
+                }
+
+                let result = this.fallback_to_getattr(db, name, result, policy);
+
+                result.map_type(|ty| ty.bind_self_typevars(db, receiver))
+            }
+
             tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);
             if let Some(fallback) = this.materialized_divergent_fallback() {
                 return fallback.member_lookup_with_policy_and_receiver(db, name, policy, receiver);
@@ -4021,14 +4072,23 @@ impl<'db> Type<'db> {
                 }
                 Type::TypeVar(typevar) => {
                     let receiver = receiver.unwrap_or(this);
-                    let bound = typevar
+                    if let Some(bound) = typevar
                         .typevar(db)
                         .bound_or_constraints(db)
-                        .map_or_else(Type::object, |bound| bound.as_type(db));
+                        .map(|bound| bound.as_type(db))
+                        && bound.to_instance(db).is_some()
+                    {
+                        // A TypeVar can be bounded by a class-object type such as `type[A]`, which
+                        // requires the full lookup path rather than instance-member lookup.
+                        return bound.member_lookup_with_policy_and_receiver(
+                            db,
+                            name,
+                            policy,
+                            Some(receiver),
+                        );
+                    }
 
-                    // Use the full lookup path because a TypeVar can be bounded by a class-object
-                    // type such as `type[A]`, not only by an instance-like type.
-                    bound.member_lookup_with_policy_and_receiver(db, name, policy, Some(receiver))
+                    instance_like_member_lookup(db, this, &name, policy, receiver)
                 }
 
                 Type::NominalInstance(instance)
@@ -4106,47 +4166,7 @@ impl<'db> Type<'db> {
                 | Type::TypeForm(..)
                 | Type::TypedDict(_) => {
                     let receiver = receiver.unwrap_or(this);
-
-                    // Enum members can be accessed through enum instances and other enum members,
-                    // e.g. `answer.YES` or `Answer.YES.NO`.
-                    if let Some(enum_class) = match this {
-                        Type::LiteralValue(literal) => literal
-                            .as_enum()
-                            .map(|enum_literal| enum_literal.enum_class_literal(db)),
-                        _ => this
-                            .nominal_class(db)
-                            .map(|class| class.class_literal(db))
-                            .and_then(|class| class.into_enum_class(db)),
-                    } && let Some(resolved_name) = enum_class.resolve_member(db, &name)
-                    {
-                        return Place::bound(Type::enum_literal(EnumLiteralType::new(
-                            db,
-                            enum_class,
-                            resolved_name,
-                        )))
-                        .into();
-                    }
-
-                    let fallback = this.instance_member(db, name_str);
-
-                    let result = this.invoke_descriptor_protocol(
-                        db,
-                        receiver,
-                        name_str,
-                        fallback,
-                        InstanceFallbackShadowsNonDataDescriptor::No,
-                        policy,
-                    );
-
-                    if result.is_class_var() && this.is_typed_dict() {
-                        // `ClassVar`s on `TypedDictFallback` cannot be accessed on inhabitants of `SomeTypedDict`.
-                        // They can only be accessed on `SomeTypedDict` directly.
-                        return Place::Undefined.into();
-                    }
-
-                    let result = this.fallback_to_getattr(db, &name, result, policy);
-
-                    result.map_type(|ty| ty.bind_self_typevars(db, receiver))
+                    instance_like_member_lookup(db, this, &name, policy, receiver)
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4019,6 +4019,17 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 }
+                Type::TypeVar(typevar) => {
+                    let receiver = receiver.unwrap_or(this);
+                    let bound = typevar
+                        .typevar(db)
+                        .bound_or_constraints(db)
+                        .map_or_else(Type::object, |bound| bound.as_type(db));
+
+                    // Use the full lookup path because a TypeVar can be bounded by a class-object
+                    // type such as `type[A]`, not only by an instance-like type.
+                    bound.member_lookup_with_policy_and_receiver(db, name, policy, Some(receiver))
+                }
 
                 Type::NominalInstance(instance)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
@@ -4084,7 +4095,6 @@ impl<'db> Type<'db> {
                 | Type::ProtocolInstance(..)
                 | Type::NewTypeInstance(..)
                 | Type::LiteralValue(..)
-                | Type::TypeVar(..)
                 | Type::SpecialForm(..)
                 | Type::KnownInstance(..)
                 | Type::PropertyInstance(..)
@@ -4140,6 +4150,9 @@ impl<'db> Type<'db> {
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
+                    // A class-object lookup can originate from a TypeVar bound such as `type[A]`.
+                    // Retain that TypeVar as the receiver so `Self` binds to `T'instance`, not `A`.
+                    let receiver = receiver.unwrap_or(this);
                     let enum_class = match this {
                         Type::ClassLiteral(literal) => literal.into_enum_class(db),
                         Type::SubclassOf(subclass_of) => subclass_of
@@ -4161,18 +4174,23 @@ impl<'db> Type<'db> {
 
                     let class_attr_plain = this.class_object_member(db, name_str, policy);
 
-                    let self_instance = this
-                    .to_instance(db)
-                    .expect("`to_instance` always returns `Some` for `ClassLiteral`, `GenericAlias`, and `SubclassOf`");
+                    let self_instance = receiver.to_instance(db).expect(
+                        "The receiver for a class-object lookup should always be instantiable",
+                    );
                     let class_attr_plain =
                         class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
 
-                    let class_attr_fallback =
-                        Type::try_call_dunder_get_on_attribute(db, class_attr_plain, None, this).0;
+                    let class_attr_fallback = Type::try_call_dunder_get_on_attribute(
+                        db,
+                        class_attr_plain,
+                        None,
+                        receiver,
+                    )
+                    .0;
 
                     let result = this.invoke_descriptor_protocol(
                         db,
-                        this,
+                        receiver,
                         name_str,
                         class_attr_fallback,
                         InstanceFallbackShadowsNonDataDescriptor::Yes,


### PR DESCRIPTION
## Summary

Fix attribute resolution for `TypeVar` bounds that are class objects like `type[A]`. Also preserve the `TypeVar` receiver during class-object lookup so `Self`-based members resolve to the bound type variable instance instead of the concrete class.

Closes https://github.com/astral-sh/ty/issues/3782

## Testing
- Added mdtests.