### PR TITLE
[ty] Allow replacing ordinary methods with compatible functions

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1016,6 +1016,38 @@ reveal_type(Derived().undeclared)  # revealed: str
 reveal_type(Derived().pure_undeclared)  # revealed: str
 ```
 
+## Assigning methods on class objects
+
+Methods accessed from class-literal types retain their precise function-literal type. Assignments to
+those methods are checked against the function's callable signature, however, so that a method can
+be replaced by a different function with the same signature.
+
+```py
+class Foo:
+    def method(self) -> None:
+        pass
+
+    def add(self, x: int, y: int, /) -> int:
+        return x + y
+
+def method_replacement(self) -> None:
+    pass
+
+def add_replacement(self: Foo, x: int, y: int, /) -> int:
+    return x * y
+
+reveal_type(Foo.method)  # revealed: def method(self) -> None
+reveal_type(Foo.add)  # revealed: def add(self, x: int, y: int, /) -> int
+
+Foo.method = method_replacement
+Foo.add = add_replacement
+
+def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
+    return x + y
+
+Foo.add = incompatible_replacement  # error: [invalid-assignment]
+```
+
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1048,6 +1048,29 @@ def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
 Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
+Replacing a `staticmethod` or `classmethod` with a plain function is invalid even if their
+signatures match. The replacement would not preserve the descriptor's binding behavior.
+
+```py
+class DescriptorMethods:
+    @staticmethod
+    def static(x: int) -> str:
+        return str(x)
+
+    @classmethod
+    def class_(cls, x: int) -> str:
+        return str(x)
+
+def static_replacement(x: int) -> str:
+    return str(x)
+
+def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
+    return str(x)
+
+DescriptorMethods.static = static_replacement  # error: [invalid-assignment]
+DescriptorMethods.class_ = class_replacement  # error: [invalid-assignment]
+```
+
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1049,7 +1049,9 @@ Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
 Replacing a `staticmethod` or `classmethod` with a plain function is invalid even if their
-signatures match. The replacement would not preserve the descriptor's binding behavior.
+signatures match. The replacement would not preserve the descriptor's binding behavior. Callable
+objects that expose the same interface through class and instance access are valid, as are functions
+wrapped in the matching descriptor.
 
 ```py
 class DescriptorMethods:
@@ -1066,6 +1068,17 @@ def static_replacement(x: int) -> str:
 
 def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
     return str(x)
+
+class CallableMock:
+    def __call__(self, x: int) -> str:
+        return str(x)
+
+mock = CallableMock()
+DescriptorMethods.static = mock
+DescriptorMethods.class_ = mock
+
+DescriptorMethods.static = staticmethod(static_replacement)
+DescriptorMethods.class_ = classmethod(class_replacement)
 
 DescriptorMethods.static = static_replacement  # error: [invalid-assignment]
 DescriptorMethods.class_ = class_replacement  # error: [invalid-assignment]

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1016,30 +1016,22 @@ reveal_type(Derived().undeclared)  # revealed: str
 reveal_type(Derived().pure_undeclared)  # revealed: str
 ```
 
-## Assigning methods on class objects
+## Replacing methods on classes
 
-Methods accessed from class-literal types retain their precise function-literal type. Assignments to
-those methods are checked against the function's callable signature, however, so that a method can
-be replaced by a different function with the same signature.
+ty allows a method to be replaced directly on a class when the new value has a compatible callable
+signature. Reading the method still returns its precise inferred type; only the assignment uses this
+compatibility check.
 
 ```py
 class Foo:
-    def method(self) -> None:
-        pass
-
     def add(self, x: int, y: int, /) -> int:
         return x + y
-
-def method_replacement(self) -> None:
-    pass
 
 def add_replacement(self: Foo, x: int, y: int, /) -> int:
     return x * y
 
-reveal_type(Foo.method)  # revealed: def method(self) -> None
 reveal_type(Foo.add)  # revealed: def add(self, x: int, y: int, /) -> int
 
-Foo.method = method_replacement
 Foo.add = add_replacement
 
 def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
@@ -1048,10 +1040,12 @@ def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
 Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
-This check deliberately compares only callable signatures. It does not require the replacement to
-preserve the original method's descriptor behavior when accessed through the class or an instance.
+`staticmethod` and `classmethod` use the same signature check. This is intentionally unsound:
+replacing either descriptor with a plain function changes how Python binds arguments.
 
 ```py
+from unittest.mock import Mock
+
 class DescriptorMethods:
     @staticmethod
     def static(x: int) -> str:
@@ -1068,49 +1062,14 @@ def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
     return str(x)
 
 DescriptorMethods.static = static_replacement
+DescriptorMethods().static(1)  # accepted by ty; raises `TypeError` at runtime
+
 DescriptorMethods.class_ = class_replacement
+DescriptorMethods.class_(1)  # accepted by ty; raises `TypeError` at runtime
 
-class ClassMock:
-    def __call__(self, cls: type[DescriptorMethods], x: int) -> str:
-        return str(x)
-
-DescriptorMethods.class_ = ClassMock()
-
-def incompatible_static_replacement(x: str) -> str:
-    return x
-
-DescriptorMethods.static = incompatible_static_replacement  # error: [invalid-assignment]
-```
-
-The same signature-only check applies when a transparent decorator produces a method-like callable
-type.
-
-```py
-from collections.abc import Callable
-from typing import ParamSpec, TypeVar
-
-P = ParamSpec("P")
-R = TypeVar("R")
-
-def transparent(function: Callable[P, R]) -> Callable[P, R]:
-    return function
-
-class DecoratedMethods:
-    @transparent
-    def method(self, x: int, /) -> str:
-        return str(x)
-
-    @staticmethod
-    @transparent
-    def static(x: int) -> str:
-        return str(x)
-
-class MethodMock:
-    def __call__(self, instance: DecoratedMethods, x: int, /) -> str:
-        return str(x)
-
-DecoratedMethods.method = MethodMock()
-DecoratedMethods.static = static_replacement
+# `Mock` accepts arbitrary arguments, so it can replace both methods.
+DescriptorMethods.static = Mock()
+DescriptorMethods.class_ = Mock()
 ```
 
 ## Accessing attributes on class objects

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1048,10 +1048,8 @@ def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
 Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
