### PR TITLE
[ty] Avoid constructing discarded speculative diagnostics

### DIFF
--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -5801,7 +5801,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
 
-                let mut speculative_builder = self.speculate();
+                let mut speculative_builder = self.speculate_without_diagnostics();
                 let inferred_ty = infer_argument_ty(
                     &mut speculative_builder,
                     (
@@ -5906,7 +5906,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // We use a speculative builder to silence any diagnostics emitted during multi-inference, as the
                     // type context is only used as a hint to infer a more assignable argument type, and should not lead
                     // to diagnostics for non-matching overloads.
-                    let mut speculative_builder = self.speculate();
+                    let mut speculative_builder = self.speculate_without_diagnostics();
                     let inferred_ty = infer_argument_ty(
                         &mut speculative_builder,
                         (
@@ -6815,7 +6815,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     } else if !has_dict_compatible_fallback {
                         // Suppress `TypedDict` diagnostics only if this literal is assignable to
                         // the non-`TypedDict` arm of the union.
-                        let mut speculative_builder = self.speculate();
+                        let mut speculative_builder = self.speculate_without_diagnostics();
                         has_dict_compatible_fallback = speculative_builder
                             .infer_dict_expression(dict, TypeContext::new(Some(element)))
                             .is_assignable_to(self.db(), element);
@@ -8489,7 +8489,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         ..
                     }) => Some(key_literal.to_str()),
                     _ => self
-                        .speculate()
+                        .speculate_without_diagnostics()
                         .get_or_infer_expression(first_arg, TypeContext::default())
                         .as_string_literal()
                         .map(|key_literal| key_literal.value(self.db())),
@@ -8857,19 +8857,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(self.db(), collection_generic_context);
 
-                let call_result = self.speculate().infer_and_check_argument_types(
-                    ArgumentsIter::from_ast(arguments),
-                    &mut call_arguments,
-                    // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                    // However, `value` would have been inferred to a be a collection with `Divergent`
-                    // element types, meaning the type context for a given argument, by which the inferred
-                    // type is keyed, may not be the same as the type context we get here. It is not immediately
-                    // clear how to retrieve those types, and so we just re-infer the argument expressions
-                    // for simplicity.
-                    &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
-                    &mut identity_bindings,
-                    call_expression_tcx,
-                );
+                let call_result = self
+                    .speculate_without_diagnostics()
+                    .infer_and_check_argument_types(
+                        ArgumentsIter::from_ast(arguments),
+                        &mut call_arguments,
+                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                        // However, `value` would have been inferred to a be a collection with `Divergent`
+                        // element types, meaning the type context for a given argument, by which the inferred
+                        // type is keyed, may not be the same as the type context we get here. It is not immediately
+                        // clear how to retrieve those types, and so we just re-infer the argument expressions
+                        // for simplicity.
+                        &mut |builder, (_, expr, tcx)| builder.infer_expression(expr, tcx),
+                        &mut identity_bindings,
+                        call_expression_tcx,
+                    );
 
                 if call_result.is_ok() {
                     for call_specialization in identity_bindings
@@ -11307,7 +11309,7 @@ impl<'db, 'ast, 'infer> MultiInferenceGuard<'db, 'ast, 'infer> {
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
         self.last_tcx = Some(tcx);
-        (self.infer_expr)(&mut builder.speculate(), tcx)
+        (self.infer_expr)(&mut builder.speculate_without_diagnostics(), tcx)
     }
 
     fn last_tcx(&self) -> TypeContext<'db> {

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -182,7 +182,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) -> Option<Type<'db>> {
         let db = self.db();
 
-        let update_ty = self.speculate().infer_expression(
+        let update_ty = self.speculate_without_diagnostics().infer_expression(
             update,
             TypeContext::new(Some(Type::TypedDict(update_context_typed_dict))),
         );

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -39,7 +39,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // committed with the fast path or left for ordinary `dict(...)` inference when we fall
             // back.
             let supports_typed_dict_context = {
-                let mut speculative_builder = self.speculate();
+                let mut speculative_builder = self.speculate_without_diagnostics();
                 infer_unpacked_keyword_types(arguments, |expr, tcx| {
                     speculative_builder.infer_expression(expr, tcx)
                 })

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -1286,21 +1286,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(db, collection_generic_context);
 
-                let call_result = self.speculate().infer_and_check_argument_types(
-                    ArgumentsIter::synthesized(&ast_arguments),
-                    &mut call_arguments,
-                    &mut |builder, (_, expr, tcx)| {
-                        // TODO: The argument types have already been inferred and stored in `call_arguments`.
-                        // However, `object` would have been inferred to a be a collection with `Divergent`
-                        // element types, meaning the type context for a given argument, by which the inferred
-                        // type is keyed, may not be the same as the type context we get here. It is not immediately
-                        // clear how to retrieve those types, and so we just re-infer the argument expressions
-                        // for simplicity.
-                        builder.infer_maybe_standalone_expression(expr, tcx)
-                    },
-                    &mut identity_bindings,
-                    TypeContext::default(),
-                );
+                let call_result = self
+                    .speculate_without_diagnostics()
+                    .infer_and_check_argument_types(
+                        ArgumentsIter::synthesized(&ast_arguments),
+                        &mut call_arguments,
+                        &mut |builder, (_, expr, tcx)| {
+                            // TODO: The argument types have already been inferred and stored in `call_arguments`.
+                            // However, `object` would have been inferred to a be a collection with `Divergent`
+                            // element types, meaning the type context for a given argument, by which the inferred
+                            // type is keyed, may not be the same as the type context we get here. It is not immediately
+                            // clear how to retrieve those types, and so we just re-infer the argument expressions
+                            // for simplicity.
+                            builder.infer_maybe_standalone_expression(expr, tcx)
+                        },
+                        &mut identity_bindings,
+                        TypeContext::default(),
+                    );
 
                 if call_result.is_ok() && boundness == Definedness::AlwaysDefined {
                     for call_specialization in identity_bindings

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -224,7 +224,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                         // Detect runtime errors from e.g. `int | "bytes"` on Python <3.14 without `__future__` annotations.
                         if !ignore_runtime_errors(self) {
-                            let mut speculative_builder = self.speculate();
+                            let mut speculative_builder = self.speculate_without_diagnostics();
                             // If the left-hand side of the union is itself a PEP-604 union,
                             // we'll already have checked whether it can be used with `|` in a previous inference step
                             // and emitted a diagnostic if it was appropriate. We should skip inferring it here to
@@ -360,7 +360,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         if !ignore_runtime_errors(self) {
                             // Infer the operands as values to report the types used by the runtime
                             // operation rather than their interpretation as type expressions.
-                            let mut speculative_builder = self.speculate();
+                            let mut speculative_builder = self.speculate_without_diagnostics();
                             let left_value = speculative_builder
                                 .infer_expression(&binary.left, TypeContext::default());
                             let right_value = speculative_builder
@@ -509,7 +509,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ),
                 ) && let [single_element] = &*list.elts
                 {
-                    let mut speculative_builder = self.speculate();
+                    let mut speculative_builder = self.speculate_without_diagnostics();
                     let inner_type = speculative_builder.infer_type_expression(single_element);
 
                     if inner_type.is_hintable(self.db()) {
@@ -540,7 +540,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             self.type_expression_context()
                         ),
                     ) {
-                        let mut speculative = self.speculate();
+                        let mut speculative = self.speculate_without_diagnostics();
                         let inner_types: Vec<Type<'db>> = tuple
                             .elts
                             .iter()
@@ -607,7 +607,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                 if !ignore_runtime_errors(self) {
                     let operand_value = self
-                        .speculate()
+                        .speculate_without_diagnostics()
                         .infer_expression(operand, TypeContext::default());
                     if let Err(error) = operand_value.try_call_dunder(
                         self.db(),
@@ -687,7 +687,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     },
                 ] = &*dict.items
                 {
-                    let mut speculative = self.speculate();
+                    let mut speculative = self.speculate_without_diagnostics();
                     let key_type = speculative.infer_type_expression(key);
                     let value_type = speculative.infer_type_expression(value);
                     if key_type.is_hintable(self.db()) && value_type.is_hintable(self.db()) {
@@ -714,7 +714,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     ),
                 ) && let [single_element] = &*set.elts
                 {
-                    let mut speculative_builder = self.speculate();
+                    let mut speculative_builder = self.speculate_without_diagnostics();
                     let inner_type = speculative_builder.infer_type_expression(single_element);
 
                     if inner_type.is_hintable(self.db()) {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -35,7 +35,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // Suppress contextual `TypeForm` evaluation only if ordinary inference already
         // produces a type-form value or satisfies the non-`TypeForm` arm of the union.
         let value_ty = self
-            .speculate()
+            .speculate_without_diagnostics()
             .infer_maybe_standalone_expression(expression, TypeContext::default());
         if matches!(value_ty.resolve_type_alias(self.db()), Type::Never)
             || self.contains_type_form_value(expression, value_ty)
@@ -49,12 +49,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // try ordinary contextual inference. This lets existing bidirectional
         // inference propagate `TypeForm` through conditionals, calls, and `await`.
         if self
-            .speculate()
+            .speculate_without_diagnostics()
             .infer_type_expression_no_store(expression)
             .is_unknown()
         {
             let contextual_ty = self
-                .speculate()
+                .speculate_without_diagnostics()
                 .infer_value_expression_impl(expression, TypeContext::new(Some(target)));
             // TODO: Remove this exception once `Unpack` produces a precise type instead of a
             // dynamic placeholder in ordinary expression inference.
@@ -88,7 +88,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 // interpreted as a `TypeForm`. Preserve its ordinary value type only when
                 // it was produced by an expression that is not itself a type expression.
                 Type::ClassLiteral(_) => builder
-                    .speculate()
+                    .speculate_without_diagnostics()
                     .infer_type_expression_no_store(expression)
                     .is_unknown(),
                 Type::NominalInstance(instance)


### PR DESCRIPTION
## Summary

`speculate()` creates a fresh inference builder whose diagnostics are discarded unless the caller later inspects or merges its context. Prior to this change, 20 speculative inference passes used only the inferred types, constraints, or applicability result, but still constructed and formatted diagnostics before dropping the builder.

This reuses `speculate_without_diagnostics()` from #26250 at every call site that does not consume diagnostics. It covers call-argument multi-inference, `MultiInferenceGuard::infer_silent`, `TypeForm` and type-expression probes, and secondary `TypedDict`, dictionary, binary-expression, call, and subscript inference. The six speculative paths that inspect diagnostics or merge a successful builder continue to use `speculate()`.

The change is intended to preserve inference and diagnostic behavior; it only avoids work whose result was already discarded.

## Performance

This is intentionally a draft so CodSpeed can measure the aggregate effect across the benchmark suite.
