### PR TITLE
[ty] Avoid shadowing hints for attribute assignments

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
+++ b/crates/ty_python_semantic/resources/mdtest/diagnostics/shadowing.md
@@ -42,3 +42,21 @@ error[invalid-assignment]: Object of type `Literal[1]` is not assignable to `def
   |
 info: Implicit shadowing of function `f`. Add an annotation to make it explicit if this is intentional
 ```
+
+## No implicit shadowing for attribute assignments
+
+```py
+from configparser import ConfigParser
+
+config = ConfigParser()
+config.optionxform = str  # snapshot: invalid-assignment
+```
+
+```snapshot
+error[invalid-assignment]: Object of type `<class 'str'>` is not assignable to attribute `optionxform` of type `def optionxform(self, optionstr: str) -> str`
+ --> src/mdtest_snippet.py:4:1
+  |
+4 | config.optionxform = str  # snapshot: invalid-assignment
+  | ^^^^^^^^^^^^^^^^^^
+  |
+```

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -1423,29 +1423,10 @@ pub(crate) fn is_invalid_typed_dict_literal(
 fn report_invalid_assignment_with_message<'db, 'ctx: 'db, T: Ranged>(
     context: &'ctx InferContext,
     node: T,
-    target_ty: Type<'db>,
     message: std::fmt::Arguments,
 ) -> Option<LintDiagnosticGuard<'db, 'ctx>> {
     let builder = context.report_lint(&INVALID_ASSIGNMENT, node)?;
-
-    let mut diag = builder.into_diagnostic(message);
-
-    match target_ty {
-        Type::ClassLiteral(class) => {
-            diag.info(format_args!(
-                "Implicit shadowing of class `{}`. Add an annotation to make it explicit if this is intentional",
-                class.name(context.db()),
-            ));
-        }
-        Type::FunctionLiteral(function) => {
-            diag.info(format_args!(
-                "Implicit shadowing of function `{}`. Add an annotation to make it explicit if this is intentional",
-                function.name(context.db()),
-            ));
-        }
-        _ => {}
-    }
-    Some(diag)
+    Some(builder.into_diagnostic(message))
 }
 
 pub(super) fn note_numbers_module_not_supported<'db>(
@@ -1619,7 +1600,6 @@ pub(super) fn report_invalid_assignment<'db>(
     let Some(mut diag) = report_invalid_assignment_with_message(
         context,
         diagnostic_range,
-        target_ty,
         format_args!(
             "Object of type `{}` is not assignable to `{}`",
             value_ty.display_with(context.db(), settings.clone()),
@@ -1628,6 +1608,24 @@ pub(super) fn report_invalid_assignment<'db>(
     ) else {
         return;
     };
+
+    if matches!(target_node, AnyNodeRef::ExprName(_)) {
+        match target_ty {
+            Type::ClassLiteral(class) => {
+                diag.info(format_args!(
+                    "Implicit shadowing of class `{}`. Add an annotation to make it explicit if this is intentional",
+                    class.name(context.db()),
+                ));
+            }
+            Type::FunctionLiteral(function) => {
+                diag.info(format_args!(
+                    "Implicit shadowing of function `{}`. Add an annotation to make it explicit if this is intentional",
+                    function.name(context.db()),
+                ));
+            }
+            _ => {}
+        }
+    }
 
     if value_node.is_some() {
         match definition_kind {
@@ -1681,7 +1679,6 @@ pub(super) fn report_invalid_attribute_assignment(
     let Some(mut diag) = report_invalid_assignment_with_message(
         context,
         range,
-        target_ty,
         format_args!(
             "Object of type `{}` is not assignable to attribute `{attribute_name}` of type `{}`",
             source_ty.display(context.db()),


### PR DESCRIPTION
## Summary

`invalid-assignment` adds an implicit-shadowing hint when an assignment replaces a class or function binding. Prior to this change, the shared diagnostic construction also attached this hint to attribute assignments whose declared type happened to be a function, even though assigning an attribute does not shadow a name binding:

```python
from configparser import ConfigParser

config = ConfigParser()
config.optionxform = str
```

This moves the shadowing-specific context to the general assignment path and only adds it for direct name targets. Invalid attribute assignments continue to report the assignability error, but no longer include misleading guidance about implicit shadowing. The existing diagnostics for direct class and function shadowing remain unchanged.

The regression snapshot covers the reported `ConfigParser.optionxform` case.

Closes https://github.com/astral-sh/ty/issues/1990.