-Replacing a `staticmethod` or `classmethod` with a plain function is invalid even if their
-signatures match. The replacement would not preserve the descriptor's binding behavior. Callable
-objects that expose the same interface through class and instance access are valid, as are functions
-wrapped in the matching descriptor.
+This check deliberately compares only callable signatures. It does not require the replacement to
+preserve the original method's descriptor behavior when accessed through the class or an instance.
 
 ```py
 class DescriptorMethods:
@@ -1069,23 +1067,32 @@ def static_replacement(x: int) -> str:
 def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
     return str(x)
 
-class CallableMock:
+DescriptorMethods.static = static_replacement
+DescriptorMethods.class_ = class_replacement
+
+class StaticMock:
     def __call__(self, x: int) -> str:
         return str(x)
 
-mock = CallableMock()
-DescriptorMethods.static = mock
-DescriptorMethods.class_ = mock
+class ClassMock:
+    def __call__(self, cls: type[DescriptorMethods], x: int) -> str:
+        return str(x)
 
-DescriptorMethods.static = staticmethod(static_replacement)
-DescriptorMethods.class_ = classmethod(class_replacement)
+DescriptorMethods.static = StaticMock()
+DescriptorMethods.class_ = ClassMock()
 
-DescriptorMethods.static = static_replacement  # error: [invalid-assignment]
-DescriptorMethods.class_ = class_replacement  # error: [invalid-assignment]
+def incompatible_static_replacement(x: str) -> str:
+    return x
+
+def incompatible_class_replacement(cls: type[DescriptorMethods], x: str) -> str:
+    return x
+
+DescriptorMethods.static = incompatible_static_replacement  # error: [invalid-assignment]
+DescriptorMethods.class_ = incompatible_class_replacement  # error: [invalid-assignment]
 ```
 
-Method-like callable targets also preserve their descriptor behavior, including through transparent
-decorators.
+The same signature-only check applies when a transparent decorator produces a method-like callable
+type.
 
 ```py
 from collections.abc import Callable
@@ -1111,11 +1118,11 @@ class MethodMock:
     def __call__(self, instance: DecoratedMethods, x: int, /) -> str:
         return str(x)
 
-DecoratedMethods.method = MethodMock()  # error: [invalid-assignment]
-DecoratedMethods.static = static_replacement  # error: [invalid-assignment]
+DecoratedMethods.method = MethodMock()
+DecoratedMethods.static = static_replacement
 ```
 
-Descriptor behavior is checked for every element of a union-valued replacement.
+Every element of a union-valued replacement must have a compatible signature.
 
 ```py
 def other_static_replacement(x: int) -> str:
@@ -1123,18 +1130,10 @@ def other_static_replacement(x: int) -> str:
 
 def replace_static(flag: bool) -> None:
     replacement = static_replacement if flag else other_static_replacement
-    DescriptorMethods.static = replacement  # error: [invalid-assignment]
-```
+    DescriptorMethods.static = replacement
 
-The receiver of a classmethod replacement must accept the class to which it is assigned.
-
-```py
-class Other: ...
-
-def incompatible_class_replacement(cls: type[Other], x: int) -> str:
-    return str(x)
-
-DescriptorMethods.class_ = classmethod(incompatible_class_replacement)  # error: [invalid-assignment]
+    incompatible = static_replacement if flag else incompatible_static_replacement
+    DescriptorMethods.static = incompatible  # error: [invalid-assignment]
 ```
 
 ## Accessing attributes on class objects

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1084,6 +1084,37 @@ DescriptorMethods.static = static_replacement  # error: [invalid-assignment]
 DescriptorMethods.class_ = class_replacement  # error: [invalid-assignment]
 ```
 
+Method-like callable targets also preserve their descriptor behavior, including through transparent
+decorators.
+
+```py
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def transparent(function: Callable[P, R]) -> Callable[P, R]:
+    return function
+
+class DecoratedMethods:
+    @transparent
+    def method(self, x: int, /) -> str:
+        return str(x)
+
+    @staticmethod
+    @transparent
+    def static(x: int) -> str:
+        return str(x)
+
+class MethodMock:
+    def __call__(self, instance: DecoratedMethods, x: int, /) -> str:
+        return str(x)
+
+DecoratedMethods.method = MethodMock()  # error: [invalid-assignment]
+DecoratedMethods.static = static_replacement  # error: [invalid-assignment]
+```
+
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1115,6 +1115,17 @@ DecoratedMethods.method = MethodMock()  # error: [invalid-assignment]
 DecoratedMethods.static = static_replacement  # error: [invalid-assignment]
 ```
 
