### PR TITLE
[ty] Avoid cycles for collection inference

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -53,6 +53,10 @@ impl AstIds {
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {
         self.uses_map[&key.into()]
     }
+
+    pub(super) fn try_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
+        self.uses_map.get(&key.into()).copied()
+    }
 }
 
 fn ast_ids(db: &dyn Db, file: File) -> &AstIds {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2630,16 +2630,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         for use_def_map in &use_def_maps {
             let mut defined_places = FxHashSet::default();
             for (_, state, _) in use_def_map.all_definitions_with_usage() {
-                let Some(definition) = state.definition() else {
-                    continue;
-                };
-                let place = definition.place(self.db);
-                if self.uses_by_collection.contains_key(&definition)
-                    && defined_places.contains(&place)
+                if let Some(definition) = state.definition()
+                    && !defined_places.insert(definition.place(self.db))
+                    && self.uses_by_collection.contains_key(&definition)
                 {
                     self.collections_requiring_cycle.insert(definition);
                 }
-                defined_places.insert(place);
             }
         }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -278,6 +278,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
     // A map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FxHashSet<Definition<'db>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -328,6 +330,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FxHashMap::default(),
             collections_by_use: FxHashMap::default(),
             uses_by_collection: FxHashMap::default(),
+            collections_requiring_cycle: FxHashSet::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -2620,6 +2623,26 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.scope_ids_by_scope.shrink_to_fit();
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();
+
+        // Replacing an existing binding can make later collection uses depend on the merge of all
+        // definitions for that place. The identity-specialized query deliberately bypasses that
+        // merge, so retain cycle-based inference for those collection definitions.
+        for use_def_map in &use_def_maps {
+            let mut defined_places = FxHashSet::default();
+            for (_, state, _) in use_def_map.all_definitions_with_usage() {
+                let Some(definition) = state.definition() else {
+                    continue;
+                };
+                let place = definition.place(self.db);
+                if self.uses_by_collection.contains_key(&definition)
+                    && defined_places.contains(&place)
+                {
+                    self.collections_requiring_cycle.insert(definition);
+                }
+                defined_places.insert(place);
+            }
+        }
+
         let uses_by_collection = FrozenMap::from_entries(
             self.uses_by_collection
                 .into_iter()
@@ -2642,6 +2665,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
+            collections_requiring_cycle: FrozenSet::from(self.collections_requiring_cycle),
             imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
@@ -4078,6 +4102,30 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
         // on collection literals. This restriction is mostly for performance reasons, as we
         // want to avoid "reads" of a collection contributing to the complexity of the cycles
         // created by full-scope collection inference.
+        match stmt {
+            ast::Stmt::AugAssign(_) => self.collections_requiring_cycle.extend(
+                current_statement
+                    .collection_uses
+                    .iter()
+                    .map(|(definition, _)| *definition),
+            ),
+            ast::Stmt::Assign(ast::StmtAssign { targets, value, .. })
+                if targets
+                    .iter()
+                    .any(|target| target.is_attribute_expr() || target.is_subscript_expr()) =>
+            {
+                let assigned_value = ExpressionNodeKey::from(value);
+                self.collections_requiring_cycle.extend(
+                    current_statement
+                        .collection_uses
+                        .iter()
+                        .filter(|(_, use_expression)| *use_expression == assigned_value)
+                        .map(|(definition, _)| *definition),
+                );
+            }
+            _ => {}
+        }
+
         current_statement
             .collection_uses
             .retain(|(_, use_expression)| {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -559,6 +559,24 @@ impl<'db> SemanticIndex<'db> {
         self.collections_by_use.get(&collection_use.into()).copied()
     }
 
+    /// If this expression is any use of an unconstrained collection literal, returns its
+    /// definition.
+    pub fn unannotated_collection_literal_at_any_use(
+        &self,
+        collection_use: &ast::Expr,
+    ) -> Option<Definition<'db>> {
+        let use_id = self.ast_ids.try_use_id(collection_use)?;
+        let scope_id = self.expression_scope_id(collection_use);
+        let use_def = self.use_def_map(scope_id);
+        let mut definitions = use_def
+            .bindings_at_use(use_id)
+            .filter_map(|binding| binding.binding.definition())
+            .filter(|definition| self.uses_by_collection.get(definition).is_some());
+
+        let definition = definitions.next()?;
+        definitions.next().is_none().then_some(definition)
+    }
+
     /// Returns all potentially constraining uses of the given unnannotated collection literal.
     pub fn constraining_collection_uses(
         &self,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -338,6 +338,9 @@ pub struct SemanticIndex<'db> {
     // Map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FrozenMap<Definition<'db>, Box<[(Statement<'db>, ExpressionNodeKey)]>>,
 
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FrozenSet<Definition<'db>>,
+
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
 
@@ -586,6 +589,11 @@ impl<'db> SemanticIndex<'db> {
             .get(&collection_def)
             .into_iter()
             .flat_map(|uses| uses.iter().copied())
+    }
+
+    /// Returns `true` if the collection has a use that requires cycle-based inference.
+    pub fn collection_requires_cycle_inference(&self, collection_def: Definition<'db>) -> bool {
+        self.collections_requiring_cycle.contains(&collection_def)
     }
 
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1029,6 +1029,63 @@ def _(values: list[str] | None):
     reveal_type(lines)  # revealed: list[str]
 ```
 
+Uses that can refer to an intervening binding require cycle-based inference. Inferring these uses
+against the original collection's identity specialization can miss widening from an augmented
+assignment:
+
+```py
+class Node: ...
+class Name(Node): ...
+
+def nodes() -> list[Node]:
+    return []
+
+def _(flag: bool) -> None:
+    values = []
+    while flag:
+        values += nodes()
+    values.append(Name())
+    values += nodes()
+```
+
+Collections that replace an existing binding also require cycle-based inference:
+
+```py
+class Paths: ...
+class DataSource: ...
+
+class Handler:
+    def __init__(self, *, paths: Paths, datasource: DataSource) -> None: ...
+
+def _(options=None):
+    if options is None:
+        options = {}
+    options.update({"paths": Paths(), "datasource": DataSource()})
+    Handler(**options)
+```
+
+Collections stored in an attribute or subscript require cycle-based inference because the assignment
+can participate in later inference cycles:
+
+```py
+import inspect
+import types
+
+class C:
+    def collect(self, items):
+        values = []
+        for item in items:
+            if isinstance(item, types.FunctionType):
+                line = getattr(item, "co_firstlineno", item.__code__.co_firstlineno)
+                module = inspect.getmodule(item)
+                values.append((line, module))
+        self.values = values
+
+    def validate(self):
+        for _, module in self.values:
+            reveal_type(module)  # revealed: ModuleType | None
+```
+
 Starred uses in a return expression continue to participate in cycle recovery:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1009,6 +1009,16 @@ def _():
     return AlternativeRule(rules)
 ```
 
+The call can also be nested inside the return expression:
+
+```py
+def _():
+    rules = []
+    rules.append(URule())
+    reveal_type(rules)  # revealed: list[Rule]
+    return (AlternativeRule(rules), 1)
+```
+
 Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -992,6 +992,44 @@ def _() -> int:
     return invalid_x6  # error: [invalid-return-type]
 ```
 
+An unannotated return can still constrain a collection when the collection is passed directly to an
+annotated call:
+
+```py
+class Rule: ...
+class URule(Rule): ...
+
+class AlternativeRule:
+    def __init__(self, rules: list[Rule]) -> None: ...
+
+def _():
+    rules = []
+    rules.append(URule())
+    reveal_type(rules)  # revealed: list[Rule]
+    return AlternativeRule(rules)
+```
+
+Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
+
+```py
+def _(values: list[str] | None):
+    lines = []
+    lines.append("header")
+    lines.extend(values)  # error: [invalid-argument-type]
+    reveal_type(lines)  # revealed: list[str]
+```
+
+Starred uses in a return expression continue to participate in cycle recovery:
+
+```py
+def consume(*values: int) -> None: ...
+def _():
+    values = []
+    values.append(1)
+    reveal_type(values)  # revealed: list[int]
+    return consume(*values)
+```
+
 ```py
 x7 = []
 x7[:] = [1, "2", 3.0]

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -502,6 +502,30 @@ fn infer_statement_types_impl<'db>(
         .finish_statement()
 }
 
+/// Infers the constraints that later statements place on an unconstrained collection literal.
+///
+/// The collection's receiver expression is inferred using the built-in collection's identity
+/// specialization, which avoids creating query cycles back to the collection literal's
+/// definition. Uses that also depend on an unconstrained collection are reported as requiring the
+/// regular cycle-based inference path.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub(super) fn infer_collection_use_constraints<'db>(
+    db: &'db dyn Db,
+    collection_def: Definition<'db>,
+) -> CollectionUseConstraintInference<'db> {
+    let file = collection_def.file(db);
+    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+
+    TypeInferenceBuilder::new(
+        db,
+        InferenceRegion::Definition(collection_def),
+        index,
+        &module,
+    )
+    .finish_collection_use_constraints(collection_def)
+}
+
 /// An `Expression` with an optional `TypeContext`.
 ///
 /// This is a Salsa supertype used as the input to `infer_expression_types` to avoid
@@ -1627,6 +1651,12 @@ pub(crate) enum StatementInference<'db> {
     Expression(&'db ExpressionInference<'db>),
     Definition(Definition<'db>, &'db DefinitionInference<'db>),
     Other(&'db StatementInferenceInner<'db>),
+}
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(super) enum CollectionUseConstraintInference<'db> {
+    Constraints(Box<[Type<'db>]>),
+    RequiresCycle,
 }
 
 impl<'db> StatementInference<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::{OnceCell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -7,6 +7,7 @@ use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
     PythonVersion,
@@ -22,11 +23,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
-    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
-    FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    CollectionUseConstraintInference, DeferredAndUndecorated, DefinitionInference,
+    DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
+    FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
+    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
+    infer_collection_use_constraints, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -184,6 +186,45 @@ fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
 /// performance problem. For now, we optimize for memory usage.
 const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 
+#[derive(Clone)]
+struct CollectionConstraintTarget<'db> {
+    definition: Definition<'db>,
+    has_dependency: Rc<Cell<bool>>,
+}
+
+struct StarredUseVisitor {
+    target: ExpressionNodeKey,
+    starred_depth: usize,
+    found: bool,
+}
+
+impl<'ast> Visitor<'ast> for StarredUseVisitor {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        if self.found {
+            return;
+        }
+        if self.starred_depth > 0 && ExpressionNodeKey::from(expression) == self.target {
+            self.found = true;
+            return;
+        }
+
+        let is_starred = matches!(expression, ast::Expr::Starred(_));
+        self.starred_depth += usize::from(is_starred);
+        walk_expr(self, expression);
+        self.starred_depth -= usize::from(is_starred);
+    }
+}
+
+fn expression_contains_starred_use(expression: &ast::Expr, target: ExpressionNodeKey) -> bool {
+    let mut visitor = StarredUseVisitor {
+        target,
+        starred_depth: 0,
+        found: false,
+    };
+    visitor.visit_expr(expression);
+    visitor.found
+}
+
 /// Builder to infer all types in a region.
 ///
 /// A builder is used by creating it with [`new()`](TypeInferenceBuilder::new), and then calling
