### PR TITLE
[ty] Avoid path lookups when sorting same-file diagnostics

### DIFF
--- a/crates/ruff_db/src/diagnostic/mod.rs
+++ b/crates/ruff_db/src/diagnostic/mod.rs
@@ -562,9 +562,13 @@ impl Ord for RenderingSortKey<'_> {
             self.diagnostic.primary_span(),
             other.diagnostic.primary_span(),
         ) {
-            let order = span1.file().path(&self.db).cmp(span2.file().path(&self.db));
-            if order.is_ne() {
-                return order;
+            let file1 = span1.file();
+            let file2 = span2.file();
+            if file1 != file2 {
+                let order = file1.path(&self.db).cmp(file2.path(&self.db));
+                if order.is_ne() {
+                    return order;
+                }
             }
 
             if let (Some(range1), Some(range2)) = (span1.range(), span2.range()) {


### PR DESCRIPTION
Skip database-backed path resolution when two diagnostics belong to the same file. Reading the file's path calls a salsa method, which adds a tracked read. While not expensive on its own, it gets expensive when comparing thousands of diagnostics.