+Descriptor behavior is checked for every element of a union-valued replacement.
+
+```py
+def other_static_replacement(x: int) -> str:
+    return str(x)
+
+def replace_static(flag: bool) -> None:
+    replacement = static_replacement if flag else other_static_replacement
+    DescriptorMethods.static = replacement  # error: [invalid-assignment]
+```
+
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1126,6 +1126,17 @@ def replace_static(flag: bool) -> None:
     DescriptorMethods.static = replacement  # error: [invalid-assignment]
 ```
 
+The receiver of a classmethod replacement must accept the class to which it is assigned.
+
+```py
+class Other: ...
+
+def incompatible_class_replacement(cls: type[Other], x: int) -> str:
+    return str(x)
+
+DescriptorMethods.class_ = classmethod(incompatible_class_replacement)  # error: [invalid-assignment]
+```
+
 ## Accessing attributes on class objects
 
 When accessing attributes on class objects, they are always looked up on the type of the class

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1070,25 +1070,16 @@ def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
 DescriptorMethods.static = static_replacement
 DescriptorMethods.class_ = class_replacement
 
-class StaticMock:
-    def __call__(self, x: int) -> str:
-        return str(x)
-
 class ClassMock:
     def __call__(self, cls: type[DescriptorMethods], x: int) -> str:
         return str(x)
 
-DescriptorMethods.static = StaticMock()
 DescriptorMethods.class_ = ClassMock()
 
 def incompatible_static_replacement(x: str) -> str:
     return x
 
-def incompatible_class_replacement(cls: type[DescriptorMethods], x: str) -> str:
-    return x
-
 DescriptorMethods.static = incompatible_static_replacement  # error: [invalid-assignment]
-DescriptorMethods.class_ = incompatible_class_replacement  # error: [invalid-assignment]
 ```
 
 The same signature-only check applies when a transparent decorator produces a method-like callable
@@ -1120,20 +1111,6 @@ class MethodMock:
 
 DecoratedMethods.method = MethodMock()
 DecoratedMethods.static = static_replacement
-```
-
-Every element of a union-valued replacement must have a compatible signature.
-
-```py
-def other_static_replacement(x: int) -> str:
-    return str(x)
-
-def replace_static(flag: bool) -> None:
-    replacement = static_replacement if flag else other_static_replacement
-    DescriptorMethods.static = replacement
-
-    incompatible = static_replacement if flag else incompatible_static_replacement
-    DescriptorMethods.static = incompatible  # error: [invalid-assignment]
 ```
 
 ## Accessing attributes on class objects

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1022,11 +1022,15 @@ An ordinary method can be replaced directly on a class by another function with 
 signature. The replacement remains an ordinary function, so Python binds it to instances in the same
 way as the original method.
 
-After the assignment, reading the method still returns the original method's precise inferred type,
-even though the runtime value is a different function. This is intentionally unsound, but the
-replacement has the same call signature and instance-binding behavior.
+A function-literal type identifies a specific function, not just its signature. This makes
+identity-sensitive code unsound: after the assignment below, `requires_original_add(Foo.add)` is
+accepted even though the function only allows the original `add`. Its assertion fails at runtime
+because `Foo.add` is now `add_replacement`. Calls to the method itself remain safe because both
+functions have compatible signatures and the same instance-binding behavior.
 
 ```py
+from ty_extensions import TypeOf
+
 class Foo:
     def add(self, x: int, y: int, /) -> int:
         return x + y
@@ -1034,9 +1038,13 @@ class Foo:
 def add_replacement(self: Foo, x: int, y: int, /) -> int:
     return x * y
 
-Foo.add = add_replacement
+original_add = Foo.add
 
-reveal_type(Foo.add)  # revealed: def add(self, x: int, y: int, /) -> int
+def requires_original_add(method: TypeOf[original_add]) -> None:
+    assert method is original_add
+
+Foo.add = add_replacement
+requires_original_add(Foo.add)  # accepted; assertion fails at runtime
 
 def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
     return x + y
@@ -1044,9 +1052,13 @@ def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
 Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
-`staticmethod` and `classmethod` attributes cannot yet be replaced this way. A plain function is
-rejected even if its signature matches because it would bind arguments differently. Supporting these
-assignments requires replacements with the corresponding decorator.
+`staticmethod` and `classmethod` attributes cannot yet be replaced this way. If `static` were
+replaced with a plain function, `DescriptorMethods.static(1)` would pass only `1`, as before, but
+`DescriptorMethods().static(1)` would also pass the instance as the first argument. If `class_` were
+replaced, `DescriptorMethods.class_(1)` would stop passing `DescriptorMethods` as the first
+argument, while `DescriptorMethods().class_(1)` would pass the instance instead of the class.
+Supporting these assignments requires replacements with the corresponding decorator (for example,
+`staticmethod(static_replacement)` or `classmethod(class_replacement)`).
 
 ```py
 class DescriptorMethods:

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1016,11 +1016,15 @@ reveal_type(Derived().undeclared)  # revealed: str
 reveal_type(Derived().pure_undeclared)  # revealed: str
 ```
 
