### PR TITLE
[ty] Support `builtins.sentinel` as well as `typing_extensions.Sentinel`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/sentinels.md
+++ b/crates/ty_python_semantic/resources/mdtest/sentinels.md
@@ -4,6 +4,11 @@
 
 Sentinels constructed with `typing_extensions.Sentinel` can be used directly in type expressions:
 
+```toml
+[environment]
+python-version = "3.10"
+```
+
 ```py
 from typing_extensions import Sentinel, assert_type
 
@@ -69,8 +74,6 @@ Sentinel objects are always truthy, expose the standard sentinel metadata attrib
 rejected as class bases:
 
 ```py
-from typing_extensions import Sentinel
-
 MISSING = Sentinel("MISSING")
 
 reveal_type(bool(MISSING))  # revealed: Literal[True]
@@ -83,8 +86,6 @@ class MissingSubclass(MISSING):  # error: [invalid-base]
 Sentinels declared in class scope can also be used in type expressions:
 
 ```py
-from typing_extensions import Sentinel, assert_type
-
 class C:
     MARKER = Sentinel("C.MARKER")
 
@@ -112,8 +113,6 @@ def class_reverse_negative(x: int | C.MARKER) -> None:
 Sentinel declarations are recognized only in module and class scope:
 
 ```py
-from typing_extensions import Sentinel
-
 def outer():
     LOCAL = Sentinel("LOCAL")
 
@@ -123,8 +122,6 @@ def outer():
 Sentinels are not generic:
 
 ```py
-from typing_extensions import Sentinel
-
 MISSING = Sentinel("MISSING")
 
 def f(x: MISSING[int]) -> None: ...  # error: [invalid-type-form]
@@ -133,8 +130,6 @@ def f(x: MISSING[int]) -> None: ...  # error: [invalid-type-form]
 Invalid sentinel constructor calls fall back to the normal call path:
 
 ```py
-from typing_extensions import Sentinel
-
 NAME = "NAME"
 
 NON_LITERAL_NAME = Sentinel(NAME)
@@ -142,4 +137,158 @@ UNKNOWN_NAME = Sentinel(UNKNOWN)  # error: [unresolved-reference]
 NON_LITERAL_REPR = Sentinel("NON_LITERAL_REPR", repr=NAME)
 UNKNOWN_REPR = Sentinel("UNKNOWN_REPR", repr=UNKNOWN)  # error: [unresolved-reference]
 UNKNOWN_KEYWORD = Sentinel("UNKNOWN_KEYWORD", unknown=NAME)  # error: [unknown-argument]
