### PR TITLE
[ty] Encode explicit Any ancestry in nominal instances

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1291,7 +1291,7 @@ impl<'db> Type<'db> {
                         .iter()
                         .any(|ty| ty.is_specialized_generic(db))
             }
-            Type::NominalInstance(instance_type) => instance_type.is_definition_generic(),
+            Type::NominalInstance(instance_type) => instance_type.is_definition_generic(db),
             Type::ProtocolInstance(protocol) => {
                 matches!(protocol.inner, Protocol::FromClass(class) if class.is_generic())
             }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -65,6 +65,22 @@ mod named_tuple;
 mod static_literal;
 mod typed_dict;
 
+bitflags::bitflags! {
+    /// Properties that affect the representation of instances of a class.
+    ///
+    /// This combines properties derived from the MRO into the existing class-classification
+    /// query, avoiding a separate cached query for each property.
+    #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, salsa::Update)]
+    pub(super) struct ClassInstanceFlags: u8 {
+        /// The class is, or inherits from, a `TypedDict` specification.
+        const TYPED_DICT = 1 << 0;
+        /// The class directly or indirectly inherits from an explicit `Any` base.
+        const INHERITS_FROM_EXPLICIT_ANY = 1 << 1;
+    }
+}
+
+impl get_size2::GetSize for ClassInstanceFlags {}
+
 /// A category of classes with code generation capabilities (with synthesized methods).
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::Update, get_size2::GetSize)]
 pub(crate) enum CodeGeneratorKind<'db> {
@@ -396,23 +412,32 @@ impl<'db> ClassLiteral<'db> {
         MroIterator::new(db, self, None)
     }
 
-    pub(crate) fn has_explicit_bases(self, db: &'db dyn Db) -> bool {
+    /// Return the properties that affect how instances of this class are represented.
+    pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
         match self {
-            Self::Static(literal) => literal.has_explicit_bases(db),
-            Self::Dynamic(literal) => !literal.explicit_bases(db).is_empty(),
-            Self::DynamicNamedTuple(_) | Self::DynamicTypedDict(_) => false,
-            Self::DynamicEnum(literal) => !literal.explicit_bases(db).is_empty(),
+            Self::Static(literal) => literal.instance_flags(db),
+            Self::DynamicTypedDict(_) => ClassInstanceFlags::TYPED_DICT,
+            Self::DynamicNamedTuple(_) => ClassInstanceFlags::empty(),
+            Self::Dynamic(literal) if literal.explicit_bases(db).is_empty() => {
+                ClassInstanceFlags::empty()
+            }
+            Self::DynamicEnum(literal) if literal.explicit_bases(db).is_empty() => {
+                ClassInstanceFlags::empty()
+            }
+            Self::Dynamic(_) | Self::DynamicEnum(_) => {
+                if self.iter_mro(db).any(ClassBase::is_explicit_any_base) {
+                    ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY
+                } else {
+                    ClassInstanceFlags::empty()
+                }
+            }
         }
     }
 
