### PR TITLE
Reserve capacity for builtin bindings

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/mod.rs
+++ b/crates/ruff_linter/src/checkers/ast/mod.rs
@@ -2757,6 +2757,13 @@ impl<'a> Checker<'a> {
     fn bind_builtins(&mut self) {
         let target_version = self.target_version();
         let settings = self.settings();
+        let builtin_count = python_builtins(target_version.minor, self.source_type.is_ipynb())
+            .count()
+            + python_magic_globals(target_version.minor).count()
+            + settings.builtins.len();
+
+        self.semantic.reserve_builtin_bindings(builtin_count);
+
         let mut bind_builtin = |builtin| {
             // Add the builtin to the scope.
             let binding_id = self.semantic.push_builtin();

--- a/crates/ruff_python_semantic/src/binding.rs
+++ b/crates/ruff_python_semantic/src/binding.rs
@@ -457,6 +457,11 @@ pub struct BindingId;
 pub struct Bindings<'a>(IndexVec<BindingId, Binding<'a>>);
 
 impl<'a> Bindings<'a> {
+    /// Reserves capacity for at least `additional` more bindings.
+    pub(crate) fn reserve_exact(&mut self, additional: usize) {
+        self.0.raw.reserve_exact(additional);
+    }
+
     /// Pushes a new [`Binding`] and returns its [`BindingId`].
     pub fn push(&mut self, binding: Binding<'a>) -> BindingId {
         self.0.push(binding)

--- a/crates/ruff_python_semantic/src/model.rs
+++ b/crates/ruff_python_semantic/src/model.rs
@@ -226,6 +226,14 @@ impl<'a> SemanticModel<'a> {
             .chain(self.typing_modules.iter().map(String::as_str))
     }
 
+    /// Reserves capacity for builtin bindings.
+    pub fn reserve_builtin_bindings(&mut self, additional: usize) {
+        // Match the capacity that repeated `push` calls would reach while avoiding the
+        // intermediate allocations.
+        self.bindings.reserve_exact(additional.next_power_of_two());
+        self.global_scope_mut().reserve_bindings(additional);
+    }
+
     /// Create a new [`Binding`] for a builtin.
     pub fn push_builtin(&mut self) -> BindingId {
         self.bindings.push(Binding {

--- a/crates/ruff_python_semantic/src/scope.rs
+++ b/crates/ruff_python_semantic/src/scope.rs
@@ -84,6 +84,11 @@ impl<'a> Scope<'a> {
         }
     }
 
+    /// Reserves capacity for at least `additional` more bindings.
+    pub(crate) fn reserve_bindings(&mut self, additional: usize) {
+        self.bindings.reserve(additional);
+    }
+
     /// Returns `true` if this scope has a binding with the given name.
     pub fn has(&self, name: &str) -> bool {
         self.bindings.contains_key(name)


### PR DESCRIPTION
Reserve semantic bindings and global-scope slots before inserting the known builtin names.