### PR TITLE
[ty] Avoid allocating disabled error context trees

### DIFF
--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -382,7 +382,7 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: Some(ErrorContextTree::enabled()),
+            context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
             disjointness_visitor: &IsDisjointVisitor::default(&builder),
@@ -811,7 +811,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
-            context_tree: Some(ErrorContextTree::enabled()),
+            context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -832,7 +832,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: Some(ErrorContextTree::enabled()),
+            context_tree: Some(ErrorContextTree::new()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -855,7 +855,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     /// Return the collected error context, or an empty tree if collection was disabled.
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
-        self.context_tree.unwrap_or_else(ErrorContextTree::enabled)
+        self.context_tree.unwrap_or_else(ErrorContextTree::new)
     }
 
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -345,7 +345,7 @@ impl<'db> Type<'db> {
             inferable,
             relation: TypeRelation::SubtypingAssuming,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: assuming,
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -382,7 +382,7 @@ impl<'db> Type<'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: ErrorContextTree::enabled(),
+            context_tree: Some(ErrorContextTree::enabled()),
             given: ConstraintSet::from_bool(&builder, false),
             relation_visitor: &HasRelationToVisitor::default(&builder),
             disjointness_visitor: &IsDisjointVisitor::default(&builder),
@@ -390,7 +390,7 @@ impl<'db> Type<'db> {
             materialization_visitor: &ApplyTypeMappingVisitor::default(),
         };
         checker.check_type_pair(db, self, target);
-        checker.context_tree
+        checker.into_error_context()
     }
 
     /// Return true if this type is assignable to type `target` using constraint-set typevar rules.
@@ -586,7 +586,7 @@ impl<'db> Type<'db> {
             inferable,
             relation,
             typevar_evaluation,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
             disjointness_visitor: &disjointness_visitor,
@@ -740,7 +740,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
     pub(super) typevar_evaluation: TypeVarEvaluation,
-    context_tree: ErrorContextTree<'db>,
+    context_tree: Option<ErrorContextTree<'db>>,
     pub(super) given: ConstraintSet<'db, 'c>,
 
     // N.B. these fields are private to reduce the risk of
@@ -769,7 +769,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable,
             relation: TypeRelation::Subtyping,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -790,7 +790,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -811,7 +811,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Lazy,
-            context_tree: ErrorContextTree::enabled(),
+            context_tree: Some(ErrorContextTree::enabled()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -832,7 +832,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
             typevar_evaluation: TypeVarEvaluation::Eager,
-            context_tree: ErrorContextTree::enabled(),
+            context_tree: Some(ErrorContextTree::enabled()),
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor,
             disjointness_visitor,
@@ -853,8 +853,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             && matches!(self.typevar_evaluation, TypeVarEvaluation::Eager)
     }
 
+    /// Return the collected error context, or an empty tree if collection was disabled.
     pub(super) fn into_error_context(self) -> ErrorContextTree<'db> {
-        self.context_tree
+        self.context_tree.unwrap_or_else(ErrorContextTree::enabled)
     }
 
     pub(super) fn always(&self) -> ConstraintSet<'db, 'c> {
@@ -867,7 +868,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     /// Provide context about a failing (assignability) relation between two types.
     pub(super) fn provide_context(&self, get_context: impl FnOnce() -> ErrorContext<'db>) {
-        self.context_tree.push(get_context);
+        if let Some(context_tree) = &self.context_tree {
+            context_tree.push(get_context);
+        }
     }
 
     /// Overwrite the error context tree with a new root context and child nodes.
@@ -876,12 +879,16 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         root: ErrorContext<'db>,
         children: impl IntoIterator<Item = ErrorContextTree<'db>>,
     ) {
-        self.context_tree.set(root, children);
+        if let Some(context_tree) = &self.context_tree {
+            context_tree.set(root, children);
+        }
     }
 
     /// Return true if error context collection is currently enabled.
     pub(super) fn is_context_collection_enabled(&self) -> bool {
-        self.context_tree.is_enabled()
+        self.context_tree
+            .as_ref()
+            .is_some_and(ErrorContextTree::is_enabled)
     }
 
     /// Temporarily suppress error context collection for the duration of `f`.