-    /// Return whether this class directly or indirectly inherits from the `Any` special form.
-    ///
-    /// This deliberately does not consider bases whose inferred type is `Any` or `Unknown`. Those
-    /// are normal dynamic bases; only an explicit `Any` base makes instances assignable to
-    /// arbitrary types.
-    #[salsa::tracked(cycle_initial=|_, _, _| false, heap_size=ruff_memory_usage::heap_size)]
-    pub(crate) fn inherits_from_any(self, db: &'db dyn Db) -> bool {
-        self.iter_mro(db).any(|base| base == ClassBase::Any)
+    /// Return whether this class directly or indirectly inherits from an explicit `Any` base.
+    pub(super) fn inherits_from_explicit_any(self, db: &'db dyn Db) -> bool {
+        self.instance_flags(db)
+            .contains(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY)
     }
 
     /// Returns the metaclass of this class.

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -26,9 +26,10 @@ use crate::{
         call::{CallError, CallErrorKind},
         callable::{CallableFunctionProvenance, CallableTypeKind},
         class::{
-            ClassMemberResult, CodeGeneratorKind, DisjointBase, DynamicTypedDictLiteral, Field,
-            FieldKind, InstanceMemberResult, MetaclassError, MetaclassErrorKind, MethodDecorator,
-            MroLookup, NamedTupleField, SlotsKind, synthesize_namedtuple_class_member,
+            ClassInstanceFlags, ClassMemberResult, CodeGeneratorKind, DisjointBase,
+            DynamicTypedDictLiteral, Field, FieldKind, InstanceMemberResult, MetaclassError,
+            MetaclassErrorKind, MethodDecorator, MroLookup, NamedTupleField, SlotsKind,
+            synthesize_namedtuple_class_member,
             typed_dict::{TypedDictFields, synthesize_typed_dict_method, typed_dict_class_member},
         },
         context::InferContext,
@@ -696,22 +697,47 @@ impl<'db> StaticClassLiteral<'db> {
             .contains(&ClassBase::Class(other))
     }
 
-    /// Return `true` if this class constitutes a typed dict specification (inherits from
-    /// `typing.TypedDict`, either directly or indirectly).
-    pub fn is_typed_dict(self, db: &'db dyn Db) -> bool {
-        #[salsa::tracked(cycle_initial=|_, _, _| false, heap_size=ruff_memory_usage::heap_size)]
-        fn is_typed_dict_inner<'db>(db: &'db dyn Db, class: StaticClassLiteral<'db>) -> bool {
-            class.iter_mro(db, None).contains(&ClassBase::TypedDict)
+    /// Return the properties that affect how instances of this class are represented.
+    pub(super) fn instance_flags(self, db: &'db dyn Db) -> ClassInstanceFlags {
+        #[salsa::tracked(
+            cycle_initial=|_, _, _| ClassInstanceFlags::empty(),
+            heap_size=ruff_memory_usage::heap_size,
+        )]
+        fn instance_flags_inner<'db>(
+            db: &'db dyn Db,
+            class: StaticClassLiteral<'db>,
+        ) -> ClassInstanceFlags {
+            let mut flags = ClassInstanceFlags::empty();
+            for base in class.iter_mro(db, None) {
+                if base.is_typed_dict() {
+                    flags.insert(ClassInstanceFlags::TYPED_DICT);
+                }
+                if base.is_explicit_any_base() {
+                    flags.insert(ClassInstanceFlags::INHERITS_FROM_EXPLICIT_ANY);
+                }
+            }
+            flags
         }
 
         if let Some(known) = self.known(db) {
-            return known.is_typed_dict_subclass();
+            return if known.is_typed_dict_subclass() {
+                ClassInstanceFlags::TYPED_DICT
+            } else {
+                ClassInstanceFlags::empty()
+            };
         }
 
         if !self.has_explicit_bases(db) {
-            return false;
+            return ClassInstanceFlags::empty();
         }
-        is_typed_dict_inner(db, self)
+        instance_flags_inner(db, self)
+    }
+
+    /// Return `true` if this class constitutes a typed dict specification (inherits from
+    /// `typing.TypedDict`, either directly or indirectly).
+    pub fn is_typed_dict(self, db: &'db dyn Db) -> bool {
+        self.instance_flags(db)
+            .contains(ClassInstanceFlags::TYPED_DICT)
     }
 
     /// Return `true` if this class is, or inherits from, a `NamedTuple` (inherits from

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -92,6 +92,11 @@ impl<'db> ClassBase<'db> {
         matches!(self, ClassBase::TypedDict)
     }
 
+    /// Return whether this is an explicit `Any` base.
+    pub(super) const fn is_explicit_any_base(self) -> bool {
+        matches!(self, ClassBase::Any)
+    }
+
     /// Convert an explicit base while preserving a direct use of the `Any` special form.
     pub(super) fn try_from_explicit_base(
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -55,7 +55,7 @@ impl<'db> Type<'db> {
             ClassLiteral::Dynamic(_)
             | ClassLiteral::DynamicNamedTuple(_)
             | ClassLiteral::DynamicEnum(_) => {
-                Type::NominalInstance(NominalInstanceType(NominalInstanceInner::NonTuple(class)))
+                Type::NominalInstance(NominalInstanceType::from_class(db, class))
             }
             // Functional TypedDicts return a TypedDict instance type.
             ClassLiteral::DynamicTypedDict(_) => Type::typed_dict(class),
@@ -80,9 +80,9 @@ impl<'db> Type<'db> {
                                 ))
                             })
                         })
-                        .unwrap_or(Type::NominalInstance(NominalInstanceType(
-                            NominalInstanceInner::NonTuple(class),
-                        ))),
+                        .unwrap_or_else(|| {
+                            Type::NominalInstance(NominalInstanceType::from_class(db, class))
+                        }),
                 }
             }
         }
