### PR TITLE
[ty] Fix `is` narrowing of NewTypes (astral-sh/ty#3552)

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/annotations/new_types.md
@@ -671,6 +671,57 @@ def f(x: N):
             reveal_type(x)  # revealed: N
 ```
 
+## `is` narrowing treats a `NewType` as its base, but `==` narrowing leaves it alone
+
+A `NewType` is an identity function at runtime (`NewType("N", Base)(x) is x`), so a `NewType`
+instance shares all of its base type's inhabitants. Two `NewType`s over the same base are therefore
+not disjoint, and an `is` comparison between them can succeed at runtime, so it must not narrow to
+`Never`:
+
+```py
+from typing import NewType, Literal
+
+class C: ...
+
+A = NewType("A", C)
+B = NewType("B", C)
+
+def share(a: A, b: B) -> None:
+    if a is b:
+        reveal_type(a)  # revealed: A & B
+
+NI = NewType("NI", int)
+
+def newtype_vs_literal(n: NI) -> None:
+    if n is 5:
+        reveal_type(n)  # revealed: NI & Literal[5]
+```
+
+But the bases still drive disjointness, so genuinely disjoint `NewType`s narrow to `Never` as
+before:
+
+```py
+def disjoint(n: NI, s: str) -> None:
+    if n is s:
+        reveal_type(n)  # revealed: Never
+```
+
+Value-equality (`==`, and `match` value patterns) deliberately does *not* narrow a `NewType`
+subject: we keep the `NewType` brand rather than narrowing it down to a member of its base. Type
+aliases to a `NewType` are treated the same way:
+
+```py
+def eq(n: NI) -> None:
+    if n == 5:
+        reveal_type(n)  # revealed: NI
+
+AliasNI = NI
+
+def eq_through_alias(n: AliasNI) -> None:
+    if n == 5:
+        reveal_type(n)  # revealed: NI
+```
+
 ## The base of a `NewType` can't be a protocol class or a `TypedDict`
 
 ```py

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -203,7 +203,8 @@ use crate::{
         CallableTypes, ClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
         Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
         enum_metadata, equality_truthiness, infer_narrowing_constraints,
-        infer_same_file_expression_type, mapping_pattern_type, sequence_pattern_type_builder,
+        infer_same_file_expression_type, mapping_pattern_type,
+        narrow::is_brand_preserving_newtype_subject, sequence_pattern_type_builder,
         singleton_pattern_type,
     },
 };
@@ -475,7 +476,14 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
         return truthiness;
     }
 
-    let narrowed_subject_ty = type_narrowed_by_previous_patterns(db, predicate, subject_ty);
+    // Previous value/enum-member patterns do not exhaust a `NewType` subject, so a trailing
+    // `case _:` stays reachable as the `NewType` rather than `Never`. Companion to the value-
+    // equality guard in `narrow.rs`; see `is_brand_preserving_newtype_subject`.
+    let narrowed_subject_ty = if is_brand_preserving_newtype_subject(db, subject_ty) {
+        subject_ty
+    } else {
+        type_narrowed_by_previous_patterns(db, predicate, subject_ty)
+    };
 
     // Consider a case where we match on a subject type of `Self` with an upper bound of `Answer`,
     // where `Answer` is a {YES, NO} enum. After a previous pattern matching on `NO`, the narrowed

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -746,6 +746,18 @@ fn merge_constraints_or<'db>(
     }
 }
 
+/// Return `true` if `ty` is a `NewType` instance whose value-equality and match-exhaustiveness
+/// narrowing we deliberately suppress, to keep the `NewType` brand rather than narrow to a member
+/// of its base. Consumed by the guard in
+/// [`NarrowingConstraintsBuilder::evaluate_expr_compare_op`] and by [`crate::reachability`].
+///
+/// Type aliases are resolved first, so an alias to a `NewType` is recognized. Limited to a *direct*
+/// `NewType` subject: a `NewType` inside a union (`N | str`) or intersection still narrows
+/// element-wise, since suppressing the whole subject would also stop the non-`NewType` parts.
+pub(crate) fn is_brand_preserving_newtype_subject<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    matches!(ty.resolve_type_alias(db), Type::NewTypeInstance(_))
+}
+
 /// Return `true` if it is possible for any two inhabitants of the given types to
 /// compare equal to each other; otherwise return `false`.
 fn could_compare_equal<'db>(db: &'db dyn Db, left_ty: Type<'db>, right_ty: Type<'db>) -> bool {
@@ -1352,6 +1364,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         op: ast::CmpOp,
         is_positive: bool,
     ) -> Option<Type<'db>> {
