### PR TITLE
[ty] Build frozen definition maps directly

### DIFF
--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -50,8 +50,15 @@ impl<K: Ord, V, S> From<std::collections::HashMap<K, V, S>> for FrozenMap<K, V> 
 }
 
 impl<K: Ord, V> FrozenMap<K, V> {
+    /// Creates a frozen map from entries with unique keys.
     pub(crate) fn from_entries(mut entries: Vec<(K, V)>) -> Self {
         entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        debug_assert!(
+            entries
+                .windows(2)
+                .all(|entries| entries[0].0 != entries[1].0),
+            "frozen map keys must be unique",
+        );
         Self(entries.into_boxed_slice())
     }
 

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -269,9 +269,12 @@ struct DefinitionsByNode<'db> {
 
 impl<'db> DefinitionsByNode<'db> {
     fn from_map(definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>) -> Self {
-        let mut single = FxHashMap::default();
-        let mut non_single = FxHashMap::default();
-        single.reserve(definitions_by_node.len());
+        let single_count = definitions_by_node
+            .values()
+            .filter(|definitions| definitions.len() == 1)
+            .count();
+        let mut single = Vec::with_capacity(single_count);
+        let mut non_single = Vec::with_capacity(definitions_by_node.len() - single_count);
 
         #[expect(
             clippy::iter_over_hash_type,
@@ -279,15 +282,15 @@ impl<'db> DefinitionsByNode<'db> {
         )]
         for (key, definitions) in definitions_by_node {
             if definitions.len() == 1 {
-                single.insert(key, definitions[0]);
+                single.push((key, definitions[0]));
             } else {
-                non_single.insert(key, definitions.into_boxed_slice());
+                non_single.push((key, definitions.into_boxed_slice()));
             }
         }
 
         Self {
-            single: FrozenMap::from(single),
-            non_single: FrozenMap::from(non_single),
+            single: FrozenMap::from_entries(single),
+            non_single: FrozenMap::from_entries(non_single),
         }
     }
 


### PR DESCRIPTION
Build the DefinitionsByNode frozen maps from exactly sized vectors instead of temporary hash maps. This removes 560 KB of allocation on Flake8 and 2.30 MB on Sphinx while preserving the unique-key invariant with a debug assertion.

## Performance

About 1-2% performance improvement on all walltime benchmarks