### PR TITLE
[ty] Run lint documentation tests in mdtest.py

### DIFF
--- a/crates/ty_python_semantic/mdtest.py
+++ b/crates/ty_python_semantic/mdtest.py
@@ -34,6 +34,11 @@ DIRS_TO_WATCH: Final = (
     CRATE_ROOT.parent / "mdtest/src",
 )
 MDTEST_DIR: Final = CRATE_ROOT / "resources" / "mdtest"
+LINT_DOCS_DIR: Final = CRATE_ROOT / "resources" / "lint_docs"
+MDTEST_SUITES: Final = (
+    ("mdtest", MDTEST_DIR),
+    ("lint_doc", LINT_DOCS_DIR),
+)
 SNAPSHOTS_DIR: Final = MDTEST_DIR / "snapshots"
 MDTEST_README: Final = CRATE_ROOT / "resources" / "README.md"
 
@@ -55,10 +60,7 @@ class MDTestRunner:
     ) -> None:
         self.mdtest_executable = None
         self.console = Console()
-        self.filters = [
-            f.removesuffix(".md").replace("/", "_").replace("-", "_")
-            for f in (filters or [])
-        ]
+        self.filters = [f.removesuffix(".md") for f in (filters or [])]
         self.enable_external = enable_external
         self.upgrade_lockfiles = upgrade_lockfiles
         self.update_snapshots = update_snapshots
@@ -152,7 +154,7 @@ class MDTestRunner:
         )
 
     @staticmethod
