### PR TITLE
[ty] Lazily allocate reachability caches

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::RefCell;
+use std::cell::{OnceCell, RefCell};
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -246,9 +246,10 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
 
     /// Reachability evaluations reused while inferring this region.
     ///
-    /// Speculative builders share this cache with their parent so repeated place lookups performed
+    /// Most inference regions never evaluate reachability, so allocate the cache lazily. Speculative
+    /// builders share an initialized cache with their parent so repeated place lookups performed
     /// during multi-inference can reuse predicate truthiness computed by the parent builder.
-    reachability_cache: Rc<ReachabilityEvaluationCache<'db>>,
+    reachability_cache: OnceCell<Rc<ReachabilityEvaluationCache<'db>>>,
 
     /// Type qualifiers (`Required`, `NotRequired`, etc.) for annotation expressions.
     /// Only populated for expressions that have non-empty qualifiers.
@@ -369,10 +370,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         module: &'ast ParsedModuleRef,
     ) -> Self {
         let scope = region.scope(db);
-        let reachability_constraints = index
-            .use_def_map(scope.file_scope_id(db))
-            .reachability_constraints();
-
         Self {
             context: InferContext::new(db, scope, module),
             index,
@@ -383,10 +380,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             deferred_state: DeferredExpressionState::None,
             expressions: FxHashMap::default(),
             expression_cache: None,
-            reachability_cache: Rc::new(ReachabilityEvaluationCache::new(
-                scope,
-                reachability_constraints,
-            )),
+            reachability_cache: OnceCell::new(),
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
@@ -401,6 +395,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: false,
             dataclass_field_specifiers: SmallVec::new(),
         }
+    }
+
+    fn reachability_cache(&self) -> &ReachabilityEvaluationCache<'db> {
+        self.reachability_cache
+            .get_or_init(|| {
+                let scope = self.scope();
+                let reachability_constraints = self
+                    .index
+                    .use_def_map(scope.file_scope_id(self.db()))
+                    .reachability_constraints();
+                Rc::new(ReachabilityEvaluationCache::new(
+                    scope,
+                    reachability_constraints,
+                ))
+            })
+            .as_ref()
     }
 
     fn discard_dict_key_assignments_for(&mut self, definition: Definition<'db>) {
@@ -1258,7 +1268,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let (mut place_and_quals, conflicting) = place_from_declarations_with_reachability_cache(
             self.db(),
             declarations,
-            &self.reachability_cache,
+            self.reachability_cache(),
         )
         .into_place_and_conflicting_declarations();
 
@@ -1449,7 +1459,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let inferred_ty = place_from_bindings_with_reachability_cache(
             self.db(),
             prior_bindings,
-            &self.reachability_cache,
+            self.reachability_cache(),
         )
         .place
         .with_qualifiers(TypeQualifiers::empty())
@@ -2319,7 +2329,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let Some(ty) = place_from_bindings_with_reachability_cache(
                 db,
                 use_def.reachable_bindings(nested_symbol_id.into()),
-                &self.reachability_cache,
+                self.reachability_cache(),
             )
             .place
             .raw_type() else {
@@ -8179,7 +8189,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let place = place_from_bindings_with_reachability_cache(
                 db,
                 bindings.clone(),
-                &self.reachability_cache,
+                self.reachability_cache(),
             );
             let Some(key) = place.first_definition.and_then(definition_key) else {
                 continue;
@@ -9160,7 +9170,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
                             db,
-                            Some(&self.reachability_cache),
+                            Some(self.reachability_cache()),
                             reachability_constraints,
                             predicates,
                             binding.reachability_constraint,
@@ -9332,7 +9342,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 place_from_bindings_with_reachability_cache(
                     db,
                     use_def.reachable_bindings(place_id),
-                    &self.reachability_cache,
+                    self.reachability_cache(),
                 )
                 .place
             } else {
@@ -9368,7 +9378,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let place = place_from_bindings_with_reachability_cache(
                 db,
                 use_def.bindings_at_use(use_id),
-                &self.reachability_cache,
+                self.reachability_cache(),
             )
             .place;
 
@@ -9422,7 +9432,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
                         db,
                         bindings,
-                        &self.reachability_cache,
+                        self.reachability_cache(),
                     );
                     if assume_bound && let Place::Defined(defined) = place_and_qualifiers.place {
                         place_and_qualifiers.place =
@@ -9631,7 +9641,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             let place = place_from_bindings_with_reachability_cache(
                                 db,
                                 bindings,
-                                &self.reachability_cache,
+                                self.reachability_cache(),
                             )
                             .place
                             .map_type(|ty| {


### PR DESCRIPTION
## Summary

Lazily allocate reachability evaluation caches for inference regions, while preserving cache sharing for speculative builders.


Small 1% performance improvement on some projects

