### PR TITLE
[`flake8-pyi`] Note that `PYI051` is an opinionated stylistic rule

### DIFF
--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -17,11 +17,20 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// that `Literal`.
 ///
 /// ## Why is this bad?
+/// This rule is opinionated and stylistic. It treats type-checking behavior as
+/// the primary signal: if the builtin supertype is present, type checkers must
+/// accept any value of that type, so the `Literal` members do not make the
+/// accepted type narrower.
+///
 /// Using a `Literal` type in a union with its builtin supertype is redundant,
 /// as the supertype will be strictly more general than the `Literal` type.
 /// For example, `Literal["A"] | str` is equivalent to `str`, and
 /// `Literal[1] | int` is equivalent to `int`, as `str` and `int` are the
 /// supertypes of `"A"` and `1` respectively.
+///
+/// If a project intentionally keeps the literal members for editor suggestions,
+/// generated documentation, or another non-type-checking purpose, disabling
+/// this rule for those annotations may be reasonable.
 ///
 /// ## Example
 /// ```pyi

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/redundant_literal_union.rs
@@ -17,20 +17,11 @@ use crate::fix::snippet::SourceCodeSnippet;
 /// that `Literal`.
 ///
 /// ## Why is this bad?
-/// This rule is opinionated and stylistic. It treats type-checking behavior as
-/// the primary signal: if the builtin supertype is present, type checkers must
-/// accept any value of that type, so the `Literal` members do not make the
-/// accepted type narrower.
-///
 /// Using a `Literal` type in a union with its builtin supertype is redundant,
 /// as the supertype will be strictly more general than the `Literal` type.
 /// For example, `Literal["A"] | str` is equivalent to `str`, and
 /// `Literal[1] | int` is equivalent to `int`, as `str` and `int` are the
 /// supertypes of `"A"` and `1` respectively.
-///
-/// If a project intentionally keeps the literal members for editor suggestions,
-/// generated documentation, or another non-type-checking purpose, disabling
-/// this rule for those annotations may be reasonable.
 ///
 /// ## Example
 /// ```pyi
@@ -45,6 +36,12 @@ use crate::fix::snippet::SourceCodeSnippet;
 ///
 /// x: Literal[b"B"] | str
 /// ```
+///
+/// ## Known issues
+/// This rule is opinionated and may not be appropriate for projects that keep
+/// literal members for editor suggestions, generated documentation, or another
+/// non-type-checking purpose. In those cases, disabling this rule for the
+/// affected annotations may be reasonable.
 #[derive(ViolationMetadata)]
 #[violation_metadata(stable_since = "v0.0.283")]
 pub(crate) struct RedundantLiteralUnion {


### PR DESCRIPTION
﻿## Summary

Clarifies the PYI051 documentation to describe the rule as opinionated and stylistic.

The added text explains that the rule focuses on type-checking behavior, while acknowledging cases where projects may intentionally keep `Literal` members for editor suggestions, generated documentation, or other non-type-checking purposes.

## Validation

- Compared the modified rule documentation against the current `main` version
- `git diff --no-index --check`

Fixes #23134