-## Replacing methods on classes
+## Allow replacing ordinary methods with compatible functions
 
-ty allows a method to be replaced directly on a class when the new value has a compatible callable
-signature. Reading the method still returns its precise inferred type; only the assignment uses this
-compatibility check.
+An ordinary method can be replaced directly on a class by another function with a compatible
+signature. The replacement remains an ordinary function, so Python binds it to instances in the same
+way as the original method.
+
+After the assignment, reading the method still returns the original method's precise inferred type,
+even though the runtime value is a different function. This is intentionally unsound, but the
+replacement has the same call signature and instance-binding behavior.
 
 ```py
 class Foo:
@@ -1030,9 +1034,9 @@ class Foo:
 def add_replacement(self: Foo, x: int, y: int, /) -> int:
     return x * y
 
-reveal_type(Foo.add)  # revealed: def add(self, x: int, y: int, /) -> int
-
 Foo.add = add_replacement
+
+reveal_type(Foo.add)  # revealed: def add(self, x: int, y: int, /) -> int
 
 def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
     return x + y
@@ -1040,12 +1044,11 @@ def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
 Foo.add = incompatible_replacement  # error: [invalid-assignment]
 ```
 
-`staticmethod` and `classmethod` use the same signature check. This is intentionally unsound:
-replacing either descriptor with a plain function changes how Python binds arguments.
+`staticmethod` and `classmethod` attributes cannot yet be replaced this way. A plain function is
+rejected even if its signature matches because it would bind arguments differently. Supporting these
+assignments requires replacements with the corresponding decorator.
 
 ```py
-from unittest.mock import Mock
-
 class DescriptorMethods:
     @staticmethod
     def static(x: int) -> str:
@@ -1061,15 +1064,8 @@ def static_replacement(x: int) -> str:
 def class_replacement(cls: type[DescriptorMethods], x: int) -> str:
     return str(x)
 
-DescriptorMethods.static = static_replacement
-DescriptorMethods().static(1)  # accepted by ty; raises `TypeError` at runtime
-
-DescriptorMethods.class_ = class_replacement
-DescriptorMethods.class_(1)  # accepted by ty; raises `TypeError` at runtime
-
-# `Mock` accepts arbitrary arguments, so it can replace both methods.
-DescriptorMethods.static = Mock()
-DescriptorMethods.class_ = Mock()
+DescriptorMethods.static = static_replacement  # error: [invalid-assignment]
+DescriptorMethods.class_ = class_replacement  # error: [invalid-assignment]
 ```
 
 ## Accessing attributes on class objects

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -1023,13 +1023,13 @@ signature. The replacement remains an ordinary function, so Python binds it to i
 way as the original method.
 
 A function-literal type identifies a specific function, not just its signature. This makes
