### PR TITLE
[ty] Match constructor call bindings in place

### DIFF
--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -976,10 +976,18 @@ impl<'db> Bindings<'db> {
         db: &'db dyn Db,
         arguments: &CallArguments<'_, 'db>,
     ) -> Self {
+        self.match_parameters_with_freshening_in_place(db, arguments);
+        self
+    }
+
+    pub(in crate::types) fn match_parameters_with_freshening_in_place(
+        &mut self,
+        db: &'db dyn Db,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
         let nonce_generator = TypeVarNonceGenerator::default();
         self.freshen_generic_contexts_in_place(db, &nonce_generator);
         self.match_parameters_in_place(db, arguments);
-        self
     }
 
     fn match_parameters_in_place(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -8779,9 +8779,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        let mut bindings = self
-            .bindings_for_call(callable_type)
-            .match_parameters(self.db(), &call_arguments);
+        let mut bindings = self.bindings_for_call(callable_type);
+        bindings.match_parameters_with_freshening_in_place(self.db(), &call_arguments);
 
         report_missing_implicit_constructor_call(
             &self.context,
@@ -8805,13 +8804,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             call_expression_tcx,
         );
 
-        let mut bindings = match bindings_result {
-            Ok(()) => bindings,
-            Err(_) => {
-                bindings.report_diagnostics(&self.context, call_expression.into());
-                return bindings.return_type(self.db());
-            }
-        };
+        if bindings_result.is_err() {
+            bindings.report_diagnostics(&self.context, call_expression.into());
+            return bindings.return_type(self.db());
+        }
 
         for binding in bindings.iter_flat_mut() {
             let binding_type = binding.callable_type;


### PR DESCRIPTION
Match constructor call bindings in place to avoid copying nested inline buffers at the call site. This reduced copied bytes by 28.3 MB on freqtrade and 6.5 MB on hydra-zen, with neutral paired timings.

Testing: Passed semantic tests, Clippy, repository hooks, and paired project profiling.