### PR TITLE
Use ArrayVec for qualified name segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ name = "ruff_python_ast"
 version = "0.0.0"
 dependencies = [
  "aho-corasick",
+ "arrayvec",
  "bitflags 2.13.0",
  "compact_str",
  "get-size2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ty_vendored = { path = "crates/ty_vendored" }
 mdtest = { path = "crates/mdtest" }
 
 aho-corasick = { version = "1.1.3" }
+arrayvec = { version = "0.7.6" }
 anstream = { version = "1.0.0" }
 anstyle = { version = "1.0.10" }
 anyhow = { version = "1.0.80" }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -24,6 +24,7 @@ ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 
 aho-corasick = { workspace = true }
+arrayvec = { workspace = true }
 bitflags = { workspace = true }
 compact_str = { workspace = true }
 get-size2 = { workspace = true, optional = true }

--- a/crates/ruff_python_ast/src/name.rs
+++ b/crates/ruff_python_ast/src/name.rs
@@ -3,6 +3,8 @@ use std::fmt::{Debug, Display, Formatter, Write};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
 
+use arrayvec::ArrayVec;
+
 use crate::Expr;
 use crate::generated::ExprName;
 
@@ -241,7 +243,7 @@ impl<'a> QualifiedName<'a> {
     #[inline]
     pub fn builtin(name: &'a str) -> Self {
         debug_assert!(!name.contains('.'));
-        Self(SegmentsVec::Stack(SegmentsStack::from_slice(&["", name])))
+        Self(SegmentsVec::from_slice(&["", name]))
     }
 
     #[inline]
@@ -568,9 +570,9 @@ impl<'a> FromIterator<&'a str> for UnqualifiedName<'a> {
 /// Stores up to 8 segments inline, and falls back to a heap-allocated vector for names with more segments.
 ///
 /// ## Note
-/// The implementation doesn't use `SmallVec` v1 because its type definition has a variance problem.
-/// The incorrect variance leads the lifetime inference in the `SemanticModel` astray, causing
-/// all sort of "strange" lifetime errors. We can switch back to `SmallVec` when v2 is released.
+/// The inline variant uses `ArrayVec` rather than `SmallVec` v1 because `SmallVec`'s type
+/// definition has a variance problem. The incorrect variance leads lifetime inference in the
+/// `SemanticModel` astray, causing all sorts of "strange" lifetime errors.
 #[derive(Clone)]
 enum SegmentsVec<'a> {
     Stack(SegmentsStack<'a>),
@@ -600,10 +602,9 @@ impl<'a> SegmentsVec<'a> {
     /// Initializes the segments from a slice.
     #[inline]
     fn from_slice(slice: &[&'a str]) -> Self {
-        if slice.len() <= SMALL_LEN {
-            SegmentsVec::Stack(SegmentsStack::from_slice(slice))
-        } else {
-            SegmentsVec::Heap(slice.to_vec())
+        match SegmentsStack::try_from(slice) {
+            Ok(stack) => SegmentsVec::Stack(stack),
+            Err(_) => SegmentsVec::Heap(slice.to_vec()),
         }
     }
 
@@ -623,7 +624,10 @@ impl<'a> SegmentsVec<'a> {
     fn push(&mut self, name: &'a str) {
         match self {
             SegmentsVec::Stack(stack) => {
-                if let Err(segments) = stack.push(name) {
+                if let Err(error) = stack.try_push(name) {
+                    let mut segments = Vec::with_capacity(stack.len() * 2);
+                    segments.extend(stack.iter().copied());
+                    segments.push(error.element());
                     *self = SegmentsVec::Heap(segments);
                 }
             }
@@ -648,7 +652,10 @@ impl<'a> SegmentsVec<'a> {
     fn extend_from_slice(&mut self, slice: &[&'a str]) {
         match self {
             SegmentsVec::Stack(stack) => {
-                if let Err(segments) = stack.extend_from_slice(slice) {
+                if stack.try_extend_from_slice(slice).is_err() {
+                    let mut segments = Vec::with_capacity(stack.len() + slice.len());
+                    segments.extend(stack.iter().copied());
+                    segments.extend_from_slice(slice);
                     *self = SegmentsVec::Heap(segments);
                 }
             }
@@ -702,10 +709,7 @@ impl<'a> FromIterator<&'a str> for SegmentsVec<'a> {
 impl<'a> From<[&'a str; 8]> for SegmentsVec<'a> {
     #[inline]
     fn from(segments: [&'a str; 8]) -> Self {
-        SegmentsVec::Stack(SegmentsStack {
-            segments,
-            len: segments.len(),
-        })
+        SegmentsVec::Stack(SegmentsStack::from(segments))
     }
 }
 
@@ -721,8 +725,26 @@ impl<'a> Extend<&'a str> for SegmentsVec<'a> {
     fn extend<T: IntoIterator<Item = &'a str>>(&mut self, iter: T) {
         match self {
             SegmentsVec::Stack(stack) => {
-                if let Err(segments) = stack.extend(iter) {
+                let mut iter = iter.into_iter();
+                let (lower, _) = iter.size_hint();
+
+                if lower > stack.remaining_capacity() {
+                    let mut segments = Vec::with_capacity(stack.len() + lower);
+                    segments.extend(stack.iter().copied());
+                    segments.extend(iter);
                     *self = SegmentsVec::Heap(segments);
+                    return;
+                }
+
+                while let Some(name) = iter.next() {
+                    if let Err(error) = stack.try_push(name) {
+                        let mut segments = Vec::with_capacity(stack.len() * 2);
+                        segments.extend(stack.iter().copied());
+                        segments.push(error.element());
+                        segments.extend(iter);
+                        *self = SegmentsVec::Heap(segments);
+                        return;
+                    }
                 }
             }
             SegmentsVec::Heap(heap) => {
@@ -733,129 +755,7 @@ impl<'a> Extend<&'a str> for SegmentsVec<'a> {
 }
 
 const SMALL_LEN: usize = 8;
-
-#[derive(Debug, Clone, Default)]
-struct SegmentsStack<'a> {
-    segments: [&'a str; SMALL_LEN],
-    len: usize,
-}
-
-impl<'a> SegmentsStack<'a> {
-    #[inline]
-    fn from_slice(slice: &[&'a str]) -> Self {
-        assert!(slice.len() <= SMALL_LEN);
-
-        let mut segments: [&'a str; SMALL_LEN] = Default::default();
-        segments[..slice.len()].copy_from_slice(slice);
-        SegmentsStack {
-            segments,
-            len: slice.len(),
-        }
-    }
-
-    const fn capacity(&self) -> usize {
-        SMALL_LEN - self.len
-    }
-
-    #[inline]
-    fn as_slice(&self) -> &[&'a str] {
-        &self.segments[..self.len]
-    }
-
-    /// Pushes `name` to the end of the segments.
-    ///
-    /// Returns `Err` with a `Vec` containing all items (including `name`) if there's not enough capacity to push the name.
-    #[inline]
-    fn push(&mut self, name: &'a str) -> Result<(), Vec<&'a str>> {
-        if self.len < self.segments.len() {
-            self.segments[self.len] = name;
-            self.len += 1;
-            Ok(())
-        } else {
-            let mut segments = Vec::with_capacity(self.len * 2);
-            segments.extend_from_slice(&self.segments);
-            segments.push(name);
-            Err(segments)
-        }
-    }
-
-    /// Reserves spaces for `additional` segments.
-    ///
-    /// Returns `Err` with a `Vec` containing all segments and a capacity to store `additional` segments if
-    /// the stack needs to spill over to the heap to store `additional` segments.
-    #[inline]
-    fn reserve(&mut self, additional: usize) -> Result<(), Vec<&'a str>> {
-        if self.capacity() >= additional {
-            Ok(())
-        } else {
-            let mut segments = Vec::with_capacity(self.len + additional);
-            segments.extend_from_slice(self.as_slice());
-            Err(segments)
-        }
-    }
-
-    #[inline]
-    fn pop(&mut self) -> Option<&'a str> {
-        if self.len > 0 {
-            self.len -= 1;
-            Some(self.segments[self.len])
-        } else {
-            None
-        }
-    }
-
-    /// Extends the segments by appending `slice` to the end.
-    ///
-    /// Returns `Err` with a `Vec` containing all segments and the segments in `slice` if there's not enough capacity to append the names.
-    #[inline]
-    fn extend_from_slice(&mut self, slice: &[&'a str]) -> Result<(), Vec<&'a str>> {
-        let new_len = self.len + slice.len();
-        if slice.len() <= self.capacity() {
-            self.segments[self.len..new_len].copy_from_slice(slice);
-            self.len = new_len;
-            Ok(())
-        } else {
-            let mut segments = Vec::with_capacity(new_len);
-            segments.extend_from_slice(self.as_slice());
-            segments.extend_from_slice(slice);
-            Err(segments)
-        }
-    }
-
-    #[inline]
-    fn extend<I>(&mut self, iter: I) -> Result<(), Vec<&'a str>>
-    where
-        I: IntoIterator<Item = &'a str>,
-    {
-        let mut iter = iter.into_iter();
-        let (lower, _) = iter.size_hint();
-
-        // There's not enough space to store the lower bound of items. Spill to the heap.
-        if let Err(mut segments) = self.reserve(lower) {
-            segments.extend(iter);
-            return Err(segments);
-        }
-
-        // Copy over up to capacity items
-        for name in iter.by_ref().take(self.capacity()) {
-            self.segments[self.len] = name;
-            self.len += 1;
-        }
-
-        let Some(item) = iter.next() else {
-            // There are no more items to copy over and they all fit into capacity.
-            return Ok(());
-        };
-
-        // There are more items and there's not enough capacity to store them on the stack.
-        // Spill over to the heap and append the remaining items.
-        let mut segments = Vec::with_capacity(self.len * 2);
-        segments.extend_from_slice(self.as_slice());
-        segments.push(item);
-        segments.extend(iter);
-        Err(segments)
-    }
-}
+type SegmentsStack<'a> = ArrayVec<&'a str, SMALL_LEN>;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Use `ArrayVec` for qualified-name inline storage so only live segments are initialized and copied. This also removes the custom length, spill, and iterator bookkeeping while preserving the eight-segment inline capacity.

## Test Plan

Testing: Ran the affected crate tests, Clippy, and repository hooks.
