### PR TITLE
[ty] Lazily initialize materialization cycle guards

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -344,10 +344,10 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
     }
 
     pub(crate) fn for_new_materialization_root(&self) -> Self {
-        let materialization_equivalence = OnceCell::new();
-        let was_empty =
-            materialization_equivalence.set(Rc::clone(self.materialization_equivalence()));
-        debug_assert!(was_empty.is_ok());
+        let materialization_equivalence = self
+            .materialization_equivalence
+            .get()
+            .map_or_else(OnceCell::new, |visitor| OnceCell::from(Rc::clone(visitor)));
 
         Self {
             default: OnceCell::new(),


### PR DESCRIPTION
New materialization roots currently initialize a cycle guard even when materialization equivalence is never used. Preserve lazy initialization while sharing an existing parent guard, avoiding 2.52 MB of allocation on attrs and 1.02 MB on AnyIO.

