### PR TITLE
[ty] Avoid moving boxed use-def map builders

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2609,7 +2609,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut use_def_maps: IndexVec<_, _> = self
             .use_def_maps
             .into_iter()
-            .map(|builder| Arc::new((*builder).finish()))
+            .map(|builder| Arc::new(builder.finish()))
             .collect();
 
         let ast_ids = super::ast_ids::AstIds::from_builders(self.ast_ids);

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -2323,7 +2323,7 @@ impl<'db> UseDefMapBuilder<'db> {
             .add_or_constraint(self.reachability, snapshot.reachability);
     }
 
-    pub(super) fn finish(mut self) -> UseDefMap<'db> {
+    pub(super) fn finish(mut self: Box<Self>) -> UseDefMap<'db> {
         let pending = self.pending_reachability.current;
         for state in self
             .symbol_states


### PR DESCRIPTION
Consume `UseDefMapBuilder` through its `Box` so finalization does not first move the builder onto the stack. This removes two copies per scope; DHAT measured 2.8 MB fewer copies on DateType and 7.4 MB on hydra-zen, with neutral heap usage and runtime.

