### PR TITLE
[`pylint`] Update fix suggestions for `__floor__`, `__trunc__`, `__length_hint__`, and `__matmul__` variants (`PLC2801`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
@@ -139,3 +139,5 @@ print((3.0).__ceil__())  # PLC2801
 print((3.0).__trunc__())  # PLC2801
 Foo().__length_hint__()  # PLC2801
 Foo().__matmul__(Foo())  # PLC2801
+foo.__rmatmul__(a)  # PLC2801
+foo.__imatmul__(foo)  # PLC2801

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
@@ -137,3 +137,5 @@ three = 1 if 1 else(3.0).__str__()
 print((3.0).__floor__())  # PLC2801
 print((3.0).__ceil__())  # PLC2801
 print((3.0).__trunc__())  # PLC2801
+Foo().__length_hint__()  # PLC2801
+Foo().__matmul__(Foo())  # PLC2801

--- a/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
+++ b/crates/ruff_linter/resources/test/fixtures/pylint/unnecessary_dunder_call.py
@@ -132,3 +132,8 @@ assert "abc".__str__() == "abc"
 
 # https://github.com/astral-sh/ruff/issues/18813
 three = 1 if 1 else(3.0).__str__()
+
+# https://github.com/astral-sh/ruff/issues/26221
+print((3.0).__floor__())  # PLC2801
+print((3.0).__ceil__())  # PLC2801
+print((3.0).__trunc__())  # PLC2801

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -417,6 +417,11 @@ impl DunderReplacement {
                 "Use `*` operator",
                 OperatorPrecedence::MulDivRemain,
             )),
