### PR TITLE
[ty] Use a SmallVec for seen type aliases

### DIFF
--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -4,6 +4,7 @@ use std::rc::Rc;
 use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 use crate::{
     Db, TypeQualifiers,
@@ -354,12 +355,14 @@ impl<'db> TypeVarInstance<'db> {
         ty: Type<'db>,
         visitor: &TypeVarDefaultVisitor<'db>,
     ) -> bool {
+        type SeenTypeAliases<'db> = SmallVec<[TypeAliasType<'db>; 1]>;
+
         #[derive(Copy, Clone)]
         struct State<'db, 'a> {
             db: &'db dyn Db,
             visitor: &'a TypeVarDefaultVisitor<'db>,
             seen_typevars: &'a RefCell<FxHashSet<TypeVarInstance<'db>>>,
-            seen_type_aliases: &'a RefCell<FxHashSet<TypeAliasType<'db>>>,
+            seen_type_aliases: &'a RefCell<SeenTypeAliases<'db>>,
         }
 
         fn typevar_default_is_self_referential<'db>(
@@ -387,8 +390,12 @@ impl<'db> TypeVarInstance<'db> {
             type_alias: TypeAliasType<'db>,
             self_identity: TypeVarIdentity<'db>,
         ) -> bool {
-            if !state.seen_type_aliases.borrow_mut().insert(type_alias) {
-                return false;
+            {
+                let mut seen_type_aliases = state.seen_type_aliases.borrow_mut();
+                if seen_type_aliases.contains(&type_alias) {
+                    return false;
+                }
+                seen_type_aliases.push(type_alias);
             }
 
             let value_type = if let Some(specialization) = type_alias.specialization(state.db) {
@@ -442,7 +449,7 @@ impl<'db> TypeVarInstance<'db> {
         }
 
         let seen_typevars = RefCell::new(FxHashSet::default());
-        let seen_type_aliases = RefCell::new(FxHashSet::default());
+        let seen_type_aliases = RefCell::new(SeenTypeAliases::new());
 
         let state = State {
             db,


### PR DESCRIPTION
## Summary

Use a `SmallVec` for type aliases visited while checking self-referential type-variable defaults. 

Running ty over the entire ecosystem corpus shows this distribution

Seen aliases | Checks | Percentage
-- | -- | --
0 | 1,728,178 | 99.868647%
1 | 2,051 | 0.118524%
2 | 122 | 0.007050%
3 | 68 | 0.003930%
4 | 29 | 0.001676%
6 | 3 | 0.000173%

A `SmallVec` with an inline capacity avoids allocations in 99%, and the linear scan is a non-brainer for up to 6 elements. There's a risk that larger `seen` result in `O(n)` scans at every level, which would justify a hash map. I'd argue that this isn't an issue in practice and we also accept `O(n)` for our recursive Type visitor. 

I'd say we use a `SmallVec`, we can always use a `SmallSet` if this ever shows up on a real world project.

## Performance

Consistent 2-3% improvement across all projects

## Test Plan

Testing: Ran focused mdtests, repository hooks, and the 162-project ecosystem corpus.