-    def _md_file_for_snapshot(snapshot_path: Path) -> Path | None:
+    def _md_file_for_snapshot(snapshot_path: Path) -> tuple[str, Path] | None:
         """Given a deleted .snap.new path, find the source .md file it belongs to.
 
         Snapshot filenames follow the pattern:
@@ -168,16 +170,24 @@ class MDTestRunner:
         if is_truncated:
             md_filename = md_filename[:-1]
 
-        for md_file in MDTEST_DIR.rglob("*.md"):
-            if is_truncated:
-                if md_file.name.startswith(md_filename):
-                    return md_file.relative_to(MDTEST_DIR)
-            elif md_file.name == md_filename:
-                return md_file.relative_to(MDTEST_DIR)
+        for test_function, mdtest_dir in MDTEST_SUITES:
+            for md_file in mdtest_dir.rglob("*.md"):
+                if is_truncated:
+                    if md_file.name.startswith(md_filename):
+                        return test_function, md_file.relative_to(mdtest_dir)
+                elif md_file.name == md_filename:
+                    return test_function, md_file.relative_to(mdtest_dir)
         return None
 
-    def _run_mdtests_for_file(self, markdown_file: Path) -> None:
-        test_name = f"mdtest::{markdown_file}"
+    @staticmethod
+    def _mdtest_for_path(path: Path) -> tuple[str, Path] | None:
+        for test_function, mdtest_dir in MDTEST_SUITES:
+            if path.is_relative_to(mdtest_dir):
+                return test_function, path.relative_to(mdtest_dir)
+        return None
+
+    def _run_mdtests_for_file(self, test_function: str, markdown_file: Path) -> None:
+        test_name = f"{test_function}::{markdown_file}"
 
         output = self._run_mdtest(["--exact", test_name], capture_output=True)
 
@@ -234,9 +244,9 @@ class MDTestRunner:
         self.console.print("[dim]Ready to watch for changes...[/dim]")
 
         for changes in watch(*DIRS_TO_WATCH):
-            new_md_files: set[Path] = set()
-            changed_md_files: set[Path] = set()
-            rejected_snapshot_md_files: set[Path] = set()
+            new_mdtests: set[tuple[str, Path]] = set()
+            changed_mdtests: set[tuple[str, Path]] = set()
+            rejected_snapshot_mdtests: set[tuple[str, Path]] = set()
             rust_code_has_changed = False
             vendored_typeshed_has_changed = False
 
@@ -261,7 +271,7 @@ class MDTestRunner:
                 ):
                     md_file = self._md_file_for_snapshot(path)
                     if md_file is not None:
-                        rejected_snapshot_md_files.add(md_file)
+                        rejected_snapshot_mdtests.add(md_file)
                     continue
 
                 match path.suffix:
@@ -274,9 +284,8 @@ class MDTestRunner:
                     case _:
                         continue
 
-                try:
-                    relative_path = Path(path).relative_to(MDTEST_DIR)
-                except ValueError:
+                mdtest = self._mdtest_for_path(path)
+                if mdtest is None:
                     continue
 
                 match change:
@@ -286,11 +295,11 @@ class MDTestRunner:
                         # it to the final name. This creates a `deleted` and `added` change.
                         # We treat those files as `changed` here.
                         if (Change.deleted, path_str) in changes:
-                            changed_md_files.add(relative_path)
+                            changed_mdtests.add(mdtest)
                         else:
-                            new_md_files.add(relative_path)
+                            new_mdtests.add(mdtest)
                     case Change.modified:
-                        changed_md_files.add(relative_path)
+                        changed_mdtests.add(mdtest)
                     case Change.deleted:
                         # No need to do anything when a Markdown test is deleted
                         pass
@@ -305,8 +314,10 @@ class MDTestRunner:
             ):
                 self._run_mdtest(self.filters)
 
-            for path in new_md_files | changed_md_files | rejected_snapshot_md_files:
-                self._run_mdtests_for_file(path)
+            for test_function, path in (
+                new_mdtests | changed_mdtests | rejected_snapshot_mdtests
+            ):
+                self._run_mdtests_for_file(test_function, path)
 
 
 def main() -> None:
@@ -316,7 +327,7 @@ def main() -> None:
     parser.add_argument(
         "filters",
         nargs="*",
-        help="Partial paths or mangled names, e.g., 'loops/for.md' or 'loops_for'",
+        help="Partial paths, e.g., 'loops/for.md' or 'invalid-argument-type.md'",
     )
     parser.add_argument(
         "--enable-external",


### PR DESCRIPTION
`ty_python_semantic` now has two Markdown-based test suites in the same Rust test harness. The existing semantic tests live under `resources/mdtest` and have names such as `mdtest::loops/for.md`. The new lint-rule documentation lives under `resources/lint_docs`; its code examples are tests with names such as `lint_doc::invalid-argument-type.md`. This PR updates the Python `mdtest.py` development runner to handle both suites correctly.

## Run lint-documentation tests when their files change

An unfiltered invocation of `mdtest.py` already ran the new documentation tests because it executed the entire Rust test binary. Watch mode was incomplete, however: it only recognized changed Markdown files under `resources/mdtest`, and it always constructed an exact test name beginning with `mdtest::`. Changes under `resources/lint_docs` were therefore ignored after the initial test run.

The runner now describes each suite using its Rust harness function and fixture root. When a Markdown file changes, it uses that mapping to identify both the path relative to the fixture root and the correct test-name prefix. Editing `resources/lint_docs/invalid-argument-type.md`, for example, now reruns `lint_doc::invalid-argument-type.md`. The same suite information is retained when rerunning a test after a pending snapshot is rejected.

## Match datatest's test-name format

The runner's command-line filter normalization was left over from the old `dir-test` harness. `dir-test` flattened fixture paths into Rust test names such as `mdtest__loops_for`, so `mdtest.py` converted `loops/for.md` to `loops_for` by removing the extension and replacing `/` and `-` with `_`.

The later migration to datatest changed test names to preserve fixture paths, producing names such as `mdtest::loops/for.md`. That migration updated the exact test name used by watch mode, but it did not remove the old normalization applied to command-line filters. Consequently, path-shaped filters no longer matched the tests they named. This became particularly misleading with the documentation suite: `invalid-argument-type.md` was converted to `invalid_argument_type`, which selected the existing `mdtest::diagnostics/invalid_argument_type.md` semantic test instead of `lint_doc::invalid-argument-type.md`.

`mdtest.py` now removes only an optional `.md` suffix from command-line filters, preserving the `/` and `-` characters used in datatest's names.