@@ -269,6 +310,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     // `xs.append("x")` with `xs.sort()` yields `str ≤ T ≤ SupportsRichComparison` instead of
     // leaking `SupportsRichComparisonT@sort` into the inferred list element type.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
+
+    /// The collection whose constraints are being inferred without depending on its definition.
+    collection_constraint_target: Option<CollectionConstraintTarget<'db>>,
 
     /// Expressions that are string annotations
     string_annotations: FxHashSet<ExpressionNodeKey>,
@@ -384,6 +428,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
+            collection_constraint_target: None,
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
             bindings: VecMap::default(),
@@ -411,6 +456,42 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ))
             })
             .as_ref()
+    }
+
+    fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
+        let target = self.collection_constraint_target.as_ref()?;
+        let collection_def = self
+            .index
+            .unannotated_collection_literal(expression)
+            .or_else(|| {
+                self.index
+                    .unannotated_collection_literal_at_any_use(expression)
+            })?;
+
+        if self.index.unannotated_collection_literal(expression) != Some(target.definition) {
+            target.has_dependency.set(true);
+        }
+
+        self.unannotated_collection_identity_type(collection_def)
+    }
+
+    fn unannotated_collection_identity_type(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<Type<'db>> {
+        let assignment = collection_def.kind(self.db()).as_unannotated_assignment()?;
+        let known_class = match assignment.value(self.module()) {
+            ast::Expr::List(list) if list.elts.is_empty() => KnownClass::List,
+            ast::Expr::Set(set) if set.elts.is_empty() => KnownClass::Set,
+            ast::Expr::Dict(dict) if dict.items.is_empty() => KnownClass::Dict,
+            _ => return None,
+        };
+        let collection_literal = known_class.try_to_class_literal(self.db())?;
+
+        Some(Type::instance(
+            self.db(),
+            collection_literal.identity_specialization(self.db()),
+        ))
     }
 
     fn discard_dict_key_assignments_for(&mut self, definition: Definition<'db>) {
@@ -6132,18 +6213,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.infer_dict_comprehension_expression(dictcomp, tcx)
             }
             ast::Expr::SetComp(setcomp) => self.infer_set_comprehension_expression(setcomp, tcx),
