### PR TITLE
[ty] Normalize recursive protocol growth during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
@@ -1,0 +1,8 @@
+# Nested iterable types
+
+Regression test for <https://github.com/astral-sh/ty/issues/3827>.
+
+```py
+while 1:
+    x = iter([[None] + [x]])  # error: [possibly-unresolved-reference]
+```

--- a/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
@@ -5,4 +5,5 @@ Regression test for <https://github.com/astral-sh/ty/issues/3827>.
 ```py
 while 1:
     x = iter([[None] + [x]])  # error: [possibly-unresolved-reference]
+    reveal_type(x)  # revealed: Iterator[Divergent]
 ```

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1223,6 +1223,8 @@ impl<'db> Type<'db> {
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
     /// tainted cycles, replace the recursive type argument with the cycle's `Divergent` marker so
     /// that the existing recursive-type normalization can converge on `C[Divergent]`.
+    /// Class-backed protocol instances participate through their nominal representation;
+    /// synthesized protocols are excluded.
     fn recursive_nominal_growth_normalized(
         self,
         db: &'db dyn Db,
@@ -1297,10 +1299,15 @@ impl<'db> Type<'db> {
             (Type::NominalInstance(current), Type::NominalInstance(previous)) => {
                 (current, previous)
             }
-            (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => (
-                current.to_nominal_instance()?,
-                previous.to_nominal_instance()?,
-            ),
+            (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => {
+                // A class-backed protocol shares a nominal specialization with its runtime class.
+                // `nominal_wrapper_normalized` reconstructs the result through `Type::instance`,
+                // which recognizes the protocol class and restores a protocol instance.
+                (
+                    current.to_nominal_instance()?,
+                    previous.to_nominal_instance()?,
+                )
+            }
             _ => return None,
         };
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1293,10 +1293,15 @@ impl<'db> Type<'db> {
             }));
         }
 
-        let (Type::NominalInstance(current), Type::NominalInstance(previous_instance)) =
-            (self, previous)
-        else {
-            return None;
+        let (current, previous_instance) = match (self, previous) {
+            (Type::NominalInstance(current), Type::NominalInstance(previous)) => {
+                (current, previous)
+            }
+            (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => (
+                current.to_nominal_instance()?,
+                previous.to_nominal_instance()?,
+            ),
+            _ => return None,
         };
 
         if current.class(db).class_literal(db) != previous_instance.class_literal(db) {


### PR DESCRIPTION
## Summary

A loop-carried value can grow through a protocol specialization on every fixed-point iteration:

```python
while 1:
    x = iter([[None] + [x]])
```

Prior to this change, we repeatedly inferred a deeper `Iterator[...]` specialization. The existing recursive-growth recovery only recognized `NominalInstance`, while `iter` returns a class-backed `ProtocolInstance`, so inference never converged.

This converts class-backed protocol instances to their nominal representation when comparing cycle iterations, allowing the existing wrapper replacement and `Divergent` normalization to converge. Synthesized protocols remain excluded from this path.

Closes https://github.com/astral-sh/ty/issues/3827.
