### PR TITLE
[ty] Reduce shared allocation overhead with triomphe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+
+[[package]]
 name = "tryfn"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4727,6 +4733,7 @@ dependencies = [
  "static_assertions",
  "thin-vec",
  "tracing",
+ "triomphe",
  "ty_combine",
  "ty_module_resolver",
  "ty_site_packages",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
     "ansi",
     "smallvec",
 ] }
+triomphe = { version = "0.1.15", default-features = false, features = ["std"] }
 tryfn = { version = "1.0.0" }
 typed-arena = { version = "2.0.2" }
 unicode-ident = { version = "1.0.12" }

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -38,6 +38,7 @@ smallvec = { workspace = true }
 static_assertions = { workspace = true }
 thin-vec = { workspace = true }
 tracing = { workspace = true }
+triomphe = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing", "os"] }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -38,6 +38,7 @@ use crate::definition::{
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
+use crate::no_weak_arc::NoWeakArc;
 use crate::place::{PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId};
 use crate::predicate::{
     CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
@@ -2607,13 +2608,13 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut place_tables: IndexVec<_, _> = self
             .place_tables
             .into_iter()
-            .map(|builder| Arc::new(builder.finish()))
+            .map(|builder| NoWeakArc::new(builder.finish()))
             .collect();
 
         let mut use_def_maps: IndexVec<_, _> = self
             .use_def_maps
             .into_iter()
-            .map(|builder| Arc::new(builder.finish()))
+            .map(|builder| NoWeakArc::new(builder.finish()))
             .collect();
 
         let ast_ids = super::ast_ids::AstIds::from_builders(self.ast_ids);

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -19,6 +19,7 @@ use smallvec::SmallVec;
 use ty_module_resolver::ModuleName;
 
 use crate::frozen::{FrozenMap, FrozenSet};
+use crate::no_weak_arc::NoWeakArc;
 use crate::place::ScopedPlaceId;
 pub use crate::statement::{Statement, StatementNodeKey};
 use ast_ids::AstIds;
@@ -48,6 +49,7 @@ pub mod expression;
 pub mod frozen;
 pub(crate) mod member;
 pub mod narrowing_constraints;
+pub mod no_weak_arc;
 pub mod node_key;
 pub mod place;
 pub mod platform;
@@ -81,11 +83,11 @@ pub fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex<'_> {
 /// Salsa can avoid invalidating dependent queries if this scope's place table
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable> {
+pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> NoWeakArc<PlaceTable> {
     let file = scope.file(db);
     let _span = tracing::trace_span!("place_table", scope=?scope.as_id(), ?file).entered();
     let index = semantic_index(db, file);
-    Arc::clone(&index.place_tables[scope.file_scope_id(db)])
+    NoWeakArc::clone(&index.place_tables[scope.file_scope_id(db)])
 }
 
 /// Returns the use-def map for a specific `scope`.
@@ -94,11 +96,11 @@ pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable>
 /// Salsa can avoid invalidating dependent queries if this scope's use-def map
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<UseDefMap<'db>> {
+pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> NoWeakArc<UseDefMap<'db>> {
     let file = scope.file(db);
     let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?file).entered();
     let index = semantic_index(db, file);
-    Arc::clone(&index.use_def_maps[scope.file_scope_id(db)])
+    NoWeakArc::clone(&index.use_def_maps[scope.file_scope_id(db)])
 }
 
 /// All the bindings made in a loop, which are visible to the entire loop via "loop header
