### PR TITLE
[ty] Infer annotation expressions under value semantics

### DIFF
--- a/crates/ty_ide/src/provide_type.rs
+++ b/crates/ty_ide/src/provide_type.rs
@@ -2,7 +2,7 @@ use crate::Db;
 use ruff_db::files::File;
 use ruff_text_size::TextRange;
 use ty_python_semantic::SemanticModel;
-use ty_python_semantic::types::print_type;
+use ty_python_semantic::types::{TypeFormType, print_type};
 
 /// Returns the endpoint-specific public type representation for the requested range.
 ///
@@ -10,6 +10,11 @@ use ty_python_semantic::types::print_type;
 pub fn provide_type(db: &dyn Db, file: File, range: TextRange) -> Option<String> {
     let model = SemanticModel::new(db, file);
     let ty = model.inferred_type_at(range)?;
+    let ty = if model.is_type_expression_at(range) {
+        TypeFormType::from_type_expression(db, ty)
+    } else {
+        ty
+    };
 
     print_type(db, ty).ok()
 }
@@ -115,9 +120,114 @@ mod tests {
             "#,
         );
 
-        // TODO: This should be `ty_extensions.TypeOf[builtins.int]` once semantic lookup can
-        // infer the runtime value type of a name in an annotation.
-        assert_snapshot!(test.provided_type(), @"builtins.int");
+        assert_snapshot!(
+            test.provided_type(),
+            @"typing.TypeForm[builtins.int]"
+        );
+    }
+
+    #[test]
+    fn provide_annotated_subexpressions() {
+        let annotation = ProvideTypeTest::with_source(
+            r#"
+            from typing import Annotated
+
+            value: <START>Annotated[int, list[str]]<END>
+            "#,
+        );
+        assert_snapshot!(
+            annotation.provided_type(),
+            @"typing.TypeForm[builtins.int]"
+        );
+
+        let literal_argument = ProvideTypeTest::with_source(
+            r#"
+            from typing import Literal
+
+            value: Literal[<START>1<END>]
+            "#,
+        );
+        assert_snapshot!(literal_argument.provided_type(), @"typing.Literal[1]");
+
+        let annotated_literal_type = ProvideTypeTest::with_source(
+            r#"
+            from typing import Annotated, Literal
+
+            value: Annotated[<START>Literal[1]<END>, 1]
+            "#,
+        );
+        assert_snapshot!(
+            annotated_literal_type.provided_type(),
+            @"typing.TypeForm[typing.Literal[1]]"
+        );
+
+        let annotated_literal_metadata = ProvideTypeTest::with_source(
+            r#"
+            from typing import Annotated, Literal
+
+            value: Annotated[Literal[1], <START>1<END>]
+            "#,
+        );
+        assert_snapshot!(
+            annotated_literal_metadata.provided_type(),
+            @"typing.Literal[1]"
+        );
+    }
+
+    #[test]
+    fn provide_string_annotation_subexpressions() {
+        let type_argument = ProvideTypeTest::with_source(
+            r#"
+            from typing import Annotated
+
+            value: "Annotated[<START>int<END>, list[str]]"
+            "#,
+        );
+        assert_snapshot!(
+            type_argument.provided_type(),
+            @"typing.TypeForm[builtins.int]"
+        );
+
+        let metadata = ProvideTypeTest::with_source(
+            r#"
+            from typing import Annotated
+
+            value: "Annotated[int, <START>list[str]<END>]"
+            "#,
+        );
+        assert_snapshot!(
+            metadata.provided_type(),
+            @"ty_extensions.TypeOf[builtins.list[builtins.str]]"
+        );
+    }
+
+    #[test]
+    fn provide_non_annotation_type_expressions() {
+        let cast = ProvideTypeTest::with_source(
+            r#"
+            from typing import cast
+
+            value = cast(<START>list[int]<END>, [])
+            "#,
+        );
+
+        assert_snapshot!(
+            cast.provided_type(),
+            @"typing.TypeForm[builtins.list[builtins.int]]"
+        );
+
+        let typevar_keyword = ProvideTypeTest::with_source(
+            r#"
+            from typing import TypeVar
+
+            T = TypeVar("T", <START>bound<END>=int)
+            "#,
+        );
+
+        assert_snapshot!(
+            typevar_keyword.provided_type(),
+            @"typing.TypeForm[builtins.int]"
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -395,6 +395,57 @@ impl<'db> SemanticModel<'db> {
         self.inferred_type_for_covering_node(&target, range)
     }
 
+    /// Returns whether the inferred type at `range` is the result of evaluating a type
+    /// expression.
+    pub fn is_type_expression_at(&self, range: TextRange) -> bool {
+        let parsed = parsed_module(self.db, self.file).load(self.db);
+        let Some(target) = covering_type_node(parsed.syntax().into(), range) else {
+            return false;
+        };
+        self.is_type_expression_for_covering_node(&target, range)
+    }
+
+    fn is_type_expression_for_covering_node(
+        &self,
+        target: &CoveringNode<'_>,
+        range: TextRange,
+    ) -> bool {
+        let expression = match (target.node(), target.parent()) {
+            (ast::AnyNodeRef::Identifier(identifier), Some(ast::AnyNodeRef::Keyword(keyword)))
+                if keyword
+                    .arg
+                    .as_ref()
+                    .is_some_and(|argument| argument.range == identifier.range) =>
+            {
+                Some(ExprRef::from(&keyword.value))
+            }
+            (ast::AnyNodeRef::ExprStringLiteral(string_expr), _) => {
+                if let Some((parsed, model)) = self.enter_string_annotation(string_expr)
+                    && let Some(target) = covering_type_node(parsed.syntax().into(), range)
+                {
+                    return model.is_type_expression_for_covering_node(&target, range);
+                }
+                return false;
+            }
+            (node, parent) => node
+                .as_expr_ref()
+                .or_else(|| parent.and_then(ast::AnyNodeRef::as_expr_ref)),
+        };
+
+        expression.is_some_and(|expression| self.expression_is_type_expression(expression))
+    }
+
+    fn expression_is_type_expression(&self, expression: ExprRef<'_>) -> bool {
+        let index = semantic_index(self.db, self.file);
+        let Some(file_scope) = index.try_expression_scope_id(&self.expr_ref_in_ast(expression))
+        else {
+            return false;
+        };
+        let scope = file_scope.to_scope_id(self.db, self.file);
+
+        infer_complete_scope_types(self.db, scope).is_type_expression(expression)
+    }
+
     /// Returns the inferred type for an already resolved covering node.
     ///
     /// `range` identifies the selected part of compound targets such as dotted module names and

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -82,6 +82,8 @@ bitflags::bitflags! {
     pub(crate) struct TypeExpressionFlags: u8 {
         /// The expression is syntactically an `Unpack[...]` type expression.
         const UNPACK = 1 << 0;
+        /// The expression is evaluated as a type expression.
+        const TYPE_EXPRESSION = 1 << 1;
     }
 }
 
@@ -896,6 +898,11 @@ impl<'db> ScopeInference<'db> {
             .as_ref()
             .and_then(|extra| extra.type_expression_flags.get(&expression.into()).copied())
             .unwrap_or_default()
+    }
+
+    pub(crate) fn is_type_expression(&self, expression: impl Into<ExpressionNodeKey>) -> bool {
+        self.type_expression_flags(expression)
+            .contains(TypeExpressionFlags::TYPE_EXPRESSION)
     }
 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -6,7 +6,7 @@ use crate::place::TypeOrigin;
 use crate::types::diagnostic::{INVALID_TYPE_FORM, REDUNDANT_FINAL_CLASSVAR};
 use crate::types::infer::builder::InferenceFlags;
 use crate::types::infer::builder::subscript::AnnotatedExprContext;
-use crate::types::infer::nearest_enclosing_class;
+use crate::types::infer::{TypeExpressionFlags, nearest_enclosing_class};
 use crate::types::string_annotation::parse_string_annotation;
 use crate::types::{
     SpecialFormType, Type, TypeAndQualifiers, TypeContext, TypeQualifier, TypeQualifiers, todo_type,
@@ -24,6 +24,7 @@ struct AnnotationExpressionInference<'db> {
     annotation_ty: TypeAndQualifiers<'db>,
     /// The type exposed for the annotation expression itself, including to IDE features.
     expression_ty: Type<'db>,
+    is_type_expression: bool,
 }
 
 impl<'db> AnnotationExpressionInference<'db> {
@@ -31,6 +32,7 @@ impl<'db> AnnotationExpressionInference<'db> {
         Self {
             expression_ty: annotation_ty.inner_type(),
             annotation_ty,
+            is_type_expression: true,
         }
     }
 
@@ -41,6 +43,7 @@ impl<'db> AnnotationExpressionInference<'db> {
         Self {
             annotation_ty,
             expression_ty,
+            is_type_expression: false,
         }
     }
 }
@@ -365,7 +368,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let AnnotationExpressionInference {
             annotation_ty,
             expression_ty,
+            is_type_expression,
         } = inferred;
+        if is_type_expression {
+            self.store_type_expression_flags(annotation, TypeExpressionFlags::TYPE_EXPRESSION);
+        }
         self.store_expression_type(annotation, expression_ty);
         self.store_qualifiers(annotation, annotation_ty.qualifiers());
 

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -75,6 +75,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             previously_in_type_expression,
         );
         self.store_expression_type(expression, ty);
+        self.store_type_expression_flags(expression, TypeExpressionFlags::TYPE_EXPRESSION);
         ty
     }
 

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -22,7 +22,8 @@ pub(super) fn walk_typeform_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
 impl get_size2::GetSize for TypeFormType<'_> {}
 
 impl<'db> TypeFormType<'db> {
-    pub(crate) fn from_type_expression(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    /// Creates the runtime type-form type for a type expression that denotes `ty`.
+    pub fn from_type_expression(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
         Type::TypeForm(Self::new(db, ty))
     }
 }


### PR DESCRIPTION
## Summary

Infer runtime value types lazily for expressions in type positions and use them for provide-type. This reports `TypeOf[int]` for parameter annotations while leaving normal type inference unchanged.

Stacked on #26108.

Opening for some initial feedback on whether this is the right approach and goes in the right direction for https://github.com/astral-sh/ty/issues/1711

Fixes https://github.com/astral-sh/ty/issues/3070

## Test Plan

Testing: Added semantic, IDE, and server coverage; affected suites, Clippy, and repository hooks pass.
