### PR TITLE
[ty] Normalize recursive `TypeOf` growth during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -230,6 +230,32 @@ min(Y)
 T = f()
 ```
 
+## Type replacement with a lazy function signature
+
+Type replacement during cycle recovery must not evaluate a function's lazy signature. Doing so can
+introduce a new dependency on the reachability of a loop header while recovering from a different
+cycle, which Salsa rejects.
+
+```toml
+[environment]
+python-version = "3.10"
+```
+
+```py
+lambda: name_4
+for name_5 in (lambda: (name_4 for unique_name_0 in name_5),):  # error: [not-iterable]
+    match 0:
+        case unique_name_2():  # error: [unresolved-reference]
+            async def name_4():
+                pass
+
+        case name_5():  # error: [invalid-match-pattern]
+            pass
+        case 0:
+            async def name_4():
+                pass
+```
+
 ## Lazy cached property behind `hasattr`
 
 This pattern used to panic with "too many cycle iterations".

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -232,9 +232,10 @@ T = f()
 
 ## Type replacement with a lazy function signature
 
-Type replacement during cycle recovery must not evaluate a function's lazy signature. Doing so can
-introduce a new dependency on the reachability of a loop header while recovering from a different
-cycle, which Salsa rejects.
+Type replacement while recovering the first `function` definition must not evaluate its lazy
+signature. The definition's reachability depends on the enclosing loop header through the match
+pattern. Evaluating the signature during `infer_definition_types` cycle recovery would therefore
+introduce a new `loop_header_reachability` dependency, which Salsa rejects.
 
 ```toml
 [environment]
@@ -242,18 +243,16 @@ python-version = "3.10"
 ```
 
 ```py
-lambda: name_4
-for name_5 in (lambda: (name_4 for unique_name_0 in name_5),):  # error: [not-iterable]
+lambda: function
+for factory in (lambda: (function for _ in factory),):  # error: [not-iterable]
     match 0:
-        case unique_name_2():  # error: [unresolved-reference]
-            async def name_4():
-                pass
+        case missing():  # error: [unresolved-reference]
+            def function(): ...
 
-        case name_5():  # error: [invalid-match-pattern]
-            pass
+        case factory():  # error: [invalid-match-pattern]
+            ...
         case 0:
-            async def name_4():
-                pass
+            def function(): ...
 ```
 
 ## Lazy cached property behind `hasattr`

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -494,7 +494,7 @@ def foo(x: "TypeOf[foo]"):
 ```
 
 A `TypeOf` self-reference nested in a nominal specialization forms a recursive type. Cycle recovery
-preserves the nominal structure and replaces the recursive argument with `Divergent`:
+preserves the outer nominal structure and replaces the recursive argument with `Divergent`:
 
 ```toml
 [environment]
@@ -515,6 +515,10 @@ reveal_type(x)  # revealed: list[Divergent]
 nested: list[tuple[TypeOf[nested]]]
 nested = [(1,)]
 reveal_type(nested)  # revealed: list[Divergent]
+
+optional: list[TypeOf[optional]] | None
+optional = [1]
+reveal_type(optional)  # revealed: list[Divergent]
 
 class Container[T]: ...
 

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -493,6 +493,36 @@ def foo(x: "TypeOf[foo]"):
     reveal_type(x)  # revealed: def foo(x: def foo(...)) -> Unknown
 ```
 