@@ -184,14 +184,26 @@ pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db
             walk_tuple_type(db, tuple, visitor);
         }
         NominalInstanceInner::Object => {}
-        NominalInstanceInner::NonTuple(class) => {
-            visitor.visit_type(db, class.into());
-        }
+        NominalInstanceInner::NonTuple(class) => visitor.visit_type(db, class.class(db).into()),
         NominalInstanceInner::SysVersionInfo => {}
     }
 }
 
 impl<'db> NominalInstanceType<'db> {
+    fn from_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        Self(NominalInstanceInner::NonTuple(
+            NominalInstanceClass::from_class(db, class),
+        ))
+    }
+
+    /// Return whether this instance's class inherits from an explicit `Any` base.
+    pub(super) const fn inherits_from_explicit_any(self) -> bool {
+        match self.0 {
+            NominalInstanceInner::NonTuple(class) => class.inherits_from_explicit_any(),
+            _ => false,
+        }
+    }
+
     /// Returns the name of the class this is an instance of.
     ///
     /// For example, for an instance of `builtins.str`, this returns `"str"`.
@@ -221,7 +233,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
-            NominalInstanceInner::NonTuple(class) => class,
+            NominalInstanceInner::NonTuple(class) => class.class(db),
             NominalInstanceInner::SysVersionInfo => {
                 sys_version_info_class(db).unwrap_or_else(|| ClassType::object(db))
             }
@@ -239,7 +251,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn known_class(&self, db: &'db dyn Db) -> Option<KnownClass> {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => Some(KnownClass::Tuple),
-            NominalInstanceInner::NonTuple(class) => class.known(db),
+            NominalInstanceInner::NonTuple(class) => class.class(db).known(db),
             NominalInstanceInner::SysVersionInfo => Some(KnownClass::VersionInfo),
             NominalInstanceInner::Object => Some(KnownClass::Object),
         }
@@ -264,7 +276,9 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::SysVersionInfo => {
                 Some(Cow::Owned(TupleSpec::version_info_spec(db)))
             }
+            NominalInstanceInner::Object => None,
             NominalInstanceInner::NonTuple(class) => {
+                let class = class.class(db);
                 // Avoid an expensive MRO traversal for common stdlib classes.
                 if class
                     .known(db)
@@ -289,7 +303,6 @@ impl<'db> NominalInstanceType<'db> {
                         _ => None,
                     })
             }
-            NominalInstanceInner::Object => None,
         }
     }
 
@@ -298,11 +311,11 @@ impl<'db> NominalInstanceType<'db> {
         matches!(self.0, NominalInstanceInner::Object)
     }
 
-    pub(super) fn is_definition_generic(self) -> bool {
+    pub(super) fn is_definition_generic(self, db: &'db dyn Db) -> bool {
         match self.0 {
-            NominalInstanceInner::NonTuple(class) => class.is_generic(),
             NominalInstanceInner::ExactTuple(_) => true,
             NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => false,
+            NominalInstanceInner::NonTuple(class) => class.class(db).is_generic(),
         }
     }
 
@@ -332,10 +345,10 @@ impl<'db> NominalInstanceType<'db> {
     /// integers or `None`.
     pub(crate) fn slice_literal(self, db: &'db dyn Db) -> Option<SliceLiteral> {
         let class = match self.0 {
+            NominalInstanceInner::NonTuple(class) => class.class(db),
             NominalInstanceInner::ExactTuple(_)
             | NominalInstanceInner::SysVersionInfo
             | NominalInstanceInner::Object => return None,
-            NominalInstanceInner::NonTuple(class) => class,
         };
         let (class_literal, specialization) = class.static_class_literal(db)?;
         let specialization = specialization?;
@@ -378,13 +391,18 @@ impl<'db> NominalInstanceType<'db> {
                     tuple.recursive_type_normalized_impl(db, div, nested)?,
                 )))
             }
-            NominalInstanceInner::NonTuple(class) => Some(Self(NominalInstanceInner::NonTuple(
-                class.recursive_type_normalized_impl(db, div, nested)?,
-            ))),
             NominalInstanceInner::SysVersionInfo => {
                 Some(Self(NominalInstanceInner::SysVersionInfo))
             }
             NominalInstanceInner::Object => Some(Self(NominalInstanceInner::Object)),