+        // A `NewType` subject is not narrowed by value-(in)equality (`==`, `!=`, or a `match`
+        // value pattern): keep the `NewType` brand rather than narrow to a member of its base.
+        // See `is_brand_preserving_newtype_subject`.
+        if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
+            && is_brand_preserving_newtype_subject(self.db, lhs_ty)
+        {
+            return None;
+        }
         if op == ast::CmpOp::Eq {
             return evaluate_type_equality(self.db, lhs_ty, rhs_ty, is_positive);
         }

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -1,6 +1,6 @@
 use crate::Db;
 use crate::types::constraints::ConstraintSet;
-use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
+use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::{ClassType, KnownUnion, Type, definition_expression_type, visitor};
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
@@ -227,16 +227,14 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: NewType<'db>,
         right: NewType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        // Two NewTypes are disjoint if they're not equal and neither inherits from the other.
-        // NewTypes have single inheritance, and a regular class can't inherit from a NewType, so
-        // it's not possible for some third type to multiply-inherit from both.
-        let relation_checker = self.as_relation_checker(TypeRelation::Subtyping);
-        relation_checker
-            .check_newtype_pair(db, left, right)
-            .or(db, self.constraints, || {
-                relation_checker.check_newtype_pair(db, right, left)
-            })
-            .negate(db, self.constraints)
+        // Two `NewType`s are disjoint exactly when their concrete bases are: each shares its base's
+        // inhabitants, so distinct `NewType`s over the same base still overlap and `a is b` can
+        // hold. Mirrors the mixed `(NewType, other)` arm.
+        self.check_type_pair(
+            db,
+            left.concrete_base_type(db),
+            right.concrete_base_type(db),
+        )
     }
 }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2953,6 +2953,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 )
             }
 
+            // A `NewType` is an identity function at runtime (`NewType("N", Base)(x) is x`), so it
+            // shares all of its base type's inhabitants. Unwrap to the concrete base before the
+            // literal/nominal arms below, so e.g. `NewType("N", bool)` vs `Literal[True]` is not
+            // wrongly reported disjoint (which would narrow an `is` comparison to `Never`).
+            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
+                self.check_newtype_pair(db, left, right)
+            }
+            (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
+                self.check_type_pair(db, newtype.concrete_base_type(db), other)
+            }
+
             (Type::LiteralValue(literal), Type::NominalInstance(instance))
             | (Type::NominalInstance(instance), Type::LiteralValue(literal)) => {
                 let positive_relation_holds = match literal.kind() {
@@ -3154,13 +3165,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 .with_recursion_guard(left, right, || {
                     self.check_nominal_instance_pair(db, left_i, right_i)
                 }),
-
-            (Type::NewTypeInstance(left), Type::NewTypeInstance(right)) => {
-                self.check_newtype_pair(db, left, right)
-            }
-            (Type::NewTypeInstance(newtype), other) | (other, Type::NewTypeInstance(newtype)) => {
-                self.check_type_pair(db, newtype.concrete_base_type(db), other)
-            }
 
             (Type::PropertyInstance(property), other)
             | (other, Type::PropertyInstance(property)) => {


### PR DESCRIPTION

Fixes astral-sh/ty#3552.

`is` narrowing collapsed NewType comparisons to `Never` because `is_disjoint_from` treated distinct NewTypes (and a NewType against a literal of its base) as disjoint. A NewType is an identity function at runtime, so NewTypes over a shared base are not disjoint and `a is b` can succeed.

The "don't narrow NewType-wrapped enums in match arms" behavior from #21157 rode on that same (incorrect) disjointness, so this PR makes disjointness runtime-correct and re-expresses that behavior explicitly:

- `types/relation.rs`: the NewType arms in the disjointness checker unwrap to the concrete base before the literal/nominal special-cases run.
- `types/newtype.rs`: two-NewType disjointness compares concrete base types instead of nominal distinctness.
- `types/narrow.rs`: a NewType subject is not narrowed by value-(in)equality (`is_brand_preserving_newtype_subject`, alias-resolving).
- `reachability.rs`: a NewType subject is not exhausted by previous value/enum patterns, so a trailing `case _:` stays reachable.

### Test plan
- New `new_types.md` cases for `is` narrowing, the disjoint boundary (`int` vs `str` still `Never`), and the `==` / alias policy.
- The existing "Don't narrow `NewType`-wrapped `Enum`s inside of match arms" test passes unchanged.
- Full `ty_python_semantic` suite green.

### Open question
The PR keeps `case _:` reachable as `N` (current behavior). With disjointness fixed, match exhaustiveness could instead narrow it to `Never` once the members are covered. Easy to flip.
