### PR TITLE
[ty] Infer empty collection types from direct covariant context

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -20,6 +20,9 @@ def default_to_empty(value: Mapping[str, int] | None = None) -> None:
         reveal_type(value)  # revealed: dict[str, int]
     reveal_type(value)  # revealed: Mapping[str, int]
 
+annotated: Mapping[str, int] = {}
+reveal_type(annotated)  # revealed: dict[str, int]
+
 def shared_key(value: Mapping[str, int] | Mapping[str, bytes] | None = None) -> None:
     if value is None:
         value = {}

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -6,6 +6,70 @@
 reveal_type({})  # revealed: dict[Unknown, Unknown]
 ```
 
+A directly contextualized empty dictionary uses fully static covariant constraints. Constraints
+shared by every compatible union arm are retained independently for keys and values:
+
+```py
+from collections.abc import Mapping
+from typing import Any, NewType
+from ty_extensions import Unknown
+
+def default_to_empty(value: Mapping[str, int] | None = None) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[str, int]
+    reveal_type(value)  # revealed: Mapping[str, int]
+
+def shared_key(value: Mapping[str, int] | Mapping[str, bytes] | None = None) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[str, Unknown]
+
+def shared_key_reversed(
+    value: Mapping[str, bytes] | Mapping[str, int] | None = None,
+) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[str, Unknown]
+
+def shared_value(value: Mapping[str, int] | Mapping[bytes, int] | None = None) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[Unknown, int]
+
+def shared_value_reversed(
+    value: Mapping[bytes, int] | Mapping[str, int] | None = None,
+) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[Unknown, int]
+
+def dynamic_invariant_key(value: Mapping[Any, int] | None = None) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[Any, int]
+
+def top_level_any(value: Mapping[str, int] | Any | None = None) -> None:
+    if value is None:
+        value = {}
+        value["key"] = "value"
+
+A = NewType("A", int)
+B = NewType("B", int)
+
+def distinct_newtypes(value: Mapping[A, int] | Mapping[B, bytes] | None = None) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[Unknown, Unknown]
+
+def nested_dynamic(
+    value: Mapping[str, list[Any]] | Mapping[str, list[Unknown]] | None = None,
+) -> None:
+    if value is None:
+        value = {}
+        reveal_type(value)  # revealed: dict[str, Unknown]
+```
+
 ## Basic dict
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/dictionary.md
@@ -6,56 +6,40 @@
 reveal_type({})  # revealed: dict[Unknown, Unknown]
 ```
 
