### PR TITLE
[ty] Store loop headers in use-def maps

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -65,9 +65,8 @@ use crate::use_def::{
 };
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
-    DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopToken,
+    DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopHeaderId,
     NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
-    get_loop_header,
 };
 
 use super::place::PlaceExprRef;
@@ -1670,14 +1669,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     }
 
     /// Create loop header definitions for all places that are bound within a loop. Return the
-    /// `LoopToken` referenced by those definitions, the set of bound place IDs, and the lower
+    /// `LoopHeaderId` referenced by those definitions, the set of bound place IDs, and the lower
     /// bound `ScopedDefinitionId` for definitions created within the loop.
     fn synthesize_loop_header_definitions(
         &mut self,
         loop_stmt: LoopStmtRef<'ast>,
         bound_places: Vec<PlaceExpr>,
-    ) -> (LoopToken<'db>, FxHashSet<ScopedPlaceId>, ScopedDefinitionId) {
-        let loop_token = LoopToken::new(self.db);
+    ) -> (LoopHeaderId, FxHashSet<ScopedPlaceId>, ScopedDefinitionId) {
+        let loop_header_id = self.current_use_def_map_mut().reserve_loop_header();
         let mut bound_place_ids: FxHashSet<ScopedPlaceId> = FxHashSet::default();
         for place_expr in bound_places {
             let place_id = self.add_place(place_expr);
@@ -1685,14 +1684,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 let loop_header_ref = LoopHeaderDefinitionNodeRef {
                     loop_stmt,
                     place: place_id,
-                    loop_token,
+                    loop_header_id,
                 };
                 // Note that `DefinitionKind::LoopHeader` doesn't shadow prior bindings.
                 self.push_additional_definition(place_id, loop_header_ref);
             }
         }
         let loop_min_definition_id = self.current_use_def_map_mut().next_definition_id();
-        (loop_token, bound_place_ids, loop_min_definition_id)
+        (loop_header_id, bound_place_ids, loop_min_definition_id)
     }
 
     /// Build a `LoopHeader` that tracks all the variables bound in a loop, which will be visible
@@ -1702,7 +1701,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
     fn populate_loop_header(
         &mut self,
         loop_header_places: &FxHashSet<ScopedPlaceId>,
-        loop_token: LoopToken<'db>,
+        loop_header_id: LoopHeaderId,
         loop_min_definition_id: ScopedDefinitionId,
     ) {
         let mut loop_header = LoopHeader::new();
@@ -1736,11 +1735,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     .mark_used(live_binding.narrowing_constraint());
             }
         }
