### PR TITLE
[ty] Don't store `source_order` in BDD nodes

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -901,6 +901,10 @@ impl<'db> ConstraintSetBuilder<'db> {
             }
         }
 
+        used_nodes.truncate(used_nodes.last_one().map_or(0, |last| last + 1));
+        used_constraints.truncate(used_constraints.last_one().map_or(0, |last| last + 1));
+        used_source_orders.truncate(used_source_orders.last_one().map_or(0, |last| last + 1));
+
         let nodes = storage
             .nodes
             .into_iter()

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -197,16 +197,16 @@ where
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let node = NodeId::distributed_or(
+        let (node, source_order) = NodeId::distributed_or(
             db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
                 constraint.verify_builder(builder);
-                constraint.node
+                (constraint.node, constraint.source_order)
             }),
         );
-        ConstraintSet::from_node(builder, node)
+        ConstraintSet::from_node(builder, node, source_order)
     }
 
     fn when_all<'db, 'c>(
@@ -215,16 +215,16 @@ where
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
-        let node = NodeId::distributed_and(
+        let (node, source_order) = NodeId::distributed_and(
             db,
             builder,
             self.map(|element| {
                 let constraint = f(element);
                 constraint.verify_builder(builder);
-                constraint.node
+                (constraint.node, constraint.source_order)
             }),
         );
-        ConstraintSet::from_node(builder, node)
+        ConstraintSet::from_node(builder, node, source_order)
     }
 }
 
@@ -242,6 +242,7 @@ where
 #[derive(Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
 pub struct OwnedConstraintSet<'db> {
     node: NodeId,
+    source_order: Option<SourceOrderId>,
     inner: Option<Arc<OwnedConstraintSetInner<'db>>>,
 }
 
@@ -252,12 +253,15 @@ struct OwnedConstraintSetInner<'db> {
     typevars: IndexVec<TypeVarId, BoundTypeVarIdentity<'db>>,
     nodes: Box<[InteriorNodeData]>,
     node_indices: RankBitBox,
+    source_orders: Box<[SourceOrder]>,
+    source_order_indices: RankBitBox,
 }
 
 impl Default for OwnedConstraintSet<'_> {
     fn default() -> Self {
         Self {
             node: ALWAYS_FALSE,
+            source_order: None,
             inner: None,
         }
     }
@@ -267,6 +271,7 @@ impl<'db> OwnedConstraintSet<'db> {
     pub(crate) fn always() -> Self {
         Self {
             node: ALWAYS_TRUE,
+            source_order: None,
             inner: None,
         }
     }
@@ -287,7 +292,7 @@ impl<'db> OwnedConstraintSet<'db> {
         let builder = ConstraintSetBuilder {
             storage: RefCell::new(storage),
         };
-        let set = ConstraintSet::from_node(&builder, self.node);
+        let set = ConstraintSet::from_node(&builder, self.node, self.source_order);
         f(&builder, set)
     }
 }
@@ -312,6 +317,16 @@ impl OwnedConstraintSetInner<'_> {
         );
         self.constraint_indices.rank(index) as usize
     }
+
+    fn retained_source_order_index(&self, id: SourceOrderId) -> usize {
+        let index = id.index();
+        debug_assert_eq!(
+            self.source_order_indices.get_bit(index),
+            Some(true),
+            "should not access constraint set source_order that was marked unused",
+        );
+        self.source_order_indices.rank(index) as usize
+    }
 }
 
 /// A set of constraints under which a type property holds.