+A `TypeOf` self-reference nested in a nominal specialization forms a recursive type. Cycle recovery
+preserves the nominal structure and replaces the recursive argument with `Divergent`:
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from ty_extensions import TypeOf
+
+direct: TypeOf[direct]
+direct = 1
+reveal_type(direct)  # revealed: Literal[1]
+
+x: list[TypeOf[x]]
+x = [1]
+reveal_type(x)  # revealed: list[Divergent]
+
+nested: list[tuple[TypeOf[nested]]]
+nested = [(1,)]
+reveal_type(nested)  # revealed: list[Divergent]
+
+class Container[T]: ...
+
+y: Container[TypeOf[y]]
+y = 1  # error: [invalid-assignment]
+reveal_type(y)  # revealed: Container[Divergent]
+```
+
 ## Recursive `TypeOf` in returned callables
 
 ```toml

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1179,6 +1179,14 @@ impl<'db> Type<'db> {
         // So we avoid unioning in the first couple iterations, and just use the later iteration's
         // result directly. We still ensure monotonicity after the first couple iterations, which
         // still ensures convergence in cases that are prone to oscillation.
+        if cycle.iteration() > crate::TAINTED_CYCLES
+            && let Some(normalized) = cycle.head_ids().find_map(|id| {
+                self.recursive_nominal_growth_normalized(db, previous, Type::divergent(id))
+            })
+        {
+            return normalized.recursive_type_normalized(db, cycle);
+        }
+
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
                 any_over_type(db, self, false, |ty| {
@@ -1202,6 +1210,48 @@ impl<'db> Type<'db> {
             UnionType::from_elements_cycle_recovery(db, [previous, self])
         }
         .recursive_type_normalized(db, cycle)
+    }
+
+    /// Normalizes a nominal type that wraps the previous cycle result in its own specialization.
+    ///
+    /// For example, an inference cycle can otherwise grow indefinitely as
+    /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
+    /// tainted cycles, replace the recursive type argument with the cycle's `Divergent` marker so
+    /// that the existing recursive-type normalization can converge on `C[Divergent]`.
+    fn recursive_nominal_growth_normalized(
+        self,
+        db: &'db dyn Db,
+        previous: Self,
+        div: Self,
+    ) -> Option<Self> {
+        let (Type::NominalInstance(current), Type::NominalInstance(previous_instance)) =
+            (self, previous)
+        else {
+            return None;
+        };
+
+        let current_class = current.class(db);
+        if current_class.class_literal(db) != previous_instance.class_literal(db) {
+            return None;
+        }
+
+        let alias = current_class.into_generic_alias()?;
+        let original_specialization = alias.specialization(db);
+        let specialization = original_specialization.apply_type_mapping(
+            db,
+            &TypeMapping::ReplaceType {
+                from: previous,
+                to: div,
+            },
+        );
+        if specialization == original_specialization {
+            return None;
+        }
+
+        Some(Type::instance(
+            db,
+            ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
+        ))
     }
 
     pub fn is_none(&self, db: &'db dyn Db) -> bool {
@@ -6093,6 +6143,12 @@ impl<'db> Type<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
+        if let TypeMapping::ReplaceType { from, to } = type_mapping
+            && self == *from
+        {
+            return *to;
+        }
+
         // If we are binding `typing.Self`, and this type is what we are binding `Self` to, return
         // early. This is not just an optimization, it also prevents us from infinitely expanding
         // the type, if it's something that can contain a `Self` reference.
@@ -6348,6 +6404,7 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf { .. } |
                 TypeMapping::ReplaceSelf { .. } |
+                TypeMapping::ReplaceType { .. } |
                 TypeMapping::Materialize(_) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -6364,6 +6421,7 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf(..) |
                 TypeMapping::ReplaceSelf { .. } |
+                TypeMapping::ReplaceType { .. } |
                 TypeMapping::Promote(..) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -7415,6 +7473,8 @@ pub enum TypeMapping<'a, 'db> {
     BindSelf(SelfBinding<'db>),
     /// Replaces occurrences of `typing.Self` with a new `Self` type variable with the given upper bound.
     ReplaceSelf { new_upper_bound: Type<'db> },
+    /// Replaces occurrences of one specific type with another.
+    ReplaceType { from: Type<'db>, to: Type<'db> },
     /// Create the top or bottom materialization of a type.
     Materialize(MaterializationKind),
     /// Replace default types in parameters of callables with `Unknown`. This is used to avoid infinite
@@ -7467,6 +7527,7 @@ impl<'db> TypeMapping<'_, 'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::BindLegacyTypevars(_)
+            | TypeMapping::ReplaceType { .. }
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
@@ -7514,6 +7575,7 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::FreshenBoundTypeVars { .. }
             | TypeMapping::BindSelf(..)
             | TypeMapping::ReplaceSelf { .. }
+            | TypeMapping::ReplaceType { .. }
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => self.clone(),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1212,7 +1212,8 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
-    /// Normalizes a nominal type that wraps the previous cycle result in its own specialization.
+    /// Normalizes nominal growth that wraps the previous cycle result in a specialization, either
+    /// directly or beneath an unambiguous union wrapper.
     ///
     /// For example, an inference cycle can otherwise grow indefinitely as
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
@@ -1224,6 +1225,35 @@ impl<'db> Type<'db> {
         previous: Self,
         div: Self,
     ) -> Option<Self> {
+        if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
+            // Only align unions when each iteration has exactly one changed arm. With multiple
+            // unmatched arms, pairing is ambiguous and can destabilize otherwise-convergent
+            // recursive cycles.
+            let current_element = current
+                .elements(db)
+                .iter()
+                .copied()
+                .filter(|element| !previous.elements(db).contains(element))
+                .exactly_one()
+                .ok()?;
+            let previous_element = previous
+                .elements(db)
+                .iter()
+                .copied()
+                .filter(|element| !current.elements(db).contains(element))
+                .exactly_one()
+                .ok()?;
+            let normalized_element =
+                current_element.recursive_nominal_growth_normalized(db, previous_element, div)?;
+            return Some(current.map_leave_aliases(db, |element| {
+                if *element == current_element {
+                    normalized_element
+                } else {
+                    *element
+                }
+            }));
+        }
+
         let (Type::NominalInstance(current), Type::NominalInstance(previous_instance)) =
             (self, previous)
         else {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1097,18 +1097,21 @@ impl<'db> FunctionType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
-        // Returned-callable rescoping and type-alias specialization should not rebuild signatures from the
-        // function literal; doing so can re-enter recursive `TypeOf` evaluation.
+        // Type replacement during cycle recovery, returned-callable rescoping, and type-alias
+        // specialization should not rebuild signatures from the function literal; doing so can
+        // re-enter recursive type inference.
         let literal = self.literal(db);
         let (updated_signature, updated_implementation_signature) = if matches!(
             type_mapping,
-            TypeMapping::ApplySpecialization(
-                ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
-            ) | TypeMapping::ApplySpecializationWithMaterialization {
-                specialization: ApplySpecialization::ReturnCallables(_)
-                    | ApplySpecialization::TypeAlias(_),
-                ..
-            }
+            TypeMapping::ReplaceType { .. }
+                | TypeMapping::ApplySpecialization(
+                    ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
+                )
+                | TypeMapping::ApplySpecializationWithMaterialization {
+                    specialization: ApplySpecialization::ReturnCallables(_)
+                        | ApplySpecialization::TypeAlias(_),
+                    ..
+                }
         ) {
             (
                 self.updated_signature(db).map(|signature| {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -375,6 +375,7 @@ impl<'db> KnownInstanceType<'db> {
                 | TypeMapping::FreshenBoundTypeVars { .. }
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
+                | TypeMapping::ReplaceType { .. }
                 | TypeMapping::Materialize(_)
                 | TypeMapping::ReplaceParameterDefaults
                 | TypeMapping::EagerExpansion

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1142,6 +1142,7 @@ impl<'db> BoundTypeVarInstance<'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::ReplaceParameterDefaults
+            | TypeMapping::ReplaceType { .. }
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => Type::TypeVar(self),


### PR DESCRIPTION
## Summary

A `TypeOf` self-reference nested in a generic specialization can cause each fixed-point iteration to wrap the previous inferred result:

```python
from ty_extensions import TypeOf

x: list[TypeOf[x]] | None
x = [1]
```

Prior to this change, we repeatedly inferred a deeper specialization such as `list[int]`, `list[list[int]]`, and so on, eventually exhausting Salsa's cycle iterations.

This detects structurally growing nominal specializations after the tainted cycle iterations, replaces the previous cycle result with the cycle's `Divergent` marker, and then reuses the existing recursive-type normalization to converge.

Closes https://github.com/astral-sh/ty/issues/3802.
