### PR TITLE
Improve the ecosystem summary skill template

### DIFF
--- a/.agents/skills/summarise-ecosystem-results/assets/report-template.md
+++ b/.agents/skills/summarise-ecosystem-results/assets/report-template.md
@@ -1,6 +1,6 @@
 <!-- Replace every placeholder and remove all HTML comments before presenting the report. Keep each prose paragraph and list item on one source line. Do not add change-count tables, bot-update timestamps, reproduction-completeness bookkeeping, import-audit details, exhaustive traceability appendices, raw URLs, or artifact hashes. -->
 
-# PR #<number> ecosystem summary
+# [PR #<number>](https://github.com/astral-sh/ruff/pull/<number>) ecosystem summary
 
 <Summarize the distinct diagnostic behavior changes and their significance. Lead with the analysis readers need; do not describe how the report was generated.>
 
@@ -20,9 +20,9 @@
 
 - Detailed report: [ecosystem-analyzer report](<report-url>)
 - Actions run: [run <id>](<run-url>)
-- Ruff comparison: `<merge-base>` to `<pr-revision>`
-- `ecosystem-analyzer`: `<revision>`
-- `mypy-primer`: `<revision>`
+- Ruff comparison: [`<merge-base>`](https://github.com/astral-sh/ruff/commit/<merge-base>) to [`<pr-revision>`](https://github.com/astral-sh/ruff/commit/<pr-revision>)
+- `ecosystem-analyzer`: [`<revision>`](https://github.com/astral-sh/ecosystem-analyzer/commit/<revision>)
+- `mypy-primer`: [`<revision>`](https://github.com/hauntsaninja/mypy_primer/commit/<revision>)
 - Project Python: `<project: version, ...>`
 - Dependency cutoff: `<EXCLUDE_NEWER>`
 - Comparison method: `<concise exact commands or method used to run both copied ty binaries>`


### PR DESCRIPTION
## Summary

- Link the PR number in generated ecosystem summary titles.
- Link Ruff, `ecosystem-analyzer`, and `mypy-primer` revisions to their GitHub commit pages.