### PR TITLE
[ty] Suppress discarded TypedDict diagnostics

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/typed_dict.md
+++ b/crates/ty_python_semantic/resources/mdtest/typed_dict.md
@@ -876,7 +876,7 @@ When assigning to a union of `TypedDict` types, the type will be narrowed based 
 literal:
 
 ```py
-from typing import TypedDict
+from typing import TypeVar, TypedDict
 from typing_extensions import NotRequired
 
 class Foo(TypedDict):
@@ -908,6 +908,9 @@ reveal_type(x4)  # revealed: Bar
 x5: Foo | Bar = {"baz": 1}
 reveal_type(x5)  # revealed: Foo | Bar
 
+x5_fallback: Foo | Bar | dict[str, object] = {"baz": 1}
+reveal_type(x5_fallback)  # revealed: dict[str, object]
+
 class FooBar1(TypedDict):
     foo: int
     bar: int
@@ -929,6 +932,21 @@ reveal_type(x7)  # revealed: FooBar1 | FooBar3
 
 x8: FooBar1 | FooBar2 | FooBar3 | None = {"foo": 1, "bar": 1}
 reveal_type(x8)  # revealed: FooBar1 | FooBar2 | FooBar3
+
+# Nested peer inference must still observe its speculative diagnostics while the outer dictionary
+# is tested against multiple TypedDicts.
+class PeerContainer(TypedDict):
+    nested: Foo
+
+PeerT = TypeVar("PeerT")
+
+def preserve_peer(value: PeerT) -> PeerT:
+    return value
+
+def _(payload: Foo | None):
+    # error: [invalid-assignment]
+    nested: PeerContainer | Bar = {"nested": preserve_peer(payload or {"unexpected": 1})}
+    reveal_type(nested)  # revealed: PeerContainer | Bar
 ```
 
 In doing so, may have to infer the same type with multiple distinct type contexts:

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -43,6 +43,7 @@ pub(crate) struct InferContext<'db, 'ast> {
     file: File,
     module: &'ast ParsedModuleRef,
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
+    diagnostics_suppressed: bool,
     /// This field tracks various flags that control how type inference should behave in the current context.
     pub(crate) inference_flags: InferenceFlags,
     bomb: DebugDropBomb,
@@ -56,6 +57,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
             module,
             file: scope.file(db),
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
+            diagnostics_suppressed: false,
             inference_flags: InferenceFlags::empty(),
             bomb: DebugDropBomb::new(
                 "`InferContext` needs to be explicitly consumed by calling `::finish` to prevent accidental loss of diagnostics.",
@@ -107,6 +109,13 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         !self.diagnostics.borrow().is_empty()
     }
 
+    /// Returns a guard that prevents diagnostic construction until it is dropped.
+    pub(super) fn suppress_diagnostics(&mut self) -> DiagnosticSuppressionGuard<'_, 'db, 'ast> {
+        debug_assert!(!self.diagnostics_suppressed);
+        self.diagnostics_suppressed = true;
+        DiagnosticSuppressionGuard { context: self }
+    }
+
     pub(super) fn is_lint_enabled(&self, lint: &'static LintMetadata) -> bool {
         LintDiagnosticGuardBuilder::severity_and_source(self, LintId::of(lint)).is_some()
     }
@@ -144,6 +153,9 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         lint: &'static LintMetadata,
         ranged: T,
     ) -> Option<LintDiagnosticGuardBuilder<'ctx, 'db>> {
+        if self.diagnostics_suppressed {
+            return None;
+        }
         LintDiagnosticGuardBuilder::new(self, lint, ranged.range())
     }
 
@@ -166,6 +178,9 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         id: DiagnosticId,
         severity: Severity,
     ) -> Option<DiagnosticGuardBuilder<'ctx, 'db>> {
+        if self.diagnostics_suppressed {
+            return None;
+        }
         DiagnosticGuardBuilder::new(self, id, severity)
     }
 