@@ -329,6 +344,10 @@ pub struct ConstraintSet<'db, 'c> {
     /// The BDD representing this constraint set
     node: NodeId,
 
+    /// The source ordering of the constraints in this constraint set. Will be `None` for terminal
+    /// nodes.
+    source_order: Option<SourceOrderId>,
+
     /// A reference to the builder that holds the storage for this constraint set's BDD
     builder: &'c ConstraintSetBuilder<'db>,
 
@@ -337,20 +356,25 @@ pub struct ConstraintSet<'db, 'c> {
 }
 
 impl<'db, 'c> ConstraintSet<'db, 'c> {
-    fn from_node(builder: &'c ConstraintSetBuilder<'db>, node: NodeId) -> Self {
+    fn from_node(
+        builder: &'c ConstraintSetBuilder<'db>,
+        node: NodeId,
+        source_order: Option<SourceOrderId>,
+    ) -> Self {
         Self {
             node,
+            source_order,
             builder,
             _invariant: PhantomData,
         }
     }
 
     fn never(builder: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self::from_node(builder, ALWAYS_FALSE)
+        Self::from_node(builder, ALWAYS_FALSE, None)
     }
 
     fn always(builder: &'c ConstraintSetBuilder<'db>) -> Self {
-        Self::from_node(builder, ALWAYS_TRUE)
+        Self::from_node(builder, ALWAYS_TRUE, None)
     }
 
     pub(crate) fn from_bool(builder: &'c ConstraintSetBuilder<'db>, b: bool) -> Self {
@@ -380,10 +404,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         lower: Option<Type<'db>>,
         upper: Option<Type<'db>>,
     ) -> Self {
-        Self::from_node(
-            builder,
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper),
-        )
+        let (node, source_order) =
+            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Returns a constraint set that constrains a typevar to be a supertype of `lower`.
@@ -433,7 +456,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         rhs: Type<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.implies_subtype_of(db, builder, lhs, rhs))
+        let (node, extra_source_order) = self.node.implies_subtype_of(db, builder, lhs, rhs);
+        let source_order = builder.ordered_source_order(self.source_order, extra_source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Returns whether this constraint set is satisfied by all of the typevars that it mentions.
@@ -472,6 +497,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         self.verify_builder(builder);
         self.node = self.node.or_with_offset(builder, other.node);
+        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
@@ -487,13 +513,14 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         self.verify_builder(builder);
         self.node = self.node.and_with_offset(builder, other.node);
+        self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
 
     /// Returns the negation of this constraint set.
     pub(crate) fn negate(self, _db: &'db dyn Db, builder: &'c ConstraintSetBuilder<'db>) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.negate(builder))
+        Self::from_node(builder, self.node.negate(builder), self.source_order)
     }
 
     /// Returns the intersection of this constraint set and another. The other constraint set is
@@ -562,7 +589,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.iff_with_offset(builder, other.node))
+        let node = self.node.iff_with_offset(builder, other.node);
+        let source_order = builder.ordered_source_order(self.source_order, other.source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Reduces the set of inferable typevars for this constraint set. You provide an iterator of
@@ -577,7 +606,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: impl IntoIterator<Item = BoundTypeVarIdentity<'db>>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.exists(db, builder, to_remove))
+        let node = self.node.exists(db, builder, to_remove);
+        Self::from_node(builder, node, self.source_order)
     }
 
     pub(crate) fn remove_noninferable(
@@ -594,10 +624,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         {
             return self;
         }
-        Self::from_node(
-            builder,
-            self.node.remove_noninferable(db, builder, inferable),
-        )
+        let node = self.node.remove_noninferable(db, builder, inferable);
+        Self::from_node(builder, node, self.source_order)
     }
 
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
@@ -710,10 +738,20 @@ struct ConstraintSetStorage<'db> {
     /// The BDD nodes that appear in any of the constraint sets constructed in this builder.
     nodes: IndexVec<NodeId, InteriorNodeData>,
 
+    /// Encodes an ordering on the constraints in a constraint set, which is based on the order
+    /// that the constraints (or more accurately, the Python expressions they're derived from)
+    /// appear in the source code. This ensures that any union and intersections types that appear
+    /// in solutions are constructed in a stable (and source-consistent) order.
+    ///
+    /// This is encoded as a binary tree over [`ConstraintId`]s. The pre-walk of that tree defines
+    /// the ordering.
+    source_orders: IndexVec<SourceOrderId, SourceOrder>,
+
     // Everything below are the memoization tables for the arenas and for our BDD operations.
     constraint_cache: FxHashMap<Constraint<'db>, ConstraintId>,
     typevar_cache: FxHashMap<BoundTypeVarIdentity<'db>, TypeVarId>,
     node_cache: FxHashMap<InteriorNodeData, NodeId>,
+    source_order_cache: FxHashMap<SourceOrder, SourceOrderId>,
     constraint_implication_cache: FxHashMap<(ConstraintId, ConstraintId), bool>,
     /// Only caches completed top-level results. Recursive results depend on active path
     /// assignments and must not use this cache.
@@ -777,6 +815,13 @@ impl ConstraintSetStorage<'_> {
         id
     }
 
+    fn adjusted_source_order_id(&self, id: SourceOrderId) -> SourceOrderId {
+        if let Some(compacted) = &self.compacted {
+            return id + compacted.source_order_indices.len();
+        }
+        id
+    }
+
     fn adjusted_typevar_id(&self, id: TypeVarId) -> TypeVarId {
         if let Some(compacted) = &self.compacted {
             return id + compacted.typevars.len();
@@ -803,12 +848,21 @@ impl<'db> ConstraintSetBuilder<'db> {
         let constraint = f(&self);
         let node = constraint.node;
         if node.is_terminal() {
-            return OwnedConstraintSet { node, inner: None };
+            return OwnedConstraintSet {
+                node,
+                source_order: None,
+                inner: None,
+            };
         }
+        let source_order = constraint
+            .source_order
+            .expect("non-terminal BDD should have source_order");
 
         let mut storage = self.storage.into_inner();
         let mut used_nodes = RankBitBox::bits_with_capacity(storage.nodes.len());
         let mut used_constraints = RankBitBox::bits_with_capacity(storage.constraints.len());
+        let mut used_source_orders = RankBitBox::bits_with_capacity(storage.source_orders.len());
+
         let mut stack = vec![node];
         while let Some(node) = stack.pop() {
             if node.is_terminal() || used_nodes[node.index()] {
@@ -821,8 +875,23 @@ impl<'db> ConstraintSetBuilder<'db> {
             stack.push(interior.if_uncertain);
             stack.push(interior.if_false);
         }
-        used_nodes.truncate(used_nodes.last_one().map_or(0, |last| last + 1));
-        used_constraints.truncate(used_constraints.last_one().map_or(0, |last| last + 1));
+
+        let mut stack = vec![source_order];
+        while let Some(source_order) = stack.pop() {
+            if used_source_orders[source_order.index()] {
+                continue;
+            }
+            used_source_orders.set(source_order.index(), true);
+            match storage.source_orders[source_order] {
+                SourceOrder::Ordered(left, right) => {
+                    stack.push(left);
+                    stack.push(right);
+                }
+                SourceOrder::Constraint(constraint) => {
+                    used_constraints.set(constraint.index(), true);
+                }
+            }
+        }
 
         let nodes = storage
             .nodes
@@ -831,6 +900,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             .filter_map(|(node, used)| used.then_some(node))
             .collect();
         let node_indices = RankBitBox::from_bits(used_nodes);
+
         let constraints = storage
             .constraints
             .into_iter()
@@ -838,16 +908,28 @@ impl<'db> ConstraintSetBuilder<'db> {
             .filter_map(|(constraint, used)| used.then_some(constraint))
             .collect();
         let constraint_indices = RankBitBox::from_bits(used_constraints);
+
+        let source_orders = storage
+            .source_orders
+            .into_iter()
+            .zip(&used_source_orders)
+            .filter_map(|(source_order, used)| used.then_some(source_order))
+            .collect();
+        let source_order_indices = RankBitBox::from_bits(used_source_orders);
+
         storage.typevars.shrink_to_fit();
 
         OwnedConstraintSet {
             node,
+            source_order: Some(source_order),
             inner: Some(Arc::new(OwnedConstraintSetInner {
                 constraints,
                 constraint_indices,
                 typevars: storage.typevars,
                 nodes,
                 node_indices,
+                source_orders,
+                source_order_indices,
             })),
         }
     }
@@ -870,7 +952,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         fn rebuild_node<'db>(
             builder: &ConstraintSetBuilder<'db>,
             inner: &OwnedConstraintSetInner<'db>,
-            constraints: &[NodeId],
+            constraints: &[(NodeId, Option<SourceOrderId>)],
             cache: &mut FxHashMap<NodeId, NodeId>,
             old_node: NodeId,
         ) -> NodeId {
@@ -896,7 +978,8 @@ impl<'db> ConstraintSetBuilder<'db> {
             // Shift the reloaded condition back to the source order recorded in the owned set;
             // solution extraction uses this order for deterministic unions and intersections.
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
-            let condition = constraints[old_constraint_index]
+            let (constraint_node, _) = constraints[old_constraint_index];
+            let condition = constraint_node
                 .with_adjusted_source_order(builder, old_interior.source_order.saturating_sub(1));
             let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
 
@@ -905,7 +988,7 @@ impl<'db> ConstraintSetBuilder<'db> {
         }
 
         if other.node.is_terminal() {
-            return ConstraintSet::from_node(self, other.node);
+            return ConstraintSet::from_node(self, other.node, None);
         }
         let inner = other
             .inner
@@ -930,10 +1013,33 @@ impl<'db> ConstraintSetBuilder<'db> {
             })
             .collect();
 
+        let mut source_orders = vec![None; inner.source_orders.len()];
+        for (i, old_source_order) in inner.source_orders.iter().copied().enumerate() {
+            match old_source_order {
+                SourceOrder::Ordered(old_left, old_right) => {
+                    let old_left_index = inner.retained_source_order_index(old_left);
+                    let new_left = source_orders[old_left_index];
+                    let old_right_index = inner.retained_source_order_index(old_right);
+                    let new_right = source_orders[old_right_index];
+                    source_orders[i] = self.ordered_source_order(new_left, new_right);
+                }
+                SourceOrder::Constraint(old_constraint) => {
+                    let old_constraint_index = inner.retained_constraint_index(old_constraint);
+                    let (_, constraint_source_order) = constraints[old_constraint_index];
+                    source_orders[i] = constraint_source_order;
+                }
+            }
+        }
+
         // Maps NodeIds in the OwnedConstraintSet to the corresponding NodeIds in this builder.
         let mut cache = FxHashMap::default();
         let node = rebuild_node(self, inner, &constraints, &mut cache, other.node);
-        ConstraintSet::from_node(self, node)
+        let old_source_order = other
+            .source_order
+            .expect("non-terminal constraint set should have a source_order");
+        let old_source_order_index = inner.retained_source_order_index(old_source_order);
+        let source_order = source_orders[old_source_order_index];
+        ConstraintSet::from_node(self, node, source_order)
     }
 
     /// Interns a single typevar, giving it a stable order in this builder
@@ -1107,6 +1213,36 @@ impl<'db> ConstraintSetBuilder<'db> {
         }
         storage.nodes[node]
     }
+
+    fn intern_source_order(&self, data: SourceOrder) -> SourceOrderId {
+        let mut storage = self.storage.borrow_mut();
+        storage.ensure_overlay_identity_caches();
+        if let Some(id) = storage.source_order_cache.get(&data) {
+            return *id;
+        }
+        let id = storage.source_orders.push(data);
+        let id = storage.adjusted_source_order_id(id);
+        storage.source_order_cache.insert(data, id);
+        id
+    }
+
+    fn ordered_source_order(
+        &self,
+        left: Option<SourceOrderId>,
+        right: Option<SourceOrderId>,
+    ) -> Option<SourceOrderId> {
+        match (left, right) {
+            (None, None) => None,
+            (None, other) | (other, None) => other,
+            (Some(left), Some(right)) => {
+                Some(self.intern_source_order(SourceOrder::Ordered(left, right)))
+            }
+        }
+    }
+
+    fn constraint_source_order(&self, constraint: ConstraintId) -> SourceOrderId {
+        self.intern_source_order(SourceOrder::Constraint(constraint))
+    }
 }
 
 impl<'db> BoundTypeVarInstance<'db> {
@@ -1151,6 +1287,23 @@ pub struct TypeVarId;
 #[newtype_index]
 #[derive(salsa::Update, get_size2::GetSize)]
 pub struct ConstraintId;
+
+#[newtype_index]
+#[derive(salsa::Update, get_size2::GetSize)]
+struct SourceOrderId;
+
+/// The nodes of the tree that defines the source ordering of the constraints in a constraint set.
+/// This is encoded as a binary tree over [`ConstraintId`]s. The pre-walk of that tree defines the
+/// ordering.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+enum SourceOrder {
+    /// Any constraint that appears in the left subtree should appear before any constraint in the
+    /// right subtree.
+    Ordered(SourceOrderId, SourceOrderId),
+
+    /// One of the constraints that appears in this ordering.
+    Constraint(ConstraintId),
+}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 enum NestedSubstitutionSide {
@@ -1422,7 +1575,7 @@ impl<'db> Constraint<'db> {
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         Self::new_node_with_bounds(db, builder, typevar, Some(lower), Some(upper))
     }
 
@@ -1435,9 +1588,9 @@ impl<'db> Constraint<'db> {
         typevar: BoundTypeVarInstance<'db>,
         mut lower: Option<Type<'db>>,
         mut upper: Option<Type<'db>>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         if lower.is_none() && upper.is_none() {
-            return ALWAYS_TRUE;
+            return (ALWAYS_TRUE, None);
         }
 
         // It's not useful for an upper bound to be an intersection type, or for a lower bound to
@@ -1450,19 +1603,19 @@ impl<'db> Constraint<'db> {
         //   (α | β) ≤ T   ⇔ (α ≤ T) ∧ (β ≤ T)
         if let Some(Type::Union(lower_union)) = lower {
             let mut result = ALWAYS_TRUE;
+            let mut source_order = None;
             for lower_element in lower_union.elements(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        Some(*lower_element),
-                        upper,
-                    ),
+                    typevar,
+                    Some(*lower_element),
+                    upper,
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
-            return result;
+            return (result, source_order);
         }
         // A negated type ¬α is represented as an intersection with no positive elements, and a
         // single negative element. We _don't_ want to treat that an "intersection" for the
@@ -1471,31 +1624,30 @@ impl<'db> Constraint<'db> {
             && !upper_intersection.is_simple_negation(db)
         {
             let mut result = ALWAYS_TRUE;
+            let mut source_order = None;
             for upper_element in upper_intersection.iter_positive(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        lower,
-                        Some(upper_element),
-                    ),
+                    typevar,
+                    lower,
+                    Some(upper_element),
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             for upper_element in upper_intersection.iter_negative(db) {
-                result = result.and_with_offset(
+                let (element_node, element_source_order) = Constraint::new_node_with_bounds(
+                    db,
                     builder,
-                    Constraint::new_node_with_bounds(
-                        db,
-                        builder,
-                        typevar,
-                        lower,
-                        Some(upper_element.negate(db)),
-                    ),
+                    typevar,
+                    lower,
+                    Some(upper_element.negate(db)),
                 );
+                result = result.and_with_offset(builder, element_node);
+                source_order = builder.ordered_source_order(source_order, element_source_order);
             }
-            return result;
+            return (result, source_order);
         }
 
         // Two identical typevars must always solve to the same type, so it is not useful to have
@@ -1522,12 +1674,11 @@ impl<'db> Constraint<'db> {
                     })
                 }) =>
             {
-                return Node::new_constraint(
-                    builder,
-                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object()),
-                    1,
-                )
-                .negate(builder);
+                let constraint =
+                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
+                let source_order = builder.constraint_source_order(constraint);
+                let node = Node::new_constraint(builder, constraint, 1).negate(builder);
+                return (node, Some(source_order));
             }
             _ => {}
         }
@@ -1561,7 +1712,7 @@ impl<'db> Constraint<'db> {
         let when = effective_lower.when_constraint_set_assignable_to_owned(db, effective_upper);
         let is_never_satisfied = when.query(|_builder, when| when.is_never_satisfied(db));
         if is_never_satisfied {
-            return ALWAYS_FALSE;
+            return (ALWAYS_FALSE, None);
         }
 
         // We have an (arbitrary) ordering for typevars. If the upper and/or lower bounds are
@@ -1578,17 +1729,16 @@ impl<'db> Constraint<'db> {
                 } else {
                     (typevar, lower)
                 };
-                Node::new_constraint(
+                let constraint = ConstraintId::new(
+                    db,
                     builder,
-                    ConstraintId::new(
-                        db,
-                        builder,
-                        typevar,
-                        Type::TypeVar(bound),
-                        Type::TypeVar(bound),
-                    ),
-                    1,
-                )
+                    typevar,
+                    Type::TypeVar(bound),
+                    Type::TypeVar(bound),
+                );
+                let source_order = builder.constraint_source_order(constraint);
+                let node = Node::new_constraint(builder, constraint, 1);
+                (node, Some(source_order))
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -1596,78 +1746,80 @@ impl<'db> Constraint<'db> {
                 if typevar.can_be_bound_for(db, builder, lower)
                     && typevar.can_be_bound_for(db, builder, upper) =>
             {
-                let lower = Node::new_constraint(
+                let lower_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        lower,
-                        None,
-                        Some(Type::TypeVar(typevar)),
-                    ),
-                    1,
+                    lower,
+                    None,
+                    Some(Type::TypeVar(typevar)),
                 );
-                let upper = Node::new_constraint(
+                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
+                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let upper_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        upper,
-                        Some(Type::TypeVar(typevar)),
-                        None,
-                    ),
-                    1,
+                    upper,
+                    Some(Type::TypeVar(typevar)),
+                    None,
                 );
-                lower.and(builder, upper)
+                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
+                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && ([T] ≤ U)
             (Type::TypeVar(lower), _) if typevar.can_be_bound_for(db, builder, lower) => {
-                let lower = Node::new_constraint(
+                let lower_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        lower,
-                        None,
-                        Some(Type::TypeVar(typevar)),
-                    ),
-                    1,
+                    lower,
+                    None,
+                    Some(Type::TypeVar(typevar)),
                 );
-                let upper = if upper.is_none() {
-                    ALWAYS_TRUE
+                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
+                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (upper_node, upper_source_order) = if upper.is_none() {
+                    (ALWAYS_TRUE, None)
                 } else {
                     Constraint::new_node_with_bounds(db, builder, typevar, None, upper)
                 };
-                lower.and(builder, upper)
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
             // L ≤ T ≤ U == (L ≤ [T]) && (T ≤ [U])
             (_, Type::TypeVar(upper)) if typevar.can_be_bound_for(db, builder, upper) => {
-                let lower = if lower.is_none() {
-                    ALWAYS_TRUE
+                let (lower_node, lower_source_order) = if lower.is_none() {
+                    (ALWAYS_TRUE, None)
                 } else {
                     Constraint::new_node_with_bounds(db, builder, typevar, lower, None)
                 };
-                let upper = Node::new_constraint(
+                let upper_constraint = ConstraintId::new_with_bounds(
+                    db,
                     builder,
-                    ConstraintId::new_with_bounds(
-                        db,
-                        builder,
-                        upper,
-                        Some(Type::TypeVar(typevar)),
-                        None,
-                    ),
-                    1,
+                    upper,
+                    Some(Type::TypeVar(typevar)),
+                    None,
                 );
-                lower.and(builder, upper)
+                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
+                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let node = lower_node.and(builder, upper_node);
+                let source_order =
+                    builder.ordered_source_order(lower_source_order, upper_source_order);
+                (node, source_order)
             }
 
-            _ => Node::new_constraint(
-                builder,
-                ConstraintId::new_with_bounds(db, builder, typevar, lower, upper),
-                1,
-            ),
+            _ => {
+                let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
+                let source_order = Some(builder.constraint_source_order(constraint));
+                let node = Node::new_constraint(builder, constraint, 1);
+                (node, source_order)
+            }
         }
     }
 }
@@ -2467,11 +2619,11 @@ impl NodeId {
     fn tree_fold<'db>(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        nodes: impl Iterator<Item = Self>,
+        nodes: impl Iterator<Item = (Self, Option<SourceOrderId>)>,
         zero: Self,
         is_one: impl Fn(Self, &'db dyn Db, &ConstraintSetBuilder<'db>) -> bool,
         mut combine: impl FnMut(Self, &ConstraintSetBuilder<'db>, Self) -> Self,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         // To implement the "linear" shape described above, we could collect the iterator elements
         // into a vector, and then use the fold at the bottom of this method to combine the
         // elements using the operator.
@@ -2496,40 +2648,49 @@ impl NodeId {
         //
         // We use a SmallVec for the accumulator so that we don't have to spill over to the heap
         // until the iterator passes 256 elements.
-        let mut accumulator: SmallVec<[(NodeId, u8); 8]> = SmallVec::default();
-        for node in nodes {
+        let mut accumulator: SmallVec<[(NodeId, Option<SourceOrderId>, u8); 8]> =
+            SmallVec::default();
+        for (node, source_order) in nodes {
             if is_one(node, db, builder) {
-                return node;
+                return (node, source_order);
             }
 
-            let (mut node, mut depth) = (node, 0);
+            let (mut node, mut source_order, mut depth) = (node, source_order, 0);
             while accumulator
                 .last()
-                .is_some_and(|(_, existing)| *existing == depth)
+                .is_some_and(|(_, _, existing)| *existing == depth)
             {
-                let (existing, _) = accumulator.pop().expect("accumulator should not be empty");
-                node = combine(existing, builder, node);
+                let (existing_node, existing_source_order, _) =
+                    accumulator.pop().expect("accumulator should not be empty");
+                node = combine(existing_node, builder, node);
+                source_order = builder.ordered_source_order(existing_source_order, source_order);
                 if is_one(node, db, builder) {
-                    return node;
+                    return (node, source_order);
                 }
                 depth += 1;
             }
-            accumulator.push((node, depth));
+            accumulator.push((node, source_order, depth));
         }
 
         // At this point, we've consumed all of the iterator. The length of the accumulator will be
         // the same as the number of 1 bits in the length of the iterator. We do a final fold to
         // produce the overall result.
-        accumulator
-            .into_iter()
-            .fold(zero, |result, (node, _)| combine(result, builder, node))
+        accumulator.into_iter().fold(
+            (zero, None),
+            |(result_node, result_source_order), (node, source_order, _)| {
+                (
+                    combine(result_node, builder, node),
+                    builder.ordered_source_order(result_source_order, source_order),
+                )
+            },
+        )
     }
 
     fn distributed_or<'db>(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        nodes: impl Iterator<Item = NodeId>,
-    ) -> Self {
+        nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
+    ) -> (Self, Option<SourceOrderId>) {
         Self::tree_fold(
             db,
             builder,
@@ -2543,8 +2704,8 @@ impl NodeId {
     fn distributed_and<'db>(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
-        nodes: impl Iterator<Item = NodeId>,
-    ) -> Self {
+        nodes: impl Iterator<Item = (NodeId, Option<SourceOrderId>)>,
+    ) -> (Self, Option<SourceOrderId>) {
         Self::tree_fold(
             db,
             builder,
@@ -2709,7 +2870,7 @@ impl NodeId {
         builder: &ConstraintSetBuilder<'db>,
         lhs: Type<'db>,
         rhs: Type<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         // When checking subtyping involving a typevar, we can turn the subtyping check into a
         // constraint (i.e, "is `T` a subtype of `int` becomes the constraint `T ≤ int`), and then
         // check when the BDD implies that constraint.
@@ -2718,7 +2879,7 @@ impl NodeId {
         // these types are coming in from arbitrary subtyping checks that the caller might want to
         // perform. So we have to take the appropriate materialization when translating the check
         // into a constraint.
-        let constraint = match (lhs, rhs) {
+        let (constraint, constraint_source_order) = match (lhs, rhs) {
             (Type::TypeVar(bound_typevar), _) => Constraint::new_node_with_bounds(
                 db,
                 builder,
@@ -2736,7 +2897,8 @@ impl NodeId {
             _ => panic!("at least one type should be a typevar"),
         };
 
-        self.implies(builder, constraint)
+        let node = self.implies(builder, constraint);
+        (node, constraint_source_order)
     }
 
     fn satisfied_by_all_typevars<'db>(
@@ -6859,17 +7021,18 @@ impl<'db> BoundTypeVarInstance<'db> {
             None => ALWAYS_TRUE,
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.top_materialization(db);
-                Constraint::new_node_with_bounds(db, builder, self, None, Some(bound))
+                let (node, _) =
+                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
+                node
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut specializations = ALWAYS_FALSE;
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    specializations = specializations.or_with_offset(
-                        builder,
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper),
-                    );
+                    let (constraint_node, _) =
+                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
+                    specializations = specializations.or_with_offset(builder, constraint_node);
                 }
                 specializations
             }
@@ -6903,10 +7066,9 @@ impl<'db> BoundTypeVarInstance<'db> {
             None => (ALWAYS_TRUE, Vec::new()),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                 let bound = bound.bottom_materialization(db);
-                (
-                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound)),
-                    Vec::new(),
-                )
+                let (node, _) =
+                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound));
+                (node, Vec::new())
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut non_gradual_constraints = ALWAYS_FALSE;
@@ -6914,7 +7076,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 for constraint in constraints.elements(db) {
                     let constraint_lower = constraint.bottom_materialization(db);
                     let constraint_upper = constraint.top_materialization(db);
-                    let constraint =
+                    let (constraint, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
                     if constraint_lower == constraint_upper {
                         non_gradual_constraints =

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -656,7 +656,8 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         self.verify_builder(builder);
-        self.node.solutions_with(db, builder, choose)
+        self.node
+            .solutions_with(db, builder, self.source_order, choose)
     }
 
     pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
@@ -1247,7 +1248,6 @@ impl<'db> ConstraintSetBuilder<'db> {
         self.intern_source_order(SourceOrder::Constraint(constraint))
     }
 
-    #[expect(dead_code)]
     fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
         let storage = self.storage.borrow();
         if let Some(compacted) = &storage.compacted {
@@ -1260,6 +1260,33 @@ impl<'db> ConstraintSetBuilder<'db> {
             return storage.source_orders[SourceOrderId::from_usize(index - split)];
         }
         storage.source_orders[source_order]
+    }
+
+    fn calculate_source_orders(
+        &self,
+        source_order: Option<SourceOrderId>,
+    ) -> FxIndexSet<ConstraintId> {
+        fn walk(
+            builder: &ConstraintSetBuilder,
+            current: SourceOrderId,
+            result: &mut FxIndexSet<ConstraintId>,
+        ) {
+            match builder.source_order_data(current) {
+                SourceOrder::Ordered(left, right) => {
+                    walk(builder, left, result);
+                    walk(builder, right, result);
+                }
+                SourceOrder::Constraint(constraint) => {
+                    result.insert(constraint);
+                }
+            }
+        }
+
+        let mut result = FxIndexSet::default();
+        if let Some(source_order) = source_order {
+            walk(self, source_order, &mut result);
+        }
+        result
     }
 }
 
@@ -2545,9 +2572,10 @@ impl NodeId {
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
+        source_order: Option<SourceOrderId>,
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
-        let path_bounds = PathBounds::compute(db, builder, self);
+        let path_bounds = PathBounds::compute(db, builder, self, source_order);
         path_bounds.solve_with(choose)
     }
 
@@ -3645,7 +3673,7 @@ impl<'db> Type<'db> {
             let when = source.when_constraint_set_assignable_to_owned(db, target);
             when.query(|builder, when| {
                 let when = when.remove_noninferable(db, builder, inferable);
-                PathBounds::compute(db, builder, when.node)
+                PathBounds::compute(db, builder, when.node, when.source_order)
             })
         }
 
@@ -3680,7 +3708,12 @@ impl<'db> PathBounds<'db> {
     ///
     /// Returns a list of paths, where each path contains the explicit lower/upper bounds for each
     /// typevar that appears in the path's constraints.
-    fn compute(db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>, node: NodeId) -> Self {
+    fn compute(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        node: NodeId,
+        source_order: Option<SourceOrderId>,
+    ) -> Self {
         match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
@@ -3696,9 +3729,19 @@ impl<'db> PathBounds<'db> {
         // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
         // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
         // retain that stable per-tie ordering.
+        let mut source_orders = builder.calculate_source_orders(source_order);
         let mut sorted_paths = Vec::new();
         node.for_each_path(db, builder, |path| {
-            let mut path: Vec<_> = path.positive_constraints().collect();
+            let mut path: Vec<_> = path
+                .positive_constraints()
+                .map(|(constraint, _)| {
+                    source_orders.insert(constraint);
+                    let source_order = source_orders
+                        .get_index_of(&constraint)
+                        .expect("every BDD constraint should have a source_order");
+                    (constraint, source_order)
+                })
+                .collect();
             path.sort_by_key(|(_, source_order)| *source_order);
             sorted_paths.push(path);
         });

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -606,8 +606,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         to_remove: impl IntoIterator<Item = BoundTypeVarIdentity<'db>>,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.exists(db, builder, to_remove);
-        Self::from_node(builder, node, self.source_order)
+        let (node, derived_source_order) = self.node.exists(db, builder, to_remove);
+        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     pub(crate) fn remove_noninferable(
@@ -624,8 +625,9 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         {
             return self;
         }
-        let node = self.node.remove_noninferable(db, builder, inferable);
-        Self::from_node(builder, node, self.source_order)
+        let (node, derived_source_order) = self.node.remove_noninferable(db, builder, inferable);
+        let source_order = builder.ordered_source_order(self.source_order, derived_source_order);
+        Self::from_node(builder, node, source_order)
     }
 
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
@@ -760,7 +762,8 @@ struct ConstraintSetStorage<'db> {
     negate_cache: FxHashMap<NodeId, NodeId>,
     or_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
     and_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    exists_one_cache: FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), NodeId>,
+    exists_one_cache:
+        FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), (NodeId, Option<SourceOrderId>)>,
     retain_one_cache: FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), NodeId>,
     restrict_one_cache: FxHashMap<(NodeId, ConstraintAssignment), (NodeId, bool)>,
     simplify_cache: FxHashMap<NodeId, NodeId>,
@@ -1243,6 +1246,21 @@ impl<'db> ConstraintSetBuilder<'db> {
     fn constraint_source_order(&self, constraint: ConstraintId) -> SourceOrderId {
         self.intern_source_order(SourceOrder::Constraint(constraint))
     }
+
+    #[expect(dead_code)]
+    fn source_order_data(&self, source_order: SourceOrderId) -> SourceOrder {
+        let storage = self.storage.borrow();
+        if let Some(compacted) = &storage.compacted {
+            let index = source_order.index();
+            let split = compacted.source_order_indices.len();
+            if index < split {
+                let compacted_index = compacted.retained_source_order_index(source_order);
+                return compacted.source_orders[compacted_index];
+            }
+            return storage.source_orders[SourceOrderId::from_usize(index - split)];
+        }
+        storage.source_orders[source_order]
+    }
 }
 
 impl<'db> BoundTypeVarInstance<'db> {
@@ -1676,9 +1694,9 @@ impl<'db> Constraint<'db> {
             {
                 let constraint =
                     ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let source_order = builder.constraint_source_order(constraint);
-                let node = Node::new_constraint(builder, constraint, 1).negate(builder);
-                return (node, Some(source_order));
+                let (node, source_order) = Node::new_constraint(builder, constraint, 1);
+                let node = node.negate(builder);
+                return (node, source_order);
             }
             _ => {}
         }
@@ -1736,9 +1754,7 @@ impl<'db> Constraint<'db> {
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                let source_order = builder.constraint_source_order(constraint);
-                let node = Node::new_constraint(builder, constraint, 1);
-                (node, Some(source_order))
+                Node::new_constraint(builder, constraint, 1)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -1753,8 +1769,8 @@ impl<'db> Constraint<'db> {
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
-                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
-                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (lower_node, lower_source_order) =
+                    Node::new_constraint(builder, lower_constraint, 1);
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
                     builder,
@@ -1762,8 +1778,8 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
-                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
-                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let (upper_node, upper_source_order) =
+                    Node::new_constraint(builder, upper_constraint, 1);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -1779,8 +1795,8 @@ impl<'db> Constraint<'db> {
                     None,
                     Some(Type::TypeVar(typevar)),
                 );
-                let lower_source_order = Some(builder.constraint_source_order(lower_constraint));
-                let lower_node = Node::new_constraint(builder, lower_constraint, 1);
+                let (lower_node, lower_source_order) =
+                    Node::new_constraint(builder, lower_constraint, 1);
                 let (upper_node, upper_source_order) = if upper.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
@@ -1806,8 +1822,8 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                     None,
                 );
-                let upper_source_order = Some(builder.constraint_source_order(upper_constraint));
-                let upper_node = Node::new_constraint(builder, upper_constraint, 1);
+                let (upper_node, upper_source_order) =
+                    Node::new_constraint(builder, upper_constraint, 1);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -1816,9 +1832,7 @@ impl<'db> Constraint<'db> {
 
             _ => {
                 let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
-                let source_order = Some(builder.constraint_source_order(constraint));
-                let node = Node::new_constraint(builder, constraint, 1);
-                (node, source_order)
+                Node::new_constraint(builder, constraint, 1)
             }
         }
     }
@@ -2103,14 +2117,17 @@ impl Node {
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintId,
         source_order: usize,
-    ) -> NodeId {
-        NodeId::with_uncertain(
-            builder,
-            constraint,
-            ALWAYS_TRUE,
-            ALWAYS_FALSE,
-            ALWAYS_FALSE,
-            source_order,
+    ) -> (NodeId, Option<SourceOrderId>) {
+        (
+            NodeId::with_uncertain(
+                builder,
+                constraint,
+                ALWAYS_TRUE,
+                ALWAYS_FALSE,
+                ALWAYS_FALSE,
+                source_order,
+            ),
+            Some(builder.constraint_source_order(constraint)),
         )
     }
 
@@ -2123,29 +2140,35 @@ impl Node {
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
         source_order: usize,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         match constraint {
-            ConstraintAssignment::Positive(constraint) => NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_TRUE,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                source_order,
+            ConstraintAssignment::Positive(constraint) => (
+                NodeId::with_uncertain(
+                    builder,
+                    constraint,
+                    ALWAYS_TRUE,
+                    ALWAYS_FALSE,
+                    ALWAYS_FALSE,
+                    source_order,
+                ),
+                Some(builder.constraint_source_order(constraint)),
             ),
-            ConstraintAssignment::Negative(constraint) => NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                ALWAYS_TRUE,
-                source_order,
+            ConstraintAssignment::Negative(constraint) => (
+                NodeId::with_uncertain(
+                    builder,
+                    constraint,
+                    ALWAYS_FALSE,
+                    ALWAYS_FALSE,
+                    ALWAYS_TRUE,
+                    source_order,
+                ),
+                Some(builder.constraint_source_order(constraint)),
             ),
-            ConstraintAssignment::Unconstrained(constraint) => {
-                // The result holds regardless of the constraint's truth value, so only
-                // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
-                // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
-                // that would throw away some of the efficiency gains this representation gives us.
+            // The result holds regardless of the constraint's truth value, so only
+            // `if_uncertain` needs to be `ALWAYS_TRUE` — `n? 0: 1: 0`. It would also be
+            // correct to use `n? 1: 1: 1` (i.e., `ALWAYS_TRUE` for all outgoing edges), but
+            // that would throw away some of the efficiency gains this representation gives us.
+            ConstraintAssignment::Unconstrained(constraint) => (
                 NodeId::with_uncertain(
                     builder,
                     constraint,
@@ -2153,8 +2176,9 @@ impl Node {
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
                     source_order,
-                )
-            }
+                ),
+                Some(builder.constraint_source_order(constraint)),
+            ),
         }
     }
 }
@@ -2985,12 +3009,17 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: impl IntoIterator<Item = BoundTypeVarIdentity<'db>>,
-    ) -> Self {
-        bound_typevars
-            .into_iter()
-            .fold(self, |abstracted, bound_typevar| {
-                abstracted.exists_one(db, builder, bound_typevar)
-            })
+    ) -> (Self, Option<SourceOrderId>) {
+        bound_typevars.into_iter().fold(
+            (self, None),
+            |(abstracted, source_order), bound_typevar| {
+                let (abstracted, abstracted_source_order) =
+                    abstracted.exists_one(db, builder, bound_typevar);
+                let source_order =
+                    builder.ordered_source_order(source_order, abstracted_source_order);
+                (abstracted, source_order)
+            },
+        )
     }
 
     fn exists_one<'db>(
@@ -2998,10 +3027,10 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevar: BoundTypeVarIdentity<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         match self.node() {
-            Node::AlwaysTrue => ALWAYS_TRUE,
-            Node::AlwaysFalse => ALWAYS_FALSE,
+            Node::AlwaysTrue => (ALWAYS_TRUE, None),
+            Node::AlwaysFalse => (ALWAYS_FALSE, None),
             Node::Interior(interior) => interior.exists_one(db, builder, bound_typevar),
         }
     }
@@ -3011,10 +3040,10 @@ impl NodeId {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         match self.node() {
-            Node::AlwaysTrue => ALWAYS_TRUE,
-            Node::AlwaysFalse => ALWAYS_FALSE,
+            Node::AlwaysTrue => (ALWAYS_TRUE, None),
+            Node::AlwaysFalse => (ALWAYS_FALSE, None),
             Node::Interior(interior) => interior.remove_noninferable(db, builder, inferable),
         }
     }
@@ -3025,10 +3054,10 @@ impl NodeId {
         builder: &ConstraintSetBuilder<'db>,
         should_remove: &mut dyn FnMut(ConstraintId) -> bool,
         path: &mut PathAssignments,
-    ) -> Self {
+    ) -> (Self, Option<SourceOrderId>) {
         match self.node() {
-            Node::AlwaysTrue => ALWAYS_TRUE,
-            Node::AlwaysFalse => ALWAYS_FALSE,
+            Node::AlwaysTrue => (ALWAYS_TRUE, None),
+            Node::AlwaysFalse => (ALWAYS_FALSE, None),
             Node::Interior(interior) => {
                 interior.abstract_one_inner(db, builder, should_remove, path)
             }
@@ -3114,8 +3143,8 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
         let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
         let left_result = left_node.ite(builder, right_result, when_not_left);
         let result = replacement.ite(builder, when_left_and_right, left_result);
@@ -3182,8 +3211,8 @@ impl NodeId {
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let left_node = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let right_node = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
         let validity = replacement.iff(builder, left_node.or(builder, right_node));
         let constrained_original = self.and(builder, validity);
         let constrained_replacement = result.and(builder, validity);
@@ -4186,7 +4215,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevar: BoundTypeVarIdentity<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         let key = (self.node(), bound_typevar);
         let storage = builder.storage.borrow();
         if let Some(result) = storage.exists_one_cache.get(&key) {
@@ -4240,7 +4269,7 @@ impl InteriorNode {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         let mut path = self.path_assignments(builder);
         let is_bare_inferable_typevar = |ty: Type<'db>| {
             ty.as_typevar()
@@ -4280,7 +4309,7 @@ impl InteriorNode {
         builder: &ConstraintSetBuilder<'db>,
         should_remove: &mut dyn FnMut(ConstraintId) -> bool,
         path: &mut PathAssignments,
-    ) -> NodeId {
+    ) -> (NodeId, Option<SourceOrderId>) {
         let self_interior = builder.interior_node_data(self.node());
         if should_remove(self_interior.constraint) {
             // If we should remove constraints involving this typevar, then we replace this node
@@ -4295,19 +4324,16 @@ impl InteriorNode {
             // TODO: This might not be stable enough, if we add more than one derived fact for this
             // constraint. If we still see inconsistent test output, we might need a more complex
             // way of tracking source order for derived facts.
-            let if_true = path
+            let (if_true, if_true_source_order) = path
                 .walk_edge(
                     db,
                     builder,
                     self_interior.constraint.when_true(),
                     self_interior.source_order,
                     |path, new_range| {
-                        let branch = self_interior.if_true.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
+                        let (branch, branch_source_order) = self_interior
+                            .if_true
+                            .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
                             .filter(|(assignment, _)| {
@@ -4315,32 +4341,37 @@ impl InteriorNode {
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
-                            .fold(branch, |branch, (assignment, source_order)| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
+                            .fold(
+                                (branch, branch_source_order),
+                                |(branch, branch_source_order), (assignment, source_order)| {
+                                    let (assignment_node, assignment_source_order) =
+                                        Node::new_satisfied_constraint(
+                                            builder,
+                                            *assignment,
+                                            *source_order,
+                                        );
+                                    (
+                                        branch.and(builder, assignment_node),
+                                        builder.ordered_source_order(
+                                            branch_source_order,
+                                            assignment_source_order,
+                                        ),
+                                    )
+                                },
+                            )
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_false = path
+                .unwrap_or((ALWAYS_FALSE, None));
+            let (if_false, if_false_source_order) = path
                 .walk_edge(
                     db,
                     builder,
                     self_interior.constraint.when_false(),
                     self_interior.source_order,
                     |path, new_range| {
-                        let branch = self_interior.if_false.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
+                        let (branch, branch_source_order) = self_interior
+                            .if_false
+                            .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
                             .filter(|(assignment, _)| {
@@ -4348,52 +4379,70 @@ impl InteriorNode {
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
-                            .fold(branch, |branch, (assignment, source_order)| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
+                            .fold(
+                                (branch, branch_source_order),
+                                |(branch, branch_source_order), (assignment, source_order)| {
+                                    let (assignment_node, assignment_source_order) =
+                                        Node::new_satisfied_constraint(
+                                            builder,
+                                            *assignment,
+                                            *source_order,
+                                        );
+                                    (
+                                        branch.and(builder, assignment_node),
+                                        builder.ordered_source_order(
+                                            branch_source_order,
+                                            assignment_source_order,
+                                        ),
+                                    )
+                                },
+                            )
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_uncertain = path
+                .unwrap_or((ALWAYS_FALSE, None));
+            let (if_uncertain, if_uncertain_source_order) = path
                 .walk_edge(
                     db,
                     builder,
                     self_interior.constraint.when_unconstrained(),
                     self_interior.source_order,
                     |path, new_range| {
-                        let branch = self_interior.if_uncertain.abstract_one_inner(
-                            db,
-                            builder,
-                            should_remove,
-                            path,
-                        );
+                        let (branch, branch_source_order) = self_interior
+                            .if_uncertain
+                            .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
                             .filter(|(assignment, _)| !should_remove(assignment.constraint()))
-                            .fold(branch, |branch, (assignment, source_order)| {
-                                branch.and(
-                                    builder,
-                                    Node::new_satisfied_constraint(
-                                        builder,
-                                        *assignment,
-                                        *source_order,
-                                    ),
-                                )
-                            })
+                            .fold(
+                                (branch, branch_source_order),
+                                |(branch, branch_source_order), (assignment, source_order)| {
+                                    let (assignment_node, assignment_source_order) =
+                                        Node::new_satisfied_constraint(
+                                            builder,
+                                            *assignment,
+                                            *source_order,
+                                        );
+                                    (
+                                        branch.and(builder, assignment_node),
+                                        builder.ordered_source_order(
+                                            branch_source_order,
+                                            assignment_source_order,
+                                        ),
+                                    )
+                                },
+                            )
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
-            if_true.or(builder, if_uncertain).or(builder, if_false)
+                .unwrap_or((ALWAYS_FALSE, None));
+
+            let node = if_true.or(builder, if_uncertain).or(builder, if_false);
+            let source_order =
+                builder.ordered_source_order(if_true_source_order, if_uncertain_source_order);
+            let source_order = builder.ordered_source_order(source_order, if_false_source_order);
+            (node, source_order)
         } else {
             // Otherwise, we abstract the if_false/if_true edges recursively.
-            let if_true = path
+            let (if_true, if_true_source_order) = path
                 .walk_edge(
                     db,
                     builder,
@@ -4405,8 +4454,8 @@ impl InteriorNode {
                             .abstract_one_inner(db, builder, should_remove, path)
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_uncertain = path
+                .unwrap_or((ALWAYS_FALSE, None));
+            let (if_uncertain, if_uncertain_source_order) = path
                 .walk_edge(
                     db,
                     builder,
@@ -4421,8 +4470,8 @@ impl InteriorNode {
                         )
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
-            let if_false = path
+                .unwrap_or((ALWAYS_FALSE, None));
+            let (if_false, if_false_source_order) = path
                 .walk_edge(
                     db,
                     builder,
@@ -4434,7 +4483,8 @@ impl InteriorNode {
                             .abstract_one_inner(db, builder, should_remove, path)
                     },
                 )
-                .unwrap_or(ALWAYS_FALSE);
+                .unwrap_or((ALWAYS_FALSE, None));
+
             // Absorb the uncertain branch into both the true and false branches before
             // constructing the ITE, matching TDD semantics: when the constraint holds the result
             // is C ∨ U, and when it doesn't the result is D ∨ U.
@@ -4442,16 +4492,22 @@ impl InteriorNode {
             // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
             // derived constraints into the result, and those constraints might appear before this
             // one in the BDD ordering.
-            Node::new_constraint(
+            let (constraint_node, constraint_source_order) = Node::new_constraint(
                 builder,
                 self_interior.constraint,
                 self_interior.source_order,
-            )
-            .ite(
+            );
+            let node = constraint_node.ite(
                 builder,
                 if_true.or(builder, if_uncertain),
                 if_false.or(builder, if_uncertain),
-            )
+            );
+            let left_source_order =
+                builder.ordered_source_order(constraint_source_order, if_true_source_order);
+            let right_source_order =
+                builder.ordered_source_order(if_uncertain_source_order, if_false_source_order);
+            let source_order = builder.ordered_source_order(left_source_order, right_source_order);
+            (node, source_order)
         }
     }
 
@@ -4672,14 +4728,15 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let new_node = Node::new_constraint(builder, new_constraint, next_source_order);
+                let (new_node, _) =
+                    Node::new_constraint(builder, new_constraint, next_source_order);
                 next_source_order += 1;
-                let positive_left_node = Node::new_satisfied_constraint(
+                let (positive_left_node, _) = Node::new_satisfied_constraint(
                     builder,
                     left_constraint.when_true(),
                     left_source_order,
                 );
-                let positive_right_node = Node::new_satisfied_constraint(
+                let (positive_right_node, _) = Node::new_satisfied_constraint(
                     builder,
                     right_constraint.when_true(),
                     right_source_order,
@@ -4741,12 +4798,12 @@ impl InteriorNode {
                 smaller_source_order,
             )) = larger_smaller
             {
-                let positive_larger_node = Node::new_satisfied_constraint(
+                let (positive_larger_node, _) = Node::new_satisfied_constraint(
                     builder,
                     larger_constraint.when_true(),
                     larger_source_order,
                 );
-                let negative_larger_node = Node::new_satisfied_constraint(
+                let (negative_larger_node, _) = Node::new_satisfied_constraint(
                     builder,
                     larger_constraint.when_false(),
                     larger_source_order,
@@ -4818,35 +4875,35 @@ impl InteriorNode {
                                 .map(|seen| (seen, intersection_constraint)),
                         );
                     }
-                    let positive_intersection_node = Node::new_satisfied_constraint(
+                    let (positive_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_true(),
                         next_source_order,
                     );
-                    let negative_intersection_node = Node::new_satisfied_constraint(
+                    let (negative_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_false(),
                         next_source_order,
                     );
                     next_source_order += 1;
 
-                    let positive_left_node = Node::new_satisfied_constraint(
+                    let (positive_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_true(),
                         left_source_order,
                     );
-                    let negative_left_node = Node::new_satisfied_constraint(
+                    let (negative_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_false(),
                         left_source_order,
                     );
 
-                    let positive_right_node = Node::new_satisfied_constraint(
+                    let (positive_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_true(),
                         right_source_order,
                     );
-                    let negative_right_node = Node::new_satisfied_constraint(
+                    let (negative_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_false(),
                         right_source_order,
@@ -4933,12 +4990,12 @@ impl InteriorNode {
                     // All of the below hold because we just proved that the intersection of left
                     // and right is empty.
 
-                    let positive_left_node = Node::new_satisfied_constraint(
+                    let (positive_left_node, _) = Node::new_satisfied_constraint(
                         builder,
                         left_constraint.when_true(),
                         left_source_order,
                     );
-                    let positive_right_node = Node::new_satisfied_constraint(
+                    let (positive_right_node, _) = Node::new_satisfied_constraint(
                         builder,
                         right_constraint.when_true(),
                         right_source_order,

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3527,12 +3527,9 @@ impl<'db> PathBounds<'db> {
             let mut path: Vec<_> = path
                 .positive_constraints()
                 .map(|(constraint, source_constraint)| {
-                    let source_order = match source_orders.get_index_of(&constraint) {
-                        Some(source_order) => source_order,
-                        None => source_orders
-                            .get_index_of(&source_constraint)
-                            .expect("every BDD constraint should have a source_order"),
-                    };
+                    let source_order = source_orders
+                        .get_index_of(&source_constraint)
+                        .expect("every BDD constraint should have a source_order");
                     (constraint, source_order)
                 })
                 .collect();

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -93,7 +93,6 @@ use std::marker::PhantomData;
 use std::ops::Range;
 use std::sync::Arc;
 
-use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -2383,35 +2382,22 @@ impl NodeId {
             Node::AlwaysFalse => {}
             Node::Interior(_) => {
                 let interior = builder.interior_node_data(self);
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_true(),
-                    interior.source_order,
-                    |path, _| {
-                        interior.if_true.for_each_path_inner(db, builder, f, path);
-                    },
-                );
+                path.walk_edge(db, builder, interior.constraint.when_true(), |path, _| {
+                    interior.if_true.for_each_path_inner(db, builder, f, path);
+                });
                 path.walk_edge(
                     db,
                     builder,
                     interior.constraint.when_unconstrained(),
-                    interior.source_order,
                     |path, _| {
                         interior
                             .if_uncertain
                             .for_each_path_inner(db, builder, f, path);
                     },
                 );
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_false(),
-                    interior.source_order,
-                    |path, _| {
-                        interior.if_false.for_each_path_inner(db, builder, f, path);
-                    },
-                );
+                path.walk_edge(db, builder, interior.constraint.when_false(), |path, _| {
+                    interior.if_false.for_each_path_inner(db, builder, f, path);
+                });
             }
         }
     }
@@ -2454,13 +2440,9 @@ impl NodeId {
                 let interior = builder.interior_node_data(self);
                 let if_true_or_uncertain = interior.if_true.or(builder, interior.if_uncertain);
                 let true_always_satisfied = path
-                    .walk_edge(
-                        db,
-                        builder,
-                        interior.constraint.when_true(),
-                        interior.source_order,
-                        |path, _| if_true_or_uncertain.is_always_satisfied_inner(db, builder, path),
-                    )
+                    .walk_edge(db, builder, interior.constraint.when_true(), |path, _| {
+                        if_true_or_uncertain.is_always_satisfied_inner(db, builder, path)
+                    })
                     .unwrap_or(true);
                 if !true_always_satisfied {
                     return false;
@@ -2468,13 +2450,9 @@ impl NodeId {
 
                 // Ditto for the if_false branch
                 let if_false_or_uncertain = interior.if_false.or(builder, interior.if_uncertain);
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_false(),
-                    interior.source_order,
-                    |path, _| if_false_or_uncertain.is_always_satisfied_inner(db, builder, path),
-                )
+                path.walk_edge(db, builder, interior.constraint.when_false(), |path, _| {
+                    if_false_or_uncertain.is_always_satisfied_inner(db, builder, path)
+                })
                 .unwrap_or(true)
             }
         }
@@ -2521,13 +2499,9 @@ impl NodeId {
                 // are each independently false. That lets us check each branch in isolation.
                 let interior = builder.interior_node_data(self);
                 let true_never_satisfied = path
-                    .walk_edge(
-                        db,
-                        builder,
-                        interior.constraint.when_true(),
-                        interior.source_order,
-                        |path, _| interior.if_true.is_never_satisfied_inner(db, builder, path),
-                    )
+                    .walk_edge(db, builder, interior.constraint.when_true(), |path, _| {
+                        interior.if_true.is_never_satisfied_inner(db, builder, path)
+                    })
                     .unwrap_or(true);
                 if !true_never_satisfied {
                     return false;
@@ -2539,7 +2513,6 @@ impl NodeId {
                         db,
                         builder,
                         interior.constraint.when_unconstrained(),
-                        interior.source_order,
                         |path, _| {
                             interior
                                 .if_uncertain
@@ -2552,17 +2525,11 @@ impl NodeId {
                 }
 
                 // Ditto for the if_false branch
-                path.walk_edge(
-                    db,
-                    builder,
-                    interior.constraint.when_false(),
-                    interior.source_order,
-                    |path, _| {
-                        interior
-                            .if_false
-                            .is_never_satisfied_inner(db, builder, path)
-                    },
-                )
+                path.walk_edge(db, builder, interior.constraint.when_false(), |path, _| {
+                    interior
+                        .if_false
+                        .is_never_satisfied_inner(db, builder, path)
+                })
                 .unwrap_or(true)
             }
         }
@@ -3734,7 +3701,7 @@ impl<'db> PathBounds<'db> {
         node.for_each_path(db, builder, |path| {
             let mut path: Vec<_> = path
                 .positive_constraints()
-                .map(|(constraint, _)| {
+                .map(|constraint| {
                     source_orders.insert(constraint);
                     let source_order = source_orders
                         .get_index_of(&constraint)
@@ -4372,27 +4339,22 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_true(),
-                    self_interior.source_order,
                     |path, new_range| {
                         let (branch, branch_source_order) = self_interior
                             .if_true
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|(assignment, _)| {
+                            .filter(|assignment| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), (assignment, source_order)| {
+                                |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(
-                                            builder,
-                                            *assignment,
-                                            *source_order,
-                                        );
+                                        Node::new_satisfied_constraint(builder, *assignment, 0);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4410,27 +4372,22 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_false(),
-                    self_interior.source_order,
                     |path, new_range| {
                         let (branch, branch_source_order) = self_interior
                             .if_false
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|(assignment, _)| {
+                            .filter(|assignment| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), (assignment, source_order)| {
+                                |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(
-                                            builder,
-                                            *assignment,
-                                            *source_order,
-                                        );
+                                        Node::new_satisfied_constraint(builder, *assignment, 0);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4448,23 +4405,18 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_unconstrained(),
-                    self_interior.source_order,
                     |path, new_range| {
                         let (branch, branch_source_order) = self_interior
                             .if_uncertain
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|(assignment, _)| !should_remove(assignment.constraint()))
+                            .filter(|assignment| !should_remove(assignment.constraint()))
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), (assignment, source_order)| {
+                                |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(
-                                            builder,
-                                            *assignment,
-                                            *source_order,
-                                        );
+                                        Node::new_satisfied_constraint(builder, *assignment, 0);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4490,7 +4442,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_true(),
-                    self_interior.source_order,
                     |path, _| {
                         self_interior
                             .if_true
@@ -4503,7 +4454,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_unconstrained(),
-                    self_interior.source_order,
                     |path, _| {
                         self_interior.if_uncertain.abstract_one_inner(
                             db,
@@ -4519,7 +4469,6 @@ impl InteriorNode {
                     db,
                     builder,
                     self_interior.constraint.when_false(),
-                    self_interior.source_order,
                     |path, _| {
                         self_interior
                             .if_false
@@ -6566,7 +6515,7 @@ impl SequentMap {
 #[derive(Debug)]
 pub(crate) struct PathAssignments {
     map: SequentMap,
-    assignments: FxIndexMap<ConstraintAssignment, usize>,
+    assignments: FxIndexSet<ConstraintAssignment>,
     /// Nested substitutions that we have already applied on the current root→terminal path.
     nested_substitutions: FxIndexSet<NestedSubstitution>,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
@@ -6583,7 +6532,7 @@ impl PathAssignments {
             .collect();
         Self {
             map: SequentMap::default(),
-            assignments: FxIndexMap::default(),
+            assignments: FxIndexSet::default(),
             nested_substitutions: FxIndexSet::default(),
             discovered,
         }
@@ -6616,7 +6565,6 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
         f: impl FnOnce(&mut Self, Range<usize>) -> R,
     ) -> Option<R> {
         // Record a snapshot of the assignments that we already knew held — both so that we can
@@ -6630,14 +6578,14 @@ impl PathAssignments {
             target: "ty_python_semantic::types::constraints::PathAssignment",
             before = %format_args!(
                 "[{}]",
-                self.assignments[..start].iter().map(|(assignment, _)| {
+                self.assignments[..start].iter().map(|assignment| {
                     assignment.display(db, builder)
                 }).format(", "),
             ),
             edge = %assignment.display(db, builder),
             "walk edge",
         );
-        let found_conflict = self.add_assignment(db, builder, assignment, source_order, false);
+        let found_conflict = self.add_assignment(db, builder, assignment);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
             // without invoking the callback.
@@ -6652,7 +6600,7 @@ impl PathAssignments {
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 new = %format_args!(
                     "[{}]",
-                    self.assignments[start..].iter().map(|(assignment, _)| {
+                    self.assignments[start..].iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -6670,17 +6618,17 @@ impl PathAssignments {
         result
     }
 
-    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = (ConstraintId, usize)> + '_ {
+    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = ConstraintId> + '_ {
         self.assignments
             .iter()
-            .filter_map(|(assignment, source_order)| match assignment {
-                ConstraintAssignment::Positive(constraint) => Some((*constraint, *source_order)),
+            .filter_map(|assignment| match assignment {
+                ConstraintAssignment::Positive(constraint) => Some(*constraint),
                 ConstraintAssignment::Negative(_) | ConstraintAssignment::Unconstrained(_) => None,
             })
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
-        self.assignments.contains_key(&assignment)
+        self.assignments.contains(&assignment)
     }
 
     fn contains_constraint(&self, constraint: ConstraintId) -> bool {
@@ -6725,8 +6673,6 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
-        source_order: usize,
-        derived: bool,
     ) -> Result<(), PathAssignmentConflict> {
         if matches!(assignment, ConstraintAssignment::Unconstrained(_)) {
             // An `Unconstrained` assignment means "this constraint can go either way". If there is
@@ -6740,19 +6686,19 @@ impl PathAssignments {
             // derive any additional information from the sequent map. We still want to record the
             // assignment, but as an optimization we can return early without actually querying the
             // sequent map.
-            self.assignments.insert(assignment, source_order);
+            self.assignments.insert(assignment);
             return Ok(());
         }
 
         // First add this assignment. If it causes a conflict, return that as an error. If we've
         // already know this assignment holds, just return.
-        if self.assignments.contains_key(&assignment.negated()) {
+        if self.assignments.contains(&assignment.negated()) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 assignment = %assignment.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
-                    self.assignments.iter().map(|(assignment, _)| {
+                    self.assignments.iter().map(|assignment| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -6761,27 +6707,11 @@ impl PathAssignments {
             return Err(PathAssignmentConflict);
         }
 
-        match self.assignments.entry(assignment) {
-            Entry::Vacant(entry) => entry.insert(source_order),
-            Entry::Occupied(mut entry) => {
-                // If a constraint appears both as an "origin" constraint (it actually appears in
-                // the BDD structure) and as a "derived" constraint (we infer it from other
-                // constraints), we should prefer the origin source_order, regardless of which
-                // order we encounter the various constraints in the BDD.
-                if !derived {
-                    *entry.get_mut() = source_order;
-                }
-                return Ok(());
-            }
-        };
+        if !self.assignments.insert(assignment) {
+            return Ok(());
+        }
 
-        // Then use our sequents to add additional facts that we know to be true. We currently
-        // reuse the `source_order` of the "real" constraint passed into `walk_edge` when we add
-        // these derived facts.
-        //
-        // TODO: This might not be stable enough, if we add more than one derived fact for this
-        // constraint. If we still see inconsistent test output, we might need a more complex
-        // way of tracking source order for derived facts.
+        // Then use our sequents to add additional facts that we know to be true.
         //
         // TODO: This is very naive at the moment, partly for expediency, and partly because we
         // don't anticipate the sequent maps to be very large. We might consider avoiding the
@@ -6802,7 +6732,7 @@ impl PathAssignments {
                     ante = %ante.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
+                        self.assignments.iter().map(|assignment| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -6827,7 +6757,7 @@ impl PathAssignments {
                     ante2 = %ante2.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|(assignment, _)| {
+                        self.assignments.iter().map(|assignment| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -6870,7 +6800,7 @@ impl PathAssignments {
         }
 
         for new_constraint in new_constraints {
-            self.add_assignment(db, builder, new_constraint.when_true(), source_order, true)?;
+            self.add_assignment(db, builder, new_constraint.when_true())?;
         }
 
         Ok(())

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -2506,31 +2506,7 @@ impl NodeId {
     /// nodes.
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
-            (Node::AlwaysTrue, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                // If lhs is always true, then the overall result is true for any assignment of
-                // rhs.
-                NodeId::with_uncertain(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                )
-            }
-            (Node::Interior(_), Node::AlwaysTrue) => {
-                let self_interior = builder.interior_node_data(self);
-                // If rhs is always true, then the overall result is true for any assignment of
-                // lhs.
-                NodeId::with_uncertain(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_TRUE,
-                    ALWAYS_FALSE,
-                )
-            }
+            (Node::AlwaysTrue, _) | (_, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
@@ -2660,25 +2636,7 @@ impl NodeId {
     /// Returns the `and` or intersection of two BDDs.
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
         match (self.node(), other.node()) {
-            (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
-            (Node::AlwaysFalse, Node::Interior(_)) => {
-                let other_interior = builder.interior_node_data(other);
-                NodeId::new(
-                    builder,
-                    other_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
-            (Node::Interior(_), Node::AlwaysFalse) => {
-                let self_interior = builder.interior_node_data(self);
-                NodeId::new(
-                    builder,
-                    self_interior.constraint,
-                    ALWAYS_FALSE,
-                    ALWAYS_FALSE,
-                )
-            }
+            (Node::AlwaysFalse, _) | (_, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -93,6 +93,7 @@ use std::marker::PhantomData;
 use std::ops::Range;
 use std::sync::Arc;
 
+use indexmap::map::Entry;
 use itertools::Itertools;
 use ruff_index::{Idx, IndexVec, newtype_index};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -3509,7 +3510,7 @@ impl<'db> PathBounds<'db> {
             Node::Interior(_) => {}
         }
 
-        let mut source_orders = builder.calculate_source_orders(source_order);
+        let source_orders = builder.calculate_source_orders(source_order);
         if let Some(path_bounds) =
             Self::compute_simple_lower_bound_conjunction(db, builder, &source_orders, node)
         {
@@ -3525,11 +3526,13 @@ impl<'db> PathBounds<'db> {
         node.for_each_path(db, builder, |path| {
             let mut path: Vec<_> = path
                 .positive_constraints()
-                .map(|constraint| {
-                    source_orders.insert(constraint);
-                    let source_order = source_orders
-                        .get_index_of(&constraint)
-                        .expect("every BDD constraint should have a source_order");
+                .map(|(constraint, source_constraint)| {
+                    let source_order = match source_orders.get_index_of(&constraint) {
+                        Some(source_order) => source_order,
+                        None => source_orders
+                            .get_index_of(&source_constraint)
+                            .expect("every BDD constraint should have a source_order"),
+                    };
                     (constraint, source_order)
                 })
                 .collect();
@@ -4144,14 +4147,14 @@ impl InteriorNode {
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|assignment| {
+                            .filter(|(assignment, _)| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), assignment| {
+                                |(branch, branch_source_order), (assignment, _)| {
                                     let (assignment_node, assignment_source_order) =
                                         Node::new_satisfied_constraint(builder, *assignment);
                                     (
@@ -4177,14 +4180,14 @@ impl InteriorNode {
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|assignment| {
+                            .filter(|(assignment, _)| {
                                 // Don't add back any derived facts if they are ones that we would have
                                 // removed!
                                 !should_remove(assignment.constraint())
                             })
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), assignment| {
+                                |(branch, branch_source_order), (assignment, _)| {
                                     let (assignment_node, assignment_source_order) =
                                         Node::new_satisfied_constraint(builder, *assignment);
                                     (
@@ -4210,10 +4213,10 @@ impl InteriorNode {
                             .abstract_one_inner(db, builder, should_remove, path);
                         path.assignments[new_range]
                             .iter()
-                            .filter(|assignment| !should_remove(assignment.constraint()))
+                            .filter(|(assignment, _)| !should_remove(assignment.constraint()))
                             .fold(
                                 (branch, branch_source_order),
-                                |(branch, branch_source_order), assignment| {
+                                |(branch, branch_source_order), (assignment, _)| {
                                     let (assignment_node, assignment_source_order) =
                                         Node::new_satisfied_constraint(builder, *assignment);
                                     (
@@ -6211,7 +6214,7 @@ impl SequentMap {
 #[derive(Debug)]
 pub(crate) struct PathAssignments {
     map: SequentMap,
-    assignments: FxIndexSet<ConstraintAssignment>,
+    assignments: FxIndexMap<ConstraintAssignment, ConstraintId>,
     /// Nested substitutions that we have already applied on the current root→terminal path.
     nested_substitutions: FxIndexSet<NestedSubstitution>,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
@@ -6228,7 +6231,7 @@ impl PathAssignments {
             .collect();
         Self {
             map: SequentMap::default(),
-            assignments: FxIndexSet::default(),
+            assignments: FxIndexMap::default(),
             nested_substitutions: FxIndexSet::default(),
             discovered,
         }
@@ -6274,14 +6277,15 @@ impl PathAssignments {
             target: "ty_python_semantic::types::constraints::PathAssignment",
             before = %format_args!(
                 "[{}]",
-                self.assignments[..start].iter().map(|assignment| {
+                self.assignments[..start].iter().map(|(assignment, _)| {
                     assignment.display(db, builder)
                 }).format(", "),
             ),
             edge = %assignment.display(db, builder),
             "walk edge",
         );
-        let found_conflict = self.add_assignment(db, builder, assignment);
+        let source_constraint = assignment.constraint();
+        let found_conflict = self.add_assignment(db, builder, assignment, source_constraint, false);
         let result = if found_conflict.is_err() {
             // If that results in the path now being impossible due to a contradiction, return
             // without invoking the callback.
@@ -6296,7 +6300,7 @@ impl PathAssignments {
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 new = %format_args!(
                     "[{}]",
-                    self.assignments[start..].iter().map(|assignment| {
+                    self.assignments[start..].iter().map(|(assignment, _)| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -6314,17 +6318,21 @@ impl PathAssignments {
         result
     }
 
-    pub(crate) fn positive_constraints(&self) -> impl Iterator<Item = ConstraintId> + '_ {
+    pub(crate) fn positive_constraints(
+        &self,
+    ) -> impl Iterator<Item = (ConstraintId, ConstraintId)> + '_ {
         self.assignments
             .iter()
-            .filter_map(|assignment| match assignment {
-                ConstraintAssignment::Positive(constraint) => Some(*constraint),
+            .filter_map(|(assignment, source_constraint)| match assignment {
+                ConstraintAssignment::Positive(constraint) => {
+                    Some((*constraint, *source_constraint))
+                }
                 ConstraintAssignment::Negative(_) | ConstraintAssignment::Unconstrained(_) => None,
             })
     }
 
     fn assignment_holds(&self, assignment: ConstraintAssignment) -> bool {
-        self.assignments.contains(&assignment)
+        self.assignments.contains_key(&assignment)
     }
 
     fn contains_constraint(&self, constraint: ConstraintId) -> bool {
@@ -6369,6 +6377,8 @@ impl PathAssignments {
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
+        source_constraint: ConstraintId,
+        derived: bool,
     ) -> Result<(), PathAssignmentConflict> {
         if matches!(assignment, ConstraintAssignment::Unconstrained(_)) {
             // An `Unconstrained` assignment means "this constraint can go either way". If there is
@@ -6382,19 +6392,19 @@ impl PathAssignments {
             // derive any additional information from the sequent map. We still want to record the
             // assignment, but as an optimization we can return early without actually querying the
             // sequent map.
-            self.assignments.insert(assignment);
+            self.assignments.insert(assignment, source_constraint);
             return Ok(());
         }
 
         // First add this assignment. If it causes a conflict, return that as an error. If we've
         // already know this assignment holds, just return.
-        if self.assignments.contains(&assignment.negated()) {
+        if self.assignment_holds(assignment.negated()) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
                 assignment = %assignment.display(db, builder),
                 facts = %format_args!(
                     "[{}]",
-                    self.assignments.iter().map(|assignment| {
+                    self.assignments.iter().map(|(assignment, _)| {
                         assignment.display(db, builder)
                     }).format(", "),
                 ),
@@ -6403,9 +6413,19 @@ impl PathAssignments {
             return Err(PathAssignmentConflict);
         }
 
-        if !self.assignments.insert(assignment) {
-            return Ok(());
-        }
+        match self.assignments.entry(assignment) {
+            Entry::Vacant(entry) => entry.insert(source_constraint),
+            Entry::Occupied(mut entry) => {
+                // If a constraint appears both as an "origin" constraint (it actually appears in
+                // the BDD structure) and as a "derived" constraint (we infer it from other
+                // constraints), we should prefer the origin source_order, regardless of which
+                // order we encounter the various constraints in the BDD.
+                if !derived {
+                    *entry.get_mut() = source_constraint;
+                }
+                return Ok(());
+            }
+        };
 
         // Then use our sequents to add additional facts that we know to be true.
         //
@@ -6428,7 +6448,7 @@ impl PathAssignments {
                     ante = %ante.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|assignment| {
+                        self.assignments.iter().map(|(assignment, _)| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -6453,7 +6473,7 @@ impl PathAssignments {
                     ante2 = %ante2.display(db, builder),
                     facts = %format_args!(
                         "[{}]",
-                        self.assignments.iter().map(|assignment| {
+                        self.assignments.iter().map(|(assignment, _)| {
                             assignment.display(db, builder)
                         }).format(", "),
                     ),
@@ -6496,7 +6516,13 @@ impl PathAssignments {
         }
 
         for new_constraint in new_constraints {
-            self.add_assignment(db, builder, new_constraint.when_true())?;
+            self.add_assignment(
+                db,
+                builder,
+                new_constraint.when_true(),
+                source_constraint,
+                true,
+            )?;
         }
 
         Ok(())

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -495,7 +495,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.or_with_offset(builder, other.node);
+        self.node = self.node.or(builder, other.node);
         self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
@@ -511,7 +511,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        self.node = self.node.and_with_offset(builder, other.node);
+        self.node = self.node.and(builder, other.node);
         self.source_order = builder.ordered_source_order(self.source_order, other.source_order);
         *self
     }
@@ -588,7 +588,7 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         other: Self,
     ) -> Self {
         self.verify_builder(builder);
-        let node = self.node.iff_with_offset(builder, other.node);
+        let node = self.node.iff(builder, other.node);
         let source_order = builder.ordered_source_order(self.source_order, other.source_order);
         Self::from_node(builder, node, source_order)
     }
@@ -620,7 +620,12 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
         if self
             .node
             .simple_lower_bound_conjunction(db, builder)
-            .all(|bound| bound.is_ok_and(|(typevar, _, _)| typevar.is_inferable(db, inferable)))
+            .all(|bound| {
+                bound.is_ok_and(|(constraint, _)| {
+                    let constraint = builder.constraint_data(constraint);
+                    constraint.typevar.is_inferable(db, inferable)
+                })
+            })
         {
             return self;
         }
@@ -760,8 +765,8 @@ struct ConstraintSetStorage<'db> {
     never_satisfied_cache: FxHashMap<NodeId, bool>,
 
     negate_cache: FxHashMap<NodeId, NodeId>,
-    or_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
-    and_cache: FxHashMap<(NodeId, NodeId, usize), NodeId>,
+    or_cache: FxHashMap<(NodeId, NodeId), NodeId>,
+    and_cache: FxHashMap<(NodeId, NodeId), NodeId>,
     exists_one_cache:
         FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), (NodeId, Option<SourceOrderId>)>,
     retain_one_cache: FxHashMap<(NodeId, BoundTypeVarIdentity<'db>), NodeId>,
@@ -981,9 +986,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             // Shift the reloaded condition back to the source order recorded in the owned set;
             // solution extraction uses this order for deterministic unions and intersections.
             let old_constraint_index = inner.retained_constraint_index(old_interior.constraint);
-            let (constraint_node, _) = constraints[old_constraint_index];
-            let condition = constraint_node
-                .with_adjusted_source_order(builder, old_interior.source_order.saturating_sub(1));
+            let (condition, _) = constraints[old_constraint_index];
             let remapped = condition.ite_uncertain(builder, if_true, if_uncertain, if_false);
 
             cache.insert(old_node, remapped);
@@ -1656,7 +1659,7 @@ impl<'db> Constraint<'db> {
                     Some(*lower_element),
                     upper,
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
@@ -1677,7 +1680,7 @@ impl<'db> Constraint<'db> {
                     lower,
                     Some(upper_element),
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             for upper_element in upper_intersection.iter_negative(db) {
@@ -1688,7 +1691,7 @@ impl<'db> Constraint<'db> {
                     lower,
                     Some(upper_element.negate(db)),
                 );
-                result = result.and_with_offset(builder, element_node);
+                result = result.and(builder, element_node);
                 source_order = builder.ordered_source_order(source_order, element_source_order);
             }
             return (result, source_order);
@@ -1720,7 +1723,7 @@ impl<'db> Constraint<'db> {
             {
                 let constraint =
                     ConstraintId::new(db, builder, typevar, Type::Never, Type::object());
-                let (node, source_order) = Node::new_constraint(builder, constraint, 1);
+                let (node, source_order) = Node::new_constraint(builder, constraint);
                 let node = node.negate(builder);
                 return (node, source_order);
             }
@@ -1780,7 +1783,7 @@ impl<'db> Constraint<'db> {
                     Type::TypeVar(bound),
                     Type::TypeVar(bound),
                 );
-                Node::new_constraint(builder, constraint, 1)
+                Node::new_constraint(builder, constraint)
             }
 
             // L ≤ T ≤ U == ([L] ≤ T) && (T ≤ [U])
@@ -1796,7 +1799,7 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint, 1);
+                    Node::new_constraint(builder, lower_constraint);
                 let upper_constraint = ConstraintId::new_with_bounds(
                     db,
                     builder,
@@ -1805,7 +1808,7 @@ impl<'db> Constraint<'db> {
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint, 1);
+                    Node::new_constraint(builder, upper_constraint);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -1822,7 +1825,7 @@ impl<'db> Constraint<'db> {
                     Some(Type::TypeVar(typevar)),
                 );
                 let (lower_node, lower_source_order) =
-                    Node::new_constraint(builder, lower_constraint, 1);
+                    Node::new_constraint(builder, lower_constraint);
                 let (upper_node, upper_source_order) = if upper.is_none() {
                     (ALWAYS_TRUE, None)
                 } else {
@@ -1849,7 +1852,7 @@ impl<'db> Constraint<'db> {
                     None,
                 );
                 let (upper_node, upper_source_order) =
-                    Node::new_constraint(builder, upper_constraint, 1);
+                    Node::new_constraint(builder, upper_constraint);
                 let node = lower_node.and(builder, upper_node);
                 let source_order =
                     builder.ordered_source_order(lower_source_order, upper_source_order);
@@ -1858,7 +1861,7 @@ impl<'db> Constraint<'db> {
 
             _ => {
                 let constraint = ConstraintId::new_with_bounds(db, builder, typevar, lower, upper);
-                Node::new_constraint(builder, constraint, 1)
+                Node::new_constraint(builder, constraint)
             }
         }
     }
@@ -2041,7 +2044,7 @@ enum Node {
     Interior(InteriorNode),
 }
 
-type SimpleLowerBound<'db> = (BoundTypeVarInstance<'db>, Type<'db>, usize);
+type SimpleLowerBound<'db> = (ConstraintId, Type<'db>);
 
 impl NodeId {
     /// Creates a new BDD node, applying local TDD reductions.
@@ -2050,16 +2053,8 @@ impl NodeId {
         constraint: ConstraintId,
         if_true: NodeId,
         if_false: NodeId,
-        source_order: usize,
     ) -> NodeId {
-        Self::with_uncertain(
-            builder,
-            constraint,
-            if_true,
-            ALWAYS_FALSE,
-            if_false,
-            source_order,
-        )
+        Self::with_uncertain(builder, constraint, if_true, ALWAYS_FALSE, if_false)
     }
 
     /// Creates a new TDD node with an explicit `if_uncertain` branch, applying local reductions.
@@ -2069,7 +2064,6 @@ impl NodeId {
         if_true: NodeId,
         if_uncertain: NodeId,
         if_false: NodeId,
-        source_order: usize,
     ) -> NodeId {
         debug_assert!(
             if_true
@@ -2121,17 +2115,11 @@ impl NodeId {
             return if_uncertain;
         }
 
-        let max_source_order = source_order
-            .max(if_true.max_source_order(builder))
-            .max(if_uncertain.max_source_order(builder))
-            .max(if_false.max_source_order(builder));
         builder.intern_interior_node(InteriorNodeData {
             constraint,
             if_true,
             if_uncertain,
             if_false,
-            source_order,
-            max_source_order,
         })
     }
 }
@@ -2142,17 +2130,9 @@ impl Node {
     fn new_constraint(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintId,
-        source_order: usize,
     ) -> (NodeId, Option<SourceOrderId>) {
         (
-            NodeId::with_uncertain(
-                builder,
-                constraint,
-                ALWAYS_TRUE,
-                ALWAYS_FALSE,
-                ALWAYS_FALSE,
-                source_order,
-            ),
+            NodeId::with_uncertain(builder, constraint, ALWAYS_TRUE, ALWAYS_FALSE, ALWAYS_FALSE),
             Some(builder.constraint_source_order(constraint)),
         )
     }
@@ -2165,7 +2145,6 @@ impl Node {
     fn new_satisfied_constraint(
         builder: &ConstraintSetBuilder<'_>,
         constraint: ConstraintAssignment,
-        source_order: usize,
     ) -> (NodeId, Option<SourceOrderId>) {
         match constraint {
             ConstraintAssignment::Positive(constraint) => (
@@ -2175,7 +2154,6 @@ impl Node {
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2186,7 +2164,6 @@ impl Node {
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2201,7 +2178,6 @@ impl Node {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    source_order,
                 ),
                 Some(builder.constraint_source_order(constraint)),
             ),
@@ -2238,37 +2214,6 @@ impl NodeId {
         }
         let interior = builder.interior_node_data(self);
         Some(interior.constraint)
-    }
-
-    fn max_source_order(self, builder: &ConstraintSetBuilder<'_>) -> usize {
-        if self.is_terminal() {
-            return 0;
-        }
-        let interior = builder.interior_node_data(self);
-        interior.max_source_order
-    }
-
-    /// Returns a copy of this BDD node with all `source_order`s adjusted by the given amount.
-    fn with_adjusted_source_order(self, builder: &ConstraintSetBuilder<'_>, delta: usize) -> Self {
-        if delta == 0 {
-            return self;
-        }
-        match self.node() {
-            Node::AlwaysTrue | Node::AlwaysFalse => self,
-            Node::Interior(_) => {
-                let interior = builder.interior_node_data(self);
-                NodeId::with_uncertain(
-                    builder,
-                    interior.constraint,
-                    interior.if_true.with_adjusted_source_order(builder, delta),
-                    interior
-                        .if_uncertain
-                        .with_adjusted_source_order(builder, delta),
-                    interior.if_false.with_adjusted_source_order(builder, delta),
-                    interior.source_order + delta,
-                )
-            }
-        }
     }
 
     /// Checks whether this BDD represents a single conjunction (of an arbitrary number of
@@ -2348,7 +2293,7 @@ impl NodeId {
                     }
 
                     node = Some(interior.if_true);
-                    Some(Ok((constraint.typevar, lower, interior.source_order)))
+                    Some(Ok((interior.constraint, lower)))
                 }
             }
         })
@@ -2559,28 +2504,7 @@ impl NodeId {
     ///
     /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
     /// nodes.
-    fn or_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        //
-        // TODO: If we store `other_offset` as a new field on InteriorNode, we might be able to
-        // avoid all of the extra work in the calls to with_adjusted_source_order, and apply the
-        // adjustment lazily when walking a BDD tree. (ditto below in the other _with_offset
-        // methods)
-        let other_offset = self.max_source_order(builder);
-        self.or_inner(builder, other, other_offset)
-    }
-
     fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.or_inner(builder, other, 0)
-    }
-
-    fn or_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysTrue, Node::AlwaysTrue) => ALWAYS_TRUE,
             (Node::AlwaysTrue, Node::Interior(_)) => {
@@ -2593,7 +2517,6 @@ impl NodeId {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    other_interior.source_order + other_offset,
                 )
             }
             (Node::Interior(_), Node::AlwaysTrue) => {
@@ -2606,13 +2529,12 @@ impl NodeId {
                     ALWAYS_FALSE,
                     ALWAYS_TRUE,
                     ALWAYS_FALSE,
-                    self_interior.source_order,
                 )
             }
-            (Node::AlwaysFalse, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysFalse, _) => other,
             (_, Node::AlwaysFalse) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.or(builder, other_interior, other_offset)
+                self_interior.or(builder, other_interior)
             }
         }
     }
@@ -2716,7 +2638,7 @@ impl NodeId {
             nodes,
             ALWAYS_FALSE,
             Self::is_always_satisfied,
-            Self::or_with_offset,
+            Self::or,
         )
     }
 
@@ -2731,31 +2653,12 @@ impl NodeId {
             nodes,
             ALWAYS_TRUE,
             Self::is_never_satisfied,
-            Self::and_with_offset,
+            Self::and,
         )
     }
 
     /// Returns the `and` or intersection of two BDDs.
-    ///
-    /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
-    /// nodes.
-    fn and_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.and_inner(builder, other, other_offset)
-    }
-
     fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.and_inner(builder, other, 0)
-    }
-
-    fn and_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         match (self.node(), other.node()) {
             (Node::AlwaysFalse, Node::AlwaysFalse) => ALWAYS_FALSE,
             (Node::AlwaysFalse, Node::Interior(_)) => {
@@ -2765,7 +2668,6 @@ impl NodeId {
                     other_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    other_interior.source_order + other_offset,
                 )
             }
             (Node::Interior(_), Node::AlwaysFalse) => {
@@ -2775,13 +2677,12 @@ impl NodeId {
                     self_interior.constraint,
                     ALWAYS_FALSE,
                     ALWAYS_FALSE,
-                    self_interior.source_order,
                 )
             }
-            (Node::AlwaysTrue, _) => other.with_adjusted_source_order(builder, other_offset),
+            (Node::AlwaysTrue, _) => other,
             (_, Node::AlwaysTrue) => self,
             (Node::Interior(self_interior), Node::Interior(other_interior)) => {
-                self_interior.and(builder, other_interior, other_offset)
+                self_interior.and(builder, other_interior)
             }
         }
     }
@@ -2796,28 +2697,10 @@ impl NodeId {
     ///
     /// In the result, `self` will appear before `other` according to the `source_order` of the BDD
     /// nodes.
-    fn iff_with_offset(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        // To ensure that `self` appears before `other` in `source_order`, we add the maximum
-        // `source_order` of the lhs to all of the `source_order`s in the rhs.
-        let other_offset = self.max_source_order(builder);
-        self.iff_inner(builder, other, other_offset)
-    }
-
     fn iff(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> Self {
-        self.iff_inner(builder, other, 0)
-    }
-
-    fn iff_inner(
-        self,
-        builder: &ConstraintSetBuilder<'_>,
-        other: Self,
-        other_offset: usize,
-    ) -> Self {
         // iff(a, b) = (a ∧ b) ∨ (¬a ∧ ¬b)
-        let a_and_b = self.and_inner(builder, other, other_offset);
-        let not_a_and_not_b =
-            self.negate(builder)
-                .and_inner(builder, other.negate(builder), other_offset);
+        let a_and_b = self.and(builder, other);
+        let not_a_and_not_b = self.negate(builder).and(builder, other.negate(builder));
         a_and_b.or(builder, not_a_and_not_b)
     }
 
@@ -2869,7 +2752,6 @@ impl NodeId {
                         then_node,
                         uncertain_node,
                         else_node,
-                        interior.source_order,
                     );
                 }
 
@@ -2933,7 +2815,7 @@ impl NodeId {
         }
 
         let mut typevars = FxHashSet::default();
-        self.for_each_unique_constraint(builder, &mut |constraint, _| {
+        self.for_each_unique_constraint(builder, &mut |constraint| {
             let constraint = builder.constraint_data(constraint);
             typevars.insert(constraint.typevar);
         });
@@ -3096,15 +2978,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∧ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_intersection<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -3138,8 +3017,8 @@ impl NodeId {
         //     false
         //
         //  (Note that the `else` branch shouldn't be reachable, but we have to provide something!)
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
         let right_result = right_node.ite(builder, ALWAYS_FALSE, when_left_but_not_right);
         let left_result = left_node.ite(builder, right_result, when_not_left);
         let result = replacement.ite(builder, when_left_and_right, left_result);
@@ -3158,15 +3037,12 @@ impl NodeId {
     }
 
     /// Returns a new BDD with any occurrence of `left ∨ right` replaced with `replacement`.
-    #[expect(clippy::too_many_arguments)]
     fn substitute_union<'db>(
         self,
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
         left: ConstraintAssignment,
-        left_source_order: usize,
         right: ConstraintAssignment,
-        right_source_order: usize,
         replacement: NodeId,
     ) -> Self {
         // We perform a Shannon expansion to find out what the input BDD evaluates to when:
@@ -3206,8 +3082,8 @@ impl NodeId {
         // Lastly, verify that the result is consistent with the input. (It must produce the same
         // results when `left ∨ right`.) If it doesn't, the substitution isn't valid, and we should
         // return the original BDD unmodified.
-        let (left_node, _) = Node::new_satisfied_constraint(builder, left, left_source_order);
-        let (right_node, _) = Node::new_satisfied_constraint(builder, right, right_source_order);
+        let (left_node, _) = Node::new_satisfied_constraint(builder, left);
+        let (right_node, _) = Node::new_satisfied_constraint(builder, right);
         let validity = replacement.iff(builder, left_node.or(builder, right_node));
         let constrained_original = self.and(builder, validity);
         let constrained_replacement = result.and(builder, validity);
@@ -3226,19 +3102,19 @@ impl NodeId {
     fn for_each_unique_constraint(
         self,
         builder: &ConstraintSetBuilder<'_>,
-        f: &mut dyn FnMut(ConstraintId, usize),
+        f: &mut dyn FnMut(ConstraintId),
     ) {
         fn walk(
             node: NodeId,
             builder: &ConstraintSetBuilder<'_>,
             seen: &mut FxHashSet<NodeId>,
-            f: &mut dyn FnMut(ConstraintId, usize),
+            f: &mut dyn FnMut(ConstraintId),
         ) {
             if node.is_terminal() || !seen.insert(node) {
                 return;
             }
             let interior = builder.interior_node_data(node);
-            f(interior.constraint, interior.source_order);
+            f(interior.constraint);
             walk(interior.if_true, builder, seen, f);
             walk(interior.if_uncertain, builder, seen, f);
             walk(interior.if_false, builder, seen, f);
@@ -3399,13 +3275,7 @@ impl NodeId {
                         return write!(f, "<{index}> SHARED");
                     }
                     let interior = builder.interior_node_data(node);
-                    write!(
-                        f,
-                        "<{index}> {} {}/{}",
-                        interior.constraint.display(db, builder),
-                        interior.source_order,
-                        interior.max_source_order,
-                    )?;
+                    write!(f, "<{index}> {}", interior.constraint.display(db, builder))?;
                     // Calling display_graph recursively here causes rustc to claim that the
                     // expect(unused) up above is unfulfilled!
                     write!(f, "\n{prefix}┡━₁ ")?;
@@ -3503,16 +3373,6 @@ struct InteriorNodeData {
     if_true: NodeId,
     if_uncertain: NodeId,
     if_false: NodeId,
-
-    /// Represents the order in which this node's constraint was added to the containing constraint
-    /// set, relative to all of the other constraints in the set. This starts off at 1 for a simple
-    /// single-constraint set (e.g. created with [`Node::new_constraint`] or
-    /// [`Node::new_satisfied_constraint`]). It will get incremented, if needed, as that simple BDD
-    /// is combined into larger BDDs.
-    source_order: usize,
-
-    /// The maximum `source_order` across this node and all of its descendants.
-    max_source_order: usize,
 }
 
 /// Accumulates lower and upper bounds for a single typevar on a single BDD path.
@@ -3687,7 +3547,10 @@ impl<'db> PathBounds<'db> {
             Node::Interior(_) => {}
         }
 
-        if let Some(path_bounds) = Self::compute_simple_lower_bound_conjunction(db, builder, node) {
+        let mut source_orders = builder.calculate_source_orders(source_order);
+        if let Some(path_bounds) =
+            Self::compute_simple_lower_bound_conjunction(db, builder, &source_orders, node)
+        {
             return path_bounds;
         }
 
@@ -3696,7 +3559,6 @@ impl<'db> PathBounds<'db> {
         // come out of `PathAssignment`s with identical `source_order`s, but if they do, those
         // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
         // retain that stable per-tie ordering.
-        let mut source_orders = builder.calculate_source_orders(source_order);
         let mut sorted_paths = Vec::new();
         node.for_each_path(db, builder, |path| {
             let mut path: Vec<_> = path
@@ -3768,18 +3630,32 @@ impl<'db> PathBounds<'db> {
     fn compute_simple_lower_bound_conjunction(
         db: &'db dyn Db,
         builder: &ConstraintSetBuilder<'db>,
+        source_orders: &FxIndexSet<ConstraintId>,
         node: NodeId,
     ) -> Option<Self> {
         let mut constraints = node
             .simple_lower_bound_conjunction(db, builder)
+            .map_ok(|(constraint, lower)| {
+                (
+                    constraint,
+                    lower,
+                    source_orders
+                        .get_index_of(&constraint)
+                        .expect("every BDD constraint should have a source_order"),
+                )
+            })
             .collect::<Result<Vec<_>, _>>()
             .ok()?;
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
 
         let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxHashMap::default();
-        for (typevar, lower, _) in constraints {
-            mappings.entry(typevar).or_default().add_lower(db, lower);
+        for (constraint, lower, _) in constraints {
+            let constraint = builder.constraint_data(constraint);
+            mappings
+                .entry(constraint.typevar)
+                .or_default()
+                .add_lower(db, lower);
         }
 
         let path = mappings
@@ -4043,7 +3919,6 @@ impl InteriorNode {
             interior.constraint,
             not_true.and(builder, not_uncertain),
             not_false.and(builder, not_uncertain),
-            interior.source_order,
         );
 
         let mut storage = builder.storage.borrow_mut();
@@ -4051,8 +3926,8 @@ impl InteriorNode {
         result
     }
 
-    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn or(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        let key = (self.node(), other.node());
         let storage = builder.storage.borrow();
         if let Some(result) = storage.or_cache.get(&key) {
             return *result;
@@ -4067,18 +3942,11 @@ impl InteriorNode {
             Ordering::Equal => NodeId::with_uncertain(
                 builder,
                 self_interior.constraint,
+                self_interior.if_true.or(builder, other_interior.if_true),
                 self_interior
-                    .if_true
-                    .or_inner(builder, other_interior.if_true, other_offset),
-                self_interior.if_uncertain.or_inner(
-                    builder,
-                    other_interior.if_uncertain,
-                    other_offset,
-                ),
-                self_interior
-                    .if_false
-                    .or_inner(builder, other_interior.if_false, other_offset),
-                self_interior.source_order,
+                    .if_uncertain
+                    .or(builder, other_interior.if_uncertain),
+                self_interior.if_false.or(builder, other_interior.if_false),
             ),
             // This is from Frisch's original description of TDDs. If self < other, we check self
             // first. Instead of distributing other into the if_true and if_false branches, we
@@ -4088,21 +3956,16 @@ impl InteriorNode {
                 builder,
                 self_interior.constraint,
                 self_interior.if_true,
-                self_interior
-                    .if_uncertain
-                    .or_inner(builder, other.node(), other_offset),
+                self_interior.if_uncertain.or(builder, other.node()),
                 self_interior.if_false,
-                self_interior.source_order,
             ),
             // Ditto above but for the other variable ordering
             Ordering::Greater => NodeId::with_uncertain(
                 builder,
                 other_interior.constraint,
                 other_interior.if_true,
-                self.node()
-                    .or_inner(builder, other_interior.if_uncertain, other_offset),
+                self.node().or(builder, other_interior.if_uncertain),
                 other_interior.if_false,
-                other_interior.source_order + other_offset,
             ),
         };
 
@@ -4111,8 +3974,8 @@ impl InteriorNode {
         result
     }
 
-    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self, other_offset: usize) -> NodeId {
-        let key = (self.node(), other.node(), other_offset);
+    fn and(self, builder: &ConstraintSetBuilder<'_>, other: Self) -> NodeId {
+        let key = (self.node(), other.node());
         let storage = builder.storage.borrow();
         if let Some(result) = storage.and_cache.get(&key) {
             return *result;
@@ -4136,48 +3999,34 @@ impl InteriorNode {
             Ordering::Equal => {
                 let if_true = self_interior
                     .if_true
-                    .and_inner(
+                    .and(
                         builder,
-                        other_interior.if_true.or_inner(
-                            builder,
-                            other_interior.if_uncertain,
-                            other_offset,
-                        ),
-                        other_offset,
+                        other_interior
+                            .if_true
+                            .or(builder, other_interior.if_uncertain),
                     )
-                    .or_inner(
+                    .or(
                         builder,
-                        self_interior.if_uncertain.and_inner(
-                            builder,
-                            other_interior.if_true,
-                            other_offset,
-                        ),
-                        0,
+                        self_interior
+                            .if_uncertain
+                            .and(builder, other_interior.if_true),
                     );
-                let if_uncertain = self_interior.if_uncertain.and_inner(
-                    builder,
-                    other_interior.if_uncertain,
-                    other_offset,
-                );
+                let if_uncertain = self_interior
+                    .if_uncertain
+                    .and(builder, other_interior.if_uncertain);
                 let if_false = self_interior
                     .if_false
-                    .and_inner(
+                    .and(
                         builder,
-                        other_interior.if_uncertain.or_inner(
-                            builder,
-                            other_interior.if_false,
-                            other_offset,
-                        ),
-                        other_offset,
+                        other_interior
+                            .if_uncertain
+                            .or(builder, other_interior.if_false),
                     )
-                    .or_inner(
+                    .or(
                         builder,
-                        self_interior.if_uncertain.and_inner(
-                            builder,
-                            other_interior.if_false,
-                            other_offset,
-                        ),
-                        0,
+                        self_interior
+                            .if_uncertain
+                            .and(builder, other_interior.if_false),
                     );
                 NodeId::with_uncertain(
                     builder,
@@ -4185,33 +4034,21 @@ impl InteriorNode {
                     if_true,
                     if_uncertain,
                     if_false,
-                    self_interior.source_order,
                 )
             }
             Ordering::Less => NodeId::with_uncertain(
                 builder,
                 self_interior.constraint,
-                self_interior
-                    .if_true
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_uncertain
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior
-                    .if_false
-                    .and_inner(builder, other.node(), other_offset),
-                self_interior.source_order,
+                self_interior.if_true.and(builder, other.node()),
+                self_interior.if_uncertain.and(builder, other.node()),
+                self_interior.if_false.and(builder, other.node()),
             ),
             Ordering::Greater => NodeId::with_uncertain(
                 builder,
                 other_interior.constraint,
-                self.node()
-                    .and_inner(builder, other_interior.if_true, other_offset),
-                self.node()
-                    .and_inner(builder, other_interior.if_uncertain, other_offset),
-                self.node()
-                    .and_inner(builder, other_interior.if_false, other_offset),
-                other_interior.source_order + other_offset,
+                self.node().and(builder, other_interior.if_true),
+                self.node().and(builder, other_interior.if_uncertain),
+                self.node().and(builder, other_interior.if_false),
             ),
         };
 
@@ -4354,7 +4191,7 @@ impl InteriorNode {
                                 (branch, branch_source_order),
                                 |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(builder, *assignment, 0);
+                                        Node::new_satisfied_constraint(builder, *assignment);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4387,7 +4224,7 @@ impl InteriorNode {
                                 (branch, branch_source_order),
                                 |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(builder, *assignment, 0);
+                                        Node::new_satisfied_constraint(builder, *assignment);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4416,7 +4253,7 @@ impl InteriorNode {
                                 (branch, branch_source_order),
                                 |(branch, branch_source_order), assignment| {
                                     let (assignment_node, assignment_source_order) =
-                                        Node::new_satisfied_constraint(builder, *assignment, 0);
+                                        Node::new_satisfied_constraint(builder, *assignment);
                                     (
                                         branch.and(builder, assignment_node),
                                         builder.ordered_source_order(
@@ -4484,11 +4321,8 @@ impl InteriorNode {
             // NB: We cannot use `Node::new` here, because the recursive calls might introduce new
             // derived constraints into the result, and those constraints might appear before this
             // one in the BDD ordering.
-            let (constraint_node, constraint_source_order) = Node::new_constraint(
-                builder,
-                self_interior.constraint,
-                self_interior.source_order,
-            );
+            let (constraint_node, constraint_source_order) =
+                Node::new_constraint(builder, self_interior.constraint);
             let node = constraint_node.ite(
                 builder,
                 if_true.or(builder, if_uncertain),
@@ -4567,7 +4401,6 @@ impl InteriorNode {
                         if_true,
                         if_uncertain,
                         if_false,
-                        self_interior.source_order,
                     ),
                     found_in_true || found_in_uncertain || found_in_false,
                 )
@@ -4580,18 +4413,12 @@ impl InteriorNode {
     }
 
     fn path_assignments(self, builder: &ConstraintSetBuilder<'_>) -> PathAssignments {
-        // Sort the constraints in this BDD by their `source_order`s before adding them to the
-        // sequent map. This ensures that constraints appear in the sequent map in a stable order.
-        // The constraints mentioned in a BDD should all have distinct `source_order`s, so an
-        // unstable sort is fine.
         let mut constraints: SmallVec<[_; 8]> = SmallVec::new();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint, source_order| {
-                constraints.push((constraint, source_order));
+            .for_each_unique_constraint(builder, &mut |constraint| {
+                constraints.push(constraint);
             });
-        constraints.sort_unstable_by_key(|(_, source_order)| *source_order);
-
-        PathAssignments::new(constraints.into_iter().map(|(constraint, _)| constraint))
+        PathAssignments::new(constraints)
     }
 
     /// Returns a simplified version of a BDD.
@@ -4623,14 +4450,9 @@ impl InteriorNode {
         // visit queue with all pairs of those constraints. (We use "combinations" because we don't
         // need to compare a constraint against itself, and because ordering doesn't matter.)
         let mut seen_constraints = FxHashSet::default();
-        let mut source_orders = FxHashMap::default();
         self.node()
-            .for_each_unique_constraint(builder, &mut |constraint, source_order| {
+            .for_each_unique_constraint(builder, &mut |constraint| {
                 seen_constraints.insert(constraint);
-                source_orders
-                    .entry(constraint)
-                    .and_modify(|existing: &mut usize| *existing = (*existing).min(source_order))
-                    .or_insert(source_order);
             });
         let mut to_visit: Vec<(_, _)> = (seen_constraints.iter().copied())
             .array_combinations()
@@ -4638,17 +4460,9 @@ impl InteriorNode {
             .collect();
 
         // Repeatedly pop constraint pairs off of the visit queue, checking whether each pair can
-        // be simplified. If we add any derived constraints, we will place them at the end in
-        // source order. (We do not have any test cases that depend on constraint sets being
-        // displayed in a consistent ordering, so we don't need to be clever in assigning these
-        // `source_order`s.)
+        // be simplified.
         let mut simplified = self.node();
-        let self_interior = builder.interior_node_data(self.node());
-        let mut next_source_order = self_interior.max_source_order + 1;
         while let Some((left_constraint, right_constraint)) = to_visit.pop() {
-            let left_source_order = source_orders[&left_constraint];
-            let right_source_order = source_orders[&right_constraint];
-
             // If the constraints refer to different typevars, the only simplifications we can make
             // are of the form `S ≤ T ∧ T ≤ int → S ≤ int`.
             let left_constraint_data = builder.constraint_data(left_constraint);
@@ -4720,19 +4534,11 @@ impl InteriorNode {
                 if seen_constraints.contains(&new_constraint) {
                     continue;
                 }
-                let (new_node, _) =
-                    Node::new_constraint(builder, new_constraint, next_source_order);
-                next_source_order += 1;
-                let (positive_left_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    left_constraint.when_true(),
-                    left_source_order,
-                );
-                let (positive_right_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    right_constraint.when_true(),
-                    right_source_order,
-                );
+                let (new_node, _) = Node::new_constraint(builder, new_constraint);
+                let (positive_left_node, _) =
+                    Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                let (positive_right_node, _) =
+                    Node::new_satisfied_constraint(builder, right_constraint.when_true());
                 let lhs = positive_left_node.and(builder, positive_right_node);
                 let intersection = new_node.ite(builder, lhs, ALWAYS_FALSE);
                 simplified = simplified.and(builder, intersection);
@@ -4767,48 +4573,24 @@ impl InteriorNode {
             // Containment: The range of one constraint might completely contain the range of the
             // other. If so, there are several potential simplifications.
             let larger_smaller = if left_constraint.implies(db, builder, right_constraint) {
-                Some((
-                    right_constraint,
-                    right_source_order,
-                    left_constraint,
-                    left_source_order,
-                ))
+                Some((right_constraint, left_constraint))
             } else if right_constraint.implies(db, builder, left_constraint) {
-                Some((
-                    left_constraint,
-                    left_source_order,
-                    right_constraint,
-                    right_source_order,
-                ))
+                Some((left_constraint, right_constraint))
             } else {
                 None
             };
-            if let Some((
-                larger_constraint,
-                larger_source_order,
-                smaller_constraint,
-                smaller_source_order,
-            )) = larger_smaller
-            {
-                let (positive_larger_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_true(),
-                    larger_source_order,
-                );
-                let (negative_larger_node, _) = Node::new_satisfied_constraint(
-                    builder,
-                    larger_constraint.when_false(),
-                    larger_source_order,
-                );
+            if let Some((larger_constraint, smaller_constraint)) = larger_smaller {
+                let (positive_larger_node, _) =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_true());
+                let (negative_larger_node, _) =
+                    Node::new_satisfied_constraint(builder, larger_constraint.when_false());
 
                 // larger ∨ smaller = larger
                 simplified = simplified.substitute_union(
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     positive_larger_node,
                 );
 
@@ -4817,9 +4599,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     negative_larger_node,
                 );
 
@@ -4829,9 +4609,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_false(),
-                    larger_source_order,
                     smaller_constraint.when_true(),
-                    smaller_source_order,
                     ALWAYS_FALSE,
                 );
 
@@ -4841,9 +4619,7 @@ impl InteriorNode {
                     db,
                     builder,
                     larger_constraint.when_true(),
-                    larger_source_order,
                     smaller_constraint.when_false(),
-                    smaller_source_order,
                     ALWAYS_TRUE,
                 );
             }
@@ -4860,7 +4636,6 @@ impl InteriorNode {
                     // represent that intersection. We also need to add the new constraint to our
                     // seen set and (if we haven't already seen it) to the to-visit queue.
                     if seen_constraints.insert(intersection_constraint) {
-                        source_orders.insert(intersection_constraint, next_source_order);
                         to_visit.extend(
                             (seen_constraints.iter().copied())
                                 .filter(|seen| *seen != intersection_constraint)
@@ -4870,45 +4645,28 @@ impl InteriorNode {
                     let (positive_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_true(),
-                        next_source_order,
                     );
                     let (negative_intersection_node, _) = Node::new_satisfied_constraint(
                         builder,
                         intersection_constraint.when_false(),
-                        next_source_order,
-                    );
-                    next_source_order += 1;
-
-                    let (positive_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let (negative_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_false(),
-                        left_source_order,
                     );
 
-                    let (positive_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
-                    let (negative_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_false(),
-                        right_source_order,
-                    );
+                    let (positive_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let (negative_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_false());
+
+                    let (positive_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
+                    let (negative_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_false());
 
                     // left ∧ right = intersection
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_intersection_node,
                     );
 
@@ -4917,9 +4675,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_intersection_node,
                     );
 
@@ -4930,9 +4686,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node.and(builder, negative_intersection_node),
                     );
 
@@ -4942,9 +4696,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node.and(builder, negative_intersection_node),
                     );
 
@@ -4955,9 +4707,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         negative_right_node.or(builder, positive_intersection_node),
                     );
 
@@ -4967,9 +4717,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         negative_left_node.or(builder, positive_intersection_node),
                     );
                 }
@@ -4982,25 +4730,17 @@ impl InteriorNode {
                     // All of the below hold because we just proved that the intersection of left
                     // and right is empty.
 
-                    let (positive_left_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        left_constraint.when_true(),
-                        left_source_order,
-                    );
-                    let (positive_right_node, _) = Node::new_satisfied_constraint(
-                        builder,
-                        right_constraint.when_true(),
-                        right_source_order,
-                    );
+                    let (positive_left_node, _) =
+                        Node::new_satisfied_constraint(builder, left_constraint.when_true());
+                    let (positive_right_node, _) =
+                        Node::new_satisfied_constraint(builder, right_constraint.when_true());
 
                     // left ∧ right = false
                     simplified = simplified.substitute_intersection(
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         ALWAYS_FALSE,
                     );
 
@@ -5009,9 +4749,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         ALWAYS_TRUE,
                     );
 
@@ -5021,9 +4759,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_true(),
-                        left_source_order,
                         right_constraint.when_false(),
-                        right_source_order,
                         positive_left_node,
                     );
 
@@ -5033,9 +4769,7 @@ impl InteriorNode {
                         db,
                         builder,
                         left_constraint.when_false(),
-                        left_source_order,
                         right_constraint.when_true(),
-                        right_source_order,
                         positive_right_node,
                     );
                 }
@@ -7062,7 +6796,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let constraint_upper = constraint.top_materialization(db);
                     let (constraint_node, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
-                    specializations = specializations.or_with_offset(builder, constraint_node);
+                    specializations = specializations.or(builder, constraint_node);
                 }
                 specializations
             }
@@ -7109,8 +6843,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                     let (constraint, _) =
                         Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
                     if constraint_lower == constraint_upper {
-                        non_gradual_constraints =
-                            non_gradual_constraints.or_with_offset(builder, constraint);
+                        non_gradual_constraints = non_gradual_constraints.or(builder, constraint);
                     } else {
                         gradual_constraints.push(constraint);
                     }
@@ -7376,15 +7109,15 @@ mod tests {
             &constraints,
             set,
             indoc! {r#"
-                <0> (U = bool) 2/4
-                ┡━₁ <1> (T = bool) 4/4
+                <0> (U = bool)
+                ┡━₁ <1> (T = bool)
                 │   ┡━₁ always
-                │   ├─? <2> (T = str) 3/3
+                │   ├─? <2> (T = str)
                 │   │   ┡━₁ always
                 │   │   ├─? never
                 │   │   └─₀ never
                 │   └─₀ never
-                ├─? <3> (U = str) 1/4
+                ├─? <3> (U = str)
                 │   ┡━₁ <1> SHARED
                 │   ├─? never
                 │   └─₀ never
@@ -7407,7 +7140,7 @@ mod tests {
             &builder,
             t_int,
             indoc! {r#"
-                <0> (T = int) 1/1
+                <0> (T = int)
                 ┡━₁ always
                 ├─? never
                 └─₀ never
@@ -7435,9 +7168,9 @@ mod tests {
             &builder,
             union,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ always
-                ├─? <1> (T = int) 1/1
+                ├─? <1> (T = int)
                 │   ┡━₁ always
                 │   ├─? never
                 │   └─₀ never
@@ -7469,15 +7202,15 @@ mod tests {
             &builder,
             intersection,
             indoc! {r#"
-                <0> (U = int) 4/4
-                ┡━₁ <1> (U = str) 2/2
+                <0> (U = int)
+                ┡━₁ <1> (U = str)
                 │   ┡━₁ always
-                │   ├─? <2> (T = int) 1/1
+                │   ├─? <2> (T = int)
                 │   │   ┡━₁ always
                 │   │   ├─? never
                 │   │   └─₀ never
                 │   └─₀ never
-                ├─? <3> (T = bool) 3/3
+                ├─? <3> (T = bool)
                 │   ┡━₁ <1> SHARED
                 │   ├─? never
                 │   └─₀ never
@@ -7502,10 +7235,10 @@ mod tests {
             &builder,
             negated,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ never
                 ├─? never
-                └─₀ <1> (T = int) 1/1
+                └─₀ <1> (T = int)
                     ┡━₁ never
                     ├─? never
                     └─₀ always
@@ -7614,7 +7347,7 @@ mod tests {
                 builder,
                 set,
                 indoc! {r#"
-                    <0> (V = bool) 1/1
+                    <0> (V = bool)
                     ┡━₁ always
                     ├─? never
                     └─₀ never
@@ -7681,7 +7414,7 @@ mod tests {
             &builder,
             loaded,
             indoc! {r#"
-                <0> (V = bool) 1/1
+                <0> (V = bool)
                 ┡━₁ always
                 ├─? never
                 └─₀ never
@@ -7733,9 +7466,9 @@ mod tests {
                 builder,
                 result,
                 indoc! {r#"
-                    <0> (U = str) 2/2
+                    <0> (U = str)
                     ┡━₁ always
-                    ├─? <1> (T = int) 1/1
+                    ├─? <1> (T = int)
                     │   ┡━₁ always
                     │   ├─? never
                     │   └─₀ never
@@ -7753,9 +7486,9 @@ mod tests {
             &builder,
             loaded,
             indoc! {r#"
-                <0> (U = str) 2/2
+                <0> (U = str)
                 ┡━₁ always
-                ├─? <1> (T = int) 1/1
+                ├─? <1> (T = int)
                 │   ┡━₁ always
                 │   ├─? never
                 │   └─₀ never


### PR DESCRIPTION
should reduce BDD storage requirements quite a bit