+```
+
+## `builtins.sentinel`
+
+On Python 3.15+, `typing_extensions.Sentinel` is still available, but it is a re-export of
+`builtins.sentinel`:
+
+```toml
+[environment]
+python-version = "3.15"
+```
+
+```py
+from typing import assert_type
+
+MISSING = sentinel("MISSING")
+OTHER = sentinel("OTHER")
+WITH_REPR = sentinel("WITH_REPR", "<with repr>")
+WITH_REPR_KEYWORD = sentinel("WITH_REPR_KEYWORD", repr="<with repr keyword>")
+
+reveal_type(MISSING)  # revealed: MISSING
+reveal_type(OTHER)  # revealed: OTHER
+reveal_type(WITH_REPR)  # revealed: WITH_REPR
+reveal_type(WITH_REPR_KEYWORD)  # revealed: WITH_REPR_KEYWORD
+
+def accepts_missing(x: MISSING) -> None: ...
+def accepts_other(x: OTHER) -> None: ...
+
+accepts_missing(MISSING)
+accepts_missing(OTHER)  # error: [invalid-argument-type]
+accepts_other(OTHER)
+accepts_other(MISSING)  # error: [invalid-argument-type]
+
+def bad_default(x: int = MISSING) -> None:  # error: [invalid-parameter-default]
+    pass
+
+def good_default(x: int | MISSING | OTHER = MISSING) -> None:
+    if x is MISSING:
+        assert_type(x, MISSING)
+        reveal_type(x)  # revealed: MISSING
+    else:
+        assert_type(x, int | OTHER)
+        reveal_type(x)  # revealed: int | OTHER
+
+good_default(1)
+good_default(MISSING)
+good_default(OTHER)
+
+def reverse_check(x: int | MISSING | OTHER) -> None:
+    if MISSING is x:
+        assert_type(x, MISSING)
+        reveal_type(x)  # revealed: MISSING
+    else:
+        assert_type(x, int | OTHER)
+        reveal_type(x)  # revealed: int | OTHER
+
+def negative_check(x: int | MISSING | OTHER) -> None:
+    if x is not MISSING:
+        assert_type(x, int | OTHER)
+        reveal_type(x)  # revealed: int | OTHER
+    else:
+        assert_type(x, MISSING)
+        reveal_type(x)  # revealed: MISSING
+
+def reverse_negative_check(x: int | MISSING | OTHER) -> None:
+    if MISSING is not x:
+        assert_type(x, int | OTHER)
+        reveal_type(x)  # revealed: int | OTHER
+    else:
+        assert_type(x, MISSING)
+        reveal_type(x)  # revealed: MISSING
+```
+
+Sentinel objects are always truthy, expose the standard sentinel metadata attributes, and are
+rejected as class bases:
+
+```py
+MISSING = sentinel("MISSING")
+
+reveal_type(bool(MISSING))  # revealed: Literal[True]
+reveal_type(MISSING.__module__)  # revealed: str
+
+class MissingSubclass(MISSING):  # error: [invalid-base]
+    pass
+```
+
+Sentinels declared in class scope can also be used in type expressions:
+
+```py
+class C:
+    MARKER = sentinel("C.MARKER")
+
+def accepts_marker(x: C.MARKER) -> None: ...
+
+accepts_marker(C.MARKER)
+
+def class_default(x: int | C.MARKER = C.MARKER) -> None:
+    if x is C.MARKER:
+        assert_type(x, C.MARKER)
+        reveal_type(x)  # revealed: MARKER
+    else:
+        assert_type(x, int)
+        reveal_type(x)  # revealed: int
+
+def class_reverse_negative(x: int | C.MARKER) -> None:
+    if C.MARKER is not x:
+        assert_type(x, int)
+        reveal_type(x)  # revealed: int
+    else:
+        assert_type(x, C.MARKER)
+        reveal_type(x)  # revealed: MARKER
+```
+
+Sentinel declarations are recognized only in module and class scope:
+
+```py
+def outer():
+    LOCAL = sentinel("LOCAL")
+
+    def inner(x: LOCAL) -> None: ...  # error: [invalid-type-form]
+```
+
+Sentinels are not generic:
+
+```py
+MISSING = sentinel("MISSING")
+
+def f(x: MISSING[int]) -> None: ...  # error: [invalid-type-form]
+```
+
+Invalid sentinel constructor calls fall back to the normal call path:
+
+```py
+NAME = "NAME"
+
+NON_LITERAL_NAME = sentinel(NAME)
+UNKNOWN_NAME = sentinel(UNKNOWN)  # error: [unresolved-reference]
+NON_LITERAL_REPR = sentinel("NON_LITERAL_REPR", repr=NAME)
+UNKNOWN_REPR = sentinel("UNKNOWN_REPR", repr=UNKNOWN)  # error: [unresolved-reference]
+UNKNOWN_KEYWORD = sentinel("UNKNOWN_KEYWORD", unknown=NAME)  # error: [unknown-argument]
+```
+
+`typing_extensions.Sentinel` continues to work on Python 3.15:
+
+```py
+import typing_extensions
+
+EXTENSIONS_MISSING = typing_extensions.Sentinel("EXTENSIONS_MISSING")
+
+def f(x: int | EXTENSIONS_MISSING): ...
+
+f(42)
+f(EXTENSIONS_MISSING)
+f(None)  # error: [invalid-argument-type]
 ```

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/deprecated.md_-_Tests_for_the_`@depr…_-_Syntax_(142fa2948c3c6cf1).snap
@@ -85,9 +85,9 @@ error[missing-argument]: No argument provided for required parameter `arg` of bo
   | ^^^^^^^^^^^^^^
   |
 info: Parameter declared here