-        // The `LoopHeader` needs to be visible to uses within the loop body that we've already
-        // walked, but all our Salsa state is generally immutable. `specify` is how we work around
-        // that. See this section of the Salsa docs:
-        // <https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs>
-        get_loop_header::specify(self.db, loop_token, loop_header);
+        use_def.set_loop_header(loop_header_id, loop_header);
     }
 
     fn synthesize_nested_binding_definitions(
@@ -3368,11 +3363,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ) => {
                 // Pre-walk the loop to collect all the bound places, then create a loop header
                 // definition for each bound place. See `struct LoopHeader` for more on this. Loop
-                // header definitions stash a token to look up the `LoopHeader` later, so that we
-                // can populate the header lazily.
+                // header definitions store the ID of a reserved `LoopHeader` that we populate
+                // after walking the body.
                 let bound_places = loop_bindings_visitor::collect_while_loop_bindings(while_stmt);
                 let mut maybe_loop_header_info = None;
-                // Avoid allocating a `LoopToken` if there are no bound places in this loop.
+                // Avoid allocating a `LoopHeader` if there are no bound places in this loop.
                 if !bound_places.is_empty() {
                     maybe_loop_header_info = Some(self.synthesize_loop_header_definitions(
                         LoopStmtRef::While(while_stmt),
@@ -3408,10 +3403,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // Collect all the loop-back bindings (including the `continue` states we just
                 // merged) and populate the `LoopHeader`.
-                if let Some((loop_token, bound_place_ids, loop_min_definition_id)) =
+                if let Some((header_id, bound_place_ids, loop_min_definition_id)) =
                     maybe_loop_header_info
                 {
-                    self.populate_loop_header(&bound_place_ids, loop_token, loop_min_definition_id);
+                    self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
                 }
 
                 // We execute the `else` branch once the condition evaluates to false. This could
@@ -3492,11 +3487,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // Pre-walk the loop to collect all the bound places, then create a loop header
                 // definition for each bound place. See `struct LoopHeader` for more on this. Loop
-                // header definitions stash a token to look up the `LoopHeader` later, so that we
-                // can populate the header lazily.
+                // header definitions store the ID of a reserved `LoopHeader` that we populate
+                // after walking the body.
                 let bound_places = loop_bindings_visitor::collect_for_loop_bindings(for_stmt);
                 let mut maybe_loop_header_info = None;
-                // Avoid allocating a `LoopToken` if there are no bound places in this loop.
+                // Avoid allocating a `LoopHeader` if there are no bound places in this loop.
                 if !bound_places.is_empty() {
                     maybe_loop_header_info = Some(self.synthesize_loop_header_definitions(
                         LoopStmtRef::For(for_stmt),
@@ -3519,10 +3514,10 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
                 // Collect all the loop-back bindings (including the `continue` states we just
                 // merged) and populate the `LoopHeader`.
-                if let Some((loop_token, bound_place_ids, loop_min_definition_id)) =
+                if let Some((header_id, bound_place_ids, loop_min_definition_id)) =
                     maybe_loop_header_info
                 {
-                    self.populate_loop_header(&bound_place_ids, loop_token, loop_min_definition_id);
+                    self.populate_loop_header(&bound_place_ids, header_id, loop_min_definition_id);
                 }
 
                 // We may execute the `else` clause without ever executing the body, so merge in

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -10,7 +10,7 @@ use ruff_text_size::{Ranged, TextRange, TextSize};
 use smallvec::SmallVec;
 
 use crate::Db;
-use crate::LoopToken;
+use crate::LoopHeaderId;
 use crate::ast_node_ref::AstNodeRef;
 use crate::member::ScopedMemberId;
 use crate::node_key::NodeKey;
@@ -353,7 +353,7 @@ pub(crate) enum DefinitionNodeRef<'ast, 'db> {
     TypeVar(&'ast ast::TypeParamTypeVar),
     ParamSpec(&'ast ast::TypeParamParamSpec),
     TypeVarTuple(&'ast ast::TypeParamTypeVarTuple),
-    LoopHeader(LoopHeaderDefinitionNodeRef<'ast, 'db>),
+    LoopHeader(LoopHeaderDefinitionNodeRef<'ast>),
 }
 
 impl<'ast> From<&'ast ast::StmtFunctionDef> for DefinitionNodeRef<'ast, '_> {
@@ -404,8 +404,8 @@ impl<'ast> From<&'ast ast::TypeParamTypeVarTuple> for DefinitionNodeRef<'ast, '_
     }
 }
 
-impl<'ast, 'db> From<LoopHeaderDefinitionNodeRef<'ast, 'db>> for DefinitionNodeRef<'ast, 'db> {
-    fn from(value: LoopHeaderDefinitionNodeRef<'ast, 'db>) -> Self {
+impl<'ast> From<LoopHeaderDefinitionNodeRef<'ast>> for DefinitionNodeRef<'ast, '_> {
+    fn from(value: LoopHeaderDefinitionNodeRef<'ast>) -> Self {
         Self::LoopHeader(value)
     }
 }
@@ -555,10 +555,10 @@ pub(crate) struct ExceptHandlerDefinitionNodeRef<'ast> {
 }
 
 #[derive(Copy, Clone, Debug)]
-pub(crate) struct LoopHeaderDefinitionNodeRef<'ast, 'db> {
+pub(crate) struct LoopHeaderDefinitionNodeRef<'ast> {
     pub(crate) loop_stmt: LoopStmtRef<'ast>,
     pub(crate) place: ScopedPlaceId,
-    pub(crate) loop_token: LoopToken<'db>,
+    pub(crate) loop_header_id: LoopHeaderId,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -784,9 +784,9 @@ impl<'db> DefinitionNodeRef<'_, 'db> {
             DefinitionNodeRef::LoopHeader(LoopHeaderDefinitionNodeRef {
                 loop_stmt,
                 place,
-                loop_token,
+                loop_header_id,
             }) => DefinitionKind::LoopHeader(LoopHeaderDefinitionKind {
-                loop_token,
+                loop_header_id,
                 loop_stmt: match loop_stmt {
                     LoopStmtRef::While(stmt) => LoopStmtKind::While(AstNodeRef::new(parsed, stmt)),
                     LoopStmtRef::For(stmt) => LoopStmtKind::For(AstNodeRef::new(parsed, stmt)),
@@ -934,7 +934,7 @@ pub enum DefinitionKind<'db> {
     TypeVar(AstNodeRef<ast::TypeParamTypeVar>),
     ParamSpec(AstNodeRef<ast::TypeParamParamSpec>),
     TypeVarTuple(AstNodeRef<ast::TypeParamTypeVarTuple>),
-    LoopHeader(LoopHeaderDefinitionKind<'db>),
+    LoopHeader(LoopHeaderDefinitionKind),
     // Boxing here helps avoid growing the memory footprint of this enum.
     NestedBindings(Box<NestedBindingsDefinitionKind>),
 }
@@ -1559,10 +1559,9 @@ impl ExceptHandlerDefinitionKind {
 
 /// Definition kind for a loop header entry.
 #[derive(Clone, Debug, get_size2::GetSize)]
-pub struct LoopHeaderDefinitionKind<'db> {
-    /// The `LoopHeader` struct isn't ready when this type of definition is created. Instead we
-    /// look it up later by passing this token to `get_loop_header`.
-    loop_token: LoopToken<'db>,
+pub struct LoopHeaderDefinitionKind {
+    /// The `LoopHeader` is reserved before walking the loop and populated afterward.
+    loop_header_id: LoopHeaderId,
     loop_stmt: LoopStmtKind,
     place: ScopedPlaceId,
 }
@@ -1573,9 +1572,9 @@ pub(crate) enum LoopStmtKind {
     For(AstNodeRef<ast::StmtFor>),
 }
 
-impl<'db> LoopHeaderDefinitionKind<'db> {
-    pub fn loop_token(&self) -> LoopToken<'db> {
-        self.loop_token
+impl LoopHeaderDefinitionKind {
+    pub fn loop_header_id(&self) -> LoopHeaderId {
+        self.loop_header_id
     }
 
     pub fn place(&self) -> ScopedPlaceId {

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -34,7 +34,7 @@ use scope::{NodeWithScopeKey, NodeWithScopeRef, Scope, ScopeId, ScopeKind, Scope
 use symbol::ScopedSymbolId;
 pub use use_def::{
     ApplicableConstraints, BindingWithConstraints, BindingWithConstraintsIterator,
-    DeclarationWithConstraint, DeclarationsIterator, LiveBinding, NarrowingEvaluator,
+    DeclarationWithConstraint, DeclarationsIterator, LiveBinding, LoopHeaderId, NarrowingEvaluator,
     ScopedDefinitionId, UseDefMap,
 };
 use use_def::{EnclosingSnapshotKey, ScopedEnclosingSnapshotId};
@@ -132,9 +132,10 @@ pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<UseDefMap<'
 /// literals (`Literal[0, 1, 2, ...]`) until we eventually reach the threshold for widening to
 /// `int` and stop iterating. (See `should_widen` and `widen_literal_types`.)
 ///
-/// There's a chicken-and-egg problem with synthesizing the `DefinitionKind::LoopHeader`
-/// definitions at the top of the loop, and assembling all the bindings in the `LoopHeader` struct
-/// that they refer to. See `LoopToken` below for how we work around that.
+/// Loop header definitions are synthesized before walking the loop body, but the bindings in the
+/// header are only known after walking all loop-back edges. The builder reserves a [`LoopHeaderId`]
+/// before the walk, fills the corresponding header afterward, and publishes the completed headers
+/// in the scope's [`UseDefMap`].
 #[derive(Debug, Clone, Default, PartialEq, Eq, Update, get_size2::GetSize)]
 pub struct LoopHeader {
     bindings: FxHashMap<ScopedPlaceId, SmallVec<[LiveBinding; 1]>>,
@@ -161,33 +162,6 @@ impl LoopHeader {
             .into_iter()
             .flatten()
     }
-}
-
-/// A Salsa token for retrieving a `LoopHeader`. See `get_loop_header` below.
-#[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
-pub struct LoopToken<'db> {}
-
-impl get_size2::GetSize for LoopToken<'_> {}
-
-/// Look up a `LoopHeader` given a `LoopToken`.
-///
-/// Loop header definitions are the very first things we encounter (synthesize) when we walk a
-/// loop, and they need to refer to the corresponding the `LoopHeader` struct that records their
-/// bindings, but that struct isn't available until we've finished walking the loop. To make this
-/// work in the largely immutable world of Salsa, we add a layer of indirection using a Salsa
-/// feature called "specify":
-/// <https://salsa-rs.github.io/salsa/overview.html#specify-the-result-of-tracked-functions-for-particular-structs>
-///
-/// When we first encounter a loop, we generate a `LoopToken` that uniquely identifies the loop but
-/// doesn't contain any data. We do a lightweight pre-walk to collect bound places (see
-/// `LoopBindingsVisitor`), and for each bound place we create a loop header definition that stores
-/// the `LoopToken`. Then after we've finished visiting the loop, we call
-/// `get_loop_header::specify` to associate the token with the completed `LoopHeader`. All of this
-/// happens while we're building the semantic index, and nothing needs to call `get_loop_header`
-/// until we get to type inference later, so the order of operations always works out.
-#[salsa::tracked(specify, heap_size=ruff_memory_usage::heap_size)]
-pub fn get_loop_header<'db>(_db: &'db dyn Db, _loop_token: LoopToken<'db>) -> LoopHeader {
-    panic!("should always be set by specify()");
 }
 
 /// Returns all attribute assignments as scope IDs for a specific class body scope.

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -269,13 +269,20 @@ use crate::use_def::place_state::{
     Bindings, Declarations, EnclosingSnapshot, LiveBindingsIterator, LiveDeclaration,
     LiveDeclarationsIterator, PlaceState,
 };
-use crate::{BoundnessAnalysis, EnclosingSnapshotResult, PossiblyNarrowedPlaces, SemanticIndex};
+use crate::{
+    BoundnessAnalysis, EnclosingSnapshotResult, LoopHeader, PossiblyNarrowedPlaces, SemanticIndex,
+};
 
 mod place_state;
 
 pub use place_state::LiveBinding;
 pub use place_state::ScopedDefinitionId;
 pub(super) use place_state::{FutureDefinitions, PreviousDefinitions};
+
+/// Identifies a [`LoopHeader`] within a single scope's [`UseDefMap`].
+#[newtype_index]
+#[derive(salsa::Update, get_size2::GetSize)]
+pub struct LoopHeaderId;
 
 /// Uniquely identifies an interned [`Bindings`] entry in [`UseDefMap::interned_bindings`].
 #[newtype_index]
@@ -589,7 +596,7 @@ struct ConstraintTables<'db> {
 
 /// Fields that are empty in most use-def maps.
 ///
-/// These fields share an allocation to avoid storing four collection headers in every
+/// These fields share an allocation to avoid storing five collection headers in every
 /// [`UseDefMap`]. They are not otherwise semantically related.
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 struct UseDefMapExtra {
@@ -607,6 +614,9 @@ struct UseDefMapExtra {
 
     /// Snapshots of bindings used to resolve references from nested scopes.
     enclosing_snapshots: FrozenIndexVec<ScopedEnclosingSnapshotId, InternedEnclosingSnapshotId>,
+
+    /// Completed loop headers in this scope.
+    loop_headers: FrozenIndexVec<LoopHeaderId, LoopHeader>,
 }
 
 static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
@@ -729,7 +739,11 @@ impl<'db> UseDefMap<'db> {
     fn extra(&self) -> &UseDefMapExtra {
         self.extra
             .as_deref()
-            .expect("bindings and member states should have been retained")
+            .expect("extra use-def data should have been retained")
+    }
+
+    pub fn loop_header(&self, id: LoopHeaderId) -> &LoopHeader {
+        &self.extra().loop_headers[id]
     }
 
     pub fn reachability_constraints(&self) -> &ReachabilityConstraints {
@@ -1534,6 +1548,9 @@ pub(super) struct UseDefMapBuilder<'db> {
     /// nested scope.
     enclosing_snapshots: EnclosingSnapshots,
 
+    /// Loop headers reserved before walking a loop and populated afterward.
+    loop_headers: IndexVec<LoopHeaderId, LoopHeader>,
+
     /// Is this a class scope?
     is_class_scope: bool,
 }
@@ -1557,8 +1574,17 @@ impl<'db> UseDefMapBuilder<'db> {
             reachable_member_definitions: IndexVec::new(),
             reachable_symbol_definitions: IndexVec::new(),
             enclosing_snapshots: EnclosingSnapshots::default(),
+            loop_headers: IndexVec::new(),
             is_class_scope,
         }
+    }
+
+    pub(super) fn reserve_loop_header(&mut self) -> LoopHeaderId {
+        self.loop_headers.push(LoopHeader::new())
+    }
+
+    pub(super) fn set_loop_header(&mut self, id: LoopHeaderId, header: LoopHeader) {
+        self.loop_headers[id] = header;
     }
 
     fn push_definition(&mut self, state: DefinitionState<'db>) -> ScopedDefinitionId {
@@ -2483,15 +2509,18 @@ impl<'db> UseDefMapBuilder<'db> {
         let member_states =
             Self::zip_place_states(end_of_scope_members, reachable_definitions_by_member);
         let multi_bindings_by_use = MultiBindingsByUse::from_map(self.multi_bindings_by_use);
+        let loop_headers = self.loop_headers;
         let extra = (!bindings_by_use.is_empty()
             || !member_states.is_empty()
-            || !enclosing_snapshots.is_empty())
+            || !enclosing_snapshots.is_empty()
+            || !loop_headers.is_empty())
         .then(|| {
             Box::new(UseDefMapExtra {
                 bindings_by_use: bindings_by_use.into(),
                 multi_bindings_by_use,
                 member_states,
                 enclosing_snapshots: enclosing_snapshots.into(),
+                loop_headers: loop_headers.into(),
             })
         });
         let predicates = self.predicates.build();

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -26,8 +26,8 @@ use ty_python_core::reachability_constraints::{
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraints, BindingWithConstraintsIterator, BoundnessAnalysis,
-    DeclarationWithConstraint, DeclarationsIterator, Truthiness, get_loop_header, global_scope,
-    place_table, use_def_map,
+    DeclarationWithConstraint, DeclarationsIterator, Truthiness, global_scope, place_table,
+    use_def_map,
 };
 
 pub(crate) use implicit_globals::{
@@ -1368,7 +1368,7 @@ fn loop_header_reachability_impl<'db>(
 
     let scope = definition.scope(db);
     let use_def = use_def_map(db, scope);
-    let loop_header = get_loop_header(db, loop_header_definition.loop_token());
+    let loop_header = use_def.loop_header(loop_header_definition.loop_header_id());
     let place = loop_header_definition.place();
 
     let mut deleted_reachability = Truthiness::AlwaysFalse;

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet;
 use ty_python_core::definition::{DefinitionCategory, DefinitionKind, DefinitionState};
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
-use ty_python_core::{SemanticIndex, get_loop_header, semantic_index};
+use ty_python_core::{SemanticIndex, semantic_index};
 
 /// Returns `true` for definition kinds that create user-facing bindings we consider for
 /// unused-binding diagnostics.
@@ -113,7 +113,7 @@ pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBi
                     continue;
                 };
 
-                let loop_header = get_loop_header(db, loop_header_definition.loop_token());
+                let loop_header = use_def_map.loop_header(loop_header_definition.loop_header_id());
                 for live_binding in loop_header.bindings_for_place(loop_header_definition.place()) {
                     if is_reachable(db, use_def_map, live_binding.reachability_constraint()) {
                         loop_header_used_definition_ids.insert(live_binding.binding());

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2199,7 +2199,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// LoopHeader` in the semantic index for more on how all this fits together.
     fn infer_loop_header_definition(
         &mut self,
-        loop_header_kind: &LoopHeaderDefinitionKind<'db>,
+        loop_header_kind: &LoopHeaderDefinitionKind,
         definition: Definition<'db>,
     ) {
         // This cutoff was chosen by benchmarking real isort to keep loop analysis


### PR DESCRIPTION
## Summary

Store loop headers in each scope's use-def map and refer to them with a lightweight scope-local ID. This removes the LoopToken tracked struct and specified get_loop_header query while preserving loop analysis behavior.

## Test Plan

Testing: Ran the focused ty core and semantic test suites.