### PR TITLE
Optimize formatter text width and indentation

### DIFF
--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -513,16 +513,30 @@ pub enum TextWidth {
 
 impl TextWidth {
     pub fn from_text(text: &str, indent_width: IndentWidth) -> TextWidth {
+        const fn is_printable_ascii(byte: u8) -> bool {
+            matches!(byte, b' '..=b'~')
+        }
+
         let mut width = 0u32;
 
-        for c in text.chars() {
-            let char_width = match c {
-                '\t' => indent_width.value(),
-                '\n' => return TextWidth::Multiline,
-                #[expect(clippy::cast_possible_truncation)]
-                c => c.width().unwrap_or(0) as u32,
-            };
-            width += char_width;
+        for (index, byte) in text.bytes().enumerate() {
+            match byte {
+                b'\t' => width += indent_width.value(),
+                b'\n' => return TextWidth::Multiline,
+                byte if is_printable_ascii(byte) => width += 1,
+                _ => {
+                    for c in text[index..].chars() {
+                        let char_width = match c {
+                            '\t' => indent_width.value(),
+                            '\n' => return TextWidth::Multiline,
+                            #[expect(clippy::cast_possible_truncation)]
+                            c => c.width().unwrap_or(0) as u32,
+                        };
+                        width += char_width;
+                    }
+                    break;
+                }
+            }
         }
 
         Self::Width(Width::new(width))
@@ -543,7 +557,22 @@ impl TextWidth {
 #[cfg(test)]
 mod tests {
 
-    use crate::format_element::{LINE_TERMINATORS, normalize_newlines};
+    use crate::IndentWidth;
+    use crate::format_element::{LINE_TERMINATORS, TextWidth, normalize_newlines};
+
+    #[test]
+    fn text_width() {
+        let indent_width = IndentWidth::try_from(4).unwrap();
+        let width = |text| {
+            TextWidth::from_text(text, indent_width)
+                .width()
+                .map(super::Width::value)
+        };
+
+        assert_eq!(width("hello"), Some(5));
+        assert_eq!(width("a寿司b"), Some(6));
+        assert_eq!(width("a\0b"), Some(2));
+    }
 
     #[test]
     fn test_normalize_newlines() {

--- a/crates/ruff_formatter/src/format_element.rs
+++ b/crates/ruff_formatter/src/format_element.rs
@@ -524,19 +524,23 @@ impl TextWidth {
                 b'\t' => width += indent_width.value(),
                 b'\n' => return TextWidth::Multiline,
                 byte if is_printable_ascii(byte) => width += 1,
-                _ => {
-                    for c in text[index..].chars() {
-                        let char_width = match c {
-                            '\t' => indent_width.value(),
-                            '\n' => return TextWidth::Multiline,
-                            #[expect(clippy::cast_possible_truncation)]
-                            c => c.width().unwrap_or(0) as u32,
-                        };
-                        width += char_width;
-                    }
-                    break;
-                }
+                _ => return Self::from_text_slow(&text[index..], indent_width, width),
             }
+        }
+
+        Self::Width(Width::new(width))
+    }
+
+    #[cold]
+    fn from_text_slow(text: &str, indent_width: IndentWidth, mut width: u32) -> TextWidth {
+        for c in text.chars() {
+            let char_width = match c {
+                '\t' => indent_width.value(),
+                '\n' => return TextWidth::Multiline,
+                #[expect(clippy::cast_possible_truncation)]
+                c => c.width().unwrap_or(0) as u32,
+            };
+            width += char_width;
         }
 
         Self::Width(Width::new(width))

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -440,25 +440,24 @@ impl<'a> Printer<'a> {
 
     fn print_text(&mut self, text: Text) {
         if !self.state.pending_indent.is_empty() {
-            let (indent_char, repeat_count) = match self.options.indent_style() {
-                IndentStyle::Tab => ('\t', 1),
-                IndentStyle::Space => (' ', self.options.indent_width()),
+            let indent = std::mem::take(&mut self.state.pending_indent);
+            let indent_level = indent.level();
+            let align = indent.align();
+            let indent_width = self.options.indent_width();
+            let line_width = u32::from(indent_level) * indent_width + u32::from(align);
+            let indent_level = usize::from(indent_level);
+            let align = usize::from(align);
+            let (indent_char, total_indent_char_count) = match self.options.indent_style() {
+                IndentStyle::Tab => ('\t', indent_level),
+                IndentStyle::Space => (' ', indent_level * indent_width as usize),
             };
 
-            let indent = std::mem::take(&mut self.state.pending_indent);
-            let total_indent_char_count = indent.level() as usize * repeat_count as usize;
+            let buffer = &mut self.state.buffer;
+            buffer.reserve(total_indent_char_count + align);
+            buffer.extend(std::iter::repeat_n(indent_char, total_indent_char_count));
+            buffer.extend(std::iter::repeat_n(' ', align));
 
-            self.state
-                .buffer
-                .reserve(total_indent_char_count + indent.align() as usize);
-
-            for _ in 0..total_indent_char_count {
-                self.print_char(indent_char);
-            }
-
-            for _ in 0..indent.align() {
-                self.print_char(' ');
-            }
+            self.state.line_width += line_width;
         }
 
         self.push_marker();

--- a/crates/ruff_formatter/src/printer/mod.rs
+++ b/crates/ruff_formatter/src/printer/mod.rs
@@ -454,8 +454,12 @@ impl<'a> Printer<'a> {
 
             let buffer = &mut self.state.buffer;
             buffer.reserve(total_indent_char_count + align);
-            buffer.extend(std::iter::repeat_n(indent_char, total_indent_char_count));
-            buffer.extend(std::iter::repeat_n(' ', align));
+            for _ in 0..total_indent_char_count {
+                buffer.push(indent_char);
+            }
+            for _ in 0..align {
+                buffer.push(' ');
+            }
 
             self.state.line_width += line_width;
         }


### PR DESCRIPTION
## Summary

Avoid Unicode width calculation for printable ASCII, keep the Unicode path cold, and write indentation directly. Improves the formatter benchmarks by 2-4%

## Test Plan

Testing: Ran formatter suites, Clippy, repository hooks, and formatter benchmarks.