@@ -303,7 +305,7 @@ impl<'db> DefinitionsByNode<'db> {
 #[derive(Debug, Update, get_size2::GetSize)]
 pub struct SemanticIndex<'db> {
     /// List of all place tables in this file, indexed by scope.
-    place_tables: FrozenIndexVec<FileScopeId, Arc<PlaceTable>>,
+    place_tables: FrozenIndexVec<FileScopeId, NoWeakArc<PlaceTable>>,
 
     /// List of all scopes in this file.
     scopes: FrozenIndexVec<FileScopeId, Scope>,
@@ -339,7 +341,7 @@ pub struct SemanticIndex<'db> {
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
 
     /// Use-def map for each scope in this file.
-    use_def_maps: FrozenIndexVec<FileScopeId, Arc<UseDefMap<'db>>>,
+    use_def_maps: FrozenIndexVec<FileScopeId, NoWeakArc<UseDefMap<'db>>>,
 
     /// Lookup table to map between node ids and ast nodes.
     ///

--- a/crates/ty_python_core/src/no_weak_arc.rs
+++ b/crates/ty_python_core/src/no_weak_arc.rs
@@ -1,0 +1,223 @@
+use std::hash::Hash;
+use std::iter::ExactSizeIterator;
+use std::mem::size_of;
+use std::ops::Deref;
+
+use get_size2::{GetSize, GetSizeTracker};
+use salsa::Update;
+use triomphe::{Arc, ThinArc};
+
+/// An atomically reference-counted pointer for values that never need weak references.
+///
+/// This wrapper lets ty use [`triomphe::Arc`] while providing the foreign trait implementations
+/// required by Salsa and ty's memory reporting.
+#[derive(Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct NoWeakArc<T: ?Sized>(Arc<T>);
+
+impl<T: ?Sized> Clone for NoWeakArc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> NoWeakArc<T> {
+    pub fn new(value: T) -> Self {
+        Self(Arc::new(value))
+    }
+}
+
+impl<T: ?Sized> NoWeakArc<T> {
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        Arc::ptr_eq(&this.0, &other.0)
+    }
+}
+
+impl<T: ?Sized> Deref for NoWeakArc<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> GetSize for NoWeakArc<T>
+where
+    T: GetSize,
+{
+    fn get_heap_size_with_tracker<Tracker: GetSizeTracker>(
+        &self,
+        mut tracker: Tracker,
+    ) -> (usize, Tracker) {
+        if tracker.track(self.0.heap_ptr()) {
+            T::get_size_with_tracker(self, tracker)
+        } else {
+            (0, tracker)
+        }
+    }
+}
+
+// SAFETY: This has the same update behavior as Salsa's implementation for `std::sync::Arc`.
+// It only updates the pointee in place when both allocations are uniquely owned; otherwise it
+// replaces the old pointer with the new one.
+#[expect(
+    unsafe_code,
+    reason = "implementing Salsa's unsafe Update contract requires dereferencing its raw pointer"
+)]
+unsafe impl<T> Update for NoWeakArc<T>
+where
+    T: Update,
+{
+    unsafe fn maybe_update(old_pointer: *mut Self, new_arc: Self) -> bool {
+        let old_arc = unsafe { &mut *old_pointer };
+
+        if Self::ptr_eq(old_arc, &new_arc) {
+            return false;
+        }
+
+        if let Some(old_inner) = Arc::get_mut(&mut old_arc.0) {
+            match Arc::try_unwrap(new_arc.0) {
+                Ok(new_inner) => unsafe { T::maybe_update(old_inner, new_inner) },
+                Err(new_arc) => {
+                    old_arc.0 = new_arc;
+                    true
+                }
+            }
+        } else {
+            old_arc.0 = new_arc.0;
+            true
+        }
+    }
+}
+
+/// An atomically reference-counted header and trailing slice stored in one allocation.
+#[derive(Debug, Eq, Hash, PartialEq)]
+#[repr(transparent)]
+pub struct ThinArcSlice<H, T>(ThinArc<H, T>);
+
+impl<H, T> Clone for ThinArcSlice<H, T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<H, T> ThinArcSlice<H, T> {
+    pub fn from_iter<I>(header: H, items: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        Self(ThinArc::from_header_and_iter(header, items.into_iter()))
+    }
+
+    pub fn header(&self) -> &H {
+        &self.0.header.header
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.0.slice
+    }
+
+    /// Mutates the contents in place when uniquely owned, cloning the allocation first when it is
+    /// shared.
+    pub fn with_make_mut<R>(&mut self, f: impl FnOnce(&mut [T]) -> R) -> R
+    where
+        H: Clone,
+        T: Clone,
+    {
+        if ThinArc::strong_count(&self.0) > 1 {
+            self.0 = ThinArc::from_header_and_iter(
+                self.header().clone(),
+                self.as_slice().iter().cloned(),
+            );
+        }
+
+        self.0.with_arc_mut(|arc| {
+            let value = Arc::get_mut(arc)
+                .expect("a ThinArc without weak references and one strong reference is unique");
+            f(value.slice_mut())
+        })
+    }
+}
+
+impl<H, T> Deref for ThinArcSlice<H, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<H, T> GetSize for ThinArcSlice<H, T>
+where
+    H: GetSize,
+    T: GetSize,
+{
+    fn get_heap_size_with_tracker<Tracker: GetSizeTracker>(
+        &self,
+        mut tracker: Tracker,
+    ) -> (usize, Tracker) {
+        if !tracker.track(self.0.heap_ptr()) {
+            return (0, tracker);
+        }
+
+        let (header_size, tracker) = H::get_size_with_tracker(self.header(), tracker);
+        let (slice_size, tracker) =
+            self.as_slice()
+                .iter()
+                .fold((size_of::<usize>(), tracker), |(size, tracker), item| {
+                    let (item_size, tracker) = T::get_size_with_tracker(item, tracker);
+                    (size + item_size, tracker)
+                });
+
+        (header_size + slice_size, tracker)
+    }
+}
+
+// SAFETY: Equal values contain only `Update`-safe headers and elements, so retaining an equal old
+// allocation across revisions is safe. Unequal values replace the complete allocation.
+#[expect(
+    unsafe_code,
+    reason = "implementing Salsa's unsafe Update contract requires dereferencing its raw pointer"
+)]
+unsafe impl<H, T> Update for ThinArcSlice<H, T>
+where
+    H: Eq + Update,
+    T: Eq + Update,
+{
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        let old_value = unsafe { &mut *old_pointer };
+        if *old_value == new_value {
+            false
+        } else {
+            *old_value = new_value;
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NoWeakArc, ThinArcSlice};
+
+    #[test]
+    fn pointers_are_thin() {
+        assert_eq!(size_of::<NoWeakArc<u64>>(), size_of::<usize>());
+        assert_eq!(size_of::<ThinArcSlice<u8, u16>>(), size_of::<usize>());
+    }
+
+    #[test]
+    fn thin_arc_slice_make_mut_uses_copy_on_write() {
+        let mut left = ThinArcSlice::from_iter(1, [2, 3]);
+        let right = left.clone();
+
+        left.with_make_mut(|slice| {
+            slice[0] = 5;
+        });
+
+        assert_eq!(*left.header(), 1);
+        assert_eq!(left.as_slice(), [5, 3]);
+        assert_eq!(*right.header(), 1);
+        assert_eq!(right.as_slice(), [2, 3]);
+    }
+}

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -91,13 +91,13 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::sync::Arc;
 
 use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