+            NominalInstanceInner::NonTuple(class) => {
+                let transformed = class
+                    .class(db)
+                    .recursive_type_normalized_impl(db, div, nested)?;
+                Some(Self(NominalInstanceInner::NonTuple(
+                    class.with_class(db, transformed),
+                )))
+            }
         }
     }
 
@@ -398,9 +416,10 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::ExactTuple(_) | NominalInstanceInner::Object => false,
             NominalInstanceInner::SysVersionInfo => true,
             NominalInstanceInner::NonTuple(class) => class
+                .class(db)
                 .known(db)
                 .map(KnownClass::is_singleton)
-                .unwrap_or_else(|| is_single_member_enum(db, class.class_literal(db))),
+                .unwrap_or_else(|| is_single_member_enum(db, class.class(db).class_literal(db))),
         }
     }
 
@@ -410,10 +429,11 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::Object => false,
             NominalInstanceInner::SysVersionInfo => true,
             NominalInstanceInner::NonTuple(class) => class
+                .class(db)
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
                 .or_else(|| Some(self.tuple_spec(db)?.is_single_valued(db)))
-                .unwrap_or_else(|| is_single_member_enum(db, class.class_literal(db))),
+                .unwrap_or_else(|| is_single_member_enum(db, class.class(db).class_literal(db))),
         }
     }
 
@@ -432,13 +452,17 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::ExactTuple(tuple) => {
                 Type::tuple(tuple.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
-            NominalInstanceInner::NonTuple(class) => {
-                Type::NominalInstance(NominalInstanceType(NominalInstanceInner::NonTuple(
-                    class.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                )))
-            }
             NominalInstanceInner::SysVersionInfo => Type::NominalInstance(self),
             NominalInstanceInner::Object => Type::object(),
+            NominalInstanceInner::NonTuple(class) => {
+                let transformed =
+                    class
+                        .class(db)
+                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                Type::NominalInstance(Self(NominalInstanceInner::NonTuple(
+                    class.with_class(db, transformed),
+                )))
+            }
         }
     }
 
@@ -453,10 +477,12 @@ impl<'db> NominalInstanceType<'db> {
             NominalInstanceInner::ExactTuple(tuple) => {
                 tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
-            NominalInstanceInner::NonTuple(class) => {
-                class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
-            }
             NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => {}
+            NominalInstanceInner::NonTuple(class) => {
+                class
+                    .class(db)
+                    .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            }
         }
     }
 }
@@ -615,9 +641,58 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
     }
 }
 
-/// [`NominalInstanceType`] is split into two variants internally as a pure
-/// optimization to avoid having to materialize the [`ClassType`] for tuple
-/// instances where it would be unnecessary (this is somewhat expensive!).
+/// The class of a nominal instance whose MRO contains an explicit `Any` base.
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct ExplicitAnyInstanceClass<'db> {
+    class: ClassType<'db>,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for ExplicitAnyInstanceClass<'_> {}
+
+/// The class stored by a non-tuple nominal instance.
+///
+/// Interning the uncommon explicit-`Any` case lets this type store the additional semantic bit
+/// without increasing the size of [`Type`].
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
+enum NominalInstanceClass<'db> {
+    Plain(ClassType<'db>),
+    InheritsFromExplicitAny(ExplicitAnyInstanceClass<'db>),
+}
+
+impl<'db> NominalInstanceClass<'db> {
+    fn from_class(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        if class.class_literal(db).inherits_from_explicit_any(db) {
+            Self::InheritsFromExplicitAny(ExplicitAnyInstanceClass::new(db, class))
+        } else {
+            Self::Plain(class)
+        }
+    }
+
+    const fn inherits_from_explicit_any(self) -> bool {
+        matches!(self, Self::InheritsFromExplicitAny(_))
+    }
+
+    fn class(self, db: &'db dyn Db) -> ClassType<'db> {
+        match self {
+            Self::Plain(class) => class,
+            Self::InheritsFromExplicitAny(class) => class.class(db),
+        }
+    }
+
+    fn with_class(self, db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        match self {
+            Self::Plain(_) => Self::Plain(class),
+            Self::InheritsFromExplicitAny(_) => {
+                Self::InheritsFromExplicitAny(ExplicitAnyInstanceClass::new(db, class))
+            }
+        }
+    }
+}
+
+/// [`NominalInstanceType`] is split into several variants internally as a pure optimization to
+/// avoid having to materialize the [`ClassType`] for tuple instances where it would be unnecessary
+/// (this is somewhat expensive!).
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::Update, get_size2::GetSize)]
 enum NominalInstanceInner<'db> {
     /// An instance of `object`.
