### PR TITLE
[ty] Reason about runtime object identity for is/is-not with NewTypes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/is.md
@@ -251,3 +251,57 @@ def h(x: object):
     else:
         reveal_type(x)  # revealed: None
 ```
+
+## `is` with `NewType` operands
+
+A `NewType` is transparent at runtime (`NewType("N", Base)(v)` returns `v` unchanged), so two
+variables whose declared types are *type-level disjoint* can still refer to the same runtime
+object. `is` narrowing must therefore not collapse such operands to `Never`. This is a regression
+test for <https://github.com/astral-sh/ty/issues/3552>.
+
+```py
+from typing import Literal, NewType, final
+
+class Foo: ...
+
+FooNewType1 = NewType("FooNewType1", Foo)
+FooNewType2 = NewType("FooNewType2", Foo)
+
+# `FooNewType1` and `FooNewType2` are type-disjoint, but both wrap `Foo`, so `foo1 is foo2` can be
+# `True` at runtime. Neither operand should be narrowed to `Never`.
+def two_newtypes_same_base(foo1: FooNewType1, foo2: FooNewType2):
+    if foo1 is foo2:
+        reveal_type(foo1)  # revealed: FooNewType1
+        reveal_type(foo2)  # revealed: FooNewType2
+
+BoolNewType = NewType("BoolNewType", bool)
+IntNewType = NewType("IntNewType", int)
+
+# A `NewType` over a literal's type is not disjoint from the literal at runtime either.
+def newtype_over_literal(true: Literal[True], one: Literal[1]):
+    if BoolNewType(true) is true:
+        reveal_type(true)  # revealed: Literal[True]
+    if IntNewType(one) is one:
+        reveal_type(one)  # revealed: Literal[1]
+```
+
+But genuinely disjoint runtime value sets must still narrow to `Never`: two distinct `@final`
+classes can never share an object, so neither can `NewType`s over them.
+
+```py
+from typing import NewType, final
+
+@final
+class FinalFoo: ...
+
+@final
+class FinalBar: ...
+
+FinalFooNewType = NewType("FinalFooNewType", FinalFoo)
+FinalBarNewType = NewType("FinalBarNewType", FinalBar)
+
+def final_disjoint_bases(f: FinalFooNewType, b: FinalBarNewType):
+    if f is b:
+        reveal_type(f)  # revealed: Never
+        reveal_type(b)  # revealed: Never
+```

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -149,7 +149,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
             ast::CmpOp::Is => {
-                if left.is_disjoint_from(db, right) {
+                // Use runtime-object disjointness, not type-level disjointness: two type-disjoint
+                // operands can still be the same runtime object across transparent `NewType`s, so
+                // `x is y` is not statically `False` in that case (see ty#3552).
+                if left.is_runtime_object_disjoint_from(db, right) {
                     Ok(Type::bool_literal(false))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
                     Ok(Type::bool_literal(true))
@@ -158,7 +161,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 }
             }
             ast::CmpOp::IsNot => {
-                if left.is_disjoint_from(db, right) {
+                if left.is_runtime_object_disjoint_from(db, right) {
                     Ok(Type::bool_literal(true))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
                     Ok(Type::bool_literal(false))

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1370,7 +1370,22 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     None
                 }
             }
-            ast::CmpOp::Is => Some(rhs_ty),
+            ast::CmpOp::Is => {
+                // Narrowing `x is y` intersects each operand's type with the other's. When the two
+                // types are type-level disjoint, that intersection collapses to `Never`. But that
+                // collapse is wrong when the operands could still point to the *same* runtime
+                // object -- most importantly across `NewType` boundaries, which are transparent at
+                // runtime. Suppress narrowing (keep the original type) in exactly that case;
+                // otherwise narrow as before, so ordinary cases like `Foo | Bar is Foo` -> `Foo`
+                // are unaffected.
+                if lhs_ty.is_disjoint_from(self.db, rhs_ty)
+                    && !lhs_ty.is_runtime_object_disjoint_from(self.db, rhs_ty)
+                {
+                    None
+                } else {
+                    Some(rhs_ty)
+                }
+            }
             ast::CmpOp::In => self.evaluate_expr_in(lhs_ty, rhs_ty),
             ast::CmpOp::NotIn => self.evaluate_expr_not_in(lhs_ty, rhs_ty),
             _ => None,

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -685,6 +685,33 @@ impl<'db> Type<'db> {
             .is_always_satisfied(db)
     }
 
+    /// Peel `NewType` transparency from this type.
+    ///
+    /// A `NewType` is a no-op at runtime: `NewType("N", Base)(v)` returns `v` unchanged, so a
+    /// value of `N` is indistinguishable at runtime from a value of `Base`. This maps a type to
+    /// the type its runtime objects actually inhabit, descending through unions.
+    /// (`NewType::concrete_base_type` already collapses a `NewType`-of-`NewType` chain.)
+    pub(crate) fn peel_newtype_transparency(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db),
+            Type::Union(union) => union.map(db, |element| (*element).peel_newtype_transparency(db)),
+            _ => self,
+        }
+    }
+
+    /// Return `true` if no two inhabitants of `self` and `other` can ever be the *same* runtime
+    /// object.
+    ///
+    /// Unlike [`Type::is_disjoint_from`], this peels `NewType` transparency first: two
+    /// type-level-disjoint `NewType`s (e.g. `NewType("A", Foo)` and `NewType("B", Foo)`) can still
+    /// wrap one and the same underlying runtime object, so they are *not* runtime-object-disjoint.
+    /// `is`/`is not` comparisons and identity narrowing must reason about runtime-object identity
+    /// rather than type-level disjointness (see ty#3552).
+    pub(crate) fn is_runtime_object_disjoint_from(self, db: &'db dyn Db, other: Type<'db>) -> bool {
+        self.peel_newtype_transparency(db)
+            .is_disjoint_from(db, other.peel_newtype_transparency(db))
+    }
+
     pub(crate) fn when_disjoint_from<'c>(
         self,
         db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Fixes astral-sh/ty#3552.

A `NewType` is transparent at runtime — `NewType("N", Base)(v)` returns `v` unchanged — so two variables whose declared types are *type-level disjoint* can still point to the **same** runtime object. ty previously reasoned about `is`/`is not` using type-level disjointness, which gave two wrong results:

```python
from typing import NewType, Literal

