### PR TITLE
[ty] Combine collection constraints before solving

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -53,6 +53,10 @@ impl AstIds {
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {
         self.uses_map[&key.into()]
     }
+
+    pub(super) fn try_use_id(&self, key: impl Into<ExpressionNodeKey>) -> Option<ScopedUseId> {
+        self.uses_map.get(&key.into()).copied()
+    }
 }
 
 fn ast_ids(db: &dyn Db, file: File) -> &AstIds {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2630,16 +2630,12 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         for use_def_map in &use_def_maps {
             let mut defined_places = FxHashSet::default();
             for (_, state, _) in use_def_map.all_definitions_with_usage() {
-                let Some(definition) = state.definition() else {
-                    continue;
-                };
-                let place = definition.place(self.db);
-                if self.uses_by_collection.contains_key(&definition)
-                    && defined_places.contains(&place)
+                if let Some(definition) = state.definition()
+                    && !defined_places.insert(definition.place(self.db))
+                    && self.uses_by_collection.contains_key(&definition)
                 {
                     self.collections_requiring_cycle.insert(definition);
                 }
-                defined_places.insert(place);
             }
         }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -274,12 +274,10 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     seen_submodule_imports: FxHashSet<String>,
     // A map from a lambda expression to its enclosing statement.
     enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
-    // A map from a constraining use of a collection literal to its definition.
+    // A map from each discovered use of a collection literal to its definition.
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
-    // A map from a collection literal definition to statements containing a constraining use.
+    // A map from a collection literal definition to constraining statements that reference it.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
-    // Collection literals with uses that require cycle-based inference.
-    collections_requiring_cycle: FxHashSet<Definition<'db>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -330,7 +328,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FxHashMap::default(),
             collections_by_use: FxHashMap::default(),
             uses_by_collection: FxHashMap::default(),
-            collections_requiring_cycle: FxHashSet::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -2624,21 +2621,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();
 
-        // Replacing an existing binding can make later collection uses depend on the merge of all
-        // definitions for that place. The identity-specialized query deliberately bypasses that
-        // merge, so retain cycle-based inference for those collection definitions.
-        for use_def_map in &use_def_maps {
-            let mut defined_places = FxHashSet::default();
-            for (_, state, _) in use_def_map.all_definitions_with_usage() {
-                if let Some(definition) = state.definition()
-                    && !defined_places.insert(definition.place(self.db))
-                    && self.uses_by_collection.contains_key(&definition)
-                {
-                    self.collections_requiring_cycle.insert(definition);
-                }
-            }
-        }
-
         let uses_by_collection = FrozenMap::from_entries(
             self.uses_by_collection
                 .into_iter()
@@ -2661,7 +2643,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
-            collections_requiring_cycle: FrozenSet::from(self.collections_requiring_cycle),
             imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
@@ -4094,70 +4075,43 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
         self.visit_stmt_impl(stmt);
         let mut current_statement = self.pop_statement();
 
-        // We currently only consider certain types of statements to introduce constraints
-        // on collection literals. This restriction is mostly for performance reasons, as we
-        // want to avoid "reads" of a collection contributing to the complexity of the cycles
-        // created by full-scope collection inference.
-        match stmt {
-            ast::Stmt::AugAssign(_) => self.collections_requiring_cycle.extend(
-                current_statement
-                    .collection_uses
-                    .iter()
-                    .map(|(definition, _)| *definition),
-            ),
-            ast::Stmt::Assign(ast::StmtAssign { targets, value, .. })
-                if targets
-                    .iter()
-                    .any(|target| target.is_attribute_expr() || target.is_subscript_expr()) =>
-            {
-                let assigned_value = ExpressionNodeKey::from(value);
-                self.collections_requiring_cycle.extend(
-                    current_statement
-                        .collection_uses
-                        .iter()
-                        .filter(|(_, use_expression)| *use_expression == assigned_value)
-                        .map(|(definition, _)| *definition),
-                );
-            }
-            _ => {}
-        }
+        let all_collection_uses = current_statement.collection_uses.clone();
+
+        // Keep every use-to-definition edge so a constraining operation on one collection can
+        // refer symbolically to another collection. Only add statements that can themselves
+        // contribute a collection constraint to the inference worklist below.
+        self.collections_by_use.extend(
+            current_statement
+                .collection_uses
+                .iter()
+                .map(|(definition, use_expression)| (*use_expression, *definition)),
+        );
 
         current_statement
             .collection_uses
-            .retain(|(_, use_expression)| {
-                match stmt {
-                    // A return involving the collection object.
-                    ruff_python_ast::Stmt::Return(_) => true,
-
-                    // A subscript assignment on the collection object.
-                    ruff_python_ast::Stmt::Assign(ast::StmtAssign { targets, .. }) => {
-                        match targets.as_slice() {
-                            [ast::Expr::Subscript(ast::ExprSubscript { value, .. })] => {
-                                ExpressionNodeKey::from(value) == *use_expression
-                            }
-                            _ => false,
-                        }
-                    }
-
-                    // An annotated assignment assigning the collection object to a new binding.
-                    ruff_python_ast::Stmt::AnnAssign(_) => true,
-
-                    // A bound-method call on the collection object.
-                    ruff_python_ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
-                        match value.as_ref() {
-                            ast::Expr::Call(ast::ExprCall { func, .. }) => match func.as_ref() {
-                                ruff_python_ast::Expr::Attribute(ast::ExprAttribute {
-                                    value,
-                                    ..
-                                }) => ExpressionNodeKey::from(value) == *use_expression,
-                                _ => false,
-                            },
-                            _ => false,
-                        }
-                    }
-
-                    _ => false,
+            .retain(|(_, use_expression)| match stmt {
+                ast::Stmt::Return(_) | ast::Stmt::AnnAssign(_) => true,
+                ast::Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => {
+                    ExpressionNodeKey::from(target.as_ref()) == *use_expression
                 }
+                ast::Stmt::Assign(ast::StmtAssign { targets, .. }) => {
+                    let mutates_collection = matches!(targets.as_slice(), [
+                        ast::Expr::Subscript(ast::ExprSubscript { value, .. })
+                    ] if ExpressionNodeKey::from(value.as_ref()) == *use_expression);
+                    mutates_collection
+                }
+                ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
+                    matches!(
+                        value.as_ref(),
+                        ast::Expr::Call(ast::ExprCall { func, .. })
+                            if matches!(
+                                func.as_ref(),
+                                ast::Expr::Attribute(ast::ExprAttribute { value, .. })
+                                    if ExpressionNodeKey::from(value.as_ref()) == *use_expression
+                            )
+                    )
+                }
+                _ => false,
             });
 
         if current_statement.lambda_expressions.is_empty()
@@ -4179,11 +4133,18 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 .map(|lambda| (lambda.into(), standalone_statement)),
         );
 
-        // The inferred element type of collection literal depends on uses of
-        // the collection in its containing scope, and so each use must be part
-        // of an standalone inferable statement to avoid large scope-level cycles.
+        // The inferred element type of a collection literal depends on uses of the collection in
+        // its containing scope. Record every use so collection inference can build one explicit
+        // constraint graph without depending on ordinary statement inference.
         let mut collection_defs = FxHashSet::default();
-        for (collection_def, use_expression) in current_statement.collection_uses {
+        // Every collection referenced by a constraining statement belongs to the same dataflow
+        // component, including collections used as arguments rather than receivers.
+        let collection_uses = if current_statement.collection_uses.is_empty() {
+            current_statement.collection_uses
+        } else {
+            all_collection_uses
+        };
+        for (collection_def, use_expression) in collection_uses {
             // If the same collection is referenced multiple times in this statement,
             // we only consider the first occurrence, as collection use constraints are
             // tracked at the statement level.
@@ -4195,9 +4156,6 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 .entry(collection_def)
                 .or_default()
                 .push((standalone_statement, use_expression));
-
-            self.collections_by_use
-                .insert(use_expression, collection_def);
         }
     }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -274,10 +274,12 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     seen_submodule_imports: FxHashSet<String>,
     // A map from a lambda expression to its enclosing statement.
     enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
-    // A map from each discovered use of a collection literal to its definition.
+    // A map from a constraining use of a collection literal to its definition.
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
-    // A map from a collection literal definition to constraining statements that reference it.
+    // A map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FxHashSet<Definition<'db>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -328,6 +330,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FxHashMap::default(),
             collections_by_use: FxHashMap::default(),
             uses_by_collection: FxHashMap::default(),
+            collections_requiring_cycle: FxHashSet::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -2621,6 +2624,21 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();
 
+        // Replacing an existing binding can make later collection uses depend on the merge of all
+        // definitions for that place. The identity-specialized query deliberately bypasses that
+        // merge, so retain cycle-based inference for those collection definitions.
+        for use_def_map in &use_def_maps {
+            let mut defined_places = FxHashSet::default();
+            for (_, state, _) in use_def_map.all_definitions_with_usage() {
+                if let Some(definition) = state.definition()
+                    && !defined_places.insert(definition.place(self.db))
+                    && self.uses_by_collection.contains_key(&definition)
+                {
+                    self.collections_requiring_cycle.insert(definition);
+                }
+            }
+        }
+
         let uses_by_collection = FrozenMap::from_entries(
             self.uses_by_collection
                 .into_iter()
@@ -2643,6 +2661,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
+            collections_requiring_cycle: FrozenSet::from(self.collections_requiring_cycle),
             imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
@@ -4075,43 +4094,70 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
         self.visit_stmt_impl(stmt);
         let mut current_statement = self.pop_statement();
 
-        let all_collection_uses = current_statement.collection_uses.clone();
-
-        // Keep every use-to-definition edge so a constraining operation on one collection can
-        // refer symbolically to another collection. Only add statements that can themselves
-        // contribute a collection constraint to the inference worklist below.
-        self.collections_by_use.extend(
-            current_statement
-                .collection_uses
-                .iter()
-                .map(|(definition, use_expression)| (*use_expression, *definition)),
-        );
+        // We currently only consider certain types of statements to introduce constraints
+        // on collection literals. This restriction is mostly for performance reasons, as we
+        // want to avoid "reads" of a collection contributing to the complexity of the cycles
+        // created by full-scope collection inference.
+        match stmt {
+            ast::Stmt::AugAssign(_) => self.collections_requiring_cycle.extend(
+                current_statement
+                    .collection_uses
+                    .iter()
+                    .map(|(definition, _)| *definition),
+            ),
+            ast::Stmt::Assign(ast::StmtAssign { targets, value, .. })
+                if targets
+                    .iter()
+                    .any(|target| target.is_attribute_expr() || target.is_subscript_expr()) =>
+            {
+                let assigned_value = ExpressionNodeKey::from(value);
+                self.collections_requiring_cycle.extend(
+                    current_statement
+                        .collection_uses
+                        .iter()
+                        .filter(|(_, use_expression)| *use_expression == assigned_value)
+                        .map(|(definition, _)| *definition),
+                );
+            }
+            _ => {}
+        }
 
         current_statement
             .collection_uses
-            .retain(|(_, use_expression)| match stmt {
-                ast::Stmt::Return(_) | ast::Stmt::AnnAssign(_) => true,
-                ast::Stmt::AugAssign(ast::StmtAugAssign { target, .. }) => {
-                    ExpressionNodeKey::from(target.as_ref()) == *use_expression
+            .retain(|(_, use_expression)| {
+                match stmt {
+                    // A return involving the collection object.
+                    ruff_python_ast::Stmt::Return(_) => true,
+
+                    // A subscript assignment on the collection object.
+                    ruff_python_ast::Stmt::Assign(ast::StmtAssign { targets, .. }) => {
+                        match targets.as_slice() {
+                            [ast::Expr::Subscript(ast::ExprSubscript { value, .. })] => {
+                                ExpressionNodeKey::from(value) == *use_expression
+                            }
+                            _ => false,
+                        }
+                    }
+
+                    // An annotated assignment assigning the collection object to a new binding.
+                    ruff_python_ast::Stmt::AnnAssign(_) => true,
+
+                    // A bound-method call on the collection object.
+                    ruff_python_ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
+                        match value.as_ref() {
+                            ast::Expr::Call(ast::ExprCall { func, .. }) => match func.as_ref() {
+                                ruff_python_ast::Expr::Attribute(ast::ExprAttribute {
+                                    value,
+                                    ..
+                                }) => ExpressionNodeKey::from(value) == *use_expression,
+                                _ => false,
+                            },
+                            _ => false,
+                        }
+                    }
+
+                    _ => false,
                 }
-                ast::Stmt::Assign(ast::StmtAssign { targets, .. }) => {
-                    let mutates_collection = matches!(targets.as_slice(), [
-                        ast::Expr::Subscript(ast::ExprSubscript { value, .. })
-                    ] if ExpressionNodeKey::from(value.as_ref()) == *use_expression);
-                    mutates_collection
-                }
-                ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
-                    matches!(
-                        value.as_ref(),
-                        ast::Expr::Call(ast::ExprCall { func, .. })
-                            if matches!(
-                                func.as_ref(),
-                                ast::Expr::Attribute(ast::ExprAttribute { value, .. })
-                                    if ExpressionNodeKey::from(value.as_ref()) == *use_expression
-                            )
-                    )
-                }
-                _ => false,
             });
 
         if current_statement.lambda_expressions.is_empty()
@@ -4133,18 +4179,11 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 .map(|lambda| (lambda.into(), standalone_statement)),
         );
 
-        // The inferred element type of a collection literal depends on uses of the collection in
-        // its containing scope. Record every use so collection inference can build one explicit
-        // constraint graph without depending on ordinary statement inference.
+        // The inferred element type of collection literal depends on uses of
+        // the collection in its containing scope, and so each use must be part
+        // of an standalone inferable statement to avoid large scope-level cycles.
         let mut collection_defs = FxHashSet::default();
-        // Every collection referenced by a constraining statement belongs to the same dataflow
-        // component, including collections used as arguments rather than receivers.
-        let collection_uses = if current_statement.collection_uses.is_empty() {
-            current_statement.collection_uses
-        } else {
-            all_collection_uses
-        };
-        for (collection_def, use_expression) in collection_uses {
+        for (collection_def, use_expression) in current_statement.collection_uses {
             // If the same collection is referenced multiple times in this statement,
             // we only consider the first occurrence, as collection use constraints are
             // tracked at the statement level.
@@ -4156,6 +4195,9 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 .entry(collection_def)
                 .or_default()
                 .push((standalone_statement, use_expression));
+
+            self.collections_by_use
+                .insert(use_expression, collection_def);
         }
     }
 

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -278,6 +278,8 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
     // A map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FxHashSet<Definition<'db>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -328,6 +330,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FxHashMap::default(),
             collections_by_use: FxHashMap::default(),
             uses_by_collection: FxHashMap::default(),
+            collections_requiring_cycle: FxHashSet::default(),
 
             seen_submodule_imports: FxHashSet::default(),
             imported_modules: FxHashSet::default(),
@@ -2620,6 +2623,26 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.scope_ids_by_scope.shrink_to_fit();
         let mut semantic_syntax_errors = self.semantic_syntax_errors.into_inner();
         semantic_syntax_errors.shrink_to_fit();
+
+        // Replacing an existing binding can make later collection uses depend on the merge of all
+        // definitions for that place. The identity-specialized query deliberately bypasses that
+        // merge, so retain cycle-based inference for those collection definitions.
+        for use_def_map in &use_def_maps {
+            let mut defined_places = FxHashSet::default();
+            for (_, state, _) in use_def_map.all_definitions_with_usage() {
+                let Some(definition) = state.definition() else {
+                    continue;
+                };
+                let place = definition.place(self.db);
+                if self.uses_by_collection.contains_key(&definition)
+                    && defined_places.contains(&place)
+                {
+                    self.collections_requiring_cycle.insert(definition);
+                }
+                defined_places.insert(place);
+            }
+        }
+
         let uses_by_collection = FrozenMap::from_entries(
             self.uses_by_collection
                 .into_iter()
@@ -2642,6 +2665,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
+            collections_requiring_cycle: FrozenSet::from(self.collections_requiring_cycle),
             imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
@@ -4078,6 +4102,30 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
         // on collection literals. This restriction is mostly for performance reasons, as we
         // want to avoid "reads" of a collection contributing to the complexity of the cycles
         // created by full-scope collection inference.
+        match stmt {
+            ast::Stmt::AugAssign(_) => self.collections_requiring_cycle.extend(
+                current_statement
+                    .collection_uses
+                    .iter()
+                    .map(|(definition, _)| *definition),
+            ),
+            ast::Stmt::Assign(ast::StmtAssign { targets, value, .. })
+                if targets
+                    .iter()
+                    .any(|target| target.is_attribute_expr() || target.is_subscript_expr()) =>
+            {
+                let assigned_value = ExpressionNodeKey::from(value);
+                self.collections_requiring_cycle.extend(
+                    current_statement
+                        .collection_uses
+                        .iter()
+                        .filter(|(_, use_expression)| *use_expression == assigned_value)
+                        .map(|(definition, _)| *definition),
+                );
+            }
+            _ => {}
+        }
+
         current_statement
             .collection_uses
             .retain(|(_, use_expression)| {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -559,6 +559,24 @@ impl<'db> SemanticIndex<'db> {
         self.collections_by_use.get(&collection_use.into()).copied()
     }
 
+    /// If this expression is any use of an unconstrained collection literal, returns its
+    /// definition.
+    pub fn unannotated_collection_literal_at_any_use(
+        &self,
+        collection_use: &ast::Expr,
+    ) -> Option<Definition<'db>> {
+        let use_id = self.ast_ids.try_use_id(collection_use)?;
+        let scope_id = self.expression_scope_id(collection_use);
+        let use_def = self.use_def_map(scope_id);
+        let mut definitions = use_def
+            .bindings_at_use(use_id)
+            .filter_map(|binding| binding.binding.definition())
+            .filter(|definition| self.uses_by_collection.get(definition).is_some());
+
+        let definition = definitions.next()?;
+        definitions.next().is_none().then_some(definition)
+    }
+
     /// Returns all potentially constraining uses of the given unnannotated collection literal.
     pub fn constraining_collection_uses(
         &self,

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -332,11 +332,14 @@ pub struct SemanticIndex<'db> {
     /// Map from a lambda expression to its containing statement.
     enclosing_lambda_statements: FrozenMap<ExpressionNodeKey, Statement<'db>>,
 
-    // Map from each discovered use of a collection literal to its definition.
+    // Map from a constraining use of a collection literal to its definition.
     collections_by_use: FrozenMap<ExpressionNodeKey, Definition<'db>>,
 
-    // Map from a collection literal definition to constraining statements that reference it.
+    // Map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FrozenMap<Definition<'db>, Box<[(Statement<'db>, ExpressionNodeKey)]>>,
+
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FrozenSet<Definition<'db>>,
 
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
@@ -550,7 +553,8 @@ impl<'db> SemanticIndex<'db> {
         self.enclosing_lambda_statements.get(&lambda).copied()
     }
 
-    /// If this is a discovered use of an unannotated collection literal, returns its definition.
+    /// If this is a potentially constraining use of an unannotated collection literal, returns
+    /// its definition.
     pub fn unannotated_collection_literal(
         &self,
         collection_use: &ast::Expr,
@@ -587,9 +591,9 @@ impl<'db> SemanticIndex<'db> {
             .flat_map(|uses| uses.iter().copied())
     }
 
-    /// Returns all unannotated collection literals with uses in this file.
-    pub fn unannotated_collections(&self) -> impl Iterator<Item = Definition<'db>> + '_ {
-        self.collections_by_use.values().copied()
+    /// Returns `true` if the collection has a use that requires cycle-based inference.
+    pub fn collection_requires_cycle_inference(&self, collection_def: Definition<'db>) -> bool {
+        self.collections_requiring_cycle.contains(&collection_def)
     }
 
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -338,6 +338,9 @@ pub struct SemanticIndex<'db> {
     // Map from a collection literal definition to statements containing a constraining use.
     uses_by_collection: FrozenMap<Definition<'db>, Box<[(Statement<'db>, ExpressionNodeKey)]>>,
 
+    // Collection literals with uses that require cycle-based inference.
+    collections_requiring_cycle: FrozenSet<Definition<'db>>,
+
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
 
@@ -586,6 +589,11 @@ impl<'db> SemanticIndex<'db> {
             .get(&collection_def)
             .into_iter()
             .flat_map(|uses| uses.iter().copied())
+    }
+
+    /// Returns `true` if the collection has a use that requires cycle-based inference.
+    pub fn collection_requires_cycle_inference(&self, collection_def: Definition<'db>) -> bool {
+        self.collections_requiring_cycle.contains(&collection_def)
     }
 
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -332,14 +332,11 @@ pub struct SemanticIndex<'db> {
     /// Map from a lambda expression to its containing statement.
     enclosing_lambda_statements: FrozenMap<ExpressionNodeKey, Statement<'db>>,
 
-    // Map from a constraining use of a collection literal to its definition.
+    // Map from each discovered use of a collection literal to its definition.
     collections_by_use: FrozenMap<ExpressionNodeKey, Definition<'db>>,
 
-    // Map from a collection literal definition to statements containing a constraining use.
+    // Map from a collection literal definition to constraining statements that reference it.
     uses_by_collection: FrozenMap<Definition<'db>, Box<[(Statement<'db>, ExpressionNodeKey)]>>,
-
-    // Collection literals with uses that require cycle-based inference.
-    collections_requiring_cycle: FrozenSet<Definition<'db>>,
 
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
@@ -553,8 +550,7 @@ impl<'db> SemanticIndex<'db> {
         self.enclosing_lambda_statements.get(&lambda).copied()
     }
 
-    /// If this is a potentially constraining use of an unannotated collection literal, returns
-    /// its definition.
+    /// If this is a discovered use of an unannotated collection literal, returns its definition.
     pub fn unannotated_collection_literal(
         &self,
         collection_use: &ast::Expr,
@@ -591,9 +587,9 @@ impl<'db> SemanticIndex<'db> {
             .flat_map(|uses| uses.iter().copied())
     }
 
-    /// Returns `true` if the collection has a use that requires cycle-based inference.
-    pub fn collection_requires_cycle_inference(&self, collection_def: Definition<'db>) -> bool {
-        self.collections_requiring_cycle.contains(&collection_def)
+    /// Returns all unannotated collection literals with uses in this file.
+    pub fn unannotated_collections(&self) -> impl Iterator<Item = Definition<'db>> + '_ {
+        self.collections_by_use.values().copied()
     }
 
     pub fn is_in_type_checking_block(&self, scope_id: FileScopeId, range: TextRange) -> bool {

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1029,6 +1029,63 @@ def _(values: list[str] | None):
     reveal_type(lines)  # revealed: list[str]
 ```
 
+Uses that can refer to an intervening binding require cycle-based inference. Inferring these uses
+against the original collection's identity specialization can miss widening from an augmented
+assignment:
+
+```py
+class Node: ...
+class Name(Node): ...
+
+def nodes() -> list[Node]:
+    return []
+
+def _(flag: bool) -> None:
+    values = []
+    while flag:
+        values += nodes()
+    values.append(Name())
+    values += nodes()
+```
+
+Collections that replace an existing binding also require cycle-based inference:
+
+```py
+class Paths: ...
+class DataSource: ...
+
+class Handler:
+    def __init__(self, *, paths: Paths, datasource: DataSource) -> None: ...
+
+def _(options=None):
+    if options is None:
+        options = {}
+    options.update({"paths": Paths(), "datasource": DataSource()})
+    Handler(**options)
+```
+
+Collections stored in an attribute or subscript require cycle-based inference because the assignment
+can participate in later inference cycles:
+
+```py
+import inspect
+import types
+
+class C:
+    def collect(self, items):
+        values = []
+        for item in items:
+            if isinstance(item, types.FunctionType):
+                line = getattr(item, "co_firstlineno", item.__code__.co_firstlineno)
+                module = inspect.getmodule(item)
+                values.append((line, module))
+        self.values = values
+
+    def validate(self):
+        for _, module in self.values:
+            reveal_type(module)  # revealed: ModuleType | None
+```
+
 Starred uses in a return expression continue to participate in cycle recovery:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1009,6 +1009,16 @@ def _():
     return AlternativeRule(rules)
 ```
 
+The call can also be nested inside the return expression:
+
+```py
+def _():
+    rules = []
+    rules.append(URule())
+    reveal_type(rules)  # revealed: list[Rule]
+    return (AlternativeRule(rules), 1)
+```
+
 Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -992,6 +992,44 @@ def _() -> int:
     return invalid_x6  # error: [invalid-return-type]
 ```
 
+An unannotated return can still constrain a collection when the collection is passed directly to an
+annotated call:
+
+```py
+class Rule: ...
+class URule(Rule): ...
+
+class AlternativeRule:
+    def __init__(self, rules: list[Rule]) -> None: ...
+
+def _():
+    rules = []
+    rules.append(URule())
+    reveal_type(rules)  # revealed: list[Rule]
+    return AlternativeRule(rules)
+```
+
+Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
+
+```py
+def _(values: list[str] | None):
+    lines = []
+    lines.append("header")
+    lines.extend(values)  # error: [invalid-argument-type]
+    reveal_type(lines)  # revealed: list[str]
+```
+
+Starred uses in a return expression continue to participate in cycle recovery:
+
+```py
+def consume(*values: int) -> None: ...
+def _():
+    values = []
+    values.append(1)
+    reveal_type(values)  # revealed: list[int]
+    return consume(*values)
+```
+
 ```py
 x7 = []
 x7[:] = [1, "2", 3.0]

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1019,7 +1019,7 @@ def _():
     return (AlternativeRule(rules), 1)
 ```
 
-Invalid bound-method calls do not contribute constraints when argument matching fails:
+Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
 
 ```py
 def _(values: list[str] | None):
@@ -1029,8 +1029,9 @@ def _(values: list[str] | None):
     reveal_type(lines)  # revealed: list[str]
 ```
 
-The collection component solver combines projected constraints across control flow and non-method
-uses, so each of the following collections widens to include both tuple types:
+Full statement inference should also combine projected constraints from bound-method calls. Each of
+the following collections requires the full-statement path, but should still widen to include both
+tuple types:
 
 ```py
 class Rule: ...
@@ -1069,7 +1070,9 @@ def augmented(include_rewrite: bool):
     pieces += []
 ```
 
-Augmented assignment contributes constraints to the same collection component as bound-method calls:
+Uses that can refer to an intervening binding require cycle-based inference. Inferring these uses
+against the original collection's identity specialization can miss widening from an augmented
+assignment:
 
 ```py
 class Node: ...
@@ -1086,7 +1089,7 @@ def _(flag: bool) -> None:
     values += nodes()
 ```
 
-Replacing a dynamic binding keeps the collection specialization dynamic:
+Collections that replace an existing binding also require cycle-based inference:
 
 ```py
 class Paths: ...
@@ -1102,8 +1105,8 @@ def _(options=None):
     Handler(**options)
 ```
 
-When a loop-carried collection is stored in an attribute, a concrete specialization supersedes the
-initial divergent loop placeholder:
+Collections stored in an attribute or subscript require cycle-based inference because the assignment
+can participate in later inference cycles:
 
 ```py
 import inspect
@@ -1124,7 +1127,7 @@ class C:
             reveal_type(module)  # revealed: ModuleType | None
 ```
 
-Starred uses in a return expression preserve constraints from earlier mutations:
+Starred uses in a return expression continue to participate in cycle recovery:
 
 ```py
 def consume(*values: int) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1019,7 +1019,7 @@ def _():
     return (AlternativeRule(rules), 1)
 ```
 
-Invalid bound-method calls should not retain diagnostics from the initial cycle iteration:
+Invalid bound-method calls do not contribute constraints when argument matching fails:
 
 ```py
 def _(values: list[str] | None):
@@ -1029,9 +1029,8 @@ def _(values: list[str] | None):
     reveal_type(lines)  # revealed: list[str]
 ```
 
-Full statement inference should also combine projected constraints from bound-method calls. Each of
-the following collections requires the full-statement path, but should still widen to include both
-tuple types:
+The collection component solver combines projected constraints across control flow and non-method
+uses, so each of the following collections widens to include both tuple types:
 
 ```py
 class Rule: ...
@@ -1070,9 +1069,7 @@ def augmented(include_rewrite: bool):
     pieces += []
 ```
 
-Uses that can refer to an intervening binding require cycle-based inference. Inferring these uses
-against the original collection's identity specialization can miss widening from an augmented
-assignment:
+Augmented assignment contributes constraints to the same collection component as bound-method calls:
 
 ```py
 class Node: ...
@@ -1089,7 +1086,7 @@ def _(flag: bool) -> None:
     values += nodes()
 ```
 
-Collections that replace an existing binding also require cycle-based inference:
+Replacing a dynamic binding keeps the collection specialization dynamic:
 
 ```py
 class Paths: ...
@@ -1105,8 +1102,8 @@ def _(options=None):
     Handler(**options)
 ```
 
-Collections stored in an attribute or subscript require cycle-based inference because the assignment
-can participate in later inference cycles:
+When a loop-carried collection is stored in an attribute, a concrete specialization supersedes the
+initial divergent loop placeholder:
 
 ```py
 import inspect
@@ -1127,7 +1124,7 @@ class C:
             reveal_type(module)  # revealed: ModuleType | None
 ```
 
-Starred uses in a return expression continue to participate in cycle recovery:
+Starred uses in a return expression preserve constraints from earlier mutations:
 
 ```py
 def consume(*values: int) -> None: ...

--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -1029,6 +1029,47 @@ def _(values: list[str] | None):
     reveal_type(lines)  # revealed: list[str]
 ```
 
+Full statement inference should also combine projected constraints from bound-method calls. Each of
+the following collections requires the full-statement path, but should still widen to include both
+tuple types:
+
+```py
+class Rule: ...
+class RewriteRule(Rule): ...
+class ArctanRule(Rule): ...
+
+class Holder:
+    pieces: object
+
+def escaped(include_rewrite: bool):
+    pieces = []
+    if include_rewrite:
+        pieces.append((RewriteRule(), True))
+    if pieces:
+        pieces.append((ArctanRule(), True))
+    reveal_type(pieces)  # revealed: list[tuple[RewriteRule, bool] | tuple[ArctanRule, bool]]
+    Holder().pieces = pieces
+
+def rebound(include_rewrite: bool):
+    pieces = None
+    if pieces is None:
+        pieces = []
+    if include_rewrite:
+        pieces.append((RewriteRule(), True))
+    if pieces:
+        pieces.append((ArctanRule(), True))
+    reveal_type(pieces)  # revealed: list[tuple[RewriteRule, bool] | tuple[ArctanRule, bool]]
+
+def augmented(include_rewrite: bool):
+    pieces = []
+    if include_rewrite:
+        pieces.append((RewriteRule(), True))
+    if pieces:
+        pieces.append((ArctanRule(), True))
+    reveal_type(pieces)  # revealed: list[tuple[RewriteRule, bool] | tuple[ArctanRule, bool]]
+    pieces += []
+```
+
 Uses that can refer to an intervening binding require cycle-based inference. Inferring these uses
 against the original collection's identity specialization can miss widening from an augmented
 assignment:

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -32,7 +32,8 @@ use crate::subscript::PyIndex;
 use crate::types::call::arguments::{CallArgumentTypes, Expansion, is_expandable_type};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
-    ConstraintBounds, ConstraintSet, ConstraintSetBuilder, PathBounds, Solutions,
+    ConstraintBounds, ConstraintSet, ConstraintSetBuilder, OwnedConstraintSet, PathBounds,
+    Solutions,
 };
 use crate::types::diagnostic::{
     CALL_NON_CALLABLE, CALL_TOP_CALLABLE, INVALID_ARGUMENT_TYPE, INVALID_DATACLASS,
@@ -205,10 +206,17 @@ impl<'db> CallableItem<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
     ) {
         match self {
             CallableItem::Regular(binding) => {
-                binding.check_types(db, constraints, argument_types, call_expression_tcx);
+                binding.check_types(
+                    db,
+                    constraints,
+                    argument_types,
+                    call_expression_tcx,
+                    constraint_projection,
+                );
             }
             CallableItem::Constructor(binding) => {
                 binding.check_types(db, constraints, argument_types, call_expression_tcx);
@@ -383,9 +391,16 @@ impl<'db> BindingsElement<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
     ) {
         for item in &mut self.items {
-            item.check_types(db, constraints, call_arguments, call_expression_tcx);
+            item.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                constraint_projection,
+            );
         }
     }
 
@@ -1028,9 +1043,34 @@ impl<'db> Bindings<'db> {
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
     ) -> Result<(), CallErrorKind> {
+        self.check_types_impl_with_projection(
+            db,
+            constraints,
+            call_arguments,
+            call_expression_tcx,
+            dataclass_field_specifiers,
+            None,
+        )
+    }
+
+    pub(crate) fn check_types_impl_with_projection(
+        &mut self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_arguments: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+        dataclass_field_specifiers: &[Type<'db>],
+        constraint_projection: Option<GenericContext<'db>>,
+    ) -> Result<(), CallErrorKind> {
         // Check types for each element (union variant)
         for element in &mut self.elements {
-            element.check_types(db, constraints, call_arguments, call_expression_tcx);
+            element.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                constraint_projection,
+            );
         }
 
         self.evaluate_known_cases(db, call_arguments, dataclass_field_specifiers);
@@ -3158,6 +3198,7 @@ impl<'db> CallableBinding<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
     ) {
         // If this callable is a bound method, prepend the self instance onto the arguments list
         // before checking.
@@ -3206,6 +3247,7 @@ impl<'db> CallableBinding<'db> {
                                 constraints,
                                 call_arguments.as_ref(),
                                 call_expression_tcx,
+                                constraint_projection,
                             );
                         }
                         return;
@@ -3219,6 +3261,7 @@ impl<'db> CallableBinding<'db> {
                             constraints,
                             call_arguments.as_ref(),
                             call_expression_tcx,
+                            constraint_projection,
                         );
                         return;
                     }
@@ -3234,6 +3277,7 @@ impl<'db> CallableBinding<'db> {
                 constraints,
                 call_arguments.as_ref(),
                 call_expression_tcx,
+                constraint_projection,
             );
         }
 
@@ -3403,7 +3447,13 @@ impl<'db> CallableBinding<'db> {
                 );
 
                 for (_, overload) in self.matching_overloads_mut() {
-                    overload.check_types(db, constraints, expanded_arguments, call_expression_tcx);
+                    overload.check_types(
+                        db,
+                        constraints,
+                        expanded_arguments,
+                        call_expression_tcx,
+                        constraint_projection,
+                    );
                 }
 
                 tracing::trace!(
@@ -4714,6 +4764,7 @@ struct ArgumentTypeChecker<'a, 'db> {
 
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    projected_constraints: Option<OwnedConstraintSet<'db>>,
 
     /// Argument indices for which specialization inference has already produced a sufficiently
     /// precise argument mismatch. We can then silence `check_argument_type` for those arguments to
@@ -4792,6 +4843,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             errors,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            projected_constraints: None,
             constraint_set_errors: vec![false; arguments.len()],
         }
     }
@@ -4847,7 +4899,11 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             .collect()
     }
 
-    fn infer_specialization(&mut self, constraints: &ConstraintSetBuilder<'db>) {
+    fn infer_specialization(
+        &mut self,
+        constraints: &ConstraintSetBuilder<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
+    ) {
         let Some(generic_context) = self.signature.generic_context else {
             return;
         };
@@ -5083,6 +5139,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
                 maybe_promote(typevar, bounds)
             };
+
+        self.projected_constraints =
+            constraint_projection.map(|context| builder.projected_constraint_set(context));
 
         let specialization = builder.build_with(generic_context, choose_solution);
 
@@ -5546,6 +5605,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         InferableTypeVars<'db>,
         Option<Specialization<'db>>,
         Type<'db>,
+        Option<OwnedConstraintSet<'db>>,
     ) {
         for (parameter_ty, builder) in self
             .parameter_tys
@@ -5557,7 +5617,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
         }
 
-        (self.inferable_typevars, self.specialization, self.return_ty)
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.return_ty,
+            self.projected_constraints,
+        )
     }
 }
 
@@ -5747,6 +5812,9 @@ pub(crate) struct Binding<'db> {
     /// The specialization that was inferred from the argument types, if the callable is generic.
     specialization: Option<Specialization<'db>>,
 
+    /// Constraints inferred for a caller-requested subset of this binding's generic context.
+    projected_constraints: Option<OwnedConstraintSet<'db>>,
+
     /// Information about which parameter(s) each argument was matched with, in argument source
     /// order.
     argument_matches: Box<[MatchedArgument<'db>]>,
@@ -5775,6 +5843,7 @@ impl<'db> Binding<'db> {
             constructor_context: None,
             inferable_typevars: InferableTypeVars::None,
             specialization: None,
+            projected_constraints: None,
             argument_matches: Box::from([]),
             variadic_argument_matched_to_variadic_parameter: false,
             parameter_tys: Box::from([]),
@@ -6214,6 +6283,7 @@ impl<'db> Binding<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
     ) {
         let parameters = self.signature.parameters();
 
@@ -6247,10 +6317,15 @@ impl<'db> Binding<'db> {
 
         // If this overload is generic, first see if we can infer a specialization of the function
         // from the arguments that were passed in.
-        checker.infer_specialization(constraints);
+        checker.infer_specialization(constraints, constraint_projection);
         checker.check_argument_types(constraints);
 
-        (self.inferable_typevars, self.specialization, self.return_ty) = checker.finish();
+        (
+            self.inferable_typevars,
+            self.specialization,
+            self.return_ty,
+            self.projected_constraints,
+        ) = checker.finish();
     }
 
     fn check_keyword_unpack_key_types(
@@ -6522,6 +6597,7 @@ impl<'db> Binding<'db> {
             return_ty: self.return_ty,
             inferable_typevars: self.inferable_typevars,
             specialization: self.specialization,
+            projected_constraints: self.projected_constraints.clone(),
             argument_matches: self.argument_matches.clone(),
             parameter_tys: self.parameter_tys.clone(),
             errors: self.errors.clone(),
@@ -6533,6 +6609,7 @@ impl<'db> Binding<'db> {
             return_ty,
             inferable_typevars,
             specialization,
+            projected_constraints,
             argument_matches,
             parameter_tys,
             errors,
@@ -6541,6 +6618,7 @@ impl<'db> Binding<'db> {
         self.return_ty = return_ty;
         self.inferable_typevars = inferable_typevars;
         self.specialization = specialization;
+        self.projected_constraints = projected_constraints;
         self.argument_matches = argument_matches;
         self.parameter_tys = parameter_tys;
         self.errors = errors;
@@ -6556,6 +6634,10 @@ impl<'db> Binding<'db> {
         self.specialization
     }
 
+    pub(crate) fn projected_constraints(&self) -> Option<&OwnedConstraintSet<'db>> {
+        self.projected_constraints.as_ref()
+    }
+
     pub(crate) fn errors(&self) -> &[BindingError<'db>] {
         &self.errors
     }
@@ -6565,6 +6647,7 @@ impl<'db> Binding<'db> {
         self.return_ty = self.initial_return_type(db);
         self.inferable_typevars = InferableTypeVars::None;
         self.specialization = None;
+        self.projected_constraints = None;
         self.argument_matches = Box::from([]);
         self.parameter_tys = Box::from([]);
         self.errors.clear();
@@ -6576,6 +6659,7 @@ struct BindingSnapshot<'db> {
     return_ty: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
     specialization: Option<Specialization<'db>>,
+    projected_constraints: Option<OwnedConstraintSet<'db>>,
     argument_matches: Box<[MatchedArgument<'db>]>,
     parameter_tys: Box<[Option<Type<'db>>]>,
     errors: Vec<BindingError<'db>>,
@@ -6617,6 +6701,9 @@ impl<'db> CallableBindingSnapshot<'db> {
                 snapshot.return_ty = binding.return_ty;
                 snapshot.inferable_typevars = binding.inferable_typevars;
                 snapshot.specialization = binding.specialization;
+                snapshot
+                    .projected_constraints
+                    .clone_from(&binding.projected_constraints);
                 snapshot
                     .argument_matches
                     .clone_from(&binding.argument_matches);

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -121,7 +121,7 @@ impl<'db> ConstructorBinding<'db> {
         }
 
         self.entry
-            .check_types(db, constraints, argument_types, call_expression_tcx);
+            .check_types(db, constraints, argument_types, call_expression_tcx, None);
 
         // Now that we've fully checked our own callable, we can determine whether downstream
         // constructors should be checked or not.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -580,6 +580,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         Self::from_node(builder, self.node.exists(db, builder, to_remove))
     }
 
+    /// Creates an owned snapshot of this constraint set without consuming its builder.
+    pub(crate) fn to_owned(self) -> OwnedConstraintSet<'db> {
+        ConstraintSetBuilder::owned_from_storage(self.node, self.builder.storage.borrow().clone())
+    }
+
     pub(crate) fn remove_noninferable(
         self,
         db: &'db dyn Db,
@@ -795,12 +800,17 @@ impl<'db> ConstraintSetBuilder<'db> {
         // constraint sets can only be used by adding them to a new builder. Operation caches from
         // the original builder aren't relevant to the new builder, and don't need to be retained.
         let constraint = f(&self);
-        let node = constraint.node;
+        Self::owned_from_storage(constraint.node, self.storage.into_inner())
+    }
+
+    fn owned_from_storage(
+        node: NodeId,
+        mut storage: ConstraintSetStorage<'db>,
+    ) -> OwnedConstraintSet<'db> {
         if node.is_terminal() {
             return OwnedConstraintSet { node, inner: None };
         }
 
-        let mut storage = self.storage.into_inner();
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());
         let mut stack = vec![node];

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -12,7 +12,7 @@ use crate::types::class::ClassType;
 use crate::types::class_base::ClassBase;
 use crate::types::constraints::{
     ConstraintBounds, ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
-    PathBounds, Solutions,
+    OwnedConstraintSet, PathBounds, Solutions,
 };
 use crate::types::infer::original_class_type;
 use crate::types::relation::{
@@ -2268,6 +2268,27 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         };
 
         self.intersect_pending_typevar_constraint(bound_typevar, bounds);
+    }
+
+    /// Adds an already-projected set of constraints to this specialization.
+    pub(crate) fn intersect_constraint_set(&mut self, set: ConstraintSet<'db, 'c>) {
+        self.pending.intersect(self.db, self.constraints, set);
+    }
+
+    /// Projects the accumulated constraints onto `generic_context` and returns an owned snapshot.
+    pub(crate) fn projected_constraint_set(
+        &self,
+        generic_context: GenericContext<'db>,
+    ) -> OwnedConstraintSet<'db> {
+        self.pending
+            .reduce_inferable(
+                self.db,
+                self.constraints,
+                self.inferable
+                    .iter(self.db)
+                    .filter(|typevar| !generic_context.contains(self.db, *typevar)),
+            )
+            .to_owned()
     }
 
     /// Finds all of the valid specializations of a constraint set, and adds their type mappings to

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -45,6 +45,7 @@
 
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
+use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashMap;
 use salsa;
@@ -509,19 +510,17 @@ fn infer_statement_types_impl<'db>(
         .finish_statement()
 }
 
-/// Infers the constraints that statements in a connected collection component place on its
-/// unannotated collection literals.
+/// Infers the constraints that later statements place on an unconstrained collection literal.
 ///
-/// Every collection is represented by its built-in identity specialization while the statements
-/// that use any collection are inferred. The resulting constraints share one merged generic
-/// context, so relationships between collections are preserved and solved together. The input
-/// definition selects the connected component without coupling unrelated collections in the same
-/// scope.
+/// The collection's receiver expression is inferred using the built-in collection's identity
+/// specialization, which avoids creating query cycles back to the collection literal's
+/// definition. Uses that also depend on an unconstrained collection are reported as requiring the
+/// regular cycle-based inference path.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub(super) fn infer_collection_use_constraints<'db>(
     db: &'db dyn Db,
     collection_def: Definition<'db>,
-) -> Type<'db> {
+) -> CollectionUseConstraintInference<'db> {
     let file = collection_def.file(db);
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
@@ -1299,9 +1298,34 @@ impl<'db> DefinitionInference<'db> {
         definition: Definition<'db>,
         cycle_recovery: Type<'db>,
     ) -> Self {
+        let mut types = DefinitionTypes::Empty;
+
+        // Eagerly store more precise types for collection literals to avoid an extra
+        // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
+        if let DefinitionKind::Assignment(assignment) = definition.kind(db) {
+            let module = parsed_module(db, definition.file(db)).load(db);
+            let known_collection = match assignment.value(&module) {
+                ast::Expr::Set(_) => Some(KnownClass::Set),
+                ast::Expr::List(_) => Some(KnownClass::List),
+                ast::Expr::Dict(_) => Some(KnownClass::Dict),
+                _ => None,
+            };
+
+            if let Some(collection_class) = known_collection
+                .and_then(|known_collection| known_collection.try_to_class_literal(db))
+            {
+                let divergent_collection = collection_class
+                    .apply_specialization(db, |generic_context| {
+                        generic_context.repeat_specialization(db, cycle_recovery)
+                    });
+
+                types = DefinitionTypes::Binding(Type::instance(db, divergent_collection));
+            }
+        }
+
         Self {
             expressions: FrozenMap::default(),
-            types: DefinitionTypes::Empty,
+            types,
             #[cfg(debug_assertions)]
             scope: definition.scope(db),
             extra: Some(Box::new(DefinitionInferenceExtra::Other(Box::new(
@@ -1367,6 +1391,16 @@ impl<'db> DefinitionInference<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
+        self.extra
+            .as_deref()?
+            .collection_use_constraints()?
+            .get(&collection_def)
     }
 
     /// Get qualifiers for an annotation expression
@@ -1601,6 +1635,16 @@ impl<'db> ExpressionInference<'db> {
             .unwrap_or_else(Type::unknown)
     }
 
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
+        self.extra
+            .as_ref()?
+            .collection_use_constraints
+            .get(&collection_def)
+    }
+
     fn fallback_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.cycle_recovery)
     }
@@ -1617,12 +1661,35 @@ pub(crate) enum StatementInference<'db> {
     Other(&'db StatementInferenceInner<'db>),
 }
 
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(super) enum CollectionUseConstraintInference<'db> {
+    Constraints(Box<[CollectionUseConstraint<'db>]>),
+    RequiresCycle,
+}
+
 impl<'db> StatementInference<'db> {
     pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
         match self {
             StatementInference::Expression(inference) => inference.expression_type(expression),
             StatementInference::Definition(_, inference) => inference.expression_type(expression),
             StatementInference::Other(inference) => inference.expression_type(expression),
+        }
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
+        match self {
+            StatementInference::Expression(inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
+            StatementInference::Definition(_, inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
+            StatementInference::Other(inference) => {
+                inference.collection_use_constraints(collection_def)
+            }
         }
     }
 }
@@ -1761,6 +1828,16 @@ impl<'db> StatementInferenceInner<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
+    }
+
+    pub(crate) fn collection_use_constraints(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
+        self.extra
+            .as_ref()?
+            .collection_use_constraints
+            .get(&collection_def)
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -53,6 +53,7 @@ use salsa::plumbing::AsId;
 use std::borrow::Cow;
 pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet, FrozenValueMap};
 
+use crate::types::constraints::OwnedConstraintSet;
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
@@ -93,7 +94,14 @@ struct TypeAndRange<'db> {
     range: TextRange,
 }
 
-type CollectionUseConstraints<'db> = FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>;
+type CollectionUseConstraints<'db> =
+    FxHashMap<Definition<'db>, FxIndexSet<CollectionUseConstraint<'db>>>;
+
+#[derive(Debug, Clone, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) enum CollectionUseConstraint<'db> {
+    Type(Type<'db>),
+    Projected(OwnedConstraintSet<'db>),
+}
 
 /// Extends the current collection-use constraints with those from the previous cycle iteration.
 ///
@@ -111,7 +119,7 @@ fn extend_collection_use_constraints<'db>(
         current
             .entry(*collection_def)
             .or_default()
-            .extend(constraints);
+            .extend(constraints.iter().cloned());
     }
 }
 
@@ -1388,7 +1396,7 @@ impl<'db> DefinitionInference<'db> {
     pub(crate) fn collection_use_constraints(
         &self,
         collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<Type<'db>>> {
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
         self.extra
             .as_deref()?
             .collection_use_constraints()?
@@ -1630,7 +1638,7 @@ impl<'db> ExpressionInference<'db> {
     pub(crate) fn collection_use_constraints(
         &self,
         collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<Type<'db>>> {
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
         self.extra
             .as_ref()?
             .collection_use_constraints
@@ -1655,7 +1663,7 @@ pub(crate) enum StatementInference<'db> {
 
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(super) enum CollectionUseConstraintInference<'db> {
-    Constraints(Box<[Type<'db>]>),
+    Constraints(Box<[CollectionUseConstraint<'db>]>),
     RequiresCycle,
 }
 
@@ -1671,7 +1679,7 @@ impl<'db> StatementInference<'db> {
     pub(crate) fn collection_use_constraints(
         &self,
         collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<Type<'db>>> {
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
         match self {
             StatementInference::Expression(inference) => {
                 inference.collection_use_constraints(collection_def)
@@ -1825,7 +1833,7 @@ impl<'db> StatementInferenceInner<'db> {
     pub(crate) fn collection_use_constraints(
         &self,
         collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<Type<'db>>> {
+    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
         self.extra
             .as_ref()?
             .collection_use_constraints

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -45,7 +45,6 @@
 
 use itertools::Either;
 use ruff_db::parsed::parsed_module;
-use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashMap;
 use salsa;
@@ -510,17 +509,19 @@ fn infer_statement_types_impl<'db>(
         .finish_statement()
 }
 
-/// Infers the constraints that later statements place on an unconstrained collection literal.
+/// Infers the constraints that statements in a connected collection component place on its
+/// unannotated collection literals.
 ///
-/// The collection's receiver expression is inferred using the built-in collection's identity
-/// specialization, which avoids creating query cycles back to the collection literal's
-/// definition. Uses that also depend on an unconstrained collection are reported as requiring the
-/// regular cycle-based inference path.
+/// Every collection is represented by its built-in identity specialization while the statements
+/// that use any collection are inferred. The resulting constraints share one merged generic
+/// context, so relationships between collections are preserved and solved together. The input
+/// definition selects the connected component without coupling unrelated collections in the same
+/// scope.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub(super) fn infer_collection_use_constraints<'db>(
     db: &'db dyn Db,
     collection_def: Definition<'db>,
-) -> CollectionUseConstraintInference<'db> {
+) -> Type<'db> {
     let file = collection_def.file(db);
     let module = parsed_module(db, file).load(db);
     let index = semantic_index(db, file);
@@ -1298,34 +1299,9 @@ impl<'db> DefinitionInference<'db> {
         definition: Definition<'db>,
         cycle_recovery: Type<'db>,
     ) -> Self {
-        let mut types = DefinitionTypes::Empty;
-
-        // Eagerly store more precise types for collection literals to avoid an extra
-        // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
-        if let DefinitionKind::Assignment(assignment) = definition.kind(db) {
-            let module = parsed_module(db, definition.file(db)).load(db);
-            let known_collection = match assignment.value(&module) {
-                ast::Expr::Set(_) => Some(KnownClass::Set),
-                ast::Expr::List(_) => Some(KnownClass::List),
-                ast::Expr::Dict(_) => Some(KnownClass::Dict),
-                _ => None,
-            };
-
-            if let Some(collection_class) = known_collection
-                .and_then(|known_collection| known_collection.try_to_class_literal(db))
-            {
-                let divergent_collection = collection_class
-                    .apply_specialization(db, |generic_context| {
-                        generic_context.repeat_specialization(db, cycle_recovery)
-                    });
-
-                types = DefinitionTypes::Binding(Type::instance(db, divergent_collection));
-            }
-        }
-
         Self {
             expressions: FrozenMap::default(),
-            types,
+            types: DefinitionTypes::Empty,
             #[cfg(debug_assertions)]
             scope: definition.scope(db),
             extra: Some(Box::new(DefinitionInferenceExtra::Other(Box::new(
@@ -1391,16 +1367,6 @@ impl<'db> DefinitionInference<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
-    }
-
-    pub(crate) fn collection_use_constraints(
-        &self,
-        collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
-        self.extra
-            .as_deref()?
-            .collection_use_constraints()?
-            .get(&collection_def)
     }
 
     /// Get qualifiers for an annotation expression
@@ -1635,16 +1601,6 @@ impl<'db> ExpressionInference<'db> {
             .unwrap_or_else(Type::unknown)
     }
 
-    pub(crate) fn collection_use_constraints(
-        &self,
-        collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
-        self.extra
-            .as_ref()?
-            .collection_use_constraints
-            .get(&collection_def)
-    }
-
     fn fallback_type(&self) -> Option<Type<'db>> {
         self.extra.as_ref().and_then(|extra| extra.cycle_recovery)
     }
@@ -1661,35 +1617,12 @@ pub(crate) enum StatementInference<'db> {
     Other(&'db StatementInferenceInner<'db>),
 }
 
-#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
-pub(super) enum CollectionUseConstraintInference<'db> {
-    Constraints(Box<[CollectionUseConstraint<'db>]>),
-    RequiresCycle,
-}
-
 impl<'db> StatementInference<'db> {
     pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
         match self {
             StatementInference::Expression(inference) => inference.expression_type(expression),
             StatementInference::Definition(_, inference) => inference.expression_type(expression),
             StatementInference::Other(inference) => inference.expression_type(expression),
-        }
-    }
-
-    pub(crate) fn collection_use_constraints(
-        &self,
-        collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
-        match self {
-            StatementInference::Expression(inference) => {
-                inference.collection_use_constraints(collection_def)
-            }
-            StatementInference::Definition(_, inference) => {
-                inference.collection_use_constraints(collection_def)
-            }
-            StatementInference::Other(inference) => {
-                inference.collection_use_constraints(collection_def)
-            }
         }
     }
 }
@@ -1828,16 +1761,6 @@ impl<'db> StatementInferenceInner<'db> {
             .get(&expression.into())
             .copied()
             .or_else(|| self.fallback_type())
-    }
-
-    pub(crate) fn collection_use_constraints(
-        &self,
-        collection_def: Definition<'db>,
-    ) -> Option<&FxIndexSet<CollectionUseConstraint<'db>>> {
-        self.extra
-            .as_ref()?
-            .collection_use_constraints
-            .get(&collection_def)
     }
 
     fn bindings(&self) -> impl ExactSizeIterator<Item = (Definition<'db>, Type<'db>)> {

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -502,6 +502,30 @@ fn infer_statement_types_impl<'db>(
         .finish_statement()
 }
 
+/// Infers the constraints that later statements place on an unconstrained collection literal.
+///
+/// The collection's receiver expression is inferred using the built-in collection's identity
+/// specialization, which avoids creating query cycles back to the collection literal's
+/// definition. Uses that also depend on an unconstrained collection are reported as requiring the
+/// regular cycle-based inference path.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub(super) fn infer_collection_use_constraints<'db>(
+    db: &'db dyn Db,
+    collection_def: Definition<'db>,
+) -> CollectionUseConstraintInference<'db> {
+    let file = collection_def.file(db);
+    let module = parsed_module(db, file).load(db);
+    let index = semantic_index(db, file);
+
+    TypeInferenceBuilder::new(
+        db,
+        InferenceRegion::Definition(collection_def),
+        index,
+        &module,
+    )
+    .finish_collection_use_constraints(collection_def)
+}
+
 /// An `Expression` with an optional `TypeContext`.
 ///
 /// This is a Salsa supertype used as the input to `infer_expression_types` to avoid
@@ -1627,6 +1651,12 @@ pub(crate) enum StatementInference<'db> {
     Expression(&'db ExpressionInference<'db>),
     Definition(Definition<'db>, &'db DefinitionInference<'db>),
     Other(&'db StatementInferenceInner<'db>),
+}
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(super) enum CollectionUseConstraintInference<'db> {
+    Constraints(Box<[Type<'db>]>),
+    RequiresCycle,
 }
 
 impl<'db> StatementInference<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, OnceCell, RefCell};
+use std::cell::{OnceCell, RefCell};
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -16,6 +16,7 @@ use ruff_python_stdlib::builtins::version_builtin_was_added;
 use ruff_python_stdlib::typing::as_pep_585_generic;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::plumbing::AsId;
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
@@ -23,12 +24,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    CollectionUseConstraint, CollectionUseConstraintInference, DeferredAndUndecorated,
-    DefinitionInference, DefinitionInferenceExtra, DefinitionTypes, ExpressionInference,
-    ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference,
-    InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
-    infer_collection_use_constraints, infer_deferred_types, infer_definition_types,
-    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
+    CollectionUseConstraint, DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra,
+    DefinitionTypes, ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet,
+    FrozenValueMap, FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra,
+    ScopeInference, ScopeInferenceExtra, infer_collection_use_constraints, infer_deferred_types,
+    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
+    infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -76,7 +77,7 @@ use crate::types::function::{
     same_module_uncached_raw_signature,
 };
 use crate::types::generics::{
-    GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, bind_typevar,
+    GenericContext, InferableTypeVars, SpecializationBuilder, bind_typevar,
     enclosing_binding_contexts,
 };
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
@@ -105,8 +106,8 @@ use crate::types::{
     IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
     MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
     SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
-    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    TypeMapping, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
+    TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
     extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
     is_discarded_dict_key_assignment, todo_type,
 };
@@ -188,53 +189,23 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 
 #[derive(Clone)]
 struct CollectionConstraintTarget<'db> {
-    definition: Definition<'db>,
-    has_dependency: Rc<Cell<bool>>,
+    identities: FxHashMap<Definition<'db>, Type<'db>>,
+    contexts: FxHashMap<Definition<'db>, GenericContext<'db>>,
+    generic_context: GenericContext<'db>,
 }
 
-#[derive(Default)]
-struct CollectionUseContext {
-    in_call: bool,
-    in_starred: bool,
+struct CollectionDependencyVisitor<'a, 'db> {
+    index: &'a SemanticIndex<'db>,
+    dependencies: &'a mut FxHashSet<Definition<'db>>,
 }
 
-struct CollectionUseContextVisitor {
-    target: ExpressionNodeKey,
-    call_depth: usize,
-    starred_depth: usize,
-    context: CollectionUseContext,
-}
-
-impl<'ast> Visitor<'ast> for CollectionUseContextVisitor {
+impl<'ast> Visitor<'ast> for CollectionDependencyVisitor<'_, '_> {
     fn visit_expr(&mut self, expression: &'ast ast::Expr) {
-        if ExpressionNodeKey::from(expression) == self.target {
-            self.context.in_call |= self.call_depth > 0;
-            self.context.in_starred |= self.starred_depth > 0;
-            return;
+        if let Some(definition) = self.index.unannotated_collection_literal(expression) {
+            self.dependencies.insert(definition);
         }
-
-        let is_call = matches!(expression, ast::Expr::Call(_));
-        let is_starred = matches!(expression, ast::Expr::Starred(_));
-        self.call_depth += usize::from(is_call);
-        self.starred_depth += usize::from(is_starred);
         walk_expr(self, expression);
-        self.call_depth -= usize::from(is_call);
-        self.starred_depth -= usize::from(is_starred);
     }
-}
-
-fn collection_use_context(
-    expression: &ast::Expr,
-    target: ExpressionNodeKey,
-) -> CollectionUseContext {
-    let mut visitor = CollectionUseContextVisitor {
-        target,
-        call_depth: 0,
-        starred_depth: 0,
-        context: CollectionUseContext::default(),
-    };
-    visitor.visit_expr(expression);
-    visitor.context
 }
 
 /// Builder to infer all types in a region.
@@ -323,6 +294,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     // leaking `SupportsRichComparisonT@sort` into the inferred list element type.
     collection_use_constraints:
         FxHashMap<Definition<'db>, FxIndexSet<CollectionUseConstraint<'db>>>,
+
+    /// Directed dependencies between collections in the active constraint component.
+    collection_constraint_dependencies: FxHashMap<Definition<'db>, FxHashSet<Definition<'db>>>,
 
     /// The collection whose constraints are being inferred without depending on its definition.
     collection_constraint_target: Option<CollectionConstraintTarget<'db>>,
@@ -441,6 +415,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
+            collection_constraint_dependencies: FxHashMap::default(),
             collection_constraint_target: None,
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
@@ -473,17 +448,110 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
         let target = self.collection_constraint_target.as_ref()?;
-        let direct_collection_def = self.index.unannotated_collection_literal(expression);
-        let collection_def = direct_collection_def.or_else(|| {
-            self.index
-                .unannotated_collection_literal_at_any_use(expression)
-        })?;
+        let collection_def = self
+            .index
+            .unannotated_collection_literal(expression)
+            .or_else(|| {
+                self.index
+                    .unannotated_collection_literal_at_any_use(expression)
+            })?;
 
-        if direct_collection_def != Some(target.definition) {
-            target.has_dependency.set(true);
+        target.identities.get(&collection_def).copied()
+    }
+
+    fn collection_constraint_identity(&self, collection_def: Definition<'db>) -> Option<Type<'db>> {
+        self.collection_constraint_target
+            .as_ref()?
+            .identities
+            .get(&collection_def)
+            .copied()
+    }
+
+    fn collection_constraint_generic_context(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<GenericContext<'db>> {
+        self.collection_constraint_target
+            .as_ref()?
+            .contexts
+            .get(&collection_def)
+            .copied()
+    }
+
+    fn collection_constraint_projection(&self) -> Option<GenericContext<'db>> {
+        self.collection_constraint_target
+            .as_ref()
+            .map(|target| target.generic_context)
+    }
+
+    fn normalize_collection_constraint_type(&self, ty: Type<'db>) -> Type<'db> {
+        if self.collection_constraint_target.is_none() {
+            return ty;
         }
 
-        self.unannotated_collection_identity_type(collection_def)
+        let divergent = RefCell::new(FxHashSet::default());
+        any_over_type(self.db(), ty, false, |nested| {
+            if nested.is_divergent() {
+                divergent.borrow_mut().insert(nested);
+            }
+            false
+        });
+        divergent.into_inner().into_iter().fold(ty, |ty, from| {
+            ty.apply_type_mapping(
+                self.db(),
+                &TypeMapping::ReplaceType {
+                    from,
+                    to: Type::Never,
+                },
+                TypeContext::default(),
+            )
+        })
+    }
+
+    fn record_collection_dependencies<'expr>(
+        &mut self,
+        collection_def: Definition<'db>,
+        expressions: impl IntoIterator<Item = &'expr ast::Expr>,
+    ) {
+        if self.collection_constraint_target.is_none() {
+            return;
+        }
+
+        let mut dependencies = FxHashSet::default();
+        let mut visitor = CollectionDependencyVisitor {
+            index: self.index,
+            dependencies: &mut dependencies,
+        };
+        for expression in expressions {
+            visitor.visit_expr(expression);
+        }
+        self.collection_constraint_dependencies
+            .entry(collection_def)
+            .or_default()
+            .extend(dependencies);
+    }
+
+    fn collection_has_recursive_dependency(&self, collection_def: Definition<'db>) -> bool {
+        fn reaches<'db>(
+            dependencies: &FxHashMap<Definition<'db>, FxHashSet<Definition<'db>>>,
+            current: Definition<'db>,
+            target: Definition<'db>,
+            visited: &mut FxHashSet<Definition<'db>>,
+        ) -> bool {
+            dependencies.get(&current).is_some_and(|next| {
+                next.iter().any(|next| {
+                    *next == target
+                        || (visited.insert(*next) && reaches(dependencies, *next, target, visited))
+                })
+            })
+        }
+
+        reaches(
+            &self.collection_constraint_dependencies,
+            collection_def,
+            collection_def,
+            &mut FxHashSet::from_iter([collection_def]),
+        )
     }
 
     fn unannotated_collection_identity_type(
@@ -492,9 +560,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Option<Type<'db>> {
         let assignment = collection_def.kind(self.db()).as_unannotated_assignment()?;
         let known_class = match assignment.value(self.module()) {
-            ast::Expr::List(list) if list.elts.is_empty() => KnownClass::List,
-            ast::Expr::Set(set) if set.elts.is_empty() => KnownClass::Set,
-            ast::Expr::Dict(dict) if dict.items.is_empty() => KnownClass::Dict,
+            ast::Expr::List(_) => KnownClass::List,
+            ast::Expr::Set(_) => KnownClass::Set,
+            ast::Expr::Dict(_) => KnownClass::Dict,
             _ => return None,
         };
         let collection_literal = known_class.try_to_class_literal(self.db())?;
@@ -502,6 +570,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(Type::instance(
             self.db(),
             collection_literal.identity_specialization(self.db()),
+        ))
+    }
+
+    fn collection_replaces_dynamic_binding(&self, collection_def: Definition<'db>) -> bool {
+        let collection_start = collection_def
+            .full_range(self.db(), self.module())
+            .range()
+            .start();
+        self.index
+            .use_def_map(collection_def.file_scope(self.db()))
+            .all_definitions_with_usage()
+            .filter_map(|(_, state, _)| state.definition())
+            .filter(|definition| {
+                *definition != collection_def
+                    && definition.place(self.db()) == collection_def.place(self.db())
+                    && definition
+                        .full_range(self.db(), self.module())
+                        .range()
+                        .start()
+                        < collection_start
+            })
+            .any(|definition| binding_type(self.db(), definition).has_dynamic(self.db()))
+    }
+
+    fn default_collection_type(&self, collection_def: Definition<'db>) -> Option<Type<'db>> {
+        let identity = self.unannotated_collection_identity_type(collection_def)?;
+        let (class_literal, _) = identity.class_specialization(self.db())?;
+        Some(Type::instance(
+            self.db(),
+            class_literal.default_specialization(self.db()),
         ))
     }
 
@@ -5138,28 +5236,57 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = assignment;
 
         // Resolve the target type, assuming a load context.
-        let target_type = match &**target {
-            ast::Expr::Name(name) => {
-                let previous_value = self.infer_name_load(name);
-                self.store_expression_type(target, previous_value);
-                previous_value
-            }
-            ast::Expr::Attribute(attr) => {
-                let previous_value = self.infer_attribute_load(attr);
-                self.store_expression_type(target, previous_value);
-                previous_value
-            }
-            ast::Expr::Subscript(subscript) => {
-                let previous_value = self.infer_subscript_load(subscript);
-                self.store_expression_type(target, previous_value);
-                previous_value
-            }
-            _ => self.infer_expression(target, TypeContext::default()),
-        };
+        let target_type = self
+            .collection_constraint_override(target)
+            .unwrap_or_else(|| match &**target {
+                ast::Expr::Name(name) => {
+                    let previous_value = self.infer_name_load(name);
+                    self.store_expression_type(target, previous_value);
+                    previous_value
+                }
+                ast::Expr::Attribute(attr) => {
+                    let previous_value = self.infer_attribute_load(attr);
+                    self.store_expression_type(target, previous_value);
+                    previous_value
+                }
+                ast::Expr::Subscript(subscript) => {
+                    let previous_value = self.infer_subscript_load(subscript);
+                    self.store_expression_type(target, previous_value);
+                    previous_value
+                }
+                _ => self.infer_expression(target, TypeContext::default()),
+            });
 
-        self.infer_augmented_op(assignment, target_type, value, &mut |builder, tcx| {
-            builder.infer_expression(value, tcx)
-        })
+        let result =
+            self.infer_augmented_op(assignment, target_type, value, &mut |builder, tcx| {
+                builder.infer_expression(value, tcx)
+            });
+
+        if self.collection_constraint_target.is_some()
+            && let Some(collection_def) = self.index.unannotated_collection_literal(target)
+        {
+            self.record_collection_dependencies(collection_def, std::iter::once(value.as_ref()));
+            let value_type = self.expression_type(value);
+            let constraint = target_type
+                .class_specialization(self.db())
+                .zip(value_type.class_specialization(self.db()))
+                .filter(|((target_class, _), (value_class, value_specialization))| {
+                    target_class == value_class
+                        && !value_specialization
+                            .types(self.db())
+                            .iter()
+                            .all(Type::is_unknown)
+                })
+                .map_or(result, |_| value_type);
+            if constraint.as_divergent().is_none() {
+                self.collection_use_constraints
+                    .entry(collection_def)
+                    .or_default()
+                    .insert(CollectionUseConstraint::Type(constraint));
+            }
+        }
+
+        result
     }
 
     fn infer_dict_key_assignment_definition(
@@ -6092,6 +6219,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
+        if self.collection_constraint_target.is_some() {
+            return self.infer_expression_impl(expression, tcx);
+        }
+
         if let Some(standalone_expression) = self.index.try_expression(expression) {
             self.infer_standalone_expression_impl(expression, standalone_expression, tcx)
         } else {
@@ -6156,6 +6287,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
+        if self.collection_constraint_target.is_some() {
+            return self.infer_expression_impl(expression, tcx);
+        }
+
         let standalone_expression = self.index.expression(expression);
         self.infer_standalone_expression_impl(expression, standalone_expression, tcx)
     }
@@ -6294,7 +6429,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ty = Type::LiteralValue(literal.to_unpromotable());
         }
 
-        if let Some(tcx) = tcx.annotation
+        if self.collection_constraint_target.is_some()
+            && let Some(tcx) = tcx.annotation
             && let Some(collection_def) = self.index.unannotated_collection_literal(expression)
         {
             self.collection_use_constraints
@@ -7375,75 +7511,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
-            match infer_collection_use_constraints(self.db(), collection_def) {
-                CollectionUseConstraintInference::Constraints(use_constraints) => {
-                    for constraint in use_constraints {
-                        match constraint {
-                            CollectionUseConstraint::Type(constraint) => {
-                                if constraint.has_unspecialized_type_var(self.db()) {
-                                    continue;
-                                }
-                                builder.infer(identity_instance, *constraint).ok()?;
-                            }
-                            CollectionUseConstraint::Projected(projected) => {
-                                let projected = constraints.load(self.db(), projected);
-                                builder.intersect_constraint_set(projected);
-                            }
-                        }
-                    }
-                }
-                CollectionUseConstraintInference::RequiresCycle => {
-                    for (statement, use_expression) in
-                        self.index.constraining_collection_uses(collection_def)
-                    {
-                        let statement_use_types = infer_statement_types(self.db(), statement);
-
-                        if let Some(divergent) = statement_use_types
-                            .expression_type(use_expression)
-                            .as_divergent()
-                        {
-                            // Infer `collection[Divergent]` for the initial cycle result.
-                            let divergent_instance = collection_alias
-                                .origin(self.db())
-                                .apply_specialization(self.db(), |generic_context| {
-                                    generic_context.repeat_specialization(
-                                        self.db(),
-                                        Type::Divergent(divergent),
-                                    )
-                                });
-
-                            builder
-                                .infer(
-                                    identity_instance,
-                                    Type::instance(self.db(), divergent_instance),
-                                )
-                                .ok()?;
-                            continue;
-                        }
-
-                        let Some(statement_constraints) =
-                            statement_use_types.collection_use_constraints(collection_def)
-                        else {
-                            continue;
-                        };
-
-                        for constraint in statement_constraints {
-                            match constraint {
-                                CollectionUseConstraint::Type(constraint) => {
-                                    if constraint.has_unspecialized_type_var(self.db()) {
-                                        continue;
-                                    }
-                                    builder.infer(identity_instance, *constraint).ok()?;
-                                }
-                                CollectionUseConstraint::Projected(projected) => {
-                                    let projected = constraints.load(self.db(), projected);
-                                    builder.intersect_constraint_set(projected);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+            let use_constraint = infer_collection_use_constraints(self.db(), collection_def);
+            builder.infer(identity_instance, *use_constraint).ok()?;
         }
 
         for (elts_index, elts) in elts.iter().enumerate() {
@@ -8457,52 +8526,31 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_arguments
     }
 
-    fn collection_use_constraint_from_specialization(
-        &self,
-        identity_instance: Type<'db>,
-        receiver_generic_context: Option<GenericContext<'db>>,
-        call_specialization: Specialization<'db>,
-    ) -> Option<CollectionUseConstraint<'db>> {
-        let constraint = identity_instance.apply_specialization(self.db(), call_specialization);
-        let Some(receiver_generic_context) = receiver_generic_context else {
-            return Some(CollectionUseConstraint::Type(constraint));
-        };
-
-        // Method-local typevars describe requirements imposed by the method, not concrete element
-        // types learned for the collection. Until collection-use constraints are represented as
-        // projected constraint sets, avoid leaking those method-local typevars into the inferred
-        // collection literal type.
-        if any_over_type(self.db(), constraint, false, |ty| {
-            ty.as_typevar().is_some_and(|typevar| {
-                !receiver_generic_context.contains(self.db(), typevar.identity(self.db()))
-            })
-        }) {
-            return None;
-        }
-
-        Some(CollectionUseConstraint::Type(constraint))
-    }
-
-    /// Records collection constraints and returns whether they are suitable for cycle-free
-    /// inference.
-    ///
-    /// Failed calls do not contribute constraints and can normally be ignored when another call
-    /// has already constrained the collection. A possibly-`None` argument requires the regular
-    /// cycle path, however, to avoid retaining the diagnostic from its initial `Divergent`
-    /// iteration alongside the stable diagnostic.
+    /// Records the projected constraints imposed by a bound collection method call.
     fn record_bound_method_collection_constraints(
         &mut self,
         attribute: &ast::ExprAttribute,
         arguments: &ast::Arguments,
         call_arguments: &mut CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) -> bool {
+    ) {
+        if self.collection_constraint_target.is_none() {
+            return;
+        }
+
         let value = &attribute.value;
         let value_type = self.expression_type(value);
 
         let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
-            return false;
+            return;
         };
+        self.record_collection_dependencies(
+            collection_def,
+            arguments
+                .args
+                .iter()
+                .chain(arguments.keywords.iter().map(|keyword| &keyword.value)),
+        );
         let Some((collection_literal, _)) =
             value_type.class_specialization(self.db()).or_else(|| {
                 // Truthiness narrowing wraps a collection used under `if collection` in an
@@ -8518,22 +8566,30 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .ok()
             })
         else {
-            return false;
+            return;
         };
-        let identity_instance = Type::instance(
-            self.db(),
-            collection_literal.identity_specialization(self.db()),
-        );
-        let collection_generic_context = collection_literal.generic_context(self.db());
+        let identity_instance = self
+            .collection_constraint_identity(collection_def)
+            .unwrap_or_else(|| {
+                Type::instance(
+                    self.db(),
+                    collection_literal.identity_specialization(self.db()),
+                )
+            });
+        let collection_generic_context = self
+            .collection_constraint_generic_context(collection_def)
+            .or_else(|| collection_literal.generic_context(self.db()));
 
         let mut identity_bindings = self
             .infer_attribute_load_impl(attribute, identity_instance)
             .bindings(self.db())
             .match_parameters(self.db(), call_arguments)
-            // Perform inference against the type variables on the receiver's generic context.
             .with_generic_context(self.db(), collection_generic_context);
 
         let mut speculative = self.speculate();
+        let constraint_projection = self
+            .collection_constraint_projection()
+            .or(collection_generic_context);
         let call_result = speculative.infer_and_check_argument_types_with_projection(
             ArgumentsIter::from_ast(arguments),
             call_arguments,
@@ -8543,24 +8599,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // keyed, may not be the same as the type context we get here. It is not immediately
             // clear how to retrieve those types, and so we just re-infer the argument expressions
             // for simplicity.
-            &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+            &mut |builder, (_, expr, tcx)| {
+                let ty = builder.infer_expression(expr, tcx);
+                builder.normalize_collection_constraint_type(ty)
+            },
             &mut identity_bindings,
             call_expression_tcx,
-            collection_generic_context,
+            constraint_projection,
         );
 
         if call_result.is_err() {
-            return !call_arguments.iter_types().any(|types| {
-                types.iter().any(|(_, ty)| {
-                    ty.is_none(self.db())
-                        || ty.as_union().is_some_and(|union| {
-                            union
-                                .elements(self.db())
-                                .iter()
-                                .any(|element| element.is_none(self.db()))
-                        })
-                })
-            });
+            return;
         }
 
         for projected in identity_bindings
@@ -8573,65 +8622,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .or_default()
                 .insert(CollectionUseConstraint::Projected(projected));
         }
-
-        if self.collection_constraint_target.is_none() {
-            for call_specialization in identity_bindings
-                .iter_flat()
-                .flat_map(CallableBinding::matching_overloads)
-                .filter_map(|(_, identity_overload)| identity_overload.specialization())
-            {
-                // Record the constraints on the receiver's generic context formed by the arguments
-                // to this bound method call.
-                let Some(constraints) = self.collection_use_constraint_from_specialization(
-                    identity_instance,
-                    collection_generic_context,
-                    call_specialization,
-                ) else {
-                    continue;
-                };
-
-                self.collection_use_constraints
-                    .entry(collection_def)
-                    .or_default()
-                    .insert(constraints);
-            }
-        }
-
-        true
-    }
-
-    fn infer_bound_method_collection_use_constraints(
-        &mut self,
-        call_expression: &ast::ExprCall,
-        collection_def: Definition<'db>,
-    ) -> bool {
-        let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) =
-            call_expression.func.as_ref()
-        else {
-            return false;
-        };
-        if self.index.unannotated_collection_literal(value) != Some(collection_def) {
-            return false;
-        }
-
-        let Some(identity_instance) = self.unannotated_collection_identity_type(collection_def)
-        else {
-            return false;
-        };
-        self.store_expression_type(value, identity_instance);
-
-        let mut call_arguments = self.prepare_call_arguments(&call_expression.arguments);
-        let supports_cycle_free_inference = self.record_bound_method_collection_constraints(
-            attribute,
-            &call_expression.arguments,
-            &mut call_arguments,
-            TypeContext::default(),
-        );
-        supports_cycle_free_inference
-            && self
-                .collection_use_constraints
-                .get(&collection_def)
-                .is_some_and(|constraints| !constraints.is_empty())
     }
 
     fn infer_call_expression(
@@ -10942,84 +10932,196 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn finish_collection_use_constraints(
         mut self,
         collection_def: Definition<'db>,
-    ) -> CollectionUseConstraintInference<'db> {
+    ) -> Type<'db> {
         self.context.defuse();
 
-        if self
-            .index
-            .collection_requires_cycle_inference(collection_def)
-        {
-            return CollectionUseConstraintInference::RequiresCycle;
+        if self.collection_replaces_dynamic_binding(collection_def) {
+            return self
+                .default_collection_type(collection_def)
+                .unwrap_or_else(Type::unknown);
         }
 
-        let has_dependency = Rc::new(Cell::new(false));
-        self.collection_constraint_target = Some(CollectionConstraintTarget {
-            definition: collection_def,
-            has_dependency: Rc::clone(&has_dependency),
-        });
+        let mut candidates = self
+            .index
+            .unannotated_collections()
+            .filter(|definition| definition.scope(self.db()) == collection_def.scope(self.db()))
+            .collect::<Vec<_>>();
+        candidates.sort_unstable();
+        candidates.dedup();
 
-        let return_is_unconstrained = self
-            .scope
-            .node(self.db())
-            .as_function()
-            .is_some_and(|function| function.node(self.module()).returns.is_none());
-
-        for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
-            let used_fast_path = match statement {
-                Statement::Expression(expression) => {
-                    match expression.node_ref(self.db()).node(self.module()) {
-                        ast::Expr::Call(call_expression) => self
-                            .infer_bound_method_collection_use_constraints(
-                                call_expression,
-                                collection_def,
-                            ),
-                        _ => false,
+        let mut definitions = FxHashSet::from_iter([collection_def]);
+        let mut statements = Vec::new();
+        let mut seen_statements = FxHashSet::default();
+        loop {
+            let mut ordered_definitions = definitions.iter().copied().collect::<Vec<_>>();
+            ordered_definitions.sort_unstable();
+            for definition in ordered_definitions {
+                for (statement, _) in self.index.constraining_collection_uses(definition) {
+                    if seen_statements.insert(statement) {
+                        statements.push(statement);
                     }
                 }
-                Statement::Other(statement) => {
-                    let statement = statement.node_ref(self.db()).node(self.module());
-                    match statement {
-                        // An unannotated return does not constrain its result, but a call within
-                        // the return expression can still constrain the collection through an
-                        // annotated argument. Starred uses participate in iterable inference and
-                        // need cycle recovery.
-                        ast::Stmt::Return(ast::StmtReturn {
-                            value: Some(value), ..
-                        }) if return_is_unconstrained => {
-                            let use_context = collection_use_context(value, use_expression);
-                            if use_context.in_starred {
-                                false
-                            } else if use_context.in_call {
-                                self.infer_statement(statement);
-                                true
-                            } else {
-                                true
-                            }
-                        }
-                        ast::Stmt::Return(_) => return_is_unconstrained,
-                        _ => false,
-                    }
-                }
-                Statement::Definition(_) => false,
-            };
+            }
 
-            if !used_fast_path {
-                return CollectionUseConstraintInference::RequiresCycle;
+            let previous_len = definitions.len();
+            definitions.extend(candidates.iter().copied().filter(|candidate| {
+                self.index
+                    .constraining_collection_uses(*candidate)
+                    .any(|(statement, _)| seen_statements.contains(&statement))
+            }));
+            if definitions.len() == previous_len {
+                break;
             }
         }
 
-        let constraints = self
-            .collection_use_constraints
-            .remove(&collection_def)
-            .unwrap_or_default()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+        let mut definitions = definitions.into_iter().collect::<Vec<_>>();
+        definitions.sort_unstable();
 
-        if has_dependency.get() {
-            CollectionUseConstraintInference::RequiresCycle
+        let mut identities = FxHashMap::default();
+        let mut contexts = FxHashMap::default();
+        let mut generic_context = None;
+        for (index, definition) in definitions.iter().enumerate() {
+            let Some(identity) = self.unannotated_collection_identity_type(*definition) else {
+                continue;
+            };
+            let Some((_, specialization)) = identity.class_specialization(self.db()) else {
+                continue;
+            };
+            let context = specialization.generic_context(self.db());
+            let Ok(delta) = u32::try_from(index + 1) else {
+                return Type::unknown();
+            };
+            let mapping = TypeMapping::FreshenBoundTypeVars {
+                generic_context: context,
+                delta,
+            };
+            let fresh_identity =
+                identity.apply_type_mapping(self.db(), &mapping, TypeContext::default());
+            let fresh_context = mapping.update_signature_generic_context(self.db(), context);
+            identities.insert(*definition, fresh_identity);
+            contexts.insert(*definition, fresh_context);
+            generic_context =
+                GenericContext::merge_optional(self.db(), generic_context, Some(fresh_context));
+        }
+        let Some(generic_context) = generic_context else {
+            return Type::unknown();
+        };
+
+        self.collection_constraint_target = Some(CollectionConstraintTarget {
+            identities: identities.clone(),
+            contexts,
+            generic_context,
+        });
+
+        for statement in statements {
+            match statement {
+                Statement::Expression(expression) => {
+                    self.infer_expression_impl(
+                        expression.node_ref(self.db()).node(self.module()),
+                        TypeContext::default(),
+                    );
+                }
+                Statement::Definition(definition) => self.infer_region_definition(definition),
+                Statement::Other(statement) => {
+                    self.infer_statement(statement.node_ref(self.db()).node(self.module()));
+                }
+            }
+        }
+
+        let constraints = ConstraintSetBuilder::new();
+        let inferable = generic_context.inferable_typevars(self.db());
+        let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
+
+        let mut constraints_by_definition = std::mem::take(&mut self.collection_use_constraints)
+            .into_iter()
+            .collect::<Vec<_>>();
+        constraints_by_definition.sort_unstable_by_key(|(definition, _)| *definition);
+        for (definition, use_constraints) in constraints_by_definition {
+            let Some(identity_instance) = identities.get(&definition).copied() else {
+                continue;
+            };
+
+            for constraint in use_constraints {
+                match constraint {
+                    CollectionUseConstraint::Type(constraint) => {
+                        let added_element_mappings = identity_instance
+                            .class_specialization(self.db())
+                            .zip(constraint.class_specialization(self.db()))
+                            .filter(|((identity_class, _), (constraint_class, _))| {
+                                identity_class == constraint_class
+                            })
+                            .is_some_and(
+                                |((_, identity_specialization), (_, constraint_specialization))| {
+                                    if identity_specialization.types(self.db()).len()
+                                        != constraint_specialization.types(self.db()).len()
+                                    {
+                                        return false;
+                                    }
+                                    for (typevar, constraint) in identity_specialization
+                                        .types(self.db())
+                                        .iter()
+                                        .filter_map(|ty| ty.as_typevar())
+                                        .zip(constraint_specialization.types(self.db()))
+                                    {
+                                        builder.add_type_mapping(
+                                            typevar,
+                                            *constraint,
+                                            TypeVarVariance::Covariant,
+                                        );
+                                    }
+                                    true
+                                },
+                            );
+                        if !added_element_mappings {
+                            builder.infer(identity_instance, constraint).ok();
+                        }
+                    }
+                    CollectionUseConstraint::Projected(projected) => {
+                        let projected = constraints.load(self.db(), &projected);
+                        builder.intersect_constraint_set(projected);
+                    }
+                }
+            }
+        }
+
+        let has_recursive_dependency = self.collection_has_recursive_dependency(collection_def);
+        let specialization = builder.build_with(generic_context, |_, bounds| {
+            let lower = bounds?.lower?;
+            let lower = if let Some(union) = lower.as_union()
+                && union
+                    .elements(self.db())
+                    .iter()
+                    .any(|element| !element.is_unknown() && element.as_divergent().is_none())
+            {
+                lower.filter_union(self.db(), |element| {
+                    !element.is_unknown() && element.as_divergent().is_none()
+                })
+            } else {
+                lower
+            };
+            Some(lower.promote(self.db()))
+        });
+        let Some(identity) = identities.get(&collection_def) else {
+            return Type::unknown();
+        };
+        let result = self.normalize_collection_constraint_type(
+            identity.apply_specialization(self.db(), specialization),
+        );
+        if has_recursive_dependency
+            && any_over_type(self.db(), result, false, |ty| ty.is_never())
+            && let Some((class_literal, _)) = result.class_specialization(self.db())
+            && let Some(context) = class_literal.generic_context(self.db())
+        {
+            Type::instance(
+                self.db(),
+                class_literal.apply_specialization(self.db(), |generic_context| {
+                    debug_assert_eq!(generic_context, context);
+                    generic_context
+                        .repeat_specialization(self.db(), Type::divergent(collection_def.as_id()))
+                }),
+            )
         } else {
-            CollectionUseConstraintInference::Constraints(constraints)
+            result
         }
     }
 
@@ -11047,6 +11149,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,
@@ -11130,6 +11233,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11226,6 +11330,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             declarations: _,
@@ -11285,6 +11390,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11424,6 +11530,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Builder only state
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11502,6 +11609,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
+            collection_constraint_dependencies: _,
         } = *self;
 
         let mut builder = TypeInferenceBuilder::new(self.db(), region, index, self.module());
@@ -11551,6 +11659,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
+            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::{OnceCell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -7,6 +7,7 @@ use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::source_text;
 use ruff_python_ast::helpers::is_dotted_name;
 use ruff_python_ast::name::Name;
+use ruff_python_ast::visitor::{Visitor, walk_expr};
 use ruff_python_ast::{
     self as ast, AnyNodeRef, ArgOrKeyword, ArgumentsSourceOrder, ExprContext, HasNodeIndex,
     PythonVersion,
@@ -22,11 +23,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
-    ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap,
-    FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference,
-    ScopeInferenceExtra, infer_deferred_types, infer_definition_types, infer_expression_types,
-    infer_same_file_expression_type, infer_unpack_types,
+    CollectionUseConstraintInference, DeferredAndUndecorated, DefinitionInference,
+    DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
+    FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
+    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
+    infer_collection_use_constraints, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -184,6 +186,45 @@ fn should_preserve_inferred_binding_type(ty: Type<'_>) -> bool {
 /// performance problem. For now, we optimize for memory usage.
 const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 
+#[derive(Clone)]
+struct CollectionConstraintTarget<'db> {
+    definition: Definition<'db>,
+    has_dependency: Rc<Cell<bool>>,
+}
+
+struct StarredUseVisitor {
+    target: ExpressionNodeKey,
+    starred_depth: usize,
+    found: bool,
+}
+
+impl<'ast> Visitor<'ast> for StarredUseVisitor {
+    fn visit_expr(&mut self, expression: &'ast ast::Expr) {
+        if self.found {
+            return;
+        }
+        if self.starred_depth > 0 && ExpressionNodeKey::from(expression) == self.target {
+            self.found = true;
+            return;
+        }
+
+        let is_starred = matches!(expression, ast::Expr::Starred(_));
+        self.starred_depth += usize::from(is_starred);
+        walk_expr(self, expression);
+        self.starred_depth -= usize::from(is_starred);
+    }
+}
+
+fn expression_contains_starred_use(expression: &ast::Expr, target: ExpressionNodeKey) -> bool {
+    let mut visitor = StarredUseVisitor {
+        target,
+        starred_depth: 0,
+        found: false,
+    };
+    visitor.visit_expr(expression);
+    visitor.found
+}
+
 /// Builder to infer all types in a region.
 ///
 /// A builder is used by creating it with [`new()`](TypeInferenceBuilder::new), and then calling
@@ -269,6 +310,9 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     // `xs.append("x")` with `xs.sort()` yields `str ≤ T ≤ SupportsRichComparison` instead of
     // leaking `SupportsRichComparisonT@sort` into the inferred list element type.
     collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
+
+    /// The collection whose constraints are being inferred without depending on its definition.
+    collection_constraint_target: Option<CollectionConstraintTarget<'db>>,
 
     /// Expressions that are string annotations
     string_annotations: FxHashSet<ExpressionNodeKey>,
@@ -384,6 +428,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
+            collection_constraint_target: None,
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
             bindings: VecMap::default(),
@@ -411,6 +456,42 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ))
             })
             .as_ref()
+    }
+
+    fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
+        let target = self.collection_constraint_target.as_ref()?;
+        let collection_def = self
+            .index
+            .unannotated_collection_literal(expression)
+            .or_else(|| {
+                self.index
+                    .unannotated_collection_literal_at_any_use(expression)
+            })?;
+
+        if self.index.unannotated_collection_literal(expression) != Some(target.definition) {
+            target.has_dependency.set(true);
+        }
+
+        self.unannotated_collection_identity_type(collection_def)
+    }
+
+    fn unannotated_collection_identity_type(
+        &self,
+        collection_def: Definition<'db>,
+    ) -> Option<Type<'db>> {
+        let assignment = collection_def.kind(self.db()).as_unannotated_assignment()?;
+        let known_class = match assignment.value(self.module()) {
+            ast::Expr::List(list) if list.elts.is_empty() => KnownClass::List,
+            ast::Expr::Set(set) if set.elts.is_empty() => KnownClass::Set,
+            ast::Expr::Dict(dict) if dict.items.is_empty() => KnownClass::Dict,
+            _ => return None,
+        };
+        let collection_literal = known_class.try_to_class_literal(self.db())?;
+
+        Some(Type::instance(
+            self.db(),
+            collection_literal.identity_specialization(self.db()),
+        ))
     }
 
     fn discard_dict_key_assignments_for(&mut self, definition: Definition<'db>) {
@@ -6132,18 +6213,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.infer_dict_comprehension_expression(dictcomp, tcx)
             }
             ast::Expr::SetComp(setcomp) => self.infer_set_comprehension_expression(setcomp, tcx),
-            ast::Expr::Name(name) => {
-                let ty = self.infer_name_expression(name);
-                tcx.annotation.map_or(ty, |target| {
-                    self.specialize_generic_class_from_context(ty, target)
-                })
-            }
-            ast::Expr::Attribute(attribute) => {
-                let ty = self.infer_attribute_expression(attribute);
-                tcx.annotation.map_or(ty, |target| {
-                    self.specialize_generic_class_from_context(ty, target)
-                })
-            }
+            ast::Expr::Name(name) => self
+                .collection_constraint_override(expression)
+                .unwrap_or_else(|| {
+                    let ty = self.infer_name_expression(name);
+                    tcx.annotation.map_or(ty, |target| {
+                        self.specialize_generic_class_from_context(ty, target)
+                    })
+                }),
+            ast::Expr::Attribute(attribute) => self
+                .collection_constraint_override(expression)
+                .unwrap_or_else(|| {
+                    let ty = self.infer_attribute_expression(attribute);
+                    tcx.annotation.map_or(ty, |target| {
+                        self.specialize_generic_class_from_context(ty, target)
+                    })
+                }),
             ast::Expr::UnaryOp(unary_op) => self.infer_unary_expression(unary_op),
             ast::Expr::BinOp(binary) => self.infer_binary_expression(binary, tcx),
             ast::Expr::BoolOp(bool_op) => self.infer_boolean_expression(bool_op, tcx),
@@ -7254,38 +7339,58 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
-            for (statement, use_expression) in
-                self.index.constraining_collection_uses(collection_def)
-            {
-                let statement_use_types = infer_statement_types(self.db(), statement);
-
-                if let Some(divergent) = statement_use_types
-                    .expression_type(use_expression)
-                    .as_divergent()
-                {
-                    // Infer `collection[Divergent]` for the initial cycle result.
-                    let divergent_instance = collection_alias
-                        .origin(self.db())
-                        .apply_specialization(self.db(), |generic_context| {
-                            generic_context
-                                .repeat_specialization(self.db(), Type::Divergent(divergent))
-                        });
-
-                    builder
-                        .infer(
-                            identity_instance,
-                            Type::instance(self.db(), divergent_instance),
-                        )
-                        .ok()?;
-                } else if let Some(constraints) =
-                    statement_use_types.collection_use_constraints(collection_def)
-                {
+            match infer_collection_use_constraints(self.db(), collection_def) {
+                CollectionUseConstraintInference::Constraints(constraints) => {
                     for constraint in constraints {
                         if constraint.has_unspecialized_type_var(self.db()) {
                             continue;
                         }
 
                         builder.infer(identity_instance, *constraint).ok()?;
+                    }
+                }
+                CollectionUseConstraintInference::RequiresCycle => {
+                    for (statement, use_expression) in
+                        self.index.constraining_collection_uses(collection_def)
+                    {
+                        let statement_use_types = infer_statement_types(self.db(), statement);
+
+                        if let Some(divergent) = statement_use_types
+                            .expression_type(use_expression)
+                            .as_divergent()
+                        {
+                            // Infer `collection[Divergent]` for the initial cycle result.
+                            let divergent_instance = collection_alias
+                                .origin(self.db())
+                                .apply_specialization(self.db(), |generic_context| {
+                                    generic_context.repeat_specialization(
+                                        self.db(),
+                                        Type::Divergent(divergent),
+                                    )
+                                });
+
+                            builder
+                                .infer(
+                                    identity_instance,
+                                    Type::instance(self.db(), divergent_instance),
+                                )
+                                .ok()?;
+                            continue;
+                        }
+
+                        let Some(constraints) =
+                            statement_use_types.collection_use_constraints(collection_def)
+                        else {
+                            continue;
+                        };
+
+                        for constraint in constraints {
+                            if constraint.has_unspecialized_type_var(self.db()) {
+                                continue;
+                            }
+
+                            builder.infer(identity_instance, *constraint).ok()?;
+                        }
                     }
                 }
             }
@@ -8331,21 +8436,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(constraint)
     }
 
+    /// Records collection constraints and returns whether they are suitable for cycle-free
+    /// inference.
+    ///
+    /// Failed calls do not contribute constraints and can normally be ignored when another call
+    /// has already constrained the collection. A possibly-`None` argument requires the regular
+    /// cycle path, however, to avoid retaining the diagnostic from its initial `Divergent`
+    /// iteration alongside the stable diagnostic.
     fn record_bound_method_collection_constraints(
         &mut self,
         attribute: &ast::ExprAttribute,
         arguments: &ast::Arguments,
         call_arguments: &mut CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) {
+    ) -> bool {
         let value = &attribute.value;
         let value_type = self.expression_type(value);
 
         let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
-            return;
+            return false;
         };
         let Some((collection_literal, _)) = value_type.class_specialization(self.db()) else {
-            return;
+            return false;
         };
 
         let identity_instance = Type::instance(
@@ -8361,7 +8473,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Perform inference against the type variables on the receiver's generic context.
             .with_generic_context(self.db(), collection_generic_context);
 
-        let call_result = self.speculate().infer_and_check_argument_types(
+        let mut speculative = self.speculate();
+        let call_result = speculative.infer_and_check_argument_types(
             ArgumentsIter::from_ast(arguments),
             call_arguments,
             // TODO: The argument types have already been inferred and stored in `call_arguments`.
@@ -8376,7 +8489,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         );
 
         if call_result.is_err() {
-            return;
+            return !call_arguments.iter_types().any(|types| {
+                types.iter().any(|(_, ty)| {
+                    ty.is_none(self.db())
+                        || ty.as_union().is_some_and(|union| {
+                            union
+                                .elements(self.db())
+                                .iter()
+                                .any(|element| element.is_none(self.db()))
+                        })
+                })
+            });
         }
 
         for call_specialization in identity_bindings
@@ -8399,6 +8522,42 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .or_default()
                 .insert(constraints);
         }
+
+        true
+    }
+
+    fn infer_bound_method_collection_use_constraints(
+        &mut self,
+        call_expression: &ast::ExprCall,
+        collection_def: Definition<'db>,
+    ) -> bool {
+        let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) =
+            call_expression.func.as_ref()
+        else {
+            return false;
+        };
+        if self.index.unannotated_collection_literal(value) != Some(collection_def) {
+            return false;
+        }
+
+        let Some(identity_instance) = self.unannotated_collection_identity_type(collection_def)
+        else {
+            return false;
+        };
+        self.store_expression_type(value, identity_instance);
+
+        let mut call_arguments = self.prepare_call_arguments(&call_expression.arguments);
+        let supports_cycle_free_inference = self.record_bound_method_collection_constraints(
+            attribute,
+            &call_expression.arguments,
+            &mut call_arguments,
+            TypeContext::default(),
+        );
+        supports_cycle_free_inference
+            && self
+                .collection_use_constraints
+                .get(&collection_def)
+                .is_some_and(|constraints| !constraints.is_empty())
     }
 
     fn infer_call_expression(
@@ -10705,6 +10864,80 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
     }
 
+    pub(super) fn finish_collection_use_constraints(
+        mut self,
+        collection_def: Definition<'db>,
+    ) -> CollectionUseConstraintInference<'db> {
+        let has_dependency = Rc::new(Cell::new(false));
+        self.collection_constraint_target = Some(CollectionConstraintTarget {
+            definition: collection_def,
+            has_dependency: Rc::clone(&has_dependency),
+        });
+
+        let return_is_unconstrained = match self.scope.node(self.db()) {
+            NodeWithScopeKind::Function(function) => function.node(self.module()).returns.is_none(),
+            _ => false,
+        };
+
+        for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
+            let used_fast_path = match statement {
+                Statement::Expression(expression) => {
+                    match expression.node_ref(self.db()).node(self.module()) {
+                        ast::Expr::Call(call_expression) => self
+                            .infer_bound_method_collection_use_constraints(
+                                call_expression,
+                                collection_def,
+                            ),
+                        _ => false,
+                    }
+                }
+                Statement::Other(statement) => {
+                    let statement = statement.node_ref(self.db()).node(self.module());
+                    match statement {
+                        // An unannotated return does not constrain its result, but a direct call can
+                        // still constrain the collection through an annotated argument. Starred
+                        // uses participate in iterable inference and need cycle recovery.
+                        ast::Stmt::Return(ast::StmtReturn {
+                            value: Some(value), ..
+                        }) if return_is_unconstrained => {
+                            if expression_contains_starred_use(value, use_expression) {
+                                false
+                            } else if matches!(value.as_ref(), ast::Expr::Call(_)) {
+                                self.infer_statement(statement);
+                                true
+                            } else {
+                                true
+                            }
+                        }
+                        ast::Stmt::Return(_) => return_is_unconstrained,
+                        _ => false,
+                    }
+                }
+                Statement::Definition(_) => false,
+            };
+
+            if !used_fast_path {
+                self.context.defuse();
+                return CollectionUseConstraintInference::RequiresCycle;
+            }
+        }
+
+        let constraints = self
+            .collection_use_constraints
+            .remove(&collection_def)
+            .unwrap_or_default()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        self.context.defuse();
+
+        if has_dependency.get() {
+            CollectionUseConstraintInference::RequiresCycle
+        } else {
+            CollectionUseConstraintInference::Constraints(constraints)
+        }
+    }
+
     pub(super) fn finish_expression(mut self) -> ExpressionInference<'db> {
         self.infer_region();
 
@@ -10728,6 +10961,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,
@@ -10810,6 +11044,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -10905,6 +11140,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expressions,
             bindings,
             called_functions,
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             declarations: _,
@@ -10963,6 +11199,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             called_functions,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11101,6 +11338,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // Builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11161,6 +11399,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ref reachability_cache,
             ref return_types_and_ranges,
             ref dataclass_field_specifiers,
+            ref collection_constraint_target,
 
             // These fields are type inference results, but do not affect the inference of a given
             // expression.
@@ -11191,6 +11430,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         builder.typevar_binding_context = typevar_binding_context;
         builder.context.inference_flags = self.inference_flags();
         builder.expression_cache.clone_from(expression_cache);
+        builder
+            .collection_constraint_target
+            .clone_from(collection_constraint_target);
         builder.reachability_cache.clone_from(reachability_cache);
         builder
             .return_types_and_ranges
@@ -11223,6 +11465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
 
             // builder only state
+            collection_constraint_target: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1,4 +1,4 @@
-use std::cell::{OnceCell, RefCell};
+use std::cell::{Cell, OnceCell, RefCell};
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -16,7 +16,6 @@ use ruff_python_stdlib::builtins::version_builtin_was_added;
 use ruff_python_stdlib::typing::as_pep_585_generic;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
-use salsa::plumbing::AsId;
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
@@ -24,12 +23,12 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    CollectionUseConstraint, DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra,
-    DefinitionTypes, ExpressionInference, ExpressionInferenceExtra, FrozenMap, FrozenSet,
-    FrozenValueMap, FunctionDecoratorInference, InferenceRegion, OtherDefinitionInferenceExtra,
-    ScopeInference, ScopeInferenceExtra, infer_collection_use_constraints, infer_deferred_types,
-    infer_definition_types, infer_expression_types, infer_same_file_expression_type,
-    infer_unpack_types,
+    CollectionUseConstraint, CollectionUseConstraintInference, DeferredAndUndecorated,
+    DefinitionInference, DefinitionInferenceExtra, DefinitionTypes, ExpressionInference,
+    ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference,
+    InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
+    infer_collection_use_constraints, infer_deferred_types, infer_definition_types,
+    infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
 use crate::diagnostic::format_enumeration;
 use crate::place::{
@@ -77,7 +76,7 @@ use crate::types::function::{
     same_module_uncached_raw_signature,
 };
 use crate::types::generics::{
-    GenericContext, InferableTypeVars, SpecializationBuilder, bind_typevar,
+    GenericContext, InferableTypeVars, Specialization, SpecializationBuilder, bind_typevar,
     enclosing_binding_contexts,
 };
 use crate::types::infer::builder::named_tuple::NamedTupleKind;
@@ -106,8 +105,8 @@ use crate::types::{
     IntersectionType, KnownClass, KnownInstanceType, KnownUnion, LiteralValueTypeKind,
     MemberLookupPolicy, ParamSpecAttrKind, Parameter, Parameters, SentinelInstance, Signature,
     SpecialFormType, SubclassOfType, Type, TypeAliasType, TypeAndQualifiers, TypeContext,
-    TypeMapping, TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance,
-    TypedDictType, UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
+    TypeQualifiers, TypeVarBoundOrConstraints, TypeVarKind, TypeVarVariance, TypedDictType,
+    UnionAccumulator, UnionBuilder, UnionType, any_over_type, binding_type,
     extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
     is_discarded_dict_key_assignment, todo_type,
 };
@@ -189,23 +188,53 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 
 #[derive(Clone)]
 struct CollectionConstraintTarget<'db> {
-    identities: FxHashMap<Definition<'db>, Type<'db>>,
-    contexts: FxHashMap<Definition<'db>, GenericContext<'db>>,
-    generic_context: GenericContext<'db>,
+    definition: Definition<'db>,
+    has_dependency: Rc<Cell<bool>>,
 }
 
-struct CollectionDependencyVisitor<'a, 'db> {
-    index: &'a SemanticIndex<'db>,
-    dependencies: &'a mut FxHashSet<Definition<'db>>,
+#[derive(Default)]
+struct CollectionUseContext {
+    in_call: bool,
+    in_starred: bool,
 }
 
-impl<'ast> Visitor<'ast> for CollectionDependencyVisitor<'_, '_> {
+struct CollectionUseContextVisitor {
+    target: ExpressionNodeKey,
+    call_depth: usize,
+    starred_depth: usize,
+    context: CollectionUseContext,
+}
+
+impl<'ast> Visitor<'ast> for CollectionUseContextVisitor {
     fn visit_expr(&mut self, expression: &'ast ast::Expr) {
-        if let Some(definition) = self.index.unannotated_collection_literal(expression) {
-            self.dependencies.insert(definition);
+        if ExpressionNodeKey::from(expression) == self.target {
+            self.context.in_call |= self.call_depth > 0;
+            self.context.in_starred |= self.starred_depth > 0;
+            return;
         }
+
+        let is_call = matches!(expression, ast::Expr::Call(_));
+        let is_starred = matches!(expression, ast::Expr::Starred(_));
+        self.call_depth += usize::from(is_call);
+        self.starred_depth += usize::from(is_starred);
         walk_expr(self, expression);
+        self.call_depth -= usize::from(is_call);
+        self.starred_depth -= usize::from(is_starred);
     }
+}
+
+fn collection_use_context(
+    expression: &ast::Expr,
+    target: ExpressionNodeKey,
+) -> CollectionUseContext {
+    let mut visitor = CollectionUseContextVisitor {
+        target,
+        call_depth: 0,
+        starred_depth: 0,
+        context: CollectionUseContext::default(),
+    };
+    visitor.visit_expr(expression);
+    visitor.context
 }
 
 /// Builder to infer all types in a region.
@@ -294,9 +323,6 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     // leaking `SupportsRichComparisonT@sort` into the inferred list element type.
     collection_use_constraints:
         FxHashMap<Definition<'db>, FxIndexSet<CollectionUseConstraint<'db>>>,
-
-    /// Directed dependencies between collections in the active constraint component.
-    collection_constraint_dependencies: FxHashMap<Definition<'db>, FxHashSet<Definition<'db>>>,
 
     /// The collection whose constraints are being inferred without depending on its definition.
     collection_constraint_target: Option<CollectionConstraintTarget<'db>>,
@@ -415,7 +441,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             qualifiers: FxHashMap::default(),
             type_expression_flags: FxHashMap::default(),
             collection_use_constraints: FxHashMap::default(),
-            collection_constraint_dependencies: FxHashMap::default(),
             collection_constraint_target: None,
             string_annotations: FxHashSet::default(),
             expected_types: FxHashMap::default(),
@@ -448,110 +473,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
         let target = self.collection_constraint_target.as_ref()?;
-        let collection_def = self
-            .index
-            .unannotated_collection_literal(expression)
-            .or_else(|| {
-                self.index
-                    .unannotated_collection_literal_at_any_use(expression)
-            })?;
+        let direct_collection_def = self.index.unannotated_collection_literal(expression);
+        let collection_def = direct_collection_def.or_else(|| {
+            self.index
+                .unannotated_collection_literal_at_any_use(expression)
+        })?;
 
-        target.identities.get(&collection_def).copied()
-    }
-
-    fn collection_constraint_identity(&self, collection_def: Definition<'db>) -> Option<Type<'db>> {
-        self.collection_constraint_target
-            .as_ref()?
-            .identities
-            .get(&collection_def)
-            .copied()
-    }
-
-    fn collection_constraint_generic_context(
-        &self,
-        collection_def: Definition<'db>,
-    ) -> Option<GenericContext<'db>> {
-        self.collection_constraint_target
-            .as_ref()?
-            .contexts
-            .get(&collection_def)
-            .copied()
-    }
-
-    fn collection_constraint_projection(&self) -> Option<GenericContext<'db>> {
-        self.collection_constraint_target
-            .as_ref()
-            .map(|target| target.generic_context)
-    }
-
-    fn normalize_collection_constraint_type(&self, ty: Type<'db>) -> Type<'db> {
-        if self.collection_constraint_target.is_none() {
-            return ty;
+        if direct_collection_def != Some(target.definition) {
+            target.has_dependency.set(true);
         }
 
-        let divergent = RefCell::new(FxHashSet::default());
-        any_over_type(self.db(), ty, false, |nested| {
-            if nested.is_divergent() {
-                divergent.borrow_mut().insert(nested);
-            }
-            false
-        });
-        divergent.into_inner().into_iter().fold(ty, |ty, from| {
-            ty.apply_type_mapping(
-                self.db(),
-                &TypeMapping::ReplaceType {
-                    from,
-                    to: Type::Never,
-                },
-                TypeContext::default(),
-            )
-        })
-    }
-
-    fn record_collection_dependencies<'expr>(
-        &mut self,
-        collection_def: Definition<'db>,
-        expressions: impl IntoIterator<Item = &'expr ast::Expr>,
-    ) {
-        if self.collection_constraint_target.is_none() {
-            return;
-        }
-
-        let mut dependencies = FxHashSet::default();
-        let mut visitor = CollectionDependencyVisitor {
-            index: self.index,
-            dependencies: &mut dependencies,
-        };
-        for expression in expressions {
-            visitor.visit_expr(expression);
-        }
-        self.collection_constraint_dependencies
-            .entry(collection_def)
-            .or_default()
-            .extend(dependencies);
-    }
-
-    fn collection_has_recursive_dependency(&self, collection_def: Definition<'db>) -> bool {
-        fn reaches<'db>(
-            dependencies: &FxHashMap<Definition<'db>, FxHashSet<Definition<'db>>>,
-            current: Definition<'db>,
-            target: Definition<'db>,
-            visited: &mut FxHashSet<Definition<'db>>,
-        ) -> bool {
-            dependencies.get(&current).is_some_and(|next| {
-                next.iter().any(|next| {
-                    *next == target
-                        || (visited.insert(*next) && reaches(dependencies, *next, target, visited))
-                })
-            })
-        }
-
-        reaches(
-            &self.collection_constraint_dependencies,
-            collection_def,
-            collection_def,
-            &mut FxHashSet::from_iter([collection_def]),
-        )
+        self.unannotated_collection_identity_type(collection_def)
     }
 
     fn unannotated_collection_identity_type(
@@ -560,9 +492,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Option<Type<'db>> {
         let assignment = collection_def.kind(self.db()).as_unannotated_assignment()?;
         let known_class = match assignment.value(self.module()) {
-            ast::Expr::List(_) => KnownClass::List,
-            ast::Expr::Set(_) => KnownClass::Set,
-            ast::Expr::Dict(_) => KnownClass::Dict,
+            ast::Expr::List(list) if list.elts.is_empty() => KnownClass::List,
+            ast::Expr::Set(set) if set.elts.is_empty() => KnownClass::Set,
+            ast::Expr::Dict(dict) if dict.items.is_empty() => KnownClass::Dict,
             _ => return None,
         };
         let collection_literal = known_class.try_to_class_literal(self.db())?;
@@ -570,36 +502,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(Type::instance(
             self.db(),
             collection_literal.identity_specialization(self.db()),
-        ))
-    }
-
-    fn collection_replaces_dynamic_binding(&self, collection_def: Definition<'db>) -> bool {
-        let collection_start = collection_def
-            .full_range(self.db(), self.module())
-            .range()
-            .start();
-        self.index
-            .use_def_map(collection_def.file_scope(self.db()))
-            .all_definitions_with_usage()
-            .filter_map(|(_, state, _)| state.definition())
-            .filter(|definition| {
-                *definition != collection_def
-                    && definition.place(self.db()) == collection_def.place(self.db())
-                    && definition
-                        .full_range(self.db(), self.module())
-                        .range()
-                        .start()
-                        < collection_start
-            })
-            .any(|definition| binding_type(self.db(), definition).has_dynamic(self.db()))
-    }
-
-    fn default_collection_type(&self, collection_def: Definition<'db>) -> Option<Type<'db>> {
-        let identity = self.unannotated_collection_identity_type(collection_def)?;
-        let (class_literal, _) = identity.class_specialization(self.db())?;
-        Some(Type::instance(
-            self.db(),
-            class_literal.default_specialization(self.db()),
         ))
     }
 
@@ -5236,57 +5138,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = assignment;
 
         // Resolve the target type, assuming a load context.
-        let target_type = self
-            .collection_constraint_override(target)
-            .unwrap_or_else(|| match &**target {
-                ast::Expr::Name(name) => {
-                    let previous_value = self.infer_name_load(name);
-                    self.store_expression_type(target, previous_value);
-                    previous_value
-                }
-                ast::Expr::Attribute(attr) => {
-                    let previous_value = self.infer_attribute_load(attr);
-                    self.store_expression_type(target, previous_value);
-                    previous_value
-                }
-                ast::Expr::Subscript(subscript) => {
-                    let previous_value = self.infer_subscript_load(subscript);
-                    self.store_expression_type(target, previous_value);
-                    previous_value
-                }
-                _ => self.infer_expression(target, TypeContext::default()),
-            });
-
-        let result =
-            self.infer_augmented_op(assignment, target_type, value, &mut |builder, tcx| {
-                builder.infer_expression(value, tcx)
-            });
-
-        if self.collection_constraint_target.is_some()
-            && let Some(collection_def) = self.index.unannotated_collection_literal(target)
-        {
-            self.record_collection_dependencies(collection_def, std::iter::once(value.as_ref()));
-            let value_type = self.expression_type(value);
-            let constraint = target_type
-                .class_specialization(self.db())
-                .zip(value_type.class_specialization(self.db()))
-                .filter(|((target_class, _), (value_class, value_specialization))| {
-                    target_class == value_class
-                        && !value_specialization
-                            .types(self.db())
-                            .iter()
-                            .all(Type::is_unknown)
-                })
-                .map_or(result, |_| value_type);
-            if constraint.as_divergent().is_none() {
-                self.collection_use_constraints
-                    .entry(collection_def)
-                    .or_default()
-                    .insert(CollectionUseConstraint::Type(constraint));
+        let target_type = match &**target {
+            ast::Expr::Name(name) => {
+                let previous_value = self.infer_name_load(name);
+                self.store_expression_type(target, previous_value);
+                previous_value
             }
-        }
+            ast::Expr::Attribute(attr) => {
+                let previous_value = self.infer_attribute_load(attr);
+                self.store_expression_type(target, previous_value);
+                previous_value
+            }
+            ast::Expr::Subscript(subscript) => {
+                let previous_value = self.infer_subscript_load(subscript);
+                self.store_expression_type(target, previous_value);
+                previous_value
+            }
+            _ => self.infer_expression(target, TypeContext::default()),
+        };
 
-        result
+        self.infer_augmented_op(assignment, target_type, value, &mut |builder, tcx| {
+            builder.infer_expression(value, tcx)
+        })
     }
 
     fn infer_dict_key_assignment_definition(
@@ -6219,10 +6092,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if self.collection_constraint_target.is_some() {
-            return self.infer_expression_impl(expression, tcx);
-        }
-
         if let Some(standalone_expression) = self.index.try_expression(expression) {
             self.infer_standalone_expression_impl(expression, standalone_expression, tcx)
         } else {
@@ -6287,10 +6156,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         expression: &ast::Expr,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        if self.collection_constraint_target.is_some() {
-            return self.infer_expression_impl(expression, tcx);
-        }
-
         let standalone_expression = self.index.expression(expression);
         self.infer_standalone_expression_impl(expression, standalone_expression, tcx)
     }
@@ -6429,8 +6294,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ty = Type::LiteralValue(literal.to_unpromotable());
         }
 
-        if self.collection_constraint_target.is_some()
-            && let Some(tcx) = tcx.annotation
+        if let Some(tcx) = tcx.annotation
             && let Some(collection_def) = self.index.unannotated_collection_literal(expression)
         {
             self.collection_use_constraints
@@ -7511,8 +7375,75 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
-            let use_constraint = infer_collection_use_constraints(self.db(), collection_def);
-            builder.infer(identity_instance, *use_constraint).ok()?;
+            match infer_collection_use_constraints(self.db(), collection_def) {
+                CollectionUseConstraintInference::Constraints(use_constraints) => {
+                    for constraint in use_constraints {
+                        match constraint {
+                            CollectionUseConstraint::Type(constraint) => {
+                                if constraint.has_unspecialized_type_var(self.db()) {
+                                    continue;
+                                }
+                                builder.infer(identity_instance, *constraint).ok()?;
+                            }
+                            CollectionUseConstraint::Projected(projected) => {
+                                let projected = constraints.load(self.db(), projected);
+                                builder.intersect_constraint_set(projected);
+                            }
+                        }
+                    }
+                }
+                CollectionUseConstraintInference::RequiresCycle => {
+                    for (statement, use_expression) in
+                        self.index.constraining_collection_uses(collection_def)
+                    {
+                        let statement_use_types = infer_statement_types(self.db(), statement);
+
+                        if let Some(divergent) = statement_use_types
+                            .expression_type(use_expression)
+                            .as_divergent()
+                        {
+                            // Infer `collection[Divergent]` for the initial cycle result.
+                            let divergent_instance = collection_alias
+                                .origin(self.db())
+                                .apply_specialization(self.db(), |generic_context| {
+                                    generic_context.repeat_specialization(
+                                        self.db(),
+                                        Type::Divergent(divergent),
+                                    )
+                                });
+
+                            builder
+                                .infer(
+                                    identity_instance,
+                                    Type::instance(self.db(), divergent_instance),
+                                )
+                                .ok()?;
+                            continue;
+                        }
+
+                        let Some(statement_constraints) =
+                            statement_use_types.collection_use_constraints(collection_def)
+                        else {
+                            continue;
+                        };
+
+                        for constraint in statement_constraints {
+                            match constraint {
+                                CollectionUseConstraint::Type(constraint) => {
+                                    if constraint.has_unspecialized_type_var(self.db()) {
+                                        continue;
+                                    }
+                                    builder.infer(identity_instance, *constraint).ok()?;
+                                }
+                                CollectionUseConstraint::Projected(projected) => {
+                                    let projected = constraints.load(self.db(), projected);
+                                    builder.intersect_constraint_set(projected);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         for (elts_index, elts) in elts.iter().enumerate() {
@@ -8526,31 +8457,52 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_arguments
     }
 
-    /// Records the projected constraints imposed by a bound collection method call.
+    fn collection_use_constraint_from_specialization(
+        &self,
+        identity_instance: Type<'db>,
+        receiver_generic_context: Option<GenericContext<'db>>,
+        call_specialization: Specialization<'db>,
+    ) -> Option<CollectionUseConstraint<'db>> {
+        let constraint = identity_instance.apply_specialization(self.db(), call_specialization);
+        let Some(receiver_generic_context) = receiver_generic_context else {
+            return Some(CollectionUseConstraint::Type(constraint));
+        };
+
+        // Method-local typevars describe requirements imposed by the method, not concrete element
+        // types learned for the collection. Until collection-use constraints are represented as
+        // projected constraint sets, avoid leaking those method-local typevars into the inferred
+        // collection literal type.
+        if any_over_type(self.db(), constraint, false, |ty| {
+            ty.as_typevar().is_some_and(|typevar| {
+                !receiver_generic_context.contains(self.db(), typevar.identity(self.db()))
+            })
+        }) {
+            return None;
+        }
+
+        Some(CollectionUseConstraint::Type(constraint))
+    }
+
+    /// Records collection constraints and returns whether they are suitable for cycle-free
+    /// inference.
+    ///
+    /// Failed calls do not contribute constraints and can normally be ignored when another call
+    /// has already constrained the collection. A possibly-`None` argument requires the regular
+    /// cycle path, however, to avoid retaining the diagnostic from its initial `Divergent`
+    /// iteration alongside the stable diagnostic.
     fn record_bound_method_collection_constraints(
         &mut self,
         attribute: &ast::ExprAttribute,
         arguments: &ast::Arguments,
         call_arguments: &mut CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
-    ) {
-        if self.collection_constraint_target.is_none() {
-            return;
-        }
-
+    ) -> bool {
         let value = &attribute.value;
         let value_type = self.expression_type(value);
 
         let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
-            return;
+            return false;
         };
-        self.record_collection_dependencies(
-            collection_def,
-            arguments
-                .args
-                .iter()
-                .chain(arguments.keywords.iter().map(|keyword| &keyword.value)),
-        );
         let Some((collection_literal, _)) =
             value_type.class_specialization(self.db()).or_else(|| {
                 // Truthiness narrowing wraps a collection used under `if collection` in an
@@ -8566,30 +8518,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .ok()
             })
         else {
-            return;
+            return false;
         };
-        let identity_instance = self
-            .collection_constraint_identity(collection_def)
-            .unwrap_or_else(|| {
-                Type::instance(
-                    self.db(),
-                    collection_literal.identity_specialization(self.db()),
-                )
-            });
-        let collection_generic_context = self
-            .collection_constraint_generic_context(collection_def)
-            .or_else(|| collection_literal.generic_context(self.db()));
+        let identity_instance = Type::instance(
+            self.db(),
+            collection_literal.identity_specialization(self.db()),
+        );
+        let collection_generic_context = collection_literal.generic_context(self.db());
 
         let mut identity_bindings = self
             .infer_attribute_load_impl(attribute, identity_instance)
             .bindings(self.db())
             .match_parameters(self.db(), call_arguments)
+            // Perform inference against the type variables on the receiver's generic context.
             .with_generic_context(self.db(), collection_generic_context);
 
         let mut speculative = self.speculate();
-        let constraint_projection = self
-            .collection_constraint_projection()
-            .or(collection_generic_context);
         let call_result = speculative.infer_and_check_argument_types_with_projection(
             ArgumentsIter::from_ast(arguments),
             call_arguments,
@@ -8599,17 +8543,24 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // keyed, may not be the same as the type context we get here. It is not immediately
             // clear how to retrieve those types, and so we just re-infer the argument expressions
             // for simplicity.
-            &mut |builder, (_, expr, tcx)| {
-                let ty = builder.infer_expression(expr, tcx);
-                builder.normalize_collection_constraint_type(ty)
-            },
+            &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
             &mut identity_bindings,
             call_expression_tcx,
-            constraint_projection,
+            collection_generic_context,
         );
 
         if call_result.is_err() {
-            return;
+            return !call_arguments.iter_types().any(|types| {
+                types.iter().any(|(_, ty)| {
+                    ty.is_none(self.db())
+                        || ty.as_union().is_some_and(|union| {
+                            union
+                                .elements(self.db())
+                                .iter()
+                                .any(|element| element.is_none(self.db()))
+                        })
+                })
+            });
         }
 
         for projected in identity_bindings
@@ -8622,6 +8573,65 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .or_default()
                 .insert(CollectionUseConstraint::Projected(projected));
         }
+
+        if self.collection_constraint_target.is_none() {
+            for call_specialization in identity_bindings
+                .iter_flat()
+                .flat_map(CallableBinding::matching_overloads)
+                .filter_map(|(_, identity_overload)| identity_overload.specialization())
+            {
+                // Record the constraints on the receiver's generic context formed by the arguments
+                // to this bound method call.
+                let Some(constraints) = self.collection_use_constraint_from_specialization(
+                    identity_instance,
+                    collection_generic_context,
+                    call_specialization,
+                ) else {
+                    continue;
+                };
+
+                self.collection_use_constraints
+                    .entry(collection_def)
+                    .or_default()
+                    .insert(constraints);
+            }
+        }
+
+        true
+    }
+
+    fn infer_bound_method_collection_use_constraints(
+        &mut self,
+        call_expression: &ast::ExprCall,
+        collection_def: Definition<'db>,
+    ) -> bool {
+        let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) =
+            call_expression.func.as_ref()
+        else {
+            return false;
+        };
+        if self.index.unannotated_collection_literal(value) != Some(collection_def) {
+            return false;
+        }
+
+        let Some(identity_instance) = self.unannotated_collection_identity_type(collection_def)
+        else {
+            return false;
+        };
+        self.store_expression_type(value, identity_instance);
+
+        let mut call_arguments = self.prepare_call_arguments(&call_expression.arguments);
+        let supports_cycle_free_inference = self.record_bound_method_collection_constraints(
+            attribute,
+            &call_expression.arguments,
+            &mut call_arguments,
+            TypeContext::default(),
+        );
+        supports_cycle_free_inference
+            && self
+                .collection_use_constraints
+                .get(&collection_def)
+                .is_some_and(|constraints| !constraints.is_empty())
     }
 
     fn infer_call_expression(
@@ -10932,196 +10942,84 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     pub(super) fn finish_collection_use_constraints(
         mut self,
         collection_def: Definition<'db>,
-    ) -> Type<'db> {
+    ) -> CollectionUseConstraintInference<'db> {
         self.context.defuse();
 
-        if self.collection_replaces_dynamic_binding(collection_def) {
-            return self
-                .default_collection_type(collection_def)
-                .unwrap_or_else(Type::unknown);
-        }
-
-        let mut candidates = self
+        if self
             .index
-            .unannotated_collections()
-            .filter(|definition| definition.scope(self.db()) == collection_def.scope(self.db()))
-            .collect::<Vec<_>>();
-        candidates.sort_unstable();
-        candidates.dedup();
-
-        let mut definitions = FxHashSet::from_iter([collection_def]);
-        let mut statements = Vec::new();
-        let mut seen_statements = FxHashSet::default();
-        loop {
-            let mut ordered_definitions = definitions.iter().copied().collect::<Vec<_>>();
-            ordered_definitions.sort_unstable();
-            for definition in ordered_definitions {
-                for (statement, _) in self.index.constraining_collection_uses(definition) {
-                    if seen_statements.insert(statement) {
-                        statements.push(statement);
-                    }
-                }
-            }
-
-            let previous_len = definitions.len();
-            definitions.extend(candidates.iter().copied().filter(|candidate| {
-                self.index
-                    .constraining_collection_uses(*candidate)
-                    .any(|(statement, _)| seen_statements.contains(&statement))
-            }));
-            if definitions.len() == previous_len {
-                break;
-            }
-        }
-
-        let mut definitions = definitions.into_iter().collect::<Vec<_>>();
-        definitions.sort_unstable();
-
-        let mut identities = FxHashMap::default();
-        let mut contexts = FxHashMap::default();
-        let mut generic_context = None;
-        for (index, definition) in definitions.iter().enumerate() {
-            let Some(identity) = self.unannotated_collection_identity_type(*definition) else {
-                continue;
-            };
-            let Some((_, specialization)) = identity.class_specialization(self.db()) else {
-                continue;
-            };
-            let context = specialization.generic_context(self.db());
-            let Ok(delta) = u32::try_from(index + 1) else {
-                return Type::unknown();
-            };
-            let mapping = TypeMapping::FreshenBoundTypeVars {
-                generic_context: context,
-                delta,
-            };
-            let fresh_identity =
-                identity.apply_type_mapping(self.db(), &mapping, TypeContext::default());
-            let fresh_context = mapping.update_signature_generic_context(self.db(), context);
-            identities.insert(*definition, fresh_identity);
-            contexts.insert(*definition, fresh_context);
-            generic_context =
-                GenericContext::merge_optional(self.db(), generic_context, Some(fresh_context));
-        }
-        let Some(generic_context) = generic_context else {
-            return Type::unknown();
-        };
-
-        self.collection_constraint_target = Some(CollectionConstraintTarget {
-            identities: identities.clone(),
-            contexts,
-            generic_context,
-        });
-
-        for statement in statements {
-            match statement {
-                Statement::Expression(expression) => {
-                    self.infer_expression_impl(
-                        expression.node_ref(self.db()).node(self.module()),
-                        TypeContext::default(),
-                    );
-                }
-                Statement::Definition(definition) => self.infer_region_definition(definition),
-                Statement::Other(statement) => {
-                    self.infer_statement(statement.node_ref(self.db()).node(self.module()));
-                }
-            }
-        }
-
-        let constraints = ConstraintSetBuilder::new();
-        let inferable = generic_context.inferable_typevars(self.db());
-        let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
-
-        let mut constraints_by_definition = std::mem::take(&mut self.collection_use_constraints)
-            .into_iter()
-            .collect::<Vec<_>>();
-        constraints_by_definition.sort_unstable_by_key(|(definition, _)| *definition);
-        for (definition, use_constraints) in constraints_by_definition {
-            let Some(identity_instance) = identities.get(&definition).copied() else {
-                continue;
-            };
-
-            for constraint in use_constraints {
-                match constraint {
-                    CollectionUseConstraint::Type(constraint) => {
-                        let added_element_mappings = identity_instance
-                            .class_specialization(self.db())
-                            .zip(constraint.class_specialization(self.db()))
-                            .filter(|((identity_class, _), (constraint_class, _))| {
-                                identity_class == constraint_class
-                            })
-                            .is_some_and(
-                                |((_, identity_specialization), (_, constraint_specialization))| {
-                                    if identity_specialization.types(self.db()).len()
-                                        != constraint_specialization.types(self.db()).len()
-                                    {
-                                        return false;
-                                    }
-                                    for (typevar, constraint) in identity_specialization
-                                        .types(self.db())
-                                        .iter()
-                                        .filter_map(|ty| ty.as_typevar())
-                                        .zip(constraint_specialization.types(self.db()))
-                                    {
-                                        builder.add_type_mapping(
-                                            typevar,
-                                            *constraint,
-                                            TypeVarVariance::Covariant,
-                                        );
-                                    }
-                                    true
-                                },
-                            );
-                        if !added_element_mappings {
-                            builder.infer(identity_instance, constraint).ok();
-                        }
-                    }
-                    CollectionUseConstraint::Projected(projected) => {
-                        let projected = constraints.load(self.db(), &projected);
-                        builder.intersect_constraint_set(projected);
-                    }
-                }
-            }
-        }
-
-        let has_recursive_dependency = self.collection_has_recursive_dependency(collection_def);
-        let specialization = builder.build_with(generic_context, |_, bounds| {
-            let lower = bounds?.lower?;
-            let lower = if let Some(union) = lower.as_union()
-                && union
-                    .elements(self.db())
-                    .iter()
-                    .any(|element| !element.is_unknown() && element.as_divergent().is_none())
-            {
-                lower.filter_union(self.db(), |element| {
-                    !element.is_unknown() && element.as_divergent().is_none()
-                })
-            } else {
-                lower
-            };
-            Some(lower.promote(self.db()))
-        });
-        let Some(identity) = identities.get(&collection_def) else {
-            return Type::unknown();
-        };
-        let result = self.normalize_collection_constraint_type(
-            identity.apply_specialization(self.db(), specialization),
-        );
-        if has_recursive_dependency
-            && any_over_type(self.db(), result, false, |ty| ty.is_never())
-            && let Some((class_literal, _)) = result.class_specialization(self.db())
-            && let Some(context) = class_literal.generic_context(self.db())
+            .collection_requires_cycle_inference(collection_def)
         {
-            Type::instance(
-                self.db(),
-                class_literal.apply_specialization(self.db(), |generic_context| {
-                    debug_assert_eq!(generic_context, context);
-                    generic_context
-                        .repeat_specialization(self.db(), Type::divergent(collection_def.as_id()))
-                }),
-            )
+            return CollectionUseConstraintInference::RequiresCycle;
+        }
+
+        let has_dependency = Rc::new(Cell::new(false));
+        self.collection_constraint_target = Some(CollectionConstraintTarget {
+            definition: collection_def,
+            has_dependency: Rc::clone(&has_dependency),
+        });
+
+        let return_is_unconstrained = self
+            .scope
+            .node(self.db())
+            .as_function()
+            .is_some_and(|function| function.node(self.module()).returns.is_none());
+
+        for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
+            let used_fast_path = match statement {
+                Statement::Expression(expression) => {
+                    match expression.node_ref(self.db()).node(self.module()) {
+                        ast::Expr::Call(call_expression) => self
+                            .infer_bound_method_collection_use_constraints(
+                                call_expression,
+                                collection_def,
+                            ),
+                        _ => false,
+                    }
+                }
+                Statement::Other(statement) => {
+                    let statement = statement.node_ref(self.db()).node(self.module());
+                    match statement {
+                        // An unannotated return does not constrain its result, but a call within
+                        // the return expression can still constrain the collection through an
+                        // annotated argument. Starred uses participate in iterable inference and
+                        // need cycle recovery.
+                        ast::Stmt::Return(ast::StmtReturn {
+                            value: Some(value), ..
+                        }) if return_is_unconstrained => {
+                            let use_context = collection_use_context(value, use_expression);
+                            if use_context.in_starred {
+                                false
+                            } else if use_context.in_call {
+                                self.infer_statement(statement);
+                                true
+                            } else {
+                                true
+                            }
+                        }
+                        ast::Stmt::Return(_) => return_is_unconstrained,
+                        _ => false,
+                    }
+                }
+                Statement::Definition(_) => false,
+            };
+
+            if !used_fast_path {
+                return CollectionUseConstraintInference::RequiresCycle;
+            }
+        }
+
+        let constraints = self
+            .collection_use_constraints
+            .remove(&collection_def)
+            .unwrap_or_default()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+
+        if has_dependency.get() {
+            CollectionUseConstraintInference::RequiresCycle
         } else {
-            result
+            CollectionUseConstraintInference::Constraints(constraints)
         }
     }
 
@@ -11149,7 +11047,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,
@@ -11233,7 +11130,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11330,7 +11226,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             bindings,
             called_functions,
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             declarations: _,
@@ -11390,7 +11285,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11530,7 +11424,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // Builder only state
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             dataclass_field_specifiers: _,
@@ -11609,7 +11502,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             discards_dict_key_assignments: _,
             qualifiers: _,
             type_expression_flags: _,
-            collection_constraint_dependencies: _,
         } = *self;
 
         let mut builder = TypeInferenceBuilder::new(self.db(), region, index, self.module());
@@ -11659,7 +11551,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             // builder only state
             collection_constraint_target: _,
-            collection_constraint_dependencies: _,
             expression_cache: _,
             reachability_cache: _,
             typevar_binding_context: _,

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -192,37 +192,49 @@ struct CollectionConstraintTarget<'db> {
     has_dependency: Rc<Cell<bool>>,
 }
 
-struct StarredUseVisitor {
-    target: ExpressionNodeKey,
-    starred_depth: usize,
-    found: bool,
+#[derive(Default)]
+struct CollectionUseContext {
+    in_call: bool,
+    in_starred: bool,
 }
 
-impl<'ast> Visitor<'ast> for StarredUseVisitor {
+struct CollectionUseContextVisitor {
+    target: ExpressionNodeKey,
+    call_depth: usize,
+    starred_depth: usize,
+    context: CollectionUseContext,
+}
+
+impl<'ast> Visitor<'ast> for CollectionUseContextVisitor {
     fn visit_expr(&mut self, expression: &'ast ast::Expr) {
-        if self.found {
-            return;
-        }
-        if self.starred_depth > 0 && ExpressionNodeKey::from(expression) == self.target {
-            self.found = true;
+        if ExpressionNodeKey::from(expression) == self.target {
+            self.context.in_call |= self.call_depth > 0;
+            self.context.in_starred |= self.starred_depth > 0;
             return;
         }
 
+        let is_call = matches!(expression, ast::Expr::Call(_));
         let is_starred = matches!(expression, ast::Expr::Starred(_));
+        self.call_depth += usize::from(is_call);
         self.starred_depth += usize::from(is_starred);
         walk_expr(self, expression);
+        self.call_depth -= usize::from(is_call);
         self.starred_depth -= usize::from(is_starred);
     }
 }
 
-fn expression_contains_starred_use(expression: &ast::Expr, target: ExpressionNodeKey) -> bool {
-    let mut visitor = StarredUseVisitor {
+fn collection_use_context(
+    expression: &ast::Expr,
+    target: ExpressionNodeKey,
+) -> CollectionUseContext {
+    let mut visitor = CollectionUseContextVisitor {
         target,
+        call_depth: 0,
         starred_depth: 0,
-        found: false,
+        context: CollectionUseContext::default(),
     };
     visitor.visit_expr(expression);
-    visitor.found
+    visitor.context
 }
 
 /// Builder to infer all types in a region.
@@ -10894,15 +10906,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 Statement::Other(statement) => {
                     let statement = statement.node_ref(self.db()).node(self.module());
                     match statement {
-                        // An unannotated return does not constrain its result, but a direct call can
-                        // still constrain the collection through an annotated argument. Starred
-                        // uses participate in iterable inference and need cycle recovery.
+                        // An unannotated return does not constrain its result, but a call within
+                        // the return expression can still constrain the collection through an
+                        // annotated argument. Starred uses participate in iterable inference and
+                        // need cycle recovery.
                         ast::Stmt::Return(ast::StmtReturn {
                             value: Some(value), ..
                         }) if return_is_unconstrained => {
-                            if expression_contains_starred_use(value, use_expression) {
+                            let use_context = collection_use_context(value, use_expression);
+                            if use_context.in_starred {
                                 false
-                            } else if matches!(value.as_ref(), ast::Expr::Call(_)) {
+                            } else if use_context.in_call {
                                 self.infer_statement(statement);
                                 true
                             } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8503,10 +8503,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
             return false;
         };
-        let Some((collection_literal, _)) = value_type.class_specialization(self.db()) else {
+        let Some((collection_literal, _)) =
+            value_type.class_specialization(self.db()).or_else(|| {
+                // Truthiness narrowing wraps a collection used under `if collection` in an
+                // intersection with `~AlwaysFalsy`.
+                let Type::Intersection(intersection) = value_type else {
+                    return None;
+                };
+                intersection
+                    .positive(self.db())
+                    .iter()
+                    .filter_map(|positive| positive.class_specialization(self.db()))
+                    .exactly_one()
+                    .ok()
+            })
+        else {
             return false;
         };
-
         let identity_instance = Type::instance(
             self.db(),
             collection_literal.identity_specialization(self.db()),
@@ -8533,9 +8546,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
             &mut identity_bindings,
             call_expression_tcx,
-            self.collection_constraint_target
-                .as_ref()
-                .and(collection_generic_context),
+            collection_generic_context,
         );
 
         if call_result.is_err() {
@@ -8552,18 +8563,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             });
         }
 
-        if self.collection_constraint_target.is_some() {
-            for projected in identity_bindings
-                .iter_flat()
-                .flat_map(CallableBinding::matching_overloads)
-                .filter_map(|(_, overload)| overload.projected_constraints().cloned())
-            {
-                self.collection_use_constraints
-                    .entry(collection_def)
-                    .or_default()
-                    .insert(CollectionUseConstraint::Projected(projected));
-            }
-        } else {
+        for projected in identity_bindings
+            .iter_flat()
+            .flat_map(CallableBinding::matching_overloads)
+            .filter_map(|(_, overload)| overload.projected_constraints().cloned())
+        {
+            self.collection_use_constraints
+                .entry(collection_def)
+                .or_default()
+                .insert(CollectionUseConstraint::Projected(projected));
+        }
+
+        if self.collection_constraint_target.is_none() {
             for call_specialization in identity_bindings
                 .iter_flat()
                 .flat_map(CallableBinding::matching_overloads)
@@ -9075,6 +9086,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx,
         );
 
+        // The collection can widen after combining constraints from all of its uses, so retain
+        // this call's constraints even if it is invalid against the type inferred by the current
+        // cycle iteration.
+        if let ast::Expr::Attribute(attribute) = func.as_ref() {
+            self.record_bound_method_collection_constraints(
+                attribute,
+                arguments,
+                &mut call_arguments,
+                call_expression_tcx,
+            );
+        }
+
         let mut bindings = match bindings_result {
             Ok(()) => bindings,
             Err(_) => {
@@ -9128,17 +9151,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     _ => {}
                 }
             }
-        }
-
-        // Record the constraints for the receiver of a bound method call, if the receiver is an
-        // unannotated collection literal.
-        if let ast::Expr::Attribute(attribute) = func.as_ref() {
-            self.record_bound_method_collection_constraints(
-                attribute,
-                arguments,
-                &mut call_arguments,
-                call_expression_tcx,
-            );
         }
 
         let db = self.db();

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -472,15 +472,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn collection_constraint_override(&self, expression: &ast::Expr) -> Option<Type<'db>> {
         let target = self.collection_constraint_target.as_ref()?;
-        let collection_def = self
-            .index
-            .unannotated_collection_literal(expression)
-            .or_else(|| {
-                self.index
-                    .unannotated_collection_literal_at_any_use(expression)
-            })?;
+        let direct_collection_def = self.index.unannotated_collection_literal(expression);
+        let collection_def = direct_collection_def.or_else(|| {
+            self.index
+                .unannotated_collection_literal_at_any_use(expression)
+        })?;
 
-        if self.index.unannotated_collection_literal(expression) != Some(target.definition) {
+        if direct_collection_def != Some(target.definition) {
             target.has_dependency.set(true);
         }
 
@@ -10885,24 +10883,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         mut self,
         collection_def: Definition<'db>,
     ) -> CollectionUseConstraintInference<'db> {
+        self.context.defuse();
+
+        if self
+            .index
+            .collection_requires_cycle_inference(collection_def)
+        {
+            return CollectionUseConstraintInference::RequiresCycle;
+        }
+
         let has_dependency = Rc::new(Cell::new(false));
         self.collection_constraint_target = Some(CollectionConstraintTarget {
             definition: collection_def,
             has_dependency: Rc::clone(&has_dependency),
         });
 
-        let return_is_unconstrained = match self.scope.node(self.db()) {
-            NodeWithScopeKind::Function(function) => function.node(self.module()).returns.is_none(),
-            _ => false,
-        };
-
-        if self
-            .index
-            .collection_requires_cycle_inference(collection_def)
-        {
-            self.context.defuse();
-            return CollectionUseConstraintInference::RequiresCycle;
-        }
+        let return_is_unconstrained = self
+            .scope
+            .node(self.db())
+            .as_function()
+            .is_some_and(|function| function.node(self.module()).returns.is_none());
 
         for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
             let used_fast_path = match statement {
@@ -10944,7 +10944,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             };
 
             if !used_fast_path {
-                self.context.defuse();
                 return CollectionUseConstraintInference::RequiresCycle;
             }
         }
@@ -10956,7 +10955,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .into_iter()
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        self.context.defuse();
 
         if has_dependency.get() {
             CollectionUseConstraintInference::RequiresCycle

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -7348,6 +7348,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let Ok(collection_def) =
                 DefinitionNodeKey::from_assignment(assignment.node(self.module())).exactly_one()
             && let Some(collection_def) = self.index.try_definition(collection_def)
+            && self
+                .index
+                .constraining_collection_uses(collection_def)
+                .next()
+                .is_some()
         {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -23,10 +23,10 @@ use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
 use super::{
-    CollectionUseConstraintInference, DeferredAndUndecorated, DefinitionInference,
-    DefinitionInferenceExtra, DefinitionTypes, ExpressionInference, ExpressionInferenceExtra,
-    FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference, InferenceRegion,
-    OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
+    CollectionUseConstraint, CollectionUseConstraintInference, DeferredAndUndecorated,
+    DefinitionInference, DefinitionInferenceExtra, DefinitionTypes, ExpressionInference,
+    ExpressionInferenceExtra, FrozenMap, FrozenSet, FrozenValueMap, FunctionDecoratorInference,
+    InferenceRegion, OtherDefinitionInferenceExtra, ScopeInference, ScopeInferenceExtra,
     infer_collection_use_constraints, infer_deferred_types, infer_definition_types,
     infer_expression_types, infer_same_file_expression_type, infer_unpack_types,
 };
@@ -321,7 +321,8 @@ pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     // generic context and existentially quantify away the method-local typevars, so combining
     // `xs.append("x")` with `xs.sort()` yields `str ≤ T ≤ SupportsRichComparison` instead of
     // leaking `SupportsRichComparisonT@sort` into the inferred list element type.
-    collection_use_constraints: FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>,
+    collection_use_constraints:
+        FxHashMap<Definition<'db>, FxIndexSet<CollectionUseConstraint<'db>>>,
 
     /// The collection whose constraints are being inferred without depending on its definition.
     collection_constraint_target: Option<CollectionConstraintTarget<'db>>,
@@ -604,7 +605,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     for (collection_def, constraints) in &extra.collection_use_constraints {
                         self.collection_use_constraints
                             .entry(*collection_def)
-                            .and_modify(|this| this.extend(constraints))
+                            .and_modify(|this| this.extend(constraints.iter().cloned()))
                             .or_insert(constraints.clone());
                     }
                 }
@@ -678,7 +679,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
-                    .and_modify(|this| this.extend(constraints))
+                    .and_modify(|this| this.extend(constraints.iter().cloned()))
                     .or_insert(constraints.clone());
             }
 
@@ -708,7 +709,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for (collection_def, constraints) in &extra.collection_use_constraints {
                 self.collection_use_constraints
                     .entry(*collection_def)
-                    .and_modify(|this| this.extend(constraints))
+                    .and_modify(|this| this.extend(constraints.iter().cloned()))
                     .or_insert(constraints.clone());
             }
         }
@@ -5701,6 +5702,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         bindings: &mut Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
     ) -> Result<(), CallErrorKind> {
+        self.infer_and_check_argument_types_with_projection(
+            ast_arguments,
+            argument_types,
+            infer_argument_ty,
+            bindings,
+            call_expression_tcx,
+            None,
+        )
+    }
+
+    fn infer_and_check_argument_types_with_projection(
+        &mut self,
+        ast_arguments: ArgumentsIter<'_>,
+        argument_types: &mut CallArguments<'_, 'db>,
+        infer_argument_ty: &mut dyn FnMut(&mut Self, ArgExpr<'db, '_>) -> Type<'db>,
+        bindings: &mut Bindings<'db>,
+        call_expression_tcx: TypeContext<'db>,
+        constraint_projection: Option<GenericContext<'db>>,
+    ) -> Result<(), CallErrorKind> {
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
 
@@ -5818,12 +5838,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx,
         );
 
-        bindings.check_types_impl(
+        bindings.check_types_impl_with_projection(
             db,
             &constraints,
             argument_types,
             call_expression_tcx,
             &self.dataclass_field_specifiers,
+            constraint_projection,
         )
     }
 
@@ -6279,7 +6300,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.collection_use_constraints
                 .entry(collection_def)
                 .or_default()
-                .insert(tcx);
+                .insert(CollectionUseConstraint::Type(tcx));
         }
 
         self.store_expression_type(expression, ty);
@@ -7355,13 +7376,20 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // For unannotated collection literals, collect any constraints created by later uses
             // of this definition in the scope.
             match infer_collection_use_constraints(self.db(), collection_def) {
-                CollectionUseConstraintInference::Constraints(constraints) => {
-                    for constraint in constraints {
-                        if constraint.has_unspecialized_type_var(self.db()) {
-                            continue;
+                CollectionUseConstraintInference::Constraints(use_constraints) => {
+                    for constraint in use_constraints {
+                        match constraint {
+                            CollectionUseConstraint::Type(constraint) => {
+                                if constraint.has_unspecialized_type_var(self.db()) {
+                                    continue;
+                                }
+                                builder.infer(identity_instance, *constraint).ok()?;
+                            }
+                            CollectionUseConstraint::Projected(projected) => {
+                                let projected = constraints.load(self.db(), projected);
+                                builder.intersect_constraint_set(projected);
+                            }
                         }
-
-                        builder.infer(identity_instance, *constraint).ok()?;
                     }
                 }
                 CollectionUseConstraintInference::RequiresCycle => {
@@ -7393,18 +7421,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             continue;
                         }
 
-                        let Some(constraints) =
+                        let Some(statement_constraints) =
                             statement_use_types.collection_use_constraints(collection_def)
                         else {
                             continue;
                         };
 
-                        for constraint in constraints {
-                            if constraint.has_unspecialized_type_var(self.db()) {
-                                continue;
+                        for constraint in statement_constraints {
+                            match constraint {
+                                CollectionUseConstraint::Type(constraint) => {
+                                    if constraint.has_unspecialized_type_var(self.db()) {
+                                        continue;
+                                    }
+                                    builder.infer(identity_instance, *constraint).ok()?;
+                                }
+                                CollectionUseConstraint::Projected(projected) => {
+                                    let projected = constraints.load(self.db(), projected);
+                                    builder.intersect_constraint_set(projected);
+                                }
                             }
-
-                            builder.infer(identity_instance, *constraint).ok()?;
                         }
                     }
                 }
@@ -8422,18 +8457,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_arguments
     }
 
-    // TODO: This should not be needed once we use constraint sets to track the usages of each
-    // container literal across a scope.
-    // https://github.com/astral-sh/ty/issues/3507
     fn collection_use_constraint_from_specialization(
         &self,
         identity_instance: Type<'db>,
         receiver_generic_context: Option<GenericContext<'db>>,
         call_specialization: Specialization<'db>,
-    ) -> Option<Type<'db>> {
+    ) -> Option<CollectionUseConstraint<'db>> {
         let constraint = identity_instance.apply_specialization(self.db(), call_specialization);
         let Some(receiver_generic_context) = receiver_generic_context else {
-            return Some(constraint);
+            return Some(CollectionUseConstraint::Type(constraint));
         };
 
         // Method-local typevars describe requirements imposed by the method, not concrete element
@@ -8448,7 +8480,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return None;
         }
 
-        Some(constraint)
+        Some(CollectionUseConstraint::Type(constraint))
     }
 
     /// Records collection constraints and returns whether they are suitable for cycle-free
@@ -8489,7 +8521,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .with_generic_context(self.db(), collection_generic_context);
 
         let mut speculative = self.speculate();
-        let call_result = speculative.infer_and_check_argument_types(
+        let call_result = speculative.infer_and_check_argument_types_with_projection(
             ArgumentsIter::from_ast(arguments),
             call_arguments,
             // TODO: The argument types have already been inferred and stored in `call_arguments`.
@@ -8501,6 +8533,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
             &mut identity_bindings,
             call_expression_tcx,
+            self.collection_constraint_target
+                .as_ref()
+                .and(collection_generic_context),
         );
 
         if call_result.is_err() {
@@ -8517,25 +8552,38 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             });
         }
 
-        for call_specialization in identity_bindings
-            .iter_flat()
-            .flat_map(CallableBinding::matching_overloads)
-            .filter_map(|(_, identity_overload)| identity_overload.specialization())
-        {
-            // Record the constraints on the receiver's generic context formed by the arguments to
-            // this bound method call.
-            let Some(constraints) = self.collection_use_constraint_from_specialization(
-                identity_instance,
-                collection_generic_context,
-                call_specialization,
-            ) else {
-                continue;
-            };
+        if self.collection_constraint_target.is_some() {
+            for projected in identity_bindings
+                .iter_flat()
+                .flat_map(CallableBinding::matching_overloads)
+                .filter_map(|(_, overload)| overload.projected_constraints().cloned())
+            {
+                self.collection_use_constraints
+                    .entry(collection_def)
+                    .or_default()
+                    .insert(CollectionUseConstraint::Projected(projected));
+            }
+        } else {
+            for call_specialization in identity_bindings
+                .iter_flat()
+                .flat_map(CallableBinding::matching_overloads)
+                .filter_map(|(_, identity_overload)| identity_overload.specialization())
+            {
+                // Record the constraints on the receiver's generic context formed by the arguments
+                // to this bound method call.
+                let Some(constraints) = self.collection_use_constraint_from_specialization(
+                    identity_instance,
+                    collection_generic_context,
+                    call_specialization,
+                ) else {
+                    continue;
+                };
 
-            self.collection_use_constraints
-                .entry(collection_def)
-                .or_default()
-                .insert(constraints);
+                self.collection_use_constraints
+                    .entry(collection_def)
+                    .or_default()
+                    .insert(constraints);
+            }
         }
 
         true
@@ -11536,7 +11584,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for (collection_def, constraints) in &collection_use_constraints {
             self.collection_use_constraints
                 .entry(*collection_def)
-                .and_modify(|this| this.extend(constraints))
+                .and_modify(|this| this.extend(constraints.iter().cloned()))
                 .or_insert(constraints.clone());
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8331,6 +8331,76 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         Some(constraint)
     }
 
+    fn record_bound_method_collection_constraints(
+        &mut self,
+        attribute: &ast::ExprAttribute,
+        arguments: &ast::Arguments,
+        call_arguments: &mut CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) {
+        let value = &attribute.value;
+        let value_type = self.expression_type(value);
+
+        let Some(collection_def) = self.index.unannotated_collection_literal(value) else {
+            return;
+        };
+        let Some((collection_literal, _)) = value_type.class_specialization(self.db()) else {
+            return;
+        };
+
+        let identity_instance = Type::instance(
+            self.db(),
+            collection_literal.identity_specialization(self.db()),
+        );
+        let collection_generic_context = collection_literal.generic_context(self.db());
+
+        let mut identity_bindings = self
+            .infer_attribute_load_impl(attribute, identity_instance)
+            .bindings(self.db())
+            .match_parameters(self.db(), call_arguments)
+            // Perform inference against the type variables on the receiver's generic context.
+            .with_generic_context(self.db(), collection_generic_context);
+
+        let call_result = self.speculate().infer_and_check_argument_types(
+            ArgumentsIter::from_ast(arguments),
+            call_arguments,
+            // TODO: The argument types have already been inferred and stored in `call_arguments`.
+            // However, `value` may have been inferred as a collection with `Divergent` element
+            // types, meaning the type context for a given argument, by which the inferred type is
+            // keyed, may not be the same as the type context we get here. It is not immediately
+            // clear how to retrieve those types, and so we just re-infer the argument expressions
+            // for simplicity.
+            &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+            &mut identity_bindings,
+            call_expression_tcx,
+        );
+
+        if call_result.is_err() {
+            return;
+        }
+
+        for call_specialization in identity_bindings
+            .iter_flat()
+            .flat_map(CallableBinding::matching_overloads)
+            .filter_map(|(_, identity_overload)| identity_overload.specialization())
+        {
+            // Record the constraints on the receiver's generic context formed by the arguments to
+            // this bound method call.
+            let Some(constraints) = self.collection_use_constraint_from_specialization(
+                identity_instance,
+                collection_generic_context,
+                call_specialization,
+            ) else {
+                continue;
+            };
+
+            self.collection_use_constraints
+                .entry(collection_def)
+                .or_default()
+                .insert(constraints);
+        }
+    }
+
     fn infer_call_expression(
         &mut self,
         call_expression: &ast::ExprCall,
@@ -8840,62 +8910,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Record the constraints for the receiver of a bound method call, if the receiver is an
         // unannotated collection literal.
-        if let ast::Expr::Attribute(attribute @ ast::ExprAttribute { value, .. }) = func.as_ref() {
-            let value_type = self.expression_type(value);
-
-            if let Some(collection_def) = self.index.unannotated_collection_literal(value)
-                && let Some((collection_literal, _)) = value_type.class_specialization(self.db())
-            {
-                let identity_instance = Type::instance(
-                    self.db(),
-                    collection_literal.identity_specialization(self.db()),
-                );
-                let collection_generic_context = collection_literal.generic_context(self.db());
-
-                let mut identity_bindings = self
-                    .infer_attribute_load_impl(attribute, identity_instance)
-                    .bindings(self.db())
-                    .match_parameters(self.db(), &call_arguments)
-                    // Perform inference against the type variables on the receiver's generic context.
-                    .with_generic_context(self.db(), collection_generic_context);
-
-                let call_result = self.speculate().infer_and_check_argument_types(
-                    ArgumentsIter::from_ast(arguments),
-                    &mut call_arguments,
-                    // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                    // However, `value` would have been inferred to a be a collection with `Divergent`
-                    // element types, meaning the type context for a given argument, by which the inferred
-                    // type is keyed, may not be the same as the type context we get here. It is not immediately
-                    // clear how to retrieve those types, and so we just re-infer the argument expressions
-                    // for simplicity.
-                    &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
-                    &mut identity_bindings,
-                    call_expression_tcx,
-                );
-
-                if call_result.is_ok() {
-                    for call_specialization in identity_bindings
-                        .iter_flat()
-                        .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
-                    {
-                        // Record the constraints on the receiver's generic context formed by
-                        // the arguments to this bound method call.
-                        let Some(constraints) = self.collection_use_constraint_from_specialization(
-                            identity_instance,
-                            collection_generic_context,
-                            call_specialization,
-                        ) else {
-                            continue;
-                        };
-
-                        self.collection_use_constraints
-                            .entry(collection_def)
-                            .or_default()
-                            .insert(constraints);
-                    }
-                }
-            }
+        if let ast::Expr::Attribute(attribute) = func.as_ref() {
+            self.record_bound_method_collection_constraints(
+                attribute,
+                arguments,
+                &mut call_arguments,
+                call_expression_tcx,
+            );
         }
 
         let db = self.db();

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -10896,6 +10896,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             _ => false,
         };
 
+        if self
+            .index
+            .collection_requires_cycle_inference(collection_def)
+        {
+            self.context.defuse();
+            return CollectionUseConstraintInference::RequiresCycle;
+        }
+
         for (statement, use_expression) in self.index.constraining_collection_uses(collection_def) {
             let used_fast_path = match statement {
                 Statement::Expression(expression) => {

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -19,7 +19,7 @@ use crate::types::diagnostic::{
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
 use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
-use crate::types::infer::{CollectionUseConstraint, InferenceFlags, TypeExpressionFlags};
+use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
 use crate::types::tuple::{Tuple, TupleType};
@@ -1254,17 +1254,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Record the constraints for the object of the subscript assignment, if the object is an
         // unannotated collection literal.
-        if self.collection_constraint_target.is_some()
+        if is_valid_assignment
             && let Some(collection_def) = self.index.unannotated_collection_literal(object)
             && let Some((class_literal, _)) = object_ty.class_specialization(db)
         {
-            self.record_collection_dependencies(collection_def, [target.slice.as_ref(), rhs_value]);
-            let identity_instance = self
-                .collection_constraint_identity(collection_def)
-                .unwrap_or_else(|| Type::instance(db, class_literal.identity_specialization(db)));
-            let collection_generic_context = self
-                .collection_constraint_generic_context(collection_def)
-                .or_else(|| class_literal.generic_context(db));
+            let identity_instance = Type::instance(db, class_literal.identity_specialization(db));
+            let collection_generic_context = class_literal.generic_context(db);
 
             let ast_arguments = [
                 ArgOrKeyword::Arg(&target.slice),
@@ -1288,41 +1283,45 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut identity_bindings = dunder_callable
                     .bindings(db)
                     .match_parameters(db, &call_arguments)
+                    // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(db, collection_generic_context);
 
-                let constraint_projection = self
-                    .collection_constraint_projection()
-                    .or(collection_generic_context);
-                let call_result = self
-                    .speculate()
-                    .infer_and_check_argument_types_with_projection(
-                        ArgumentsIter::synthesized(&ast_arguments),
-                        &mut call_arguments,
-                        &mut |builder, (_, expr, tcx)| {
-                            // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                            // However, `object` would have been inferred to a be a collection with `Divergent`
-                            // element types, meaning the type context for a given argument, by which the inferred
-                            // type is keyed, may not be the same as the type context we get here. It is not immediately
-                            // clear how to retrieve those types, and so we just re-infer the argument expressions
-                            // for simplicity.
-                            let ty = builder.infer_maybe_standalone_expression(expr, tcx);
-                            builder.normalize_collection_constraint_type(ty)
-                        },
-                        &mut identity_bindings,
-                        TypeContext::default(),
-                        constraint_projection,
-                    );
+                let call_result = self.speculate().infer_and_check_argument_types(
+                    ArgumentsIter::synthesized(&ast_arguments),
+                    &mut call_arguments,
+                    &mut |builder, (_, expr, tcx)| {
+                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                        // However, `object` would have been inferred to a be a collection with `Divergent`
+                        // element types, meaning the type context for a given argument, by which the inferred
+                        // type is keyed, may not be the same as the type context we get here. It is not immediately
+                        // clear how to retrieve those types, and so we just re-infer the argument expressions
+                        // for simplicity.
+                        builder.infer_maybe_standalone_expression(expr, tcx)
+                    },
+                    &mut identity_bindings,
+                    TypeContext::default(),
+                );
 
                 if call_result.is_ok() && boundness == Definedness::AlwaysDefined {
-                    for projected in identity_bindings
+                    for call_specialization in identity_bindings
                         .iter_flat()
                         .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, overload)| overload.projected_constraints().cloned())
+                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
                     {
+                        // Record the constraints on the receiver's generic context formed by
+                        // the arguments to this dunder call.
+                        let Some(constraints) = self.collection_use_constraint_from_specialization(
+                            identity_instance,
+                            collection_generic_context,
+                            call_specialization,
+                        ) else {
+                            continue;
+                        };
+
                         self.collection_use_constraints
                             .entry(collection_def)
                             .or_default()
-                            .insert(CollectionUseConstraint::Projected(projected));
+                            .insert(constraints);
                     }
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -19,7 +19,7 @@ use crate::types::diagnostic::{
 use crate::types::generics::{GenericContext, InferableTypeVars, bind_typevar};
 use crate::types::infer::builder::annotation_expression::PEP613Policy;
 use crate::types::infer::builder::{ArgExpr, ArgumentsIter, MultiInferenceGuard};
-use crate::types::infer::{InferenceFlags, TypeExpressionFlags};
+use crate::types::infer::{CollectionUseConstraint, InferenceFlags, TypeExpressionFlags};
 use crate::types::special_form::AliasSpec;
 use crate::types::subscript::{LegacyGenericOrigin, SubscriptError, SubscriptErrorKind};
 use crate::types::tuple::{Tuple, TupleType};
@@ -1254,12 +1254,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Record the constraints for the object of the subscript assignment, if the object is an
         // unannotated collection literal.
-        if is_valid_assignment
+        if self.collection_constraint_target.is_some()
             && let Some(collection_def) = self.index.unannotated_collection_literal(object)
             && let Some((class_literal, _)) = object_ty.class_specialization(db)
         {
-            let identity_instance = Type::instance(db, class_literal.identity_specialization(db));
-            let collection_generic_context = class_literal.generic_context(db);
+            self.record_collection_dependencies(collection_def, [target.slice.as_ref(), rhs_value]);
+            let identity_instance = self
+                .collection_constraint_identity(collection_def)
+                .unwrap_or_else(|| Type::instance(db, class_literal.identity_specialization(db)));
+            let collection_generic_context = self
+                .collection_constraint_generic_context(collection_def)
+                .or_else(|| class_literal.generic_context(db));
 
             let ast_arguments = [
                 ArgOrKeyword::Arg(&target.slice),
@@ -1283,45 +1288,41 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut identity_bindings = dunder_callable
                     .bindings(db)
                     .match_parameters(db, &call_arguments)
-                    // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(db, collection_generic_context);
 
-                let call_result = self.speculate().infer_and_check_argument_types(
-                    ArgumentsIter::synthesized(&ast_arguments),
-                    &mut call_arguments,
-                    &mut |builder, (_, expr, tcx)| {
-                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                        // However, `object` would have been inferred to a be a collection with `Divergent`
-                        // element types, meaning the type context for a given argument, by which the inferred
-                        // type is keyed, may not be the same as the type context we get here. It is not immediately
-                        // clear how to retrieve those types, and so we just re-infer the argument expressions
-                        // for simplicity.
-                        builder.infer_maybe_standalone_expression(expr, tcx)
-                    },
-                    &mut identity_bindings,
-                    TypeContext::default(),
-                );
+                let constraint_projection = self
+                    .collection_constraint_projection()
+                    .or(collection_generic_context);
+                let call_result = self
+                    .speculate()
+                    .infer_and_check_argument_types_with_projection(
+                        ArgumentsIter::synthesized(&ast_arguments),
+                        &mut call_arguments,
+                        &mut |builder, (_, expr, tcx)| {
+                            // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                            // However, `object` would have been inferred to a be a collection with `Divergent`
+                            // element types, meaning the type context for a given argument, by which the inferred
+                            // type is keyed, may not be the same as the type context we get here. It is not immediately
+                            // clear how to retrieve those types, and so we just re-infer the argument expressions
+                            // for simplicity.
+                            let ty = builder.infer_maybe_standalone_expression(expr, tcx);
+                            builder.normalize_collection_constraint_type(ty)
+                        },
+                        &mut identity_bindings,
+                        TypeContext::default(),
+                        constraint_projection,
+                    );
 
                 if call_result.is_ok() && boundness == Definedness::AlwaysDefined {
-                    for call_specialization in identity_bindings
+                    for projected in identity_bindings
                         .iter_flat()
                         .flat_map(CallableBinding::matching_overloads)
-                        .filter_map(|(_, identity_overload)| identity_overload.specialization())
+                        .filter_map(|(_, overload)| overload.projected_constraints().cloned())
                     {
-                        // Record the constraints on the receiver's generic context formed by
-                        // the arguments to this dunder call.
-                        let Some(constraints) = self.collection_use_constraint_from_specialization(
-                            identity_instance,
-                            collection_generic_context,
-                            call_specialization,
-                        ) else {
-                            continue;
-                        };
-
                         self.collection_use_constraints
                             .entry(collection_def)
                             .or_default()
-                            .insert(constraints);
+                            .insert(CollectionUseConstraint::Projected(projected));
                     }
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -338,6 +338,23 @@ fn first_public_binding<'db>(db: &'db TestDb, file: File, name: &str) -> Definit
 }
 
 #[test]
+fn unconstrained_collection_without_uses_skips_constraint_query() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[Unknown]");
+
+    let events = db.take_salsa_events();
+    let x = first_public_binding(&db, file, "x");
+    assert_function_query_was_not_run(&db, infer_collection_use_constraints, x, &events);
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -385,6 +385,36 @@ fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyho
 }
 
 #[test]
+fn collection_escape_uses_cycle_based_constraints() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []\nx.append(1)\nd = {}\nd['x'] = x")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[int]");
+
+    let events = db.take_salsa_events();
+    let module = parsed_module(&db, file).load(&db);
+    let index = semantic_index(&db, file);
+    let x = first_public_binding(&db, file, "x");
+    let Statement::Expression(append) = index.try_statement(&module.syntax().body[1]).unwrap()
+    else {
+        panic!("expected `x.append(1)` to be a standalone expression");
+    };
+
+    assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
+    assert_function_query_was_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(append),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -385,7 +385,7 @@ fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyho
 }
 
 #[test]
-fn collection_escape_uses_cycle_based_constraints() -> anyhow::Result<()> {
+fn collection_escape_uses_collection_constraint_query() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_file("/src/a.py", "x = []\nx.append(1)\nd = {}\nd['x'] = x")?;
 
@@ -404,7 +404,7 @@ fn collection_escape_uses_cycle_based_constraints() -> anyhow::Result<()> {
     };
 
     assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
-    assert_function_query_was_run(
+    assert_function_query_was_not_run(
         &db,
         infer_expression_types_impl,
         InferExpression::Bare(append),

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -385,7 +385,7 @@ fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyho
 }
 
 #[test]
-fn collection_escape_uses_collection_constraint_query() -> anyhow::Result<()> {
+fn collection_escape_uses_cycle_based_constraints() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_file("/src/a.py", "x = []\nx.append(1)\nd = {}\nd['x'] = x")?;
 
@@ -404,7 +404,7 @@ fn collection_escape_uses_collection_constraint_query() -> anyhow::Result<()> {
     };
 
     assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
-    assert_function_query_was_not_run(
+    assert_function_query_was_run(
         &db,
         infer_expression_types_impl,
         InferExpression::Bare(append),

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -355,6 +355,36 @@ fn unconstrained_collection_without_uses_skips_constraint_query() -> anyhow::Res
 }
 
 #[test]
+fn unconstrained_collection_with_use_uses_cycle_free_constraint_query() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_file("/src/a.py", "x = []\nx.append(1)")?;
+
+    let file = system_path_to_file(&db, "/src/a.py").unwrap();
+    db.clear_salsa_events();
+    let x_ty = global_symbol(&db, file, "x").place.expect_type();
+    assert_eq!(x_ty.display(&db).to_string(), "list[int]");
+
+    let events = db.take_salsa_events();
+    let module = parsed_module(&db, file).load(&db);
+    let index = semantic_index(&db, file);
+    let x = first_public_binding(&db, file, "x");
+    let Statement::Expression(append) = index.try_statement(&module.syntax().body[1]).unwrap()
+    else {
+        panic!("expected `x.append(1)` to be a standalone expression");
+    };
+
+    assert_function_query_was_run(&db, infer_collection_use_constraints, x, &events);
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(append),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
     let mut db = setup_db();
 


### PR DESCRIPTION
## Summary

When an unannotated collection is constrained by multiple uses, we currently solve each use independently. This can commit to a type too early and produce false-positive diagnostics:

```python
class Rule: ...
class RewriteRule(Rule): ...
class ArctanRule(Rule): ...

def build(include_rewrite: bool):
    pieces = []
    if include_rewrite:
        pieces.append((RewriteRule(), True))
    if pieces:
        pieces.append((ArctanRule(), True))
```

We currently infer `pieces` as `list[tuple[RewriteRule, bool]]` and reject the second `append`. This change keeps the constraints from each use unsolved, combines them, and solves once, inferring `list[tuple[RewriteRule, bool] | tuple[ArctanRule, bool]]` without an error.

Collecting these constraints directly also avoids the repeated fixed-point inference that caused the SymPy performance regression. Cases whose constraints depend on broader control flow still use full statement inference, which now preserves the projected constraints before solving the collection type.

Closes https://github.com/astral-sh/ty/issues/3505.
