### PR TITLE
docs(editors/features): fix dead ruff preview/preview.md link

### DIFF
--- a/docs/editors/features.md
+++ b/docs/editors/features.md
@@ -42,7 +42,7 @@ alt="Formatting a document in VS Code"
 ### Markdown code blocks
 
 *This feature is currently only available in
-[preview mode](https://docs.astral.sh/ruff/preview/preview.md#preview).*
+[preview mode](https://docs.astral.sh/ruff/preview/#preview).*
 
 The Ruff formatter can also format Python code blocks in Markdown files.
 The Ruff VS Code extension provides the `Format Document` command for


### PR DESCRIPTION
Replaces `https://docs.astral.sh/ruff/preview/preview.md#preview` (404 — `preview.md` filename retired) with `https://docs.astral.sh/ruff/preview/#preview` (200 — canonical URL under the `/preview/` landing).