@@ -236,6 +251,28 @@ impl fmt::Debug for InferContext<'_, '_> {
             .field("diagnostics", &self.diagnostics)
             .field("defused", &self.bomb)
             .finish()
+    }
+}
+
+/// Prevents diagnostic construction while holding an exclusive borrow of an inference context.
+///
+/// The exclusive borrow prevents recursive expression inference from accidentally inheriting the
+/// suppression state.
+pub(super) struct DiagnosticSuppressionGuard<'ctx, 'db, 'ast> {
+    context: &'ctx mut InferContext<'db, 'ast>,
+}
+
+impl<'db, 'ast> std::ops::Deref for DiagnosticSuppressionGuard<'_, 'db, 'ast> {
+    type Target = InferContext<'db, 'ast>;
+
+    fn deref(&self) -> &Self::Target {
+        self.context
+    }
+}
+
+impl Drop for DiagnosticSuppressionGuard<'_, '_, '_> {
+    fn drop(&mut self) {
+        self.context.diagnostics_suppressed = false;
     }
 }
 

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -109,11 +109,10 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         !self.diagnostics.borrow().is_empty()
     }
 
-    /// Returns a guard that prevents diagnostic construction until it is dropped.
-    pub(super) fn suppress_diagnostics(&mut self) -> DiagnosticSuppressionGuard<'_, 'db, 'ast> {
+    /// Prevents diagnostic construction for this inference context.
+    pub(super) fn suppress_diagnostics(&mut self) {
         debug_assert!(!self.diagnostics_suppressed);
         self.diagnostics_suppressed = true;
-        DiagnosticSuppressionGuard { context: self }
     }
 
     pub(super) fn is_lint_enabled(&self, lint: &'static LintMetadata) -> bool {
@@ -153,9 +152,6 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         lint: &'static LintMetadata,
         ranged: T,
     ) -> Option<LintDiagnosticGuardBuilder<'ctx, 'db>> {
-        if self.diagnostics_suppressed {
-            return None;
-        }
         LintDiagnosticGuardBuilder::new(self, lint, ranged.range())
     }
 
@@ -178,9 +174,6 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
         id: DiagnosticId,
         severity: Severity,
     ) -> Option<DiagnosticGuardBuilder<'ctx, 'db>> {
-        if self.diagnostics_suppressed {
-            return None;
-        }
         DiagnosticGuardBuilder::new(self, id, severity)
     }
 
@@ -251,28 +244,6 @@ impl fmt::Debug for InferContext<'_, '_> {
             .field("diagnostics", &self.diagnostics)
             .field("defused", &self.bomb)
             .finish()
-    }
-}
-
-/// Prevents diagnostic construction while holding an exclusive borrow of an inference context.
-///
-/// The exclusive borrow prevents recursive expression inference from accidentally inheriting the
-/// suppression state.
-pub(super) struct DiagnosticSuppressionGuard<'ctx, 'db, 'ast> {
-    context: &'ctx mut InferContext<'db, 'ast>,
-}
-
-impl<'db, 'ast> std::ops::Deref for DiagnosticSuppressionGuard<'_, 'db, 'ast> {
-    type Target = InferContext<'db, 'ast>;
-
-    fn deref(&self) -> &Self::Target {
-        self.context
-    }
-}
-
-impl Drop for DiagnosticSuppressionGuard<'_, '_, '_> {
-    fn drop(&mut self) {
-        self.context.diagnostics_suppressed = false;
     }
 }
 
