### PR TITLE
[ty] Avoid lookup maps for small place tables

### DIFF
--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -11,7 +11,7 @@ use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
-const LINEAR_SEARCH_THRESHOLD: usize = 16;
+const LINEAR_SEARCH_THRESHOLD: usize = 8;
 
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -11,6 +11,9 @@ use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
+// Selected using CodSpeed and measurements across the 162-project ecosystem corpus.
+// Member-expression equality is relatively expensive, and raising the cutoff to 16 regressed
+// performance for comparatively little additional memory savings.
 const LINEAR_SEARCH_THRESHOLD: usize = 8;
 
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -11,7 +11,7 @@ use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
-// Selected using CodSpeed and measurements across the 162-project ecosystem corpus.
+// Selected using performance and memory profiling across the 162-project ecosystem corpus.
 // Member-expression equality is relatively expensive, and raising the cutoff to 16 regressed
 // performance for comparatively little additional memory savings.
 const LINEAR_SEARCH_THRESHOLD: usize = 8;
@@ -424,12 +424,48 @@ impl Hash for MemberExprRef<'_> {
 #[derive(Ord, PartialOrd, get_size2::GetSize, salsa::Update)]
 pub struct ScopedMemberId;
 
+/// Map from member path to its ID.
+///
+/// Uses a hash table to avoid storing the path twice.
+#[derive(Debug, Default, get_size2::GetSize)]
+struct MemberReverseTable(hashbrown::HashTable<ScopedMemberId>);
+
+impl MemberReverseTable {
+    fn member_id(
+        &self,
+        members: &IndexVec<ScopedMemberId, Member>,
+        member: &MemberExprRef<'_>,
+    ) -> Option<ScopedMemberId> {
+        self.0
+            .find(hash_single(member), |id| members[*id].expression == *member)
+            .copied()
+    }
+
+    fn entry<'a>(
+        &'a mut self,
+        members: &IndexVec<ScopedMemberId, Member>,
+        member: &Member,
+    ) -> Entry<'a, ScopedMemberId> {
+        let member = member.expression.as_ref();
+        self.0.entry(
+            hash_single(&member),
+            |id| members[*id].expression.as_ref() == member,
+            |id| hash_single(&members[*id].expression.as_ref()),
+        )
+    }
+
+    fn shrink_to_fit(&mut self, members: &IndexVec<ScopedMemberId, Member>) {
+        self.0
+            .shrink_to_fit(|id| hash_single(&members[*id].expression.as_ref()));
+    }
+}
+
 /// The members of a scope. Allows lookup by member path and [`ScopedMemberId`].
 #[derive(Default, get_size2::GetSize)]
 pub(super) struct MemberTable {
     members: IndexVec<ScopedMemberId, Member>,
     /// Reverse lookup retained only when linear search would be expensive.
-    map: Option<Box<hashbrown::HashTable<ScopedMemberId>>>,
+    reverse: Option<Box<MemberReverseTable>>,
 }
 
 impl MemberTable {
@@ -456,10 +492,6 @@ impl MemberTable {
         self.members.iter()
     }
 
-    fn hash_member_expression_ref(member: &MemberExprRef) -> u64 {
-        hash_single(member)
-    }
-
     /// Returns the ID of the member with the given expression, if it exists.
     pub(crate) fn member_id<'a>(
         &self,
@@ -467,11 +499,8 @@ impl MemberTable {
     ) -> Option<ScopedMemberId> {
         let member = member.into();
 
-        if let Some(map) = self.map.as_deref() {
-            let hash = Self::hash_member_expression_ref(&member);
-            return map
-                .find(hash, |id| self.members[*id].expression == member)
-                .copied();
+        if let Some(reverse) = self.reverse.as_deref() {
+            return reverse.member_id(&self.members, &member);
         }
 
         self.members
@@ -508,10 +537,7 @@ impl std::fmt::Debug for MemberTable {
 #[derive(Debug, Default)]
 pub(super) struct MemberTableBuilder {
     table: MemberTable,
-    /// Map from member path to its ID.
-    ///
-    /// Small finished tables discard this map and use linear lookup; large tables retain it.
-    map: hashbrown::HashTable<ScopedMemberId>,
+    reverse: MemberReverseTable,
 }
 
 impl MemberTableBuilder {
@@ -520,26 +546,14 @@ impl MemberTableBuilder {
         member: impl Into<MemberExprRef<'a>>,
     ) -> Option<ScopedMemberId> {
         let member = member.into();
-        let hash = MemberTable::hash_member_expression_ref(&member);
-        self.map
-            .find(hash, |id| self.table.members[*id].expression == member)
-            .copied()
+        self.reverse.member_id(&self.table.members, &member)
     }
 
     /// Adds a member to the table or updates the flags of an existing member if it already exists.
     ///
     /// Members are identified by their expression, which is hashed to find the entry in the table.
     pub(super) fn add(&mut self, mut member: Member) -> (ScopedMemberId, bool) {
-        let member_ref = member.expression.as_ref();
-        let hash = MemberTable::hash_member_expression_ref(&member_ref);
-        let entry = self.map.entry(
-            hash,
-            |id| self.table.members[*id].expression.as_ref() == member.expression.as_ref(),
-            |id| {
-                let ref_expr = self.table.members[*id].expression.as_ref();
-                MemberTable::hash_member_expression_ref(&ref_expr)
-            },
-        );
+        let entry = self.reverse.entry(&self.table.members, &member);
 
         match entry {
             Entry::Occupied(entry) => {
@@ -562,15 +576,15 @@ impl MemberTableBuilder {
     }
 
     pub(super) fn build(self) -> MemberTable {
-        let Self { mut table, mut map } = self;
+        let Self {
+            mut table,
+            mut reverse,
+        } = self;
         table.members.shrink_to_fit();
 
         if table.members.len() > LINEAR_SEARCH_THRESHOLD {
-            map.shrink_to_fit(|id| {
-                let ref_expr = table.members[*id].expression.as_ref();
-                MemberTable::hash_member_expression_ref(&ref_expr)
-            });
-            table.map = Some(Box::new(map));
+            reverse.shrink_to_fit(&table.members);
+            table.reverse = Some(Box::new(reverse));
         }
 
         table

--- a/crates/ty_python_core/src/member.rs
+++ b/crates/ty_python_core/src/member.rs
@@ -11,6 +11,8 @@ use std::fmt::Write as _;
 use std::hash::{Hash, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
+const LINEAR_SEARCH_THRESHOLD: usize = 16;
+
 /// A member access, e.g. `x.y` or `x[1]` or `x["foo"]`.
 #[derive(Clone, Debug, PartialEq, Eq, get_size2::GetSize)]
 pub struct Member {
@@ -423,11 +425,8 @@ pub struct ScopedMemberId;
 #[derive(Default, get_size2::GetSize)]
 pub(super) struct MemberTable {
     members: IndexVec<ScopedMemberId, Member>,
-
-    /// Map from member path to its ID.
-    ///
-    /// Uses a hash table to avoid storing the path twice.
-    map: hashbrown::HashTable<ScopedMemberId>,
+    /// Reverse lookup retained only when linear search would be expensive.
+    map: Option<Box<hashbrown::HashTable<ScopedMemberId>>>,
 }
 
 impl MemberTable {
@@ -464,10 +463,17 @@ impl MemberTable {
         member: impl Into<MemberExprRef<'a>>,
     ) -> Option<ScopedMemberId> {
         let member = member.into();
-        let hash = Self::hash_member_expression_ref(&member);
-        self.map
-            .find(hash, |id| self.members[*id].expression == member)
-            .copied()
+
+        if let Some(map) = self.map.as_deref() {
+            let hash = Self::hash_member_expression_ref(&member);
+            return map
+                .find(hash, |id| self.members[*id].expression == member)
+                .copied();
+        }
+
+        self.members
+            .iter_enumerated()
+            .find_map(|(id, candidate)| (candidate.expression == member).then_some(id))
     }
 
     pub(crate) fn place_id_by_instance_attribute_name(&self, name: &str) -> Option<ScopedMemberId> {
@@ -499,16 +505,31 @@ impl std::fmt::Debug for MemberTable {
 #[derive(Debug, Default)]
 pub(super) struct MemberTableBuilder {
     table: MemberTable,
+    /// Map from member path to its ID.
+    ///
+    /// Small finished tables discard this map and use linear lookup; large tables retain it.
+    map: hashbrown::HashTable<ScopedMemberId>,
 }
 
 impl MemberTableBuilder {
+    pub(super) fn member_id<'a>(
+        &self,
+        member: impl Into<MemberExprRef<'a>>,
+    ) -> Option<ScopedMemberId> {
+        let member = member.into();
+        let hash = MemberTable::hash_member_expression_ref(&member);
+        self.map
+            .find(hash, |id| self.table.members[*id].expression == member)
+            .copied()
+    }
+
     /// Adds a member to the table or updates the flags of an existing member if it already exists.
     ///
     /// Members are identified by their expression, which is hashed to find the entry in the table.
     pub(super) fn add(&mut self, mut member: Member) -> (ScopedMemberId, bool) {
         let member_ref = member.expression.as_ref();
         let hash = MemberTable::hash_member_expression_ref(&member_ref);
-        let entry = self.table.map.entry(
+        let entry = self.map.entry(
             hash,
             |id| self.table.members[*id].expression.as_ref() == member.expression.as_ref(),
             |id| {
@@ -538,12 +559,17 @@ impl MemberTableBuilder {
     }
 
     pub(super) fn build(self) -> MemberTable {
-        let mut table = self.table;
+        let Self { mut table, mut map } = self;
         table.members.shrink_to_fit();
-        table.map.shrink_to_fit(|id| {
-            let ref_expr = table.members[*id].expression.as_ref();
-            MemberTable::hash_member_expression_ref(&ref_expr)
-        });
+
+        if table.members.len() > LINEAR_SEARCH_THRESHOLD {
+            map.shrink_to_fit(|id| {
+                let ref_expr = table.members[*id].expression.as_ref();
+                MemberTable::hash_member_expression_ref(&ref_expr)
+            });
+            table.map = Some(Box::new(map));
+        }
+
         table
     }
 }

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
-const LINEAR_SEARCH_THRESHOLD: usize = 16;
+const LINEAR_SEARCH_THRESHOLD: usize = 8;
 
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -6,9 +6,9 @@ use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
-// Selected using CodSpeed and measurements across the 162-project ecosystem corpus. Symbol-name
-// equality is cheap enough that raising the cutoff from 8 to 16 reduced retained memory without a
-// measurable performance regression.
+// Selected using performance and memory profiling across the 162-project ecosystem corpus.
+// Symbol-name equality is cheap enough that raising the cutoff from 8 to 16 reduced retained
+// memory without a measurable performance regression.
 const LINEAR_SEARCH_THRESHOLD: usize = 16;
 
 /// Uniquely identifies a symbol in a given scope.
@@ -159,6 +159,47 @@ impl Symbol {
     }
 }
 
+/// Map from symbol name to its ID.
+///
+/// Uses a hash table to avoid storing the name twice.
+#[derive(Debug, Default, get_size2::GetSize)]
+struct SymbolReverseTable(hashbrown::HashTable<ScopedSymbolId>);
+
+impl SymbolReverseTable {
+    fn symbol_id(
+        &self,
+        symbols: &IndexVec<ScopedSymbolId, Symbol>,
+        name: &str,
+    ) -> Option<ScopedSymbolId> {
+        self.0
+            .find(Self::hash_name(name), |id| symbols[*id].name == name)
+            .copied()
+    }
+
+    fn entry<'a>(
+        &'a mut self,
+        symbols: &IndexVec<ScopedSymbolId, Symbol>,
+        symbol: &Symbol,
+    ) -> Entry<'a, ScopedSymbolId> {
+        self.0.entry(
+            Self::hash_name(symbol.name()),
+            |id| &symbols[*id].name == symbol.name(),
+            |id| Self::hash_name(&symbols[*id].name),
+        )
+    }
+
+    fn shrink_to_fit(&mut self, symbols: &IndexVec<ScopedSymbolId, Symbol>) {
+        self.0
+            .shrink_to_fit(|id| Self::hash_name(&symbols[*id].name));
+    }
+
+    fn hash_name(name: &str) -> u64 {
+        let mut h = FxHasher::default();
+        name.hash(&mut h);
+        h.finish()
+    }
+}
+
 /// The symbols of a given scope.
 ///
 /// Allows lookup by name and a symbol's ID.
@@ -166,7 +207,7 @@ impl Symbol {
 pub(super) struct SymbolTable {
     symbols: IndexVec<ScopedSymbolId, Symbol>,
     /// Reverse lookup retained only when linear search would be expensive.
-    map: Option<Box<hashbrown::HashTable<ScopedSymbolId>>>,
+    reverse: Option<Box<SymbolReverseTable>>,
 }
 
 impl SymbolTable {
@@ -190,10 +231,8 @@ impl SymbolTable {
 
     /// Look up the ID of a symbol by its name.
     pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        if let Some(map) = self.map.as_deref() {
-            return map
-                .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
-                .copied();
+        if let Some(reverse) = self.reverse.as_deref() {
+            return reverse.symbol_id(&self.symbols, name);
         }
 
         self.symbols
@@ -204,12 +243,6 @@ impl SymbolTable {
     /// Iterate over the symbols in this symbol table.
     pub(crate) fn iter(&self) -> std::slice::Iter<'_, Symbol> {
         self.symbols.iter()
-    }
-
-    fn hash_name(name: &str) -> u64 {
-        let mut h = FxHasher::default();
-        name.hash(&mut h);
-        h.finish()
     }
 }
 
@@ -231,30 +264,17 @@ impl std::fmt::Debug for SymbolTable {
 #[derive(Debug, Default)]
 pub(super) struct SymbolTableBuilder {
     table: SymbolTable,
-    /// Map from symbol name to its ID.
-    ///
-    /// Uses a hash table to avoid storing the name twice. Small finished tables discard this map
-    /// and use linear lookup; large tables retain it.
-    map: hashbrown::HashTable<ScopedSymbolId>,
+    reverse: SymbolReverseTable,
 }
 
 impl SymbolTableBuilder {
     pub(super) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        self.map
-            .find(SymbolTable::hash_name(name), |id| {
-                self.table.symbols[*id].name == name
-            })
-            .copied()
+        self.reverse.symbol_id(&self.table.symbols, name)
     }
 
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
-        let hash = SymbolTable::hash_name(symbol.name());
-        let entry = self.map.entry(
-            hash,
-            |id| &self.table.symbols[*id].name == symbol.name(),
-            |id| SymbolTable::hash_name(&self.table.symbols[*id].name),
-        );
+        let entry = self.reverse.entry(&self.table.symbols, &symbol);
 
         match entry {
             Entry::Occupied(entry) => {
@@ -276,12 +296,15 @@ impl SymbolTableBuilder {
     }
 
     pub(super) fn build(self) -> SymbolTable {
-        let Self { mut table, mut map } = self;
+        let Self {
+            mut table,
+            mut reverse,
+        } = self;
         table.symbols.shrink_to_fit();
 
         if table.symbols.len() > LINEAR_SEARCH_THRESHOLD {
-            map.shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
-            table.map = Some(Box::new(map));
+            reverse.shrink_to_fit(&table.symbols);
+            table.reverse = Some(Box::new(reverse));
         }
 
         table

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -6,6 +6,9 @@ use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
+// Selected using CodSpeed and measurements across the 162-project ecosystem corpus. Symbol-name
+// equality is cheap enough that raising the cutoff from 8 to 16 reduced retained memory without a
+// measurable performance regression.
 const LINEAR_SEARCH_THRESHOLD: usize = 16;
 
 /// Uniquely identifies a symbol in a given scope.

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -6,6 +6,8 @@ use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
+const LINEAR_SEARCH_THRESHOLD: usize = 16;
+
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]
 #[derive(Ord, PartialOrd, get_size2::GetSize)]
@@ -160,11 +162,8 @@ impl Symbol {
 #[derive(Default, get_size2::GetSize)]
 pub(super) struct SymbolTable {
     symbols: IndexVec<ScopedSymbolId, Symbol>,
-
-    /// Map from symbol name to its ID.
-    ///
-    /// Uses a hash table to avoid storing the name twice.
-    map: hashbrown::HashTable<ScopedSymbolId>,
+    /// Reverse lookup retained only when linear search would be expensive.
+    map: Option<Box<hashbrown::HashTable<ScopedSymbolId>>>,
 }
 
 impl SymbolTable {
@@ -188,9 +187,15 @@ impl SymbolTable {
 
     /// Look up the ID of a symbol by its name.
     pub(crate) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
-        self.map
-            .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
-            .copied()
+        if let Some(map) = self.map.as_deref() {
+            return map
+                .find(Self::hash_name(name), |id| self.symbols[*id].name == name)
+                .copied();
+        }
+
+        self.symbols
+            .iter_enumerated()
+            .find_map(|(id, symbol)| (symbol.name == name).then_some(id))
     }
 
     /// Iterate over the symbols in this symbol table.
@@ -223,13 +228,26 @@ impl std::fmt::Debug for SymbolTable {
 #[derive(Debug, Default)]
 pub(super) struct SymbolTableBuilder {
     table: SymbolTable,
+    /// Map from symbol name to its ID.
+    ///
+    /// Uses a hash table to avoid storing the name twice. Small finished tables discard this map
+    /// and use linear lookup; large tables retain it.
+    map: hashbrown::HashTable<ScopedSymbolId>,
 }
 
 impl SymbolTableBuilder {
+    pub(super) fn symbol_id(&self, name: &str) -> Option<ScopedSymbolId> {
+        self.map
+            .find(SymbolTable::hash_name(name), |id| {
+                self.table.symbols[*id].name == name
+            })
+            .copied()
+    }
+
     /// Add a new symbol to this scope or update the flags if a symbol with the same name already exists.
     pub(super) fn add(&mut self, mut symbol: Symbol) -> (ScopedSymbolId, bool) {
         let hash = SymbolTable::hash_name(symbol.name());
-        let entry = self.table.map.entry(
+        let entry = self.map.entry(
             hash,
             |id| &self.table.symbols[*id].name == symbol.name(),
             |id| SymbolTable::hash_name(&self.table.symbols[*id].name),
@@ -255,11 +273,14 @@ impl SymbolTableBuilder {
     }
 
     pub(super) fn build(self) -> SymbolTable {
-        let mut table = self.table;
+        let Self { mut table, mut map } = self;
         table.symbols.shrink_to_fit();
-        table
-            .map
-            .shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
+
+        if table.symbols.len() > LINEAR_SEARCH_THRESHOLD {
+            map.shrink_to_fit(|id| SymbolTable::hash_name(&table.symbols[*id].name));
+            table.map = Some(Box::new(map));
+        }
+
         table
     }
 }

--- a/crates/ty_python_core/src/symbol.rs
+++ b/crates/ty_python_core/src/symbol.rs
@@ -6,7 +6,7 @@ use rustc_hash::FxHasher;
 use std::hash::{Hash as _, Hasher as _};
 use std::ops::{Deref, DerefMut};
 
-const LINEAR_SEARCH_THRESHOLD: usize = 8;
+const LINEAR_SEARCH_THRESHOLD: usize = 16;
 
 /// Uniquely identifies a symbol in a given scope.
 #[newtype_index]


### PR DESCRIPTION
## Summary

Avoid retaining reverse-lookup hash tables for completed place tables when linear lookup is cheaper. Builders continue to use the existing hash tables to deduplicate entries; when construction finishes, symbol tables with at most 16 entries and member tables with at most eight entries discard the index and use allocation-free linear lookup. Larger tables retain the existing `hashbrown::HashTable`.

This supersedes #26156. The thresholds are independently benchmarked because comparing member expressions is more expensive than comparing symbol names. A cutoff of eight avoids that PR's CodSpeed regression for members, while 16 recovers more symbol-table memory without a measurable CPU regression.

## Performance

At the final 16/8 cutoffs, the [latest CI memory report](https://github.com/astral-sh/ruff/pull/26177#issuecomment-4759738744) shows:

| Project | Total retained memory | `semantic_index` |
|---|---:|---:|
| flake8 | -1.73% | -6.28% |
| trio | -1.32% | -5.46% |
| sphinx | -0.95% | -4.70% |
| prefect | -1.10% | -4.76% |

The initial 8/8 cutoff eliminated #26156's CodSpeed regression: 15 of 23 ty microbenchmarks improved, with the full range between -0.34% and +0.34%, while the project benchmarks ranged from -0.08% to +0.06% ([microbenchmarks](https://app.codspeed.io/astral-sh/ruff/runs/6a36f6131ae269f74d1669d4), [projects](https://app.codspeed.io/astral-sh/ruff/runs/6a36f7811ae269f74d1669e6)). Raising only the symbol cutoff from 8 to 16 was classified as `No Change` across every benchmark: the microbenchmarks ranged from -0.7% to +0.4% and the project benchmarks from -0.2% to 0.0% ([microbenchmark comparison](https://app.codspeed.io/astral-sh/ruff/runs/compare/6a3882d970b8d54c83d90b25..6a38860b70b8d54c83d90b66), [project comparison](https://app.codspeed.io/astral-sh/ruff/runs/compare/6a38844570b8d54c83d90b4b..6a38878824ada329fad74da8)). That change saves an additional 0.12–0.18% of total retained memory and 0.64–0.91% of `semantic_index` memory.

## Ecosystem distribution

I temporarily instrumented final table construction and post-build lookups across all **162** projects in the ecosystem-analyzer's pinned mypy-primer corpus. The final cutoffs give the two structures similar lookup exposure while avoiding indexes for most tables:

| Structure | Cutoff | Nonempty tables without an index | Nonempty linear lookup share | Comparisons per linear lookup |
|---|---:|---:|---:|---:|
| Symbols | 16 | 93.55% | 38.56% | 5.56 |
| Members | 8 | 86.20% | 46.50% | 2.58 |

For symbols, increasing the cutoff from 8 to 16 removes another **217,586** indexes across the corpus runs and avoids 29.7 MiB of aggregate map storage while moving 16.64% of lookups to linear search. Applying the same increase to members would avoid only 9.8 MiB while moving another 24.96% of lookups to linear search, raising their nonempty linear lookup share to 71.74%. This supports the asymmetric 16/8 cutoffs.

The aggregate byte totals repeat common dependencies across independent project runs and should be read comparatively, not as whole-process memory totals.
