### PR TITLE
[ty] Benchmark salsa-rs/salsa#1179

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,7 +3731,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3757,12 +3757,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,15 +1417,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1437,11 +1428,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3740,8 +3731,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc1e32b8d1a486e3a45a5480fb5dca7912f49262a8916a67378064da4fe1ab"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3767,14 +3757,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67dad477a3e3a484a7c2311c1d25160fb270214981be24022de7de8a206a3300"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f70e101fb3bd599960e79e719e70d85142730e5b45f3269246086ed218562"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=6132b1bcf9ac86cbe909eb5319807c49619d634a#6132b1bcf9ac86cbe909eb5319807c49619d634a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,7 +3731,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=eb4cbbb4167fdb7ca50757fee380c9d8e0526376#eb4cbbb4167fdb7ca50757fee380c9d8e0526376"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3757,12 +3757,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=eb4cbbb4167fdb7ca50757fee380c9d8e0526376#eb4cbbb4167fdb7ca50757fee380c9d8e0526376"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=179fdce102a3da45166235e99a33c4ab97cbdc30#179fdce102a3da45166235e99a33c4ab97cbdc30"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=eb4cbbb4167fdb7ca50757fee380c9d8e0526376#eb4cbbb4167fdb7ca50757fee380c9d8e0526376"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "179fdce102a3da45166235e99a33c4ab97cbdc30", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "eb4cbbb4167fdb7ca50757fee380c9d8e0526376", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,8 +156,8 @@ regex-automata = { version = "0.4.9" }
 regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
-# When updating salsa, make sure to also update the version in `fuzz/Cargo.toml`
-salsa = { version = "0.27.0", default-features = false, features = [
+# When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "6132b1bcf9ac86cbe909eb5319807c49619d634a", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "6132b1bcf9ac86cbe909eb5319807c49619d634a", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "179fdce102a3da45166235e99a33c4ab97cbdc30", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "6132b1bcf9ac86cbe909eb5319807c49619d634a", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "179fdce102a3da45166235e99a33c4ab97cbdc30", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { version = "0.27.0", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "6132b1bcf9ac86cbe909eb5319807c49619d634a", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "179fdce102a3da45166235e99a33c4ab97cbdc30", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "eb4cbbb4167fdb7ca50757fee380c9d8e0526376", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",


### PR DESCRIPTION
## Summary

Pin Salsa to salsa-rs/salsa#1179 to benchmark the smaller table page size against the Salsa master baseline in #26201.

## Test Plan

Testing: All 696 ty_python_semantic tests and repository hooks passed.