### PR TITLE
[ty] Reserve capacity for recursive union normalization

### DIFF
--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -360,7 +360,7 @@ impl<'db> UnionType<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db)
+        let mut builder = UnionBuilder::with_capacity(db, self.elements(db).len())
             .unpack_aliases(false)
             .cycle_recovery(true)
             .recursively_defined(self.recursively_defined(db));

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -516,9 +516,13 @@ impl<'db> UnionAccumulator<'db> {
 
 impl<'db> UnionBuilder<'db> {
     pub(crate) fn new(db: &'db dyn Db) -> Self {
+        Self::with_capacity(db, 0)
+    }
+
+    pub(crate) fn with_capacity(db: &'db dyn Db, capacity: usize) -> Self {
         Self {
             db,
-            elements: vec![],
+            elements: Vec::with_capacity(capacity),
             unpack_aliases: true,
             cycle_recovery: false,
             recursively_defined: RecursivelyDefined::No,


### PR DESCRIPTION
Use the source union’s element count as the initial `UnionBuilder` capacity during recursive normalization. This avoids 6.3 MB and 6.5k allocations on hydra with neutral runtime and retained memory.

Testing: Passed semantic tests, Clippy, and repository hooks.