### PR TITLE
[ty] Reserve pending reachability chain capacity

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -1283,6 +1283,16 @@ impl PendingReachability {
             let mut unapplied = SmallVec::<[ScopedReachabilityConstraintId; 4]>::new();
             let mut current = target;
             while current != pending.reachability {
+                if unapplied.len() == unapplied.capacity() {
+                    // Reserve once for deep chains instead of repeatedly growing the spill buffer.
+                    let mut remaining = 0;
+                    let mut ancestor = current;
+                    while ancestor != pending.reachability {
+                        remaining += 1;
+                        ancestor = self.constraints[ancestor].parent;
+                    }
+                    unapplied.reserve_exact(remaining);
+                }
                 let event = &self.constraints[current];
                 unapplied.push(event.constraint);
                 assert_ne!(


### PR DESCRIPTION
Deep pending-reachability chains currently grow their spill buffer repeatedly. Count the unmaterialized tail at the first spill and reserve its exact capacity, removing 18k allocations on Tanjun with neutral copy traffic and runtime.

Testing: Passed core tests, Clippy, and repository hooks.