-            ast::Expr::Name(name) => {
-                let ty = self.infer_name_expression(name);
-                tcx.annotation.map_or(ty, |target| {
-                    self.specialize_generic_class_from_context(ty, target)
-                })
-            }
-            ast::Expr::Attribute(attribute) => {
-                let ty = self.infer_attribute_expression(attribute);
-                tcx.annotation.map_or(ty, |target| {
-                    self.specialize_generic_class_from_context(ty, target)
-                })
-            }
+            ast::Expr::Name(name) => self
+                .collection_constraint_override(expression)
+                .unwrap_or_else(|| {
+                    let ty = self.infer_name_expression(name);
+                    tcx.annotation.map_or(ty, |target| {
+                        self.specialize_generic_class_from_context(ty, target)
+                    })
+                }),
+            ast::Expr::Attribute(attribute) => self
+                .collection_constraint_override(expression)
+                .unwrap_or_else(|| {
+                    let ty = self.infer_attribute_expression(attribute);
+                    tcx.annotation.map_or(ty, |target| {
+                        self.specialize_generic_class_from_context(ty, target)
+                    })
+                }),
             ast::Expr::UnaryOp(unary_op) => self.infer_unary_expression(unary_op),
             ast::Expr::BinOp(binary) => self.infer_binary_expression(binary, tcx),
             ast::Expr::BoolOp(bool_op) => self.infer_boolean_expression(bool_op, tcx),
