### PR TITLE
[ty] Reduce allocations for simple constraint conjunctions

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3297,6 +3297,7 @@ fn is_possibly_constraint_set_assignable<'db>(
 pub(crate) enum PathBounds<'db> {
     Unsatisfiable,
     Unconstrained,
+    Single(Box<[PathBound<'db>]>),
     Constrained(Box<[Box<[PathBound<'db>]>]>),
 }
 
@@ -3389,7 +3390,9 @@ impl<'db> PathBounds<'db> {
             .simple_lower_bound_conjunction(db, builder)
             .collect::<Result<Vec<_>, _>>()
             .ok()?;
-        constraints.sort_by_key(|(_, _, source_order)| *source_order);
+        // Unlike derived `PathAssignment` constraints, constraints directly in a BDD have
+        // distinct `source_order`s, so this sort does not need to be stable.
+        constraints.sort_unstable_by_key(|(_, _, source_order)| *source_order);
 
         if let Some(&(typevar, _, _)) = constraints.first()
             && constraints
@@ -3400,7 +3403,7 @@ impl<'db> PathBounds<'db> {
                 UnionType::from_elements(db, constraints.into_iter().map(|(_, lower, _)| lower));
             let path: Box<[PathBound<'db>]> =
                 Box::new([(typevar, ConstraintBounds::new(Some(lower), None))]);
-            return Some(PathBounds::Constrained(Box::new([path])));
+            return Some(PathBounds::Single(path));
         }
 
         let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
@@ -3413,7 +3416,7 @@ impl<'db> PathBounds<'db> {
             .drain()
             .map(|(bound_typevar, bounds)| (bound_typevar, bounds.finish(db)))
             .collect();
-        Some(PathBounds::Constrained(Box::new([path])))
+        Some(PathBounds::Single(path))
     }
 
     pub(crate) fn solve(
@@ -3443,6 +3446,7 @@ impl<'db> PathBounds<'db> {
         let paths = match self {
             PathBounds::Unsatisfiable => return Solutions::Unsatisfiable,
             PathBounds::Unconstrained => return Solutions::Unconstrained,
+            PathBounds::Single(path) => std::slice::from_ref(path),
             PathBounds::Constrained(paths) => paths,
         };
 

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -3391,6 +3391,18 @@ impl<'db> PathBounds<'db> {
             .ok()?;
         constraints.sort_by_key(|(_, _, source_order)| *source_order);
 
+        if let Some(&(typevar, _, _)) = constraints.first()
+            && constraints
+                .iter()
+                .all(|(constraint_typevar, _, _)| *constraint_typevar == typevar)
+        {
+            let lower =
+                UnionType::from_elements(db, constraints.into_iter().map(|(_, lower, _)| lower));
+            let path: Box<[PathBound<'db>]> =
+                Box::new([(typevar, ConstraintBounds::new(Some(lower), None))]);
+            return Some(PathBounds::Constrained(Box::new([path])));
+        }
+
         let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxHashMap::default();
         for (typevar, lower, _) in constraints {


### PR DESCRIPTION
## Summary

This is stacked on #26248.

The simple-lower-bound fast path still creates an `FxHashMap` and an `FxIndexSet` while accumulating path bounds. In the common case where every constraint targets the same type variable, that grouping and deduplication machinery is unnecessary.

After preserving source order, this recognizes a single-type-variable conjunction and builds its union directly from the collected lower bounds. Mixed-type-variable conjunctions continue through the existing map-based fallback.

The fast path also retained a one-element outer path allocation and used a stable sort even though constraints directly in a BDD have distinct source orders. `PathBounds::Single` stores the path directly, while an unstable sort avoids auxiliary scratch allocation for larger conjunctions without changing ordering.

Together, these changes remove the map and set allocations from the single-type-variable case, the outer allocation from every simple-conjunction path, and the stable-sort scratch allocation. The full `ty_python_semantic` suite, crate-level Clippy, and file-scoped repository hooks pass.
