### PR TITLE
[ty] Refactor Markdown rendering to model state transitions more explicitly

### DIFF
--- a/crates/ty_ide/src/docstring/markdown/general.rs
+++ b/crates/ty_ide/src/docstring/markdown/general.rs
@@ -1,18 +1,53 @@
 use std::borrow::Cow;
 
+use ruff_text_size::TextSize;
+
 use super::super::document::preformatted::MarkdownFence;
 
 mod inline;
 
-/// Applies whole-docstring Markdown escaping and code-fence handling.
+// Here lies a monument to robust parsing and escaping:
+// a codefence with SO MANY backticks that surely no one will ever accidentally
+// break out of it, even if they're writing python documentation about markdown
+// code fences and are showing off how you can use more than 3 backticks.
+const FENCE: &str = "```````````";
+
+/// Renders normalized docstring source as Markdown.
 ///
-/// This function assumes the input has had its whitespace normalized by
-/// `docstring::documentation_trim`, so leading whitespace is always a space,
-/// and newlines are always `\n`.
+/// Outside recognized code blocks, leading indentation is encoded as
+/// non-breaking spaces. This preserves the source's visual alignment without
+/// allowing Markdown to interpret the indentation as block syntax. For example,
+/// a continuation line can align with the start of a parameter description
+/// without becoming an indented code block.
+///
+/// See [`render_fragment_into`] for fragments whose indentation should remain
+/// available to the Markdown parser.
+pub(super) fn render_into(output: &mut String, docstring: &str) {
+    render_with_indentation_mode(output, docstring, LeadingIndentation::DisplayOnly);
+}
+
+/// Renders a normalized, extracted docstring fragment as Markdown.
+///
+/// Outside recognized code blocks, leading indentation remains ordinary spaces,
+/// allowing Markdown to interpret fragment-relative block structure such as
+/// nested lists and indented code blocks. [`render_into`] instead preserves
+/// indentation for display only.
+pub(super) fn render_fragment_into(output: &mut String, fragment: &str) {
+    render_with_indentation_mode(output, fragment, LeadingIndentation::MarkdownSyntax);
+}
+
+/// Renders normalized docstring source with the selected treatment of leading indentation.
+///
+/// Callers must expand tabs and normalize line endings to `\n`, as done by
+/// `docstring::documentation_trim` and `docstring::documentation_fragment_trim`.
+/// This function treats leading ASCII spaces as indentation. The indentation
+/// mode only applies outside recognized code blocks; code-block indentation
+/// always remains ordinary spaces.
 ///
 /// The general approach here is:
 ///
-/// * Encode line indentation and breaks so that the rendered output mirrors the source layout
+/// * Depending on the value of `leading_indentation`, encode line indentation
+///   and breaks so that the rendered output mirrors the source layout
 /// * Escape problematic things where necessary (bare `__dunder__` => `\_\_dunder\_\_`)
 /// * Introduce code fences where appropriate
 ///
@@ -36,112 +71,57 @@ mod inline;
 /// with longer docs
 /// </code>
 /// ```