@@ -7254,38 +7339,58 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
-            for (statement, use_expression) in
-                self.index.constraining_collection_uses(collection_def)
-            {
-                let statement_use_types = infer_statement_types(self.db(), statement);
-
-                if let Some(divergent) = statement_use_types
-                    .expression_type(use_expression)
-                    .as_divergent()
-                {
-                    // Infer `collection[Divergent]` for the initial cycle result.
-                    let divergent_instance = collection_alias
-                        .origin(self.db())
-                        .apply_specialization(self.db(), |generic_context| {
-                            generic_context
-                                .repeat_specialization(self.db(), Type::Divergent(divergent))
-                        });
-
-                    builder
-                        .infer(
-                            identity_instance,
-                            Type::instance(self.db(), divergent_instance),
-                        )
-                        .ok()?;
-                } else if let Some(constraints) =
-                    statement_use_types.collection_use_constraints(collection_def)
-                {
+            match infer_collection_use_constraints(self.db(), collection_def) {
+                CollectionUseConstraintInference::Constraints(constraints) => {
                     for constraint in constraints {
                         if constraint.has_unspecialized_type_var(self.db()) {
                             continue;
                         }
 
                         builder.infer(identity_instance, *constraint).ok()?;
+                    }
+                }
+                CollectionUseConstraintInference::RequiresCycle => {
+                    for (statement, use_expression) in
+                        self.index.constraining_collection_uses(collection_def)
+                    {
+                        let statement_use_types = infer_statement_types(self.db(), statement);
+
+                        if let Some(divergent) = statement_use_types
+                            .expression_type(use_expression)
+                            .as_divergent()
+                        {
+                            // Infer `collection[Divergent]` for the initial cycle result.
+                            let divergent_instance = collection_alias
+                                .origin(self.db())
+                                .apply_specialization(self.db(), |generic_context| {
+                                    generic_context.repeat_specialization(
+                                        self.db(),
+                                        Type::Divergent(divergent),
+                                    )
+                                });
+
+                            builder
+                                .infer(
+                                    identity_instance,
+                                    Type::instance(self.db(), divergent_instance),
+                                )
+                                .ok()?;
+                            continue;
+                        }
+
+                        let Some(constraints) =
+                            statement_use_types.collection_use_constraints(collection_def)
+                        else {
+                            continue;
+                        };
+
+                        for constraint in constraints {
+                            if constraint.has_unspecialized_type_var(self.db()) {
+                                continue;
+                            }
+
+                            builder.infer(identity_instance, *constraint).ok()?;
+                        }
                     }
                 }
             }
@@ -8331,21 +8436,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(constraint)
     }
 
+    /// Records collection constraints and returns whether they are suitable for cycle-free
+    /// inference.
+    ///
+    /// Failed calls do not contribute constraints and can normally be ignored when another call
+    /// has already constrained the collection. A possibly-`None` argument requires the regular
+    /// cycle path, however, to avoid retaining the diagnostic from its initial `Divergent`
+    /// iteration alongside the stable diagnostic.
     fn record_bound_method_collection_constraints(
         &mut self,
         attribute: &ast::ExprAttribute,
         arguments: &ast::Arguments,
         call_arguments: &mut CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) {
+    ) -> bool {
         let value = &attribute.value;
         let value_type = self.expression_type(value);
 
         let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
-            return;
+            return false;
         };
         let Some((collection_literal, _)) = value_type.class_specialization(self.db()) else {
-            return;
+            return false;
         };
 
         let identity_instance = Type::instance(
@@ -8361,7 +8473,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Perform inference against the type variables on the receiver's generic context.
             .with_generic_context(self.db(), collection_generic_context);
 
-        let call_result = self.speculate().infer_and_check_argument_types(
+        let mut speculative = self.speculate();
+        let call_result = speculative.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),
             call_arguments,
             // TODO: The argument types have already been inferred and stored in `call_arguments`.
@@ -8376,7 +8489,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         if call_result.is_err() {
-            return;
+            return !call_arguments.iter_types().any(|types| {
+                types.iter().any(|(_, ty)| {
+                    ty.is_none(self.db())
+                        || ty.as_union().is_some_and(|union| {
+                            union
+                                .elements(self.db())
+                                .iter()
+                                .any(|element| element.is_none(self.db()))
+                        })
+                })
+            });
         }
 
         for call_specialization in identity_bindings
@@ -8399,6 +8522,42 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .or_default()
                 .insert(constraints);
         }
+
+        true
+    }
+
+    fn infer_bound_method_collection_use_constraints(
+        &mut self,
+        call_expression: &ast::ExprCall,
+        collection_def: Definition<'db>,
+    ) -> bool {
+        let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) =
+            call_expression.func.as_ref()
+        else {
+            return false;
+        };
+        if self.index.unannotated_collection_literal(value) != Some(collection_def) {
+            return false;
+        }
+
+        let Some(identity_instance) = self.unannotated_collection_identity_type(collection_def)
+        else {
+            return false;
+        };
+        self.store_expression_type(value, identity_instance);
+
+        let mut call_arguments = self.prepare_call_arguments(&call_expression.arguments);
+        let supports_cycle_free_inference = self.record_bound_method_collection_constraints(
+            attribute,
+            &call_expression.arguments,
+            &mut call_arguments,
+            TypeContext::default(),
+        );
+        supports_cycle_free_inference
+            && self
+                .collection_use_constraints
+                .get(&collection_def)
+                .is_some_and(|constraints| !constraints.is_empty())
     }
 
     fn infer_call_expression(
@@ -10705,6 +10864,80 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    pub(super) fn finish_collection_use_constraints(
+        mut self,
+        collection_def: Definition<'db>,
+    ) -> CollectionUseConstraintInference<'db> {
+        let has_dependency = Rc::new(Cell::new(false));
+        self.collection_constraint_target = Some(CollectionConstraintTarget {
+            definition: collection_def,
+            has_dependency: Rc::clone(&has_dependency),
+        });
+
+        let return_is_unconstrained = match self.scope.node(self.db()) {
+            NodeWithScopeKind::Function(function) => function.node(self.module()).returns.is_none(),
+            _ => false,
+        };
+
+        for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
+            let used_fast_path = match statement {
+                Statement::Expression(expression) => {
+                    match expression.node_ref(self.db()).node(self.module()) {
+                        ast::Expr::Call(call_expression) => self
+                            .infer_bound_method_collection_use_constraints(
+                                call_expression,
+                                collection_def,
+                            ),
+                        _ => false,
+                    }
+                }
+                Statement::Other(statement) => {
+                    let statement = statement.node_ref(self.db()).node(self.module());
+                    match statement {
+                        // An unannotated return does not constrain its result, but a direct call can
+                        // still constrain the collection through an annotated argument. Starred
+                        // uses participate in iterable inference and need cycle recovery.
+                        ast::Stmt::Return(ast::StmtReturn {
+                            value: Some(value), ..
+                        }) if return_is_unconstrained => {
+                            if expression_contains_starred_use(value, use_expression) {
+                                false
+                            } else if matches!(value.as_ref(), ast::Expr::Call(_)) {
+                                self.infer_statement(statement);
+                                true
+                            } else {
+                                true
+                            }
+                        }
+                        ast::Stmt::Return(_) => return_is_unconstrained,
+                        _ => false,
+                    }
+                }
+                Statement::Definition(_) => false,
+            };
+
+            if !used_fast_path {
+                self.context.defuse();
+                return CollectionUseConstraintInference::RequiresCycle;
+            }
+        }
+
+        let constraints = self
+            .collection_use_constraints
+            .remove(&collection_def)
+            .unwrap_or_default()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        self.context.defuse();
+
+        if has_dependency.get() {
+            CollectionUseConstraintInference::RequiresCycle
+        } else {
+            CollectionUseConstraintInference::Constraints(constraints)
+        }
+    }
+
     pub(super) fn finish_expression(mut self) -> ExpressionInference<'db> {
         self.infer_region();
 