@@ -889,10 +896,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// Note: we may eventually not need this method once we properly retain error
     /// context everywhere.
     pub(super) fn without_context_collection<R>(&self, f: impl FnOnce() -> R) -> R {
-        let was_enabled = self.context_tree.is_enabled();
-        self.context_tree.set_enabled(false);
+        let Some(context_tree) = &self.context_tree else {
+            return f();
+        };
+        let was_enabled = context_tree.is_enabled();
+        context_tree.set_enabled(false);
         let result = f();
-        self.context_tree.set_enabled(was_enabled);
+        context_tree.set_enabled(was_enabled);
         result
     }
 
@@ -1548,15 +1558,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 };
 
                 let mut elements_context = vec![];
-                let context_collection_enabled = self.is_context_collection_enabled();
+                let context_tree = self.context_tree.as_ref().filter(|tree| tree.is_enabled());
 
                 let elements = union.elements(db);
                 let result = elements
                     .iter()
                     .when_any(db, self.constraints, |&elem_ty| {
                         let result = self.check_type_pair(db, source, elem_ty);
-                        if context_collection_enabled {
-                            let ctx = self.context_tree.take();
+                        if let Some(context_tree) = context_tree {
+                            let ctx = context_tree.take();
                             if !ctx.is_empty() {
                                 elements_context.push(ctx);
                             }
@@ -1565,7 +1575,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     })
                     .or(db, self.constraints, is_new_type_of_union);
 
-                if context_collection_enabled
+                if context_tree.is_some()
                     && !elements_context.is_empty()
                     && result.is_never_satisfied(db)
                 {
@@ -1655,14 +1665,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 // `object & ~str`).
 
                 let mut elements_context = vec![];
-                let context_collection_enabled = self.is_context_collection_enabled();
+                let context_tree = self.context_tree.as_ref().filter(|tree| tree.is_enabled());
 
                 let result = intersection
                     .positive_elements_or_object(db)
                     .when_any(db, self.constraints, |elem_ty| {
                         let result = self.check_type_pair(db, elem_ty, target);
-                        if context_collection_enabled {
-                            let ctx = self.context_tree.take();
+                        if let Some(context_tree) = context_tree {
+                            let ctx = context_tree.take();
                             if !ctx.is_empty() {
                                 elements_context.push(ctx);
                             }
@@ -1681,7 +1691,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         }
                     });
 
-                if context_collection_enabled
+                if context_tree.is_some()
                     && !elements_context.is_empty()
                     && result.is_never_satisfied(db)
                 {
@@ -2325,7 +2335,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             relation: TypeRelation::Redundancy { pure: true },
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: self.given,
             inferable: InferableTypeVars::None,
             relation_visitor: self.relation_visitor,
@@ -2411,7 +2421,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
             inferable: self.inferable,
-            context_tree: ErrorContextTree::disabled(),
+            context_tree: None,
             given: self.given,
             relation_visitor: self.relation_visitor,
             disjointness_visitor: self.disjointness_visitor,

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -431,13 +431,16 @@ impl<'db> ErrorContextNode<'db> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorContextTree<'db> {
-    root: Rc<RefCell<ErrorContextNode<'db>>>,
+    root: Option<Rc<RefCell<ErrorContextNode<'db>>>>,
     enabled: Cell<bool>,
 }
 
 impl PartialEq for ErrorContextTree<'_> {
     fn eq(&self, other: &Self) -> bool {
-        *self.root.borrow() == *other.root.borrow()
+        match (&self.root, &other.root) {
+            (Some(left), Some(right)) => *left.borrow() == *right.borrow(),
+            _ => self.is_empty() && other.is_empty(),
+        }
     }
 }
 
@@ -446,10 +449,10 @@ impl Eq for ErrorContextTree<'_> {}
 impl<'db> From<ErrorContext<'db>> for ErrorContextTree<'db> {
     fn from(context: ErrorContext<'db>) -> Self {
         Self {
-            root: Rc::new(RefCell::new(ErrorContextNode {
+            root: Some(Rc::new(RefCell::new(ErrorContextNode {
                 context,
                 children: Vec::new(),
-            })),
+            }))),
             enabled: Cell::new(true),
         }
     }
@@ -459,17 +462,14 @@ impl<'db> ErrorContextTree<'db> {
     /// Create a new, empty error context tree with collection disabled.
     pub(crate) fn disabled() -> Self {
         Self {
-            root: Rc::default(),
+            root: None,
             enabled: Cell::new(false),
         }
     }
 
     /// Create a new, empty error context tree with collection enabled.
     pub(crate) fn enabled() -> Self {
-        Self {
-            root: Rc::default(),
-            enabled: Cell::new(true),
-        }
+        ErrorContext::Empty.into()
     }
 
     pub(crate) fn is_enabled(&self) -> bool {
@@ -477,12 +477,15 @@ impl<'db> ErrorContextTree<'db> {
     }
 
     pub(crate) fn set_enabled(&self, enabled: bool) {
+        debug_assert!(!enabled || self.root.is_some());
         self.enabled.set(enabled);
     }
 
     /// Returns `true` if the tree has no renderable content.
     pub(crate) fn is_empty(&self) -> bool {
-        self.root.borrow().is_empty()
+        self.root
+            .as_ref()
+            .is_none_or(|root| root.borrow().is_empty())
     }
 
     /// Push a new error context node, making the existing tree a child of the new context.
@@ -490,10 +493,13 @@ impl<'db> ErrorContextTree<'db> {
         if !self.is_enabled() {
             return;
         }
+        let Some(root_cell) = &self.root else {
+            return;
+        };
         let context = get_context();
-        let root = self.root.take();
+        let root = root_cell.take();
         let children = if root.is_empty() { vec![] } else { vec![root] };
-        *self.root.borrow_mut() = ErrorContextNode { context, children };
+        *root_cell.borrow_mut() = ErrorContextNode { context, children };
     }
 
     /// Overwrite the error context tree with a new root context and child nodes.
@@ -505,11 +511,14 @@ impl<'db> ErrorContextTree<'db> {
         if !self.is_enabled() {
             return;
         }
-        *self.root.borrow_mut() = ErrorContextNode {
+        let Some(root) = &self.root else {
+            return;
+        };
+        *root.borrow_mut() = ErrorContextNode {
             context,
             children: children
                 .into_iter()
-                .map(|child_context| child_context.root.take())
+                .filter_map(|child_context| child_context.root.map(|root| root.take()))
                 .filter(|child| !child.is_empty())
                 .collect(),
         };
@@ -518,7 +527,10 @@ impl<'db> ErrorContextTree<'db> {
     /// Return the full tree, replacing it with an empty tree.
     pub(crate) fn take(&self) -> Self {
         ErrorContextTree {
-            root: Rc::new(RefCell::new(std::mem::take(&mut *self.root.borrow_mut()))),
+            root: self
+                .root
+                .as_ref()
+                .map(|root| Rc::new(RefCell::new(std::mem::take(&mut *root.borrow_mut())))),
             enabled: Cell::new(self.enabled.get()),
         }
     }
@@ -529,10 +541,12 @@ impl<'db> ErrorContextTree<'db> {
         db: &'db dyn Db,
         diag: &mut LintDiagnosticGuard<'_, '_>,
     ) {
+        let Some(root) = &self.root else {
+            return;
+        };
         let mut output_lines = Vec::new();
         let mut help_messages = FxOrderSet::default();
-        self.root
-            .borrow()
+        root.borrow()
             .render_tree(db, &mut output_lines, &mut help_messages, "", "");
         for line in output_lines {
             diag.info(line);

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -457,7 +457,7 @@ impl<'db> From<ErrorContext<'db>> for ErrorContextTree<'db> {
 
 impl<'db> ErrorContextTree<'db> {
     /// Create a new, empty error context tree with collection enabled.
-    pub(crate) fn enabled() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             root: Rc::default(),
             enabled: Cell::new(true),

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -431,16 +431,13 @@ impl<'db> ErrorContextNode<'db> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ErrorContextTree<'db> {
-    root: Option<Rc<RefCell<ErrorContextNode<'db>>>>,
+    root: Rc<RefCell<ErrorContextNode<'db>>>,
     enabled: Cell<bool>,
 }
 
 impl PartialEq for ErrorContextTree<'_> {
     fn eq(&self, other: &Self) -> bool {
-        match (&self.root, &other.root) {
-            (Some(left), Some(right)) => *left.borrow() == *right.borrow(),
-            _ => self.is_empty() && other.is_empty(),
-        }
+        *self.root.borrow() == *other.root.borrow()
     }
 }
 
@@ -449,27 +446,22 @@ impl Eq for ErrorContextTree<'_> {}
 impl<'db> From<ErrorContext<'db>> for ErrorContextTree<'db> {
     fn from(context: ErrorContext<'db>) -> Self {
         Self {
-            root: Some(Rc::new(RefCell::new(ErrorContextNode {
+            root: Rc::new(RefCell::new(ErrorContextNode {
                 context,
                 children: Vec::new(),
-            }))),
+            })),
             enabled: Cell::new(true),
         }
     }
 }
 
 impl<'db> ErrorContextTree<'db> {
-    /// Create a new, empty error context tree with collection disabled.
-    pub(crate) fn disabled() -> Self {
-        Self {
-            root: None,
-            enabled: Cell::new(false),
-        }
-    }
-
     /// Create a new, empty error context tree with collection enabled.
     pub(crate) fn enabled() -> Self {
-        ErrorContext::Empty.into()
+        Self {
+            root: Rc::default(),
+            enabled: Cell::new(true),
+        }
     }
 
     pub(crate) fn is_enabled(&self) -> bool {
@@ -477,15 +469,12 @@ impl<'db> ErrorContextTree<'db> {
     }
 
     pub(crate) fn set_enabled(&self, enabled: bool) {
-        debug_assert!(!enabled || self.root.is_some());
         self.enabled.set(enabled);
     }
 
     /// Returns `true` if the tree has no renderable content.
     pub(crate) fn is_empty(&self) -> bool {
-        self.root
-            .as_ref()
-            .is_none_or(|root| root.borrow().is_empty())
+        self.root.borrow().is_empty()
     }
 
     /// Push a new error context node, making the existing tree a child of the new context.
@@ -493,13 +482,10 @@ impl<'db> ErrorContextTree<'db> {
         if !self.is_enabled() {
             return;
         }
-        let Some(root_cell) = &self.root else {
-            return;
-        };
         let context = get_context();
-        let root = root_cell.take();
+        let root = self.root.take();
         let children = if root.is_empty() { vec![] } else { vec![root] };
-        *root_cell.borrow_mut() = ErrorContextNode { context, children };
+        *self.root.borrow_mut() = ErrorContextNode { context, children };
     }
 
     /// Overwrite the error context tree with a new root context and child nodes.
@@ -511,14 +497,11 @@ impl<'db> ErrorContextTree<'db> {
         if !self.is_enabled() {
             return;
         }
-        let Some(root) = &self.root else {
-            return;
-        };
-        *root.borrow_mut() = ErrorContextNode {
+        *self.root.borrow_mut() = ErrorContextNode {
             context,
             children: children
                 .into_iter()
-                .filter_map(|child_context| child_context.root.map(|root| root.take()))
+                .map(|child_context| child_context.root.take())
                 .filter(|child| !child.is_empty())
                 .collect(),
         };
@@ -527,10 +510,7 @@ impl<'db> ErrorContextTree<'db> {
     /// Return the full tree, replacing it with an empty tree.
     pub(crate) fn take(&self) -> Self {
         ErrorContextTree {
-            root: self
-                .root
-                .as_ref()
-                .map(|root| Rc::new(RefCell::new(std::mem::take(&mut *root.borrow_mut())))),
+            root: Rc::new(RefCell::new(std::mem::take(&mut *self.root.borrow_mut()))),
             enabled: Cell::new(self.enabled.get()),
         }
     }
@@ -541,12 +521,10 @@ impl<'db> ErrorContextTree<'db> {
         db: &'db dyn Db,
         diag: &mut LintDiagnosticGuard<'_, '_>,
     ) {
-        let Some(root) = &self.root else {
-            return;
-        };
         let mut output_lines = Vec::new();
         let mut help_messages = FxOrderSet::default();
-        root.borrow()
+        self.root
+            .borrow()
             .render_tree(db, &mut output_lines, &mut help_messages, "", "");
         for line in output_lines {
             diag.info(line);


### PR DESCRIPTION
Disabled relation checks currently allocate an empty error-context root that can never be populated. This PR represents them as `None` to avoid the allocation. This reduces allocations by as much as 10% on some projects.

