### PR TITLE
docs(installation): fix dead alpinelinux testing repo link

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,8 +74,8 @@ on the official repositories:
 $ pacman -S ruff
 ```
 
-For **Alpine** users, Ruff is also available as [`ruff`](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ruff)
-on the testing repositories:
+For **Alpine** users, Ruff is also available as [`ruff`](https://pkgs.alpinelinux.org/package/edge/community/x86_64/ruff)
+on the community repositories:
 
 ```console
 $ apk add ruff


### PR DESCRIPTION
Replaces `https://pkgs.alpinelinux.org/package/edge/testing/x86_64/ruff` (404 — Alpine promoted ruff from `testing` to `community`) with `https://pkgs.alpinelinux.org/package/edge/community/x86_64/ruff` (200). Updates prose from 'testing repositories' to 'community repositories'.