### PR TITLE
[ty] Preserve frozen map invariants

### DIFF
--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -19,7 +19,7 @@ impl<K, V> FrozenMap<K, V> {
         &mut self,
     ) -> impl DoubleEndedIterator<Item = (&K, &mut V)> + ExactSizeIterator + std::iter::FusedIterator
     {
-        self.0.iter_mut().map(split_entry_mut)
+        self.into_iter()
     }
 
     pub fn keys(&self) -> impl DoubleEndedIterator<Item = &K> + ExactSizeIterator {
@@ -110,12 +110,8 @@ impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
         std::iter::Map<std::slice::IterMut<'a, (K, V)>, fn(&'a mut (K, V)) -> (&'a K, &'a mut V)>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut().map(split_entry_mut)
+        self.0.iter_mut().map(|(key, value)| (&*key, value))
     }
-}
-
-fn split_entry_mut<K, V>((key, value): &mut (K, V)) -> (&K, &mut V) {
-    (&*key, value)
 }
 
 #[newtype_index]

--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -124,11 +124,15 @@ struct FrozenValueIndex;
 
 fn sort_and_deduplicate<K: Ord, V>(mut entries: Vec<(K, V)>) -> Vec<(K, V)> {
     entries.sort_by(|(left, _), (right, _)| left.cmp(right));
-
-    // Deduplicating in reverse preserves the last value for each key.
-    entries.reverse();
-    entries.dedup_by(|(left, _), (right, _)| left == right);
-    entries.reverse();
+    entries.dedup_by(|(later_key, later_value), (earlier_key, earlier_value)| {
+        if later_key == earlier_key {
+            // `dedup_by` removes the later entry, so move its value to the retained entry.
+            std::mem::swap(later_value, earlier_value);
+            true
+        } else {
+            false
+        }
+    });
 
     entries
 }
@@ -185,10 +189,12 @@ impl<K, V> FrozenValueMap<K, V> {
         V: Copy + Eq + Hash,
         F: FnMut(K, V) -> V,
     {
-        *self = self
-            .iter()
-            .map(|(key, value)| (key, map(key, value)))
-            .collect();
+        let (entries, values) =
+            index_values(self.iter().map(|(key, value)| (key, map(key, value))));
+        *self = Self {
+            entries: FrozenMap(entries.into_boxed_slice()),
+            values: values.into(),
+        };
     }
 }
 

--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -118,6 +118,10 @@ impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
 #[derive(get_size2::GetSize, salsa::Update)]
 struct FrozenValueIndex;
 
