### PR TITLE
docs: fix two broken external documentation links

### DIFF
--- a/docs/editors/features.md
+++ b/docs/editors/features.md
@@ -42,7 +42,7 @@ alt="Formatting a document in VS Code"
 ### Markdown code blocks
 
 *This feature is currently only available in
-[preview mode](https://docs.astral.sh/ruff/preview/preview.md#preview).*
+[preview mode](https://docs.astral.sh/ruff/preview/).*
 
 The Ruff formatter can also format Python code blocks in Markdown files.
 The Ruff VS Code extension provides the `Format Document` command for

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,8 +74,8 @@ on the official repositories:
 $ pacman -S ruff
 ```
 
-For **Alpine** users, Ruff is also available as [`ruff`](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ruff)
-on the testing repositories:
+For **Alpine** users, Ruff is also available as [`ruff`](https://pkgs.alpinelinux.org/package/edge/community/x86_64/ruff)
+on the community repositories:
 
 ```console
 $ apk add ruff


### PR DESCRIPTION
## Summary

Two minimal link fixes found via automated sweep of the docs directory:

- **docs/editors/features.md:45** — drop trailing `.md` and `#preview` anchor from the Ruff preview URL.
  - Old: `https://docs.astral.sh/ruff/preview/preview.md#preview` (404)
  - New: `https://docs.astral.sh/ruff/preview/` (200)
- **docs/installation.md:77-78** — update Alpine package URL and surrounding copy to match the upstream repository rename from `testing` to `community`.
  - Old: `https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ruff` (404)
  - New: `https://pkgs.alpinelinux.org/package/edge/community/x86_64/ruff` (200)

## Verification

Both old URLs return HTTP 404; both new URLs return HTTP 200.

## Why two changes in one PR

Both are 1-2 line docs-only link fixes targeting dead external URLs. Bundle is intentional per the project's docs PR pattern.

Out of scope: the same preview.md #preview pattern also appears in changelogs/0.5.x.md (historical changelog entry — skipped).