### PR TITLE
[ty] Mutate constructor bindings in place

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -5044,23 +5044,6 @@ impl<'db> Type<'db> {
                 Place::Undefined => None,
             }
         }
-        fn bind_constructor_new<'db>(
-            db: &'db dyn Db,
-            bindings: Bindings<'db>,
-            self_type: Type<'db>,
-        ) -> Bindings<'db> {
-            bindings.map(|binding| {
-                let mut binding = binding;
-                // If descriptor binding produced a bound callable, bake that into the signature
-                // first, then bind `cls` for constructor-call semantics (the call site omits `cls`).
-                // Note: This intentionally preserves `type.__call__` behavior for `@classmethod __new__`,
-                // which receives an extra implicit `cls` and errors at call sites.
-                binding.bake_bound_type_into_overloads(db);
-                binding.bound_type = Some(self_type);
-                binding
-            })
-        }
-
         let class_literal = class.class_literal(db);
         let class_generic_context = class_literal.generic_context(db);
 
@@ -5159,13 +5142,14 @@ impl<'db> Type<'db> {
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
             Some(place) => match resolve_dunder_new_callable(db, self_type, place) {
                 Some((new_callable, definedness)) => {
-                    let mut bindings =
-                        bind_constructor_new(db, new_callable.bindings(db), self_type)
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::New,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
+                    let mut bindings = new_callable.bindings(db);
+                    bindings.bind_constructor_new(db, self_type);
+                    let mut bindings = bindings
+                        .into_constructor_bindings(
+                            constructor_instance_ty,
+                            ConstructorCallableKind::New,
+                        )
+                        .with_constructed_instance_type(db, constructor_instance_ty);
                     if definedness == Definedness::PossiblyUndefined {
                         bindings.set_implicit_dunder_new_is_possibly_unbound();
                     }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -307,16 +307,6 @@ impl<'db> CallableItem<'db> {
         }
     }
 
-    fn map<F>(self, f: &F) -> CallableItem<'db>
-    where
-        F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
-    {
-        match self {
-            CallableItem::Regular(binding) => CallableItem::Regular(f(binding)),
-            CallableItem::Constructor(binding) => CallableItem::Constructor(binding.map(f)),
-        }
-    }
-
     fn wrap_as_constructor(
         self,
         constructed_instance_type: Type<'db>,
@@ -923,27 +913,23 @@ impl<'db> Bindings<'db> {
         }
     }
 
-    fn map_with<F>(self, f: &F) -> Self
-    where
-        F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
-    {
-        Self {
-            callable_type: self.callable_type,
-            implicit_dunder_new_is_possibly_unbound: self.implicit_dunder_new_is_possibly_unbound,
-            implicit_dunder_init_is_possibly_unbound: self.implicit_dunder_init_is_possibly_unbound,
-            enclosing_binding_contexts: self.enclosing_binding_contexts,
-            elements: self
-                .elements
-                .into_iter()
-                .map(|elem| BindingsElement {
-                    items: elem.items.into_iter().map(|item| item.map(f)).collect(),
-                })
-                .collect(),
-        }
-    }
+    pub(in crate::types) fn bind_constructor_new(&mut self, db: &'db dyn Db, self_type: Type<'db>) {
+        for item in self.iter_callable_items_mut() {
+            let binding = item.callable_mut();
+            // If descriptor binding produced a bound callable, bake that into the signature
+            // first, then bind `cls` for constructor-call semantics (the call site omits `cls`).
+            // Note: This intentionally preserves `type.__call__` behavior for `@classmethod __new__`,
+            // which receives an extra implicit `cls` and errors at call sites.
+            binding.bake_bound_type_into_overloads(db);
+            binding.bound_type = Some(self_type);
 
-    pub(crate) fn map(self, f: impl Fn(CallableBinding<'db>) -> CallableBinding<'db>) -> Self {
-        self.map_with(&f)
+            if let CallableItem::Constructor(binding) = item {
+                // TODO: Model the nested constructor chain if we want to support class objects
+                // assigned to `__new__`. Until then, preserve the old mapping behavior by
+                // dropping downstream constructor checks instead of panicking.
+                binding.downstream_constructor = None;
+            }
+        }
     }
 
     fn freshen_generic_contexts_in_place(

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -161,20 +161,6 @@ impl<'db> ConstructorBinding<'db> {
         self.downstream_constructor.as_deref_mut()
     }
 
-    pub(super) fn map<F>(self, f: &F) -> ConstructorBinding<'db>
-    where
-        F: Fn(CallableBinding<'db>) -> CallableBinding<'db>,
-    {
-        // TODO: Model the nested constructor chain if we want to support class objects assigned to
-        // `__new__`. For now, map the callable itself and drop its downstream constructor checks
-        // instead of panicking.
-        ConstructorBinding {
-            entry: f(self.entry),
-            constructor_context: self.constructor_context,
-            downstream_constructor: None,
-        }
-    }
-
     /// Compute the overall effective return type of this `ConstructorBinding`.
     pub(super) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
         let constructed_instance_type = self.constructed_instance_type();


### PR DESCRIPTION
Mutate constructor bindings in place instead of rebuilding their nested inline buffers through a generic mapping pipeline. This reduces copied bytes by 15.8 MB on freqtrade and 1.0 MB on hydra-zen; paired timings were noisy and showed no statistically significant regression.

Testing: Passed semantic tests, Clippy, repository hooks, and paired project profiling.