+/// Sorts entries by key and removes duplicate keys, retaining the last value for each key.
+///
+/// Stable sorting preserves the input order of equal-key entries, allowing the deduplication
+/// pass to provide last-entry-wins semantics like standard map collection.
 fn sort_and_deduplicate<K: Ord, V>(mut entries: Vec<(K, V)>) -> Vec<(K, V)> {
     entries.sort_by(|(left, _), (right, _)| left.cmp(right));
     entries.dedup_by(|(later_key, later_value), (earlier_key, earlier_value)| {

--- a/crates/ty_python_core/src/frozen.rs
+++ b/crates/ty_python_core/src/frozen.rs
@@ -15,8 +15,11 @@ impl<K, V> FrozenMap<K, V> {
         self.0.iter()
     }
 
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, (K, V)> {
-        self.0.iter_mut()
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl DoubleEndedIterator<Item = (&K, &mut V)> + ExactSizeIterator + std::iter::FusedIterator
+    {
+        self.0.iter_mut().map(split_entry_mut)
     }
 
     pub fn keys(&self) -> impl DoubleEndedIterator<Item = &K> + ExactSizeIterator {
@@ -30,9 +33,7 @@ impl<K, V> FrozenMap<K, V> {
 
 impl<K: Ord, V> FromIterator<(K, V)> for FrozenMap<K, V> {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        let mut entries = iter.into_iter().collect::<Vec<_>>();
-        entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
-        entries.dedup_by(|(left, _), (right, _)| left == right);
+        let entries = sort_and_deduplicate(iter.into_iter().collect());
         Self(entries.into_boxed_slice())
     }
 }
@@ -104,17 +105,33 @@ impl<'a, K, V> IntoIterator for &'a FrozenMap<K, V> {
 }
 
 impl<'a, K, V> IntoIterator for &'a mut FrozenMap<K, V> {
-    type Item = &'a mut (K, V);
-    type IntoIter = std::slice::IterMut<'a, (K, V)>;
+    type Item = (&'a K, &'a mut V);
+    type IntoIter =
+        std::iter::Map<std::slice::IterMut<'a, (K, V)>, fn(&'a mut (K, V)) -> (&'a K, &'a mut V)>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
+        self.0.iter_mut().map(split_entry_mut)
     }
+}
+
+fn split_entry_mut<K, V>((key, value): &mut (K, V)) -> (&K, &mut V) {
+    (&*key, value)
 }
 
 #[newtype_index]
 #[derive(get_size2::GetSize, salsa::Update)]
 struct FrozenValueIndex;
+
+fn sort_and_deduplicate<K: Ord, V>(mut entries: Vec<(K, V)>) -> Vec<(K, V)> {
+    entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    // Deduplicating in reverse preserves the last value for each key.
+    entries.reverse();
+    entries.dedup_by(|(left, _), (right, _)| left == right);
+    entries.reverse();
+
+    entries
+}
 
 fn index_values<K, V>(
     entries: impl IntoIterator<Item = (K, V)>,
@@ -181,9 +198,7 @@ where
     V: Copy + Eq + Hash,
 {
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        let mut source_entries = iter.into_iter().collect::<Vec<_>>();
-        source_entries.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
-        source_entries.dedup_by(|(left, _), (right, _)| left == right);
+        let source_entries = sort_and_deduplicate(iter.into_iter().collect());
 
         let (entries, values) = index_values(source_entries);
 
@@ -266,6 +281,30 @@ mod tests {
     use super::{FrozenMap, FrozenValueMap};
 
     #[test]
+    fn frozen_map_preserves_last_value_for_duplicate_keys() {
+        let map = FrozenMap::from_iter([(2, "two"), (1, "first"), (1, "last")]);
+
+        assert_eq!(
+            map.iter().copied().collect::<Vec<_>>(),
+            vec![(1, "last"), (2, "two")]
+        );
+    }
+
+    #[test]
+    fn frozen_map_iterates_with_mutable_values() {
+        let mut map = FrozenMap::from_iter([(2, 20), (1, 10)]);
+
+        for (key, value) in &mut map {
+            *value += *key;
+        }
+
+        assert_eq!(
+            map.iter().copied().collect::<Vec<_>>(),
+            vec![(1, 11), (2, 22)]
+        );
+    }
+
+    #[test]
     fn frozen_value_map_deduplicates_values() {
         let map = FrozenValueMap::from_iter([(3, [1; 4]), (1, [2; 4]), (2, [1; 4])]);
 
@@ -276,6 +315,13 @@ mod tests {
             map.iter().collect::<Vec<_>>(),
             vec![(1, [2; 4]), (2, [1; 4]), (3, [1; 4])]
         );
+    }
+
+    #[test]
+    fn frozen_value_map_preserves_last_value_for_duplicate_keys() {
+        let map = FrozenValueMap::from_iter([(2, 20), (1, 10), (1, 11)]);
+
+        assert_eq!(map.iter().collect::<Vec<_>>(), vec![(1, 11), (2, 20)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`FrozenMap` stores entries in sorted key order, but mutable iteration previously exposed `&mut (K, V)`. That allowed callers to mutate keys and invalidate the ordering required by binary search.

This preserves mutable-value iteration while exposing keys only by shared reference. Existing cycle-normalization callers can still update values, but the collection now enforces frozen keys through its API.

`FromIterator` for `FrozenMap` and `FrozenValueMap` also previously used unstable sorting before deduplication, so duplicate keys retained an arbitrary value. Both representations now consistently retain the last value for each key, matching standard map collection behavior. Deduplication performs a single pass over the sorted entries and swaps only duplicate values rather than reversing the collection.

`FrozenValueMap::map_values` now rebuilds its value index directly from the existing sorted, unique entries, avoiding an intermediate vector and redundant sorting while still deduplicating the mapped values. Regression tests cover mutable-value iteration, duplicate-key handling, and value rededuplication.
