### PR TITLE
[`pyupgrade`] Clarify `UP029` as a Python 2 compatibility rule

### DIFF
--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -11,7 +11,7 @@ use crate::{AlwaysFixableViolation, Fix};
 
 /// ## What it does
 /// Checks for imports of Python 3 builtins from Python 2 compatibility shims
-/// such as `builtins`, `io`, and `six`.
+/// such as `python-future` and `six`.
 ///
 /// ## Why is this bad?
 /// These shims existed to access Python 3 builtins from code that also ran on

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -10,15 +10,12 @@ use crate::rules::pyupgrade::rules::is_import_required_by_isort;
 use crate::{AlwaysFixableViolation, Fix};
 
 /// ## What it does
-/// Checks for imports from Python 2 compatibility shims that are unnecessary
-/// on Python 3, such as `from builtins import str` or `from six.moves import
-/// filter`.
+/// Checks for imports of Python 3 builtins from Python 2 compatibility shims
+/// such as `builtins`, `io`, and `six`.
 ///
 /// ## Why is this bad?
-/// These modules (`builtins`, `io.open`, and the `six` / `six.moves` family)
-/// were used to access Python 3 builtins from Python 2-compatible code. On
-/// Python 3, the names they re-export are already builtins, so the imports
-/// are redundant and can be removed.
+/// These shims existed to access Python 3 builtins from code that also ran on
+/// Python 2. On Python 3-only code, the imports are redundant.
 ///
 /// ## Example
 /// ```python

--- a/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
+++ b/crates/ruff_linter/src/rules/pyupgrade/rules/unnecessary_builtin_import.rs
@@ -10,11 +10,15 @@ use crate::rules::pyupgrade::rules::is_import_required_by_isort;
 use crate::{AlwaysFixableViolation, Fix};
 
 /// ## What it does
-/// Checks for unnecessary imports of builtins.
+/// Checks for imports from Python 2 compatibility shims that are unnecessary
+/// on Python 3, such as `from builtins import str` or `from six.moves import
+/// filter`.
 ///
 /// ## Why is this bad?
-/// Builtins are always available. Importing them is unnecessary and should be
-/// removed to avoid confusion.
+/// These modules (`builtins`, `io.open`, and the `six` / `six.moves` family)
+/// were used to access Python 3 builtins from Python 2-compatible code. On
+/// Python 3, the names they re-export are already builtins, so the imports
+/// are redundant and can be removed.
 ///
 /// ## Example
 /// ```python


### PR DESCRIPTION
Hi! Small intro contribution to ruff #21148.

The current UP029 docs read like the rule catches any import of a builtin (e.g. `from builtins import tuple`), but the rule only fires on a fixed allowlist of Python 2 / Python 3 compatibility imports from `builtins`, `io.open`, `six`, and `six.moves`. The issue reporter pointed this out and matches what the upstream pyupgrade rule was originally designed for.

Scope is just the `## What it does` and `## Why is this bad?` doc comments. Violation message, example, fix, and rule logic are untouched, so no snapshots move.

Hand-wrote the PR summary per the AI policy.

Closes #21148.