### PR TITLE
docs(editors/setup): fix dead kde.org stable5 kate links

### DIFF
--- a/docs/editors/setup.md
+++ b/docs/editors/setup.md
@@ -367,8 +367,8 @@ hx -v path/to/file.py
 
 ## Kate
 
-1. Activate the [LSP Client plugin](https://docs.kde.org/stable5/en/kate/kate/plugins.html#kate-application-plugins).
-1. Setup LSP Client [as desired](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html).
+1. Activate the [LSP Client plugin](https://docs.kde.org/stable/en/kate/kate/plugins.html#kate-application-plugins).
+1. Setup LSP Client [as desired](https://docs.kde.org/stable/en/kate/kate/kate-application-plugin-lspclient.html).
 1. Finally, add this to `Settings` -> `Configure Kate` -> `LSP Client` -> `User Server Settings`:
 
 ```json
@@ -384,7 +384,7 @@ hx -v path/to/file.py
 }
 ```
 
-See [LSP Client documentation](https://docs.kde.org/stable5/en/kate/kate/kate-application-plugin-lspclient.html) for more details
+See [LSP Client documentation](https://docs.kde.org/stable/en/kate/kate/kate-application-plugin-lspclient.html) for more details
 on how to configure the server from there.
 
 !!! important


### PR DESCRIPTION
Replaces 3 `https://docs.kde.org/stable5/en/kate/...` URLs (404 — KDE moved their docs versioning scheme from `stable5` to `stable`) with the canonical `https://docs.kde.org/stable/en/kate/...` URLs (200).