-identity-sensitive code unsound: after the assignment below, `requires_original_add(Foo.add)` is
-accepted even though the function only allows the original `add`. Its assertion fails at runtime
-because `Foo.add` is now `add_replacement`. Calls to the method itself remain safe because both
-functions have compatible signatures and the same instance-binding behavior.
+identity-sensitive code unsound: after the assignment below, `Foo.add is original_add` is inferred
+as `Literal[True]`, even though it evaluates to `False` at runtime and the assertion fails. Calls to
+the method itself remain safe because both functions have compatible signatures and the same
+instance-binding behavior.
 
 ```py
-from ty_extensions import TypeOf
+from typing import Literal
 
 class Foo:
     def add(self, x: int, y: int, /) -> int:
@@ -1040,11 +1040,11 @@ def add_replacement(self: Foo, x: int, y: int, /) -> int:
 
 original_add = Foo.add
 
-def requires_original_add(method: TypeOf[original_add]) -> None:
-    assert method is original_add
+def requires_true(value: Literal[True]) -> None:
+    assert value
 
 Foo.add = add_replacement
-requires_original_add(Foo.add)  # accepted; assertion fails at runtime
+requires_true(Foo.add is original_add)  # accepted; assertion fails at runtime
 
 def incompatible_replacement(self: Foo, x: str, y: str, /) -> str:
     return x + y

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2649,10 +2649,66 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
+        // A replacement for a staticmethod or classmethod must expose the same callable interface
+        // through both class and instance access. Once the descriptor protocol has been applied,
+        // normalize the resulting callables because their descriptor kinds are no longer relevant.
+        let descriptor_callable = |ty: Type<'db>, instance: Option<Type<'db>>| {
+            ty.try_call_dunder_get(db, instance, object_ty)
+                .map_or(ty, |(ty, _)| ty)
+                .try_upcast_to_callable(db)
+                .map(|callables| {
+                    callables
+                        .map(|callable| callable.into_regular(db))
+                        .into_type(db)
+                })
+        };
+
+        let descriptor_assignment_is_valid =
+            |value_ty: Type<'db>, attr_ty: Type<'db>| -> Option<bool> {
+                let Type::FunctionLiteral(function) = attr_ty else {
+                    return None;
+                };
+                if !matches!(object_ty, Type::ClassLiteral(_))
+                    || !matches!(
+                        function.callable_type_kind(db),
+                        CallableTypeKind::StaticMethodLike | CallableTypeKind::ClassMethodLike
+                    )
+                {
+                    return None;
+                }
+
+                let instance_ty = object_ty.to_instance(db)?;
+                Some([None, Some(instance_ty)].into_iter().all(|instance| {
+                    let Some(target_ty) = descriptor_callable(attr_ty, instance) else {
+                        return false;
+                    };
+                    let Some(value_ty) = descriptor_callable(value_ty, instance) else {
+                        return false;
+                    };
+                    value_ty.is_assignable_to(db, target_ty)
+                }))
+            };
+
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
         let ensure_assignable_to =
             |builder: &Self, value_ty: Type<'db>, attr_ty: Type<'db>| -> bool {
                 let assignable = value_ty.is_assignable_to(db, attr_ty);
+                if !assignable && emit_diagnostics {
+                    report_invalid_attribute_assignment(
+                        &builder.context,
+                        target.range(),
+                        attr_ty,
+                        value_ty,
+                        attribute,
+                    );
+                }
+                assignable
+            };
+
+        let ensure_assignable_to_class_attribute =
+            |builder: &Self, value_ty: Type<'db>, attr_ty: Type<'db>| -> bool {
+                let assignable = descriptor_assignment_is_valid(value_ty, attr_ty)
+                    .unwrap_or_else(|| value_ty.is_assignable_to(db, attr_ty));
                 if !assignable && emit_diagnostics {
                     report_invalid_attribute_assignment(
                         &builder.context,
@@ -3233,7 +3289,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
-                                    ensure_assignable_to(self, value_ty, class_attr_ty),
+                                    ensure_assignable_to_class_attribute(
+                                        self,
+                                        value_ty,
+                                        class_attr_ty,
+                                    ),
                                     class_attr_boundness,
                                 )
                             } else {
@@ -3292,7 +3352,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                             }
 
-                            ensure_assignable_to(self, value_ty, class_attr_ty)
+                            ensure_assignable_to_class_attribute(self, value_ty, class_attr_ty)
                         } else {
                             infer_value_ty(self, TypeContext::default());
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2649,95 +2649,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
-        // A method replacement must expose the same callable interface through both class and
-        // instance access. Once the descriptor protocol has been applied, normalize the resulting
-        // callables because their descriptor kinds are no longer relevant.
-        let instance_ty = object_ty.to_instance(db);
-        let descriptor_callable = |ty: Type<'db>, instance: Option<Type<'db>>| {
-            ty.try_call_dunder_get(db, instance, object_ty)
-                .map_or(ty, |(ty, _)| ty)
-                .try_upcast_to_callable(db)
-                .map(|callables| {
-                    callables
-                        .map(|callable| callable.into_regular(db))
-                        .into_type(db)
-                })
-        };
-
-        let classmethod_receiver_is_valid = |ty: Type<'db>| {
-            if let Some(specialization) = ty.known_specialization(db, KnownClass::Classmethod) {
-                return specialization.types(db).first().is_some_and(|receiver_ty| {
-                    instance_ty
-                        .is_some_and(|instance_ty| instance_ty.is_assignable_to(db, *receiver_ty))
-                });
-            }
-
-            ty.try_upcast_to_callable(db).is_none_or(|callables| {
-                callables
-                    .iter()
-                    .filter(|callable| callable.is_classmethod_like(db))
-                    .all(|callable| {
-                        callable
-                            .signatures(db)
-                            .iter()
-                            .any(|signature| signature.can_bind_self_to(db, object_ty))
-                    })
-            })
-        };
-
-        let descriptor_assignment_is_valid =
-            |value_ty: Type<'db>, attr_ty: Type<'db>| -> Option<bool> {
-                let target_is_method_like = match attr_ty {
-                    Type::FunctionLiteral(function) => matches!(
-                        function.callable_type_kind(db),
-                        CallableTypeKind::FunctionLike
-                            | CallableTypeKind::StaticMethodLike
-                            | CallableTypeKind::ClassMethodLike
-                    ),
-                    Type::Callable(callable) => callable.is_method_like(db),
-                    _ => false,
-                };
-                if !matches!(object_ty, Type::ClassLiteral(_)) || !target_is_method_like {
-                    return None;
-                }
-                let instance_ty = instance_ty?;
-                let value_tys = match value_ty {
-                    Type::Union(union) => union.elements(db),
-                    _ => std::slice::from_ref(&value_ty),
-                };
-
-                Some(value_tys.iter().copied().all(|value_ty| {
-                    classmethod_receiver_is_valid(value_ty)
-                        && [None, Some(instance_ty)].into_iter().all(|instance| {
-                            descriptor_callable(value_ty, instance)
-                                .zip(descriptor_callable(attr_ty, instance))
-                                .is_some_and(|(value_ty, target_ty)| {
-                                    value_ty.is_assignable_to(db, target_ty)
-                                })
-                        })
-                }))
-            };
-
         // This closure should only be called if `value_ty` was inferred with `attr_ty` as type context.
         let ensure_assignable_to =
             |builder: &Self, value_ty: Type<'db>, attr_ty: Type<'db>| -> bool {
                 let assignable = value_ty.is_assignable_to(db, attr_ty);
-                if !assignable && emit_diagnostics {
-                    report_invalid_attribute_assignment(
-                        &builder.context,
-                        target.range(),
-                        attr_ty,
-                        value_ty,
-                        attribute,
-                    );
-                }
-                assignable
-            };
-
-        let ensure_assignable_to_class_attribute =
-            |builder: &Self, value_ty: Type<'db>, attr_ty: Type<'db>| -> bool {
-                let assignable = descriptor_assignment_is_valid(value_ty, attr_ty)
-                    .unwrap_or_else(|| value_ty.is_assignable_to(db, attr_ty));
                 if !assignable && emit_diagnostics {
                     report_invalid_attribute_assignment(
                         &builder.context,
@@ -2766,13 +2681,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
-            if matches!(object_ty, Type::ClassLiteral(_))
-                && let Type::FunctionLiteral(function) = attr_ty
-                && function.callable_type_kind(db) == CallableTypeKind::FunctionLike
-            {
-                Type::Callable(function.into_callable_type(db))
-            } else {
-                attr_ty
+            if !matches!(object_ty, Type::ClassLiteral(_)) {
+                return attr_ty;
+            }
+
+            // Method monkeypatches are checked against the declared callable signature only. Erase
+            // the callable kind so descriptor binding does not affect assignment compatibility.
+            match attr_ty {
+                Type::FunctionLiteral(function) => {
+                    Type::Callable(function.into_callable_type(db).into_regular(db))
+                }
+                Type::Callable(callable) if callable.is_method_like(db) => {
+                    Type::Callable(callable.into_regular(db))
+                }
+                _ => attr_ty,
             }
         };
 
@@ -3318,11 +3240,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
-                                    ensure_assignable_to_class_attribute(
-                                        self,
-                                        value_ty,
-                                        class_attr_ty,
-                                    ),
+                                    ensure_assignable_to(self, value_ty, class_attr_ty),
                                     class_attr_boundness,
                                 )
                             } else {
@@ -3381,7 +3299,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                             }
 
-                            ensure_assignable_to_class_attribute(self, value_ty, class_attr_ty)
+                            ensure_assignable_to(self, value_ty, class_attr_ty)
                         } else {
                             infer_value_ty(self, TypeContext::default());
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2649,60 +2649,40 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> bool {
         let db = self.db();
 
-        // A replacement for a staticmethod or classmethod must expose the same callable interface
-        // through both class and instance access. Once the descriptor protocol has been applied,
-        // normalize the resulting callables because their descriptor kinds are no longer relevant.
+        // A method replacement must expose the same callable interface through both class and
+        // instance access. Once the descriptor protocol has been applied, normalize the resulting
+        // callables because their descriptor kinds are no longer relevant.
+        let instance_ty = object_ty.to_instance(db);
         let descriptor_callable = |ty: Type<'db>, instance: Option<Type<'db>>| {
-            let descriptor_callable_element = |ty: Type<'db>| {
-                ty.try_call_dunder_get(db, instance, object_ty)
-                    .map_or(ty, |(ty, _)| ty)
-                    .try_upcast_to_callable(db)
-                    .map(|callables| {
-                        callables
-                            .map(|callable| callable.into_regular(db))
-                            .into_type(db)
-                    })
-            };
-
-            match ty {
-                Type::Union(union) => {
-                    union.try_map(db, |element| descriptor_callable_element(*element))
-                }
-                _ => descriptor_callable_element(ty),
-            }
+            ty.try_call_dunder_get(db, instance, object_ty)
+                .map_or(ty, |(ty, _)| ty)
+                .try_upcast_to_callable(db)
+                .map(|callables| {
+                    callables
+                        .map(|callable| callable.into_regular(db))
+                        .into_type(db)
+                })
         };
 
         let classmethod_receiver_is_valid = |ty: Type<'db>| {
-            let receiver_is_valid = |ty: Type<'db>| {
-                if let Some(specialization) = ty.known_specialization(db, KnownClass::Classmethod) {
-                    let Some(receiver_ty) = specialization.types(db).first() else {
-                        return false;
-                    };
-                    return object_ty
-                        .to_instance(db)
-                        .is_some_and(|instance_ty| instance_ty.is_assignable_to(db, *receiver_ty));
-                }
-
-                let signatures = match ty {
-                    Type::FunctionLiteral(function) if function.is_classmethod(db) => {
-                        Some(function.signature(db))
-                    }
-                    Type::Callable(callable) if callable.is_classmethod_like(db) => {
-                        Some(callable.signatures(db))
-                    }
-                    _ => None,
-                };
-                signatures.is_none_or(|signatures| {
-                    signatures
-                        .iter()
-                        .any(|signature| signature.can_bind_self_to(db, object_ty))
-                })
-            };
-
-            match ty {
-                Type::Union(union) => union.elements(db).iter().copied().all(receiver_is_valid),
-                _ => receiver_is_valid(ty),
+            if let Some(specialization) = ty.known_specialization(db, KnownClass::Classmethod) {
+                return specialization.types(db).first().is_some_and(|receiver_ty| {
+                    instance_ty
+                        .is_some_and(|instance_ty| instance_ty.is_assignable_to(db, *receiver_ty))
+                });
             }
+
+            ty.try_upcast_to_callable(db).is_none_or(|callables| {
+                callables
+                    .iter()
+                    .filter(|callable| callable.is_classmethod_like(db))
+                    .all(|callable| {
+                        callable
+                            .signatures(db)
+                            .iter()
+                            .any(|signature| signature.can_bind_self_to(db, object_ty))
+                    })
+            })
         };
 
         let descriptor_assignment_is_valid =
@@ -2720,19 +2700,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !matches!(object_ty, Type::ClassLiteral(_)) || !target_is_method_like {
                     return None;
                 }
-                if !classmethod_receiver_is_valid(value_ty) {
-                    return Some(false);
-                }
+                let instance_ty = instance_ty?;
+                let value_tys = match value_ty {
+                    Type::Union(union) => union.elements(db),
+                    _ => std::slice::from_ref(&value_ty),
+                };
 
-                let instance_ty = object_ty.to_instance(db)?;
-                Some([None, Some(instance_ty)].into_iter().all(|instance| {
-                    let Some(target_ty) = descriptor_callable(attr_ty, instance) else {
-                        return false;
-                    };
-                    let Some(value_ty) = descriptor_callable(value_ty, instance) else {
-                        return false;
-                    };
-                    value_ty.is_assignable_to(db, target_ty)
+                Some(value_tys.iter().copied().all(|value_ty| {
+                    classmethod_receiver_is_valid(value_ty)
+                        && [None, Some(instance_ty)].into_iter().all(|instance| {
+                            descriptor_callable(value_ty, instance)
+                                .zip(descriptor_callable(attr_ty, instance))
+                                .is_some_and(|(value_ty, target_ty)| {
+                                    value_ty.is_assignable_to(db, target_ty)
+                                })
+                        })
                 }))
             };
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2683,9 +2683,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
             if matches!(object_ty, Type::ClassLiteral(_))
                 && let Type::FunctionLiteral(function) = attr_ty
+                && function.callable_type_kind(db) == CallableTypeKind::FunctionLike
             {
-                // Compare method assignments by signature without considering descriptor binding.
-                Type::Callable(function.into_callable_type(db).into_regular(db))
+                Type::Callable(function.into_callable_type(db))
             } else {
                 attr_ty
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2680,6 +2680,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             attr_ty
         };
 
+        let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
+            if matches!(object_ty, Type::ClassLiteral(_))
+                && let Type::FunctionLiteral(function) = attr_ty
+            {
+                Type::Callable(function.into_callable_type(db))
+            } else {
+                attr_ty
+            }
+        };
+
         match object_ty {
             Type::Union(union) => {
                 let mut infer_value_ty = MultiInferenceGuard::new(infer_value_ty);
@@ -3218,6 +3228,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 let class_attr_ty =
                                     class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
+                                let class_attr_ty = class_attribute_write_type(class_attr_ty);
                                 let value_ty = infer_value_ty
                                     .infer_silent(self, TypeContext::new(Some(class_attr_ty)));
                                 (
@@ -3260,6 +3271,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let class_attr_ty =
                                 class_attr_ty.bind_self_typevars(db, class_attr_self_ty);
+                            let class_attr_ty = class_attribute_write_type(class_attr_ty);
                             let value_ty =
                                 infer_value_ty(self, TypeContext::new(Some(class_attr_ty)));
                             if emit_diagnostics

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2683,6 +2683,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
             if matches!(object_ty, Type::ClassLiteral(_))
                 && let Type::FunctionLiteral(function) = attr_ty
+                && function.callable_type_kind(db) == CallableTypeKind::FunctionLike
             {
                 Type::Callable(function.into_callable_type(db))
             } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2665,15 +2665,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let descriptor_assignment_is_valid =
             |value_ty: Type<'db>, attr_ty: Type<'db>| -> Option<bool> {
-                let Type::FunctionLiteral(function) = attr_ty else {
-                    return None;
-                };
-                if !matches!(object_ty, Type::ClassLiteral(_))
-                    || !matches!(
+                let target_is_method_like = match attr_ty {
+                    Type::FunctionLiteral(function) => matches!(
                         function.callable_type_kind(db),
-                        CallableTypeKind::StaticMethodLike | CallableTypeKind::ClassMethodLike
-                    )
-                {
+                        CallableTypeKind::FunctionLike
+                            | CallableTypeKind::StaticMethodLike
+                            | CallableTypeKind::ClassMethodLike
+                    ),
+                    Type::Callable(callable) => callable.is_method_like(db),
+                    _ => false,
+                };
+                if !matches!(object_ty, Type::ClassLiteral(_)) || !target_is_method_like {
                     return None;
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2681,18 +2681,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
-            if !matches!(object_ty, Type::ClassLiteral(_)) {
-                return attr_ty;
+            if matches!(object_ty, Type::ClassLiteral(_))
+                && let Type::FunctionLiteral(function) = attr_ty
+            {
+                // Compare method assignments by signature without considering descriptor binding.
+                Type::Callable(function.into_callable_type(db).into_regular(db))
+            } else {
+                attr_ty
             }
-
-            // Method monkeypatches are checked against the declared callable signature only. Erase
-            // the callable kind so descriptor binding does not affect assignment compatibility.
-            let callable = match attr_ty {
-                Type::FunctionLiteral(function) => function.into_callable_type(db),
-                Type::Callable(callable) if callable.is_method_like(db) => callable,
-                _ => return attr_ty,
-            };
-            Type::Callable(callable.into_regular(db))
         };
 
         match object_ty {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2653,14 +2653,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // through both class and instance access. Once the descriptor protocol has been applied,
         // normalize the resulting callables because their descriptor kinds are no longer relevant.
         let descriptor_callable = |ty: Type<'db>, instance: Option<Type<'db>>| {
-            ty.try_call_dunder_get(db, instance, object_ty)
-                .map_or(ty, |(ty, _)| ty)
-                .try_upcast_to_callable(db)
-                .map(|callables| {
-                    callables
-                        .map(|callable| callable.into_regular(db))
-                        .into_type(db)
-                })
+            let descriptor_callable_element = |ty: Type<'db>| {
+                ty.try_call_dunder_get(db, instance, object_ty)
+                    .map_or(ty, |(ty, _)| ty)
+                    .try_upcast_to_callable(db)
+                    .map(|callables| {
+                        callables
+                            .map(|callable| callable.into_regular(db))
+                            .into_type(db)
+                    })
+            };
+
+            match ty {
+                Type::Union(union) => {
+                    union.try_map(db, |element| descriptor_callable_element(*element))
+                }
+                _ => descriptor_callable_element(ty),
+            }
         };
 
         let descriptor_assignment_is_valid =

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2672,6 +2672,39 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
+        let classmethod_receiver_is_valid = |ty: Type<'db>| {
+            let receiver_is_valid = |ty: Type<'db>| {
+                if let Some(specialization) = ty.known_specialization(db, KnownClass::Classmethod) {
+                    let Some(receiver_ty) = specialization.types(db).first() else {
+                        return false;
+                    };
+                    return object_ty
+                        .to_instance(db)
+                        .is_some_and(|instance_ty| instance_ty.is_assignable_to(db, *receiver_ty));
+                }
+
+                let signatures = match ty {
+                    Type::FunctionLiteral(function) if function.is_classmethod(db) => {
+                        Some(function.signature(db))
+                    }
+                    Type::Callable(callable) if callable.is_classmethod_like(db) => {
+                        Some(callable.signatures(db))
+                    }
+                    _ => None,
+                };
+                signatures.is_none_or(|signatures| {
+                    signatures
+                        .iter()
+                        .any(|signature| signature.can_bind_self_to(db, object_ty))
+                })
+            };
+
+            match ty {
+                Type::Union(union) => union.elements(db).iter().copied().all(receiver_is_valid),
+                _ => receiver_is_valid(ty),
+            }
+        };
+
         let descriptor_assignment_is_valid =
             |value_ty: Type<'db>, attr_ty: Type<'db>| -> Option<bool> {
                 let target_is_method_like = match attr_ty {
@@ -2686,6 +2719,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
                 if !matches!(object_ty, Type::ClassLiteral(_)) || !target_is_method_like {
                     return None;
+                }
+                if !classmethod_receiver_is_valid(value_ty) {
+                    return Some(false);
                 }
 
                 let instance_ty = object_ty.to_instance(db)?;

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2687,15 +2687,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Method monkeypatches are checked against the declared callable signature only. Erase
             // the callable kind so descriptor binding does not affect assignment compatibility.
-            match attr_ty {
-                Type::FunctionLiteral(function) => {
-                    Type::Callable(function.into_callable_type(db).into_regular(db))
-                }
-                Type::Callable(callable) if callable.is_method_like(db) => {
-                    Type::Callable(callable.into_regular(db))
-                }
-                _ => attr_ty,
-            }
+            let callable = match attr_ty {
+                Type::FunctionLiteral(function) => function.into_callable_type(db),
+                Type::Callable(callable) if callable.is_method_like(db) => callable,
+                _ => return attr_ty,
+            };
+            Type::Callable(callable.into_regular(db))
         };
 
         match object_ty {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2680,6 +2680,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             attr_ty
         };
 
+        // Allow monkeypatching an ordinary method with a compatible function:
+        //
+        // ```python
+        // class C:
+        //     def method(self, value: int) -> str: ...
+        //
+        // def replacement(self: C, value: int) -> str: ...
+        // C.method = replacement
+        // ```
         let class_attribute_write_type = |attr_ty: Type<'db>| -> Type<'db> {
             if matches!(object_ty, Type::ClassLiteral(_))
                 && let Type::FunctionLiteral(function) = attr_ty


### PR DESCRIPTION
## Summary

We currently retain a function-literal type when reading an ordinary method from a class literal. Because each function definition has its own singleton type, assigning a different function is rejected even when its signature and binding behavior match:

```python
class Foo:
    def method(self, value: int) -> str:
        return str(value)

def replacement(self: Foo, value: int) -> str:
    return f"replacement: {value}"

Foo.method = replacement
```

This widens the declared method to its function-like callable type only while checking a class attribute assignment. Reads continue to retain the original function-literal type, while replacements must have a compatible signature and ordinary instance-binding behavior.

This is intentionally unsound for function identity: after the assignment, the runtime value of `Foo.method` is `replacement`, but its inferred type still identifies the method declared in `Foo`. `staticmethod` and `classmethod` attributes are not widened because replacing either descriptor with a plain function changes how class and instance access bind arguments. Supporting those cases would require a replacement with the corresponding descriptor.

Closes https://github.com/astral-sh/ty/issues/2648.
