### PR TITLE
[ty] Benchmark salsa-rs/salsa#1177

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8#d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3759,12 +3759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8#d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8#d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=4ef094435d92107081a0ae5c9a6dcf31badea08b#4ef094435d92107081a0ae5c9a6dcf31badea08b"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3759,12 +3759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=4ef094435d92107081a0ae5c9a6dcf31badea08b#4ef094435d92107081a0ae5c9a6dcf31badea08b"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=4ef094435d92107081a0ae5c9a6dcf31badea08b#4ef094435d92107081a0ae5c9a6dcf31badea08b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3759,12 +3759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=2188fa7a09647492cd60412950e4f5c1a4b60374#2188fa7a09647492cd60412950e4f5c1a4b60374"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3759,12 +3759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=28835e1a96daebed9509d52a5dc9b68e27a63432#28835e1a96daebed9509d52a5dc9b68e27a63432"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,7 +3733,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "salsa"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
 dependencies = [
  "boxcar",
  "compact_str",
@@ -3759,12 +3759,12 @@ dependencies = [
 [[package]]
 name = "salsa-macro-rules"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
 
 [[package]]
 name = "salsa-macros"
 version = "0.27.0"
-source = "git+https://github.com/salsa-rs/salsa.git?rev=f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894#f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894"
+source = "git+https://github.com/salsa-rs/salsa.git?rev=7ad3a395c74832058179c0c040b7cfdfdfaa88e6#7ad3a395c74832058179c0c040b7cfdfdfaa88e6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7ad3a395c74832058179c0c040b7cfdfdfaa88e6", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "28835e1a96daebed9509d52a5dc9b68e27a63432", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "28835e1a96daebed9509d52a5dc9b68e27a63432", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2188fa7a09647492cd60412950e4f5c1a4b60374", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2188fa7a09647492cd60412950e4f5c1a4b60374", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "4ef094435d92107081a0ae5c9a6dcf31badea08b", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ regex-syntax = { version = "0.8.8" }
 rustc-hash = { version = "2.0.0" }
 rustc-stable-hash = { version = "0.1.2" }
 # When updating salsa, make sure to also update the revision in `fuzz/Cargo.toml`
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7ad3a395c74832058179c0c040b7cfdfdfaa88e6", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2188fa7a09647492cd60412950e4f5c1a4b60374", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "4ef094435d92107081a0ae5c9a6dcf31badea08b", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "28835e1a96daebed9509d52a5dc9b68e27a63432", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "2188fa7a09647492cd60412950e4f5c1a4b60374", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7ad3a395c74832058179c0c040b7cfdfdfaa88e6", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "7ad3a395c74832058179c0c040b7cfdfdfaa88e6", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "28835e1a96daebed9509d52a5dc9b68e27a63432", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -33,7 +33,7 @@ ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }
-salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "d1a042b2f1164a9ef0ec8d4713f5c45b5a90a6d8", default-features = false, features = [
+salsa = { git = "https://github.com/salsa-rs/salsa.git", rev = "f226c448b6dfe18dc04bd7c0be9b6bbefc1ca894", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",


### PR DESCRIPTION
## Summary

Pin Salsa to salsa-rs/salsa#1177 to benchmark deferred database attachment against the Salsa master baseline in #26201.

## Test Plan

Testing: All 696 ty_python_semantic tests and repository hooks passed.