### PR TITLE
[ty] Implement "find references" for constructors

### DIFF
--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1628,6 +1628,853 @@ func<CURSOR>_alias()
     }
 
     #[test]
+    fn constructor_references_include_class_and_explicit_calls() {
+        let test = cursor_test(
+            "
+class Foo:
+    def __in<CURSOR>it__(self) -> None:
+        pass
+
+Foo()
+Foo.__init__(object.__new__(Foo))
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 3 references
+         --> main.py:3:9
+          |
+        3 |     def __init__(self) -> None:
+          |         --------
+        4 |         pass
+        5 |
+        6 | Foo()
+          | ---
+        7 | Foo.__init__(object.__new__(Foo))
+          |     --------
+          |
+        ");
+        assert_snapshot!(test.references_without_declaration(), @"
+        info[references]: Found 2 references
+         --> main.py:6:1
+          |
+        6 | Foo()
+          | ---
+        7 | Foo.__init__(object.__new__(Foo))
+          |     --------
+          |
+        ");
+    }
+
+    #[test]
+    fn class_references_keep_class_call_target() {
+        let test = cursor_test(
+            "
+class F<CURSOR>oo:
+    def __init__(self) -> None:
+        pass
+
+Foo()
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:2:7
+          |
+        2 | class Foo:
+          |       ---
+        3 |     def __init__(self) -> None:
+        4 |         pass
+        5 |
+        6 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn constructor_references_include_cross_file_alias_and_inherited_calls() {
+        let test = CursorTest::builder()
+            .source(
+                "model.py",
+                "
+class Box:
+    def __in<CURSOR>it__(self) -> None:
+        pass
+
+class Child(Box):
+    pass
+
+Alias = Box
+",
+            )
+            .source(
+                "caller.py",
+                "
+import model
+from model import Alias, Box as ImportedBox, Child
+
+model.Box()
+ImportedBox()
+Alias()
+Child()
+",
+            )
+            .build();
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 5 references
+         --> caller.py:5:7
+          |
+        5 | model.Box()
+          |       ---
+        6 | ImportedBox()
+          | -----------
+        7 | Alias()
+          | -----
+        8 | Child()
+          | -----
+          |
+         ::: model.py:3:9
+          |
+        3 |     def __init__(self) -> None:
+          |         --------
+          |
+        ");
+    }
+
+    #[test]
+    fn new_references_include_class_call() {
+        let test = cursor_test(
+            "
+class Foo:
+    def __ne<CURSOR>w__(cls):
+        return super().__new__(cls)
+
+Foo()
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:9
+          |
+        3 |     def __new__(cls):
+          |         -------
+        4 |         return super().__new__(cls)
+        5 |
+        6 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn init_references_include_calls_when_new_has_same_signature() {
+        let test = cursor_test(
+            r#"
+from typing import Self
+
+class Foo:
+    def __new__(cls, value: int) -> Self:
+        return object.__new__(cls)
+
+    def __in<CURSOR>it__(self, value: int) -> None:
+        pass
+
+Foo(1)
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:8:9
+           |
+         8 |     def __init__(self, value: int) -> None:
+           |         --------
+         9 |         pass
+        10 |
+        11 | Foo(1)
+           | ---
+           |
+        ");
+    }
+
+    #[test]
+    fn known_class_new_references_include_direct_call() {
+        let test = cursor_test(
+            r#"
+class TupleSubclass(tuple):
+    pass
+
+explicit = tuple.__ne<CURSOR>w__
+direct = tuple()
+inherited = TupleSubclass()
+"#,
+        );
+
+        assert_snapshot!(test.references());
+    }
+
+    #[test]
+    fn known_class_init_references_include_direct_call() {
+        let test = cursor_test(
+            r#"
+class PropertySubclass(property):
+    pass
+
+explicit = property.__in<CURSOR>it__
+direct = property()
+inherited = PropertySubclass()
+"#,
+        );
+
+        assert_snapshot!(test.references());
+    }
+
+    #[test]
+    fn polymorphic_class_calls_reference_constructor() {
+        let test = cursor_test(
+            r#"
+class Foo:
+    def __in<CURSOR>it__(self) -> None: pass
+
+class Bar:
+    def __init__(self) -> None: pass
+
+def from_subclass(cls: type[Foo]) -> None:
+    cls()
+
+def from_typevar[T: Foo](cls: type[T]) -> T:
+    return cls()
+
+def from_union(flag: bool) -> None:
+    constructor = Foo if flag else Bar
+    constructor()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 4 references
+          --> main.py:3:9
+           |
+         3 |     def __init__(self) -> None: pass
+           |         --------
+           |
+          ::: main.py:9:5
+           |
+         9 |     cls()
+           |     ---
+        10 |
+        11 | def from_typevar[T: Foo](cls: type[T]) -> T:
+        12 |     return cls()
+           |            ---
+        13 |
+        14 | def from_union(flag: bool) -> None:
+        15 |     constructor = Foo if flag else Bar
+        16 |     constructor()
+           |     -----------
+           |
+        ");
+    }
+
+    #[test]
+    fn possibly_reached_init_is_a_constructor_reference() {
+        let test = cursor_test(
+            r#"
+from typing import Self
+
+class Foo:
+    def __new__(cls, flag: bool) -> Self | int:
+        return object.__new__(cls) if flag else 1
+
+    def __in<CURSOR>it__(self, flag: bool) -> None: pass
+
+Foo(True)
+Foo("invalid")
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 3 references
+          --> main.py:8:9
+           |
+         8 |     def __init__(self, flag: bool) -> None: pass
+           |         --------
+         9 |
+        10 | Foo(True)
+           | ---
+        11 | Foo("invalid")
+           | ---
+           |
+        "#);
+    }
+
+    #[test]
+    fn generated_init_preserves_inherited_new_reference() {
+        let test = cursor_test(
+            r#"
+from dataclasses import dataclass
+from typing import Self
+
+class Base:
+    def __ne<CURSOR>w__(cls, value: int) -> Self:
+        return object.__new__(cls)
+
+@dataclass
+class Child(Base):
+    value: int
+
+Child(1)
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:6:9
+           |
+         6 |     def __new__(cls, value: int) -> Self:
+           |         -------
+           |
+          ::: main.py:13:1
+           |
+        13 | Child(1)
+           | -----
+           |
+        ");
+    }
+
+    #[test]
+    fn inherited_generated_init_shadows_grandparent_reference() {
+        let test = cursor_test(
+            r#"
+from dataclasses import dataclass
+
+class Base:
+    def __in<CURSOR>it__(self) -> None: pass
+
+@dataclass
+class Generated(Base):
+    value: int
+
+class Child(Generated):
+    pass
+
+Base()
+Generated(1)
+Child(1)
+"#,
+        );
+
+        assert_snapshot!(test.references());
+    }
+
+    #[test]
+    fn short_circuited_dispatch_does_not_reference_init() {
+        let test = cursor_test(
+            r#"
+class Base:
+    def __in<CURSOR>it__(self) -> None: pass
+
+class ForeignNew(Base):
+    def __new__(cls) -> int: return 1
+
+class Meta(type):
+    def __call__(cls) -> object: return object()
+
+class MetaFactory(Base, metaclass=Meta): pass
+
+Base()
+ForeignNew()
+MetaFactory()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:3:9
+           |
+         3 |     def __init__(self) -> None: pass
+           |         --------
+           |
+          ::: main.py:13:1
+           |
+        13 | Base()
+           | ----
+           |
+        ");
+    }
+
+    #[test]
+    fn constructor_dispatch_uses_matching_overload_return() {
+        let test = cursor_test(
+            r#"
+from typing import Self, overload
+
+class Foo:
+    @overload
+    def __new__(cls, value: int) -> int: ...
+    @overload
+    def __new__(cls, value: str) -> Self: ...
+    def __new__(cls, value: int | str) -> Self | int:
+        return 1 if isinstance(value, int) else object.__new__(cls)
+
+    def __in<CURSOR>it__(self, value: object) -> None: pass
+
+Foo(1)
+Foo("one")
+"#,
+        );
+
+        assert_snapshot!(test.references(), @r#"
+        info[references]: Found 2 references
+          --> main.py:12:9
+           |
+        12 |     def __init__(self, value: object) -> None: pass
+           |         --------
+        13 |
+        14 | Foo(1)
+        15 | Foo("one")
+           | ---
+           |
+        "#);
+    }
+
+    #[test]
+    fn metaclass_call_short_circuits_new_reference() {
+        let test = cursor_test(
+            r#"
+class Base:
+    def __ne<CURSOR>w__(cls): return object.__new__(cls)
+
+class Meta(type):
+    def __call__(cls) -> object: return object()
+
+class MetaFactory(Base, metaclass=Meta): pass
+
+Base()
+MetaFactory()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:3:9
+           |
+         3 |     def __new__(cls): return object.__new__(cls)
+           |         -------
+           |
+          ::: main.py:10:1
+           |
+        10 | Base()
+           | ----
+           |
+        ");
+    }
+
+    #[test]
+    fn foreign_returning_new_is_still_referenced() {
+        let test = cursor_test(
+            r#"
+class Foo:
+    def __ne<CURSOR>w__(cls) -> int: return 1
+    def __init__(self) -> None: pass
+
+Foo()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:9
+          |
+        3 |     def __new__(cls) -> int: return 1
+          |         -------
+        4 |     def __init__(self) -> None: pass
+        5 |
+        6 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn enum_lookup_does_not_reference_custom_new() {
+        let test = cursor_test(
+            r#"
+from enum import Enum
+
+class Color(Enum):
+    RED = 1
+
+    def __ne<CURSOR>w__(cls, value: int):
+        member = object.__new__(cls)
+        member._value_ = value
+        return member
+
+Color(1)
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 1 references
+         --> main.py:7:9
+          |
+        7 |     def __new__(cls, value: int):
+          |         -------
+          |
+        ");
+    }
+
+    #[test]
+    fn dunder_named_classes_are_constructor_references() {
+        let test = cursor_test(
+            r#"
+class __init__:
+    def __in<CURSOR>it__(self) -> None:
+        pass
+
+__init__()
+Alias = __init__
+Alias()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 3 references
+         --> main.py:3:9
+          |
+        3 |     def __init__(self) -> None:
+          |         --------
+        4 |         pass
+        5 |
+        6 | __init__()
+          | --------
+        7 | Alias = __init__
+        8 | Alias()
+          | -----
+          |
+        ");
+    }
+
+    #[test]
+    fn compound_explicit_method_call_has_one_reference_per_method() {
+        let test = cursor_test(
+            r#"
+class Foo:
+    def __in<CURSOR>it__(self) -> None:
+        pass
+
+class Bar:
+    def __init__(self) -> None:
+        pass
+
+flag = True
+(Foo.__init__ if flag else Bar.__init__)(object.__new__(Foo))
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:3:9
+           |
+         3 |     def __init__(self) -> None:
+           |         --------
+           |
+          ::: main.py:11:6
+           |
+        11 | (Foo.__init__ if flag else Bar.__init__)(object.__new__(Foo))
+           |      --------
+           |
+        ");
+    }
+
+    #[test]
+    fn decorated_init_references_include_class_call() {
+        let test = cursor_test(
+            r#"
+def preserve[T](value: T) -> T: return value
+class Foo:
+    @preserve
+    def __in<CURSOR>it__(self) -> None: pass
+Foo()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:5:9
+          |
+        5 |     def __init__(self) -> None: pass
+          |         --------
+        6 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn decorated_new_references_include_class_call() {
+        let test = cursor_test(
+            r#"
+from typing import Self
+def preserve[T](value: T) -> T: return value
+class Foo:
+    @staticmethod
+    @preserve
+    def __ne<CURSOR>w__(cls) -> Self: return object.__new__(cls)
+Foo()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:7:9
+          |
+        7 |     def __new__(cls) -> Self: return object.__new__(cls)
+          |         -------
+        8 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn any_decorated_new_references_include_class_call() {
+        let test = cursor_test(
+            r#"
+from typing import Any, Self
+
+def opaque(value: object) -> Any: return value
+
+class Foo:
+    @opaque
+    def __ne<CURSOR>w__(cls) -> Self: return object.__new__(cls)
+
+    def __init__(self) -> None: pass
+
+Foo()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:8:9
+           |
+         8 |     def __new__(cls) -> Self: return object.__new__(cls)
+           |         -------
+         9 |
+        10 |     def __init__(self) -> None: pass
+        11 |
+        12 | Foo()
+           | ---
+           |
+        ");
+    }
+
+    #[test]
+    fn constructor_references_require_explicit_call_expressions() {
+        let test = cursor_test(
+            r#"
+class Decorator:
+    def __in<CURSOR>it__(self, decorated: object | None = None) -> None:
+        pass
+
+    def __call__(self, decorated: object) -> object:
+        return decorated
+
+@Decorator
+def bare():
+    pass
+
+@Decorator()
+def called():
+    pass
+
+def factory() -> type[Decorator]:
+    return Decorator
+
+@factory()
+def returned_class():
+    pass
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:3:9
+           |
+         3 |     def __init__(self, decorated: object | None = None) -> None:
+           |         --------
+           |
+          ::: main.py:13:2
+           |
+        13 | @Decorator()
+           |  ---------
+           |
+        ");
+    }
+
+    #[test]
+    fn string_annotations_do_not_create_constructor_references() {
+        let test = cursor_test(
+            r#"
+class Foo:
+    def __in<CURSOR>it__(self) -> None:
+        pass
+
+annotation: "Foo()"
+Foo()
+"#,
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:9
+          |
+        3 |     def __init__(self) -> None:
+          |         --------
+          |
+         ::: main.py:7:1
+          |
+        7 | Foo()
+          | ---
+          |
+        ");
+    }
+
+    #[test]
+    fn assigned_constructor_implementation_does_not_include_class_call() {
+        let test = cursor_test(
+            "
+class Foo:
+    def constr<CURSOR>uct(self) -> None: pass
+    __init__ = construct
+
+Foo()
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:3:9
+          |
+        3 |     def construct(self) -> None: pass
+          |         ---------
+        4 |     __init__ = construct
+          |                ---------
+          |
+        ");
+    }
+
+    #[test]
+    fn assigned_constructor_binding_does_not_include_class_call() {
+        let test = cursor_test(
+            "
+def constructor(self) -> None: pass
+
+class Foo:
+    __in<CURSOR>it__ = constructor
+
+Foo()
+Foo.__init__(object.__new__(Foo))
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+         --> main.py:5:5
+          |
+        5 |     __init__ = constructor
+          |     --------
+        6 |
+        7 | Foo()
+        8 | Foo.__init__(object.__new__(Foo))
+          |     --------
+          |
+        ");
+    }
+
+    #[test]
+    fn non_source_constructors_shadow_inherited_function() {
+        let test = cursor_test(
+            "
+from dataclasses import dataclass
+
+def replacement(self) -> None: pass
+
+class Base:
+    def __in<CURSOR>it__(self) -> None: pass
+
+class Child(Base):
+    __init__ = replacement
+
+@dataclass
+class Generated(Base):
+    value: int
+
+Dynamic = type(\"Dynamic\", (Base,), {\"__init__\": replacement})
+class DynamicChild(Dynamic): pass
+Base()
+Child()
+Generated(1)
+Dynamic()
+DynamicChild()
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 2 references
+          --> main.py:7:9
+           |
+         7 |     def __init__(self) -> None: pass
+           |         --------
+           |
+          ::: main.py:18:1
+           |
+        18 | Base()
+           | ----
+           |
+        ");
+    }
+
+    #[test]
+    fn call_references_do_not_include_implicit_dunder_call_invocation() {
+        let test = cursor_test(
+            "
+class Callable:
+    def __ca<CURSOR>ll__(self) -> None: pass
+
+Callable()()
+",
+        );
+
+        assert_snapshot!(test.references(), @"
+        info[references]: Found 1 references
+         --> main.py:3:9
+          |
+        3 |     def __call__(self) -> None: pass
+          |         --------
+          |
+        ");
+    }
+
+    #[test]
+    fn references_from_call_parentheses_do_not_include_constructor_calls() {
+        let test = cursor_test(
+            "
+class Foo:
+    def __init__(self) -> None: pass
+
+Foo(<CURSOR>)
+",
+        );
+
+        assert_snapshot!(test.references(), @"No references found");
+    }
+
+    #[test]
     fn import_alias() {
         let test = CursorTest::builder()
             .source(

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -20,8 +20,9 @@ use ruff_python_ast::{
     visitor::source_order::{SourceOrderVisitor, TraversalSignal},
 };
 use ruff_text_size::Ranged;
-use ty_python_core::definition::{Definition, DefinitionState};
+use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
 use ty_python_core::scope::ScopeKind;
+use ty_python_semantic::types::ide_support::constructor_definitions_for_call;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
 /// Mode for references search behavior
@@ -87,9 +88,18 @@ pub(crate) fn references(
 
     // Extract the target text from the goto target for fast comparison
     let target_text = goto_target.to_string()?;
+    let search_constructor_calls =
+        should_search_constructor_calls(db, &target_definitions, &target_text, mode);
 
     // Find all of the references to the symbol within this file
-    let mut references = references_for_file(db, file, &target_definitions, &target_text, mode);
+    let mut references = references_for_file(
+        db,
+        file,
+        &target_definitions,
+        &target_text,
+        search_constructor_calls,
+        mode,
+    );
 
     // Check if we should search across files based on the mode
     let search_across_files = matches!(
@@ -127,15 +137,25 @@ pub(crate) fn references(
                     s.spawn(move |_| {
                         let db = &*db;
 
-                        // First do a simple text search to see if there is a potential match in the file
+                        // First do a simple text search to see if there is a potential match in the
+                        // file. Constructor searches must skip this prefilter because `Foo()` can
+                        // reference `Foo.__init__` or `Foo.__new__` without containing either
+                        // method name.
                         let source = ruff_db::source::source_text(db, other_file);
-                        if !contains_identifier(&source, needle) {
+                        if !search_constructor_calls && !contains_identifier(&source, needle) {
                             return;
                         }
 
-                        // If the target text is found, do the more expensive semantic analysis
+                        // Perform the more expensive semantic analysis after the prefilter.
                         let references = if is_externally_visible_symbol {
-                            references_for_file(db, other_file, target_definitions, needle, mode)
+                            references_for_file(
+                                db,
+                                other_file,
+                                target_definitions,
+                                needle,
+                                search_constructor_calls,
+                                mode,
+                            )
                         } else {
                             references_for_keyword_arguments_in_file(
                                 db,
@@ -187,6 +207,7 @@ fn references_for_keyword_arguments_in_file(
         references: &mut references,
         mode,
         target_text,
+        search_constructor_calls: false,
         ancestors: Vec::new(),
     });
 
@@ -232,6 +253,7 @@ fn references_for_file(
     file: File,
     target_definitions: &Definitions<'_>,
     target_text: &str,
+    search_constructor_calls: bool,
     mode: ReferencesMode,
 ) -> Vec<ReferenceTarget> {
     let parsed = ruff_db::parsed::parsed_module(db, file);
@@ -246,6 +268,7 @@ fn references_for_file(
         mode,
         tokens: module.tokens(),
         target_text,
+        search_constructor_calls,
         ancestors: Vec::new(),
     };
 
@@ -339,6 +362,31 @@ fn parameter_owner_is_externally_visible_for_target(
     matches!(owner, Some(AnyNodeRef::StmtFunctionDef(_)))
 }
 
+/// Returns whether finding references should also search class calls such as `Foo()`.
+///
+/// A call to `Foo()` can invoke `Foo.__init__` or `Foo.__new__`, even though the call site contains
+/// neither method name. The additional search is only needed when finding references to an
+/// `__init__` or `__new__` method defined on a class.
+fn should_search_constructor_calls(
+    db: &dyn Db,
+    target_definitions: &Definitions<'_>,
+    target_text: &str,
+    mode: ReferencesMode,
+) -> bool {
+    matches!(
+        mode,
+        ReferencesMode::References | ReferencesMode::ReferencesSkipDeclaration
+    ) && matches!(target_text, "__init__" | "__new__")
+        && target_definitions.iter().any(|resolved| {
+            let Some(definition) = resolved.definition() else {
+                return false;
+            };
+            matches!(*definition.kind(db), DefinitionKind::Function(_))
+                && definition.scope(db).scope(db).kind() == ScopeKind::Class
+                && definition.name(db).is_some_and(|name| name == target_text)
+        })
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum OccurrenceKind {
     /// An identifier that references a symbol.
@@ -376,6 +424,7 @@ struct LocalReferencesFinder<'a> {
     references: &'a mut Vec<ReferenceTarget>,
     mode: ReferencesMode,
     target_text: &'a str,
+    search_constructor_calls: bool,
     ancestors: Vec<AnyNodeRef<'a>>,
 }
 
@@ -384,6 +433,11 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
         self.ancestors.push(node);
 
         match node {
+            AnyNodeRef::ExprCall(call) => {
+                if self.search_constructor_calls {
+                    self.check_constructor_call(call);
+                }
+            }
             AnyNodeRef::ExprName(name_expr) => {
                 // If the name doesn't match our target text, this isn't a match
                 if name_expr.id.as_str() != self.target_text {
@@ -462,6 +516,8 @@ impl<'a> SourceOrderVisitor<'a> for LocalReferencesFinder<'a> {
                         mode: self.mode,
                         tokens: sub_ast.tokens(),
                         target_text: self.target_text,
+                        // Parsed string annotations do not execute their expressions.
+                        search_constructor_calls: false,
                         ancestors: Vec::new(),
                     };
                     sub_finder.visit_expr(sub_ast.expr());
@@ -557,6 +613,27 @@ impl<'a> LocalReferencesFinder<'a> {
             .goto_declaration(self.model, &goto_target)?;
 
         Some(definitions)
+    }
+
+    /// Records a constructor-method reference for an explicit class call.
+    fn check_constructor_call(&mut self, call: &'a ast::ExprCall) {
+        let matches_target = constructor_definitions_for_call(self.model, call)
+            .into_iter()
+            .any(|current| {
+                self.target_definitions
+                    .iter()
+                    .any(|target| target.definition() == Some(current))
+            });
+        if !matches_target {
+            return;
+        }
+
+        let range = match &*call.func {
+            ast::Expr::Attribute(attribute) => attribute.attr.range,
+            expression => expression.range(),
+        };
+        let target = ReferenceTarget::new(self.model.file(), range, ReferenceKind::Read);
+        self.references.push(target);
     }
 
     fn check_covering_node(&mut self, covering_node: &CoveringNode<'_>, kind: OccurrenceKind) {

--- a/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__inherited_generated_init_shadows_grandparent_reference.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__inherited_generated_init_shadows_grandparent_reference.snap
@@ -1,0 +1,15 @@
+---
+source: crates/ty_ide/src/find_references.rs
+expression: test.references()
+---
+info[references]: Found 2 references
+  --> main.py:5:9
+   |
+ 5 |     def __init__(self) -> None: pass
+   |         --------
+   |
+  ::: main.py:14:1
+   |
+14 | Base()
+   | ----
+   |

--- a/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__known_class_init_references_include_direct_call.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__known_class_init_references_include_direct_call.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ty_ide/src/find_references.rs
+expression: test.references()
+---
+info[references]: Found 3 references
+ --> main.py:5:21
+  |
+5 | explicit = property.__init__
+  |                     --------
+6 | direct = property()
+  |          --------
+7 | inherited = PropertySubclass()
+  |             ----------------
+  |

--- a/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__known_class_new_references_include_direct_call.snap
+++ b/crates/ty_ide/src/snapshots/ty_ide__find_references__tests__known_class_new_references_include_direct_call.snap
@@ -1,0 +1,14 @@
+---
+source: crates/ty_ide/src/find_references.rs
+expression: test.references()
+---
+info[references]: Found 3 references
+ --> main.py:5:18
+  |
+5 | explicit = tuple.__new__
+  |                  -------
+6 | direct = tuple()
+  |          -----
+7 | inherited = TupleSubclass()
+  |             -------------
+  |

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5157,7 +5157,9 @@ impl<'db> Type<'db> {
             return fallback_bindings();
         };
 
-        bindings.with_generic_context(db, class_generic_context)
+        bindings
+            .with_generic_context(db, class_generic_context)
+            .with_constructor_source_class(class)
     }
 
     /// Calls `self`. Returns a [`CallError`] if `self` is (always or possibly) not callable, or if

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -60,11 +60,12 @@ use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
     BindingContext, BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes,
-    ClassLiteral, DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType, GenericAlias,
-    InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass, KnownInstanceType,
-    LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType, SpecialFormType,
-    TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
+    ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams, DynamicType,
+    GenericAlias, InternedConstraintSet, IntersectionType, KnownBoundMethodType, KnownClass,
+    KnownInstanceType, LiteralValueTypeKind, NominalInstanceType, PropertyInstanceType,
+    SpecialFormType, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+    TypeVarVariance, UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums,
+    list_members,
 };
 use crate::{DisplaySettings, FxOrderSet, Program};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
@@ -72,6 +73,15 @@ use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
 use ty_python_core::semantic_index;
 
 pub(crate) use self::constructor::ConstructorCallableKind;
+
+/// Determines when call analysis retains a downstream constructor step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DownstreamConstructorPolicy {
+    /// Keep downstream steps only when type checking confirms an instance return.
+    RequireInstanceReturn,
+    /// Keep downstream steps whenever a declared return can produce an instance.
+    AllowPossibleInstanceReturn,
+}
 
 fn generic_contexts_mentioned_in_type<'db>(
     db: &'db dyn Db,
@@ -205,13 +215,20 @@ impl<'db> CallableItem<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        downstream_policy: DownstreamConstructorPolicy,
     ) {
         match self {
             CallableItem::Regular(binding) => {
                 binding.check_types(db, constraints, argument_types, call_expression_tcx);
             }
             CallableItem::Constructor(binding) => {
-                binding.check_types(db, constraints, argument_types, call_expression_tcx);
+                binding.check_types(
+                    db,
+                    constraints,
+                    argument_types,
+                    call_expression_tcx,
+                    downstream_policy,
+                );
             }
         }
     }
@@ -383,9 +400,16 @@ impl<'db> BindingsElement<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        downstream_policy: DownstreamConstructorPolicy,
     ) {
         for item in &mut self.items {
-            item.check_types(db, constraints, call_arguments, call_expression_tcx);
+            item.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                downstream_policy,
+            );
         }
     }
 
@@ -538,6 +562,15 @@ impl<'db> Bindings<'db> {
         }
     }
 
+    fn set_constructor_source_class_in_place(&mut self, class: ClassType<'db>) {
+        for constructor in self.iter_constructor_items_mut() {
+            constructor.set_source_class(class);
+            if let Some(downstream) = constructor.downstream_constructor_mut() {
+                downstream.set_constructor_source_class_in_place(class);
+            }
+        }
+    }
+
     fn apply_generic_context_in_place(
         &mut self,
         db: &'db dyn Db,
@@ -653,6 +686,12 @@ impl<'db> Bindings<'db> {
         self
     }
 
+    /// Retains the source class for every step in this constructor chain.
+    pub(crate) fn with_constructor_source_class(mut self, class: ClassType<'db>) -> Self {
+        self.set_constructor_source_class_in_place(class);
+        self
+    }
+
     pub(crate) fn into_constructor_bindings(
         mut self,
         constructor_instance_type: Type<'db>,
@@ -747,6 +786,40 @@ impl<'db> Bindings<'db> {
     fn iter_constructor_items(&self) -> impl Iterator<Item = &ConstructorBinding<'db>> {
         self.iter_callable_items()
             .filter_map(CallableItem::as_constructor)
+    }
+
+    /// Returns whether these bindings contain constructor call steps.
+    pub(crate) fn has_constructor_bindings(&self, db: &'db dyn Db) -> bool {
+        self.iter_callable_items().any(|item| {
+            item.as_constructor().is_some()
+                || item.callable().effective_constructor_source(db).is_some()
+        })
+    }
+
+    /// Visits the reachable constructor steps retained in this binding graph.
+    ///
+    /// The type-checking policy determines whether this contains only definitely reached steps or
+    /// every step that a runtime result may reach.
+    pub(crate) fn visit_reachable_constructors(
+        &self,
+        db: &'db dyn Db,
+        visit: &mut impl FnMut(ClassType<'db>, ConstructorCallableKind),
+    ) {
+        for item in self.iter_callable_items() {
+            let constructor = item.as_constructor();
+            if let Some((class, kind)) = item.callable().effective_constructor_source(db) {
+                visit(class, kind);
+            } else if let Some((class, kind)) =
+                constructor.and_then(|constructor| constructor.source_class_and_kind(db))
+            {
+                visit(class, kind);
+            }
+            if let Some(downstream) =
+                constructor.and_then(ConstructorBinding::downstream_constructor)
+            {
+                downstream.visit_reachable_constructors(db, visit);
+            }
+        }
     }
 
     fn iter_constructor_items_mut(&mut self) -> impl Iterator<Item = &mut ConstructorBinding<'db>> {
@@ -996,19 +1069,61 @@ impl<'db> Bindings<'db> {
     /// parameters, and any errors resulting from binding the call, all for each union element and
     /// overload (if any).
     pub(crate) fn check_types(
-        mut self,
+        self,
         db: &'db dyn Db,
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
     ) -> Result<Self, CallError<'db>> {
-        match self.check_types_impl(
+        self.check_types_with_downstream_policy(
             db,
             constraints,
             call_arguments,
             call_expression_tcx,
             dataclass_field_specifiers,
+            DownstreamConstructorPolicy::RequireInstanceReturn,
+        )
+    }
+
+    /// Type-checks a call while retaining every constructor step that may run.
+    ///
+    /// Unlike ordinary call analysis, invalid arguments and return types that only sometimes
+    /// produce the constructed instance do not discard downstream constructor steps.
+    pub(crate) fn check_types_for_constructor_references(
+        self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_arguments: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+        dataclass_field_specifiers: &[Type<'db>],
+    ) -> Result<Self, CallError<'db>> {
+        self.check_types_with_downstream_policy(
+            db,
+            constraints,
+            call_arguments,
+            call_expression_tcx,
+            dataclass_field_specifiers,
+            DownstreamConstructorPolicy::AllowPossibleInstanceReturn,
+        )
+    }
+
+    fn check_types_with_downstream_policy(
+        mut self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_arguments: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+        dataclass_field_specifiers: &[Type<'db>],
+        downstream_policy: DownstreamConstructorPolicy,
+    ) -> Result<Self, CallError<'db>> {
+        match self.check_types_impl_with_downstream_policy(
+            db,
+            constraints,
+            call_arguments,
+            call_expression_tcx,
+            dataclass_field_specifiers,
+            downstream_policy,
         ) {
             Ok(()) => Ok(self),
             Err(err) => Err(CallError(err, Box::new(self))),
@@ -1023,9 +1138,34 @@ impl<'db> Bindings<'db> {
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
     ) -> Result<(), CallErrorKind> {
+        self.check_types_impl_with_downstream_policy(
+            db,
+            constraints,
+            call_arguments,
+            call_expression_tcx,
+            dataclass_field_specifiers,
+            DownstreamConstructorPolicy::RequireInstanceReturn,
+        )
+    }
+
+    fn check_types_impl_with_downstream_policy(
+        &mut self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        call_arguments: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+        dataclass_field_specifiers: &[Type<'db>],
+        downstream_policy: DownstreamConstructorPolicy,
+    ) -> Result<(), CallErrorKind> {
         // Check types for each element (union variant)
         for element in &mut self.elements {
-            element.check_types(db, constraints, call_arguments, call_expression_tcx);
+            element.check_types(
+                db,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+                downstream_policy,
+            );
         }
 
         self.evaluate_known_cases(db, call_arguments, dataclass_field_specifiers);
@@ -1039,6 +1179,7 @@ impl<'db> Bindings<'db> {
                 call_arguments,
                 call_expression_tcx,
                 dataclass_field_specifiers,
+                downstream_policy,
             );
         }
 
@@ -2907,6 +3048,31 @@ impl<'db> CallableBinding<'db> {
             matching_overload_before_type_checking: None,
             overloads: smallvec![],
         }
+    }
+
+    /// Returns the source represented by a synthesized, effective class-call signature.
+    ///
+    /// Bespoke known-class bindings retain their exact class as the callable type, so reference
+    /// analysis can recover constructor identity without changing their call semantics.
+    fn effective_constructor_source(
+        &self,
+        db: &'db dyn Db,
+    ) -> Option<(ClassType<'db>, ConstructorCallableKind)> {
+        let Type::ClassLiteral(class) = self.callable_type else {
+            return None;
+        };
+        let kind = match class.known(db)? {
+            KnownClass::Object | KnownClass::Property | KnownClass::Super => {
+                ConstructorCallableKind::Init
+            }
+            KnownClass::Bool
+            | KnownClass::Deprecated
+            | KnownClass::FunctoolsPartial
+            | KnownClass::Tuple
+            | KnownClass::TypeAliasType => ConstructorCallableKind::New,
+            _ => return None,
+        };
+        Some((ClassType::NonGeneric(class), kind))
     }
 
     /// Rewrites overload signatures as if an implicit bound receiver argument had already been

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -1,10 +1,10 @@
-use super::{Binding, Bindings, CallableBinding, CallableItem};
+use super::{Binding, Bindings, CallableBinding, CallableItem, DownstreamConstructorPolicy};
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::generics::Specialization;
 use crate::types::signatures::Parameter;
-use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeContext};
+use crate::types::{BoundTypeVarInstance, ClassLiteral, ClassType, DynamicType, Type, TypeContext};
 
 /// Bindings for a constructor call.
 ///
@@ -20,8 +20,8 @@ use crate::types::{BoundTypeVarInstance, ClassLiteral, DynamicType, Type, TypeCo
 pub(super) struct ConstructorBinding<'db> {
     /// The `CallableBinding` for this individual constructor method.
     pub(super) entry: CallableBinding<'db>,
-    /// Context for the constructor callable: the instance type being constructed and the kind of
-    /// constructor method.
+    /// Context for the constructor callable: the instance type being constructed, its source
+    /// class when known, and the kind of constructor method.
     pub(super) constructor_context: ConstructorContext<'db>,
     /// The next downstream constructor method, if any, to be (conditionally) checked after this
     /// one.
@@ -60,6 +60,11 @@ impl<'db> ConstructorBinding<'db> {
         self.constructor_context = self.constructor_context.with_instance_type(instance_type);
     }
 
+    /// Retains the class that supplied this constructor chain for source navigation.
+    pub(super) fn set_source_class(&mut self, class: ClassType<'db>) {
+        self.constructor_context = self.constructor_context.with_source_class(class);
+    }
+
     pub(super) fn set_downstream_constructor(&mut self, bindings: Bindings<'db>) {
         self.downstream_constructor = Some(Box::new(bindings));
     }
@@ -84,6 +89,7 @@ impl<'db> ConstructorBinding<'db> {
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
+        downstream_policy: DownstreamConstructorPolicy,
     ) {
         /// For constructors which may have downstreams (that is, metaclass `__call__` or `__new__`),
         /// analyze their overloads to determine whether to check downstream constructors.
@@ -95,6 +101,7 @@ impl<'db> ConstructorBinding<'db> {
         fn should_check_downstream<'db>(
             binding: &ConstructorBinding<'db>,
             db: &'db dyn Db,
+            downstream_policy: DownstreamConstructorPolicy,
         ) -> bool {
             let constructor_kind = binding.constructor_kind();
             if constructor_kind.is_init() || binding.downstream_constructor().is_none() {
@@ -103,21 +110,44 @@ impl<'db> ConstructorBinding<'db> {
 
             let callable = binding.callable();
 
-            if callable.as_result().is_err() {
+            if downstream_policy == DownstreamConstructorPolicy::RequireInstanceReturn
+                && callable.as_result().is_err()
+            {
                 return false;
             }
 
             let constructed_instance_type = binding.constructed_instance_type();
             let constructor_class_literal = binding.constructed_class_literal(db);
 
-            // If any matching overload returns the constructed instance type itself, or an instance of
-            // the constructed class, we need to check downstream constructors.
-            callable.matching_overloads().any(|(_, overload)| {
+            let reaches_downstream = |overload: &Binding<'db>| {
                 overload.return_ty == constructed_instance_type
-                    || constructor_class_literal.is_some_and(|class_literal| {
-                        constructor_returns_instance(db, class_literal, overload.return_ty)
-                    })
-            })
+                    || constructor_class_literal.is_some_and(
+                        |class_literal| match downstream_policy {
+                            DownstreamConstructorPolicy::RequireInstanceReturn => {
+                                constructor_returns_instance(db, class_literal, overload.return_ty)
+                            }
+                            DownstreamConstructorPolicy::AllowPossibleInstanceReturn => {
+                                constructor_may_return_instance(
+                                    db,
+                                    class_literal,
+                                    overload.return_ty,
+                                )
+                            }
+                        },
+                    )
+            };
+
+            // Prefer the overloads selected for this call. An invalid call may not select any;
+            // reference analysis then keeps every path that any declared overload could invoke.
+            let mut matching_overloads = callable.matching_overloads();
+            if matching_overloads.clone().next().is_some() {
+                matching_overloads.any(|(_, overload)| reaches_downstream(overload))
+            } else if downstream_policy == DownstreamConstructorPolicy::AllowPossibleInstanceReturn
+            {
+                callable.overloads().iter().any(reaches_downstream)
+            } else {
+                false
+            }
         }
 
         self.entry
@@ -125,7 +155,7 @@ impl<'db> ConstructorBinding<'db> {
 
         // Now that we've fully checked our own callable, we can determine whether downstream
         // constructors should be checked or not.
-        if !should_check_downstream(self, db) {
+        if !should_check_downstream(self, db, downstream_policy) {
             // If not, we can discard the downstream constructor bindings entirely.
             self.downstream_constructor = None;
         }
@@ -139,16 +169,18 @@ impl<'db> ConstructorBinding<'db> {
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
         dataclass_field_specifiers: &[Type<'db>],
+        downstream_policy: DownstreamConstructorPolicy,
     ) {
         if let Some(downstream) = self.downstream_constructor_mut() {
             // We discard the result here, but that's fine; it's `report_diagnostics` and
             // `as_result` that ultimately matter.
-            let _ = downstream.check_types_impl(
+            let _ = downstream.check_types_impl_with_downstream_policy(
                 db,
                 constraints,
                 argument_types,
                 call_expression_tcx,
                 dataclass_field_specifiers,
+                downstream_policy,
             );
         }
     }
@@ -488,11 +520,28 @@ impl<'db> ConstructorBinding<'db> {
         )
     }
 
-    fn constructed_class_literal(&self, db: &'db dyn Db) -> Option<ClassLiteral<'db>> {
+    fn constructed_class(&self, db: &'db dyn Db) -> Option<ClassType<'db>> {
         self.constructed_instance_type()
             .as_nominal_instance()
-            // TODO may need to handle `Type::KnownInstance` here as well?
-            .map(|instance| instance.class(db).class_literal(db))
+            .map(|instance| instance.class(db))
+    }
+
+    fn constructed_class_literal(&self, db: &'db dyn Db) -> Option<ClassLiteral<'db>> {
+        // TODO may need to handle `Type::KnownInstance` here as well?
+        self.constructed_class(db)
+            .map(|class| class.class_literal(db))
+    }
+
+    /// Returns the source class and the role of this step in its constructor chain.
+    pub(super) fn source_class_and_kind(
+        &self,
+        db: &'db dyn Db,
+    ) -> Option<(ClassType<'db>, ConstructorCallableKind)> {
+        let class = self
+            .constructor_context
+            .source_class()
+            .or_else(|| self.constructed_class(db))?;
+        Some((class, self.constructor_kind()))
     }
 
     fn constructor_kind(&self) -> ConstructorCallableKind {
@@ -503,6 +552,7 @@ impl<'db> ConstructorBinding<'db> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct ConstructorContext<'db> {
     instance_type: Type<'db>,
+    source_class: Option<ClassType<'db>>,
     kind: ConstructorCallableKind,
 }
 
@@ -510,6 +560,7 @@ impl<'db> ConstructorContext<'db> {
     pub(super) fn new(instance_type: Type<'db>, kind: ConstructorCallableKind) -> Self {
         Self {
             instance_type,
+            source_class: None,
             kind,
         }
     }
@@ -521,8 +572,19 @@ impl<'db> ConstructorContext<'db> {
         }
     }
 
+    fn with_source_class(self, source_class: ClassType<'db>) -> Self {
+        Self {
+            source_class: Some(source_class),
+            ..self
+        }
+    }
+
     fn instance_type(self) -> Type<'db> {
         self.instance_type
+    }
+
+    fn source_class(self) -> Option<ClassType<'db>> {
+        self.source_class
     }
 
     fn kind(self) -> ConstructorCallableKind {
@@ -581,6 +643,25 @@ fn constructor_returns_instance<'db>(
         // type, or it will return an explicit annotation of the protocol type itself, in which
         // case we shouldn't (and don't) consider it an instance of the subclass.
         _ => false,
+    }
+}
+
+/// Returns whether the annotated constructor result can take the instance-returning path.
+///
+/// Reference analysis treats unions and gradual types conservatively because the downstream
+/// constructor can still run for at least one runtime result.
+fn constructor_may_return_instance<'db>(
+    db: &'db dyn Db,
+    class_literal: ClassLiteral<'db>,
+    return_ty: Type<'db>,
+) -> bool {
+    match return_ty.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .any(|element| constructor_may_return_instance(db, class_literal, *element)),
+        Type::Dynamic(_) => true,
+        return_ty => constructor_returns_instance(db, class_literal, return_ty),
     }
 }
 

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -3,9 +3,11 @@ use std::collections::HashMap;
 use crate::FxIndexSet;
 use crate::place::builtins_module_scope;
 use crate::reachability::is_range_reachable;
+use crate::types::call::bind::ConstructorCallableKind;
 use crate::types::call::{CallArguments, CallError, MatchedArgument};
 use crate::types::class::{DynamicClassAnchor, DynamicEnumAnchor, DynamicNamedTupleAnchor};
 use crate::types::constraints::ConstraintSetBuilder;
+use crate::types::member::class_member;
 use crate::types::signatures::{ParametersKind, Signature};
 use crate::types::{
     CallDunderError, CallableTypes, ClassBase, ClassLiteral, ClassType, KnownClass, KnownFunction,
@@ -781,6 +783,123 @@ pub fn call_signature_details<'db>(
     }
 }
 
+/// Returns the source-backed constructor-method definitions reached by a class call.
+///
+/// Checked constructor bindings provide every possible class target and omit downstream methods
+/// that `__new__` or metaclass `__call__` cannot reach. Source declarations are resolved directly
+/// from those classes, independently of their decorated callable types. Assignment-defined
+/// constructors and calls to ordinary functions or methods return no definitions.
+pub fn constructor_definitions_for_call<'db>(
+    model: &SemanticModel<'db>,
+    call_expr: &ast::ExprCall,
+) -> Vec<Definition<'db>> {
+    let db = model.db();
+    let Some(called_type) = call_expr.func.inferred_type(model) else {
+        return Vec::new();
+    };
+
+    let bindings = called_type.bindings(db);
+    if !bindings.has_constructor_bindings(db) {
+        return Vec::new();
+    }
+
+    let bindings = full_bindings_for_call(
+        model,
+        bindings,
+        call_expr,
+        FullBindingPurpose::ConstructorReferences,
+    );
+    let mut definitions = FxIndexSet::default();
+    bindings.visit_reachable_constructors(db, &mut |class, kind| {
+        match kind {
+            ConstructorCallableKind::MetaclassCall => {}
+            ConstructorCallableKind::New => {
+                definitions.extend(source_constructor_definitions(db, class, "__new__"));
+            }
+            ConstructorCallableKind::Init => {
+                // Reaching `__init__` also proves that the preceding class-construction stage was
+                // not short-circuited. Resolve `__new__` directly in case a decorator erased its
+                // callable type from the binding graph.
+                definitions.extend(source_constructor_definitions(db, class, "__new__"));
+                definitions.extend(source_constructor_definitions(db, class, "__init__"));
+            }
+        }
+    });
+    definitions.into_iter().collect()
+}
+
+fn source_constructor_definitions<'db>(
+    db: &'db dyn Db,
+    class: ClassType<'db>,
+    name: &str,
+) -> Vec<Definition<'db>> {
+    if KnownClass::Enum
+        .to_class_literal(db)
+        .as_class_literal()
+        .is_some_and(|enum_class| class.is_subtype_of_class_literal(db, enum_class))
+    {
+        return Vec::new();
+    }
+
+    let Some((class_literal, _)) = class.static_class_literal(db) else {
+        return Vec::new();
+    };
+
+    constructor_function_definitions(db, ClassLiteral::Static(class_literal), name)
+}
+
+fn constructor_function_definitions<'db>(
+    db: &'db dyn Db,
+    class_literal: ClassLiteral<'db>,
+    name: &str,
+) -> Vec<Definition<'db>> {
+    for class in class_literal.iter_mro(db).filter_map(ClassBase::into_class) {
+        // A dynamic class can shadow source-backed declarations later in the MRO.
+        let Some((ancestor, specialization)) = class.static_class_literal(db) else {
+            return Vec::new();
+        };
+
+        if ancestor.is_known(db, KnownClass::Object) {
+            break;
+        }
+
+        if class_member(db, ancestor.body_scope(db), name).is_undefined()
+            && ancestor
+                .own_synthesized_member(db, specialization, None, name)
+                .is_some()
+        {
+            return Vec::new();
+        }
+
+        let scope = ancestor.body_scope(db);
+        let place_table = ty_python_core::place_table(db, scope);
+        let Some(place_id) = place_table.symbol_id(name) else {
+            continue;
+        };
+        let use_def = use_def_map(db, scope);
+        let definitions = reachable_definitions(
+            db,
+            use_def
+                .reachable_symbol_declarations(place_id)
+                .filter_map(|declaration| declaration.declaration.definition())
+                .chain(
+                    use_def
+                        .reachable_symbol_bindings(place_id)
+                        .filter_map(|binding| binding.binding.definition()),
+                ),
+        );
+
+        if !definitions.is_empty() {
+            return definitions
+                .into_iter()
+                .filter(|definition| matches!(*definition.kind(db), DefinitionKind::Function(_)))
+                .collect();
+        }
+    }
+
+    Vec::new()
+}
+
 /// Resolve overloads for a callable type using call arguments,
 /// returning the single matching signature if exactly one matches.
 fn resolve_single_overload<'db>(
@@ -825,15 +944,22 @@ pub enum CallArgumentForm {
     Type,
 }
 
-/// Fully binds and type-checks a call expression against the given callee type.
+#[derive(Debug, Clone, Copy)]
+enum FullBindingPurpose {
+    CallArgumentForms,
+    ConstructorReferences,
+}
+
+/// Fully binds and type-checks a call expression against the called expression's type.
 ///
-/// This is the expensive path for call-argument form analysis: it matches call-site arguments to
-/// parameters, checks argument types, and preserves the resulting bindings even when the call is
-/// invalid so IDE features can inspect the best available binding information.
-fn full_type_bindings_for_call<'db>(
+/// The selected purpose controls whether downstream constructor steps must be confirmed by type
+/// checking or are retained whenever they may run. Invalid calls preserve their binding details so
+/// IDE features can inspect the best available information.
+fn full_bindings_for_call<'db>(
     model: &SemanticModel<'db>,
-    func_type: Type<'db>,
+    bindings: crate::types::call::Bindings<'db>,
     call_expr: &ast::ExprCall,
+    purpose: FullBindingPurpose,
 ) -> crate::types::call::Bindings<'db> {
     let db = model.db();
     let call_arguments =
@@ -844,17 +970,25 @@ fn full_type_bindings_for_call<'db>(
         });
     let constraints = ConstraintSetBuilder::new();
 
-    func_type
-        .bindings(db)
-        .match_parameters(db, &call_arguments)
-        .check_types(
+    let bindings = bindings.match_parameters(db, &call_arguments);
+    let checked = match purpose {
+        FullBindingPurpose::CallArgumentForms => bindings.check_types(
             db,
             &constraints,
             &call_arguments,
             TypeContext::default(),
             &[],
-        )
-        .unwrap_or_else(|CallError(_, bindings)| *bindings)
+        ),
+        FullBindingPurpose::ConstructorReferences => bindings
+            .check_types_for_constructor_references(
+                db,
+                &constraints,
+                &call_arguments,
+                TypeContext::default(),
+                &[],
+            ),
+    };
+    checked.unwrap_or_else(|CallError(_, bindings)| *bindings)
 }
 
 // These are the callables whose arguments were historically classified as type expressions.
@@ -913,15 +1047,20 @@ pub fn call_argument_forms(
     let db = model.db();
 
     // Ordinary callables have only value-form arguments for IDE purposes, so skip full binding.
-    if !func_type
-        .bindings(db)
+    let bindings = func_type.bindings(db);
+    if !bindings
         .iter_flat()
         .any(|binding| known_type_form_parameter_index(db, binding.callable_type).is_some())
     {
         return vec![CallArgumentForm::Value; argument_count];
     }
 
-    let bindings = full_type_bindings_for_call(model, func_type, call_expr);
+    let bindings = full_bindings_for_call(
+        model,
+        bindings,
+        call_expr,
+        FullBindingPurpose::CallArgumentForms,
+    );
 
     let mut argument_forms = vec![CallArgumentForm::Unknown; argument_count];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

This implements the "find references" language server feature for constructor definitions (i.e., `def __init__` and `def __new__`).

The approach I've taken is to extend the existing AST traversal that we already use to find references for other definition types. This is simple and matches existing precedent (which I think is appropriate for a first pass), but it defers potential performance optimizations, so we should revisit as appropriate based on user feedback.

Closes https://github.com/astral-sh/ty/issues/3406.

## Test Plan

<!-- How was it tested? -->
