### PR TITLE
fix(linter): apply RUF027 fixes before F401 fixes (#20803)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_3.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_3.py
@@ -1,0 +1,3 @@
+from sys import byteorder
+
+print("Byte order: {byteorder}-endian")

--- a/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_F401.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/RUF027_F401.py
@@ -1,0 +1,20 @@
+"""Regression test for https://github.com/astral-sh/ruff/issues/20803.
+
+When `missing-fstring-syntax` (RUF027) and `unused-import` (F401) both fire
+on the same module — RUF027 promoting a string literal to an f-string that
+interpolates a name only bound by the unused import — applying both fixes
+on the same pass produces code that raises `NameError` at runtime:
+
+    from sys import byteorder
+    print("Byte order: {byteorder}-endian")
+    # F401 fix removes the import; RUF027 fix inserts `f`.
+    # Result: print(f"...") but `byteorder` is no longer defined.
+
+The fix sorts RUF027 before F401 in the fixer, so the f-string fix applies
+first; F401's fix is then skipped on the same pass (the fixer has advanced
+past the import's start position). On the next pass the f-string
+interpolation marks the import as used and F401 does not fire.
+"""
+from sys import byteorder
+
+print("Byte order: {byteorder}-endian")

--- a/crates/ruff_linter/src/fix/mod.rs
+++ b/crates/ruff_linter/src/fix/mod.rs
@@ -140,6 +140,24 @@ fn cmp_fix(name1: &str, name2: &str, fix1: &Fix, fix2: &Fix) -> std::cmp::Orderi
     } else {
         std::cmp::Ordering::Equal
     }
+    // Always apply `MissingFStringSyntax` (RUF027) before `UnusedImport` (F401). If both fixes
+    // apply to the same module, RUF027 may promote a string literal to an f-string whose only
+    // reference to the imported name is the interpolation. Removing the import on the same pass
+    // would leave a `NameError` at runtime. Sorting RUF027 first causes the F401 fix to be
+    // skipped on this pass (because the fixer has advanced past the import's start position),
+    // and on the next pass the f-string interpolation marks the import as used.
+    // See https://github.com/astral-sh/ruff/issues/20803
+    .then_with(|| {
+        let missing_fstring_syntax = Rule::MissingFStringSyntax.name().as_str();
+        let unused_import = Rule::UnusedImport.name().as_str();
+        if (name1, name2) == (missing_fstring_syntax, unused_import) {
+            std::cmp::Ordering::Less
+        } else if (name1, name2) == (unused_import, missing_fstring_syntax) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    })
     // Apply fixes in order of their start position.
     .then_with(|| fix1.min_start().cmp(&fix2.min_start()))
     // Break ties in the event of overlapping rules, for some specific combinations.

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -259,7 +259,7 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test for https://github.com/astral-sh/ruff/issues/20803.
+    /// Regression test for <https://github.com/astral-sh/ruff/issues/20803>.
     ///
     /// When both RUF027 (`missing-fstring-syntax`) and F401 (`unused-import`) fire
     /// on the same module — RUF027 promoting a string literal to an f-string that

--- a/crates/ruff_linter/src/rules/ruff/mod.rs
+++ b/crates/ruff_linter/src/rules/ruff/mod.rs
@@ -72,6 +72,7 @@ mod tests {
     #[test_case(Rule::MissingFStringSyntax, Path::new("RUF027_0.py"))]
     #[test_case(Rule::MissingFStringSyntax, Path::new("RUF027_1.py"))]
     #[test_case(Rule::MissingFStringSyntax, Path::new("RUF027_2.py"))]
+    #[test_case(Rule::MissingFStringSyntax, Path::new("RUF027_3.py"))]
     #[test_case(Rule::InvalidFormatterSuppressionComment, Path::new("RUF028.py"))]
     #[test_case(Rule::UnusedAsync, Path::new("RUF029.py"))]
     #[test_case(Rule::AssertWithPrintMessage, Path::new("RUF030.py"))]
@@ -255,6 +256,34 @@ mod tests {
                 ..LinterSettings::for_rule(Rule::MissingFStringSyntax)
             },
         );
