### PR TITLE
[ty] Use SmallVec for `CycleDetector::seen`

### DIFF
--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -3086,7 +3086,7 @@ fn is_name_like_token(token: &Token) -> bool {
 /// on `CompletionBuilder`.
 fn completion_kind_from_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<CompletionKind> {
     type CompletionKindVisitor<'db> =
-        CycleDetector<CompletionKind, Type<'db>, Option<CompletionKind>>;
+        CycleDetector<CompletionKind, Type<'db>, Option<CompletionKind>, 3>;
 
     fn imp<'db>(
         db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -512,6 +512,7 @@ impl<'db> SemanticModel<'db> {
             StringLiteralCandidates,
             Type<'db>,
             Vec<ExpectedStringLiteralCompletion<'db>>,
+            3,
         >;
 
         fn collect<'db>(

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -377,8 +377,7 @@ pub(crate) type FindLegacyTypeVarsVisitor<'db> =
 pub(crate) struct FindLegacyTypeVars;
 
 /// A [`CycleDetector`] that is used in `visit_specialization` methods.
-pub(crate) type SpecializationVisitor<'db> =
-    CycleDetector<VisitSpecialization, Type<'db>, (), 3>;
+pub(crate) type SpecializationVisitor<'db> = CycleDetector<VisitSpecialization, Type<'db>, (), 3>;
 pub(crate) struct VisitSpecialization;
 
 /// How a generic type has been specialized.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -289,7 +289,7 @@ struct ApplyBottomMaterialization;
 struct ApplyMaterializationEquivalence;
 
 type MaterializationEquivalenceVisitor<'db> =
-    Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool>>;
+    Rc<CycleDetector<ApplyMaterializationEquivalence, (Type<'db>, Type<'db>), bool, 1>>;
 
 /// A [`TypeTransformer`] that is used in `apply_type_mapping` methods.
 ///
@@ -370,13 +370,15 @@ impl Default for ApplyTypeMappingVisitor<'_> {
 }
 
 /// A [`CycleDetector`] that is used in `find_legacy_typevars` methods.
-pub(crate) type FindLegacyTypeVarsVisitor<'db> = CycleDetector<FindLegacyTypeVars, Type<'db>, ()>;
+pub(crate) type FindLegacyTypeVarsVisitor<'db> =
+    CycleDetector<FindLegacyTypeVars, Type<'db>, (), 3>;
 
 #[derive(Debug)]
 pub(crate) struct FindLegacyTypeVars;
 
 /// A [`CycleDetector`] that is used in `visit_specialization` methods.
-pub(crate) type SpecializationVisitor<'db> = CycleDetector<VisitSpecialization, Type<'db>, ()>;
+pub(crate) type SpecializationVisitor<'db> =
+    CycleDetector<VisitSpecialization, Type<'db>, (), 3>;
 pub(crate) struct VisitSpecialization;
 
 /// How a generic type has been specialized.

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -334,7 +334,7 @@ impl<'db> Type<'db> {
 
 /// A [`CycleDetector`] that is used in `try_bool` methods.
 pub(crate) type TryBoolVisitor<'db> =
-    CycleDetector<TryBool, Type<'db>, Result<Truthiness, BoolError<'db>>>;
+    CycleDetector<TryBool, Type<'db>, Result<Truthiness, BoolError<'db>>, 3>;
 pub(crate) struct TryBool;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -26,17 +26,17 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use rustc_hash::{FxHashMap, FxHashSet};
+use smallvec::SmallVec;
 
 use crate::Db;
-use crate::FxIndexSet;
 use crate::types::Type;
 
-pub(crate) type TypeTransformer<'db, Tag> = CycleDetector<Tag, Type<'db>, Type<'db>>;
+pub(crate) type TypeTransformer<'db, Tag> = CycleDetector<Tag, Type<'db>, Type<'db>, 3>;
 
 impl<Tag> Default for TypeTransformer<'_, Tag> {
     fn default() -> Self {
         CycleDetector {
-            seen: RefCell::new(FxIndexSet::default()),
+            seen: RefCell::new(SmallVec::new()),
             cache: RefCell::new(FxHashMap::default()),
             fallback: None,
             _tag: PhantomData,
@@ -44,14 +44,16 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
     }
 }
 
-pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<Tag, (Type<'db>, Type<'db>), C>;
+pub(crate) type PairVisitor<'db, Tag, C> = CycleDetector<Tag, (Type<'db>, Type<'db>), C, 1>;
 
+/// `CycleDetector` is temporary, so callers should choose the capacity that keeps observed cycle
+/// paths inline even when that makes `seen` slightly larger than an `FxIndexSet<T>`.
 #[derive(Debug)]
-pub struct CycleDetector<Tag, T, R> {
+pub struct CycleDetector<Tag, T, R, const INLINE_CAPACITY: usize> {
     /// If the type we're visiting is present in `seen`, it indicates that we've hit a cycle (due
     /// to a recursive type); we need to immediately short circuit the whole operation and return
     /// the fallback value. That's why we pop items off the end of `seen` after we've visited them.
-    seen: RefCell<FxIndexSet<T>>,
+    seen: RefCell<SmallVec<[T; INLINE_CAPACITY]>>,
 
     /// Unlike `seen`, this field is a pure performance optimisation (and an essential one). If the
     /// type we're trying to normalize is present in `cache`, it doesn't necessarily mean we've hit
@@ -66,10 +68,10 @@ pub struct CycleDetector<Tag, T, R> {
     _tag: PhantomData<Tag>,
 }
 
-impl<Tag, T, R> CycleDetector<Tag, T, R> {
+impl<Tag, T, R, const INLINE_CAPACITY: usize> CycleDetector<Tag, T, R, INLINE_CAPACITY> {
     pub fn new(fallback: R) -> Self {
         CycleDetector {
-            seen: RefCell::new(FxIndexSet::default()),
+            seen: RefCell::new(SmallVec::new()),
             cache: RefCell::new(FxHashMap::default()),
             fallback: Some(fallback),
             _tag: PhantomData,
@@ -77,14 +79,16 @@ impl<Tag, T, R> CycleDetector<Tag, T, R> {
     }
 }
 
-impl<Tag, T: Hash + Eq + Clone, R: Clone> CycleDetector<Tag, T, R> {
+impl<Tag, T: Hash + Eq + Clone, R: Clone, const INLINE_CAPACITY: usize>
+    CycleDetector<Tag, T, R, INLINE_CAPACITY>
+{
     /// Some recursive types cannot be evaluated for equality using simple hash values.
     /// `is_cycle` provides a manual equality check.
     /// `on_cycle` returns the type to be used as a fallback during the cycle.
     fn visit_or_else(
         &self,
         item: T,
-        is_cycle: impl FnOnce(&FxIndexSet<T>, &T) -> bool,
+        is_cycle: impl FnOnce(&[T], &T) -> bool,
         on_cycle: impl FnOnce(T) -> R,
         func: impl FnOnce() -> R,
     ) -> R {
@@ -93,9 +97,10 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone> CycleDetector<Tag, T, R> {
         }
 
         // We hit a cycle
-        if is_cycle(&self.seen.borrow(), &item) || !self.seen.borrow_mut().insert(item.clone()) {
+        if is_cycle(&self.seen.borrow(), &item) {
             return on_cycle(item);
         }
+        self.seen.borrow_mut().push(item.clone());
 
         let ret = func();
 
@@ -110,7 +115,7 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone> CycleDetector<Tag, T, R> {
         debug_assert!(self.fallback.is_some());
         self.visit_or_else(
             item,
-            FxIndexSet::contains,
+            <[T]>::contains,
             |_| self.fallback.clone().unwrap(),
             func,
         )
@@ -158,7 +163,9 @@ impl<'db, Tag> TypeTransformer<'db, Tag> {
     }
 }
 
-impl<Tag, T, R: Default> Default for CycleDetector<Tag, T, R> {
+impl<Tag, T, R: Default, const INLINE_CAPACITY: usize> Default
+    for CycleDetector<Tag, T, R, INLINE_CAPACITY>
+{
     fn default() -> Self {
         CycleDetector::new(R::default())
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -22,7 +22,7 @@ enum BinaryExpressionOperandTypes<'db> {
 }
 
 type BinaryExpressionVisitor<'db> =
-    CycleDetector<ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>>;
+    CycleDetector<ast::Operator, (Type<'db>, ast::Operator, Type<'db>), Option<Type<'db>>, 1>;
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
     pub(super) fn infer_binary_expression(

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -64,7 +64,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn typed_dict_key_expected_type(&self, ty: Type<'db>) -> Option<Type<'db>> {
         struct TypedDictKeyExpectedType;
         type TypedDictKeyExpectedTypeVisitor<'db> =
-            CycleDetector<TypedDictKeyExpectedType, Type<'db>, Option<Type<'db>>>;
+            CycleDetector<TypedDictKeyExpectedType, Type<'db>, Option<Type<'db>>, 3>;
 
         fn imp<'db>(
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -74,7 +74,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     fn contains_type_form_value(&self, expression: &ast::Expr, ty: Type<'db>) -> bool {
         struct ContainsTypeFormValue;
         type ContainsTypeFormValueVisitor<'db> =
-            CycleDetector<ContainsTypeFormValue, Type<'db>, bool>;
+            CycleDetector<ContainsTypeFormValue, Type<'db>, bool, 3>;
 
         fn imp<'db>(
             builder: &TypeInferenceBuilder<'db, '_>,

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -27,6 +27,7 @@ pub(super) type BinaryComparisonVisitor<'db> = CycleDetector<
     ast::CmpOp,
     (Type<'db>, ast::CmpOp, Type<'db>),
     Result<Type<'db>, UnsupportedComparisonError<'db>>,
+    1,
 >;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -714,6 +714,7 @@ pub(crate) type HasRelationToVisitor<'db, 'c> = CycleDetector<
     TypeRelation,
     (Type<'db>, Type<'db>, TypeRelation, TypeVarEvaluation),
     ConstraintSet<'db, 'c>,
+    1,
 >;
 
 impl<'db, 'c> HasRelationToVisitor<'db, 'c> {

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -38,7 +38,7 @@ impl<'db> Type<'db> {
     pub(crate) fn project_type_form(self, db: &'db dyn Db) -> Type<'db> {
         struct TypeFormArgument;
         type TypeFormArgumentVisitor<'db> =
-            CycleDetector<TypeFormArgument, Type<'db>, Option<Type<'db>>>;
+            CycleDetector<TypeFormArgument, Type<'db>, Option<Type<'db>>, 3>;
 
         fn project<'db>(
             db: &'db dyn Db,

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1736,5 +1736,5 @@ impl<'db> TypeVarBoundOrConstraints<'db> {
 
 /// A [`CycleDetector`] that is used in `TypeVarInstance::default_type`.
 pub(crate) type TypeVarDefaultVisitor<'db> =
-    CycleDetector<VisitTypeVarDefault, TypeVarInstance<'db>, Option<Type<'db>>>;
+    CycleDetector<VisitTypeVarDefault, TypeVarInstance<'db>, Option<Type<'db>>, 6>;
 pub(crate) struct VisitTypeVarDefault;


### PR DESCRIPTION
Store the `CycleDetector::seen` in a `SmallVec` instead of a `FxIndexSet`. We always push a type into `seen`, even if this ends being the only type that we visited. Today, this always results in an allocation. 

This PR uses a `SmallVec` for seen instead.


Cutoff | seen |
-- | -- | 
1 | 81.20% |
2 | 94.97% |
3 | 98.64% |
4 | 99.61% |
8 | 99.994% 
16 | 99.99996% |
32 | 99.99996% |


As you can see, almost all `CycleDetectors` store at most 2-3 elements, in which case a simple vector `contains` is much faster. 

I was worried about what if `seen` grows very large. However, running ty over all ecosystem projects: maximum 52 in `mitmproxy` for six detectors; another eight reached 51. The next-highest project maximum was only 14.

So there are a few large `seen` tables but they're still bound where a `O(n)` scan is reasonable. On top, our current implementation is already `O(n)`, and a larger `seen` also results in a much deeper stack because seen tracks stack depth. That's why I think a `Vec` (or small vec) is perfectly fine here. Especially because it does perform better than my small set implementation https://github.com/astral-sh/ruff/pull/26171



## Performance

See Codspeed report. This also helps reduce allocations by a lot (up to 5.6% for some projects)