-    --> stdlib/typing_extensions.pyi:1167:28
+    --> stdlib/typing_extensions.pyi:1168:28
      |
-1167 |         def __call__(self, arg: _T, /) -> _T: ...
+1168 |         def __call__(self, arg: _T, /) -> _T: ...
      |                            ^^^^^^^
      |
 

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -870,7 +870,7 @@ impl KnownClass {
             Self::ParamSpecArgs => "ParamSpecArgs",
             Self::ParamSpecKwargs => "ParamSpecKwargs",
             Self::TypeVarTuple => "TypeVarTuple",
-            Self::Sentinel => "Sentinel",
+            Self::Sentinel => "sentinel",
             Self::TypeAliasType => "TypeAliasType",
             Self::NoDefaultType => "_NoDefaultType",
             Self::NewType => "NewType",
@@ -1257,12 +1257,18 @@ impl KnownClass {
             Self::TypeAliasType
             | Self::ExtensionsTypeVar
             | Self::TypeVarTuple
-            | Self::Sentinel
             | Self::ExtensionsParamSpec
             | Self::ParamSpecArgs
             | Self::ParamSpecKwargs
             | Self::Deprecated
             | Self::NewType => KnownModule::TypingExtensions,
+            Self::Sentinel => {
+                if Program::get(db).python_version(db) >= PythonVersion::PY315 {
+                    KnownModule::Builtins
+                } else {
+                    KnownModule::TypingExtensions
+                }
+            }
             Self::NoDefaultType => {
                 let python_version = Program::get(db).python_version(db);
 
@@ -1574,7 +1580,7 @@ impl KnownClass {
             "ParamSpecArgs" => &[Self::ParamSpecArgs],
             "ParamSpecKwargs" => &[Self::ParamSpecKwargs],
             "TypeVarTuple" => &[Self::TypeVarTuple],
-            "Sentinel" => &[Self::Sentinel],
+            "sentinel" => &[Self::Sentinel],
             "ChainMap" => &[Self::ChainMap],
             "Counter" => &[Self::Counter],
             "defaultdict" => &[Self::DefaultDict],

--- a/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
+++ b/crates/ty_vendored/vendor/typeshed/stdlib/typing_extensions.pyi
@@ -143,6 +143,7 @@ __all__ = [
     "override",
     "Protocol",
     "Sentinel",
+    "sentinel",
     "reveal_type",
     "runtime",
     "runtime_checkable",
@@ -1560,19 +1561,24 @@ else:
         """
 
 # PEP 661
-class Sentinel:
-    """Create a unique sentinel object.
+if sys.version_info >= (3, 15):
+    from builtins import sentinel as sentinel
+else:
+    class sentinel:
+        """Create a unique sentinel object.
 
-    *name* should be the name of the variable to which the return value shall be assigned.
+        *name* should be the name of the variable to which the return value shall be assigned.
 
-    *repr*, if supplied, will be used for the repr of the sentinel object.
-    If not provided, "<name>" will be used.
-    """
+        *repr*, if supplied, will be used for the repr of the sentinel object.
+        If not provided, "<name>" will be used.
+        """
 
-    def __init__(self, name: str, repr: str | None = None) -> None: ...
-    if sys.version_info >= (3, 14):
-        def __or__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
-        def __ror__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
-    else:
-        def __or__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
-        def __ror__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
+        def __init__(self, name: str, repr: str | None = None) -> None: ...
+        if sys.version_info >= (3, 14):
+            def __or__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
+            def __ror__(self, other: Any) -> UnionType: ...  # other can be any type form legal for unions
+        else:
+            def __or__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
+            def __ror__(self, other: Any) -> _SpecialForm: ...  # other can be any type form legal for unions
+
+Sentinel = sentinel


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/3752.

Unfortunately this does require some minor changes to typeshed (https://github.com/python/typeshed/pull/15934), which are themselves blocked on a new `typing_extensions` release. It would be possible to fix https://github.com/astral-sh/ty/issues/3752 without those changes, but it would be significantly less trivial, so I think I'd prefer to just wait for those upstream changes.

## Test Plan

added new mdtests