### PR TITLE
[ty] Recover from dynamic class code generator cycles

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/3720_dynamic_class_codegen_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3720_dynamic_class_codegen_cycle.md
@@ -1,0 +1,25 @@
+# Regression test for #3720
+
+Regression test for [this issue](https://github.com/astral-sh/ty/issues/3720).
+
+Computing the code generator (dataclass-like / namedtuple-like behavior) of a dynamically created
+class (`type(...)`) whose bases refer back to the class could form a Salsa query cycle through
+`code_generator_of_dynamic_class`, panicking with `dependency graph cycle`. The query now recovers
+from cycles the same way its static-class sibling does (`cycle_initial=|_, _, _| None`), so checking
+this fuzzer-discovered snippet must not panic.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from abc import ABC
+from typing import NamedTuple
+
+# error: [invalid-argument-type] "Invalid argument to parameter 2 (`bases`) of `type()`"
+# error: [invalid-named-tuple] "is not a valid identifier"
+T = type("T", NamedTuple("T", [("", "T")]), {})
+T()
+T = ABC
+```

--- a/crates/ty_python_semantic/resources/mdtest/regression/3720_dynamic_class_codegen_cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3720_dynamic_class_codegen_cycle.md
@@ -2,12 +2,6 @@
 
 Regression test for [this issue](https://github.com/astral-sh/ty/issues/3720).
 
-Computing the code generator (dataclass-like / namedtuple-like behavior) of a dynamically created
-class (`type(...)`) whose bases refer back to the class could form a Salsa query cycle through
-`code_generator_of_dynamic_class`, panicking with `dependency graph cycle`. The query now recovers
-from cycles the same way its static-class sibling does (`cycle_initial=|_, _, _| None`), so checking
-this fuzzer-discovered snippet must not panic.
-
 ```toml
 [environment]
 python-version = "3.12"

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -154,7 +154,9 @@ impl<'db> CodeGeneratorKind<'db> {
     }
 
     fn from_dynamic_class(db: &'db dyn Db, class: DynamicClassLiteral<'db>) -> Option<Self> {
-        #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(cycle_initial=|_, _, _| None,
+            heap_size=ruff_memory_usage::heap_size
+        )]
         fn code_generator_of_dynamic_class<'db>(
             db: &'db dyn Db,
             class: DynamicClassLiteral<'db>,


### PR DESCRIPTION
## Summary

Determining whether a dynamically created class has dataclass- or named-tuple-like behavior can re-enter the same query while resolving a self-referential base:

```python
from abc import ABC
from typing import NamedTuple

T = type("T", NamedTuple("T", [("", "T")]), {})
T()
T = ABC
```

Prior to this change, `code_generator_of_dynamic_class` had no cycle recovery, so this input panicked with `dependency graph cycle`. This applies the same recovery used for static classes, treating a cyclic result as having no code generator rather than panicking.

Closes https://github.com/astral-sh/ty/issues/3720.
