### PR TITLE
[ty] Remove redundant use-def state shrinking

### DIFF
--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -67,8 +67,7 @@ impl<'db> PredicatesBuilder<'db> {
         self.predicates.push(predicate)
     }
 
-    pub(crate) fn build(mut self) -> Predicates<'db> {
-        self.predicates.shrink_to_fit();
+    pub(crate) fn build(self) -> Predicates<'db> {
         self.predicates.into()
     }
 }

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2337,14 +2337,6 @@ impl<'db> UseDefMapBuilder<'db> {
             );
         }
 
-        self.all_definitions.shrink_to_fit();
-        self.used_bindings.shrink_to_fit();
-        self.reachable_symbol_definitions.shrink_to_fit();
-        self.reachable_member_definitions.shrink_to_fit();
-        self.bindings_by_use.shrink_to_fit();
-        self.range_reachability.shrink_to_fit();
-        self.enclosing_snapshots.shrink_to_fit();
-
         let place_state_count = self.symbol_states.len()
             + self.member_states.len()
             + self.reachable_symbol_definitions.len()
@@ -2545,7 +2537,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_use.push(interned_id);
         }
 
-        interned_ids_by_use.shrink_to_fit();
         interned_ids_by_use
     }
 
@@ -2562,7 +2553,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_place.push(interned_id);
         }
 
-        interned_ids_by_place.shrink_to_fit();
         interned_ids_by_place
     }
 
@@ -2590,7 +2580,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_member.push(interned_id);
         }
 
-        interned_ids_by_member.shrink_to_fit();
         interned_ids_by_member
     }
 
@@ -2616,7 +2605,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_snapshot.push(interned_id);
         }
 
-        interned_ids_by_snapshot.shrink_to_fit();
         interned_ids_by_snapshot
     }
 }


### PR DESCRIPTION
## Summary

Remove explicit `shrink_to_fit` calls when the underlying buffer is immediately discarded or a later boxed conversion already performs the required compaction. This avoids transient copying without retaining excess capacity.

## Performance

Small 1-2% performance improvement, also reduces the total number of allocations