### PR TITLE
[ty] Preserve regular kind for callable instances

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -777,6 +777,41 @@ def _(
     reveal_type(c8)  # revealed: (x: int) -> str
 ```
 
+A callable instance upcast to a callable type is still a regular callable when stored as a class
+attribute, even if its `__call__` method is function-like. Explicit descriptor behavior is still
+respected:
+
+```py
+from functools import partial
+from typing import Callable
+from ty_extensions import into_callable
+
+class CallableInstance:
+    def __call__(self, value: int, /) -> str:
+        return str(value)
+
+instance = CallableInstance()
+
+class Owner:
+    callback = into_callable(instance)
+
+Owner().callback(1)
+Owner().callback()  # error: [missing-argument]
+
+class DescriptorCallableInstance:
+    def __call__(self, value: int, /) -> str:
+        return str(value)
+
+    def __get__(self, owner, instance) -> Callable[[], str]:
+        return partial(self, 42)
+
+class DescriptorOwner:
+    callback = DescriptorCallableInstance()
+
+DescriptorOwner().callback(1)  # error: [too-many-positional-arguments]
+DescriptorOwner().callback()
+```
+
 Narrowed callable enum values can still be used with callable type extraction:
 
 ```py

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -125,6 +125,9 @@ impl<'db> Type<'db> {
                     place
                         .ty
                         .try_upcast_to_callable_with_policy_and_context(db, policy, context)
+                        // The callable instance itself doesn't inherit the descriptor behavior of
+                        // its `__call__` method.
+                        .map(|callables| callables.map(|callable| callable.into_regular(db)))
                 } else {
                     None
                 }


### PR DESCRIPTION
## Summary

A callable instance was upcast through the type of its bound `__call__` method. Because bound methods are function-like, the instance itself incorrectly inherited function-like descriptor behavior.

Callable instances do not automatically bind an additional receiver when stored as class attributes, so treating them as function-like is wrong.

## Validation

Add mdtest.

There are a few false positives in the ecosystem report, which just highlight the fact that we shouldn't make this regular vs function-like distinction impact assignability of callable types, or else we should more eagerly promote inferred function-like callable types to regular callable types. Just because a callable type specialization was originally inferred from a function-like callable doesn't mean that it should only accept function-like callables. But regardless, the inference fixed in this PR was clearly a bug.
