### PR TITLE
[ty] Store cycle-detector cache entries inline

### DIFF
--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -69,68 +69,6 @@ pub struct CycleDetector<Tag, T, R, const INLINE_CAPACITY: usize> {
     _tag: PhantomData<Tag>,
 }
 
-/// The memoized results for a [`CycleDetector`].
-///
-/// Most populated cycle-detector caches contain at most two results. Keep those results inline,
-/// but spill on the third distinct result so lookups in wider caches remain hashed.
-#[derive(Debug)]
-enum CycleDetectorCache<T, R> {
-    Empty,
-    One((T, R)),
-    Two([(T, R); 2]),
-    Spilled(FxHashMap<T, R>),
-}
-
-impl<T, R> CycleDetectorCache<T, R> {
-    const fn new() -> Self {
-        Self::Empty
-    }
-
-    fn get(&self, item: &T) -> Option<&R>
-    where
-        T: Hash + Eq,
-    {
-        match self {
-            Self::Empty => None,
-            Self::One((cached_item, result)) => (cached_item == item).then_some(result),
-            Self::Two(entries) => entries
-                .iter()
-                .find_map(|(cached_item, result)| (cached_item == item).then_some(result)),
-            Self::Spilled(cache) => cache.get(item),
-        }
-    }
-
-    /// Inserts a result after the caller has checked that `item` is not already cached.
-    fn insert_new(&mut self, item: T, result: R)
-    where
-        T: Hash + Eq,
-    {
-        let entry = (item, result);
-        *self = match mem::replace(self, Self::Empty) {
-            Self::Empty => Self::One(entry),
-            Self::One(first) => Self::Two([first, entry]),
-            Self::Two(entries) => Self::spill(entries, entry),
-            Self::Spilled(mut cache) => {
-                cache.insert(entry.0, entry.1);
-                Self::Spilled(cache)
-            }
-        };
-    }
-
-    #[cold]
-    fn spill(entries: [(T, R); 2], third: (T, R)) -> Self
-    where
-        T: Hash + Eq,
-    {
-        Self::Spilled(entries.into_iter().chain([third]).collect())
-    }
-
-    #[cfg(test)]
-    fn is_spilled(&self) -> bool {
-        matches!(self, Self::Spilled(_))
-    }
-}
-
 impl<Tag, T, R, const INLINE_CAPACITY: usize> CycleDetector<Tag, T, R, INLINE_CAPACITY> {
     pub fn new(fallback: R) -> Self {
         CycleDetector {
@@ -231,6 +169,68 @@ impl<Tag, T, R: Default, const INLINE_CAPACITY: usize> Default
 {
     fn default() -> Self {
         CycleDetector::new(R::default())
+    }
+}
+
+/// The memoized results for a [`CycleDetector`].
+///
+/// Most populated cycle-detector caches contain at most two results. Keep those results inline,
+/// but spill on the third distinct result so lookups in wider caches remain hashed.
+#[derive(Debug)]
+enum CycleDetectorCache<T, R> {
+    Empty,
+    One((T, R)),
+    Two([(T, R); 2]),
+    Spilled(FxHashMap<T, R>),
+}
+
+impl<T, R> CycleDetectorCache<T, R> {
+    const fn new() -> Self {
+        Self::Empty
+    }
+
+    fn get(&self, item: &T) -> Option<&R>
+    where
+        T: Hash + Eq,
+    {
+        match self {
+            Self::Empty => None,
+            Self::One((cached_item, result)) => (cached_item == item).then_some(result),
+            Self::Two(entries) => entries
+                .iter()
+                .find_map(|(cached_item, result)| (cached_item == item).then_some(result)),
+            Self::Spilled(cache) => cache.get(item),
+        }
+    }
+
+    /// Inserts a result after the caller has checked that `item` is not already cached.
+    fn insert_new(&mut self, item: T, result: R)
+    where
+        T: Hash + Eq,
+    {
+        let entry = (item, result);
+        *self = match mem::replace(self, Self::Empty) {
+            Self::Empty => Self::One(entry),
+            Self::One(first) => Self::Two([first, entry]),
+            Self::Two(entries) => Self::spill(entries, entry),
+            Self::Spilled(mut cache) => {
+                cache.insert(entry.0, entry.1);
+                Self::Spilled(cache)
+            }
+        };
+    }
+
+    #[cold]
+    fn spill(entries: [(T, R); 2], third: (T, R)) -> Self
+    where
+        T: Hash + Eq,
+    {
+        Self::Spilled(entries.into_iter().chain([third]).collect())
+    }
+
+    #[cfg(test)]
+    fn is_spilled(&self) -> bool {
+        matches!(self, Self::Spilled(_))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -208,6 +208,7 @@ impl<T, R> CycleDetectorCache<T, R> {
     where
         T: Hash + Eq,
     {
+        debug_assert!(self.get(&item).is_none());
         let entry = (item, result);
         *self = match mem::replace(self, Self::Empty) {
             Self::Empty => Self::One(entry),
@@ -229,7 +230,7 @@ impl<T, R> CycleDetectorCache<T, R> {
     }
 
     #[cfg(test)]
-    fn is_spilled(&self) -> bool {
+    const fn is_spilled(&self) -> bool {
         matches!(self, Self::Spilled(_))
     }
 }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -26,7 +26,7 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 use std::mem;
 
-use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::Db;
@@ -71,13 +71,12 @@ pub struct CycleDetector<Tag, T, R, const INLINE_CAPACITY: usize> {
 
 /// The memoized results for a [`CycleDetector`].
 ///
-/// Almost all populated cycle-detector caches contain at most two results. Keep those results
-/// inline, but spill on the third distinct result so lookups in the rare wider caches remain
-/// hashed.
+/// Most populated cycle-detector caches contain at most two results. Keep those results inline,
+/// but spill on the third distinct result so lookups in wider caches remain hashed.
 #[derive(Debug)]
 enum CycleDetectorCache<T, R> {
     Empty,
-    One { item: T, result: R },
+    One((T, R)),
     Two([(T, R); 2]),
     Spilled(FxHashMap<T, R>),
 }
@@ -93,10 +92,7 @@ impl<T, R> CycleDetectorCache<T, R> {
     {
         match self {
             Self::Empty => None,
-            Self::One {
-                item: cached_item,
-                result,
-            } => (cached_item == item).then_some(result),
+            Self::One((cached_item, result)) => (cached_item == item).then_some(result),
             Self::Two(entries) => entries
                 .iter()
                 .find_map(|(cached_item, result)| (cached_item == item).then_some(result)),
@@ -109,28 +105,13 @@ impl<T, R> CycleDetectorCache<T, R> {
     where
         T: Hash + Eq,
     {
-        match self {
-            Self::Empty => {
-                *self = Self::One { item, result };
-                return;
-            }
-            Self::Spilled(cache) => {
-                cache.insert(item, result);
-                return;
-            }
-            Self::One { .. } | Self::Two(_) => {}
-        }
-
-        let previous = mem::replace(self, Self::Empty);
-        *self = match previous {
-            Self::Empty => Self::One { item, result },
-            Self::One {
-                item: cached_item,
-                result: cached_result,
-            } => Self::Two([(cached_item, cached_result), (item, result)]),
-            Self::Two(entries) => Self::spill(entries, (item, result)),
+        let entry = (item, result);
+        *self = match mem::replace(self, Self::Empty) {
+            Self::Empty => Self::One(entry),
+            Self::One(first) => Self::Two([first, entry]),
+            Self::Two(entries) => Self::spill(entries, entry),
             Self::Spilled(mut cache) => {
-                cache.insert(item, result);
+                cache.insert(entry.0, entry.1);
                 Self::Spilled(cache)
             }
         };
@@ -141,12 +122,7 @@ impl<T, R> CycleDetectorCache<T, R> {
     where
         T: Hash + Eq,
     {
-        let mut cache = FxHashMap::with_capacity_and_hasher(3, FxBuildHasher);
-        for (item, result) in entries {
-            cache.insert(item, result);
-        }
-        cache.insert(third.0, third.1);
-        Self::Spilled(cache)
+        Self::Spilled(entries.into_iter().chain([third]).collect())
     }
 
     #[cfg(test)]
@@ -311,48 +287,22 @@ impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::Cell;
-
     use super::CycleDetector;
 
     struct TestCycleDetector;
     type Detector = CycleDetector<TestCycleDetector, u8, u8, 1>;
 
     #[test]
-    fn caches_one_result_inline() {
-        let detector = Detector::new(0);
-        let calls = Cell::new(0);
-
-        assert_eq!(
-            detector.visit(1, || {
-                calls.set(calls.get() + 1);
-                10
-            }),
-            10
-        );
-        assert!(!detector.cache.borrow().is_spilled());
-
-        assert_eq!(
-            detector.visit(1, || {
-                calls.set(calls.get() + 1);
-                20
-            }),
-            10
-        );
-        assert_eq!(calls.get(), 1);
-    }
-
-    #[test]
-    fn spills_multiple_results() {
+    fn caches_results_and_spills_after_two_entries() {
         let detector = Detector::new(0);
 
         assert_eq!(detector.visit(1, || 10), 10);
+        assert_eq!(detector.visit(1, || 40), 10);
         assert_eq!(detector.visit(2, || 20), 20);
         assert!(!detector.cache.borrow().is_spilled());
         assert_eq!(detector.visit(3, || 30), 30);
         assert!(detector.cache.borrow().is_spilled());
 
-        assert_eq!(detector.visit(1, || 40), 10);
         assert_eq!(detector.visit(2, || 40), 20);
         assert_eq!(detector.visit(3, || 40), 30);
     }

--- a/crates/ty_python_semantic/src/types/cyclic.rs
+++ b/crates/ty_python_semantic/src/types/cyclic.rs
@@ -24,8 +24,9 @@ use std::cell::RefCell;
 use std::cmp::Eq;
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::mem;
 
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::Db;
@@ -37,7 +38,7 @@ impl<Tag> Default for TypeTransformer<'_, Tag> {
     fn default() -> Self {
         CycleDetector {
             seen: RefCell::new(SmallVec::new()),
-            cache: RefCell::new(FxHashMap::default()),
+            cache: RefCell::new(CycleDetectorCache::new()),
             fallback: None,
             _tag: PhantomData,
         }
@@ -61,18 +62,104 @@ pub struct CycleDetector<Tag, T, R, const INLINE_CAPACITY: usize> {
     /// chain we're currently in. Since this cache is just a performance optimisation, it doesn't
     /// make sense to pop items off the end of the cache after they've been visited (it would
     /// sort-of defeat the point of a cache if we did!)
-    cache: RefCell<FxHashMap<T, R>>,
+    cache: RefCell<CycleDetectorCache<T, R>>,
 
     fallback: Option<R>,
 
     _tag: PhantomData<Tag>,
 }
 
+/// The memoized results for a [`CycleDetector`].
+///
+/// Almost all populated cycle-detector caches contain at most two results. Keep those results
+/// inline, but spill on the third distinct result so lookups in the rare wider caches remain
+/// hashed.
+#[derive(Debug)]
+enum CycleDetectorCache<T, R> {
+    Empty,
+    One { item: T, result: R },
+    Two([(T, R); 2]),
+    Spilled(FxHashMap<T, R>),
+}
+
+impl<T, R> CycleDetectorCache<T, R> {
+    const fn new() -> Self {
+        Self::Empty
+    }
+
+    fn get(&self, item: &T) -> Option<&R>
+    where
+        T: Hash + Eq,
+    {
+        match self {
+            Self::Empty => None,
+            Self::One {
+                item: cached_item,
+                result,
+            } => (cached_item == item).then_some(result),
+            Self::Two(entries) => entries
+                .iter()
+                .find_map(|(cached_item, result)| (cached_item == item).then_some(result)),
+            Self::Spilled(cache) => cache.get(item),
+        }
+    }
+
+    /// Inserts a result after the caller has checked that `item` is not already cached.
+    fn insert_new(&mut self, item: T, result: R)
+    where
+        T: Hash + Eq,
+    {
+        match self {
+            Self::Empty => {
+                *self = Self::One { item, result };
+                return;
+            }
+            Self::Spilled(cache) => {
+                cache.insert(item, result);
+                return;
+            }
+            Self::One { .. } | Self::Two(_) => {}
+        }
+
+        let previous = mem::replace(self, Self::Empty);
+        *self = match previous {
+            Self::Empty => Self::One { item, result },
+            Self::One {
+                item: cached_item,
+                result: cached_result,
+            } => Self::Two([(cached_item, cached_result), (item, result)]),
+            Self::Two(entries) => Self::spill(entries, (item, result)),
+            Self::Spilled(mut cache) => {
+                cache.insert(item, result);
+                Self::Spilled(cache)
+            }
+        };
+    }
+
+    #[cold]
+    fn spill(entries: [(T, R); 2], third: (T, R)) -> Self
+    where
+        T: Hash + Eq,
+    {
+        let mut cache = FxHashMap::with_capacity_and_hasher(3, FxBuildHasher);
+        for (item, result) in entries {
+            cache.insert(item, result);
+        }
+        cache.insert(third.0, third.1);
+        Self::Spilled(cache)
+    }
+
+    #[cfg(test)]
+    fn is_spilled(&self) -> bool {
+        matches!(self, Self::Spilled(_))
+    }
+}
+
 impl<Tag, T, R, const INLINE_CAPACITY: usize> CycleDetector<Tag, T, R, INLINE_CAPACITY> {
     pub fn new(fallback: R) -> Self {
         CycleDetector {
             seen: RefCell::new(SmallVec::new()),
-            cache: RefCell::new(FxHashMap::default()),
+            cache: RefCell::new(CycleDetectorCache::new()),
             fallback: Some(fallback),
             _tag: PhantomData,
         }
@@ -92,8 +179,8 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone, const INLINE_CAPACITY: usize>
         on_cycle: impl FnOnce(T) -> R,
         func: impl FnOnce() -> R,
     ) -> R {
-        if let Some(val) = self.cache.borrow().get(&item) {
-            return val.clone();
+        if let Some(result) = self.cache.borrow().get(&item) {
+            return result.clone();
         }
 
         // We hit a cycle
@@ -105,7 +192,7 @@ impl<Tag, T: Hash + Eq + Clone, R: Clone, const INLINE_CAPACITY: usize>
         let ret = func();
 
         self.seen.borrow_mut().pop();
-        self.cache.borrow_mut().insert(item, ret.clone());
+        self.cache.borrow_mut().insert_new(item, ret.clone());
 
         ret
     }
@@ -219,5 +306,54 @@ struct ActiveRecursionGuard<'a, T: Hash + Eq> {
 impl<T: Hash + Eq> Drop for ActiveRecursionGuard<'_, T> {
     fn drop(&mut self) {
         self.seen.borrow_mut().remove(self.item);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::CycleDetector;
+
+    struct TestCycleDetector;
+    type Detector = CycleDetector<TestCycleDetector, u8, u8, 1>;
+
+    #[test]
+    fn caches_one_result_inline() {
+        let detector = Detector::new(0);
+        let calls = Cell::new(0);
+
+        assert_eq!(
+            detector.visit(1, || {
+                calls.set(calls.get() + 1);
+                10
+            }),
+            10
+        );
+        assert!(!detector.cache.borrow().is_spilled());
+
+        assert_eq!(
+            detector.visit(1, || {
+                calls.set(calls.get() + 1);
+                20
+            }),
+            10
+        );
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[test]
+    fn spills_multiple_results() {
+        let detector = Detector::new(0);
+
+        assert_eq!(detector.visit(1, || 10), 10);
+        assert_eq!(detector.visit(2, || 20), 20);
+        assert!(!detector.cache.borrow().is_spilled());
+        assert_eq!(detector.visit(3, || 30), 30);
+        assert!(detector.cache.borrow().is_spilled());
+
+        assert_eq!(detector.visit(1, || 40), 10);
+        assert_eq!(detector.visit(2, || 40), 20);
+        assert_eq!(detector.visit(3, || 40), 30);
     }
 }


### PR DESCRIPTION
## Summary

We always push at least one type into the `CycleDetector` cache, even if that was the only typed that needed visiting.


This PR adds an inline storage that avoids allocating for the most common cases. 

Cutoff | populated
-- | -- 
1 | 74.32%
2 | 89.48%
3 | 92.66%
4 | 95.33%
8 | 98.07%
16 |99.27%
32 | 99.89%

As you can see, most `CycleDetector` (90%) contain at most two cached elements. That's what this PR uses as inline cache. We keep using a `FxHashMap` for cases with more than two elements.

I also considered using a `SmallVec`, but `cache` can grow large


p50 | p90 | p95 | p99 | p99.9 | Maximum
--  | --  | --  |--   | --    |-- 
1   | 3   | 4   | 15  | 33    | 1423


## Benchmarks

Codspeed reports about a 2-3% perf improvement for most projects

## Test Plan

Testing: Passed the ty semantic test suite, Clippy, repository hooks, and wall-time benchmarks.
