### PR TITLE
Lazily create source files for lint diagnostics

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -3426,18 +3426,14 @@ pub(crate) fn check_ast(
 /// a [`Violation`] to the contained [`Diagnostic`] collection on `Drop`.
 pub(crate) struct LintContext<'a> {
     diagnostics: RefCell<Vec<Diagnostic>>,
-    source_file: SourceFile,
+    source_file: LazySourceFile<'a>,
     rules: RuleTable,
     settings: &'a LinterSettings,
 }
 
 impl<'a> LintContext<'a> {
-    /// Create a new collector with the given `source_file` and an empty collection of
-    /// `Diagnostic`s.
-    pub(crate) fn new(path: &Path, contents: &str, settings: &'a LinterSettings) -> Self {
-        let source_file =
-            SourceFileBuilder::new(path.to_string_lossy().as_ref(), contents).finish();
-
+    /// Create a new collector for `path` with an empty collection of `Diagnostic`s.
+    pub(crate) fn new(path: &'a Path, contents: &'a str, settings: &'a LinterSettings) -> Self {
         // Ignore diagnostics based on per-file-ignores.
         let mut rules = settings.rules.clone();
         for ignore in crate::fs::ignores_from_path(path, &settings.per_file_ignores) {
@@ -3446,7 +3442,7 @@ impl<'a> LintContext<'a> {
 
         Self {
             diagnostics: RefCell::default(),
-            source_file,
+            source_file: LazySourceFile::new(path, contents),
             rules,
             settings,
         }
@@ -3463,7 +3459,7 @@ impl<'a> LintContext<'a> {
     ) -> DiagnosticGuard<'chk, 'a> {
         DiagnosticGuard {
             context: self,
-            diagnostic: Some(kind.into_diagnostic(range, &self.source_file)),
+            diagnostic: Some(kind.into_diagnostic(range, self.source_file())),
             rule: T::rule(),
             before_drop_fns: SmallVec::new(),
         }
@@ -3483,7 +3479,7 @@ impl<'a> LintContext<'a> {
         if self.is_rule_enabled(rule) {
             Some(DiagnosticGuard {
                 context: self,
-                diagnostic: Some(kind.into_diagnostic(range, &self.source_file)),
+                diagnostic: Some(kind.into_diagnostic(range, self.source_file())),
                 rule,
                 before_drop_fns: SmallVec::new(),
             })
@@ -3508,7 +3504,7 @@ impl<'a> LintContext<'a> {
             range,
             None,
             None,
-            self.source_file.clone(),
+            self.source_file().clone(),
             None,
             T::rule(),
         );
@@ -3558,7 +3554,7 @@ impl<'a> LintContext<'a> {
     }
 
     #[inline]
-    pub(crate) fn into_parts(self) -> (Vec<Diagnostic>, SourceFile) {
+    pub(crate) fn into_parts(self) -> (Vec<Diagnostic>, LazySourceFile<'a>) {
         (self.diagnostics.into_inner(), self.source_file)
     }
 
@@ -3577,9 +3573,30 @@ impl<'a> LintContext<'a> {
         self.settings
     }
 
-    #[cfg(any(feature = "test-rules", test))]
-    pub(crate) const fn source_file(&self) -> &SourceFile {
-        &self.source_file
+    pub(crate) fn source_file(&self) -> &SourceFile {
+        self.source_file.get()
+    }
+}
+
+pub(crate) struct LazySourceFile<'a> {
+    path: &'a Path,
+    contents: &'a str,
+    file: OnceCell<SourceFile>,
+}
+
+impl LazySourceFile<'_> {
+    fn new<'a>(path: &'a Path, contents: &'a str) -> LazySourceFile<'a> {
+        LazySourceFile {
+            path,
+            contents,
+            file: OnceCell::new(),
+        }
+    }
+
+    pub(crate) fn get(&self) -> &SourceFile {
+        self.file.get_or_init(|| {
+            SourceFileBuilder::new(self.path.to_string_lossy().as_ref(), self.contents).finish()
+        })
     }
 }
 
@@ -3737,7 +3754,7 @@ impl DiagnosticGuard<'_, '_> {
         message: impl IntoDiagnosticMessage + 'a,
         range: impl Ranged,
     ) {
-        let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let span = Span::from(self.context.source_file().clone()).with_range(range.range());
         let message = message.into_diagnostic_message();
         debug_assert!(
             !message.as_str().is_empty(),
@@ -3749,7 +3766,7 @@ impl DiagnosticGuard<'_, '_> {
 
     /// Add a secondary annotation without a message at the given range.
     pub(crate) fn secondary_annotation_without_message(&mut self, range: impl Ranged) {
-        let span = Span::from(self.context.source_file.clone()).with_range(range.range());
+        let span = Span::from(self.context.source_file().clone()).with_range(range.range());
         let ann = Annotation::secondary(span);
         self.diagnostic.as_mut().unwrap().annotate(ann);
     }

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -13,9 +13,8 @@ use ruff_python_ast::{ModModule, PySourceType, PythonVersion};
 use ruff_python_codegen::Stylist;
 use ruff_python_index::Indexer;
 use ruff_python_parser::{ParseError, ParseOptions, Parsed, UnsupportedSyntaxError};
-use ruff_source_file::SourceFile;
 
-use crate::checkers::ast::{LintContext, check_ast};
+use crate::checkers::ast::{LazySourceFile, LintContext, check_ast};
 use crate::checkers::filesystem::check_file_path;
 use crate::checkers::imports::check_imports;
 use crate::checkers::noqa::check_noqa;
@@ -360,12 +359,10 @@ pub fn check_path(
         }
     }
 
-    let syntax_errors = parsed.unsupported_syntax_errors();
-
     diagnostics_to_messages(
         diagnostics,
         parsed.errors(),
-        syntax_errors,
+        parsed.unsupported_syntax_errors(),
         &semantic_syntax_errors,
         directives,
         &source_file,
@@ -515,20 +512,20 @@ fn diagnostics_to_messages(
     unsupported_syntax_errors: &[UnsupportedSyntaxError],
     semantic_syntax_errors: &[SemanticSyntaxError],
     directives: &Directives,
-    source_file: &SourceFile,
+    source_file: &LazySourceFile<'_>,
 ) -> Vec<Diagnostic> {
     parse_errors
         .iter()
         .map(|parse_error| {
-            Diagnostic::invalid_syntax(source_file.clone(), &parse_error.error, parse_error)
+            Diagnostic::invalid_syntax(source_file.get().clone(), &parse_error.error, parse_error)
         })
         .chain(unsupported_syntax_errors.iter().map(|syntax_error| {
-            Diagnostic::invalid_syntax(source_file.clone(), syntax_error, syntax_error)
+            Diagnostic::invalid_syntax(source_file.get().clone(), syntax_error, syntax_error)
         }))
         .chain(
             semantic_syntax_errors
                 .iter()
-                .map(|error| Diagnostic::invalid_syntax(source_file.clone(), error, error)),
+                .map(|error| Diagnostic::invalid_syntax(source_file.get().clone(), error, error)),
         )
         .chain(diagnostics.into_iter().map(|mut diagnostic| {
             if let Some(range) = diagnostic.range() {


### PR DESCRIPTION
## Summary

Lazily create the `SourceFile` used by lint diagnostics so files without diagnostics do not copy their entire source text.

## Test Plan

Testing: Passed the Ruff linter test suite, Clippy, and repository hooks.
