### PR TITLE
[ty] Add a go-to destination for `Divergent`

### DIFF
--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -166,6 +166,34 @@ mod tests {
     }
 
     #[test]
+    fn goto_type_of_divergent() {
+        let test = cursor_test(
+            r#"
+            class D:
+                def copy(self, other: "D"):
+                    self.x = other.x
+
+            D().x<CURSOR>
+            "#,
+        );
+
+        assert_snapshot!(test.goto_type_definition(), @"
+        info[goto-type definition]: Go to type definition
+          --> main.py:LL:5
+           |
+        LL | D().x
+           |     ^ Clicking here
+           |
+        info: Found 1 type definition
+          --> stdlib/ty_extensions.pyi:LL:1
+           |
+        LL | Divergent: _SpecialForm
+           | ---------
+           |
+        ");
+    }
+
+    #[test]
     fn goto_type_of_expression_with_function_type() {
         let test = cursor_test(
             r#"

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6876,12 +6876,12 @@ impl<'db> Type<'db> {
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::AmbiguousOverload,
             ) => Type::SpecialForm(SpecialFormType::Unknown).definition(db),
+            Self::Divergent(_) => Type::SpecialForm(SpecialFormType::Divergent).definition(db),
             Self::AlwaysTruthy => Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db),
             Self::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
 
             // These types have no definition
-            Self::Divergent(_)
-            | Self::Dynamic(
+            Self::Dynamic(
                 DynamicType::Todo(_)
                 | DynamicType::TodoUnpack
                 | DynamicType::TodoStarredExpression

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -256,6 +256,7 @@ impl<'db> ClassBase<'db> {
                 | SpecialFormType::TypeOf
                 | SpecialFormType::CallableTypeOf
                 | SpecialFormType::RegularCallableTypeOf
+                | SpecialFormType::Divergent
                 | SpecialFormType::AlwaysTruthy
                 | SpecialFormType::AlwaysFalsy
                 | SpecialFormType::TypeForm => None,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -2459,6 +2459,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             | SpecialFormType::TypeAlias
             | SpecialFormType::TypedDict
             | SpecialFormType::Unknown
+            | SpecialFormType::Divergent
             | SpecialFormType::Any
             | SpecialFormType::NamedTuple => {
                 if !self.in_string_annotation() {

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -77,6 +77,8 @@ pub enum SpecialFormType {
     Never,
     /// The symbol `ty_extensions.Unknown`
     Unknown,
+    /// The symbol `ty_extensions.Divergent`
+    Divergent,
     /// The symbol `ty_extensions.AlwaysTruthy`
     AlwaysTruthy,
     /// The symbol `ty_extensions.AlwaysFalsy`
@@ -159,6 +161,7 @@ impl SpecialFormType {
             | Self::CallableTypeOf
             | Self::RegularCallableTypeOf
             | Self::Unknown
+            | Self::Divergent
             | Self::AlwaysTruthy
             | Self::AlwaysFalsy => KnownClass::SpecialForm,
 
@@ -272,6 +275,7 @@ impl SpecialFormType {
             NoReturn,
             Never,
             Unknown,
+            Divergent,
             AlwaysTruthy,
             AlwaysFalsy,
             Not,
@@ -339,6 +343,7 @@ impl SpecialFormType {
                     SpecialFormType::TypingSelf => Self::TypingSelf,
                     SpecialFormType::Union => Self::Union,
                     SpecialFormType::Unknown => Self::Unknown,
+                    SpecialFormType::Divergent => Self::Divergent,
                     SpecialFormType::Generic => Self::Generic,
                     SpecialFormType::NamedTuple => Self::NamedTuple,
                     SpecialFormType::Any => Self::Any,
@@ -397,6 +402,7 @@ impl SpecialFormType {
                 SpecialFormTypeBuilder::TypingSelf => Self::TypingSelf,
                 SpecialFormTypeBuilder::Union => Self::Union,
                 SpecialFormTypeBuilder::Unknown => Self::Unknown,
+                SpecialFormTypeBuilder::Divergent => Self::Divergent,
                 SpecialFormTypeBuilder::Generic => Self::Generic,
                 SpecialFormTypeBuilder::NamedTuple => Self::NamedTuple,
                 SpecialFormTypeBuilder::Any => Self::Any,
@@ -471,6 +477,7 @@ impl SpecialFormType {
             }
 
             Self::Unknown
+            | Self::Divergent
             | Self::AlwaysTruthy
             | Self::AlwaysFalsy
             | Self::Not
@@ -534,6 +541,7 @@ impl SpecialFormType {
             | Self::NoReturn
             | Self::Never
             | Self::Unknown
+            | Self::Divergent
             | Self::AlwaysTruthy
             | Self::AlwaysFalsy
             | Self::Not
@@ -594,6 +602,7 @@ impl SpecialFormType {
             | Self::TypingSelf
             | Self::Union
             | Self::Unknown
+            | Self::Divergent
             | Self::TypeOf
             | Self::Any  // can be used in `issubclass()` but not `isinstance()`.
             | Self::Unpack => false,
@@ -634,6 +643,7 @@ impl SpecialFormType {
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::ChainMap) => "ChainMap",
             SpecialFormType::LegacyStdlibAlias(LegacyStdlibAlias::OrderedDict) => "OrderedDict",
             SpecialFormType::Unknown => "Unknown",
+            SpecialFormType::Divergent => "Divergent",
             SpecialFormType::AlwaysTruthy => "AlwaysTruthy",
             SpecialFormType::AlwaysFalsy => "AlwaysFalsy",
             SpecialFormType::Not => "Not",
@@ -683,6 +693,7 @@ impl SpecialFormType {
             SpecialFormType::CollectionsAbcCallable => &[KnownModule::CollectionsAbc],
 
             SpecialFormType::Unknown
+            | SpecialFormType::Divergent
             | SpecialFormType::AlwaysTruthy
             | SpecialFormType::AlwaysFalsy
             | SpecialFormType::Not
@@ -728,6 +739,10 @@ impl SpecialFormType {
             Self::LiteralString => Ok(Type::literal_string()),
             Self::Any => Ok(Type::any()),
             Self::Unknown => Ok(Type::unknown()),
+            Self::Divergent => Err(InvalidTypeExpression::InvalidType(
+                Type::SpecialForm(self),
+                scope_id,
+            )),
             Self::AlwaysTruthy => Ok(Type::AlwaysTruthy),
             Self::AlwaysFalsy => Ok(Type::AlwaysFalsy),
 

--- a/crates/ty_vendored/ty_extensions/ty_extensions.pyi
+++ b/crates/ty_vendored/ty_extensions/ty_extensions.pyi
@@ -12,6 +12,18 @@ def static_assert(condition: object, msg: LiteralString | None = None) -> None: 
 
 # Types
 Unknown: _SpecialForm
+Divergent: _SpecialForm
+"""
+`Divergent` represents type-level recursion that does not converge.
+
+Type inference can be recursive. ty analyzes inference cycles repeatedly, looking for a
+stable result. If each iteration produces a new type, ty replaces the non-convergent part
+with `Divergent`.
+
+Like `Any` and `Unknown`, `Divergent` is a gradual type, so ty allows any operation on it.
+Unlike `Unknown`, it does not represent missing type information. It is an internal type
+used by ty and cannot be used in annotations.
+"""
 AlwaysTruthy: _SpecialForm
 AlwaysFalsy: _SpecialForm
 


### PR DESCRIPTION
## Summary

`Divergent` is here to stay, and we've documented what it means: https://github.com/astral-sh/ty/commit/d299a29cc182e9ade2ef9f96e2002acbc209aee8. This PR adds a go-to target for the type, so that users can command+click on the type when it appears in inlay hints in VSCode, and they'll be taken to a definition that has documentation explaining the type's meaning.

## Test Plan

Hovering over an inlay hint in a local deploy of the playground:

<details>
<summary>Screenshot</summary>

<img width="1678" height="942" alt="image" src="https://github.com/user-attachments/assets/a4061e24-145d-4bfd-ba82-d7c9b9ba4c1f" />

</details>