### PR TITLE
[ty] Support experimental client capability for improved docstring rendering in VS Code.

### DIFF
--- a/crates/ty_ide/src/docstring.rs
+++ b/crates/ty_ide/src/docstring.rs
@@ -15,7 +15,7 @@ use ruff_python_trivia::{PythonWhitespace, leading_indentation};
 use ruff_source_file::UniversalNewlines;
 use std::sync::LazyLock;
 
-use crate::MarkupKind;
+use crate::{MarkdownRenderOptions, MarkupKind};
 
 // Static regex instances to avoid recompilation
 static GOOGLE_SECTION_REGEX: LazyLock<Regex> = LazyLock::new(|| {
@@ -51,7 +51,7 @@ impl Docstring {
     pub fn render(&self, kind: MarkupKind) -> String {
         match kind {
             MarkupKind::PlainText => self.render_plaintext(),
-            MarkupKind::Markdown => self.render_markdown(),
+            MarkupKind::Markdown => self.render_markdown(MarkdownRenderOptions::new()),
         }
     }
 
@@ -60,10 +60,10 @@ impl Docstring {
         documentation_trim(&self.0)
     }
 
-    /// Render the docstring for markdown display
-    pub fn render_markdown(&self) -> String {
+    /// Render the docstring for Markdown display using the available capabilities.
+    pub fn render_markdown(&self, options: MarkdownRenderOptions) -> String {
         let trimmed = documentation_trim(&self.0);
-        markdown::render(&trimmed)
+        markdown::render(&trimmed, options)
     }
 
     /// Extract parameter documentation from popular docstring formats.
@@ -481,7 +481,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r"
+        assert_snapshot!(render_markdown(&docstring), @r"
         Here \_this\_ and \_\_\_that\_\_ should be escaped<HB>
         Here *this* and **that** should be untouched<HB>
         Here `this` and ``that`` should be untouched<HB>
@@ -522,7 +522,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Parse a URL into 6 components:<HB>
         &lt;scheme&gt;://&lt;netloc&gt;/&lt;path&gt;;&lt;params&gt;?&lt;query&gt;#&lt;fragment&gt;<HB>
         <HB>
@@ -558,7 +558,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Check out this great example code:  <HB>
         ```````````python
             x_y = "hello"
@@ -597,7 +597,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Check out this great example code  <HB>
         ```````````python
             x_y = "hello"
@@ -637,7 +637,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Check out this great example code<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;  <HB>
         ```````````python
@@ -675,7 +675,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Check out this great example code:<HB>
         ```````````python
             x_y = "hello"
@@ -710,7 +710,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Check out this great example code:  <HB>
         ```````````python
             x_y = "hello"
@@ -748,7 +748,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         The thing you need to understand is that computers are hard.<HB>
         <HB>
         **Warning:**<HB>
@@ -788,7 +788,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         Some much-updated docs<HB>
         <HB>
         **Added in version 3.0:**<HB>
@@ -817,7 +817,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         **wow this is some changes Deprecated since version 1.2.3:**<HB>
         &nbsp;&nbsp;&nbsp;&nbsp;x = 2
         ");
@@ -840,7 +840,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ```python
@@ -868,7 +868,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         `````python
@@ -895,7 +895,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ~~~~~python
@@ -927,7 +927,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func...<HB>
         <HB>
         Returns:<HB>
@@ -962,7 +962,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func...<HB>
         <HB>
         Returns:<HB>
@@ -989,7 +989,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ````python
@@ -1011,7 +1011,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ~~~~~python
@@ -1035,7 +1035,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ``````we still think this is a codefence```
@@ -1059,7 +1059,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         My cool func:<HB>
         <HB>
         ~~~~~~we still think this is a codefence~~~
@@ -1083,7 +1083,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Here's some code!<HB>
         <HB>
         <HB>
@@ -1110,7 +1110,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Here's some Rust code!<HB>
         <HB>
         <HB>
@@ -1133,7 +1133,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         wow this is some code<HB>
         ```````````abc
             x = 2
@@ -1156,7 +1156,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Here's some code!<HB>
         <HB>
         <HB>
@@ -1183,7 +1183,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Here's some Rust code!<HB>
         <HB>
         <HB>
@@ -1212,7 +1212,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description<HB>
         <HB>
         ```````````python
@@ -1242,7 +1242,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description<HB>
         <HB>
         ```````````python
@@ -1266,7 +1266,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         ```````````python
         >>> thing.do_thing()
         wow it did the thing
@@ -1293,7 +1293,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description:  <HB>
         ```````````python
             >>> thing.do_thing()
@@ -1318,7 +1318,7 @@ mod tests {
 
         let docstring = Docstring::new(docstring.to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         And so you can see that<HB>
         ```````````python
             >>> thing.do_thing()
@@ -1369,7 +1369,7 @@ mod tests {
             str: The return value description
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -1441,7 +1441,7 @@ mod tests {
             The return value description
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Parameters<HB>
@@ -1499,7 +1499,7 @@ mod tests {
         'This is the second line of the docstring.'
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @r"
+        assert_snapshot!(render_markdown(&docstring), @r"
         Insert an entry into the list of warnings filters (at the front).<HB>
         <HB>
         'param1' -- The first parameter description<HB>
@@ -1531,7 +1531,7 @@ mod tests {
 
         assert_snapshot!(docstring.render_plaintext(), @"This is a simple function description without parameter documentation.");
 
-        assert_snapshot!(docstring.render_markdown(), @"This is a simple function description without parameter documentation.");
+        assert_snapshot!(render_markdown(&docstring), @"This is a simple function description without parameter documentation.");
     }
 
     #[test]
@@ -1580,7 +1580,7 @@ mod tests {
             NumPy-style parameter
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -1603,7 +1603,7 @@ mod tests {
         let _snap = bind_docstring_snapshot_filters();
         let docstring = Docstring::new(":param value: First line.\n    Second line.".to_owned());
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         ## Parameters
         **value**<HB>
         First line.
@@ -1654,7 +1654,7 @@ mod tests {
         :rtype: str
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.
 
         ## Parameters
@@ -1734,7 +1734,7 @@ mod tests {
             NumPy-style parameter
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -1815,7 +1815,7 @@ mod tests {
             The return value description
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Parameters<HB>
@@ -1884,7 +1884,7 @@ mod tests {
                 A parameter without type annotation
         ");
 
-        assert_snapshot!(docstring.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring), @"
         This is a function description.<HB>
         <HB>
         Parameters<HB>
@@ -1945,7 +1945,7 @@ mod tests {
             param2 (int): The second parameter
         ");
 
-        assert_snapshot!(docstring_windows.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring_windows), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -1961,7 +1961,7 @@ mod tests {
             param2 (int): The second parameter
         ");
 
-        assert_snapshot!(docstring_mac.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring_mac), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -1977,7 +1977,7 @@ mod tests {
             param2 (int): The second parameter
         ");
 
-        assert_snapshot!(docstring_unix.render_markdown(), @"
+        assert_snapshot!(render_markdown(&docstring_unix), @"
         This is a function description.<HB>
         <HB>
         Args:<HB>
@@ -2015,7 +2015,7 @@ Done.
 
         // The blank line between foo() and bar() should be preserved inside the code block,
         // NOT cause the code block to end early with bar() rendered as regular text.
-        assert_snapshot!(docstring.render_markdown(), @r#"
+        assert_snapshot!(render_markdown(&docstring), @r#"
         Example:<HB>
         <HB>
         ```````````python
@@ -2033,5 +2033,9 @@ Done.
         ```````````
         Done.
         "#);
+    }
+
+    fn render_markdown(docstring: &Docstring) -> String {
+        docstring.render_markdown(MarkdownRenderOptions::new())
     }
 }

--- a/crates/ty_ide/src/docstring/markdown.rs
+++ b/crates/ty_ide/src/docstring/markdown.rs
@@ -2,14 +2,15 @@ mod general;
 mod structured;
 
 use super::DocstringFragment;
+use crate::MarkdownRenderOptions;
 
 /// Render Markdown for a source docstring.
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline
 /// normalization (typically via `docstring::documentation_trim`).
-pub(super) fn render(source: &str) -> String {
+pub(super) fn render(source: &str, options: MarkdownRenderOptions) -> String {
     let mut output = String::new();
-    structured::render_into(&mut output, source);
+    structured::render_into(&mut output, source, options);
     output
 }
 

--- a/crates/ty_ide/src/docstring/markdown/structured.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured.rs
@@ -5,6 +5,7 @@ use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
 use super::general;
+use crate::MarkdownRenderOptions;
 use crate::docstring::document::preformatted::MarkdownFence;
 
 mod rst;
@@ -13,12 +14,17 @@ mod rst;
 ///
 /// `source` must have already undergone PEP-257 trimming and universal newline
 /// normalization (typically via `docstring::documentation_trim`).
-pub(super) fn render_into(output: &mut String, source: &str) {
-    render_sections_into(output, source, rst::structured_sections(source));
+pub(super) fn render_into(output: &mut String, source: &str, options: MarkdownRenderOptions) {
+    render_sections_into(output, source, rst::structured_sections(source), options);
 }
 
 /// Renders a docstring from non-overlapping structured sections and general source fragments.
-fn render_sections_into(output: &mut String, source: &str, sections: Vec<Section>) {
+fn render_sections_into(
+    output: &mut String,
+    source: &str,
+    sections: Vec<Section>,
+    options: MarkdownRenderOptions,
+) {
     if sections.is_empty() {
         general::render_into(output, source);
         return;
@@ -57,7 +63,7 @@ fn render_sections_into(output: &mut String, source: &str, sections: Vec<Section
                 if !output.is_empty() {
                     ensure_blank_line(output);
                 }
-                section.render_markdown(output);
+                section.render_markdown(output, options);
             }
         }
     }
@@ -143,7 +149,7 @@ impl Section {
     }
 
     /// Renders the section as Markdown into the given buffer.
-    fn render_markdown(&self, output: &mut String) {
+    fn render_markdown(&self, output: &mut String, options: MarkdownRenderOptions) {
         let mut rendered_section = false;
         for kind in SectionKind::iter() {
             if render_markdown_section(
@@ -151,6 +157,7 @@ impl Section {
                 kind.heading(),
                 self.items.iter().filter(move |item| item.kind == kind),
                 rendered_section,
+                options,
             ) {
                 rendered_section = true;
             }
@@ -194,7 +201,15 @@ impl SectionItem {
         self.display_name.is_none() && self.ty.is_none() && self.description_source.is_empty()
     }
 
-    fn render(&self, output: &mut String) {
+    fn render(&self, output: &mut String, options: MarkdownRenderOptions) {
+        if options.supports_html_ul() {
+            // Use a bare `<ul>` per item as an indentation container.
+            //
+            // The additional blank line ensures that the item body is
+            // interpreted as Markdown rather than raw HTML.
+            output.push_str("<ul>\n\n");
+        }
+
         let mut has_label = false;
 
         if let Some(name) = self.display_name.as_deref() {
@@ -249,6 +264,10 @@ impl SectionItem {
                 }
             }
         }
+
+        if options.supports_html_ul() {
+            output.push_str("\n\n</ul>");
+        }
     }
 }
 
@@ -283,6 +302,7 @@ fn render_markdown_section<'a>(
     heading: &str,
     fields: impl Iterator<Item = &'a SectionItem>,
     rendered_previous_section: bool,
+    options: MarkdownRenderOptions,
 ) -> bool {
     let mut rendered_field = false;
 
@@ -299,7 +319,7 @@ fn render_markdown_section<'a>(
             output.push_str("\n\n");
         }
 
-        field.render(output);
+        field.render(output, options);
         rendered_field = true;
     }
 
@@ -466,10 +486,11 @@ mod tests {
     use insta::{Settings, assert_snapshot};
     use ruff_text_size::{TextRange, TextSize};
 
-    use super::{Section, SectionItem, SectionKind, render_sections_into};
+    use super::{MarkdownRenderOptions, Section, SectionItem, SectionKind, render_sections_into};
 
     #[test]
     fn sections_render_in_canonical_order() {
+        let _snap = bind_markdown_snapshot_filters();
         let section = section_block(vec![
             SectionItem::new(
                 SectionKind::Raises,
@@ -515,35 +536,79 @@ mod tests {
             ),
         ]);
 
-        assert_snapshot!(render_markdown(&section), @r"
+        assert_snapshot!(render_markdown(&section, MarkdownRenderOptions::new()), @r"
         ## Parameters
-        **value**: `str`  
+        **value**: `str`<HB>
         The value.
 
         ## Keyword Arguments
-        **limit**: `int`  
+        **limit**: `int`<HB>
         Maximum result count.
 
         ## Other Parameters
-        **kw\_only**: `str`  
+        **kw\_only**: `str`<HB>
         Less common option.
 
         ## Attributes
-        **cache**: `dict[str, object]`  
+        **cache**: `dict[str, object]`<HB>
         Cached data.
 
         ## Returns
-        `bool`  
+        `bool`<HB>
         Whether validation passed.
 
         ## Yields
-        **item**: `Iterator[int]`  
+        **item**: `Iterator[int]`<HB>
         Generated values.
 
         ## Raises
-        `ValueError`  
+        `ValueError`<HB>
         Invalid value.
         ");
+    }
+
+    #[test]
+    fn section_items_use_html_list_indentation_when_supported() {
+        let _snap = bind_markdown_snapshot_filters();
+        let section = section_block(vec![
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("value"),
+                Some("str"),
+                "The value.",
+            ),
+            SectionItem::new(
+                SectionKind::Parameters,
+                Some("nested"),
+                None,
+                "- parent\n  - child",
+            ),
+        ]);
+
+        assert_snapshot!(
+            render_markdown(
+                &section,
+                MarkdownRenderOptions::new().with_html_ul(true),
+            ),
+            @"
+        ## Parameters
+        <ul>
+
+        **value**: `str`<HB>
+        The value.
+
+        </ul>
+
+        <ul>
+
+        **nested**
+
+        - parent<HB>
+          - child
+
+        </ul>
+        "
+        );
     }
 
     #[test]
@@ -571,6 +636,7 @@ mod tests {
 
     #[test]
     fn section_items_escape_bold_names() {
+        let _snap = bind_markdown_snapshot_filters();
         let section = section_block(vec![
             SectionItem::new(
                 SectionKind::Parameters,
@@ -592,15 +658,15 @@ mod tests {
             ),
         ]);
 
-        assert_snapshot!(render_markdown(&section), @r"
+        assert_snapshot!(render_markdown(&section, MarkdownRenderOptions::new()), @r"
         ## Parameters
-        **\*args**  
+        **\*args**<HB>
         Escaped name.
 
-        **\_\_value\_\_**  
+        **\_\_value\_\_**<HB>
         Escaped name.
 
-        **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**  
+        **&lt;value&gt; &amp; \[docs\](target) \| \~deleted\~**<HB>
         Escaped name.
         ");
     }
@@ -629,7 +695,7 @@ mod tests {
             ),
         ]);
 
-        assert_snapshot!(render_markdown(&section), @"
+        assert_snapshot!(render_markdown(&section, MarkdownRenderOptions::new()), @"
         ## Parameters
         **paragraphs**<HB>
         First paragraph.
@@ -659,7 +725,7 @@ mod tests {
             "Introduction.\n2. Continuation.",
         )]);
 
-        assert_snapshot!(render_markdown(&section), @"
+        assert_snapshot!(render_markdown(&section, MarkdownRenderOptions::new()), @"
         ## Parameters
         **ordered**<HB>
         Introduction.<HB>
@@ -670,11 +736,18 @@ mod tests {
     #[test]
     fn docstrings_without_structured_sections_are_rendered_as_general_content() {
         let docstring = "Summary.\n\nDetails.";
+        let expected = "Summary.  \n  \nDetails.";
 
-        assert_eq!(
-            render_sections(docstring, Vec::new()),
-            "Summary.  \n  \nDetails."
+        assert_eq!(render_sections(docstring, Vec::new()), expected);
+
+        let mut with_html_list_support = String::new();
+        render_sections_into(
+            &mut with_html_list_support,
+            docstring,
+            Vec::new(),
+            MarkdownRenderOptions::new().with_html_ul(true),
         );
+        assert_eq!(with_html_list_support, expected);
     }
 
     #[test]
@@ -693,11 +766,12 @@ mod tests {
 
     #[test]
     fn following_prose_does_not_continue_a_rendered_parameter_paragraph() {
+        let _snap = bind_markdown_snapshot_filters();
         let rendered = render_parameter_docstring("Value.", "After.");
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**  
+        **value**<HB>
         Value.
 
         After.
@@ -770,6 +844,7 @@ mod tests {
 
     #[test]
     fn adjacent_sections_are_separated() {
+        let _snap = bind_markdown_snapshot_filters();
         let raw = "ab";
         let rendered = render_sections(
             raw,
@@ -797,11 +872,11 @@ mod tests {
 
         assert_snapshot!(rendered, @"
         ## Parameters
-        **value**  
+        **value**<HB>
         The value.
 
         ## Returns
-        `bool`  
+        `bool`<HB>
         The result.
         ");
     }
@@ -843,9 +918,9 @@ mod tests {
         );
     }
 
-    fn render_markdown(section: &Section) -> String {
+    fn render_markdown(section: &Section, options: MarkdownRenderOptions) -> String {
         let mut output = String::new();
-        section.render_markdown(&mut output);
+        section.render_markdown(&mut output, options);
         output
     }
 
@@ -888,7 +963,7 @@ mod tests {
 
     fn render_sections(raw: &str, sections: Vec<Section>) -> String {
         let mut output = String::new();
-        render_sections_into(&mut output, raw, sections);
+        render_sections_into(&mut output, raw, sections, MarkdownRenderOptions::new());
         output
     }
 

--- a/crates/ty_ide/src/docstring/markdown/structured/rst.rs
+++ b/crates/ty_ide/src/docstring/markdown/structured/rst.rs
@@ -236,7 +236,7 @@ impl<'a> SupplementalTypeFields<'a> {
 mod tests {
     use insta::{Settings, assert_snapshot};
 
-    use super::super::render_into;
+    use super::super::{MarkdownRenderOptions, render_into};
 
     #[test]
     fn render_parameters_with_inline_and_supplemental_types() {
@@ -818,7 +818,7 @@ Summary.
 
     fn render_docstring(raw: &str) -> String {
         let mut output = String::new();
-        render_into(&mut output, raw);
+        render_into(&mut output, raw, MarkdownRenderOptions::new());
         output
     }
 

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1,6 +1,6 @@
 use crate::docstring::{Docstring, DocstringFragment};
 use crate::goto::{Definitions, GotoTarget, docstring_for_call_definition, find_goto_target};
-use crate::{Db, MarkupKind, RangedValue};
+use crate::{Db, MarkdownRenderOptions, MarkupKind, RangedValue};
 use ruff_db::files::{File, FileRange};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
@@ -224,6 +224,7 @@ impl<'db> Hover<'db> {
             db,
             hover: self,
             kind,
+            markdown_options: MarkdownRenderOptions::new(),
         }
     }
 
@@ -254,6 +255,16 @@ pub struct DisplayHover<'db, 'a> {
     db: &'db dyn Db,
     hover: &'a Hover<'db>,
     kind: MarkupKind,
+    markdown_options: MarkdownRenderOptions,
+}
+
+impl DisplayHover<'_, '_> {
+    /// Configures the capabilities available to the Markdown renderer.
+    #[must_use]
+    pub const fn with_markdown_options(mut self, options: MarkdownRenderOptions) -> Self {
+        self.markdown_options = options;
+        self
+    }
 }
 
 impl fmt::Display for DisplayHover<'_, '_> {
@@ -264,7 +275,9 @@ impl fmt::Display for DisplayHover<'_, '_> {
                 self.kind.horizontal_line().fmt(f)?;
             }
 
-            content.display(self.db, self.kind).fmt(f)?;
+            content
+                .display(self.db, self.kind, self.markdown_options)
+                .fmt(f)?;
             first = false;
         }
 
@@ -300,11 +313,17 @@ pub enum HoverContent<'db> {
 }
 
 impl<'db> HoverContent<'db> {
-    fn display(&self, db: &'db dyn Db, kind: MarkupKind) -> DisplayHoverContent<'_, 'db> {
+    fn display(
+        &self,
+        db: &'db dyn Db,
+        kind: MarkupKind,
+        markdown_options: MarkdownRenderOptions,
+    ) -> DisplayHoverContent<'_, 'db> {
         DisplayHoverContent {
             db,
             content: self,
             kind,
+            markdown_options,
         }
     }
 }
@@ -313,6 +332,7 @@ pub(crate) struct DisplayHoverContent<'a, 'db> {
     db: &'db dyn Db,
     content: &'a HoverContent<'db>,
     kind: MarkupKind,
+    markdown_options: MarkdownRenderOptions,
 }
 
 impl<'db> DisplayHoverContent<'_, 'db> {
@@ -387,7 +407,10 @@ impl fmt::Display for DisplayHoverContent<'_, '_> {
                     .fenced_code_block(format!("(key of {owner}) {key}: {ty_string}"), syntax)
                     .fmt(f)
             }
-            HoverContent::Docstring(docstring) => docstring.render(self.kind).fmt(f),
+            HoverContent::Docstring(docstring) => match self.kind {
+                MarkupKind::PlainText => docstring.render_plaintext().fmt(f),
+                MarkupKind::Markdown => docstring.render_markdown(self.markdown_options).fmt(f),
+            },
             HoverContent::DocstringFragment(fragment) => fragment.render(self.kind).fmt(f),
         }
     }

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -49,7 +49,7 @@ pub use hover::hover;
 pub use inlay_hints::{
     InlayHintKind, InlayHintLabel, InlayHintSettings, InlayHintTextEdit, inlay_hints,
 };
-pub use markup::MarkupKind;
+pub use markup::{MarkdownRenderOptions, MarkupKind};
 pub use references::ReferencesMode;
 pub use rename::{can_rename, rename};
 pub use selection_range::selection_range;

--- a/crates/ty_ide/src/markup.rs
+++ b/crates/ty_ide/src/markup.rs
@@ -7,6 +7,30 @@ pub enum MarkupKind {
     Markdown,
 }
 
+/// Capabilities available to the Markdown renderer.
+#[derive(Copy, Clone, Debug, Default)]
+pub struct MarkdownRenderOptions {
+    html_ul: bool,
+}
+
+impl MarkdownRenderOptions {
+    /// Creates options that do not enable any renderer-generated HTML.
+    pub const fn new() -> Self {
+        Self { html_ul: false }
+    }
+
+    /// Enables renderer-generated HTML `<ul>` elements.
+    #[must_use]
+    pub const fn with_html_ul(mut self, supported: bool) -> Self {
+        self.html_ul = supported;
+        self
+    }
+
+    pub(crate) const fn supports_html_ul(self) -> bool {
+        self.html_ul
+    }
+}
+
 impl MarkupKind {
     pub(crate) const fn fenced_code_block<T>(
         self,

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -35,6 +35,7 @@ bitflags::bitflags! {
         const DIAGNOSTIC_RELATED_INFORMATION = 1 << 17;
         const PREFER_MARKDOWN_IN_COMPLETION = 1 << 18;
         const COMPLETION_ITEM_SNIPPET_SUPPORT = 1 << 19;
+        const MARKDOWN_HTML_UL_INDENTATION = 1 << 20;
     }
 }
 
@@ -189,11 +190,35 @@ impl ResolvedClientCapabilities {
         self.contains(Self::PREFER_MARKDOWN_IN_COMPLETION)
     }
 
+    pub(crate) const fn markdown_render_options(self) -> ty_ide::MarkdownRenderOptions {
+        ty_ide::MarkdownRenderOptions::new()
+            .with_html_ul(self.contains(Self::MARKDOWN_HTML_UL_INDENTATION))
+    }
+
     pub(super) fn new(client_capabilities: &ClientCapabilities) -> Self {
         let mut flags = Self::empty();
 
         let workspace = client_capabilities.workspace.as_ref();
         let text_document = client_capabilities.text_document.as_ref();
+
+        let supports_html_ul = client_capabilities
+            .general
+            .as_ref()
+            .and_then(|general| general.markdown.as_ref())
+            .and_then(|markdown| markdown.allowed_tags.as_ref())
+            .is_some_and(|tags| tags.iter().any(|tag| tag.eq_ignore_ascii_case("ul")));
+        let supports_bare_ul_indentation = client_capabilities
+            .experimental
+            .as_ref()
+            .and_then(|experimental| experimental.get("ty"))
+            .and_then(|ty| ty.get("markdown"))
+            .and_then(|markdown| markdown.get("bareUlIndentation"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or_default();
+
+        if supports_html_ul && supports_bare_ul_indentation {
+            flags |= Self::MARKDOWN_HTML_UL_INDENTATION;
+        }
 
         if workspace
             .and_then(|workspace| workspace.diagnostics.as_ref()?.refresh_support)

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -68,6 +68,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
         if completions.is_empty() {
             return Ok(None);
         }
+        let markdown_options = client_capabilities.markdown_render_options();
 
         // Safety: we just checked that completions is not empty.
         let max_index_len = OneIndexed::new(completions.len()).unwrap().digits().get();
@@ -113,7 +114,10 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
                         .resolved_client_capabilities()
                         .prefers_markdown_in_completion()
                     {
-                        (lsp_types::MarkupKind::Markdown, docstring.render_markdown())
+                        (
+                            lsp_types::MarkupKind::Markdown,
+                            docstring.render_markdown(markdown_options),
+                        )
                     } else {
                         (
                             lsp_types::MarkupKind::PlainText,

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -61,7 +61,14 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
             (MarkupKind::PlainText, lsp_types::MarkupKind::PlainText)
         };
 
-        let contents = range_info.display(db, markup_kind).to_string();
+        let contents = range_info
+            .display(db, markup_kind)
+            .with_markdown_options(
+                snapshot
+                    .resolved_client_capabilities()
+                    .markdown_render_options(),
+            )
+            .to_string();
 
         Ok(Some(lsp_types::Hover {
             contents: MarkupContent {

--- a/crates/ty_server/tests/e2e/completions.rs
+++ b/crates/ty_server/tests/e2e/completions.rs
@@ -629,6 +629,43 @@ fn documentation_supports_only_plain_text() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn structured_documentation_uses_html_list_indentation_when_supported() -> Result<()> {
+    let markdown = structured_completion_documentation(Some(vec!["ul".to_string()]), Some(true))?;
+
+    insta::assert_snapshot!(markdown, @"
+    Summary.
+
+    ## Parameters
+    <ul>
+
+    **value**: `str`  
+    The input value.
+
+    </ul>
+    ");
+    Ok(())
+}
+
+#[test]
+fn structured_documentation_avoids_html_list_indentation_without_support() -> Result<()> {
+    let markdown = structured_completion_documentation(None, None)?;
+
+    insta::assert_snapshot!(markdown, @"
+    Summary.
+
+    ## Parameters
+    **value**: `str`  
+    The input value.
+    ");
+
+    assert_eq!(
+        structured_completion_documentation(Some(vec!["ul".to_string()]), None)?,
+        markdown,
+    );
+    Ok(())
+}
+
 fn documentation_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
     let workspace_root = SystemPath::new("src");
     let document_path = SystemPath::new("src/foo.py");
@@ -665,4 +702,48 @@ foo_
     };
 
     Ok(markup.kind)
+}
+
+fn structured_completion_documentation(
+    allowed_tags: Option<Vec<String>>,
+    bare_ul_indentation: Option<bool>,
+) -> Result<String> {
+    let workspace_root = SystemPath::new("src");
+    let document_path = SystemPath::new("src/foo.py");
+    let document_content = r#"def documented(value: str) -> None:
+    """Summary.
+
+    :param str value: The input value.
+    """
+    ...
+
+docum
+"#;
+
+    let mut builder = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(document_path, document_content)?
+        .with_completion_documentation_format(vec![MarkupKind::Markdown]);
+    if let Some(allowed_tags) = allowed_tags {
+        builder = builder.with_markdown_allowed_tags(allowed_tags);
+    }
+    if let Some(supported) = bare_ul_indentation {
+        builder = builder.with_ty_markdown_bare_ul_indentation(supported);
+    }
+
+    let mut server = builder.build().wait_until_workspaces_are_initialized();
+    server.open_text_document(document_path, document_content, 1);
+
+    let completions =
+        server.completion_request(&server.file_uri(document_path), Position::new(7, 5));
+    let documentation = completions
+        .into_iter()
+        .find(|completion| completion.label == "documented")
+        .and_then(|completion| completion.documentation)
+        .expect("Expected documentation for function completion");
+    let Documentation::MarkupContent(markup) = documentation else {
+        panic!("Expected markup documentation");
+    };
+
+    Ok(markup.value)
 }

--- a/crates/ty_server/tests/e2e/hover.rs
+++ b/crates/ty_server/tests/e2e/hover.rs
@@ -40,6 +40,57 @@ fn supports_only_plain_text() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn structured_docstrings_use_html_list_indentation_when_supported() -> Result<()> {
+    let markdown = structured_hover(Some(vec!["ul".to_string()]), Some(true))?;
+    insta::assert_snapshot!(&markdown, @"
+    ```python
+    def documented(value: str) -> None
+    ```
+    ---
+    Summary.
+
+    ## Parameters
+    <ul>
+
+    **value**: `str`  
+    The input value.
+
+    </ul>
+    ");
+
+    for tag in ["UL", "Ul"] {
+        assert_eq!(
+            structured_hover(Some(vec![tag.to_string()]), Some(true))?,
+            markdown
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn structured_docstrings_avoid_html_list_indentation_without_support() -> Result<()> {
+    let without_allowed_tags = structured_hover(None, None)?;
+    insta::assert_snapshot!(&without_allowed_tags, @"
+    ```python
+    def documented(value: str) -> None
+    ```
+    ---
+    Summary.
+
+    ## Parameters
+    **value**: `str`  
+    The input value.
+    ");
+
+    let unrelated_allowed_tag = structured_hover(Some(vec!["p".to_string()]), Some(true))?;
+    assert_eq!(unrelated_allowed_tag, without_allowed_tags);
+
+    let without_ty_capability = structured_hover(Some(vec!["ul".to_string()]), None)?;
+    assert_eq!(without_ty_capability, without_allowed_tags);
+    Ok(())
+}
+
 fn hover_content_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
     let workspace_root = SystemPath::new("src");
     let document_path = SystemPath::new("src/foo.py");
@@ -64,4 +115,44 @@ fn hover_content_format(formats: Vec<MarkupKind>) -> Result<MarkupKind> {
     };
 
     Ok(markup.kind)
+}
+
+fn structured_hover(
+    allowed_tags: Option<Vec<String>>,
+    bare_ul_indentation: Option<bool>,
+) -> Result<String> {
+    let workspace_root = SystemPath::new("src");
+    let document_path = SystemPath::new("src/foo.py");
+    let document_content = r#"def documented(value: str) -> None:
+    """Summary.
+
+    :param str value: The input value.
+    """
+    ...
+
+documented("x")
+"#;
+
+    let mut builder = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(document_path, document_content)?
+        .with_hover_content_format(vec![MarkupKind::Markdown]);
+    if let Some(allowed_tags) = allowed_tags {
+        builder = builder.with_markdown_allowed_tags(allowed_tags);
+    }
+    if let Some(supported) = bare_ul_indentation {
+        builder = builder.with_ty_markdown_bare_ul_indentation(supported);
+    }
+
+    let mut server = builder.build().wait_until_workspaces_are_initialized();
+    server.open_text_document(document_path, document_content, 1);
+
+    let hover = server
+        .hover_request(document_path, Position::new(7, 1))
+        .expect("Expected a hover response");
+    let Contents::MarkupContent(markup) = hover.contents else {
+        panic!("Expected markup content");
+    };
+
+    Ok(markup.value)
 }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1378,6 +1378,29 @@ impl TestServerBuilder {
         self
     }
 
+    /// Set the HTML tags supported by the client's Markdown renderer.
+    pub(crate) fn with_markdown_allowed_tags(mut self, tags: Vec<String>) -> Self {
+        self.client_capabilities
+            .general
+            .get_or_insert_default()
+            .markdown
+            .get_or_insert_default()
+            .allowed_tags = Some(tags);
+        self
+    }
+
+    /// Opt into ty's bare `<ul>` Markdown indentation convention.
+    pub(crate) fn with_ty_markdown_bare_ul_indentation(mut self, supported: bool) -> Self {
+        self.client_capabilities.experimental = Some(serde_json::json!({
+            "ty": {
+                "markdown": {
+                    "bareUlIndentation": supported,
+                },
+            },
+        }));
+        self
+    }
+
     /// Set custom client capabilities (overrides any previously set capabilities)
     #[expect(dead_code)]
     pub(crate) fn with_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Test Plan

<!-- How was it tested? -->
