### PR TITLE
[ty] Compact use-def binding interner keys

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -300,15 +300,9 @@ impl InternedPlaceStateId {
     }
 }
 
-#[derive(Clone, Copy)]
-struct InternedBindingsKey {
-    id: InternedBindingsId,
-    preserved_unbound_narrowing_constraint: Option<ScopedNarrowingConstraint>,
-}
-
 struct PlaceStateInterner {
     interned_bindings: RetainedBindingsBuilder,
-    interned_ids_by_bindings: hashbrown::HashTable<InternedBindingsKey>,
+    interned_ids_by_bindings: hashbrown::HashTable<InternedBindingsId>,
     interned_declarations: RetainedDeclarationsBuilder,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
     // Undeclared states are common and can be interned by their dense constraint IDs.
@@ -346,42 +340,27 @@ impl PlaceStateInterner {
             return interned_id;
         }
 
-        let preserved_unbound_narrowing_constraint =
-            bindings.preserved_unbound_narrowing_constraint();
-        let hash = Self::hash_bindings(preserved_unbound_narrowing_constraint, bindings.as_slice());
+        // The retained representation discards the unbound narrowing constraint, so it isn't
+        // part of the interned identity.
+        let hash = Self::hash_bindings(bindings.as_slice());
         let interned_bindings = &mut self.interned_bindings;
         let entry = self.interned_ids_by_bindings.entry(
             hash,
-            |key| {
-                key.preserved_unbound_narrowing_constraint == preserved_unbound_narrowing_constraint
-                    && interned_bindings[key.id] == *bindings.as_slice()
-            },
-            |key| {
-                Self::hash_bindings(
-                    key.preserved_unbound_narrowing_constraint,
-                    &interned_bindings[key.id],
-                )
-            },
+            |id| interned_bindings.get(*id) == bindings.as_slice(),
+            |id| Self::hash_bindings(interned_bindings.get(*id)),
         );
         match entry {
-            hashbrown::hash_table::Entry::Occupied(entry) => entry.get().id,
+            hashbrown::hash_table::Entry::Occupied(entry) => *entry.get(),
             hashbrown::hash_table::Entry::Vacant(entry) => {
                 let interned_id = interned_bindings.push(bindings);
-                entry.insert(InternedBindingsKey {
-                    id: interned_id,
-                    preserved_unbound_narrowing_constraint,
-                });
+                entry.insert(interned_id);
                 interned_id
             }
         }
     }
 
-    fn hash_bindings(
-        preserved_unbound_narrowing_constraint: Option<ScopedNarrowingConstraint>,
-        live_bindings: &[LiveBinding],
-    ) -> u64 {
+    fn hash_bindings(live_bindings: &[LiveBinding]) -> u64 {
         let mut hasher = FxHasher::default();
-        preserved_unbound_narrowing_constraint.hash(&mut hasher);
         live_bindings.hash(&mut hasher);
         hasher.finish()
     }
@@ -509,14 +488,6 @@ impl RetainedBindingsBuilder {
             ends: self.ends.into(),
             live_bindings: self.live_bindings.into_boxed_slice(),
         }
-    }
-}
-
-impl Index<InternedBindingsId> for RetainedBindingsBuilder {
-    type Output = [LiveBinding];
-
-    fn index(&self, index: InternedBindingsId) -> &Self::Output {
-        self.get(index)
     }
 }
 

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -240,13 +240,14 @@
 //! visits a `StmtIf` node.
 
 use std::collections::hash_map::Entry;
+use std::hash::{Hash as _, Hasher as _};
 use std::ops::Index;
 use std::rc::Rc;
 use std::sync::LazyLock;
 
 use ruff_index::{FrozenIndexVec, Idx, IndexSlice, IndexVec, newtype_index};
 use ruff_text_size::TextRange;
-use rustc_hash::{FxBuildHasher, FxHashMap};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHasher};
 use smallvec::SmallVec;
 use thin_vec::ThinVec;
 
@@ -299,9 +300,15 @@ impl InternedPlaceStateId {
     }
 }
 