-A directly contextualized empty dictionary uses fully static covariant constraints. Constraints
-shared by every compatible union arm are retained independently for keys and values:
+## Empty dictionaries with an expected type
+
+An empty dictionary can use the key and value types from an expected `Mapping`. If it matches more
+than one union member, ty keeps a key or value type only when all matching members agree. `Any` is
+preserved as a key type, and different `NewType`s remain distinct:
 
 ```py
 from collections.abc import Mapping
 from typing import Any, NewType
-from ty_extensions import Unknown
 
 def default_to_empty(value: Mapping[str, int] | None = None) -> None:
     if value is None:
         value = {}
         reveal_type(value)  # revealed: dict[str, int]
-    reveal_type(value)  # revealed: Mapping[str, int]
 
 annotated: Mapping[str, int] = {}
 reveal_type(annotated)  # revealed: dict[str, int]
 
-def shared_key(value: Mapping[str, int] | Mapping[str, bytes] | None = None) -> None:
+def same_key(value: Mapping[str, int] | Mapping[str, bytes] | None = None) -> None:
     if value is None:
         value = {}
         reveal_type(value)  # revealed: dict[str, Unknown]
 
-def shared_key_reversed(
-    value: Mapping[str, bytes] | Mapping[str, int] | None = None,
-) -> None:
-    if value is None:
-        value = {}
-        reveal_type(value)  # revealed: dict[str, Unknown]
-
-def shared_value(value: Mapping[str, int] | Mapping[bytes, int] | None = None) -> None:
-    if value is None:
-        value = {}
-        reveal_type(value)  # revealed: dict[Unknown, int]
-
-def shared_value_reversed(
+def same_value(
     value: Mapping[bytes, int] | Mapping[str, int] | None = None,
 ) -> None:
     if value is None:
         value = {}
         reveal_type(value)  # revealed: dict[Unknown, int]
 
-def dynamic_invariant_key(value: Mapping[Any, int] | None = None) -> None:
+def any_key(value: Mapping[Any, int] | None = None) -> None:
     if value is None:
         value = {}
         reveal_type(value)  # revealed: dict[Any, int]
-
-def top_level_any(value: Mapping[str, int] | Any | None = None) -> None:
-    if value is None:
-        value = {}
-        value["key"] = "value"
 
 A = NewType("A", int)
 B = NewType("B", int)
@@ -64,13 +48,6 @@ def distinct_newtypes(value: Mapping[A, int] | Mapping[B, bytes] | None = None) 
     if value is None:
         value = {}
         reveal_type(value)  # revealed: dict[Unknown, Unknown]
-
-def nested_dynamic(
-    value: Mapping[str, list[Any]] | Mapping[str, list[Unknown]] | None = None,
-) -> None:
-    if value is None:
-        value = {}
-        reveal_type(value)  # revealed: dict[str, Unknown]
 ```
 
 ## Basic dict

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -27,6 +27,12 @@ def conflicting(items: Sequence[str] | Sequence[bytes] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
+
+annotated: Sequence[int] = []
+reveal_type(annotated)  # revealed: list[int]
+
+annotated_agreeing: Iterable[int] | Reversible[int] = []
+reveal_type(annotated_agreeing)  # revealed: list[int]
 ```
 
 Semantically equivalent fully static element types also count as agreement:

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -29,6 +29,31 @@ def conflicting(items: Sequence[str] | Sequence[bytes] | None = None) -> None:
         reveal_type(items)  # revealed: list[Unknown]
 ```
 
+Semantically equivalent fully static element types also count as agreement:
+
+```py
+from collections.abc import Iterable
+from typing import Protocol, TypeVar
+
+ElementT_co = TypeVar("ElementT_co", covariant=True)
+
+class SupportsGetItem(Protocol[ElementT_co]):
+    def __getitem__(self, index: int, /) -> ElementT_co: ...
+
+class P1(Protocol):
+    def method(self) -> int: ...
+
+class P2(Protocol):
+    def method(self) -> int: ...
+
+def equivalent_protocols(
+    items: Iterable[P1] | SupportsGetItem[P2] | None = None,
+) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[P1]
+```
+
 Dynamic element types, including nested dynamic types, retain the normal `Unknown` fallback
 independent of union order:
 

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -6,45 +6,33 @@
 reveal_type([])  # revealed: list[Unknown]
 ```
 
-A directly contextualized empty list uses a fully static covariant element type when every
-compatible union arm agrees:
+## Empty lists with an expected type
+
+An empty list can use the element type from an expected `Sequence`. If it matches more than one
+union member, ty keeps the element type only when all matching members agree. Equivalent element
+types count as agreement:
 
 ```py
 from collections.abc import Iterable, Reversible, Sequence
+from typing import Protocol
 
 def default_to_empty(items: Sequence[int] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[int]
-    reveal_type(items)  # revealed: Sequence[int]
-
-def agreeing(items: Iterable[int] | Reversible[int] | None = None) -> None:
-    if items is None:
-        items = []
-        reveal_type(items)  # revealed: list[int]
-
-def conflicting(items: Sequence[str] | Sequence[bytes] | None = None) -> None:
-    if items is None:
-        items = []
-        reveal_type(items)  # revealed: list[Unknown]
 
 annotated: Sequence[int] = []
 reveal_type(annotated)  # revealed: list[int]
 
-annotated_agreeing: Iterable[int] | Reversible[int] = []
-reveal_type(annotated_agreeing)  # revealed: list[int]
-```
+def same_element_type(items: Iterable[int] | Reversible[int] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[int]
 
-Semantically equivalent fully static element types also count as agreement:
-
-```py
-from collections.abc import Iterable
-from typing import Protocol, TypeVar
-
-ElementT_co = TypeVar("ElementT_co", covariant=True)
-
-class SupportsGetItem(Protocol[ElementT_co]):
-    def __getitem__(self, index: int, /) -> ElementT_co: ...
+def different_element_types(items: Sequence[str] | Sequence[bytes] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
 
 class P1(Protocol):
     def method(self) -> int: ...
@@ -53,49 +41,50 @@ class P2(Protocol):
     def method(self) -> int: ...
 
 def equivalent_protocols(
-    items: Iterable[P1] | SupportsGetItem[P2] | None = None,
+    items: Iterable[P1] | Reversible[P2] | None = None,
 ) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[P1]
 ```
 
-Dynamic element types, including nested dynamic types, retain the normal `Unknown` fallback
-independent of union order:
+`Any` and `Unknown` do not provide a precise element type, even when nested inside another type. A
+separate `Any` union member also leaves the list open to any element type. Reversing the union
+members does not change the result:
 
 ```py
 from collections.abc import Sequence
 from typing import Any
 from ty_extensions import Unknown
 
-def any_first(items: Sequence[Any] | Sequence[int] | None = None) -> None:
+def any_then_int(items: Sequence[Any] | Sequence[int] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def int_first(items: Sequence[int] | Sequence[Any] | None = None) -> None:
+def int_then_any(items: Sequence[int] | Sequence[Any] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def any_unknown_first(items: Sequence[Any] | Sequence[Unknown] | None = None) -> None:
+def any_then_unknown(items: Sequence[Any] | Sequence[Unknown] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def unknown_any_first(items: Sequence[Unknown] | Sequence[Any] | None = None) -> None:
+def unknown_then_any(items: Sequence[Unknown] | Sequence[Any] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def nested_any_first(
+def nested_any_then_unknown(
     items: Sequence[list[Any]] | Sequence[list[Unknown]] | None = None,
 ) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def nested_unknown_first(
+def nested_unknown_then_any(
     items: Sequence[list[Unknown]] | Sequence[list[Any]] | None = None,
 ) -> None:
     if items is None:
@@ -105,11 +94,11 @@ def nested_unknown_first(
 def top_level_any(items: Sequence[int] | Any | None = None) -> None:
     if items is None:
         items = []
-        items.append("x")
+        reveal_type(items)  # revealed: list[Unknown]
 ```
 
-The effective variance of a structural constraint determines whether the fallback applies. Mixed
-covariant and invariant arms remain order-independent:
+The protocol below uses its type parameter for both iteration and containment, but only `__iter__`
+constrains the list's element type. Reversing the union members must not change the result:
 
 ```py
 from collections.abc import Iterable, Iterator
@@ -117,36 +106,36 @@ from typing import Protocol, TypeVar
 
 ElementT = TypeVar("ElementT")
 
-class IterableConsumer(Protocol[ElementT]):
+class IterableAndContainer(Protocol[ElementT]):
     def __iter__(self) -> Iterator[ElementT]: ...
     def __contains__(self, value: ElementT, /) -> bool: ...
 
-def protocol_int_first(
-    items: IterableConsumer[int] | IterableConsumer[str] | None = None,
+def int_then_str(
+    items: IterableAndContainer[int] | IterableAndContainer[str] | None = None,
 ) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def protocol_str_first(
-    items: IterableConsumer[str] | IterableConsumer[int] | None = None,
+def str_then_int(
+    items: IterableAndContainer[str] | IterableAndContainer[int] | None = None,
 ) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def covariant_first(items: Iterable[int] | list[str] | None = None) -> None:
+def iterable_then_list(items: Iterable[int] | list[str] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 
-def invariant_first(items: list[str] | Iterable[int] | None = None) -> None:
+def list_then_iterable(items: list[str] | Iterable[int] | None = None) -> None:
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
 ```
 
-Covariant context is not propagated through an enclosing generic call:
+An expected type for a generic call is not applied directly to an empty list passed to that call:
 
 ```py
 from collections.abc import Iterable, Sequence
@@ -157,11 +146,11 @@ T = TypeVar("T")
 def identity(value: T) -> T:
     return value
 
-wrapped_int_first: Iterable[int] | Sequence[str] = identity([])
-reveal_type(wrapped_int_first)  # revealed: list[Unknown]
+wrapped_iterable_first: Iterable[int] | Sequence[str] = identity([])
+reveal_type(wrapped_iterable_first)  # revealed: list[Unknown]
 
-wrapped_str_first: Sequence[str] | Iterable[int] = identity([])
-reveal_type(wrapped_str_first)  # revealed: list[Unknown]
+wrapped_sequence_first: Sequence[str] | Iterable[int] = identity([])
+reveal_type(wrapped_sequence_first)  # revealed: list[Unknown]
 ```
 
 ## List of tuples

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -6,6 +6,128 @@
 reveal_type([])  # revealed: list[Unknown]
 ```
 
+A directly contextualized empty list uses a fully static covariant element type when every
+compatible union arm agrees:
+
+```py
+from collections.abc import Iterable, Reversible, Sequence
+
+def default_to_empty(items: Sequence[int] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[int]
+    reveal_type(items)  # revealed: Sequence[int]
+
+def agreeing(items: Iterable[int] | Reversible[int] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[int]
+
+def conflicting(items: Sequence[str] | Sequence[bytes] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+```
+
+Dynamic element types, including nested dynamic types, retain the normal `Unknown` fallback
+independent of union order:
+
+```py
+from collections.abc import Sequence
+from typing import Any
+from ty_extensions import Unknown
+
+def any_first(items: Sequence[Any] | Sequence[int] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def int_first(items: Sequence[int] | Sequence[Any] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def any_unknown_first(items: Sequence[Any] | Sequence[Unknown] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def unknown_any_first(items: Sequence[Unknown] | Sequence[Any] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def nested_any_first(
+    items: Sequence[list[Any]] | Sequence[list[Unknown]] | None = None,
+) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def nested_unknown_first(
+    items: Sequence[list[Unknown]] | Sequence[list[Any]] | None = None,
+) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+```
+
+The effective variance of a structural constraint determines whether the fallback applies. Mixed
+covariant and invariant arms remain order-independent:
+
+```py
+from collections.abc import Iterable, Iterator
+from typing import Protocol, TypeVar
+
+ElementT = TypeVar("ElementT")
+
+class IterableConsumer(Protocol[ElementT]):
+    def __iter__(self) -> Iterator[ElementT]: ...
+    def __contains__(self, value: ElementT, /) -> bool: ...
+
+def protocol_int_first(
+    items: IterableConsumer[int] | IterableConsumer[str] | None = None,
+) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def protocol_str_first(
+    items: IterableConsumer[str] | IterableConsumer[int] | None = None,
+) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def covariant_first(items: Iterable[int] | list[str] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+
+def invariant_first(items: list[str] | Iterable[int] | None = None) -> None:
+    if items is None:
+        items = []
+        reveal_type(items)  # revealed: list[Unknown]
+```
+
+Covariant context is not propagated through an enclosing generic call:
+
+```py
+from collections.abc import Iterable, Sequence
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def identity(value: T) -> T:
+    return value
+
+wrapped_int_first: Iterable[int] | Sequence[str] = identity([])
+reveal_type(wrapped_int_first)  # revealed: list[Unknown]
+
+wrapped_str_first: Sequence[str] | Iterable[int] = identity([])
+reveal_type(wrapped_str_first)  # revealed: list[Unknown]
+```
+
 ## List of tuples
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
+++ b/crates/ty_python_semantic/resources/mdtest/literal/collections/list.md
@@ -95,6 +95,11 @@ def nested_unknown_first(
     if items is None:
         items = []
         reveal_type(items)  # revealed: list[Unknown]
+
+def top_level_any(items: Sequence[int] | Any | None = None) -> None:
+    if items is None:
+        items = []
+        items.append("x")
 ```
 
 The effective variance of a structural constraint determines whether the fallback applies. Mixed

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6950,6 +6950,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = tcx.narrow_targets(db);
+        let has_dynamic_narrow_target = use_empty_list_consensus
+            && narrow_targets
+                .as_deref()
+                .is_some_and(|targets| targets.iter().any(Type::is_dynamic));
         let narrow_targets = narrow_targets
             .as_deref()
             .into_iter()
@@ -6958,7 +6962,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if use_empty_list_consensus {
             let mut narrowed_result: Option<(Type<'db>, Self)> = None;
-            let mut candidates_agree = true;
+            let mut candidates_agree = !has_dynamic_narrow_target;
             let mut uses_empty_covariant_context = false;
 
             for narrowed_ty in narrow_targets {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6909,14 +6909,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             InferenceRegion::Expression(current_expr, _) => {
                 current_expr.node_ref(db).index() == *collection_expr.node_index()
             }
-            InferenceRegion::Definition(definition) => {
-                let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
-                    return false;
-                };
-                assignment.value(self.module()).is_some_and(|value| {
-                    value.node_index().load() == collection_expr.node_index().load()
-                })
-            }
+            InferenceRegion::Definition(definition) => matches!(
+                definition.kind(db),
+                DefinitionKind::AnnotatedAssignment(assignment)
+                    if assignment.value(self.module()).is_some_and(|value| {
+                        value.node_index().load() == collection_expr.node_index().load()
+                    })
+            ),
             _ => false,
         }
     }
@@ -6931,11 +6930,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         let db = self.db();
+        let is_inference_root =
+            collection_expr.is_some_and(|expr| self.is_collection_literal_inference_root(expr));
         let use_empty_collection_consensus =
             matches!(collection_class, KnownClass::List | KnownClass::Dict)
                 && elts.is_empty()
-                && collection_expr
-                    .is_some_and(|expr| self.is_collection_literal_inference_root(expr));
+                && is_inference_root;
 
         let mut try_narrow = |narrowed_ty| {
             let mut speculative_builder = self.speculate();
@@ -6944,7 +6944,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let (inferred_ty, uses_empty_covariant_context) = speculative_builder
                 .infer_collection_literal_impl(
                     collection_class,
-                    collection_expr,
+                    is_inference_root,
                     elts,
                     infer_elt_expression,
                     TypeContext::new(Some(narrowed_ty)),
@@ -7029,7 +7029,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     return self
                         .infer_collection_literal_impl(
                             collection_class,
-                            collection_expr,
+                            is_inference_root,
                             elts,
                             infer_elt_expression,
                             TypeContext::new(Some(common_ty)),
@@ -7051,7 +7051,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         self.infer_collection_literal_impl(
             collection_class,
-            collection_expr,
+            is_inference_root,
             elts,
             infer_elt_expression,
             tcx,
@@ -7064,7 +7064,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_collection_literal_impl<'expr, const N: usize>(
         &mut self,
         collection_class: KnownClass,
-        collection_expr: Option<ast::ExprRef<'_>>,
+        is_inference_root: bool,
         elts: &[[Option<&'expr ast::Expr>; N]],
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
@@ -7100,8 +7100,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
         let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
-        let is_inference_root =
-            collection_expr.is_some_and(|expr| self.is_collection_literal_inference_root(expr));
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7238,25 +7236,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && elts
                 .iter()
                 .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
-        let empty_covariant_context: SmallVec<[BoundTypeVarIdentity<'db>; 2]> =
-            if matches!(collection_class, KnownClass::List | KnownClass::Dict)
+        let has_empty_collection_context =
+            matches!(collection_class, KnownClass::List | KnownClass::Dict)
                 && elts.is_empty()
-                && is_inference_root
-            {
-                elt_tcx_constraints
-                    .iter()
-                    .filter_map(|(identity, ty)| {
-                        (!ty.has_dynamic(self.db())
-                            && elt_tcx_variance
-                                .get(identity)
-                                .is_some_and(|variance| variance.is_covariant()))
-                        .then_some(*identity)
-                    })
-                    .collect()
-            } else {
-                SmallVec::new()
-            };
-        let uses_empty_covariant_context = !empty_covariant_context.is_empty();
+                && is_inference_root;
+        let db = self.db();
+        let allows_empty_covariant_context = |identity| {
+            has_empty_collection_context
+                && elt_tcx_constraints
+                    .get(&identity)
+                    .is_some_and(|ty| !ty.has_dynamic(db))
+                && elt_tcx_variance
+                    .get(&identity)
+                    .is_some_and(|variance| variance.is_covariant())
+        };
+        let uses_empty_covariant_context = elt_tys
+            .clone()
+            .any(|typevar| allows_empty_covariant_context(typevar.identity(self.db())));
 
         let mut pre_inferred_elt_tys = None;
 
@@ -7275,7 +7271,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if elt_tcx_variance
                         .get(&identity)
                         .is_some_and(|variance| variance.is_covariant())
-                        && !empty_covariant_context.contains(&identity)
+                        && !allows_empty_covariant_context(identity)
                     {
                         return None;
                     }
@@ -7356,7 +7352,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if elt_tcx_variance
                 .get(&elt_ty_identity)
                 .is_some_and(|variance| variance.is_covariant())
-                && !empty_covariant_context.contains(&elt_ty_identity)
+                && !allows_empty_covariant_context(elt_ty_identity)
             {
                 continue;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -184,6 +184,11 @@ fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
 /// performance problem. For now, we optimize for memory usage.
 const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 
+struct CollectionLiteralInference<'db> {
+    ty: Type<'db>,
+    empty_covariant_context: bool,
+}
+
 /// Builder to infer all types in a region.
 ///
 /// A builder is used by creating it with [`new()`](TypeInferenceBuilder::new), and then calling
@@ -6903,6 +6908,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
     }
 
+    /// Returns whether `collection_expr` is the expression owned by the current inference region.
+    ///
+    /// This lets collection inference use an expected type for a directly assigned empty literal
+    /// without applying the same rule to empty literals nested inside another expression. An
+    /// annotated assignment uses a definition inference region, so its right-hand side also counts
+    /// as the root expression.
+    ///
+    /// ```python
+    /// from collections.abc import Sequence
+    ///
+    /// items: Sequence[int] = []
+    /// nested: Sequence[Sequence[int]] = [[]]  # The inner `[]` is not an inference root.
+    /// ```
     fn is_collection_literal_inference_root(&self, collection_expr: ast::ExprRef<'_>) -> bool {
         let db = self.db();
         match self.region {
@@ -6941,25 +6959,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut speculative_builder = self.speculate();
 
             // Attempt to infer the collection literal using the narrowed type context.
-            let (inferred_ty, uses_empty_covariant_context) = speculative_builder
-                .infer_collection_literal_impl(
-                    collection_class,
-                    is_inference_root,
-                    elts,
-                    infer_elt_expression,
-                    TypeContext::new(Some(narrowed_ty)),
-                )?;
+            let inference = speculative_builder.infer_collection_literal_impl(
+                collection_class,
+                is_inference_root,
+                elts,
+                infer_elt_expression,
+                TypeContext::new(Some(narrowed_ty)),
+            )?;
 
             // Ensure the inferred return type is assignable to the narrowed declared type.
-            if !inferred_ty.is_assignable_to(db, narrowed_ty) {
+            if !inference.ty.is_assignable_to(db, narrowed_ty) {
                 return None;
             }
 
-            Some((
-                inferred_ty,
-                speculative_builder,
-                uses_empty_covariant_context,
-            ))
+            Some((inference, speculative_builder))
         };
 
         // If the type context is a union, attempt to narrow to a specific element.
@@ -6978,16 +6991,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mut narrowed_result: Option<(Type<'db>, Self)> = None;
             let mut common_types: Option<SmallVec<[Type<'db>; 2]>> = None;
             let mut replaced_candidate_type = false;
-            let mut uses_empty_covariant_context = false;
+            let mut empty_covariant_context = false;
 
             for narrowed_ty in narrow_targets {
-                let Some((inferred_ty, speculative_builder, candidate_uses_covariant_context)) =
-                    try_narrow(*narrowed_ty)
-                else {
+                let Some((inference, speculative_builder)) = try_narrow(*narrowed_ty) else {
                     continue;
                 };
 
-                let Some(specialization) = inferred_ty.known_specialization(db, collection_class)
+                let Some(specialization) = inference.ty.known_specialization(db, collection_class)
                 else {
                     continue;
                 };
@@ -7010,8 +7021,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 } else {
                     common_types = Some(candidate_types);
                 }
-                uses_empty_covariant_context |= candidate_uses_covariant_context;
-                narrowed_result.get_or_insert((inferred_ty, speculative_builder));
+                empty_covariant_context |= inference.empty_covariant_context;
+                narrowed_result.get_or_insert((inference.ty, speculative_builder));
             }
 
             if let Some((inferred_ty, speculative_builder)) = narrowed_result {
@@ -7020,7 +7031,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     replaced_candidate_type = true;
                 }
 
-                if uses_empty_covariant_context
+                if empty_covariant_context
                     && replaced_candidate_type
                     && let Some(common_types) = common_types
                 {
@@ -7034,7 +7045,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             infer_elt_expression,
                             TypeContext::new(Some(common_ty)),
                         )
-                        .map(|(ty, _)| ty);
+                        .map(|inference| inference.ty);
                 }
 
                 self.extend(speculative_builder);
@@ -7042,9 +7053,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         } else {
             for narrowed_ty in narrow_targets {
-                if let Some((inferred_ty, speculative_builder, _)) = try_narrow(*narrowed_ty) {
+                if let Some((inference, speculative_builder)) = try_narrow(*narrowed_ty) {
                     self.extend(speculative_builder);
-                    return Some(inferred_ty);
+                    return Some(inference.ty);
                 }
             }
         }
@@ -7056,7 +7067,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             infer_elt_expression,
             tcx,
         )
-        .map(|(ty, _)| ty)
+        .map(|inference| inference.ty)
     }
 
     // Infer the type of a collection literal expression and whether it uses a fully static,
@@ -7068,7 +7079,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         elts: &[[Option<&'expr ast::Expr>; N]],
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
-    ) -> Option<(Type<'db>, bool)> {
+    ) -> Option<CollectionLiteralInference<'db>> {
         // Extract the type variable `T` from `list[T]` in typeshed.
         let elt_tys = |collection_class: KnownClass| {
             let collection_alias = collection_class
@@ -7250,7 +7261,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .get(&identity)
                     .is_some_and(|variance| variance.is_covariant())
         };
-        let uses_empty_covariant_context = elt_tys
+        let empty_covariant_context = elt_tys
             .clone()
             .any(|typevar| allows_empty_covariant_context(typevar.identity(self.db())));
 
@@ -7315,9 +7326,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .specialize_recursive(self.db(), specialization.into_iter().map(Some))
                     },
                 );
-                return Type::from(class_type)
-                    .to_instance(self.db())
-                    .map(|ty| (ty, uses_empty_covariant_context));
+                return Type::from(class_type).to_instance(self.db()).map(|ty| {
+                    CollectionLiteralInference {
+                        ty,
+                        empty_covariant_context,
+                    }
+                });
             }
 
             pre_inferred_elt_tys = Some(inferred_elts);
@@ -7560,7 +7574,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         Type::from(class_type)
             .to_instance(self.db())
-            .map(|ty| (ty, uses_empty_covariant_context))
+            .map(|ty| CollectionLiteralInference {
+                ty,
+                empty_covariant_context,
+            })
     }
 
     /// Infer the type of the `iter` expression of the first comprehension.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6913,39 +6913,92 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         let db = self.db();
+        let use_empty_list_consensus = collection_class == KnownClass::List
+            && elts.is_empty()
+            && collection_expr.is_some_and(|collection_expr| {
+                matches!(
+                    self.region,
+                    InferenceRegion::Expression(current_expr, _)
+                        if current_expr.node_ref(db).index() == *collection_expr.node_index()
+                )
+            });
 
         let mut try_narrow = |narrowed_ty| {
             let mut speculative_builder = self.speculate();
 
             // Attempt to infer the collection literal using the narrowed type context.
-            let inferred_ty = speculative_builder.infer_collection_literal_impl(
-                collection_class,
-                collection_expr,
-                elts,
-                infer_elt_expression,
-                TypeContext::new(Some(narrowed_ty)),
-            )?;
+            let (inferred_ty, uses_empty_covariant_context) = speculative_builder
+                .infer_collection_literal_impl(
+                    collection_class,
+                    collection_expr,
+                    elts,
+                    infer_elt_expression,
+                    TypeContext::new(Some(narrowed_ty)),
+                )?;
 
             // Ensure the inferred return type is assignable to the narrowed declared type.
             if !inferred_ty.is_assignable_to(db, narrowed_ty) {
                 return None;
             }
 
-            // Successfully narrowed to an element of the union.
-            self.extend(speculative_builder);
-            Some(inferred_ty)
+            Some((
+                inferred_ty,
+                speculative_builder,
+                uses_empty_covariant_context,
+            ))
         };
 
         // If the type context is a union, attempt to narrow to a specific element.
-        for narrowed_ty in tcx
-            .narrow_targets(db)
+        let narrow_targets = tcx.narrow_targets(db);
+        let narrow_targets = narrow_targets
             .as_deref()
             .into_iter()
             .flatten()
-            .filter(|ty| ty.class_specialization(db).is_some())
-        {
-            if let Some(result) = try_narrow(*narrowed_ty) {
-                return Some(result);
+            .filter(|ty| ty.class_specialization(db).is_some());
+
+        if use_empty_list_consensus {
+            let mut narrowed_result = None;
+            let mut candidates_agree = true;
+            let mut uses_empty_covariant_context = false;
+
+            for narrowed_ty in narrow_targets {
+                let Some((inferred_ty, speculative_builder, candidate_uses_covariant_context)) =
+                    try_narrow(*narrowed_ty)
+                else {
+                    continue;
+                };
+
+                if let Some((previous_ty, _)) = &narrowed_result
+                    && inferred_ty != *previous_ty
+                {
+                    candidates_agree = false;
+                }
+                uses_empty_covariant_context |= candidate_uses_covariant_context;
+                narrowed_result.get_or_insert((inferred_ty, speculative_builder));
+            }
+
+            if let Some((inferred_ty, speculative_builder)) = narrowed_result {
+                if uses_empty_covariant_context && !candidates_agree {
+                    return self
+                        .infer_collection_literal_impl(
+                            collection_class,
+                            collection_expr,
+                            elts,
+                            infer_elt_expression,
+                            TypeContext::default(),
+                        )
+                        .map(|(ty, _)| ty);
+                }
+
+                self.extend(speculative_builder);
+                return Some(inferred_ty);
+            }
+        } else {
+            for narrowed_ty in narrow_targets {
+                if let Some((inferred_ty, speculative_builder, _)) = try_narrow(*narrowed_ty) {
+                    self.extend(speculative_builder);
+                    return Some(inferred_ty);
+                }
             }
         }
 
@@ -6956,9 +7009,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             infer_elt_expression,
             tcx,
         )
+        .map(|(ty, _)| ty)
     }
 
-    // Infer the type of a collection literal expression.
+    // Infer the type of a collection literal expression and whether it uses a fully static,
+    // covariant context for a directly contextualized empty list.
     fn infer_collection_literal_impl<'expr, const N: usize>(
         &mut self,
         collection_class: KnownClass,
@@ -6966,7 +7021,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         elts: &[[Option<&'expr ast::Expr>; N]],
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
-    ) -> Option<Type<'db>> {
+    ) -> Option<(Type<'db>, bool)> {
         // Extract the type variable `T` from `list[T]` in typeshed.
         let elt_tys = |collection_class: KnownClass| {
             let collection_alias = collection_class
@@ -6998,6 +7053,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
         let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
+        let inference_root = collection_expr.and_then(|collection_expr| match self.region {
+            InferenceRegion::Expression(current_expr, _)
+                if current_expr.node_ref(self.db()).index() == *collection_expr.node_index() =>
+            {
+                Some(current_expr)
+            }
+            _ => None,
+        });
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7134,6 +7197,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && elts
                 .iter()
                 .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
+        let uses_empty_covariant_context = collection_class == KnownClass::List
+            && elts.is_empty()
+            && inference_root.is_some()
+            && elt_tcx_constraints.len() == 1
+            && elt_tcx_constraints
+                .values()
+                .all(|ty| !ty.has_dynamic(self.db()))
+            && elt_tcx_variance
+                .values()
+                .any(|variance| variance.is_covariant());
 
         let mut pre_inferred_elt_tys = None;
 
@@ -7152,6 +7225,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if elt_tcx_variance
                         .get(&identity)
                         .is_some_and(|variance| variance.is_covariant())
+                        && !uses_empty_covariant_context
                     {
                         return None;
                     }
@@ -7195,7 +7269,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .specialize_recursive(self.db(), specialization.into_iter().map(Some))
                     },
                 );
-                return Type::from(class_type).to_instance(self.db());
+                return Type::from(class_type)
+                    .to_instance(self.db())
+                    .map(|ty| (ty, uses_empty_covariant_context));
             }
 
             pre_inferred_elt_tys = Some(inferred_elts);
@@ -7230,6 +7306,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if elt_tcx_variance
                 .get(&elt_ty_identity)
                 .is_some_and(|variance| variance.is_covariant())
+                && !uses_empty_covariant_context
             {
                 continue;
             }
@@ -7244,9 +7321,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if tcx.annotation.is_none()
-            && let Some(collection_expr) = collection_expr
-            && let InferenceRegion::Expression(current_expr, _) = self.region
-            && current_expr.node_ref(self.db()).index() == *collection_expr.node_index()
+            && let Some(current_expr) = inference_root
             && let Some(assignment) = current_expr.assigned_to(self.db())
             && let Ok(collection_def) =
                 DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()
@@ -7436,7 +7511,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             });
 
-        Type::from(class_type).to_instance(self.db())
+        Type::from(class_type)
+            .to_instance(self.db())
+            .map(|ty| (ty, uses_empty_covariant_context))
     }
 
     /// Infer the type of the `iter` expression of the first comprehension.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6957,7 +6957,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .filter(|ty| ty.class_specialization(db).is_some());
 
         if use_empty_list_consensus {
-            let mut narrowed_result = None;
+            let mut narrowed_result: Option<(Type<'db>, Self)> = None;
             let mut candidates_agree = true;
             let mut uses_empty_covariant_context = false;
 
@@ -6968,10 +6968,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 };
 
-                if let Some((previous_ty, _)) = &narrowed_result
-                    && inferred_ty != *previous_ty
-                {
-                    candidates_agree = false;
+                if let Some((previous_ty, _)) = &narrowed_result {
+                    candidates_agree &=
+                        if inferred_ty.has_dynamic(db) || previous_ty.has_dynamic(db) {
+                            inferred_ty == *previous_ty
+                        } else {
+                            inferred_ty.is_equivalent_to(db, *previous_ty)
+                        };
                 }
                 uses_empty_covariant_context |= candidate_uses_covariant_context;
                 narrowed_result.get_or_insert((inferred_ty, speculative_builder));

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6931,9 +6931,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
         let db = self.db();
-        let use_empty_list_consensus = collection_class == KnownClass::List
-            && elts.is_empty()
-            && collection_expr.is_some_and(|expr| self.is_collection_literal_inference_root(expr));
+        let use_empty_collection_consensus =
+            matches!(collection_class, KnownClass::List | KnownClass::Dict)
+                && elts.is_empty()
+                && collection_expr
+                    .is_some_and(|expr| self.is_collection_literal_inference_root(expr));
 
         let mut try_narrow = |narrowed_ty| {
             let mut speculative_builder = self.speculate();
@@ -6962,7 +6964,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = tcx.narrow_targets(db);
-        let has_dynamic_narrow_target = use_empty_list_consensus
+        let has_dynamic_narrow_target = use_empty_collection_consensus
             && narrow_targets
                 .as_deref()
                 .is_some_and(|targets| targets.iter().any(Type::is_dynamic));
@@ -6972,9 +6974,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .flatten()
             .filter(|ty| ty.class_specialization(db).is_some());
 
-        if use_empty_list_consensus {
+        if use_empty_collection_consensus {
             let mut narrowed_result: Option<(Type<'db>, Self)> = None;
-            let mut candidates_agree = !has_dynamic_narrow_target;
+            let mut common_types: Option<SmallVec<[Type<'db>; 2]>> = None;
+            let mut replaced_candidate_type = false;
             let mut uses_empty_covariant_context = false;
 
             for narrowed_ty in narrow_targets {
@@ -6984,27 +6987,52 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 };
 
-                if let Some((previous_ty, _)) = &narrowed_result {
-                    candidates_agree &=
-                        if inferred_ty.has_dynamic(db) || previous_ty.has_dynamic(db) {
-                            inferred_ty == *previous_ty
-                        } else {
-                            inferred_ty.is_equivalent_to(db, *previous_ty)
-                        };
+                let Some(specialization) = inferred_ty.known_specialization(db, collection_class)
+                else {
+                    continue;
+                };
+                let candidate_types: SmallVec<[Type<'db>; 2]> =
+                    specialization.types(db).iter().copied().collect();
+
+                if let Some(common_types) = &mut common_types {
+                    for (common_ty, candidate_ty) in common_types.iter_mut().zip(candidate_types) {
+                        let candidates_agree =
+                            if common_ty.has_dynamic(db) || candidate_ty.has_dynamic(db) {
+                                *common_ty == candidate_ty
+                            } else {
+                                common_ty.is_equivalent_to(db, candidate_ty)
+                            };
+                        if !candidates_agree {
+                            *common_ty = Type::unknown();
+                            replaced_candidate_type = true;
+                        }
+                    }
+                } else {
+                    common_types = Some(candidate_types);
                 }
                 uses_empty_covariant_context |= candidate_uses_covariant_context;
                 narrowed_result.get_or_insert((inferred_ty, speculative_builder));
             }
 
             if let Some((inferred_ty, speculative_builder)) = narrowed_result {
-                if uses_empty_covariant_context && !candidates_agree {
+                if has_dynamic_narrow_target && let Some(common_types) = &mut common_types {
+                    common_types.fill(Type::unknown());
+                    replaced_candidate_type = true;
+                }
+
+                if uses_empty_covariant_context
+                    && replaced_candidate_type
+                    && let Some(common_types) = common_types
+                {
+                    let common_ty =
+                        collection_class.to_specialized_instance(db, common_types.as_slice());
                     return self
                         .infer_collection_literal_impl(
                             collection_class,
                             collection_expr,
                             elts,
                             infer_elt_expression,
-                            TypeContext::default(),
+                            TypeContext::new(Some(common_ty)),
                         )
                         .map(|(ty, _)| ty);
                 }
@@ -7032,7 +7060,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     // Infer the type of a collection literal expression and whether it uses a fully static,
-    // covariant context for a directly contextualized empty list.
+    // covariant context for a directly contextualized empty list or dictionary.
     fn infer_collection_literal_impl<'expr, const N: usize>(
         &mut self,
         collection_class: KnownClass,
@@ -7210,16 +7238,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && elts
                 .iter()
                 .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
-        let uses_empty_covariant_context = collection_class == KnownClass::List
-            && elts.is_empty()
-            && is_inference_root
-            && elt_tcx_constraints.len() == 1
-            && elt_tcx_constraints
-                .values()
-                .all(|ty| !ty.has_dynamic(self.db()))
-            && elt_tcx_variance
-                .values()
-                .any(|variance| variance.is_covariant());
+        let empty_covariant_context: SmallVec<[BoundTypeVarIdentity<'db>; 2]> =
+            if matches!(collection_class, KnownClass::List | KnownClass::Dict)
+                && elts.is_empty()
+                && is_inference_root
+            {
+                elt_tcx_constraints
+                    .iter()
+                    .filter_map(|(identity, ty)| {
+                        (!ty.has_dynamic(self.db())
+                            && elt_tcx_variance
+                                .get(identity)
+                                .is_some_and(|variance| variance.is_covariant()))
+                        .then_some(*identity)
+                    })
+                    .collect()
+            } else {
+                SmallVec::new()
+            };
+        let uses_empty_covariant_context = !empty_covariant_context.is_empty();
 
         let mut pre_inferred_elt_tys = None;
 
@@ -7238,7 +7275,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     if elt_tcx_variance
                         .get(&identity)
                         .is_some_and(|variance| variance.is_covariant())
-                        && !uses_empty_covariant_context
+                        && !empty_covariant_context.contains(&identity)
                     {
                         return None;
                     }
@@ -7319,7 +7356,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if elt_tcx_variance
                 .get(&elt_ty_identity)
                 .is_some_and(|variance| variance.is_covariant())
-                && !uses_empty_covariant_context
+                && !empty_covariant_context.contains(&elt_ty_identity)
             {
                 continue;
             }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6903,6 +6903,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         })
     }
 
+    fn is_collection_literal_inference_root(&self, collection_expr: ast::ExprRef<'_>) -> bool {
+        let db = self.db();
+        match self.region {
+            InferenceRegion::Expression(current_expr, _) => {
+                current_expr.node_ref(db).index() == *collection_expr.node_index()
+            }
+            InferenceRegion::Definition(definition) => {
+                let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
+                    return false;
+                };
+                assignment.value(self.module()).is_some_and(|value| {
+                    value.node_index().load() == collection_expr.node_index().load()
+                })
+            }
+            _ => false,
+        }
+    }
+
     // Infer the type of a collection literal expression.
     fn infer_collection_literal<'expr, const N: usize>(
         &mut self,
@@ -6915,13 +6933,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let use_empty_list_consensus = collection_class == KnownClass::List
             && elts.is_empty()
-            && collection_expr.is_some_and(|collection_expr| {
-                matches!(
-                    self.region,
-                    InferenceRegion::Expression(current_expr, _)
-                        if current_expr.node_ref(db).index() == *collection_expr.node_index()
-                )
-            });
+            && collection_expr.is_some_and(|expr| self.is_collection_literal_inference_root(expr));
 
         let mut try_narrow = |narrowed_ty| {
             let mut speculative_builder = self.speculate();
@@ -7060,14 +7072,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
         let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
-        let inference_root = collection_expr.and_then(|collection_expr| match self.region {
-            InferenceRegion::Expression(current_expr, _)
-                if current_expr.node_ref(self.db()).index() == *collection_expr.node_index() =>
-            {
-                Some(current_expr)
-            }
-            _ => None,
-        });
+        let is_inference_root =
+            collection_expr.is_some_and(|expr| self.is_collection_literal_inference_root(expr));
 
         // Remove any union elements of that are unrelated to the collection type.
         //
@@ -7206,7 +7212,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .any(|elts| matches!(elts.as_slice(), [None, Some(_)]));
         let uses_empty_covariant_context = collection_class == KnownClass::List
             && elts.is_empty()
-            && inference_root.is_some()
+            && is_inference_root
             && elt_tcx_constraints.len() == 1
             && elt_tcx_constraints
                 .values()
@@ -7328,7 +7334,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if tcx.annotation.is_none()
-            && let Some(current_expr) = inference_root
+            && is_inference_root
+            && let InferenceRegion::Expression(current_expr, _) = self.region
             && let Some(assignment) = current_expr.assigned_to(self.db())
             && let Ok(collection_def) =
                 DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()


### PR DESCRIPTION
## Summary

Prior to this change, an empty list or dictionary did not use its surrounding collection annotation to fill in missing element types:

```python
from collections.abc import Mapping, Sequence

items: Sequence[int] = []
mapping: Mapping[str, int] = {}

reveal_type(items)  # main: list[Unknown]; this PR: list[int]
reveal_type(mapping)  # main: dict[str, Unknown]; this PR: dict[str, int]
```

With this change, an empty list or dictionary can take its element types from the type expected at that location. In the example above, `Sequence[int]` supplies `int` for the list, while `Mapping[str, int]` supplies `str` and `int` for the dictionary. This applies when the empty literal is assigned directly, including in an annotated assignment or in a fallback like `if items is None: items = []`.

If an empty literal matches several members of a union, we keep only the parts on which every member agrees. For example, `Mapping[str, int] | Mapping[str, bytes]` gives `{}` the type `dict[str, Unknown]`: both mappings agree on the key type, but not the value type. `Any` and `Unknown` keep the result conservative.

Closes https://github.com/astral-sh/ty/issues/3258.