+            "__matmul__" => Some(Self::Operator(
+                "@",
+                "Use `@` operator",
+                OperatorPrecedence::MulDivRemain,
+            )),
             "__ne__" => Some(Self::Operator(
                 "!=",
                 "Use `!=` operator",
@@ -546,6 +551,7 @@ impl DunderReplacement {
             "__init__" => Some(Self::MessageOnly("Instantiate class directly")),
             "__instancecheck__" => Some(Self::MessageOnly("Use `isinstance()` builtin")),
             "__invert__" => Some(Self::MessageOnly("Use `~` operator")),
+            "__length_hint__" => Some(Self::MessageOnly("Use `operator.length_hint()` function")),
             "__neg__" => Some(Self::MessageOnly("Multiply by -1 instead")),
             "__pos__" => Some(Self::MessageOnly("Multiply by +1 instead")),
             "__pow__" => Some(Self::MessageOnly("Use ** operator or `pow()` builtin")),

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -531,6 +531,7 @@ impl DunderReplacement {
             "__delattr__" => Some(Self::MessageOnly("Use `del` statement")),
             "__delitem__" => Some(Self::MessageOnly("Use `del` statement")),
             "__divmod__" => Some(Self::MessageOnly("Use `divmod()` builtin")),
+            "__floor__" => Some(Self::MessageOnly("Use `math.floor()` function")),
             "__format__" => Some(Self::MessageOnly(
                 "Use `format` builtin, format string method, or f-string",
             )),
@@ -554,7 +555,7 @@ impl DunderReplacement {
                 "Mutate attribute directly or use setattr built-in function",
             )),
             "__setitem__" => Some(Self::MessageOnly("Use subscript assignment")),
-            "__truncate__" => Some(Self::MessageOnly("Use `math.trunc()` function")),
+            "__trunc__" => Some(Self::MessageOnly("Use `math.trunc()` function")),
 
             _ => None,
         }

--- a/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
+++ b/crates/ruff_linter/src/rules/pylint/rules/unnecessary_dunder_call.rs
@@ -352,6 +352,11 @@ impl DunderReplacement {
                 "Use `<<=` operator",
                 OperatorPrecedence::Assign,
             )),
+            "__imatmul__" => Some(Self::Operator(
+                "@=",
+                "Use `@=` operator",
+                OperatorPrecedence::Assign,
+            )),
             "__imod__" => Some(Self::Operator(
                 "%=",
                 "Use `%=` operator",
@@ -472,6 +477,11 @@ impl DunderReplacement {
                 "<<",
                 "Use `<<` operator",
                 OperatorPrecedence::LeftRightShift,
+            )),
+            "__rmatmul__" => Some(Self::ROperator(
+                "@",
+                "Use `@` operator",
+                OperatorPrecedence::MulDivRemain,
             )),
             "__rmod__" => Some(Self::ROperator(
                 "%",

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
@@ -1160,6 +1160,7 @@ PLC2801 Unnecessary dunder call to `__length_hint__`. Use `operator.length_hint(
 140 | Foo().__length_hint__()  # PLC2801
     | ^^^^^^^^^^^^^^^^^^^^^^^
 141 | Foo().__matmul__(Foo())  # PLC2801
+142 | foo.__rmatmul__(a)  # PLC2801
     |
 help: Use `operator.length_hint()` function
 
@@ -1170,11 +1171,48 @@ PLC2801 [*] Unnecessary dunder call to `__matmul__`. Use `@` operator.
 140 | Foo().__length_hint__()  # PLC2801
 141 | Foo().__matmul__(Foo())  # PLC2801
     | ^^^^^^^^^^^^^^^^^^^^^^^
+142 | foo.__rmatmul__(a)  # PLC2801
+143 | foo.__imatmul__(foo)  # PLC2801
     |
 help: Use `@` operator
     |
 140 | Foo().__length_hint__()  # PLC2801
     - Foo().__matmul__(Foo())  # PLC2801
 141 + Foo() @ Foo()  # PLC2801
+142 | foo.__rmatmul__(a)  # PLC2801
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+PLC2801 [*] Unnecessary dunder call to `__rmatmul__`. Use `@` operator.
+   --> unnecessary_dunder_call.py:142:1
+    |
+140 | Foo().__length_hint__()  # PLC2801
+141 | Foo().__matmul__(Foo())  # PLC2801
+142 | foo.__rmatmul__(a)  # PLC2801
+    | ^^^^^^^^^^^^^^^^^^
+143 | foo.__imatmul__(foo)  # PLC2801
+    |
+help: Use `@` operator
+    |
+141 | Foo().__matmul__(Foo())  # PLC2801
+    - foo.__rmatmul__(a)  # PLC2801
+142 + a @ foo  # PLC2801
+143 | foo.__imatmul__(foo)  # PLC2801
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+PLC2801 [*] Unnecessary dunder call to `__imatmul__`. Use `@=` operator.
+   --> unnecessary_dunder_call.py:143:1
+    |
+141 | Foo().__matmul__(Foo())  # PLC2801
+142 | foo.__rmatmul__(a)  # PLC2801
+143 | foo.__imatmul__(foo)  # PLC2801
+    | ^^^^^^^^^^^^^^^^^^^^
+    |
+help: Use `@=` operator
+    |
+142 | foo.__rmatmul__(a)  # PLC2801
+    - foo.__imatmul__(foo)  # PLC2801
+143 + foo @= foo  # PLC2801
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
@@ -1105,11 +1105,46 @@ PLC2801 [*] Unnecessary dunder call to `__str__`. Use `str()` builtin.
 133 | # https://github.com/astral-sh/ruff/issues/18813
 134 | three = 1 if 1 else(3.0).__str__()
     |                    ^^^^^^^^^^^^^^^
+135 |
+136 | # https://github.com/astral-sh/ruff/issues/26221
     |
 help: Use `str()` builtin
     |
 133 | # https://github.com/astral-sh/ruff/issues/18813
     - three = 1 if 1 else(3.0).__str__()
 134 + three = 1 if 1 else str(3.0)
+135 |
     |
 note: This is an unsafe fix and may change runtime behavior
+
+PLC2801 Unnecessary dunder call to `__floor__`. Use `math.floor()` function.
+   --> unnecessary_dunder_call.py:137:7
+    |
+136 | # https://github.com/astral-sh/ruff/issues/26221
+137 | print((3.0).__floor__())  # PLC2801
+    |       ^^^^^^^^^^^^^^^^^
+138 | print((3.0).__ceil__())  # PLC2801
+139 | print((3.0).__trunc__())  # PLC2801
+    |
+help: Use `math.floor()` function
+
+PLC2801 Unnecessary dunder call to `__ceil__`. Use `math.ceil()` function.
+   --> unnecessary_dunder_call.py:138:7
+    |
+136 | # https://github.com/astral-sh/ruff/issues/26221
+137 | print((3.0).__floor__())  # PLC2801
+138 | print((3.0).__ceil__())  # PLC2801
+    |       ^^^^^^^^^^^^^^^^
+139 | print((3.0).__trunc__())  # PLC2801
+    |
+help: Use `math.ceil()` function
+
+PLC2801 Unnecessary dunder call to `__trunc__`. Use `math.trunc()` function.
+   --> unnecessary_dunder_call.py:139:7
+    |
+137 | print((3.0).__floor__())  # PLC2801
+138 | print((3.0).__ceil__())  # PLC2801
+139 | print((3.0).__trunc__())  # PLC2801
+    |       ^^^^^^^^^^^^^^^^^
+    |
+help: Use `math.trunc()` function

--- a/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
+++ b/crates/ruff_linter/src/rules/pylint/snapshots/ruff_linter__rules__pylint__tests__PLC2801_unnecessary_dunder_call.py.snap
@@ -1136,6 +1136,7 @@ PLC2801 Unnecessary dunder call to `__ceil__`. Use `math.ceil()` function.
 138 | print((3.0).__ceil__())  # PLC2801
     |       ^^^^^^^^^^^^^^^^
 139 | print((3.0).__trunc__())  # PLC2801
+140 | Foo().__length_hint__()  # PLC2801
     |
 help: Use `math.ceil()` function
 
@@ -1146,5 +1147,34 @@ PLC2801 Unnecessary dunder call to `__trunc__`. Use `math.trunc()` function.
 138 | print((3.0).__ceil__())  # PLC2801
 139 | print((3.0).__trunc__())  # PLC2801
     |       ^^^^^^^^^^^^^^^^^
+140 | Foo().__length_hint__()  # PLC2801
+141 | Foo().__matmul__(Foo())  # PLC2801
     |
 help: Use `math.trunc()` function
+
+PLC2801 Unnecessary dunder call to `__length_hint__`. Use `operator.length_hint()` function.
+   --> unnecessary_dunder_call.py:140:1
+    |
+138 | print((3.0).__ceil__())  # PLC2801
+139 | print((3.0).__trunc__())  # PLC2801
+140 | Foo().__length_hint__()  # PLC2801
+    | ^^^^^^^^^^^^^^^^^^^^^^^
+141 | Foo().__matmul__(Foo())  # PLC2801
+    |
+help: Use `operator.length_hint()` function
+
+PLC2801 [*] Unnecessary dunder call to `__matmul__`. Use `@` operator.
+   --> unnecessary_dunder_call.py:141:1
+    |
+139 | print((3.0).__trunc__())  # PLC2801
+140 | Foo().__length_hint__()  # PLC2801
+141 | Foo().__matmul__(Foo())  # PLC2801
+    | ^^^^^^^^^^^^^^^^^^^^^^^
+    |
+help: Use `@` operator
+    |
+140 | Foo().__length_hint__()  # PLC2801
+    - Foo().__matmul__(Foo())  # PLC2801
+141 + Foo() @ Foo()  # PLC2801
+    |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
Summary
--

Fixes #26221 by adding a fix title mapping for `__floor__` and `__trunc__`. `__floor__` was missing
entirely, while `__trunc__` was misspelled as `__truncate__` in the mapping function.

Test Plan
--

New tests showing the `help` message
