### PR TITLE
[ty] Make error-on-warning the default

### DIFF
--- a/crates/ruff_dev/src/generate_ty_cli_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_cli_reference.rs
@@ -221,19 +221,32 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                     output.push_str(&format!(", <code>-{short_alias}</code>"));
                 }
 
-                // Re-implements private `Arg::is_takes_value_set` used in `Command::get_opts`
-                if opt
-                    .get_num_args()
-                    .unwrap_or_else(|| 1.into())
-                    .takes_values()
+                // Re-implements private `Arg::is_takes_value_set` used in `Command::get_opts`.
+                let num_args = opt.get_num_args().unwrap_or_else(|| 1.into());
+                if num_args.takes_values()
+                    && let Some(values) = opt.get_value_names()
                 {
-                    if let Some(values) = opt.get_value_names() {
-                        for value in values {
-                            output.push_str(&format!(
-                                " <i>{}</i>",
-                                value.to_lowercase().replace('_', "-")
-                            ));
+                    let is_optional = num_args.min_values() == 0;
+                    let prefix = match (opt.is_require_equals_set(), is_optional) {
+                        (true, true) => "[=",
+                        (true, false) => "=",
+                        (false, true) => " [",
+                        (false, false) => " ",
+                    };
+                    output.push_str(prefix);
+
+                    for (index, value) in values.iter().enumerate() {
+                        if index > 0 {
+                            output.push(' ');
                         }
+                        output.push_str(&format!(
+                            "<i>{}</i>",
+                            value.to_lowercase().replace('_', "-")
+                        ));
+                    }
+
+                    if is_optional {
+                        output.push(']');
                     }
                 }
                 output.push_str("</dt>");
@@ -326,7 +339,14 @@ mod tests {
 
     use crate::generate_all::Mode;
 
-    use super::{Args, main};
+    use super::{Args, generate, main};
+
+    #[test]
+    fn optional_value_that_requires_equals_uses_equals() {
+        assert!(
+            generate().contains("<code>--error-on-warning</code></a>[=<i>error-on-warning</i>]")
+        );
+    }
 
     #[test]
     fn ty_cli_reference_is_up_to_date() -> Result<()> {

--- a/crates/ruff_dev/src/generate_ty_cli_reference.rs
+++ b/crates/ruff_dev/src/generate_ty_cli_reference.rs
@@ -221,32 +221,19 @@ fn generate_command<'a>(output: &mut String, command: &'a Command, parents: &mut
                     output.push_str(&format!(", <code>-{short_alias}</code>"));
                 }
 
-                // Re-implements private `Arg::is_takes_value_set` used in `Command::get_opts`.
-                let num_args = opt.get_num_args().unwrap_or_else(|| 1.into());
-                if num_args.takes_values()
-                    && let Some(values) = opt.get_value_names()
+                // Re-implements private `Arg::is_takes_value_set` used in `Command::get_opts`
+                if opt
+                    .get_num_args()
+                    .unwrap_or_else(|| 1.into())
+                    .takes_values()
                 {
-                    let is_optional = num_args.min_values() == 0;
-                    let prefix = match (opt.is_require_equals_set(), is_optional) {
-                        (true, true) => "[=",
-                        (true, false) => "=",
-                        (false, true) => " [",
-                        (false, false) => " ",
-                    };
-                    output.push_str(prefix);
-
-                    for (index, value) in values.iter().enumerate() {
-                        if index > 0 {
-                            output.push(' ');
+                    if let Some(values) = opt.get_value_names() {
+                        for value in values {
+                            output.push_str(&format!(
+                                " <i>{}</i>",
+                                value.to_lowercase().replace('_', "-")
+                            ));
                         }
-                        output.push_str(&format!(
-                            "<i>{}</i>",
-                            value.to_lowercase().replace('_', "-")
-                        ));
-                    }
-
-                    if is_optional {
-                        output.push(']');
                     }
                 }
                 output.push_str("</dt>");
@@ -339,14 +326,7 @@ mod tests {
 
     use crate::generate_all::Mode;
 
-    use super::{Args, generate, main};
-
-    #[test]
-    fn optional_value_that_requires_equals_uses_equals() {
-        assert!(
-            generate().contains("<code>--error-on-warning</code></a>[=<i>error-on-warning</i>]")
-        );
-    }
+    use super::{Args, main};
 
     #[test]
     fn ty_cli_reference_is_up_to_date() -> Result<()> {

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -52,11 +52,14 @@ over all configuration files.</p>
 </dd><dt id="ty-check--config-file"><a href="#ty-check--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>ty.toml</code> file to use for configuration.</p>
 <p>While ty configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>TY_CONFIG_FILE</code> environment variable.</p></dd><dt id="ty-check--error"><a href="#ty-check--error"><code>--error</code></a> <i>rule</i></dt><dd><p>Treat the given rule as having severity 'error'. Can be specified multiple times. Use 'all' to apply to all rules.</p>
-</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a></dt><dd><p>Use exit code 1 if there are any warning-level diagnostics. Defaults to true</p>
+</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a></dt><dd><p>Use exit code 1 if there are any warning-level diagnostics.</p>
+<p>Cannot be used in combination with <code>--exit-zero</code> or <code>--exit-zero-on-warning</code>.</p>
 </dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
 <p>Uses gitignore-style syntax to exclude files and directories from type checking. Supports patterns like <code>tests/</code>, <code>*.tmp</code>, <code>**/__pycache__/**</code>.</p>
-</dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics</p>
-</dd><dt id="ty-check--exit-zero-on-warning"><a href="#ty-check--exit-zero-on-warning"><code>--exit-zero-on-warning</code></a></dt><dd><p>Use exit code 0 if there are no error-level diagnostics. Defaults to false</p>
+</dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics.</p>
+<p>Cannot be used in combination with <code>--error-on-warning</code>.</p>
+</dd><dt id="ty-check--exit-zero-on-warning"><a href="#ty-check--exit-zero-on-warning"><code>--exit-zero-on-warning</code></a></dt><dd><p>Use exit code 0 if there are no error-level diagnostics.</p>
+<p>Cannot be used in combination with <code>--error-on-warning</code>.</p>
 </dd><dt id="ty-check--extra-search-path"><a href="#ty-check--extra-search-path"><code>--extra-search-path</code></a> <i>path</i></dt><dd><p>Additional path to use as a module-resolution source (can be passed multiple times).</p>
 <p>This is an advanced option that should usually only be used for first-party or third-party modules that are not installed into your Python environment in a conventional way. Use <code>--python</code> to point ty to your Python environment if it is in an unusual location.</p>
 </dd><dt id="ty-check--fix"><a href="#ty-check--fix"><code>--fix</code></a></dt><dd><p>Apply fixes to resolve errors</p>

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -52,14 +52,11 @@ over all configuration files.</p>
 </dd><dt id="ty-check--config-file"><a href="#ty-check--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>ty.toml</code> file to use for configuration.</p>
 <p>While ty configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>TY_CONFIG_FILE</code> environment variable.</p></dd><dt id="ty-check--error"><a href="#ty-check--error"><code>--error</code></a> <i>rule</i></dt><dd><p>Treat the given rule as having severity 'error'. Can be specified multiple times. Use 'all' to apply to all rules.</p>
-</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a>[=<i>error-on-warning</i>]</dt><dd><p>Use exit code 1, even if all diagnostics only had <code>warning</code> severity. Defaults to <code>true</code></p>
-<p>Possible values:</p>
-<ul>
-<li><code>true</code></li>
-<li><code>false</code></li>
-</ul></dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
+</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a></dt><dd><p>Use exit code 1 if there are any warning-level diagnostics. Defaults to true</p>
+</dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
 <p>Uses gitignore-style syntax to exclude files and directories from type checking. Supports patterns like <code>tests/</code>, <code>*.tmp</code>, <code>**/__pycache__/**</code>.</p>
 </dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics</p>
+</dd><dt id="ty-check--exit-zero-on-warning"><a href="#ty-check--exit-zero-on-warning"><code>--exit-zero-on-warning</code></a></dt><dd><p>Use exit code 0 if there are no error-level diagnostics. Defaults to false</p>
 </dd><dt id="ty-check--extra-search-path"><a href="#ty-check--extra-search-path"><code>--extra-search-path</code></a> <i>path</i></dt><dd><p>Additional path to use as a module-resolution source (can be passed multiple times).</p>
 <p>This is an advanced option that should usually only be used for first-party or third-party modules that are not installed into your Python environment in a conventional way. Use <code>--python</code> to point ty to your Python environment if it is in an unusual location.</p>
 </dd><dt id="ty-check--fix"><a href="#ty-check--fix"><code>--fix</code></a></dt><dd><p>Apply fixes to resolve errors</p>

--- a/crates/ty/docs/cli.md
+++ b/crates/ty/docs/cli.md
@@ -52,8 +52,12 @@ over all configuration files.</p>
 </dd><dt id="ty-check--config-file"><a href="#ty-check--config-file"><code>--config-file</code></a> <i>path</i></dt><dd><p>The path to a <code>ty.toml</code> file to use for configuration.</p>
 <p>While ty configuration can be included in a <code>pyproject.toml</code> file, it is not allowed in this context.</p>
 <p>May also be set with the <code>TY_CONFIG_FILE</code> environment variable.</p></dd><dt id="ty-check--error"><a href="#ty-check--error"><code>--error</code></a> <i>rule</i></dt><dd><p>Treat the given rule as having severity 'error'. Can be specified multiple times. Use 'all' to apply to all rules.</p>
-</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a></dt><dd><p>Use exit code 1 if there are any warning-level diagnostics</p>
-</dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
+</dd><dt id="ty-check--error-on-warning"><a href="#ty-check--error-on-warning"><code>--error-on-warning</code></a>[=<i>error-on-warning</i>]</dt><dd><p>Use exit code 1, even if all diagnostics only had <code>warning</code> severity. Defaults to <code>true</code></p>
+<p>Possible values:</p>
+<ul>
+<li><code>true</code></li>
+<li><code>false</code></li>
+</ul></dd><dt id="ty-check--exclude"><a href="#ty-check--exclude"><code>--exclude</code></a> <i>exclude</i></dt><dd><p>Glob patterns for files to exclude from type checking.</p>
 <p>Uses gitignore-style syntax to exclude files and directories from type checking. Supports patterns like <code>tests/</code>, <code>*.tmp</code>, <code>**/__pycache__/**</code>.</p>
 </dd><dt id="ty-check--exit-zero"><a href="#ty-check--exit-zero"><code>--exit-zero</code></a></dt><dd><p>Always use exit code 0, even when there are error-level diagnostics</p>
 </dd><dt id="ty-check--extra-search-path"><a href="#ty-check--extra-search-path"><code>--extra-search-path</code></a> <i>path</i></dt><dd><p>Additional path to use as a module-resolution source (can be passed multiple times).</p>

--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -13,7 +13,9 @@ Valid severities are:
 * `ignore`: Disable the rule.
 * `warn`: Enable the rule and create a warning diagnostic.
 * `error`: Enable the rule and create an error diagnostic.
-  ty will exit with a non-zero code if any error diagnostics are emitted.
+
+By default, ty exits with code 1 if it emits any warning or error diagnostics.
+Set `terminal.error-on-warning` to `false` to exit with code 0 if all diagnostics have `warning` severity.
 
 **Default value**: `{...}`
 
@@ -850,11 +852,11 @@ if they exist and are not packages (i.e. they do not contain `__init__.py` or `_
 
 ### `error-on-warning`
 
-Use exit code 1 if there are any warning-level diagnostics.
+Use exit code 1, even if all diagnostics only had `warning` severity.
 
-Defaults to `false`.
+Defaults to `true`.
 
-**Default value**: `false`
+**Default value**: `true`
 
 **Type**: `bool`
 
@@ -864,16 +866,16 @@ Defaults to `false`.
 
     ```toml
     [tool.ty.terminal]
-    # Error if ty emits any warning-level diagnostics.
-    error-on-warning = true
+    # Exit with code 0 if all diagnostics had `warning` severity.
+    error-on-warning = false
     ```
 
 === "ty.toml"
 
     ```toml
     [terminal]
-    # Error if ty emits any warning-level diagnostics.
-    error-on-warning = true
+    # Exit with code 0 if all diagnostics had `warning` severity.
+    error-on-warning = false
     ```
 
 ---

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -157,21 +157,17 @@ pub(crate) struct CheckCommand {
     #[arg(long, env = EnvVars::TY_OUTPUT_FORMAT)]
     pub(crate) output_format: Option<OutputFormat>,
 
-    /// Use exit code 1, even if all diagnostics only had `warning` severity. Defaults to `true`.
-    #[arg(
-        long,
-        conflicts_with = "exit_zero",
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-        action = ArgAction::Set,
-        value_parser = clap::builder::BoolishValueParser::new()
-    )]
+    /// Use exit code 1 if there are any warning-level diagnostics. Defaults to true.
+    #[arg(long, conflicts_with = "exit_zero", default_missing_value = "true", num_args=0..1)]
     pub(crate) error_on_warning: Option<bool>,
 
     /// Always use exit code 0, even when there are error-level diagnostics.
     #[arg(long)]
     pub(crate) exit_zero: bool,
+
+    /// Use exit code 0 if there are no error-level diagnostics. Defaults to false.
+    #[arg(long, conflicts_with = "error_on_warning")]
+    pub(crate) exit_zero_on_warning: bool,
 
     /// Watch files for changes and recheck files related to the changed files.
     #[arg(long, short = 'W')]
@@ -248,6 +244,10 @@ impl CheckCommand {
             .no_respect_ignore_files
             .then_some(false)
             .or(self.respect_ignore_files);
+        let error_on_warning = self
+            .exit_zero_on_warning
+            .then_some(false)
+            .or(self.error_on_warning);
         let options = Options {
             environment: Some(EnvironmentOptions {
                 python_version: self.python_version.map(Into::into).map(RangedValue::cli),
@@ -268,7 +268,7 @@ impl CheckCommand {
                 output_format: self
                     .output_format
                     .map(|output_format| RangedValue::cli(output_format.into())),
-                error_on_warning: self.error_on_warning,
+                error_on_warning,
             }),
             src: Some(SrcOptions {
                 respect_ignore_files,

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -157,8 +157,16 @@ pub(crate) struct CheckCommand {
     #[arg(long, env = EnvVars::TY_OUTPUT_FORMAT)]
     pub(crate) output_format: Option<OutputFormat>,
 
-    /// Use exit code 1 if there are any warning-level diagnostics.
-    #[arg(long, conflicts_with = "exit_zero", default_missing_value = "true", num_args=0..1)]
+    /// Use exit code 1, even if all diagnostics only had `warning` severity. Defaults to `true`.
+    #[arg(
+        long,
+        conflicts_with = "exit_zero",
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        action = ArgAction::Set,
+        value_parser = clap::builder::BoolishValueParser::new()
+    )]
     pub(crate) error_on_warning: Option<bool>,
 
     /// Always use exit code 0, even when there are error-level diagnostics.

--- a/crates/ty/src/args.rs
+++ b/crates/ty/src/args.rs
@@ -157,15 +157,21 @@ pub(crate) struct CheckCommand {
     #[arg(long, env = EnvVars::TY_OUTPUT_FORMAT)]
     pub(crate) output_format: Option<OutputFormat>,
 
-    /// Use exit code 1 if there are any warning-level diagnostics. Defaults to true.
+    /// Use exit code 1 if there are any warning-level diagnostics.
+    ///
+    /// Cannot be used in combination with `--exit-zero` or `--exit-zero-on-warning`.
     #[arg(long, conflicts_with = "exit_zero", default_missing_value = "true", num_args=0..1)]
     pub(crate) error_on_warning: Option<bool>,
 
     /// Always use exit code 0, even when there are error-level diagnostics.
+    ///
+    /// Cannot be used in combination with `--error-on-warning`.
     #[arg(long)]
     pub(crate) exit_zero: bool,
 
-    /// Use exit code 0 if there are no error-level diagnostics. Defaults to false.
+    /// Use exit code 0 if there are no error-level diagnostics.
+    ///
+    /// Cannot be used in combination with `--error-on-warning`.
     #[arg(long, conflicts_with = "error_on_warning")]
     pub(crate) exit_zero_on_warning: bool,
 

--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -7,9 +7,9 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
     // Long flag
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true"), @"
-    success: false
-    exit_code: 1
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=false"), @"
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
@@ -24,11 +24,11 @@ fn cli_config_args_toml_string_basic() -> anyhow::Result<()> {
     ");
 
     // Short flag
-    assert_cmd_snapshot!(case.command().arg("-c").arg("terminal.error-on-warning=true"), @"
-    success: false
-    exit_code: 1
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("-c").arg("terminal.error-on-warning=false"), @"
+    success: true
+    exit_code: 0
     ----- stdout -----
-    error[unresolved-reference]: Name `x` used when not defined
+    warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
       |
     1 | print(x)  # [unresolved-reference]
@@ -50,16 +50,16 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
             "ty.toml",
             r#"
             [terminal]
-            error-on-warning = true
+            error-on-warning = false
             "#,
         ),
         ("test.py", r"print(x)  # [unresolved-reference]"),
     ])?;
 
-    // Exit code of 1 due to the setting in `ty.toml`
+    // Exit code of 0 due to the setting in `ty.toml`
     assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
@@ -73,10 +73,10 @@ fn cli_config_args_overrides_ty_toml() -> anyhow::Result<()> {
     ----- stderr -----
     ");
 
-    // Exit code of 0 because the `ty.toml` setting is overwritten by `--config`
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=false"), @"
-    success: true
-    exit_code: 0
+    // Exit code of 1 because the `ty.toml` setting is overwritten by `--config`
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config").arg("terminal.error-on-warning=true"), @"
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
@@ -141,7 +141,7 @@ fn cli_config_args_invalid_option() -> anyhow::Result<()> {
 
 #[test]
 fn config_file_override() -> anyhow::Result<()> {
-    // Set `error-on-warning` to true in the configuration file
+    // Set `error-on-warning` to false in the configuration file
     // Explicitly set `--warn unresolved-reference` to ensure the rule warns instead of errors
     let case = CliTest::with_files(vec![
         ("test.py", r"print(x)  # [unresolved-reference]"),
@@ -149,15 +149,15 @@ fn config_file_override() -> anyhow::Result<()> {
             "ty-override.toml",
             r#"
             [terminal]
-            error-on-warning = true
+            error-on-warning = false
             "#,
         ),
     ])?;
 
-    // Ensure flag works via CLI arg
+    // Ensure the configuration file is loaded via the CLI argument
     assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--config-file").arg("ty-override.toml"), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
@@ -171,10 +171,10 @@ fn config_file_override() -> anyhow::Result<()> {
     ----- stderr -----
     ");
 
-    // Ensure the flag works via an environment variable
+    // Ensure the configuration file is loaded via the environment variable
     assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").env("TY_CONFIG_FILE", "ty-override.toml"), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7

--- a/crates/ty/tests/cli/exit_code.rs
+++ b/crates/ty/tests/cli/exit_code.rs
@@ -7,8 +7,8 @@ fn only_warnings() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
     assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7
@@ -21,6 +21,28 @@ fn only_warnings() -> anyhow::Result<()> {
 
     ----- stderr -----
     ");
+
+    Ok(())
+}
+
+#[test]
+fn only_warnings_and_error_on_warning_is_false() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
+
+    for value in ["FaLsE", "0"] {
+        let output = case
+            .command()
+            .arg(format!("--error-on-warning={value}"))
+            .arg("--warn")
+            .arg("unresolved-reference")
+            .output()?;
+
+        assert!(
+            output.status.success(),
+            "`--error-on-warning={value}` failed:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     Ok(())
 }
@@ -64,7 +86,7 @@ fn only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
         "#,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--error-on-warning"), @"
+    assert_cmd_snapshot!(case.command().arg("--error-on-warning").arg("test.py"), @"
     success: true
     exit_code: 0
     ----- stdout -----
@@ -107,21 +129,21 @@ fn no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
 }
 
 #[test]
-fn no_errors_but_error_on_warning_is_enabled_in_configuration() -> anyhow::Result<()> {
+fn only_warnings_and_error_on_warning_is_disabled_in_configuration() -> anyhow::Result<()> {
     let case = CliTest::with_files([
         ("test.py", r"print(x)  # [unresolved-reference]"),
         (
             "ty.toml",
             r#"
             [terminal]
-            error-on-warning = true
+            error-on-warning = false
         "#,
         ),
     ])?;
 
     assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference"), @"
-    success: false
-    exit_code: 1
+    success: true
+    exit_code: 0
     ----- stdout -----
     warning[unresolved-reference]: Name `x` used when not defined
      --> test.py:1:7

--- a/crates/ty/tests/cli/exit_code.rs
+++ b/crates/ty/tests/cli/exit_code.rs
@@ -26,23 +26,42 @@ fn only_warnings() -> anyhow::Result<()> {
 }
 
 #[test]
-fn only_warnings_and_error_on_warning_is_false() -> anyhow::Result<()> {
+fn only_warnings_and_exit_zero_on_warning() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
 
-    for value in ["FaLsE", "0"] {
-        let output = case
-            .command()
-            .arg(format!("--error-on-warning={value}"))
-            .arg("--warn")
-            .arg("unresolved-reference")
-            .output()?;
+    let output = case
+        .command()
+        .arg("--exit-zero-on-warning")
+        .arg("--warn")
+        .arg("unresolved-reference")
+        .output()?;
 
-        assert!(
-            output.status.success(),
-            "`--error-on-warning={value}` failed:\n{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    assert!(
+        output.status.success(),
+        "`--exit-zero-on-warning` failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(())
+}
+
+#[test]
+fn error_on_warning_conflicts_with_exit_zero_on_warning() -> anyhow::Result<()> {
+    let case = CliTest::with_file("test.py", "")?
+        .with_filter(r"Usage: ty(?:\.exe)? check", "Usage: ty check");
+
+    assert_cmd_snapshot!(case.command().arg("--error-on-warning").arg("--exit-zero-on-warning"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    error: the argument '--error-on-warning' cannot be used with '--exit-zero-on-warning'
+
+    Usage: ty check --error-on-warning [PATH]...
+
+    For more information, try '--help'.
+    ");
 
     Ok(())
 }
@@ -106,8 +125,17 @@ fn only_info_and_error_on_warning_is_true() -> anyhow::Result<()> {
 }
 
 #[test]
-fn no_errors_but_error_on_warning_is_true() -> anyhow::Result<()> {
-    let case = CliTest::with_file("test.py", r"print(x)  # [unresolved-reference]")?;
+fn only_warnings_and_error_on_warning_overrides_configuration() -> anyhow::Result<()> {
+    let case = CliTest::with_files([
+        ("test.py", r"print(x)  # [unresolved-reference]"),
+        (
+            "ty.toml",
+            r#"
+            [terminal]
+            error-on-warning = false
+        "#,
+        ),
+    ])?;
 
     assert_cmd_snapshot!(case.command().arg("--error-on-warning").arg("--warn").arg("unresolved-reference"), @"
     success: false
@@ -197,7 +225,7 @@ fn both_warnings_and_errors() -> anyhow::Result<()> {
 }
 
 #[test]
-fn both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::Result<()> {
+fn both_warnings_and_errors_and_exit_zero_on_warning() -> anyhow::Result<()> {
     let case = CliTest::with_file(
         "test.py",
         r###"
@@ -206,7 +234,7 @@ fn both_warnings_and_errors_and_error_on_warning_is_true() -> anyhow::Result<()>
         "###,
     )?;
 
-    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--error-on-warning"), @"
+    assert_cmd_snapshot!(case.command().arg("--warn").arg("unresolved-reference").arg("--exit-zero-on-warning"), @"
     success: false
     exit_code: 1
     ----- stdout -----

--- a/crates/ty/tests/cli/main.rs
+++ b/crates/ty/tests/cli/main.rs
@@ -427,8 +427,8 @@ fn user_configuration() -> anyhow::Result<()> {
     assert_cmd_snapshot!(
         case.command().arg("--verbose").current_dir(case.root().join("project")).env(config_env_var, config_directory.as_os_str()),
         @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> main.py:2:5

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1213,9 +1213,9 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
         ("test.py", ""),
     ])?;
 
-    assert_cmd_snapshot!(case.command(), @r"
-    success: true
-    exit_code: 0
+    assert_cmd_snapshot!(case.command(), @"
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unsupported-python-version]: Ignoring unsupported inferred Python version `3.16`; ty will use Python 3.14 instead.
      --> venv/pyvenv.cfg:2:16
@@ -1226,7 +1226,7 @@ fn config_file_python_setting_directory_with_unsupported_python_version() -> any
     info: Expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`.
     info: Set `environment.python-version` explicitly to override the inferred version.
     info: The version was inferred from your virtual environment metadata.
-    
+
     Found 1 diagnostic
 
     ----- stderr -----
@@ -2285,8 +2285,8 @@ fn src_root_deprecation_warning() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
      --> pyproject.toml:3:8
@@ -2320,8 +2320,8 @@ fn src_root_deprecation_warning_with_environment_root() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
      --> pyproject.toml:3:8
@@ -2362,8 +2362,8 @@ fn environment_root_takes_precedence_over_src_root() -> anyhow::Result<()> {
     // The test should pass because environment.root points to ./app where my_module.py exists
     // If src.root took precedence, it would fail because my_module.py doesn't exist in ./src
     assert_cmd_snapshot!(case.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[deprecated-setting]: The `src.root` setting is deprecated. Use `environment.root` instead.
      --> pyproject.toml:3:8

--- a/crates/ty/tests/cli/rule_selection.rs
+++ b/crates/ty/tests/cli/rule_selection.rs
@@ -46,8 +46,8 @@ fn configuration_rule_severity() -> anyhow::Result<()> {
     )?;
 
     assert_cmd_snapshot!(case.command().arg("--verbose"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
@@ -126,8 +126,8 @@ fn cli_rule_severity() -> anyhow::Result<()> {
             .arg("--warn")
             .arg("unresolved-import"),
         @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unresolved-import]: Cannot resolve imported module `does_not_exit`
      --> test.py:2:8
@@ -205,8 +205,8 @@ fn cli_rule_severity_precedence() -> anyhow::Result<()> {
             .arg("--ignore")
             .arg("unresolved-reference"),
         @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> test.py:2:5
@@ -241,8 +241,8 @@ fn configuration_unknown_rules() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command(), @r#"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unknown-rule]: Unknown rule `division-by-zer`. Did you mean `division-by-zero`?
      --> pyproject.toml:3:1
@@ -265,8 +265,8 @@ fn cli_unknown_rules() -> anyhow::Result<()> {
     let case = CliTest::with_file("test.py", "print(10)")?;
 
     assert_cmd_snapshot!(case.command().arg("--ignore").arg("division-by-zer"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unknown-rule]: Unknown rule `division-by-zer`. Did you mean `division-by-zero`?
 
@@ -390,8 +390,8 @@ fn overrides_precedence() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command().arg("--verbose"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[division-by-zero]: Cannot divide object of type `Literal[4]` by zero
      --> tests/test_main.py:2:5
@@ -659,8 +659,8 @@ fn overrides_missing_include_exclude() -> anyhow::Result<()> {
     ])?;
 
     assert_cmd_snapshot!(case.command().arg("--verbose"), @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unnecessary-overrides-section]: Unnecessary `overrides` section
      --> pyproject.toml:5:1
@@ -915,8 +915,8 @@ fn cli_all_rules_warn() -> anyhow::Result<()> {
             .arg("--warn")
             .arg("all"),
         @"
-    success: true
-    exit_code: 0
+    success: false
+    exit_code: 1
     ----- stdout -----
     warning[unresolved-reference]: Name `prin` used when not defined
      --> test.py:2:1

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -78,7 +78,9 @@ pub struct Options {
     /// * `ignore`: Disable the rule.
     /// * `warn`: Enable the rule and create a warning diagnostic.
     /// * `error`: Enable the rule and create an error diagnostic.
-    ///   ty will exit with a non-zero code if any error diagnostics are emitted.
+    ///
+    /// By default, ty exits with code 1 if it emits any warning or error diagnostics.
+    /// Set `terminal.error-on-warning` to `false` to exit with code 0 if all diagnostics have `warning` severity.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[option(
         default = r#"{...}"#,
@@ -429,7 +431,7 @@ impl Options {
                 .as_deref()
                 .copied()
                 .unwrap_or_default(),
-            error_on_warning: terminal_options.error_on_warning.unwrap_or_default(),
+            error_on_warning: terminal_options.error_on_warning.unwrap_or(true),
         };
 
         let src_options = self.src.or_default();
@@ -1430,15 +1432,15 @@ pub struct TerminalOptions {
         "#
     )]
     pub output_format: Option<RangedValue<OutputFormat>>,
-    /// Use exit code 1 if there are any warning-level diagnostics.
+    /// Use exit code 1, even if all diagnostics only had `warning` severity.
     ///
-    /// Defaults to `false`.
+    /// Defaults to `true`.
     #[option(
-        default = r#"false"#,
+        default = r#"true"#,
         value_type = "bool",
         example = r#"
-        # Error if ty emits any warning-level diagnostics.
-        error-on-warning = true
+        # Exit with code 0 if all diagnostics had `warning` severity.
+        error-on-warning = false
         "#
     )]
     pub error_on_warning: Option<bool>,

--- a/crates/ty_project/src/metadata/settings.rs
+++ b/crates/ty_project/src/metadata/settings.rs
@@ -62,10 +62,19 @@ impl Settings {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default, get_size2::GetSize)]
+#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]
 pub struct TerminalSettings {
     pub output_format: OutputFormat,
     pub error_on_warning: bool,
+}
+
+impl Default for TerminalSettings {
+    fn default() -> Self {
+        Self {
+            output_format: OutputFormat::default(),
+            error_on_warning: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize)]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -40,7 +40,7 @@ Settings: Settings {
     rules: <RULES>,
     terminal: TerminalSettings {
         output_format: Full,
-        error_on_warning: false,
+        error_on_warning: true,
     },
     src: SrcSettings {
         respect_ignore_files: true,

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -36,7 +36,7 @@
       ]
     },
     "rules": {
-      "description": "Configures the enabled rules and their severity.\n\nThe keys are either rule names or `all` to set a default severity for all rules.\nSee [the rules documentation](https://ty.dev/rules) for a list of all available rules.\n\nValid severities are:\n\n* `ignore`: Disable the rule.\n* `warn`: Enable the rule and create a warning diagnostic.\n* `error`: Enable the rule and create an error diagnostic.\n  ty will exit with a non-zero code if any error diagnostics are emitted.",
+      "description": "Configures the enabled rules and their severity.\n\nThe keys are either rule names or `all` to set a default severity for all rules.\nSee [the rules documentation](https://ty.dev/rules) for a list of all available rules.\n\nValid severities are:\n\n* `ignore`: Disable the rule.\n* `warn`: Enable the rule and create a warning diagnostic.\n* `error`: Enable the rule and create an error diagnostic.\n\nBy default, ty exits with code 1 if it emits any warning or error diagnostics.\nSet `terminal.error-on-warning` to `false` to exit with code 0 if all diagnostics have `warning` severity.",
       "anyOf": [
         {
           "$ref": "#/definitions/Rules"
@@ -1650,7 +1650,7 @@
       "type": "object",
       "properties": {
         "error-on-warning": {
-          "description": "Use exit code 1 if there are any warning-level diagnostics.\n\nDefaults to `false`.",
+          "description": "Use exit code 1, even if all diagnostics only had `warning` severity.\n\nDefaults to `true`.",
           "type": [
             "boolean",
             "null"


### PR DESCRIPTION
## Summary

- Make warning diagnostics produce exit code 1 by default.
- Add `--exit-zero-on-warning` as an explicit command-line opt-out while preserving the existing `--error-on-warning` override.
- Keep `terminal.error-on-warning` configurable and regenerate ty's CLI reference, configuration documentation, schema, and affected snapshots.

You generally want warnings to lead to an exit code of 1 if you're invoking ty in CI, or from a runner like pre-commit/prek. (pre-commit/prek actually suppress all stdout/stderr output if a hook exits with code 0.) We could try to detect environment variables like `CI=1` or `PRE_COMMIT=1`, but that feels fragile, and it's also surprising/annoying if ty "magically" behaves differently in CI than it does locally. Humans generally don't care much about the exit code locally, so we don't expect this to have a significant impact for local usage outside of pre-commit/prek.

This PR therefore changes the global default to exiting with code 1, even if all diagnostics have `warning` severity. This remains configurable by setting `tool.ty.terminal.error-on-warning = false` in a `pyproject.toml` file. On the command line, `--exit-zero-on-warning` provides the inverse opt-out, while the existing `--error-on-warning` flag remains available as an explicit override.