-pub(super) fn render_into(output: &mut String, docstring: &str) {
-    render_with_indentation_mode(output, docstring, LeadingIndentation::DisplayOnly);
-}
-
-/// Renders an extracted docstring fragment with ordinary spaces for indentation.
-///
-/// Unlike [`render_into`], this emits leading indentation outside code blocks as ordinary spaces,
-/// allowing Markdown to interpret it as block syntax such as nested lists.
-pub(super) fn render_fragment_into(output: &mut String, fragment: &str) {
-    render_with_indentation_mode(output, fragment, LeadingIndentation::MarkdownSyntax);
-}
-
-/// How to emit leading indentation outside recognized code blocks.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum LeadingIndentation {
-    /// Emit `&nbsp;` so that indentation affects display without activating Markdown syntax.
-    DisplayOnly,
-    /// Emit ordinary spaces that Markdown can interpret as block syntax.
-    MarkdownSyntax,
-}
-
 fn render_with_indentation_mode(
     output: &mut String,
-    docstring: &str,
+    source: &str,
     leading_indentation: LeadingIndentation,
 ) {
-    // Here lies a monumemnt to robust parsing and escaping:
-    // a codefence with SO MANY backticks that surely no one will ever accidentally
-    // break out of it, even if they're writing python documentation about markdown
-    // code fences and are showing off how you can use more than 3 backticks.
-    const FENCE: &str = "```````````";
     // TODO: there is a convention that `singletick` is for items that can
     // be looked up in-scope while ``multitick`` is for opaque inline code.
     // While rendering this we should make note of all the `singletick` locations
     // and (possibly in a higher up piece of logic) try to resolve the names for
     // cross-linking. (Similar to `TypeDetails` in the type formatting code.)
     let mut first_line = true;
-    let mut block_indent = 0;
-    let mut in_doctest = false;
-    let mut in_markdown_with_fence = None;
-    let mut starting_literal = None;
-    let mut in_literal = false;
-    let mut in_any_code = false;
+    let mut renderer = Renderer::new(output);
     let mut temp_owned_line;
-    for line in docstring.lines() {
+    for line in source.lines() {
         // We can assume leading whitespace has been normalized
         let trimmed_source_line = line.trim_start_matches(' ');
         let mut rendered_line = trimmed_source_line;
-        let line_indent = line.len() - trimmed_source_line.len();
+        let line_indent = TextSize::of(line) - TextSize::of(trimmed_source_line);
 
-        // First thing's first, add a newline to start the new line
-        if !first_line {
-            // If we're not in a codeblock, add trailing space to the line to authentically wrap it
-            // (Lines ending with two spaces tell markdown to preserve a linebreak)
-            if !in_any_code {
-                output.push_str("  ");
-            }
-            // Only push newlines if we're not scanning for a real line
-            if starting_literal.is_none() {
-                output.push('\n');
-            }
-        }
+        // First things first, prepare the prefix for the new line.
+        renderer.prepare_line(first_line);
         first_line = false;
 
         // If we're in a literal block and we find a non-empty dedented line, end the block
         // TODO: we should remove all the trailing blank lines
         // (Just pop all trailing `\n` from `output`?)
-        if in_literal && line_indent < block_indent && !rendered_line.is_empty() {
-            in_literal = false;
-            in_any_code = false;
-            block_indent = 0;
-            output.push_str(FENCE);
-            output.push('\n');
+        if let Some(indent) = renderer.block_state.rst_literal_indent()
+            && !rendered_line.is_empty()
+            && line_indent < indent
+        {
+            renderer.finish_rest_literal();
         }
 
         // We previously entered a literal block and we just found our first non-blank line
         // So now we're actually in the literal block
-        if let Some(literal) = starting_literal
+        if let Some(language) = renderer.block_state.pending_rst_literal_language()
             && !rendered_line.is_empty()
         {
-            starting_literal = None;
-            in_literal = true;
-            in_any_code = true;
-            block_indent = line_indent;
-            output.push('\n');
-            output.push_str(FENCE);
-            output.push_str(literal);
-            output.push('\n');
+            renderer.start_rest_literal(language, line_indent);
         }
 
         // If we're not in a codeblock and we see something that signals a doctest, start one
-        if !in_any_code && rendered_line.starts_with(">>>") {
-            block_indent = line_indent;
-            in_doctest = true;
-            in_any_code = true;
-            // TODO: is there something more specific? `pycon`?
-            output.push_str(FENCE);
-            output.push_str("python\n");
+        if renderer.block_state.is_prose() && rendered_line.starts_with(">>>") {
+            renderer.start_doctest();
         }
 
         // If we're not in a codeblock and we see a markdown codefence, start one
-        if !in_any_code && let Some(fence) = MarkdownFence::find(trimmed_source_line) {
+        if renderer.block_state.is_prose()
+            && let Some(fence) = MarkdownFence::find(trimmed_source_line)
+        {
             // Unlike other blocks we don't need to emit fences because it's already markdown
-            block_indent = line_indent;
-            in_any_code = true;
-            in_markdown_with_fence = Some(fence);
             // Render the line verbatim without its indent and move on.
             //
             // If there's any indent this is really just Bad Syntax but it "makes sense"
@@ -156,36 +136,36 @@ fn render_with_indentation_mode(
             //
             // We "make this work" by stripping the indent on the fences but preserving the
             // full indent of the lines between the fences
-            output.push_str(rendered_line);
+            renderer.start_markdown_fence(fence, rendered_line);
             continue;
         // If we're in a markdown code fence and this line seems to terminate it, end the block
-        } else if let Some(fence) = in_markdown_with_fence
-            && fence.is_closed_by(rendered_line)
+        } else if renderer
+            .block_state
+            .markdown_fence_is_closed_by(rendered_line)
         {
-            in_any_code = false;
-            block_indent = 0;
-            in_markdown_with_fence = None;
             // Render the line without its indent and move on.
-            output.push_str(rendered_line);
+            renderer.finish_markdown_fence(rendered_line);
             continue;
         }
 
         // If we're not in a codeblock and we see something that signals a literal block, start one
-        let parsed_lit = rendered_line
+        let parsed_literal = trimmed_source_line
             // first check for a line ending with `::`
             .strip_suffix("::")
             .map(|prefix| (prefix, None))
             // if that fails, look for a line ending with `:: lang`
             .or_else(|| {
-                let (prefix, lang) = rendered_line.rsplit_once(' ')?;
+                let (prefix, lang) = trimmed_source_line.rsplit_once(' ')?;
                 let prefix = prefix.trim_end().strip_suffix("::")?;
                 Some((prefix, Some(lang)))
             });
-        if !in_any_code && let Some((without_lit, lang)) = parsed_lit {
-            let mut without_directive = without_lit;
+        if renderer.block_state.is_prose()
+            && let Some((without_literal, lang)) = parsed_literal
+        {
+            let mut without_directive = without_literal;
             let mut directive = None;
             // Parse out a directive like `.. warning::`
-            if let Some((prefix, directive_str)) = without_lit.rsplit_once(' ')
+            if let Some((prefix, directive_str)) = without_literal.rsplit_once(' ')
                 && let Some(without_directive_str) = prefix.strip_suffix("..")
             {
                 directive = Some(directive_str);
@@ -208,7 +188,7 @@ fn render_with_indentation_mode(
                 rendered_line = without_directive.trim_end();
             }
 
-            starting_literal = match directive {
+            match directive {
                 // Special directives that should be plaintext
                 Some(
                     "attention" | "caution" | "danger" | "error" | "hint" | "important" | "note"
@@ -249,55 +229,250 @@ fn render_with_indentation_mode(
                     temp_owned_line = format!("**{without_directive}{pretty_directive}{suffix}:**");
 
                     rendered_line = temp_owned_line.as_str();
-                    None
                 }
-                // Things that just mean "it's code"
-                Some(
-                    "code-block" | "sourcecode" | "code" | "testcode" | "testsetup" | "testcleanup",
-                ) => lang.or(Some("python")),
-                // Unknown (python I guess?)
-                Some(_) => lang.or(Some("python")),
-                // default to python
-                None => lang.or(Some("python")),
-            };
+                // All other directives are code and default to Python.
+                _ => renderer.start_pending_rest_literal(lang.unwrap_or("python")),
+            }
         }
 
         // Add this line's indentation.
-        // We could subtract the block_indent here but in practice it's uglier
+        // We could subtract the literal block's indentation here but in practice it's uglier
         // TODO: should we not do this if the `line.is_empty()`? When would it matter?
-        for _ in 0..line_indent {
-            // Outside code blocks, emit indentation according to the selected mode.
-            if !in_any_code && matches!(leading_indentation, LeadingIndentation::DisplayOnly) {
-                // TODO: would the raw unicode codepoint be handled *better* or *worse*
-                // by various IDEs? VS Code handles this approach well, at least.
-                output.push_str("&nbsp;");
-            } else {
-                output.push(' ');
-            }
+        renderer.push_indentation(line_indent, leading_indentation);
+
+        if renderer.block_state.is_doctest() && rendered_line.is_empty() {
+            renderer.finish_doctest();
+            continue;
         }
 
-        if !in_any_code {
-            inline::render_line(output, rendered_line);
-        } else if rendered_line.is_empty() {
-            if in_doctest {
-                // This is the end of a doctest
-                block_indent = 0;
-                in_any_code = false;
-                in_doctest = false;
-                output.push_str(FENCE);
-            }
-        } else {
-            // Print the line verbatim, it's in code
-            output.push_str(rendered_line);
+        renderer.render_line(rendered_line);
+    }
+    renderer.finish_document();
+}
+
+/// How to emit leading indentation outside recognized code blocks.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LeadingIndentation {
+    /// Emit `&nbsp;` so that indentation affects display without activating Markdown syntax.
+    DisplayOnly,
+    /// Emit ordinary spaces that Markdown can interpret as block syntax.
+    MarkdownSyntax,
+}
+
+/// Renders docstring lines while preserving state across block and line boundaries.
+struct Renderer<'source, 'output> {
+    line_prefix: LinePrefix,
+    block_state: BlockState<'source>,
+    output: &'output mut String,
+}
+
+impl<'source, 'output> Renderer<'source, 'output> {
+    fn new(output: &'output mut String) -> Self {
+        Self {
+            line_prefix: LinePrefix::default(),
+            block_state: BlockState::default(),
+            output,
         }
     }
-    // Flush codeblock
-    if in_any_code {
-        output.push('\n');
-        if let Some(fence) = in_markdown_with_fence {
-            output.push_str(fence.marker());
+
+    fn prepare_line(&mut self, first_line: bool) {
+        self.line_prefix.prepare(&self.block_state, first_line);
+    }
+
+    fn push_indentation(&mut self, indentation: TextSize, leading_indentation: LeadingIndentation) {
+        self.line_prefix.push_indentation(
+            indentation.to_usize(),
+            &self.block_state,
+            leading_indentation,
+        );
+    }
+
+    /// Flushes content buffered for the current line.
+    fn flush_pending_line(&mut self) {
+        self.line_prefix.emit(self.output);
+    }
+
+    fn finish_rest_literal(&mut self) {
+        debug_assert!(matches!(self.block_state, BlockState::RestLiteral { .. }));
+        self.flush_pending_line();
+        self.block_state = BlockState::Prose;
+        self.output.push_str(FENCE);
+        self.output.push('\n');
+    }
+
+    fn start_pending_rest_literal(&mut self, language: &'source str) {
+        self.block_state = BlockState::PendingRestLiteral { language };
+    }
+
+    fn start_rest_literal(&mut self, language: &str, indent: TextSize) {
+        self.flush_pending_line();
+        self.block_state = BlockState::RestLiteral { indent };
+        self.output.push('\n');
+        self.output.push_str(FENCE);
+        self.output.push_str(language);
+        self.output.push('\n');
+    }
+
+    fn start_doctest(&mut self) {
+        self.flush_pending_line();
+        self.block_state = BlockState::Doctest;
+        // TODO: is there something more specific? `pycon`?
+        self.output.push_str(FENCE);
+        self.output.push_str("python\n");
+    }
+
+    fn finish_doctest(&mut self) {
+        debug_assert!(matches!(self.block_state, BlockState::Doctest));
+        self.flush_pending_line();
+        self.block_state = BlockState::Prose;
+        self.output.push_str(FENCE);
+    }
+
+    fn start_markdown_fence(&mut self, fence: MarkdownFence<'source>, line: &str) {
+        self.flush_pending_line();
+        self.block_state = BlockState::MarkdownFence(fence);
+        self.output.push_str(line);
+    }
+
+    fn finish_markdown_fence(&mut self, line: &str) {
+        debug_assert!(matches!(self.block_state, BlockState::MarkdownFence(_)));
+        self.flush_pending_line();
+        self.block_state = BlockState::Prose;
+        self.output.push_str(line);
+    }
+
+    fn render_line(&mut self, line: &str) {
+        self.flush_pending_line();
+        if self.block_state.is_code() {
+            self.output.push_str(line);
         } else {
-            output.push_str(FENCE);
+            inline::render_line(self.output, line);
         }
+    }
+
+    fn finish_document(mut self) {
+        self.flush_pending_line();
+        match self.block_state {
+            BlockState::Prose | BlockState::PendingRestLiteral { .. } => {}
+            BlockState::RestLiteral { .. } | BlockState::Doctest => {
+                self.output.push('\n');
+                self.output.push_str(FENCE);
+            }
+            BlockState::MarkdownFence(fence) => {
+                self.output.push('\n');
+                self.output.push_str(fence.marker());
+            }
+        }
+    }
+}
+
+/// Buffers the separator and indentation that must be emitted before each rendered line.
+#[derive(Default)]
+struct LinePrefix {
+    rendered: String,
+}
+
+impl LinePrefix {
+    /// Prepares us to render the next line by buffering the separator required
+    /// to delineate it from the previous line.
+    fn prepare(&mut self, block_state: &BlockState<'_>, first_line: bool) {
+        self.rendered.clear();
+        if first_line {
+            // If this is the first source line of the fragment that we're rendering,
+            // then there is no previous line to delineate from the next one.
+            return;
+        }
+
+        if !block_state.is_code() {
+            // Two trailing spaces turn the next newline into a Markdown hard
+            // break, thereby preserving the source line boundary.
+            self.rendered.push_str("  ");
+        }
+
+        // Suppress source line boundaries after a reST literal marker while we
+        // wait for its content. This allows us to collapse any intervening
+        // newlines that are purely structural.
+        if !block_state.is_pending_rst_literal() {
+            self.rendered.push('\n');
+        }
+    }
+
+    /// Adds the next line's indentation to the buffered prefix.
+    fn push_indentation(
+        &mut self,
+        indentation: usize,
+        block_state: &BlockState<'_>,
+        leading_indentation: LeadingIndentation,
+    ) {
+        for _ in 0..indentation {
+            if !block_state.is_code()
+                && matches!(leading_indentation, LeadingIndentation::DisplayOnly)
+            {
+                // TODO: would the raw unicode codepoint be handled *better* or *worse*
+                // by various IDEs? VS Code handles this approach well, at least.
+                self.rendered.push_str("&nbsp;");
+            } else {
+                self.rendered.push(' ');
+            }
+        }
+    }
+
+    /// Writes the buffered prefix to `output` and clears it.
+    fn emit(&mut self, output: &mut String) {
+        output.push_str(&self.rendered);
+        self.rendered.clear();
+    }
+}
+
+#[derive(Default)]
+enum BlockState<'a> {
+    #[default]
+    Prose,
+    PendingRestLiteral {
+        language: &'a str,
+    },
+    RestLiteral {
+        indent: TextSize,
+    },
+    Doctest,
+    MarkdownFence(MarkdownFence<'a>),
+}
+
+impl<'docstring> BlockState<'docstring> {
+    const fn is_prose(&self) -> bool {
+        matches!(self, Self::Prose)
+    }
+
+    const fn is_code(&self) -> bool {
+        matches!(
+            self,
+            Self::RestLiteral { .. } | Self::Doctest | Self::MarkdownFence(_)
+        )
+    }
+
+    const fn is_pending_rst_literal(&self) -> bool {
+        matches!(self, Self::PendingRestLiteral { .. })
+    }
+
+    const fn is_doctest(&self) -> bool {
+        matches!(self, Self::Doctest)
+    }
+
+    const fn rst_literal_indent(&self) -> Option<TextSize> {
+        match self {
+            Self::RestLiteral { indent } => Some(*indent),
+            _ => None,
+        }
+    }
+
+    const fn pending_rst_literal_language(&self) -> Option<&'docstring str> {
+        match self {
+            Self::PendingRestLiteral { language } => Some(*language),
+            _ => None,
+        }
+    }
+
+    fn markdown_fence_is_closed_by(&self, line: &str) -> bool {
+        matches!(self, Self::MarkdownFence(fence) if fence.is_closed_by(line))
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This refactors our Markdown rendering for docstrings to model the state and transitions of the rendering logic more explicitly. Encapsulating each state transition in its own method makes it easier to [extend that logic to support rendering of ReST hyperlinks](https://github.com/astral-sh/ruff/pull/25907).

## Test Plan

This is a pure refactor that relies on existing test coverage.
<!-- How was it tested? -->
