### PR TITLE
[`perflint`] Clarify that `PERF402` applies to any iterable

### DIFF
--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -7,14 +7,14 @@ use crate::Violation;
 use crate::checkers::ast::Checker;
 
 /// ## What it does
-/// Checks for `for` loops that can be replaced by a making a copy of a list.
+/// Checks for `for` loops that append every item of an iterable to a list,
+/// which can be replaced with `list()`.
 ///
 /// ## Why is this bad?
-/// When creating a copy of an existing list using a for-loop, prefer
-/// `list` or `list.copy` instead. Making a direct copy is more readable and
-/// more performant.
+/// When populating a list from an iterable with a `for` loop, prefer `list()`
+/// instead. The `list()` call is more readable and more performant.
 ///
-/// Using the below as an example, the `list`-based copy is ~2x faster on
+/// Using the below as an example, the `list()`-based copy is ~2x faster on
 /// Python 3.11.
 ///
 /// Note that, as with all `perflint` rules, this is only intended as a

--- a/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
+++ b/crates/ruff_linter/src/rules/perflint/rules/manual_list_copy.rs
@@ -8,13 +8,14 @@ use crate::checkers::ast::Checker;
 
 /// ## What it does
 /// Checks for `for` loops that append every item of an iterable to a list,
-/// which can be replaced with `list()`.
+/// which can be replaced with a call to `list`.
 ///
 /// ## Why is this bad?
-/// When populating a list from an iterable with a `for` loop, prefer `list()`
-/// instead. The `list()` call is more readable and more performant.
+/// When populating a list from an iterable with a `for` loop, prefer `list`
+/// instead. The `list` call is more readable and more performant. For an
+/// existing list, you can also use `list.copy` instead of `list`.
 ///
-/// Using the below as an example, the `list()`-based copy is ~2x faster on
+/// Using the below as an example, the `list`-based copy is ~2x faster on
 /// Python 3.11.
 ///
 /// Note that, as with all `perflint` rules, this is only intended as a


### PR DESCRIPTION
First contribution here, hi! Picking up #21593 as a small intro PR.

PERF402's current "What it does" says it catches copies of an "existing list", but the rule also fires whenever a `for` loop appends every item of any iterable to a list while the source isn't required to be a list (only the destination is). The issue reporter pointed this out and suggested wording closer to "for loops that can be replaced with `list()`", which is what I went with here.

Scope is intentionally tiny: just the `## What it does` and `## Why is this bad?` doc comments. Violation message, example, rule logic, and tests are unchanged so no snapshots move.

Closes #21593.