+#[derive(Clone, Copy)]
+struct InternedBindingsKey {
+    id: InternedBindingsId,
+    preserved_unbound_narrowing_constraint: Option<ScopedNarrowingConstraint>,
+}
+
 struct PlaceStateInterner {
     interned_bindings: RetainedBindingsBuilder,
-    interned_ids_by_bindings: FxHashMap<Bindings, InternedBindingsId>,
+    interned_ids_by_bindings: hashbrown::HashTable<InternedBindingsKey>,
     interned_declarations: RetainedDeclarationsBuilder,
     interned_ids_by_declarations: FxHashMap<Declarations, InternedDeclarationsId>,
     // Undeclared states are common and can be interned by their dense constraint IDs.
@@ -316,7 +323,7 @@ impl PlaceStateInterner {
     fn with_capacity(bindings: usize, declaration_map: usize, declarations: usize) -> Self {
         Self {
             interned_bindings: RetainedBindingsBuilder::with_capacity(bindings),
-            interned_ids_by_bindings: FxHashMap::with_capacity_and_hasher(bindings, FxBuildHasher),
+            interned_ids_by_bindings: hashbrown::HashTable::with_capacity(bindings),
             interned_declarations: RetainedDeclarationsBuilder::with_capacity(declarations),
             interned_ids_by_declarations: FxHashMap::with_capacity_and_hasher(
                 declaration_map,
@@ -328,25 +335,55 @@ impl PlaceStateInterner {
         }
     }
 
-    fn intern_bindings(&mut self, bindings: Bindings) -> InternedBindingsId {
+    fn intern_bindings(&mut self, bindings: &Bindings) -> InternedBindingsId {
         if bindings.is_always_unbound() {
             if let Some(interned_id) = self.always_unbound_bindings {
                 return interned_id;
             }
 
-            let interned_id = self.interned_bindings.push(&bindings);
+            let interned_id = self.interned_bindings.push(bindings);
             self.always_unbound_bindings = Some(interned_id);
             return interned_id;
         }
 
-        match self.interned_ids_by_bindings.entry(bindings) {
-            Entry::Occupied(entry) => *entry.get(),
-            Entry::Vacant(entry) => {
-                let interned_id = self.interned_bindings.push(entry.key());
-                entry.insert(interned_id);
+        let preserved_unbound_narrowing_constraint =
+            bindings.preserved_unbound_narrowing_constraint();
+        let hash = Self::hash_bindings(preserved_unbound_narrowing_constraint, bindings.as_slice());
+        let interned_bindings = &mut self.interned_bindings;
+        let entry = self.interned_ids_by_bindings.entry(
+            hash,
+            |key| {
+                key.preserved_unbound_narrowing_constraint == preserved_unbound_narrowing_constraint
+                    && interned_bindings[key.id] == *bindings.as_slice()
+            },
+            |key| {
+                Self::hash_bindings(
+                    key.preserved_unbound_narrowing_constraint,
+                    &interned_bindings[key.id],
+                )
+            },
+        );
+        match entry {
+            hashbrown::hash_table::Entry::Occupied(entry) => entry.get().id,
+            hashbrown::hash_table::Entry::Vacant(entry) => {
+                let interned_id = interned_bindings.push(bindings);
+                entry.insert(InternedBindingsKey {
+                    id: interned_id,
+                    preserved_unbound_narrowing_constraint,
+                });
                 interned_id
             }
         }
+    }
+
+    fn hash_bindings(
+        preserved_unbound_narrowing_constraint: Option<ScopedNarrowingConstraint>,
+        live_bindings: &[LiveBinding],
+    ) -> u64 {
+        let mut hasher = FxHasher::default();
+        preserved_unbound_narrowing_constraint.hash(&mut hasher);
+        live_bindings.hash(&mut hasher);
+        hasher.finish()
     }
 
     fn intern_declarations(&mut self, declarations: Declarations) -> InternedDeclarationsId {
@@ -391,7 +428,7 @@ impl PlaceStateInterner {
 
     fn intern_place_state(
         &mut self,
-        bindings: Bindings,
+        bindings: &Bindings,
         declarations: Declarations,
     ) -> InternedPlaceStateId {
         InternedPlaceStateId(
@@ -402,7 +439,7 @@ impl PlaceStateInterner {
 
     fn retain_place_state(
         &mut self,
-        bindings: Bindings,
+        bindings: &Bindings,
         declarations: Declarations,
     ) -> InternedPlaceStateId {
         // Other retained declarations rarely repeat. Keep the compact IDs without hashing every
@@ -449,6 +486,16 @@ impl RetainedBindingsBuilder {
         self.ends.push(end)
     }
 
+    fn get(&self, index: InternedBindingsId) -> &[LiveBinding] {
+        let end = self.ends[index];
+        let start = if index.index() == 0 {
+            0
+        } else {
+            self.ends[InternedBindingsId::new(index.index() - 1)]
+        };
+        &self.live_bindings[start as usize..end as usize]
+    }
+
     fn finish(
         self,
         narrowing_constraints: &mut NarrowingConstraintsBuilder,
@@ -462,6 +509,14 @@ impl RetainedBindingsBuilder {
             ends: self.ends.into(),
             live_bindings: self.live_bindings.into_boxed_slice(),
         }
+    }
+}
+
+impl Index<InternedBindingsId> for RetainedBindingsBuilder {
+    type Output = [LiveBinding];
+
+    fn index(&self, index: InternedBindingsId) -> &Self::Output {
+        self.get(index)
     }
 }
 
@@ -2518,7 +2573,7 @@ impl<'db> UseDefMapBuilder<'db> {
             },
         ) in definitions_by_definition
         {
-            let bindings = place_state_interner.intern_bindings(bindings);
+            let bindings = place_state_interner.intern_bindings(&bindings);
             let declarations = declarations
                 .map(|declarations| place_state_interner.intern_declarations(declarations));
             interned_ids_by_definition.push((
@@ -2541,7 +2596,7 @@ impl<'db> UseDefMapBuilder<'db> {
             IndexVec::with_capacity(bindings_by_use.len());
 
         for bindings in bindings_by_use {
-            let interned_id = place_state_interner.intern_bindings(bindings);
+            let interned_id = place_state_interner.intern_bindings(&bindings);
             interned_ids_by_use.push(interned_id);
         }
 
@@ -2558,7 +2613,7 @@ impl<'db> UseDefMapBuilder<'db> {
 
         for place_state in place_states {
             let (bindings, declarations) = get_parts(place_state);
-            let interned_id = place_state_interner.retain_place_state(bindings, declarations);
+            let interned_id = place_state_interner.retain_place_state(&bindings, declarations);
             interned_ids_by_place.push(interned_id);
         }
 
@@ -2580,7 +2635,7 @@ impl<'db> UseDefMapBuilder<'db> {
                 Entry::Vacant(entry) => {
                     let place_state = entry.key();
                     let interned_id = place_state_interner.intern_place_state(
-                        place_state.bindings().clone(),
+                        place_state.bindings(),
                         place_state.declarations().clone(),
                     );
                     entry.insert(interned_id);
@@ -2606,7 +2661,7 @@ impl<'db> UseDefMapBuilder<'db> {
         for snapshot in enclosing_snapshots {
             let interned_id = match snapshot {
                 EnclosingSnapshot::Bindings(bindings) => {
-                    let interned_bindings_id = place_state_interner.intern_bindings(bindings);
+                    let interned_bindings_id = place_state_interner.intern_bindings(&bindings);
                     InternedEnclosingSnapshotId::Bindings(interned_bindings_id)
                 }
                 EnclosingSnapshot::Constraint(constraint) => {

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -228,6 +228,12 @@ pub(super) struct Bindings {
 }
 
 impl Bindings {
+    pub(super) fn preserved_unbound_narrowing_constraint(
+        &self,
+    ) -> Option<ScopedNarrowingConstraint> {
+        self.unbound_narrowing_constraint
+    }
+
     pub(super) fn is_always_unbound(&self) -> bool {
         let [binding] = self.live_bindings.as_slice() else {
             return false;

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -228,12 +228,6 @@ pub(super) struct Bindings {
 }
 
 impl Bindings {
-    pub(super) fn preserved_unbound_narrowing_constraint(
-        &self,
-    ) -> Option<ScopedNarrowingConstraint> {
-        self.unbound_narrowing_constraint
-    }
-
     pub(super) fn is_always_unbound(&self) -> bool {
         let [binding] = self.live_bindings.as_slice() else {
             return false;


### PR DESCRIPTION
Store compact IDs in the use-def bindings reverse index instead of cloning complete `Bindings` values as hash-map keys.

This reduces allocations by 4.7 MB on attrs, 8.1 MB on Flake8, and 12.5 MB on AnyIO with neutral timing. Walltime benchmarks improve by 1-2%.

The main downside is that this introduces a `HashTable` where changing `Bindings` requires updating the manual hash function
