### PR TITLE
[ty] Batch signature typevar freshness scans

### DIFF
--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -852,42 +852,19 @@ impl<'db> Signature<'db> {
         db: &'db dyn Db,
         generic_context: GenericContext<'db>,
     ) -> Option<TypeVarNonce> {
-        let mut max_freshness = None;
-        let mut update = |freshness| {
-            max_freshness = max_freshness.max(freshness);
-        };
+        let typevars = self
+            .generic_context
+            .into_iter()
+            .flat_map(|context| context.variables(db))
+            .map(Type::TypeVar);
+        let parameters = self.parameters.iter().flat_map(|parameter| {
+            std::iter::once(parameter.annotated_type()).chain(parameter.default_type())
+        });
+        let types = typevars
+            .chain(parameters)
+            .chain(std::iter::once(self.return_ty));
 
-        if let Some(signature_generic_context) = self.generic_context {
-            for typevar in signature_generic_context.variables(db) {
-                update(max_typevar_freshness_matching_generic_context(
-                    db,
-                    Type::TypeVar(typevar),
-                    generic_context,
-                ));
-            }
-        }
-
-        for param in &self.parameters {
-            update(max_typevar_freshness_matching_generic_context(
-                db,
-                param.annotated_type(),
-                generic_context,
-            ));
-            if let Some(default_ty) = param.default_type() {
-                update(max_typevar_freshness_matching_generic_context(
-                    db,
-                    default_ty,
-                    generic_context,
-                ));
-            }
-        }
-        update(max_typevar_freshness_matching_generic_context(
-            db,
-            self.return_ty,
-            generic_context,
-        ));
-
-        max_freshness
+        max_typevar_freshness_matching_generic_context(db, types, generic_context)
     }
 
     pub(crate) fn find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -782,7 +782,7 @@ impl<'db> TypeVarNonceGenerator<'db> {
 
 pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
     db: &'db dyn Db,
-    ty: Type<'db>,
+    types: impl IntoIterator<Item = Type<'db>>,
     generic_context: GenericContext<'db>,
 ) -> Option<TypeVarNonce> {
     struct MatchingFreshnessCollector<'db> {
@@ -836,7 +836,9 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
     }
 
     let collector = MatchingFreshnessCollector::new(db, generic_context);
-    collector.visit_type(db, ty);
+    for ty in types {
+        collector.visit_type(db, ty);
+    }
     collector.max_freshness.get()
 }
 


### PR DESCRIPTION
## Summary

When freshening the bound type variables in a generic signature, we first find the maximum existing freshness for the matching generic context. Previously, we scanned every signature type with a separate collector. This rebuilt the same set of base type-variable identities and created a new recursion guard for every generic parameter, parameter annotation, default, and return type.

This changes `max_typevar_freshness_matching_generic_context` to accept the complete iterator of signature types and scan them with one collector. Reusing the collector avoids repeated setup and allows the shared recursion guard to skip types that occur more than once in the signature, without changing freshness selection.

## Performance

CodSpeed's CPU simulation improves DateType by 9.0%, from 310.19 ms to 284.61 ms.

https://app.codspeed.io/astral-sh/ruff/runs/compare/6a38908270b8d54c83d90c07..6a3893e0c0fb8aa7459346b6