@@ -636,7 +711,7 @@ enum NominalInstanceInner<'db> {
     ///
     /// This variant includes types that are subtypes of "exact tuple" types,
     /// because they represent "all instances of a class that is a tuple subclass".
-    NonTuple(ClassType<'db>),
+    NonTuple(NominalInstanceClass<'db>),
     /// The singleton `sys.version_info` value.
     SysVersionInfo,
 }
@@ -724,9 +799,9 @@ impl<'db> ProtocolInstanceType<'db> {
     /// treated in a nominal way.
     pub(super) fn to_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
         match self.inner {
-            Protocol::FromClass(class) => {
-                Some(NominalInstanceType(NominalInstanceInner::NonTuple(*class)))
-            }
+            Protocol::FromClass(class) => Some(NominalInstanceType(
+                NominalInstanceInner::NonTuple(NominalInstanceClass::Plain(*class)),
+            )),
             Protocol::Synthesized(_) => None,
         }
     }

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -1095,7 +1095,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 })
         };
 
-        let result = match (source, target) {
+        match (source, target) {
             // Everything is a subtype of `object`.
             (_, Type::NominalInstance(target)) if target.is_object() => self.always(),
             (_, Type::ProtocolInstance(target)) if target.is_equivalent_to_object(db) => {
@@ -1117,6 +1117,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // "too many cycle iterations" panics).
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
                 ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+            }
+
+            // Instances of classes that inherit from an explicit `Any` base retain their nominal
+            // identity and precise members, but have the same assignability as `Any`.
+            (Type::NominalInstance(source), _)
+                if self.relation.is_assignability() && source.inherits_from_explicit_any() =>
+            {
+                self.always()
             }
 
             (Type::TypeAlias(source_alias), _) => self.with_recursion_guard(source, target, || {
@@ -2206,25 +2214,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // Other than the special cases enumerated above, nominal-instance types are never
             // subtypes of any other variants
             (Type::NominalInstance(_), _) => self.never(),
-        };
-
-        // A nominal instance that inherits from an explicit `Any` base is assignable to any type.
-        // Nominal targets already handle `ClassBase::Any` while walking the source MRO, so only
-        // check failed relations to non-nominal targets here.
-        if !result.is_always_satisfied(db)
-            && let Type::NominalInstance(source) = source
-            && !matches!(target, Type::NominalInstance(_))
-            && self.relation.is_assignability()
-            && let class = source.class(db).class_literal(db)
-            && class.has_explicit_bases(db)
-            && class.inherits_from_any(db)
-        {
-            // Discard error context from the failed relation that this fallback overrides.
-            self.context_tree.take();
-            return self.always();
         }
-
-        result
     }
 
     pub(super) fn check_property_instance_pair(


### PR DESCRIPTION
## Summary

In #26034, we kept instances of classes that inherit from an explicit `Any` base nominal, then recovered `Any` assignability through a fallback after the ordinary relation check failed. That avoided increasing the size of `Type`, but required the relation checker to inspect the source class's MRO after the fact and discard any error context produced by the failed check.

This records explicit-`Any` ancestry when we construct a nominal instance instead. Static classes compute the bit in the same tracked MRO walk that already classifies `TypedDict` instances, avoiding a second cached query; dynamic classes derive the same flags from their existing cached MRO. `ClassBase::Any` remains the compact MRO marker that distinguishes an explicit `Any` base from a base expression whose inferred type is `Any` or `Unknown`.

Within `NominalInstanceInner::NonTuple`, a small `NominalInstanceClass` enum keeps ordinary `ClassType`s inline and stores only the uncommon marked case behind an interned handle. Nesting the marker inside the existing non-tuple payload means that `NominalInstanceInner` does not need a dedicated explicit-`Any` variant, and the release layout assertion continues to keep `Type` at 16 bytes.

Behavior remains unchanged from #26034. With the marker available directly on nominal instances, the relation checker handles `Any` assignability in an ordinary match arm. This removes the failed-relation fallback and its error-context reset entirely.

The CI memory report decreases total reported memory on all four projects: 5.06 kB on flake8, 23.64 kB on Trio, 132.16 kB on Sphinx, and 238.84 kB on Prefect.