@@ -10728,6 +10961,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,
@@ -10810,6 +11044,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -10905,6 +11140,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             bindings,
             called_functions,
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             declarations: _,
@@ -10963,6 +11199,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             called_functions,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11101,6 +11338,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // Builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11161,6 +11399,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ref reachability_cache,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
+            ref collection_constraint_target,
 
             // These fields are type inference results, but do not affect the inference of a given
             // expression.
@@ -11191,6 +11430,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.typevar_binding_context = typevar_binding_context;
         builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
+        builder
+            .collection_constraint_target
+            .clone_from(collection_constraint_target);
         builder.reachability_cache.clone_from(reachability_cache);
         builder
             .return_types_and_ranges
@@ -11223,6 +11465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -192,37 +192,49 @@ struct CollectionConstraintTarget<'db> {
     has_dependency: Rc<Cell<bool>>,
 }
 
-struct StarredUseVisitor {
-    target: ExpressionNodeKey,
-    starred_depth: usize,
-    found: bool,
+#[derive(Default)]
+struct CollectionUseContext {
+    in_call: bool,
+    in_starred: bool,
 }
 
-impl<'ast> Visitor<'ast> for StarredUseVisitor {
+struct CollectionUseContextVisitor {
+    target: ExpressionNodeKey,
+    call_depth: usize,
+    starred_depth: usize,
+    context: CollectionUseContext,
+}
+
+impl<'ast> Visitor<'ast> for CollectionUseContextVisitor {
     fn visit_expr(&mut self, expression: &'ast ast::Expr) {
-        if self.found {
-            return;
-        }
-        if self.starred_depth > 0 && ExpressionNodeKey::from(expression) == self.target {
-            self.found = true;
+        if ExpressionNodeKey::from(expression) == self.target {
+            self.context.in_call |= self.call_depth > 0;
+            self.context.in_starred |= self.starred_depth > 0;
             return;
         }
 
+        let is_call = matches!(expression, ast::Expr::Call(_));
         let is_starred = matches!(expression, ast::Expr::Starred(_));
+        self.call_depth += usize::from(is_call);
         self.starred_depth += usize::from(is_starred);
         walk_expr(self, expression);
+        self.call_depth -= usize::from(is_call);
         self.starred_depth -= usize::from(is_starred);
     }
 }
 
-fn expression_contains_starred_use(expression: &ast::Expr, target: ExpressionNodeKey) -> bool {
-    let mut visitor = StarredUseVisitor {
+fn collection_use_context(
+    expression: &ast::Expr,
+    target: ExpressionNodeKey,
+) -> CollectionUseContext {
+    let mut visitor = CollectionUseContextVisitor {
         target,
+        call_depth: 0,
         starred_depth: 0,
-        found: false,
+        context: CollectionUseContext::default(),
     };
     visitor.visit_expr(expression);
-    visitor.found
+    visitor.context
 }
 
 /// Builder to infer all types in a region.
@@ -10894,15 +10906,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 Statement::Other(statement) => {
                     let statement = statement.node_ref(self.db()).node(self.module());
                     match statement {
-                        // An unannotated return does not constrain its result, but a direct call can
-                        // still constrain the collection through an annotated argument. Starred
-                        // uses participate in iterable inference and need cycle recovery.
+                        // An unannotated return does not constrain its result, but a call within
+                        // the return expression can still constrain the collection through an
+                        // annotated argument. Starred uses participate in iterable inference and
+                        // need cycle recovery.
                         ast::Stmt::Return(ast::StmtReturn {
                             value: Some(value), ..
                         }) if return_is_unconstrained => {
-                            if expression_contains_starred_use(value, use_expression) {
+                            let use_context = collection_use_context(value, use_expression);
+                            if use_context.in_starred {
                                 false
-                            } else if matches!(value.as_ref(), ast::Expr::Call(_)) {
+                            } else if use_context.in_call {
                                 self.infer_statement(statement);
                                 true
                             } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -472,15 +472,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
         let target = self.collection_constraint_target.as_ref()?;
-        let collection_def = self
-            .index
-            .unannotated_collection_literal(expression)
-            .or_else(|| {
-                self.index
-                    .unannotated_collection_literal_at_any_use(expression)
-            })?;
+        let direct_collection_def = self.index.unannotated_collection_literal(expression);
+        let collection_def = direct_collection_def.or_else(|| {
+            self.index
+                .unannotated_collection_literal_at_any_use(expression)
+        })?;
 
-        if self.index.unannotated_collection_literal(expression) != Some(target.definition) {
+        if direct_collection_def != Some(target.definition) {
             target.has_dependency.set(true);
         }
 
@@ -10885,24 +10883,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         mut self,
         collection_def: Definition<'db>,
     ) -> CollectionUseConstraintInference<'db> {
+        self.context.defuse();
+
+        if self
+            .index
+            .collection_requires_cycle_inference(collection_def)
+        {
+            return CollectionUseConstraintInference::RequiresCycle;
+        }
+
         let has_dependency = Rc::new(Cell::new(false));
         self.collection_constraint_target = Some(CollectionConstraintTarget {
             definition: collection_def,
             has_dependency: Rc::clone(&has_dependency),
         });
 
-        let return_is_unconstrained = match self.scope.node(self.db()) {
-            NodeWithScopeKind::Function(function) => function.node(self.module()).returns.is_none(),
-            _ => false,
-        };
-
-        if self
-            .index
-            .collection_requires_cycle_inference(collection_def)
-        {
-            self.context.defuse();
-            return CollectionUseConstraintInference::RequiresCycle;
-        }
+        let return_is_unconstrained = self
+            .scope
+            .node(self.db())
+            .as_function()
+            .is_some_and(|function| function.node(self.module()).returns.is_none());
 
         for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
             let used_fast_path = match statement {
@@ -10944,7 +10944,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if !used_fast_path {
-                self.context.defuse();
                 return CollectionUseConstraintInference::RequiresCycle;
             }
         }
@@ -10956,7 +10955,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .into_iter()
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        self.context.defuse();
 
         if has_dependency.get() {
             CollectionUseConstraintInference::RequiresCycle

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7348,6 +7348,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Ok(collection_def) =
                 DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()
             && let Some(collection_def) = self.index.try_definition(collection_def)
+            && self
+                .index
+                .constraining_collection_uses(collection_def)
+                .next()
+                .is_some()
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8331,6 +8331,76 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(constraint)
     }
 
+    fn record_bound_method_collection_constraints(
+        &mut self,
+        attribute: &ast::ExprAttribute,
+        arguments: &ast::Arguments,
+        call_arguments: &mut CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) {
+        let value = &attribute.value;
+        let value_type = self.expression_type(value);
+
+        let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
+            return;
+        };
+        let Some((collection_literal, _)) = value_type.class_specialization(self.db()) else {
+            return;
+        };
+
+        let identity_instance = Type::instance(
+            self.db(),
+            collection_literal.identity_specialization(self.db()),
+        );
+        let collection_generic_context = collection_literal.generic_context(self.db());
+
+        let mut identity_bindings = self
+            .infer_attribute_load_impl(attribute, identity_instance)
+            .bindings(self.db())
+            .match_parameters(self.db(), call_arguments)
+            // Perform inference against the type variables on the receiver's generic context.
+            .with_generic_context(self.db(), collection_generic_context);
+
+        let call_result = self.speculate().infer_and_check_argument_types(
+            ArgumentsIter::from_ast(arguments),
+            call_arguments,
+            // TODO: The argument types have already been inferred and stored in `call_arguments`.
+            // However, `value` may have been inferred as a collection with `Divergent` element
+            // types, meaning the type context for a given argument, by which the inferred type is
+            // keyed, may not be the same as the type context we get here. It is not immediately
+            // clear how to retrieve those types, and so we just re-infer the argument expressions
+            // for simplicity.
+            &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+            &mut identity_bindings,
+            call_expression_tcx,
+        );
+
+        if call_result.is_err() {
+            return;
+        }
+
+        for call_specialization in identity_bindings
+            .iter_flat()
+            .flat_map(CallableBinding::matching_overloads)
+            .filter_map(|(_, identity_overload)| identity_overload.specialization())
+        {
+            // Record the constraints on the receiver's generic context formed by the arguments to
+            // this bound method call.
+            let Some(constraints) = self.collection_use_constraint_from_specialization(
+                identity_instance,
+                collection_generic_context,
+                call_specialization,
+            ) else {
+                continue;
+            };
+
+            self.collection_use_constraints
+                .entry(collection_def)
+                .or_default()
+                .insert(constraints);
+        }
+    }
+
     fn infer_call_expression(
         &mut self,
         call_expression: &ast::ExprCall,
@@ -8840,62 +8910,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Record the constraints for the receiver of a bound method call, if the receiver is an
         // unannotated collection literal.
-        if let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) = func.as_ref() {
-            let value_type = self.expression_type(value);
-
-            if let Some(collection_def) = self.index.unannotated_collection_literal(value)
-                && let Some((collection_literal, _)) = value_type.class_specialization(self.db())
-            {
-                let identity_instance = Type::instance(
-                    self.db(),
-                    collection_literal.identity_specialization(self.db()),
-                );
-                let collection_generic_context = collection_literal.generic_context(self.db());
-
-                let mut identity_bindings = self
-                    .infer_attribute_load_impl(attribute, identity_instance)
-                    .bindings(self.db())
-                    .match_parameters(self.db(), &call_arguments)
-                    // Perform inference against the type variables on the receiver's generic context.
-                    .with_generic_context(self.db(), collection_generic_context);
-
-                let call_result = self.speculate().infer_and_check_argument_types(
-                    ArgumentsIter::from_ast(arguments),
-                    &mut call_arguments,
-                    // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                    // However, `value` would have been inferred to a be a collection with `Divergent`
-                    // element types, meaning the type context for a given argument, by which the inferred
-                    // type is keyed, may not be the same as the type context we get here. It is not immediately
-                    // clear how to retrieve those types, and so we just re-infer the argument expressions
-                    // for simplicity.
-                    &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
-                    &mut identity_bindings,
-                    call_expression_tcx,
-                );
-
-                if call_result.is_ok() {
-                    for call_specialization in identity_bindings
-                        .iter_flat()
-                        .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
-                    {
-                        // Record the constraints on the receiver's generic context formed by
-                        // the arguments to this bound method call.
-                        let Some(constraints) = self.collection_use_constraint_from_specialization(
-                            identity_instance,
-                            collection_generic_context,
-                            call_specialization,
-                        ) else {
-                            continue;
-                        };
-
-                        self.collection_use_constraints
-                            .entry(collection_def)
-                            .or_default()
-                            .insert(constraints);
-                    }
-                }
-            }
+        if let ast::Expr::Attribute(attribute) = func.as_ref() {
+            self.record_bound_method_collection_constraints(
+                attribute,
+                arguments,
+                &mut call_arguments,
+                call_expression_tcx,
+            );
         }
 
         let db = self.db();

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10896,6 +10896,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => false,
         };
 
+        if self
+            .index
+            .collection_requires_cycle_inference(collection_def)
+        {
+            self.context.defuse();
+            return CollectionUseConstraintInference::RequiresCycle;
+        }
+
         for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
             let used_fast_path = match statement {
                 Statement::Expression(expression) => {

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -338,6 +338,23 @@ fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definit
 }
 
 #[test]
+fn unconstrained_collection_without_uses_skips_constraint_query() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[Unknown]");
+
+    let events = db.take_salsa_events();
+    let x = first_public_binding(&db, file, "x");
+    assert_function_query_was_not_run(&db, infer_collection_use_constraints, x, &events);
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -385,6 +385,36 @@ fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyho
 }
 
 #[test]
+fn collection_escape_uses_cycle_based_constraints() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []\nx.append(1)\nd = {}\nd['x'] = x")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[int]");
+
+    let events = db.take_salsa_events();
+    let module = parsed_module(&db, file).load(&db);
+    let index = semantic_index(&db, file);
+    let x = first_public_binding(&db, file, "x");
+    let Statement::Expression(append) = index.try_statement(&module.syntax().body[1]).unwrap()
+    else {
+        panic!("expected `x.append(1)` to be a standalone expression");
+    };
+
+    assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
+    assert_function_query_was_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(append),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -355,6 +355,36 @@ fn unconstrained_collection_without_uses_skips_constraint_query() -> anyhow::Res
 }
 
 #[test]
+fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []\nx.append(1)")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[int]");
+
+    let events = db.take_salsa_events();
+    let module = parsed_module(&db, file).load(&db);
+    let index = semantic_index(&db, file);
+    let x = first_public_binding(&db, file, "x");
+    let Statement::Expression(append) = index.try_statement(&module.syntax().body[1]).unwrap()
+    else {
+        panic!("expected `x.append(1)` to be a standalone expression");
+    };
+
+    assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(append),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 


### PR DESCRIPTION
## Summary

- avoid Salsa fixed-point cycles when an unannotated collection is constrained by later bound-method calls
- replay supported collection constraints through a cycle-free tracked query
- retain cycle-based inference when a collection replaces an existing binding, participates in augmented assignment, escapes through an attribute or subscript, or otherwise depends on unsupported inference
- preserve constraints from calls nested inside return expressions

This is PR 2 of 2 in a stacked series, on top of #26197.

## Why

Empty unannotated collections can currently query later statements to determine their element type. In long scopes such as `sympy.core.mul.Mul.flatten`, that creates repeated Salsa fixed-point cycles and dominates type-checking time.

The new query specializes the enclosing inference region by collection identity and records supported constraints without depending on the original collection expression. We keep the established cycle-recovery path for collection definitions whose type depends on rebinding, augmented assignment, attribute or subscript escape, recursive uses, starred uses, or unsupported call shapes. This preserves existing diagnostics for those cases without giving up the cycle-free path for direct collection mutations.

## Performance

Against SymPy at `22fc107a94eaabc4f6eb31470b39db65abb7a394` with `TY_MAX_PARALLELISM=1`:

- `sympy/core/mul.py`: median 0.85s -> 0.37s (about 56% faster)
- full SymPy: median 2.05s -> 1.71s (about 17% faster)
- diagnostic output remains byte-for-byte identical (14,176 diagnostics)

Closes https://github.com/astral-sh/ty/issues/3505.
