### PR TITLE
[ty] Normalize recursive intersection growth during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -258,6 +258,35 @@ while True:
     reveal_type(x)  # revealed: list[list[Divergent] | set[Divergent]] | set[list[Divergent] | set[Divergent]]
 ```
 
+## Recursive intersection growth with multiple narrowing targets
+
+When narrowing creates multiple complete DNF distributions of the previous union, cycle recovery
+should normalize every complete group.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import TypeIs
+
+class Container[T]: ...
+class Other[T]: ...
+
+def is_container_or_other[T](x: object, y: T) -> TypeIs[Container[T] | Other[T]]:
+    return True
+
+while True:
+    # error: [possibly-unresolved-reference]
+    # error: [possibly-unresolved-reference]
+    if is_container_or_other(x, type(x)):
+        x = [x]  # error: [possibly-unresolved-reference]
+    else:
+        x = {x}  # error: [possibly-unresolved-reference]
+    reveal_type(x)  # revealed: list[list[Divergent] | set[Divergent]] | set[list[Divergent] | set[Divergent]]
+```
+
 ## Type replacement with a lazy function signature
 
 Type replacement while recovering the first `function` definition must not evaluate its lazy

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -255,6 +255,7 @@ while True:
         x = [x]  # error: [possibly-unresolved-reference]
     else:
         x = {x}  # error: [possibly-unresolved-reference]
+    reveal_type(x)  # revealed: list[list[Divergent] | set[Divergent]] | set[list[Divergent] | set[Divergent]]
 ```
 
 ## Type replacement with a lazy function signature

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -230,6 +230,33 @@ min(Y)
 T = f()
 ```
 
