### PR TITLE
[ty] Short-circuit terminal narrowing constraints

### DIFF
--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -561,6 +561,12 @@ pub(crate) fn narrow_type_by_constraint<'db>(
     base_ty: Type<'db>,
     place: ScopedPlaceId,
 ) -> Type<'db> {
+    match id {
+        ScopedNarrowingConstraint::ALWAYS_TRUE => return base_ty,
+        ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
+        _ => {}
+    }
+
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {
@@ -832,58 +838,54 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn project(&mut self, id: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
         type Id = ScopedNarrowingConstraint;
 
-        if !id.is_terminal()
-            && let Some(cached) = self.project_cache.get(&id)
-        {
+        match id {
+            Id::ALWAYS_TRUE => return ProjectedNarrowingNodeId::ALWAYS_TRUE,
+            Id::ALWAYS_FALSE => return ProjectedNarrowingNodeId::ALWAYS_FALSE,
+            _ => {}
+        }
+
+        if let Some(cached) = self.project_cache.get(&id) {
             return *cached;
         }
 
-        let projected = match id {
-            Id::ALWAYS_TRUE => ProjectedNarrowingNodeId::ALWAYS_TRUE,
-            Id::ALWAYS_FALSE => ProjectedNarrowingNodeId::ALWAYS_FALSE,
-            _ => {
-                let node = self.constraints.get_interior_node(id);
-                let predicate = self.predicates[node.atom];
+        let node = self.constraints.get_interior_node(id);
+        let predicate = self.predicates[node.atom];
 
-                if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                    let if_uncertain = self.project(node.if_uncertain);
-                    match analyze_single(self.db, &predicate) {
-                        Truthiness::AlwaysTrue => {
-                            let if_true = self.project(node.if_true);
-                            self.graph.or(if_true, if_uncertain)
-                        }
-                        Truthiness::AlwaysFalse => {
-                            let if_false = self.project(node.if_false);
-                            self.graph.or(if_false, if_uncertain)
-                        }
-                        Truthiness::Ambiguous => {
-                            unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
-                        }
-                    }
-                } else {
+        let projected = if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+            let if_uncertain = self.project(node.if_uncertain);
+            match analyze_single(self.db, &predicate) {
+                Truthiness::AlwaysTrue => {
                     let if_true = self.project(node.if_true);
-                    let if_uncertain = self.project(node.if_uncertain);
-                    let if_false = self.project(node.if_false);
-                    let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
-
-                    if pos_constraint.is_none() && neg_constraint.is_none() {
-                        let either = self.graph.or(if_true, if_false);
-                        self.graph.or(either, if_uncertain)
-                    } else {
-                        self.graph.add_node(ProjectedNarrowingNode {
-                            atom: node.atom,
-                            if_true,
-                            if_uncertain,
-                            if_false,
-                        })
-                    }
+                    self.graph.or(if_true, if_uncertain)
                 }
+                Truthiness::AlwaysFalse => {
+                    let if_false = self.project(node.if_false);
+                    self.graph.or(if_false, if_uncertain)
+                }
+                Truthiness::Ambiguous => {
+                    unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
+                }
+            }
+        } else {
+            let if_true = self.project(node.if_true);
+            let if_uncertain = self.project(node.if_uncertain);
+            let if_false = self.project(node.if_false);
+            let (pos_constraint, neg_constraint) = self.predicate_constraints(node.atom);
+
+            if pos_constraint.is_none() && neg_constraint.is_none() {
+                let either = self.graph.or(if_true, if_false);
+                self.graph.or(either, if_uncertain)
+            } else {
+                self.graph.add_node(ProjectedNarrowingNode {
+                    atom: node.atom,
+                    if_true,
+                    if_uncertain,
+                    if_false,
+                })
             }
         };
 
-        if !id.is_terminal() {
-            self.project_cache.insert(id, projected);
-        }
+        self.project_cache.insert(id, projected);
         projected
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -832,7 +832,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
     fn project(&mut self, id: ScopedNarrowingConstraint) -> ProjectedNarrowingNodeId {
         type Id = ScopedNarrowingConstraint;
 
-        if let Some(cached) = self.project_cache.get(&id) {
+        if !id.is_terminal()
+            && let Some(cached) = self.project_cache.get(&id)
+        {
             return *cached;
         }
 
@@ -879,7 +881,9 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
             }
         };
 
-        self.project_cache.insert(id, projected);
+        if !id.is_terminal() {
+            self.project_cache.insert(id, projected);
+        }
         projected
     }
 }


### PR DESCRIPTION
Short-circuit in `narrow_type_by_constraint` and avoid caching terminal nodes, as they're trivial to solve.

Small 1% perf improvement, reduces overall allocations