+        Ok(())
+    }
+
+    /// Regression test for https://github.com/astral-sh/ruff/issues/20803.
+    ///
+    /// When both RUF027 (`missing-fstring-syntax`) and F401 (`unused-import`) fire
+    /// on the same module — RUF027 promoting a string literal to an f-string that
+    /// interpolates a name only bound by the unused import — applying both fixes
+    /// on the same pass produces a `NameError` at runtime. Sorting RUF027 first in
+    /// the fixer means the f-string fix applies first and F401's fix is skipped on
+    /// the same pass; on the next pass the f-string interpolation marks the import
+    /// as used and F401 does not fire.
+    #[test]
+    fn missing_fstring_syntax_and_unused_import() -> Result<()> {
+        use ruff_python_ast::{PySourceType, SourceType};
+
+        let path = test_resource_path("fixtures").join("ruff/RUF027_F401.py");
+        let source_type = SourceType::Python(PySourceType::from(&path));
+        let source_kind = SourceKind::from_path(&path, source_type)?.expect("valid source");
+        let settings = settings::LinterSettings::for_rules(vec![
+            Rule::MissingFStringSyntax,
+            Rule::UnusedImport,
+        ]);
+
+        let (diagnostics, transformed) = test_contents(&source_kind, &path, &settings);
+        assert_diagnostics!(diagnostics);
+
+        insta::assert_snapshot!(transformed.source_code());
         Ok(())
     }
 

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_3.py.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__RUF027_RUF027_3.py.snap
@@ -1,0 +1,18 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+RUF027 [*] Possible f-string without an `f` prefix
+ --> RUF027_3.py:3:7
+  |
+1 | from sys import byteorder
+2 |
+3 | print("Byte order: {byteorder}-endian")
+  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+help: Add `f` prefix
+  |
+2 |
+  - print("Byte order: {byteorder}-endian")
+3 + print(f"Byte order: {byteorder}-endian")
+  |
+note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_and_unused_import-2.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_and_unused_import-2.snap
@@ -1,0 +1,24 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+expression: transformed.source_code()
+---
+"""Regression test for https://github.com/astral-sh/ruff/issues/20803.
+
+When `missing-fstring-syntax` (RUF027) and `unused-import` (F401) both fire
+on the same module — RUF027 promoting a string literal to an f-string that
+interpolates a name only bound by the unused import — applying both fixes
+on the same pass produces code that raises `NameError` at runtime:
+
+    from sys import byteorder
+    print("Byte order: {byteorder}-endian")
+    # F401 fix removes the import; RUF027 fix inserts `f`.
+    # Result: print(f"...") but `byteorder` is no longer defined.
+
+The fix sorts RUF027 before F401 in the fixer, so the f-string fix applies
+first; F401's fix is then skipped on the same pass (the fixer has advanced
+past the import's start position). On the next pass the f-string
+interpolation marks the import as used and F401 does not fire.
+"""
+from sys import byteorder
+
+print(f"Byte order: {byteorder}-endian")

--- a/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_and_unused_import.snap
+++ b/crates/ruff_linter/src/rules/ruff/snapshots/ruff_linter__rules__ruff__tests__missing_fstring_syntax_and_unused_import.snap
@@ -1,0 +1,35 @@
+---
+source: crates/ruff_linter/src/rules/ruff/mod.rs
+---
+F401 [*] `sys.byteorder` imported but unused
+  --> RUF027_F401.py:18:17
+   |
+16 | interpolation marks the import as used and F401 does not fire.
+17 | """
+18 | from sys import byteorder
+   |                 ^^^^^^^^^
+19 |
+20 | print("Byte order: {byteorder}-endian")
+   |
+help: Remove unused import: `sys.byteorder`
+   |
+17 | """
+   - from sys import byteorder
+18 |
+   |
+
+RUF027 [*] Possible f-string without an `f` prefix
+  --> RUF027_F401.py:20:7
+   |
+18 | from sys import byteorder
+19 |
+20 | print("Byte order: {byteorder}-endian")
+   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+help: Add `f` prefix
+   |
+19 |
+   - print("Byte order: {byteorder}-endian")
+20 + print(f"Byte order: {byteorder}-endian")
+   |
+note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

When both `missing-fstring-syntax` (RUF027) and `unused-import` (F401) fire on the same module, RUF027 may promote a string literal to an f-string that interpolates a name only bound by the unused import. Applying both fixes on the same pass removes the import and leaves an undefined name in the f-string, producing a `NameError` at runtime:

```python
from sys import byteorder
print("Byte order: {byteorder}-endian")
```

becomes

```python
print(f"Byte order: {byteorder}-endian")  # NameError: byteorder
```

Sort RUF027 before F401 in the fixer so the f-string fix applies first; F401's fix is then skipped on the same pass because the fixer has advanced past the import's start position. On the next pass the f-string interpolation marks the import as used and F401 does not fire.

## Test plan

- New fixture `RUF027_F401.py` exercises the conflict.
- New regression test `missing_fstring_syntax_and_unused_import` asserts the converged output keeps the import and adds the `f` prefix.
- Existing test fixtures still pass (RUF027_0/1/2/3 are existing rule-level tests; no behavior change for files that don't trigger both rules).

Fixes #20803