+## Recursive intersection growth
+
+Narrowing a loop-carried type can distribute the previous union across intersections. Cycle recovery
+should recognize the distributed previous elements instead of growing the type on every iteration.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+from typing import TypeIs
+
+class Container[T]: ...
+
+def is_container[T](x: object, y: T) -> TypeIs[Container[T]]:
+    return True
+
+while True:
+    # error: [possibly-unresolved-reference]
+    # error: [possibly-unresolved-reference]
+    if is_container(x, type(x)):
+        x = [x]  # error: [possibly-unresolved-reference]
+    else:
+        x = {x}  # error: [possibly-unresolved-reference]
+```
+
 ## Type replacement with a lazy function signature
 
 Type replacement while recovering the first `function` definition must not evaluate its lazy

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -502,7 +502,7 @@ python-version = "3.14"
 ```
 
 ```py
-from ty_extensions import TypeOf
+from ty_extensions import Intersection, TypeOf
 
 direct: TypeOf[direct]
 direct = 1
@@ -525,6 +525,13 @@ class Container[T]: ...
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
+
+intersection: Intersection[
+    list[TypeOf[intersection]],
+    Container[TypeOf[intersection]],
+]
+intersection = [1]  # error: [invalid-assignment]
+reveal_type(intersection)  # revealed: list[Divergent] & Container[Divergent]
 
 union: list[TypeOf[union]] | Container[TypeOf[union]]
 union = [1]

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -551,6 +551,13 @@ with_protocol: Intersection[
 with_protocol = [1]  # error: [invalid-assignment]
 reveal_type(with_protocol)  # revealed: list[Divergent] & Container[Divergent] & P
 
+flattened: Intersection[
+    list[Intersection[TypeOf[flattened], P]],
+    Container[Intersection[TypeOf[flattened], P]],
+]
+flattened = [1]  # error: [invalid-assignment]
+reveal_type(flattened)  # revealed: list[Divergent] & Container[Divergent]
+
 union: list[TypeOf[union]] | Container[TypeOf[union]]
 union = [1]
 reveal_type(union)  # revealed: list[Divergent]

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -528,6 +528,9 @@ class Stable: ...
 class P(Protocol):
     value: int
 
+class GenericProtocol[T](Protocol):
+    value: T
+
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
@@ -535,6 +538,10 @@ reveal_type(y)  # revealed: Container[Divergent]
 single: Intersection[Container[TypeOf[single]], Stable]
 single = 1  # error: [invalid-assignment]
 reveal_type(single)  # revealed: Container[Divergent] & Stable
+
+protocol_single: Intersection[GenericProtocol[TypeOf[protocol_single]], Stable]
+protocol_single = 1  # error: [invalid-assignment]
+reveal_type(protocol_single)  # revealed: GenericProtocol[Divergent] & Stable
 
 intersection: Intersection[
     list[TypeOf[intersection]],

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -502,6 +502,8 @@ python-version = "3.14"
 ```
 
 ```py
+from typing import Protocol
+
 from ty_extensions import Intersection, TypeOf
 
 direct: TypeOf[direct]
@@ -523,6 +525,9 @@ reveal_type(optional)  # revealed: list[Divergent]
 class Container[T]: ...
 class Stable: ...
 
+class P(Protocol):
+    value: int
+
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
@@ -537,6 +542,14 @@ intersection: Intersection[
 ]
 intersection = [1]  # error: [invalid-assignment]
 reveal_type(intersection)  # revealed: list[Divergent] & Container[Divergent]
+
+with_protocol: Intersection[
+    list[TypeOf[with_protocol]],
+    Container[TypeOf[with_protocol]],
+    P,
+]
+with_protocol = [1]  # error: [invalid-assignment]
+reveal_type(with_protocol)  # revealed: list[Divergent] & Container[Divergent] & P
 
 union: list[TypeOf[union]] | Container[TypeOf[union]]
 union = [1]

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -521,10 +521,15 @@ optional = [1]
 reveal_type(optional)  # revealed: list[Divergent]
 
 class Container[T]: ...
+class Stable: ...
 
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
+
+single: Intersection[Container[TypeOf[single]], Stable]
+single = 1  # error: [invalid-assignment]
+reveal_type(single)  # revealed: Container[Divergent] & Stable
 
 intersection: Intersection[
     list[TypeOf[intersection]],

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1354,6 +1354,7 @@ impl<'db> Type<'db> {
         div: Self,
     ) -> Option<Self> {
         let current_class = current.class(db);
+        let original = Type::instance(db, current_class);
         let alias = current_class.into_generic_alias()?;
         let original_specialization = alias.specialization(db);
         let specialization = original_specialization.apply_type_mapping(
@@ -1367,7 +1368,6 @@ impl<'db> Type<'db> {
             db,
             ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
         );
-        let original = Type::NominalInstance(current);
 
         if let Type::Union(wrapped_union) = wrapped {
             normalized =

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1218,6 +1218,15 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
+    /// Returns the nominal representation of a nominal or class-backed protocol instance.
+    fn as_cycle_recovery_nominal_instance(self) -> Option<NominalInstanceType<'db>> {
+        match self {
+            Type::NominalInstance(instance) => Some(instance),
+            Type::ProtocolInstance(protocol) => protocol.to_nominal_instance(),
+            _ => None,
+        }
+    }
+
     /// Normalizes nominal growth that wraps the previous cycle result in one or more
     /// specializations, either directly or beneath an unambiguous union or intersection wrapper.
     ///
@@ -1241,7 +1250,7 @@ impl<'db> Type<'db> {
             let mut replacements = 0;
             let normalized = current.map_positive(db, |element| {
                 element
-                    .as_nominal_instance()
+                    .as_cycle_recovery_nominal_instance()
                     .and_then(|instance| {
                         Self::nominal_wrapper_normalized(
                             db,
@@ -1322,21 +1331,8 @@ impl<'db> Type<'db> {
             }));
         }
 
-        let (current, previous_instance) = match (self, previous) {
-            (Type::NominalInstance(current), Type::NominalInstance(previous)) => {
-                (current, previous)
-            }
-            (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => {
-                // A class-backed protocol shares a nominal specialization with its runtime class.
-                // `nominal_wrapper_normalized` reconstructs the result through `Type::instance`,
-                // which recognizes the protocol class and restores a protocol instance.
-                (
-                    current.to_nominal_instance()?,
-                    previous.to_nominal_instance()?,
-                )
-            }
-            _ => return None,
-        };
+        let current = self.as_cycle_recovery_nominal_instance()?;
+        let previous_instance = previous.as_cycle_recovery_nominal_instance()?;
 
         if current.class(db).class_literal(db) != previous_instance.class_literal(db) {
             return None;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -98,7 +98,7 @@ pub use crate::types::typevar::{
 };
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::{any_over_positive_type, any_over_type, find_over_type};
+use crate::types::visitor::{any_over_positive_type, any_over_type, find_over_positive_type};
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
@@ -1383,11 +1383,11 @@ impl<'db> Type<'db> {
             _ => false,
         };
 
-        while let Some(intersection) = find_over_type(db, normalized, false, |ty| match ty {
-            Type::Intersection(intersection) if contains_wrapped_intersection(intersection) => {
-                Some(intersection)
-            }
-            _ => None,
+        while let Some(intersection) = find_over_positive_type(db, normalized, false, |ty| {
+            let Type::Intersection(intersection) = ty else {
+                return None;
+            };
+            contains_wrapped_intersection(intersection).then_some(intersection)
         }) {
             let replacement = intersection.map_positive(db, |element| {
                 if let Type::Intersection(wrapped) = wrapped
@@ -1424,7 +1424,7 @@ impl<'db> Type<'db> {
     ) -> Self {
         let mut normalized = current;
         while let Some((distributed, replacement)) =
-            find_over_type(db, normalized, false, |ty| match ty {
+            find_over_positive_type(db, normalized, false, |ty| match ty {
                 Type::Union(distributed) => {
                     Self::union_distribution_normalized(db, distributed, wrapped, div)
                         .map(|replacement| (distributed, replacement))

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1373,20 +1373,45 @@ impl<'db> Type<'db> {
         }
 
         if let Type::Union(wrapped_union) = wrapped {
-            if !original_specialization
-                .types(db)
-                .iter()
-                .any(|position| Self::is_union_distribution_position(db, *position, wrapped_union))
-            {
+            let replacements: smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]> =
+                original_specialization
+                    .types(db)
+                    .iter()
+                    .copied()
+                    .filter(|position| {
+                        Self::is_union_distribution_position(db, *position, wrapped_union)
+                    })
+                    .map(|position| {
+                        (
+                            position,
+                            Self::union_distribution_position_normalized(
+                                db,
+                                position,
+                                wrapped_union,
+                                div,
+                            ),
+                        )
+                    })
+                    .collect();
+            if replacements.is_empty() {
                 return None;
             }
 
-            return Self::nominal_wrapper_elements_normalized(
-                db,
-                current,
-                wrapped_union.elements(db),
-                div,
+            let original = Type::NominalInstance(current);
+            let normalized = replacements.iter().fold(
+                original,
+                |normalized, (position, normalized_position)| {
+                    normalized.apply_type_mapping(
+                        db,
+                        &TypeMapping::ReplaceType {
+                            from: *position,
+                            to: *normalized_position,
+                        },
+                        TypeContext::default(),
+                    )
+                },
             );
+            return (normalized != original).then_some(normalized);
         }
 
         let contains_wrapped_intersection = |intersection: IntersectionType<'db>| match wrapped {
@@ -1428,28 +1453,27 @@ impl<'db> Type<'db> {
         (normalized != Type::NominalInstance(current)).then_some(normalized)
     }
 
-    /// Replaces the complete set of previous union arms after their coverage has been validated.
-    fn nominal_wrapper_elements_normalized(
+    /// Replaces the complete set of previous union arms within one validated distribution
+    /// position.
+    fn union_distribution_position_normalized(
         db: &'db dyn Db,
-        current: NominalInstanceType<'db>,
-        wrapped_elements: &[Self],
+        current: Self,
+        wrapped: UnionType<'db>,
         div: Self,
-    ) -> Option<Self> {
-        let original = Type::NominalInstance(current);
-        let normalized = wrapped_elements
+    ) -> Self {
+        wrapped
+            .elements(db)
             .iter()
-            .fold(original, |normalized, wrapped| {
+            .fold(current, |normalized, wrapped_element| {
                 normalized.apply_type_mapping(
                     db,
                     &TypeMapping::ReplaceType {
-                        from: *wrapped,
+                        from: *wrapped_element,
                         to: div,
                     },
                     TypeContext::default(),
                 )
-            });
-
-        (normalized != original).then_some(normalized)
+            })
     }
 
     /// Returns whether one specialization position contains a complete, positive distribution

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1372,31 +1372,39 @@ impl<'db> Type<'db> {
             return Some(normalized);
         }
 
-        let contains_wrapped_elements = |intersection: IntersectionType<'db>| match wrapped {
-            Type::Union(wrapped) => intersection
-                .positive(db)
-                .iter()
-                .any(|element| wrapped.elements(db).contains(element)),
+        if let Type::Union(wrapped_union) = wrapped {
+            if !wrapped_union.elements(db).iter().all(|wrapped_element| {
+                any_over_type(db, normalized, false, |ty| ty == *wrapped_element)
+            }) {
+                return None;
+            }
+
+            return Self::nominal_wrapper_elements_normalized(
+                db,
+                current,
+                wrapped_union.elements(db),
+                div,
+            );
+        }
+
+        let contains_wrapped_intersection = |intersection: IntersectionType<'db>| match wrapped {
             Type::Intersection(wrapped) if wrapped.negative(db).is_empty() => wrapped
                 .positive(db)
                 .iter()
                 .all(|element| intersection.positive(db).contains(element)),
             _ => false,
         };
-        let is_wrapped_element = |element: &Type<'db>| match wrapped {
-            Type::Union(wrapped) => wrapped.elements(db).contains(element),
-            Type::Intersection(wrapped) => wrapped.positive(db).contains(element),
-            _ => false,
-        };
 
         while let Some(intersection) = find_over_type(db, normalized, false, |ty| match ty {
-            Type::Intersection(intersection) if contains_wrapped_elements(intersection) => {
+            Type::Intersection(intersection) if contains_wrapped_intersection(intersection) => {
                 Some(intersection)
             }
             _ => None,
         }) {
             let replacement = intersection.map_positive(db, |element| {
-                if is_wrapped_element(element) {
+                if let Type::Intersection(wrapped) = wrapped
+                    && wrapped.positive(db).contains(element)
+                {
                     div
                 } else {
                     *element
@@ -1416,6 +1424,30 @@ impl<'db> Type<'db> {
         }
 
         (normalized != Type::NominalInstance(current)).then_some(normalized)
+    }
+
+    /// Replaces the complete set of previous union arms after their coverage has been validated.
+    fn nominal_wrapper_elements_normalized(
+        db: &'db dyn Db,
+        current: NominalInstanceType<'db>,
+        wrapped_elements: &[Self],
+        div: Self,
+    ) -> Option<Self> {
+        let original = Type::NominalInstance(current);
+        let normalized = wrapped_elements
+            .iter()
+            .fold(original, |normalized, wrapped| {
+                normalized.apply_type_mapping(
+                    db,
+                    &TypeMapping::ReplaceType {
+                        from: *wrapped,
+                        to: div,
+                    },
+                    TypeContext::default(),
+                )
+            });
+
+        (normalized != original).then_some(normalized)
     }
 
     pub fn is_none(&self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1233,8 +1233,8 @@ impl<'db> Type<'db> {
         previous: Self,
         div: Self,
     ) -> Option<Self> {
-        // As with unions below, multiple intersection elements can each wrap the previous
-        // intersection. Requiring multiple replacements avoids ambiguous single-element matches.
+        // Unlike aligning different union elements below, replacing the complete previous
+        // intersection beneath a nominal specialization is unambiguous even for one element.
         if let (Type::Intersection(current), Type::Intersection(previous)) = (self, previous)
             && current.negative(db) == previous.negative(db)
         {
@@ -1258,7 +1258,7 @@ impl<'db> Type<'db> {
                         .inspect(|_| replacements += 1)
                         .unwrap_or(*element)
                 });
-                if replacements > 1 {
+                if replacements > 0 {
                     return Some(normalized);
                 }
             }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1478,21 +1478,61 @@ impl<'db> Type<'db> {
             matches!(
                 ty,
                 Type::Union(distributed)
-                    if wrapped.elements(db).iter().all(|wrapped_element| {
-                        distributed.elements(db).iter().any(|branch| {
-                            Self::contains_positive_type(db, *branch, *wrapped_element)
-                                && wrapped
-                                    .elements(db)
-                                    .iter()
-                                    .filter(|candidate| {
-                                        Self::contains_positive_type(db, *branch, **candidate)
-                                    })
-                                    .exactly_one()
-                                    .is_ok()
-                        })
-                    })
+                    if Self::matching_union_distribution(db, distributed, wrapped).is_some()
             )
         })
+    }
+
+    /// Returns the branches in a single structural distribution of `wrapped`.
+    fn matching_union_distribution(
+        db: &'db dyn Db,
+        current: UnionType<'db>,
+        wrapped: UnionType<'db>,
+    ) -> Option<Vec<(Self, Self)>> {
+        let representative = wrapped.elements(db).first().copied()?;
+        let mut groups: Vec<(Self, Vec<(Self, Self)>)> = Vec::new();
+
+        for branch in current.elements(db) {
+            let Ok(wrapped_element) = wrapped
+                .elements(db)
+                .iter()
+                .copied()
+                .filter(|candidate| Self::contains_positive_type(db, *branch, *candidate))
+                .exactly_one()
+            else {
+                continue;
+            };
+            let canonical = branch.apply_type_mapping(
+                db,
+                &TypeMapping::ReplaceType {
+                    from: wrapped_element,
+                    to: representative,
+                },
+                TypeContext::default(),
+            );
+
+            if let Some((_, branches)) = groups
+                .iter_mut()
+                .find(|(group_canonical, _)| *group_canonical == canonical)
+            {
+                branches.push((*branch, wrapped_element));
+            } else {
+                groups.push((canonical, vec![(*branch, wrapped_element)]));
+            }
+        }
+
+        groups
+            .into_iter()
+            .filter(|(_, branches)| {
+                wrapped.elements(db).iter().all(|wrapped_element| {
+                    branches
+                        .iter()
+                        .any(|(_, branch_element)| branch_element == wrapped_element)
+                })
+            })
+            .map(|(_, branches)| branches)
+            .exactly_one()
+            .ok()
     }
 
     /// Returns whether `current` contains `target` outside negative intersection elements.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1471,7 +1471,7 @@ impl<'db> Type<'db> {
         }))
     }
 
-    /// Returns the branches in a single structural distribution of `wrapped`.
+    /// Returns the branches in every complete structural distribution of `wrapped`.
     fn matching_union_distribution(
         db: &'db dyn Db,
         current: UnionType<'db>,
@@ -1509,7 +1509,7 @@ impl<'db> Type<'db> {
             }
         }
 
-        groups
+        let matched: Vec<_> = groups
             .into_iter()
             .filter(|(_, branches)| {
                 wrapped.elements(db).iter().all(|wrapped_element| {
@@ -1518,9 +1518,10 @@ impl<'db> Type<'db> {
                         .any(|(_, branch_element)| branch_element == wrapped_element)
                 })
             })
-            .map(|(_, branches)| branches)
-            .exactly_one()
-            .ok()
+            .flat_map(|(_, branches)| branches)
+            .collect();
+
+        (!matched.is_empty()).then_some(matched)
     }
 
     /// Returns whether `current` contains `target` outside negative intersection elements.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1373,9 +1373,11 @@ impl<'db> Type<'db> {
         }
 
         if let Type::Union(wrapped_union) = wrapped {
-            if !wrapped_union.elements(db).iter().all(|wrapped_element| {
-                any_over_type(db, normalized, false, |ty| ty == *wrapped_element)
-            }) {
+            if !original_specialization
+                .types(db)
+                .iter()
+                .any(|position| Self::is_union_distribution_position(db, *position, wrapped_union))
+            {
                 return None;
             }
 
@@ -1448,6 +1450,27 @@ impl<'db> Type<'db> {
             });
 
         (normalized != original).then_some(normalized)
+    }
+
+    /// Returns whether one specialization position contains a complete, positive distribution
+    /// of `wrapped`.
+    fn is_union_distribution_position(
+        db: &'db dyn Db,
+        current: Self,
+        wrapped: UnionType<'db>,
+    ) -> bool {
+        any_over_type(db, current, false, |ty| matches!(ty, Type::Union(_)))
+            && any_over_type(db, current, false, |ty| matches!(ty, Type::Intersection(_)))
+            && wrapped.elements(db).iter().all(|wrapped_element| {
+                any_over_type(db, current, false, |ty| ty == *wrapped_element)
+                    && !any_over_type(db, current, false, |ty| {
+                        matches!(
+                            ty,
+                            Type::Intersection(intersection)
+                                if intersection.negative(db).contains(wrapped_element)
+                        )
+                    })
+            })
     }
 
     pub fn is_none(&self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1370,38 +1370,8 @@ impl<'db> Type<'db> {
         let original = Type::NominalInstance(current);
 
         if let Type::Union(wrapped_union) = wrapped {
-            let replacements: smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]> = specialization
-                .types(db)
-                .iter()
-                .copied()
-                .filter(|position| {
-                    Self::is_union_distribution_position(db, *position, wrapped_union)
-                })
-                .map(|position| {
-                    (
-                        position,
-                        Self::union_distribution_position_normalized(
-                            db,
-                            position,
-                            wrapped_union,
-                            div,
-                        ),
-                    )
-                })
-                .collect();
-            normalized = replacements.iter().fold(
-                normalized,
-                |normalized, (position, normalized_position)| {
-                    normalized.apply_type_mapping(
-                        db,
-                        &TypeMapping::ReplaceType {
-                            from: *position,
-                            to: *normalized_position,
-                        },
-                        TypeContext::default(),
-                    )
-                },
-            );
+            normalized =
+                Self::union_distribution_position_normalized(db, normalized, wrapped_union, div);
             return (normalized != original).then_some(normalized);
         }
 
@@ -1499,22 +1469,6 @@ impl<'db> Type<'db> {
                 *branch
             }
         }))
-    }
-
-    /// Returns whether one specialization position contains a complete, positive distribution
-    /// of `wrapped`.
-    fn is_union_distribution_position(
-        db: &'db dyn Db,
-        current: Self,
-        wrapped: UnionType<'db>,
-    ) -> bool {
-        any_over_type(db, current, false, |ty| {
-            matches!(
-                ty,
-                Type::Union(distributed)
-                    if Self::matching_union_distribution(db, distributed, wrapped).is_some()
-            )
-        })
     }
 
     /// Returns the branches in a single structural distribution of `wrapped`.

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -98,7 +98,7 @@ pub use crate::types::typevar::{
 };
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::{any_over_type, find_over_type};
+use crate::types::visitor::{any_over_positive_type, any_over_type, find_over_type};
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
@@ -1571,13 +1571,15 @@ impl<'db> Type<'db> {
 
     /// Returns whether `current` contains `target` outside negative intersection elements.
     fn contains_positive_type(db: &'db dyn Db, current: Self, target: Self) -> bool {
-        any_over_type(db, current, false, |ty| ty == target)
+        any_over_positive_type(db, current, false, |ty| ty == target)
             && !any_over_type(db, current, false, |ty| {
-                matches!(
-                    ty,
-                    Type::Intersection(intersection)
-                        if intersection.negative(db).contains(&target)
-                )
+                let Type::Intersection(intersection) = ty else {
+                    return false;
+                };
+                intersection
+                    .negative(db)
+                    .iter()
+                    .any(|negative| any_over_type(db, *negative, false, |nested| nested == target))
             })
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1367,39 +1367,30 @@ impl<'db> Type<'db> {
             db,
             ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
         );
-
-        if specialization != original_specialization {
-            return Some(normalized);
-        }
+        let original = Type::NominalInstance(current);
 
         if let Type::Union(wrapped_union) = wrapped {
-            let replacements: smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]> =
-                original_specialization
-                    .types(db)
-                    .iter()
-                    .copied()
-                    .filter(|position| {
-                        Self::is_union_distribution_position(db, *position, wrapped_union)
-                    })
-                    .map(|position| {
-                        (
+            let replacements: smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]> = specialization
+                .types(db)
+                .iter()
+                .copied()
+                .filter(|position| {
+                    Self::is_union_distribution_position(db, *position, wrapped_union)
+                })
+                .map(|position| {
+                    (
+                        position,
+                        Self::union_distribution_position_normalized(
+                            db,
                             position,
-                            Self::union_distribution_position_normalized(
-                                db,
-                                position,
-                                wrapped_union,
-                                div,
-                            ),
-                        )
-                    })
-                    .collect();
-            if replacements.is_empty() {
-                return None;
-            }
-
-            let original = Type::NominalInstance(current);
-            let normalized = replacements.iter().fold(
-                original,
+                            wrapped_union,
+                            div,
+                        ),
+                    )
+                })
+                .collect();
+            normalized = replacements.iter().fold(
+                normalized,
                 |normalized, (position, normalized_position)| {
                     normalized.apply_type_mapping(
                         db,
@@ -1450,7 +1441,7 @@ impl<'db> Type<'db> {
             );
         }
 
-        (normalized != Type::NominalInstance(current)).then_some(normalized)
+        (normalized != original).then_some(normalized)
     }
 
     /// Replaces the complete set of previous union arms within one validated distribution

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1358,7 +1358,7 @@ impl<'db> Type<'db> {
         let original_specialization = alias.specialization(db);
         let specialization = original_specialization.apply_type_mapping(
             db,
-            &TypeMapping::ReplaceType {
+            &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                 from: wrapped,
                 to: div,
             },
@@ -1403,7 +1403,7 @@ impl<'db> Type<'db> {
             }
             normalized = normalized.apply_type_mapping(
                 db,
-                &TypeMapping::ReplaceType {
+                &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                     from: Type::Intersection(intersection),
                     to: replacement,
                 },
@@ -1434,7 +1434,7 @@ impl<'db> Type<'db> {
         {
             normalized = normalized.apply_type_mapping(
                 db,
-                &TypeMapping::ReplaceType {
+                &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                     from: Type::Union(distributed),
                     to: replacement,
                 },
@@ -1459,7 +1459,7 @@ impl<'db> Type<'db> {
             {
                 branch.apply_type_mapping(
                     db,
-                    &TypeMapping::ReplaceType {
+                    &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                         from: *wrapped_element,
                         to: div,
                     },
@@ -1492,7 +1492,7 @@ impl<'db> Type<'db> {
             };
             let canonical = branch.apply_type_mapping(
                 db,
-                &TypeMapping::ReplaceType {
+                &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                     from: wrapped_element,
                     to: representative,
                 },
@@ -6426,7 +6426,7 @@ impl<'db> Type<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
-        if let TypeMapping::ReplaceType { from, to } = type_mapping
+        if let TypeMapping::ReplaceTypeOutsideNegativeIntersections { from, to } = type_mapping
             && self == *from
         {
             return *to;
@@ -6575,13 +6575,24 @@ impl<'db> Type<'db> {
                     builder =
                         builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
                 }
-                // Promotion should remove negative contributions from intersections,
-                // so we don't preserve them here when promotion is enabled.
-                if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
-                    for negative in intersection.negative(db) {
-                        builder = builder.add_negative(
-                            negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
-                        );
+                match type_mapping {
+                    // Promotion should remove negative contributions from intersections,
+                    // so we don't preserve them here when promotion is enabled.
+                    TypeMapping::Promote(PromotionMode::On, _) => {}
+                    TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. } => {
+                        for negative in intersection.negative(db) {
+                            builder = builder.add_negative(*negative);
+                        }
+                    }
+                    _ => {
+                        for negative in intersection.negative(db) {
+                            builder = builder.add_negative(negative.apply_type_mapping_impl(
+                                db,
+                                &type_mapping.flip(),
+                                tcx,
+                                visitor,
+                            ));
+                        }
                     }
                 }
                 builder.build()
@@ -6687,7 +6698,7 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf { .. } |
                 TypeMapping::ReplaceSelf { .. } |
-                TypeMapping::ReplaceType { .. } |
+                TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. } |
                 TypeMapping::Materialize(_) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -6704,7 +6715,7 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf(..) |
                 TypeMapping::ReplaceSelf { .. } |
-                TypeMapping::ReplaceType { .. } |
+                TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. } |
                 TypeMapping::Promote(..) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -7756,8 +7767,9 @@ pub enum TypeMapping<'a, 'db> {
     BindSelf(SelfBinding<'db>),
     /// Replaces occurrences of `typing.Self` with a new `Self` type variable with the given upper bound.
     ReplaceSelf { new_upper_bound: Type<'db> },
-    /// Replaces occurrences of one specific type with another.
-    ReplaceType { from: Type<'db>, to: Type<'db> },
+    /// Replaces occurrences of one specific type with another without descending into negative
+    /// intersection elements.
+    ReplaceTypeOutsideNegativeIntersections { from: Type<'db>, to: Type<'db> },
     /// Create the top or bottom materialization of a type.
     Materialize(MaterializationKind),
     /// Replace default types in parameters of callables with `Unknown`. This is used to avoid infinite
@@ -7810,7 +7822,7 @@ impl<'db> TypeMapping<'_, 'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::BindLegacyTypevars(_)
-            | TypeMapping::ReplaceType { .. }
+            | TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. }
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
@@ -7858,7 +7870,7 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::FreshenBoundTypeVars { .. }
             | TypeMapping::BindSelf(..)
             | TypeMapping::ReplaceSelf { .. }
-            | TypeMapping::ReplaceType { .. }
+            | TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. }
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => self.clone(),

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1452,11 +1452,42 @@ impl<'db> Type<'db> {
         wrapped: UnionType<'db>,
         div: Self,
     ) -> Self {
-        wrapped
-            .elements(db)
-            .iter()
-            .fold(current, |normalized, wrapped_element| {
-                normalized.apply_type_mapping(
+        let mut normalized = current;
+        while let Some((distributed, replacement)) =
+            find_over_type(db, normalized, false, |ty| match ty {
+                Type::Union(distributed) => {
+                    Self::union_distribution_normalized(db, distributed, wrapped, div)
+                        .map(|replacement| (distributed, replacement))
+                }
+                _ => None,
+            })
+        {
+            normalized = normalized.apply_type_mapping(
+                db,
+                &TypeMapping::ReplaceType {
+                    from: Type::Union(distributed),
+                    to: replacement,
+                },
+                TypeContext::default(),
+            );
+        }
+        normalized
+    }
+
+    /// Normalizes only the matched branches of one distributed union.
+    fn union_distribution_normalized(
+        db: &'db dyn Db,
+        current: UnionType<'db>,
+        wrapped: UnionType<'db>,
+        div: Self,
+    ) -> Option<Self> {
+        let matched = Self::matching_union_distribution(db, current, wrapped)?;
+        Some(current.map_leave_aliases(db, |branch| {
+            if let Some((_, wrapped_element)) = matched
+                .iter()
+                .find(|(matched_branch, _)| matched_branch == branch)
+            {
+                branch.apply_type_mapping(
                     db,
                     &TypeMapping::ReplaceType {
                         from: *wrapped_element,
@@ -1464,7 +1495,10 @@ impl<'db> Type<'db> {
                     },
                     TypeContext::default(),
                 )
-            })
+            } else {
+                *branch
+            }
+        }))
     }
 
     /// Returns whether one specialization position contains a complete, positive distribution

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1368,6 +1368,10 @@ impl<'db> Type<'db> {
             ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
         );
 
+        if specialization != original_specialization {
+            return Some(normalized);
+        }
+
         let contains_wrapped_elements = |intersection: IntersectionType<'db>| match wrapped {
             Type::Union(wrapped) => intersection
                 .positive(db)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1238,29 +1238,23 @@ impl<'db> Type<'db> {
         if let (Type::Intersection(current), Type::Intersection(previous)) = (self, previous)
             && current.negative(db) == previous.negative(db)
         {
-            let previous_elements = previous.positive(db);
-            if previous_elements
-                .iter()
-                .all(|element| matches!(element, Type::NominalInstance(_)))
-            {
-                let mut replacements = 0;
-                let normalized = current.map_positive(db, |element| {
-                    element
-                        .as_nominal_instance()
-                        .and_then(|instance| {
-                            Self::nominal_wrapper_normalized(
-                                db,
-                                instance,
-                                Type::Intersection(previous),
-                                div,
-                            )
-                        })
-                        .inspect(|_| replacements += 1)
-                        .unwrap_or(*element)
-                });
-                if replacements > 0 {
-                    return Some(normalized);
-                }
+            let mut replacements = 0;
+            let normalized = current.map_positive(db, |element| {
+                element
+                    .as_nominal_instance()
+                    .and_then(|instance| {
+                        Self::nominal_wrapper_normalized(
+                            db,
+                            instance,
+                            Type::Intersection(previous),
+                            div,
+                        )
+                    })
+                    .inspect(|_| replacements += 1)
+                    .unwrap_or(*element)
+            });
+            if replacements > 0 {
+                return Some(normalized);
             }
         }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1345,8 +1345,8 @@ impl<'db> Type<'db> {
         Self::nominal_wrapper_normalized(db, current, previous, div)
     }
 
-    /// Replaces `wrapped` beneath the outer nominal specialization in `current`, including union
-    /// elements that were distributed across intersections.
+    /// Replaces `wrapped` beneath the outer nominal specialization in `current`, including
+    /// set-theoretic elements that were distributed or flattened into intersections.
     fn nominal_wrapper_normalized(
         db: &'db dyn Db,
         current: NominalInstanceType<'db>,
@@ -1368,37 +1368,47 @@ impl<'db> Type<'db> {
             ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
         );
 
-        if let Type::Union(wrapped) = wrapped {
-            while let Some(intersection) = find_over_type(db, normalized, false, |ty| match ty {
-                Type::Intersection(intersection)
-                    if intersection
-                        .positive(db)
-                        .iter()
-                        .any(|element| wrapped.elements(db).contains(element)) =>
-                {
-                    Some(intersection)
-                }
-                _ => None,
-            }) {
-                let replacement = intersection.map_positive(db, |element| {
-                    if wrapped.elements(db).contains(element) {
-                        div
-                    } else {
-                        *element
-                    }
-                });
-                if replacement == Type::Intersection(intersection) {
-                    break;
-                }
-                normalized = normalized.apply_type_mapping(
-                    db,
-                    &TypeMapping::ReplaceType {
-                        from: Type::Intersection(intersection),
-                        to: replacement,
-                    },
-                    TypeContext::default(),
-                );
+        let contains_wrapped_elements = |intersection: IntersectionType<'db>| match wrapped {
+            Type::Union(wrapped) => intersection
+                .positive(db)
+                .iter()
+                .any(|element| wrapped.elements(db).contains(element)),
+            Type::Intersection(wrapped) if wrapped.negative(db).is_empty() => wrapped
+                .positive(db)
+                .iter()
+                .all(|element| intersection.positive(db).contains(element)),
+            _ => false,
+        };
+        let is_wrapped_element = |element: &Type<'db>| match wrapped {
+            Type::Union(wrapped) => wrapped.elements(db).contains(element),
+            Type::Intersection(wrapped) => wrapped.positive(db).contains(element),
+            _ => false,
+        };
+
+        while let Some(intersection) = find_over_type(db, normalized, false, |ty| match ty {
+            Type::Intersection(intersection) if contains_wrapped_elements(intersection) => {
+                Some(intersection)
             }
+            _ => None,
+        }) {
+            let replacement = intersection.map_positive(db, |element| {
+                if is_wrapped_element(element) {
+                    div
+                } else {
+                    *element
+                }
+            });
+            if replacement == Type::Intersection(intersection) {
+                break;
+            }
+            normalized = normalized.apply_type_mapping(
+                db,
+                &TypeMapping::ReplaceType {
+                    from: Type::Intersection(intersection),
+                    to: replacement,
+                },
+                TypeContext::default(),
+            );
         }
 
         (normalized != Type::NominalInstance(current)).then_some(normalized)

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1483,17 +1483,36 @@ impl<'db> Type<'db> {
         current: Self,
         wrapped: UnionType<'db>,
     ) -> bool {
-        any_over_type(db, current, false, |ty| matches!(ty, Type::Union(_)))
-            && any_over_type(db, current, false, |ty| matches!(ty, Type::Intersection(_)))
-            && wrapped.elements(db).iter().all(|wrapped_element| {
-                any_over_type(db, current, false, |ty| ty == *wrapped_element)
-                    && !any_over_type(db, current, false, |ty| {
-                        matches!(
-                            ty,
-                            Type::Intersection(intersection)
-                                if intersection.negative(db).contains(wrapped_element)
-                        )
+        any_over_type(db, current, false, |ty| {
+            matches!(
+                ty,
+                Type::Union(distributed)
+                    if wrapped.elements(db).iter().all(|wrapped_element| {
+                        distributed.elements(db).iter().any(|branch| {
+                            Self::contains_positive_type(db, *branch, *wrapped_element)
+                                && wrapped
+                                    .elements(db)
+                                    .iter()
+                                    .filter(|candidate| {
+                                        Self::contains_positive_type(db, *branch, **candidate)
+                                    })
+                                    .exactly_one()
+                                    .is_ok()
+                        })
                     })
+            )
+        })
+    }
+
+    /// Returns whether `current` contains `target` outside negative intersection elements.
+    fn contains_positive_type(db: &'db dyn Db, current: Self, target: Self) -> bool {
+        any_over_type(db, current, false, |ty| ty == target)
+            && !any_over_type(db, current, false, |ty| {
+                matches!(
+                    ty,
+                    Type::Intersection(intersection)
+                        if intersection.negative(db).contains(&target)
+                )
             })
     }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1397,7 +1397,7 @@ impl<'db> Type<'db> {
             if replacement == Type::Intersection(intersection) {
                 break;
             }
-            normalized = normalized.apply_type_mapping(
+            let next = normalized.apply_type_mapping(
                 db,
                 &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                     from: Type::Intersection(intersection),
@@ -1405,6 +1405,10 @@ impl<'db> Type<'db> {
                 },
                 TypeContext::default(),
             );
+            if next == normalized {
+                break;
+            }
+            normalized = next;
         }
 
         (normalized != original).then_some(normalized)
@@ -1428,7 +1432,7 @@ impl<'db> Type<'db> {
                 _ => None,
             })
         {
-            normalized = normalized.apply_type_mapping(
+            let next = normalized.apply_type_mapping(
                 db,
                 &TypeMapping::ReplaceTypeOutsideNegativeIntersections {
                     from: Type::Union(distributed),
@@ -1436,6 +1440,10 @@ impl<'db> Type<'db> {
                 },
                 TypeContext::default(),
             );
+            if next == normalized {
+                break;
+            }
+            normalized = next;
         }
         normalized
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -98,7 +98,7 @@ pub use crate::types::typevar::{
 };
 pub use crate::types::variance::TypeVarVariance;
 use crate::types::variance::VarianceInferable;
-use crate::types::visitor::any_over_type;
+use crate::types::visitor::{any_over_type, find_over_type};
 use crate::{Db, FxOrderSet, Program};
 pub(crate) use class::{ClassLiteral, ClassType, GenericAlias, StaticClassLiteral};
 pub use class::{KnownClass, MethodDecorator};
@@ -1219,7 +1219,7 @@ impl<'db> Type<'db> {
     }
 
     /// Normalizes nominal growth that wraps the previous cycle result in one or more
-    /// specializations, either directly or beneath an unambiguous union wrapper.
+    /// specializations, either directly or beneath an unambiguous union or intersection wrapper.
     ///
     /// For example, an inference cycle can otherwise grow indefinitely as
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
@@ -1233,6 +1233,37 @@ impl<'db> Type<'db> {
         previous: Self,
         div: Self,
     ) -> Option<Self> {
+        // As with unions below, multiple intersection elements can each wrap the previous
+        // intersection. Requiring multiple replacements avoids ambiguous single-element matches.
+        if let (Type::Intersection(current), Type::Intersection(previous)) = (self, previous)
+            && current.negative(db) == previous.negative(db)
+        {
+            let previous_elements = previous.positive(db);
+            if previous_elements
+                .iter()
+                .all(|element| matches!(element, Type::NominalInstance(_)))
+            {
+                let mut replacements = 0;
+                let normalized = current.map_positive(db, |element| {
+                    element
+                        .as_nominal_instance()
+                        .and_then(|instance| {
+                            Self::nominal_wrapper_normalized(
+                                db,
+                                instance,
+                                Type::Intersection(previous),
+                                div,
+                            )
+                        })
+                        .inspect(|_| replacements += 1)
+                        .unwrap_or(*element)
+                });
+                if replacements > 1 {
+                    return Some(normalized);
+                }
+            }
+        }
+
         if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
             let previous_elements = previous.elements(db);
 
@@ -1320,7 +1351,8 @@ impl<'db> Type<'db> {
         Self::nominal_wrapper_normalized(db, current, previous, div)
     }
 
-    /// Replaces `wrapped` beneath the outer nominal specialization in `current`.
+    /// Replaces `wrapped` beneath the outer nominal specialization in `current`, including union
+    /// elements that were distributed across intersections.
     fn nominal_wrapper_normalized(
         db: &'db dyn Db,
         current: NominalInstanceType<'db>,
@@ -1337,14 +1369,45 @@ impl<'db> Type<'db> {
                 to: div,
             },
         );
-        if specialization == original_specialization {
-            return None;
-        }
-
-        Some(Type::instance(
+        let mut normalized = Type::instance(
             db,
             ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
-        ))
+        );
+
+        if let Type::Union(wrapped) = wrapped {
+            while let Some(intersection) = find_over_type(db, normalized, false, |ty| match ty {
+                Type::Intersection(intersection)
+                    if intersection
+                        .positive(db)
+                        .iter()
+                        .any(|element| wrapped.elements(db).contains(element)) =>
+                {
+                    Some(intersection)
+                }
+                _ => None,
+            }) {
+                let replacement = intersection.map_positive(db, |element| {
+                    if wrapped.elements(db).contains(element) {
+                        div
+                    } else {
+                        *element
+                    }
+                });
+                if replacement == Type::Intersection(intersection) {
+                    break;
+                }
+                normalized = normalized.apply_type_mapping(
+                    db,
+                    &TypeMapping::ReplaceType {
+                        from: Type::Intersection(intersection),
+                        to: replacement,
+                    },
+                    TypeContext::default(),
+                );
+            }
+        }
+
+        (normalized != Type::NominalInstance(current)).then_some(normalized)
     }
 
     pub fn is_none(&self, db: &'db dyn Db) -> bool {

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1103,7 +1103,7 @@ impl<'db> FunctionType<'db> {
         let literal = self.literal(db);
         let (updated_signature, updated_implementation_signature) = if matches!(
             type_mapping,
-            TypeMapping::ReplaceType { .. }
+            TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. }
                 | TypeMapping::ApplySpecialization(
                     ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
                 )

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -375,7 +375,7 @@ impl<'db> KnownInstanceType<'db> {
                 | TypeMapping::FreshenBoundTypeVars { .. }
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
-                | TypeMapping::ReplaceType { .. }
+                | TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. }
                 | TypeMapping::Materialize(_)
                 | TypeMapping::ReplaceParameterDefaults
                 | TypeMapping::EagerExpansion

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -436,6 +436,50 @@ fn recursive_nominal_growth_rejects_nested_negative_occurrences() {
     }
 }
 
+#[test]
+fn recursive_nominal_growth_recomputes_overlapping_positions() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let first_distribution = UnionType::from_elements(
+        &db,
+        [
+            IntersectionType::from_two_elements(&db, list_int, Type::unknown()),
+            IntersectionType::from_two_elements(&db, list_str, Type::unknown()),
+        ],
+    );
+    let second_distribution = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::Set.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let nested = Type::heterogeneous_tuple(&db, [first_distribution, second_distribution]);
+    let current = KnownClass::Dict.to_specialized_instance(&db, &[first_distribution, nested]);
+    let normalized_nested = Type::heterogeneous_tuple(
+        &db,
+        [div, KnownClass::Set.to_specialized_instance(&db, &[div])],
+    );
+    let expected = KnownClass::Dict.to_specialized_instance(&db, &[div, normalized_nested]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized dict should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -290,6 +290,38 @@ fn recursive_nominal_growth_rejects_unrelated_union_and_intersection() {
     );
 }
 
+#[test]
+fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            IntersectionType::from_two_elements(&db, list_int, Type::unknown()),
+            IntersectionType::from_two_elements(&db, list_str, Type::unknown()),
+        ],
+    );
+    let current = KnownClass::Dict.to_specialized_instance(&db, &[previous, distributed]);
+    let expected = KnownClass::Dict.to_specialized_instance(&db, &[div, div]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized dict should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -190,6 +190,29 @@ fn recursive_nominal_growth_requires_all_union_elements() {
     );
 }
 
+#[test]
+fn recursive_nominal_growth_requires_structural_union_distribution() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let current = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Dict.to_specialized_instance(&db, &[list_int, list_str]),
+            KnownClass::Dict.to_specialized_instance(&db, &[list_str, list_int]),
+        ],
+    );
+
+    assert_eq!(
+        current.recursive_nominal_growth_normalized(&db, previous, div),
+        None
+    );
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -472,6 +472,70 @@ fn recursive_nominal_growth_rejects_distributions_under_negation() {
 }
 
 #[test]
+fn recursive_nominal_growth_rejects_exact_intersection_under_negation() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
+    let excluded = IntersectionBuilder::new(&db)
+        .add_positive(Type::object())
+        .add_negative(KnownClass::Set.to_specialized_instance(&db, &[previous]))
+        .build();
+    let wrapper = KnownClass::List.to_specialized_instance(&db, &[excluded]);
+    let current = IntersectionType::from_two_elements(&db, wrapper, Type::unknown());
+
+    assert_eq!(
+        current.recursive_nominal_growth_normalized(&db, previous, div),
+        None
+    );
+}
+
+#[test]
+fn recursive_nominal_growth_preserves_negative_distribution_copies() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distribution = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::Set.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let excluded = IntersectionBuilder::new(&db)
+        .add_positive(Type::object())
+        .add_negative(KnownClass::List.to_specialized_instance(&db, &[distribution]))
+        .build();
+    let position = Type::heterogeneous_tuple(&db, [distribution, excluded]);
+    let current = KnownClass::List.to_specialized_instance(&db, &[position]);
+    let normalized_position = Type::heterogeneous_tuple(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[div]),
+            excluded,
+        ],
+    );
+    let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_position]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_recomputes_overlapping_positions() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -258,6 +258,64 @@ fn recursive_nominal_growth_normalizes_multiple_distribution_groups() {
 }
 
 #[test]
+fn recursive_nominal_growth_stops_at_opaque_distributed_union() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::Set.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let literal = Type::KnownInstance(KnownInstanceType::Literal(InternedType::new(
+        &db,
+        distributed,
+    )));
+    let current = KnownClass::List.to_specialized_instance(&db, &[literal]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        None
+    );
+}
+
+#[test]
+fn recursive_nominal_growth_stops_at_opaque_flattened_intersection() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
+    let literal = Type::KnownInstance(KnownInstanceType::Literal(InternedType::new(&db, previous)));
+    let current = KnownClass::List.to_specialized_instance(&db, &[literal]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        None
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_requires_all_union_elements() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -322,6 +322,40 @@ fn recursive_nominal_growth_requires_matching_branch_structure() {
 }
 
 #[test]
+fn recursive_nominal_growth_only_normalizes_matched_union_subtree() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            IntersectionType::from_two_elements(&db, list_int, Type::unknown()),
+            IntersectionType::from_two_elements(&db, list_str, Type::unknown()),
+        ],
+    );
+    let position = Type::heterogeneous_tuple(&db, [distributed, list_int]);
+    let current = KnownClass::List.to_specialized_instance(&db, &[position]);
+    let normalized_position = Type::heterogeneous_tuple(&db, [div, list_int]);
+    let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_position]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -251,6 +251,45 @@ fn recursive_nominal_growth_only_replaces_distributed_position() {
     assert_eq!(normalized, expected);
 }
 
+#[test]
+fn recursive_nominal_growth_rejects_unrelated_union_and_intersection() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let unrelated_union = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Int.to_instance(&db),
+            KnownClass::Str.to_instance(&db),
+        ],
+    );
+    let list_bytes =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Bytes.to_instance(&db)]);
+    let unrelated_intersection =
+        IntersectionType::from_two_elements(&db, list_bytes, Type::unknown());
+    let position = Type::heterogeneous_tuple(
+        &db,
+        [list_int, list_str, unrelated_union, unrelated_intersection],
+    );
+    let current = KnownClass::List.to_specialized_instance(&db, &[position]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        None
+    );
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -291,6 +291,37 @@ fn recursive_nominal_growth_rejects_unrelated_union_and_intersection() {
 }
 
 #[test]
+fn recursive_nominal_growth_requires_matching_branch_structure() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let unrelated = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::List.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let current = KnownClass::List.to_specialized_instance(&db, &[unrelated]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        None
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -134,6 +134,24 @@ fn protocol_cycle_recovery_widens_unrelated_specializations() {
 }
 
 #[test]
+fn recursive_nominal_growth_normalizes_protocol_intersection_arm() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
+    let protocol = KnownClass::Iterable.to_specialized_instance(&db, &[previous]);
+    let current = IntersectionType::from_two_elements(&db, protocol, Type::unknown());
+    let normalized_protocol = KnownClass::Iterable.to_specialized_instance(&db, &[div]);
+    let expected = IntersectionType::from_two_elements(&db, normalized_protocol, Type::unknown());
+
+    assert_eq!(
+        current.recursive_nominal_growth_normalized(&db, previous, div),
+        Some(expected)
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_preserves_unrelated_intersections() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -101,6 +101,39 @@ fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
     );
 }
 
+#[test]
+fn recursive_nominal_growth_preserves_unrelated_intersections() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let int_intersection = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
+    let str_intersection = IntersectionType::from_two_elements(&db, list_str, Type::unknown());
+    let current = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Dict.to_specialized_instance(&db, &[previous, int_intersection]),
+            KnownClass::Dict.to_specialized_instance(&db, &[str_intersection, previous]),
+        ],
+    );
+
+    let normalized = current
+        .recursive_nominal_growth_normalized(&db, previous, div)
+        .expect("both union arms contain the previous type");
+    let expected = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Dict.to_specialized_instance(&db, &[div, int_intersection]),
+            KnownClass::Dict.to_specialized_instance(&db, &[str_intersection, div]),
+        ],
+    );
+
+    assert_eq!(normalized, expected);
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -134,6 +134,62 @@ fn recursive_nominal_growth_preserves_unrelated_intersections() {
     assert_eq!(normalized, expected);
 }
 
+#[test]
+fn recursive_nominal_growth_normalizes_complete_union_distribution() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            IntersectionType::from_two_elements(&db, list_int, Type::unknown()),
+            IntersectionType::from_two_elements(&db, list_str, Type::unknown()),
+        ],
+    );
+    let current = KnownClass::List.to_specialized_instance(&db, &[distributed]);
+    let expected = KnownClass::List.to_specialized_instance(&db, &[div]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
+#[test]
+fn recursive_nominal_growth_requires_all_union_elements() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let partial = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
+    let current = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::List.to_specialized_instance(&db, &[partial]),
+            KnownClass::Set.to_specialized_instance(&db, &[partial]),
+        ],
+    );
+
+    assert_eq!(
+        current.recursive_nominal_growth_normalized(&db, previous, div),
+        None
+    );
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -437,6 +437,41 @@ fn recursive_nominal_growth_rejects_nested_negative_occurrences() {
 }
 
 #[test]
+fn recursive_nominal_growth_rejects_distributions_under_negation() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distribution = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::Set.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let excluded = IntersectionBuilder::new(&db)
+        .add_positive(Type::object())
+        .add_negative(KnownClass::List.to_specialized_instance(&db, &[distribution]))
+        .build();
+    let current = KnownClass::List.to_specialized_instance(&db, &[excluded]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        None
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_recomputes_overlapping_positions() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -167,6 +167,47 @@ fn recursive_nominal_growth_normalizes_complete_union_distribution() {
 }
 
 #[test]
+fn recursive_nominal_growth_normalizes_multiple_distribution_groups() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[list_int]),
+            KnownClass::Set.to_specialized_instance(&db, &[list_str]),
+            KnownClass::List.to_specialized_instance(&db, &[list_int]),
+            KnownClass::List.to_specialized_instance(&db, &[list_str]),
+        ],
+    );
+    let current = KnownClass::List.to_specialized_instance(&db, &[distributed]);
+    let normalized_distribution = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Set.to_specialized_instance(&db, &[div]),
+            KnownClass::List.to_specialized_instance(&db, &[div]),
+        ],
+    );
+    let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_distribution]);
+
+    assert_eq!(
+        Type::nominal_wrapper_normalized(
+            &db,
+            current
+                .as_nominal_instance()
+                .expect("a specialized list should be a nominal instance"),
+            previous,
+            div,
+        ),
+        Some(expected)
+    );
+}
+
+#[test]
 fn recursive_nominal_growth_requires_all_union_elements() {
     let db = setup_db();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -213,6 +213,44 @@ fn recursive_nominal_growth_requires_structural_union_distribution() {
     );
 }
 
+#[test]
+fn recursive_nominal_growth_only_replaces_distributed_position() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let distributed = UnionType::from_elements(
+        &db,
+        [
+            IntersectionType::from_two_elements(&db, list_int, Type::unknown()),
+            IntersectionType::from_two_elements(&db, list_str, Type::unknown()),
+        ],
+    );
+    let current = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Dict.to_specialized_instance(&db, &[distributed, list_int]),
+            KnownClass::Dict.to_specialized_instance(&db, &[distributed, list_str]),
+        ],
+    );
+
+    let normalized = current
+        .recursive_nominal_growth_normalized(&db, previous, div)
+        .expect("both union arms contain a complete distribution");
+    let expected = UnionType::from_elements(
+        &db,
+        [
+            KnownClass::Dict.to_specialized_instance(&db, &[div, list_int]),
+            KnownClass::Dict.to_specialized_instance(&db, &[div, list_str]),
+        ],
+    );
+
+    assert_eq!(normalized, expected);
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -50,6 +50,30 @@ fn list_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
         .expect("a specialized `list` should be a generic alias")
 }
 
+fn recursive_union_types(db: &dyn Db) -> (Type<'_>, Type<'_>, Type<'_>, Type<'_>) {
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int = KnownClass::List.to_specialized_instance(db, &[KnownClass::Int.to_instance(db)]);
+    let list_str = KnownClass::List.to_specialized_instance(db, &[KnownClass::Str.to_instance(db)]);
+    let previous = UnionType::from_elements(db, [list_int, list_str]);
+    (div, list_int, list_str, previous)
+}
+
+fn normalize_nominal_wrapper<'db>(
+    db: &'db dyn Db,
+    current: Type<'db>,
+    wrapped: Type<'db>,
+    div: Type<'db>,
+) -> Option<Type<'db>> {
+    Type::nominal_wrapper_normalized(
+        db,
+        current
+            .as_nominal_instance()
+            .expect("the outer wrapper should be a nominal instance"),
+        wrapped,
+        div,
+    )
+}
+
 fn oscillating_type_cycle_recover<'db>(
     db: &'db dyn Db,
     cycle: &salsa::Cycle,
@@ -136,9 +160,7 @@ fn protocol_cycle_recovery_widens_unrelated_specializations() {
 #[test]
 fn recursive_nominal_growth_normalizes_protocol_intersection_arm() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let (div, list_int, _, _) = recursive_union_types(&db);
     let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
     let protocol = KnownClass::Iterable.to_specialized_instance(&db, &[previous]);
     let current = IntersectionType::from_two_elements(&db, protocol, Type::unknown());
@@ -154,12 +176,7 @@ fn recursive_nominal_growth_normalizes_protocol_intersection_arm() {
 #[test]
 fn recursive_nominal_growth_preserves_unrelated_intersections() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let int_intersection = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
     let str_intersection = IntersectionType::from_two_elements(&db, list_str, Type::unknown());
     let current = UnionType::from_elements(
@@ -187,12 +204,7 @@ fn recursive_nominal_growth_preserves_unrelated_intersections() {
 #[test]
 fn recursive_nominal_growth_normalizes_complete_union_distribution() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -204,14 +216,7 @@ fn recursive_nominal_growth_normalizes_complete_union_distribution() {
     let expected = KnownClass::List.to_specialized_instance(&db, &[div]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }
@@ -219,12 +224,7 @@ fn recursive_nominal_growth_normalizes_complete_union_distribution() {
 #[test]
 fn recursive_nominal_growth_normalizes_multiple_distribution_groups() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -245,14 +245,7 @@ fn recursive_nominal_growth_normalizes_multiple_distribution_groups() {
     let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_distribution]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }
@@ -260,12 +253,7 @@ fn recursive_nominal_growth_normalizes_multiple_distribution_groups() {
 #[test]
 fn recursive_nominal_growth_stops_at_opaque_distributed_union() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -279,51 +267,24 @@ fn recursive_nominal_growth_stops_at_opaque_distributed_union() {
     )));
     let current = KnownClass::List.to_specialized_instance(&db, &[literal]);
 
-    assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
-        None
-    );
+    assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
 }
 
 #[test]
 fn recursive_nominal_growth_stops_at_opaque_flattened_intersection() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let (div, list_int, _, _) = recursive_union_types(&db);
     let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
     let literal = Type::KnownInstance(KnownInstanceType::Literal(InternedType::new(&db, previous)));
     let current = KnownClass::List.to_specialized_instance(&db, &[literal]);
 
-    assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
-        None
-    );
+    assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
 }
 
 #[test]
 fn recursive_nominal_growth_requires_all_union_elements() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, _, previous) = recursive_union_types(&db);
     let partial = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
     let current = UnionType::from_elements(
         &db,
@@ -342,12 +303,7 @@ fn recursive_nominal_growth_requires_all_union_elements() {
 #[test]
 fn recursive_nominal_growth_requires_structural_union_distribution() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let current = UnionType::from_elements(
         &db,
         [
@@ -365,12 +321,7 @@ fn recursive_nominal_growth_requires_structural_union_distribution() {
 #[test]
 fn recursive_nominal_growth_only_replaces_distributed_position() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -403,12 +354,7 @@ fn recursive_nominal_growth_only_replaces_distributed_position() {
 #[test]
 fn recursive_nominal_growth_rejects_unrelated_union_and_intersection() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let unrelated_union = UnionType::from_elements(
         &db,
         [
@@ -426,28 +372,13 @@ fn recursive_nominal_growth_rejects_unrelated_union_and_intersection() {
     );
     let current = KnownClass::List.to_specialized_instance(&db, &[position]);
 
-    assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
-        None
-    );
+    assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
 }
 
 #[test]
 fn recursive_nominal_growth_requires_matching_branch_structure() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let unrelated = UnionType::from_elements(
         &db,
         [
@@ -457,28 +388,13 @@ fn recursive_nominal_growth_requires_matching_branch_structure() {
     );
     let current = KnownClass::List.to_specialized_instance(&db, &[unrelated]);
 
-    assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
-        None
-    );
+    assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
 }
 
 #[test]
 fn recursive_nominal_growth_only_normalizes_matched_union_subtree() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -492,14 +408,7 @@ fn recursive_nominal_growth_only_normalizes_matched_union_subtree() {
     let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_position]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }
@@ -507,12 +416,7 @@ fn recursive_nominal_growth_only_normalizes_matched_union_subtree() {
 #[test]
 fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distributed = UnionType::from_elements(
         &db,
         [
@@ -524,14 +428,7 @@ fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
     let expected = KnownClass::Dict.to_specialized_instance(&db, &[div, div]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized dict should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }
@@ -539,12 +436,7 @@ fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
 #[test]
 fn recursive_nominal_growth_rejects_nested_negative_occurrences() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let excluded_int = IntersectionBuilder::new(&db)
         .add_positive(Type::object())
         .add_negative(KnownClass::Set.to_specialized_instance(&db, &[list_int]))
@@ -571,29 +463,14 @@ fn recursive_nominal_growth_rejects_nested_negative_occurrences() {
         ),
     ] {
         let current = KnownClass::List.to_specialized_instance(&db, &[position]);
-        assert_eq!(
-            Type::nominal_wrapper_normalized(
-                &db,
-                current
-                    .as_nominal_instance()
-                    .expect("a specialized list should be a nominal instance"),
-                previous,
-                div,
-            ),
-            None
-        );
+        assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
     }
 }
 
 #[test]
 fn recursive_nominal_growth_rejects_distributions_under_negation() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distribution = UnionType::from_elements(
         &db,
         [
@@ -607,25 +484,13 @@ fn recursive_nominal_growth_rejects_distributions_under_negation() {
         .build();
     let current = KnownClass::List.to_specialized_instance(&db, &[excluded]);
 
-    assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
-        None
-    );
+    assert_eq!(normalize_nominal_wrapper(&db, current, previous, div), None);
 }
 
 #[test]
 fn recursive_nominal_growth_rejects_exact_intersection_under_negation() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let (div, list_int, _, _) = recursive_union_types(&db);
     let previous = IntersectionType::from_two_elements(&db, list_int, Type::unknown());
     let excluded = IntersectionBuilder::new(&db)
         .add_positive(Type::object())
@@ -643,12 +508,7 @@ fn recursive_nominal_growth_rejects_exact_intersection_under_negation() {
 #[test]
 fn recursive_nominal_growth_preserves_negative_distribution_copies() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let distribution = UnionType::from_elements(
         &db,
         [
@@ -672,14 +532,7 @@ fn recursive_nominal_growth_preserves_negative_distribution_copies() {
     let expected = KnownClass::List.to_specialized_instance(&db, &[normalized_position]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized list should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }
@@ -687,12 +540,7 @@ fn recursive_nominal_growth_preserves_negative_distribution_copies() {
 #[test]
 fn recursive_nominal_growth_recomputes_overlapping_positions() {
     let db = setup_db();
-    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
-    let list_int =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
-    let list_str =
-        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
-    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let (div, list_int, list_str, previous) = recursive_union_types(&db);
     let first_distribution = UnionType::from_elements(
         &db,
         [
@@ -716,14 +564,7 @@ fn recursive_nominal_growth_recomputes_overlapping_positions() {
     let expected = KnownClass::Dict.to_specialized_instance(&db, &[div, normalized_nested]);
 
     assert_eq!(
-        Type::nominal_wrapper_normalized(
-            &db,
-            current
-                .as_nominal_instance()
-                .expect("a specialized dict should be a nominal instance"),
-            previous,
-            div,
-        ),
+        normalize_nominal_wrapper(&db, current, previous, div),
         Some(expected)
     );
 }

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -50,7 +50,7 @@ fn list_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
         .expect("a specialized `list` should be a generic alias")
 }
 
-fn oscillating_generic_alias_cycle_recover<'db>(
+fn oscillating_type_cycle_recover<'db>(
     db: &'db dyn Db,
     cycle: &salsa::Cycle,
     previous: &Type<'db>,
@@ -61,7 +61,7 @@ fn oscillating_generic_alias_cycle_recover<'db>(
 
 #[salsa::tracked(
     cycle_initial=|_, id| Type::divergent(id),
-    cycle_fn=oscillating_generic_alias_cycle_recover,
+    cycle_fn=oscillating_type_cycle_recover,
 )]
 fn oscillating_generic_alias(db: &dyn Db) -> Type<'_> {
     let previous = oscillating_generic_alias(db);
@@ -74,6 +74,22 @@ fn oscillating_generic_alias(db: &dyn Db) -> Type<'_> {
     };
 
     list_alias(db, argument).into()
+}
+
+#[salsa::tracked(
+    cycle_initial=|_, id| Type::divergent(id),
+    cycle_fn=oscillating_type_cycle_recover,
+)]
+fn oscillating_protocol(db: &dyn Db) -> Type<'_> {
+    let previous = oscillating_protocol(db);
+    let int_protocol =
+        KnownClass::Iterable.to_specialized_instance(db, &[KnownClass::Int.to_instance(db)]);
+
+    if previous == int_protocol {
+        KnownClass::Iterable.to_specialized_instance(db, &[KnownClass::Str.to_instance(db)])
+    } else {
+        int_protocol
+    }
 }
 
 #[test]
@@ -99,6 +115,22 @@ fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
         int.merge_cycle_recovery(&db, list_alias(&db, unknown_generic))
             .is_none()
     );
+}
+
+#[test]
+fn protocol_cycle_recovery_widens_unrelated_specializations() {
+    let db = setup_db();
+    let int_protocol =
+        KnownClass::Iterable.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let str_protocol =
+        KnownClass::Iterable.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let Type::Union(result) = oscillating_protocol(&db) else {
+        panic!("cycle recovery should widen both protocol specializations");
+    };
+
+    assert_eq!(result.elements(&db).len(), 2);
+    assert!(result.elements(&db).contains(&int_protocol));
+    assert!(result.elements(&db).contains(&str_protocol));
 }
 
 #[test]

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -387,6 +387,55 @@ fn recursive_nominal_growth_normalizes_exact_and_distributed_occurrences() {
     );
 }
 
+#[test]
+fn recursive_nominal_growth_rejects_nested_negative_occurrences() {
+    let db = setup_db();
+    let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
+    let list_int =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Int.to_instance(&db)]);
+    let list_str =
+        KnownClass::List.to_specialized_instance(&db, &[KnownClass::Str.to_instance(&db)]);
+    let previous = UnionType::from_elements(&db, [list_int, list_str]);
+    let excluded_int = IntersectionBuilder::new(&db)
+        .add_positive(Type::object())
+        .add_negative(KnownClass::Set.to_specialized_instance(&db, &[list_int]))
+        .build();
+    let excluded_str = IntersectionBuilder::new(&db)
+        .add_positive(Type::object())
+        .add_negative(KnownClass::Set.to_specialized_instance(&db, &[list_str]))
+        .build();
+
+    for position in [
+        UnionType::from_elements(
+            &db,
+            [
+                Type::heterogeneous_tuple(&db, [excluded_int]),
+                Type::heterogeneous_tuple(&db, [excluded_str]),
+            ],
+        ),
+        UnionType::from_elements(
+            &db,
+            [
+                Type::heterogeneous_tuple(&db, [list_int, excluded_int]),
+                Type::heterogeneous_tuple(&db, [list_str, excluded_str]),
+            ],
+        ),
+    ] {
+        let current = KnownClass::List.to_specialized_instance(&db, &[position]);
+        assert_eq!(
+            Type::nominal_wrapper_normalized(
+                &db,
+                current
+                    .as_nominal_instance()
+                    .expect("a specialized list should be a nominal instance"),
+                previous,
+                div,
+            ),
+            None
+        );
+    }
+}
+
 /// All other tests also make sure that `Type::Todo` works as expected. This particular
 /// test makes sure that we handle `Todo` types correctly, even if they originate from
 /// different sources.

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1144,7 +1144,7 @@ impl<'db> BoundTypeVarInstance<'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::ReplaceParameterDefaults
-            | TypeMapping::ReplaceType { .. }
+            | TypeMapping::ReplaceTypeOutsideNegativeIntersections { .. }
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => Type::TypeVar(self),

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -308,7 +308,7 @@ impl<'db> TypeCollector<'db> {
     }
 }
 
-/// Implementation for `any_over_type` and `find_over_type`.
+/// Implementation for the `any_over_type` and `find_over_type` variants.
 fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
     ty: Type<'db>,
@@ -423,4 +423,18 @@ where
     T: Copy + PartialEq,
 {
     any_over_type_impl(db, ty, should_visit_lazy_type_attributes, true, query)
+}
+
+/// Recurse into positive intersection elements and return the first non-`None` value returned by
+/// the closure.
+pub(super) fn find_over_positive_type<'db, T>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    should_visit_lazy_type_attributes: bool,
+    query: impl Fn(Type<'db>) -> Option<T>,
+) -> Option<T>
+where
+    T: Copy + PartialEq,
+{
+    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, false, query)
 }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -313,6 +313,7 @@ fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
+    should_visit_negative_intersection_elements: bool,
     query: F,
 ) -> T
 where
@@ -324,6 +325,7 @@ where
         recursion_guard: TypeCollector<'db>,
         found_matching_type: Cell<U>,
         should_visit_lazy_type_attributes: bool,
+        should_visit_negative_intersection_elements: bool,
     }
 
     impl<'db, U> TypeVisitor<'db> for AnyOverTypeVisitor<'db, '_, U>
@@ -347,6 +349,16 @@ where
             }
             walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
         }
+
+        fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
+            if self.should_visit_negative_intersection_elements {
+                walk_intersection_type(db, intersection, self);
+            } else {
+                for element in intersection.positive(db) {
+                    self.visit_type(db, *element);
+                }
+            }
+        }
     }
 
     let visitor = AnyOverTypeVisitor {
@@ -354,6 +366,7 @@ where
         recursion_guard: TypeCollector::default(),
         found_matching_type: Cell::default(),
         should_visit_lazy_type_attributes,
+        should_visit_negative_intersection_elements,
     };
     visitor.visit_type(db, ty);
     visitor.found_matching_type.get()
@@ -373,7 +386,18 @@ pub(super) fn any_over_type<'db>(
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, true, query)
+}
+
+/// Return `true` if `ty`, or any of the types contained in positive intersection elements,
+/// match the closure passed in.
+pub(super) fn any_over_positive_type<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    should_visit_lazy_type_attributes: bool,
+    query: impl Fn(Type<'db>) -> bool,
+) -> bool {
+    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, false, query)
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type
@@ -398,5 +422,5 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, true, query)
 }


### PR DESCRIPTION
## Summary

A recursive `TypeOf` can appear under multiple intersection arms, causing each fixed-point iteration to wrap the full previous intersection:

```python
from ty_extensions import Intersection, TypeOf

class Container[T]: ...

x: Intersection[list[TypeOf[x]], Container[TypeOf[x]]]
x = [1]
```

Prior to this change, cycle recovery only aligned recursive growth across union arms. Intersections and DNF-distributed union elements therefore continued to grow until Salsa exhausted its cycle iterations.

This extends recursive-growth recovery to recognize exact, flattened, and structurally distributed occurrences of the previous cycle result inside nominal specializations. It normalizes every complete structural distribution to `Divergent`, handles class-backed protocol instances, and repeats replacement until overlapping occurrences are resolved.

The matching and replacement traversals are polarity-aware: negative intersection elements and unrelated specializations are preserved, partial or structurally inconsistent distributions are rejected, and opaque types that cannot be rewritten stop without looping. Regression coverage exercises the original `Intersection` and `TypeIs` hangs along with these recovery boundaries.

Closes https://github.com/astral-sh/ty/issues/3826.