class Foo: ...
FooNewType1 = NewType("FooNewType1", Foo)
FooNewType2 = NewType("FooNewType2", Foo)

def f(foo1: FooNewType1, foo2: FooNewType2):
    if foo1 is foo2:        # can be `True` at runtime
        reveal_type(foo1)   # was: Never  ->  now: FooNewType1
        reveal_type(foo2)   # was: Never  ->  now: FooNewType2

BoolNewType = NewType("BoolNewType", bool)
def g(true: Literal[True]):
    if BoolNewType(true) is true:   # `True` at runtime
        reveal_type(true)           # was: Never  ->  now: Literal[True]
```

`FooNewType1` and `FooNewType2` are correctly *disjoint* types, but concluding that no object can inhabit both — so `is` must be `False`, the branch is unreachable, and the operands are `Never` — is unsound across a `NewType` boundary.

## Fix

Add `Type::is_runtime_object_disjoint_from`, which peels `NewType` transparency (via `concrete_base_type`, descending through unions) before checking `is_disjoint_from`, and use it in two places:

1. **`is`/`is not` comparison inference** (`types/infer/comparisons.rs`): infer `bool` instead of a static `Literal[False]`/`Literal[True]` when the operands could be the same runtime object, so the branch is no longer treated as unreachable.
2. **`is` narrowing** (`types/narrow.rs`): don't narrow an operand to the `Never` intersection when the two operands are type-disjoint but could share a runtime object.

The type-level intersection simplification (`FooNewType1 & FooNewType2` → `Never`) is unchanged and still correct. Genuinely disjoint runtime value sets — e.g. `NewType`s over two distinct `@final` classes — still narrow to `Never`. For any pair not involving a `NewType`, `is_runtime_object_disjoint_from` is identical to `is_disjoint_from`, so behavior is unchanged outside `NewType`s.

## Test Plan

- New regression section in `narrow/conditionals/is.md` covering the same-base-`NewType`, `NewType`-over-`Literal`, and the `@final` (still-`Never`) cases.
- `cargo test -p ty_python_semantic --test mdtest` → **464 passed, 0 failed**.
- `cargo clippy -p ty_python_semantic --all-targets` → clean; `rustfmt --check` → clean.