+use ty_python_core::no_weak_arc::NoWeakArc;
 use ty_python_core::rank::RankBitBox;
 
 use crate::types::class::GenericAlias;
@@ -242,7 +242,7 @@ where
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
 pub struct OwnedConstraintSet<'db> {
     node: NodeId,
-    inner: Option<Arc<OwnedConstraintSetInner<'db>>>,
+    inner: Option<NoWeakArc<OwnedConstraintSetInner<'db>>>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
@@ -687,7 +687,7 @@ struct ConstraintSetStorage<'db> {
     ///
     /// IDs below the overlay split points are looked up in this storage; newly interned entries
     /// are stored in the dense local arenas below.
-    compacted: Option<Arc<OwnedConstraintSetInner<'db>>>,
+    compacted: Option<NoWeakArc<OwnedConstraintSetInner<'db>>>,
 
     /// Constraints are the variables of our BDD. They are interned to give them a space-efficient
     /// identity. Constraints are added to this arena as they are encountered when constructing
@@ -836,7 +836,7 @@ impl<'db> ConstraintSetBuilder<'db> {
 
         OwnedConstraintSet {
             node,
-            inner: Some(Arc::new(OwnedConstraintSetInner {
+            inner: Some(NoWeakArc::new(OwnedConstraintSetInner {
                 constraints,
                 constraint_indices,
                 typevars: storage.typevars,

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -11,11 +11,11 @@
 //! arguments must match _at least one_ overload.
 
 use std::slice::Iter;
-use std::sync::Arc;
 
 use itertools::{Either, EitherOrBoth, Itertools};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
+use ty_python_core::no_weak_arc::ThinArcSlice;
 
 use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
@@ -927,15 +927,17 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         self_type: impl FnOnce() -> Option<Type<'db>>,
     ) {
-        if let Some(first_parameter) = self.parameters.data.value.first()
-            && first_parameter.is_positional()
-            && first_parameter.annotated_type.is_unknown()
-            && first_parameter.inferred_annotation
-            && let Some(self_type) = self_type()
-            && let Some(first_parameter) =
-                Arc::make_mut(&mut self.parameters.data).value.first_mut()
-        {
-            first_parameter.annotated_type = self_type;
+        let needs_annotation = self.parameters.as_slice().first().is_some_and(|parameter| {
+            parameter.is_positional()
+                && parameter.annotated_type.is_unknown()
+                && parameter.inferred_annotation
+        });
+        if needs_annotation && let Some(self_type) = self_type() {
+            self.parameters.data.with_make_mut(|parameters| {
+                if let Some(first_parameter) = parameters.first_mut() {
+                    first_parameter.annotated_type = self_type;
+                }
+            });
 
             // If we've added an implicit `self` annotation, we might need to update the
             // signature's generic context, too. (The generic context should include any synthetic
@@ -3188,24 +3190,18 @@ pub(crate) enum ParametersKind<'db> {
 // between the `value` and `kind` field, it would be better to structure it such that these
 // invariants are followed at the type level instead.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
-struct ParametersData<'db> {
-    // TODO: use SmallVec here once invariance bug is fixed
-    value: Box<[Parameter<'db>]>,
-    kind: ParametersKind<'db>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) struct Parameters<'db> {
-    data: Arc<ParametersData<'db>>,
+    data: ThinArcSlice<ParametersKind<'db>, Parameter<'db>>,
 }
 
 impl<'db> Parameters<'db> {
-    fn from_parts(value: impl Into<Box<[Parameter<'db>]>>, kind: ParametersKind<'db>) -> Self {
+    fn from_parts<I>(value: I, kind: ParametersKind<'db>) -> Self
+    where
+        I: IntoIterator<Item = Parameter<'db>>,
+        I::IntoIter: ExactSizeIterator,
+    {
         Self {
-            data: Arc::new(ParametersData {
-                value: value.into(),
-                kind,
-            }),
+            data: ThinArcSlice::from_iter(kind, value),
         }
     }
 
@@ -3341,34 +3337,34 @@ impl<'db> Parameters<'db> {
 
     /// Create an empty parameter list.
     pub(crate) fn empty() -> Self {
-        Self::from_parts(Box::default(), ParametersKind::Standard)
+        Self::from_parts([], ParametersKind::Standard)
     }
 
     pub(crate) fn as_slice(&self) -> &[Parameter<'db>] {
-        &self.data.value
+        self.data.as_slice()
     }
 
     pub(crate) fn kind(&self) -> ParametersKind<'db> {
-        self.data.kind
+        *self.data.header()
     }
 
     /// Returns `true` if the parameters represent a gradual form using `...` as the only parameter
     /// or a `Concatenate` form with `...` as the last argument.
     pub(crate) fn is_gradual(&self) -> bool {
         matches!(
-            self.data.kind,
+            self.kind(),
             ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
         )
     }
 
     pub(crate) fn is_top(&self) -> bool {
-        matches!(self.data.kind, ParametersKind::Top)
+        matches!(self.kind(), ParametersKind::Top)
     }
 
     /// Returns `true` if the parameters are a standard parameter list (not gradual, top,
     /// `ParamSpec`, or `Concatenate`).
     pub(crate) fn is_standard(&self) -> bool {
-        matches!(self.data.kind, ParametersKind::Standard)
+        matches!(self.kind(), ParametersKind::Standard)
     }
 
     /// Returns the bound `ParamSpec` type variable if the parameter list is exactly `P`.
@@ -3377,7 +3373,7 @@ impl<'db> Parameters<'db> {
     ///
     /// [`as_paramspec_with_prefix`]: Self::as_paramspec_with_prefix
     pub(crate) fn as_paramspec(&self) -> Option<BoundTypeVarInstance<'db>> {
-        match self.data.kind {
+        match self.kind() {
             ParametersKind::ParamSpec(bound_typevar) => Some(bound_typevar),
             _ => None,
         }
@@ -3392,12 +3388,11 @@ impl<'db> Parameters<'db> {
     pub(crate) fn as_paramspec_with_prefix<'a>(
         &'a self,
     ) -> Option<(&'a [Parameter<'db>], BoundTypeVarInstance<'db>)> {
-        match self.data.kind {
+        match self.kind() {
             ParametersKind::ParamSpec(typevar) => Some((&[], typevar)),
-            ParametersKind::Concatenate(ConcatenateTail::ParamSpec(typevar)) => Some((
-                &self.data.value[..self.data.value.len().saturating_sub(2)],
-                typevar,
-            )),
+            ParametersKind::Concatenate(ConcatenateTail::ParamSpec(typevar)) => {
+                Some((&self.as_slice()[..self.len().saturating_sub(2)], typevar))
+            }
             _ => None,
         }
     }
@@ -3647,7 +3642,7 @@ impl<'db> Parameters<'db> {
     ) -> Self {
         if let TypeMapping::Materialize(materialization_kind) = type_mapping
             && matches!(
-                self.data.kind,
+                self.kind(),
                 ParametersKind::Gradual | ParametersKind::Concatenate(ConcatenateTail::Gradual)
             )
         {
@@ -3666,21 +3661,19 @@ impl<'db> Parameters<'db> {
         // Parameters are in contravariant position, so we need to flip the type mapping.
         let type_mapping = type_mapping.flip();
 
-        let value: Box<[_]> = self
-            .data
-            .value
-            .iter()
-            .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
-            .collect();
-
-        Self::from_parts(value, self.data.kind)
+        Self::from_parts(
+            self.data
+                .iter()
+                .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor)),
+            self.kind(),
+        )
     }
     pub(crate) fn len(&self) -> usize {
-        self.data.value.len()
+        self.data.len()
     }
 
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Parameter<'db>> {
-        self.data.value.iter()
+        self.data.iter()
     }
 
     /// Iterate initial positional parameters, not including variadic parameter, if any.
@@ -3694,7 +3687,7 @@ impl<'db> Parameters<'db> {
 
     /// Return parameter at given index, or `None` if index is out-of-range.
     pub(crate) fn get(&self, index: usize) -> Option<&Parameter<'db>> {
-        self.data.value.get(index)
+        self.data.get(index)
     }
 
     /// Return positional parameter at given index, or `None` if `index` is out of range.
@@ -3792,9 +3785,9 @@ impl<'db> Parameters<'db> {
         };
 
         let mut expanded = Vec::with_capacity(self.len());
-        expanded.extend_from_slice(&self.data.value[..variadic_index]);
+        expanded.extend_from_slice(&self.as_slice()[..variadic_index]);
         expanded.extend_from_slice(mapped_signature.parameters().as_slice());
-        expanded.extend_from_slice(&self.data.value[variadic_index + 2..]);
+        expanded.extend_from_slice(&self.as_slice()[variadic_index + 2..]);
         Parameters::new(db, expanded)
     }
 }
@@ -3804,7 +3797,7 @@ impl<'db, 'a> IntoIterator for &'a Parameters<'db> {
     type IntoIter = std::slice::Iter<'a, Parameter<'db>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.data.value.iter()
+        self.data.iter()
     }
 }
 
@@ -3812,7 +3805,7 @@ impl<'db> std::ops::Index<usize> for Parameters<'db> {
     type Output = Parameter<'db>;
 
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data.value[index]
+        &self.data[index]
     }
 }
 


### PR DESCRIPTION
## Summary

Use `triomphe` to reduce allocation and reference-counting overhead for parameter lists, semantic scope tables, and owned constraint sets. This reduces reported retained memory across all memory-report projects, with signature storage improving by roughly 1.5–5.3%.

## Test Plan

Testing: Passed ty core and semantic tests, Clippy, repository hooks, and memory benchmarks.
