### PR TITLE
[ty] Reuse the first union bindings buffer

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -591,14 +591,19 @@ impl<'db> Bindings<'db> {
             combined.elements.extend(bindings.elements);
         }
 
-        assert!(!combined.elements.is_empty());
+        let Self {
+            callable_type: _,
+            implicit_dunder_new_is_possibly_unbound,
+            implicit_dunder_init_is_possibly_unbound,
+            elements,
+            enclosing_binding_contexts: _,
+        } = combined;
+        assert!(!elements.is_empty());
         Self {
             callable_type,
-            implicit_dunder_new_is_possibly_unbound: combined
-                .implicit_dunder_new_is_possibly_unbound,
-            implicit_dunder_init_is_possibly_unbound: combined
-                .implicit_dunder_init_is_possibly_unbound,
-            elements: combined.elements,
+            implicit_dunder_new_is_possibly_unbound,
+            implicit_dunder_init_is_possibly_unbound,
+            elements,
             enclosing_binding_contexts: None,
         }
     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -579,9 +579,13 @@ impl<'db> Bindings<'db> {
     where
         I: IntoIterator<Item = Bindings<'db>>,
     {
-        let mut implicit_dunder_new_is_possibly_unbound = false;
-        let mut implicit_dunder_init_is_possibly_unbound = false;
-        let mut elements_acc = SmallVec::new();
+        let mut bindings_iter = bindings_iter.into_iter();
+        let first = bindings_iter.next().expect("bindings must not be empty");
+        let mut implicit_dunder_new_is_possibly_unbound =
+            first.implicit_dunder_new_is_possibly_unbound;
+        let mut implicit_dunder_init_is_possibly_unbound =
+            first.implicit_dunder_init_is_possibly_unbound;
+        let mut elements_acc = first.elements;
 
         // Preserve each input's existing union/intersection structure.
         for set in bindings_iter {

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -580,24 +580,23 @@ impl<'db> Bindings<'db> {
         I: IntoIterator<Item = Bindings<'db>>,
     {
         let mut bindings_iter = bindings_iter.into_iter();
-        let mut combined = bindings_iter.next().expect("bindings must not be empty");
-
         // Use the first binding as the accumulator to reuse its elements buffer.
-        for bindings in bindings_iter {
-            combined.implicit_dunder_new_is_possibly_unbound |=
-                bindings.implicit_dunder_new_is_possibly_unbound;
-            combined.implicit_dunder_init_is_possibly_unbound |=
-                bindings.implicit_dunder_init_is_possibly_unbound;
-            combined.elements.extend(bindings.elements);
-        }
-
         let Self {
             callable_type: _,
-            implicit_dunder_new_is_possibly_unbound,
-            implicit_dunder_init_is_possibly_unbound,
-            elements,
+            mut implicit_dunder_new_is_possibly_unbound,
+            mut implicit_dunder_init_is_possibly_unbound,
+            mut elements,
             enclosing_binding_contexts: _,
-        } = combined;
+        } = bindings_iter.next().expect("bindings must not be empty");
+
+        for bindings in bindings_iter {
+            implicit_dunder_new_is_possibly_unbound |=
+                bindings.implicit_dunder_new_is_possibly_unbound;
+            implicit_dunder_init_is_possibly_unbound |=
+                bindings.implicit_dunder_init_is_possibly_unbound;
+            elements.extend(bindings.elements);
+        }
+
         assert!(!elements.is_empty());
         Self {
             callable_type,

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -592,9 +592,15 @@ impl<'db> Bindings<'db> {
         }
 
         assert!(!combined.elements.is_empty());
-        combined.callable_type = callable_type;
-        combined.enclosing_binding_contexts = None;
-        combined
+        Self {
+            callable_type,
+            implicit_dunder_new_is_possibly_unbound: combined
+                .implicit_dunder_new_is_possibly_unbound,
+            implicit_dunder_init_is_possibly_unbound: combined
+                .implicit_dunder_init_is_possibly_unbound,
+            elements: combined.elements,
+            enclosing_binding_contexts: None,
+        }
     }
 
     /// Creates a new `Bindings` from an iterator of [`Bindings`]s for an intersection type.

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -580,30 +580,21 @@ impl<'db> Bindings<'db> {
         I: IntoIterator<Item = Bindings<'db>>,
     {
         let mut bindings_iter = bindings_iter.into_iter();
-        let first = bindings_iter.next().expect("bindings must not be empty");
-        let mut implicit_dunder_new_is_possibly_unbound =
-            first.implicit_dunder_new_is_possibly_unbound;
-        let mut implicit_dunder_init_is_possibly_unbound =
-            first.implicit_dunder_init_is_possibly_unbound;
-        let mut elements_acc = first.elements;
+        let mut combined = bindings_iter.next().expect("bindings must not be empty");
 
-        // Preserve each input's existing union/intersection structure.
-        for set in bindings_iter {
-            implicit_dunder_new_is_possibly_unbound |= set.implicit_dunder_new_is_possibly_unbound;
-            implicit_dunder_init_is_possibly_unbound |=
-                set.implicit_dunder_init_is_possibly_unbound;
-            elements_acc.extend(set.elements);
+        // Use the first binding as the accumulator to reuse its elements buffer.
+        for bindings in bindings_iter {
+            combined.implicit_dunder_new_is_possibly_unbound |=
+                bindings.implicit_dunder_new_is_possibly_unbound;
+            combined.implicit_dunder_init_is_possibly_unbound |=
+                bindings.implicit_dunder_init_is_possibly_unbound;
+            combined.elements.extend(bindings.elements);
         }
 
-        let elements = elements_acc;
-        assert!(!elements.is_empty());
-        Self {
-            callable_type,
-            elements,
-            implicit_dunder_new_is_possibly_unbound,
-            implicit_dunder_init_is_possibly_unbound,
-            enclosing_binding_contexts: None,
-        }
+        assert!(!combined.elements.is_empty());
+        combined.callable_type = callable_type;
+        combined.enclosing_binding_contexts = None;
+        combined
     }
 
     /// Creates a new `Bindings` from an iterator of [`Bindings`]s for an intersection type.


### PR DESCRIPTION
## Summary

Avoid allocating a new `SmallVec` when unioning `Bindings`. Instead, reuse the first element's buffer. 

## Benchmark

A 1-3% performance improvement on most walltime projects.