@@ -447,6 +418,10 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
         ctx: &'ctx InferContext<'db, 'ctx>,
         lint: LintId,
     ) -> Option<(Severity, LintSource)> {
+        if ctx.diagnostics_suppressed {
+            return None;
+        }
+
         // The comment below was copied from the original
         // implementation of diagnostic reporting. The code
         // has been refactored, but this still kind of looked
@@ -567,6 +542,10 @@ impl<'db, 'ctx> DiagnosticGuardBuilder<'db, 'ctx> {
         id: DiagnosticId,
         severity: Severity,
     ) -> Option<DiagnosticGuardBuilder<'db, 'ctx>> {
+        if ctx.diagnostics_suppressed {
+            return None;
+        }
+
         if !ctx.db.should_check_file(ctx.file) {
             return None;
         }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6798,7 +6798,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(typed_dict) = annotation.as_typed_dict() {
                 // If there is a single typed dict annotation, infer against it directly.
                 if let Some(ty) =
-                    self.infer_typed_dict_expression(dict, typed_dict, &mut item_types, true)
+                    self.infer_typed_dict_expression(dict, typed_dict, &mut item_types)
                 {
                     return ty;
                 }
@@ -6826,7 +6826,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !has_dict_compatible_fallback
                 {
                     if let Some(ty) =
-                        self.infer_typed_dict_expression(dict, *typed_dict, &mut item_types, true)
+                        self.infer_typed_dict_expression(dict, *typed_dict, &mut item_types)
                     {
                         return ty;
                     }
@@ -6849,15 +6849,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Reuse nested expressions that receive the same field context across candidates.
                     let teardown = self.setup_expression_cache();
                     for typed_dict in typed_dicts {
-                        // Suppress validation diagnostics for discarded candidates. A mixed union
-                        // like `TypedDict | dict[str, Any]` should remain quiet when the dict arm
-                        // accepts the literal.
-                        if let Some(inferred_ty) = self.speculate().infer_typed_dict_expression(
-                            dict,
-                            typed_dict,
-                            &mut item_types,
-                            false,
-                        ) {
+                        // Suppress diagnostics for discarded candidates. A mixed union like
+                        // `TypedDict | dict[str, Any]` should remain quiet when the dict arm accepts
+                        // the literal.
+                        if let Some(inferred_ty) = self
+                            .speculate_without_diagnostics()
+                            .infer_typed_dict_expression(dict, typed_dict, &mut item_types)
+                        {
                             narrowed_tys.push(inferred_ty);
                         }
 
@@ -11178,6 +11176,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .dataclass_field_specifiers
             .clone_from(dataclass_field_specifiers);
 
+        builder
+    }
+
+    /// Returns a speculative builder that does not construct diagnostics.
+    fn speculate_without_diagnostics(&self) -> Self {
+        let mut builder = self.speculate();
+        builder.context.suppress_diagnostics();
         builder
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -6798,7 +6798,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(typed_dict) = annotation.as_typed_dict() {
                 // If there is a single typed dict annotation, infer against it directly.
                 if let Some(ty) =
-                    self.infer_typed_dict_expression(dict, typed_dict, &mut item_types)
+                    self.infer_typed_dict_expression(dict, typed_dict, &mut item_types, true)
                 {
                     return ty;
                 }
@@ -6826,7 +6826,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !has_dict_compatible_fallback
                 {
                     if let Some(ty) =
-                        self.infer_typed_dict_expression(dict, *typed_dict, &mut item_types)
+                        self.infer_typed_dict_expression(dict, *typed_dict, &mut item_types, true)
                     {
                         return ty;
                     }
@@ -6849,14 +6849,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Reuse nested expressions that receive the same field context across candidates.
                     let teardown = self.setup_expression_cache();
                     for typed_dict in typed_dicts {
-                        // Disable diagnostics as we attempt to narrow to specific `TypedDict`
-                        // elements of the union. Mixed unions like `TypedDict | dict[str, Any]`
-                        // should not emit `TypedDict` diagnostics if a non-`TypedDict` arm accepts
-                        // the literal.
+                        // Suppress validation diagnostics for discarded candidates. A mixed union
+                        // like `TypedDict | dict[str, Any]` should remain quiet when the dict arm
+                        // accepts the literal.
                         if let Some(inferred_ty) = self.speculate().infer_typed_dict_expression(
                             dict,
                             typed_dict,
                             &mut item_types,
+                            false,
                         ) {
                             narrowed_tys.push(inferred_ty);
                         }

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -323,7 +323,6 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         dict: &ast::ExprDict,
         typed_dict: TypedDictType<'db>,
         item_types: &mut FxHashMap<NodeIndex, Type<'db>>,
-        emit_validation_diagnostics: bool,
     ) -> Option<Type<'db>> {
         let ast::ExprDict {
             range: _,
@@ -358,30 +357,21 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             item_types.insert(item.value.node_index().load(), value_ty);
         }
 
-        let validate = |context| {
-            validate_typed_dict_dict_literal(
-                context,
-                typed_dict,
-                dict,
-                dict.into(),
-                |expr: &ast::Expr, tcx: TypeContext<'db>| {
-                    item_types
-                        .get(&expr.node_index().load())
-                        .copied()
-                        .unwrap_or_else(|| {
-                            let _ = tcx;
-                            Type::unknown()
-                        })
-                },
-            )
-        };
-
-        if emit_validation_diagnostics {
-            validate(&self.context)
-        } else {
-            let context = self.context.suppress_diagnostics();
-            validate(&context)
-        }
+        validate_typed_dict_dict_literal(
+            &self.context,
+            typed_dict,
+            dict,
+            dict.into(),
+            |expr: &ast::Expr, tcx: TypeContext<'db>| {
+                item_types
+                    .get(&expr.node_index().load())
+                    .copied()
+                    .unwrap_or_else(|| {
+                        let _ = tcx;
+                        Type::unknown()
+                    })
+            },
+        )
         .ok()
         .map(|_| Type::TypedDict(typed_dict))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -323,6 +323,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         dict: &ast::ExprDict,
         typed_dict: TypedDictType<'db>,
         item_types: &mut FxHashMap<NodeIndex, Type<'db>>,
+        emit_validation_diagnostics: bool,
     ) -> Option<Type<'db>> {
         let ast::ExprDict {
             range: _,
@@ -357,21 +358,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             item_types.insert(item.value.node_index().load(), value_ty);
         }
 
-        validate_typed_dict_dict_literal(
-            &self.context,
-            typed_dict,
-            dict,
-            dict.into(),
-            |expr: &ast::Expr, tcx: TypeContext<'db>| {
-                item_types
-                    .get(&expr.node_index().load())
-                    .copied()
-                    .unwrap_or_else(|| {
-                        let _ = tcx;
-                        Type::unknown()
-                    })
-            },
-        )
+        let validate = |context| {
+            validate_typed_dict_dict_literal(
+                context,
+                typed_dict,
+                dict,
+                dict.into(),
+                |expr: &ast::Expr, tcx: TypeContext<'db>| {
+                    item_types
+                        .get(&expr.node_index().load())
+                        .copied()
+                        .unwrap_or_else(|| {
+                            let _ = tcx;
+                            Type::unknown()
+                        })
+                },
+            )
+        };
+
+        if emit_validation_diagnostics {
+            validate(&self.context)
+        } else {
+            let context = self.context.suppress_diagnostics();
+            validate(&context)
+        }
         .ok()
         .map(|_| Type::TypedDict(typed_dict))
     }


### PR DESCRIPTION
## Summary

When we infer a dictionary literal against a union containing multiple `TypedDict` types, we speculatively validate the literal against each candidate. Prior to this change, rejected candidates still constructed and formatted diagnostics even though we discarded the candidate builder and its diagnostics.

This adds scoped diagnostic suppression around candidate validation. Key and value inference, including nested speculation, continues with diagnostics enabled; only the final validation of already-inferred item types is suppressed. Direct `TypedDict` annotations and single-`TypedDict` unions without a compatible fallback continue to report diagnostics normally.

The regression coverage ensures that a mixed `TypedDict | dict[...]` fallback remains quiet while nested inference can still use speculative diagnostics to select its fallback.

## Performance

Across 21 single-threaded `ty_walltime::pydantic` samples, median and p95 both improve by 9.7% (3.377s to 3.049s median; 3.394s to 3.064s p95). Matched Callgrind runs retire 12.35% fewer instructions; the discarded validation-diagnostic edge falls by 99.79%, while the control workload is unchanged.
