### PR TITLE
[ty] Normalize recursive `TypeOf` across multiple union arms

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -525,6 +525,14 @@ class Container[T]: ...
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
+
+union: list[TypeOf[union]] | Container[TypeOf[union]]
+union = [1]
+reveal_type(union)  # revealed: list[Divergent]
+
+stable_union: list[TypeOf[stable_union]] | Container[TypeOf[stable_union]] | None
+stable_union = [1]
+reveal_type(stable_union)  # revealed: list[Divergent]
 ```
 
 ## Recursive `TypeOf` in returned callables

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1212,8 +1212,8 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
-    /// Normalizes nominal growth that wraps the previous cycle result in a specialization, either
-    /// directly or beneath an unambiguous union wrapper.
+    /// Normalizes nominal growth that wraps the previous cycle result in one or more
+    /// specializations, either directly or beneath an unambiguous union wrapper.
     ///
     /// For example, an inference cycle can otherwise grow indefinitely as
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
@@ -1226,6 +1226,41 @@ impl<'db> Type<'db> {
         div: Self,
     ) -> Option<Self> {
         if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
+            let previous_elements = previous.elements(db);
+
+            // Multiple union arms may each grow by wrapping the entire previous union. Normalize
+            // only when every previous arm is nominal and at least two changed current arms are
+            // nominal wrappers; arms shared with the previous union remain unchanged.
+            if previous_elements
+                .iter()
+                .all(|element| matches!(element, Type::NominalInstance(_)))
+                && let Some(replacements) = current
+                    .elements(db)
+                    .iter()
+                    .copied()
+                    .filter(|element| !previous_elements.contains(element))
+                    .map(|element| {
+                        Self::nominal_wrapper_normalized(
+                            db,
+                            element.as_nominal_instance()?,
+                            Type::Union(previous),
+                            div,
+                        )
+                        .map(|normalized| (element, normalized))
+                    })
+                    .collect::<Option<smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]>>>()
+                && replacements.len() > 1
+            {
+                return Some(current.map_leave_aliases(db, |element| {
+                    replacements
+                        .iter()
+                        .find_map(|(original, normalized)| {
+                            (*original == *element).then_some(*normalized)
+                        })
+                        .unwrap_or(*element)
+                }));
+            }
+
             // Only align unions when each iteration has exactly one changed arm. With multiple
             // unmatched arms, pairing is ambiguous and can destabilize otherwise-convergent
             // recursive cycles.
@@ -1260,17 +1295,27 @@ impl<'db> Type<'db> {
             return None;
         };
 
-        let current_class = current.class(db);
-        if current_class.class_literal(db) != previous_instance.class_literal(db) {
+        if current.class(db).class_literal(db) != previous_instance.class_literal(db) {
             return None;
         }
 
+        Self::nominal_wrapper_normalized(db, current, previous, div)
+    }
+
+    /// Replaces `wrapped` beneath the outer nominal specialization in `current`.
+    fn nominal_wrapper_normalized(
+        db: &'db dyn Db,
+        current: NominalInstanceType<'db>,
+        wrapped: Self,
+        div: Self,
+    ) -> Option<Self> {
+        let current_class = current.class(db);
         let alias = current_class.into_generic_alias()?;
         let original_specialization = alias.specialization(db);
         let specialization = original_specialization.apply_type_mapping(
             db,
             &TypeMapping::ReplaceType {
-                from: previous,
+                from: wrapped,
                 to: div,
             },
         );


### PR DESCRIPTION
## Summary

A recursive `TypeOf` can appear in multiple union arms, causing each fixed-point iteration to wrap the full previous union:

```python
from ty_extensions import TypeOf

class Container[T]: ...

x: list[TypeOf[x]] | Container[TypeOf[x]] | None
x = [1]
```

Prior to this change, both nominal arms grew on every iteration while the stable `None` arm prevented the existing single-arm alignment from applying, eventually exhausting Salsa's cycle iterations.

This identifies multiple changed nominal arms that each wrap the previous union, replaces their recursive argument with the cycle's `Divergent` marker, and preserves unchanged arms. Single changed arms and gradual-type unions continue to use the existing recovery path.
