### PR TITLE
[ty] Remove redundant imported modules Arc

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2646,7 +2646,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
-            imported_modules: Arc::new(FrozenSet::from(self.imported_modules)),
+            imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
             semantic_syntax_errors,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -348,7 +348,7 @@ pub struct SemanticIndex<'db> {
     ast_ids: AstIds,
 
     /// The set of modules that are imported anywhere within this file.
-    imported_modules: Arc<FrozenSet<ModuleName>>,
+    imported_modules: FrozenSet<ModuleName>,
 
     /// Flags about the global scope (code usage impacting inference)
     has_future_annotations: bool,


### PR DESCRIPTION
## Summary

Remove the redundant Arc around the semantic index's imported modules. FrozenSet already owns compact boxed storage, and callers only borrow this collection.

## Test Plan

Testing: Passed the ty_python_core test suite and repository hooks.