### PR TITLE
[ty] Implement rust-analyzer's "Click for full compiler diagnostic" feature

### DIFF
--- a/crates/ty_server/README.md
+++ b/crates/ty_server/README.md
@@ -1,0 +1,32 @@
+# The ty Language Server
+
+`ty server` implements the Language Server Protocol for ty's editor integrations.
+
+## LSP extensions
+
+This document describes ty's extensions to the Language Server Protocol. These extensions are a best-effort contract between the server and its clients; when in doubt, consult the implementation.
+
+Client capabilities for these extensions are advertised through the `experimental` field of [`ClientCapabilities`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities).
+
+### Full diagnostic output
+
+Experimental client capability: `{ "fullDiagnosticOutput": boolean }`
+
+When this capability is `true`, ty includes a human-readable multiline rendering of a diagnostic in the diagnostic's `data` field.
+
+```ts
+interface Diagnostic {
+    // Standard LSP fields omitted.
+    data?: {
+        /** A human-readable multiline rendering of the diagnostic. */
+        rendered?: string;
+
+        /** The original ty diagnostic identifier, such as `invalid-argument-type`. */
+        diagnostic_id?: string;
+
+        // Other ty-specific fields may also be present.
+    };
+}
+```
+
+For diagnostics that support this extension, `rendered` and `diagnostic_id` are either both present or both absent. Clients may use `diagnostic_id` to preserve the original identifier if they replace `Diagnostic.code` with a link to the rendered output. Clients must preserve `Diagnostic.data` when returning a diagnostic in a `textDocument/codeAction` request so that code actions continue to work.

--- a/crates/ty_server/README.md
+++ b/crates/ty_server/README.md
@@ -2,31 +2,4 @@
 
 `ty server` implements the Language Server Protocol for ty's editor integrations.
 
-## LSP extensions
-
-This document describes ty's extensions to the Language Server Protocol. These extensions are a best-effort contract between the server and its clients; when in doubt, consult the implementation.
-
-Client capabilities for these extensions are advertised through the `experimental` field of [`ClientCapabilities`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#clientCapabilities).
-
-### Full diagnostic output
-
-Experimental client capability: `{ "fullDiagnosticOutput": boolean }`
-
-When this capability is `true`, ty includes a human-readable multiline rendering of a diagnostic in the diagnostic's `data` field.
-
-```ts
-interface Diagnostic {
-    // Standard LSP fields omitted.
-    data?: {
-        /** A human-readable multiline rendering of the diagnostic. */
-        rendered?: string;
-
-        /** The original ty diagnostic identifier, such as `invalid-argument-type`. */
-        diagnostic_id?: string;
-
-        // Other ty-specific fields may also be present.
-    };
-}
-```
-
-For diagnostics that support this extension, `rendered` and `diagnostic_id` are either both present or both absent. Clients may use `diagnostic_id` to preserve the original identifier if they replace `Diagnostic.code` with a link to the rendered output. Clients must preserve `Diagnostic.data` when returning a diagnostic in a `textDocument/codeAction` request so that code actions continue to work.
+Extensions to the protocol are documented in the [ty language server documentation](https://docs.astral.sh/ty/features/language-server/).

--- a/crates/ty_server/src/capabilities.rs
+++ b/crates/ty_server/src/capabilities.rs
@@ -35,6 +35,7 @@ bitflags::bitflags! {
         const DIAGNOSTIC_RELATED_INFORMATION = 1 << 17;
         const PREFER_MARKDOWN_IN_COMPLETION = 1 << 18;
         const COMPLETION_ITEM_SNIPPET_SUPPORT = 1 << 19;
+        const FULL_DIAGNOSTIC_OUTPUT = 1 << 20;
     }
 }
 
@@ -174,6 +175,11 @@ impl ResolvedClientCapabilities {
         self.contains(Self::DIAGNOSTIC_RELATED_INFORMATION)
     }
 
+    /// Returns `true` if the client supports opening fully rendered diagnostics.
+    pub(crate) const fn supports_full_diagnostic_output(self) -> bool {
+        self.contains(Self::FULL_DIAGNOSTIC_OUTPUT)
+    }
+
     /// Returns `true` if the client supports "label details" in completion items.
     pub(crate) const fn supports_completion_item_label_details(self) -> bool {
         self.contains(Self::COMPLETION_ITEM_LABEL_DETAILS_SUPPORT)
@@ -247,6 +253,17 @@ impl ResolvedClientCapabilities {
             {
                 flags |= Self::DIAGNOSTIC_RELATED_INFORMATION;
             }
+        }
+
+        if client_capabilities
+            .experimental
+            .as_ref()
+            // Protocol: crates/ty_server/README.md#full-diagnostic-output
+            .and_then(|experimental| experimental.get("fullDiagnosticOutput"))
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or_default()
+        {
+            flags |= Self::FULL_DIAGNOSTIC_OUTPUT;
         }
 
         if text_document

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -9,11 +9,12 @@ use lsp_types::{
 };
 use ruff_diagnostics::Applicability;
 use ruff_text_size::Ranged;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use ty_ide::{Hint, hints};
 
-use ruff_db::diagnostic::{Annotation, Severity, SubDiagnostic};
+use ruff_db::diagnostic::{Annotation, DisplayDiagnosticConfig, Severity, SubDiagnostic};
 use ruff_db::files::{File, FileRange};
+use ruff_db::source::source_text;
 use ruff_db::system::SystemPathBuf;
 use serde::{Deserialize, Serialize};
 use ty_project::{Db as _, ProjectDatabase};
@@ -37,29 +38,64 @@ pub(super) struct Diagnostics {
 impl Diagnostics {
     /// Computes the result ID for `diagnostics`.
     ///
-    /// Returns `None` if there are no diagnostics.
+    /// The result ID is `None` if there are no diagnostics or hints.
     pub(super) fn result_id_from_hash(
+        db: &dyn Db,
         diagnostics: &[ruff_db::diagnostic::Diagnostic],
         unnecessary_hints: &[Hint],
+        client_capabilities: ResolvedClientCapabilities,
     ) -> Option<String> {
         if diagnostics.is_empty() && unnecessary_hints.is_empty() {
             return None;
         }
 
-        // Generate result ID based on raw diagnostic content only.
+        // Generate the base result ID from raw diagnostic content.
         let mut hasher = DefaultHasher::new();
 
         diagnostics.hash(&mut hasher);
         unnecessary_hints.hash(&mut hasher);
+
+        if client_capabilities.supports_full_diagnostic_output() {
+            // The rendered output includes source snippets that aren't part of the raw diagnostic.
+            // Hash each referenced file's source once so that source-only changes invalidate the
+            // result without eagerly rendering every diagnostic. Hashing the entire file is
+            // deliberately conservative: an edit outside the rendered context can cause a full
+            // report, but an edit inside it can never leave stale rendered output on the client.
+            let mut hashed_files = FxHashSet::default();
+
+            for diagnostic in diagnostics {
+                let annotations = diagnostic
+                    .sub_diagnostics()
+                    .iter()
+                    .flat_map(SubDiagnostic::annotations)
+                    .chain(diagnostic.annotations());
+
+                for annotation in annotations {
+                    let file = annotation.get_span().expect_ty_file();
+                    if hashed_files.insert(file) {
+                        source_text(db, file).as_str().hash(&mut hasher);
+                    }
+                }
+            }
+        }
 
         Some(format!("{:016x}", hasher.finish()))
     }
 
     /// Computes the result ID for the diagnostics.
     ///
-    /// Returns `None` if there are no diagnostics.
-    pub(super) fn result_id(&self) -> Option<String> {
-        Self::result_id_from_hash(&self.items, &self.unnecessary_hints)
+    /// The result ID is `None` if there are no diagnostics or hints.
+    pub(super) fn result_id(
+        &self,
+        db: &dyn Db,
+        client_capabilities: ResolvedClientCapabilities,
+    ) -> Option<String> {
+        Self::result_id_from_hash(
+            db,
+            &self.items,
+            &self.unnecessary_hints,
+            client_capabilities,
+        )
     }
 
     pub(super) fn to_lsp_diagnostics(
@@ -77,7 +113,7 @@ impl Diagnostics {
                 cell_diagnostics.entry(cell_uri.clone()).or_default();
             }
 
-            for diagnostic in &*self.items {
+            for diagnostic in &self.items {
                 let Some((uri, lsp_diagnostic)) = to_lsp_diagnostic(
                     db,
                     diagnostic,
@@ -478,7 +514,12 @@ pub(super) fn to_lsp_diagnostic(
             None
         };
 
-    let data = DiagnosticData::try_from_diagnostic(db, diagnostic, encoding);
+    let data = DiagnosticData::try_from_diagnostic(
+        db,
+        diagnostic,
+        encoding,
+        FullDiagnosticOutput::from_client_capabilities(client_capabilities),
+    );
 
     let mut message = if supports_related_information {
         // Show both the primary and annotation messages if available,
@@ -566,10 +607,41 @@ fn sub_diagnostic_to_related_information(
     })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FullDiagnosticOutput {
+    Enabled,
+    Disabled,
+}
+
+impl FullDiagnosticOutput {
+    fn from_client_capabilities(client_capabilities: ResolvedClientCapabilities) -> Self {
+        if client_capabilities.supports_full_diagnostic_output() {
+            Self::Enabled
+        } else {
+            Self::Disabled
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize)]
-pub(crate) struct DiagnosticData {
+pub(crate) struct FullDiagnosticData {
+    rendered: String,
+    pub(crate) diagnostic_id: String,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub(crate) fix: Option<DiagnosticFixData>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub(crate) struct DiagnosticFixData {
     pub(crate) fix_title: String,
     pub(crate) edits: HashMap<Uri, Vec<lsp_types::TextEdit>>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum DiagnosticData {
+    Full(FullDiagnosticData),
+    Fix(DiagnosticFixData),
 }
 
 impl DiagnosticData {
@@ -577,7 +649,30 @@ impl DiagnosticData {
         db: &dyn Db,
         diagnostic: &ruff_db::diagnostic::Diagnostic,
         encoding: PositionEncoding,
+        full_diagnostic_output: FullDiagnosticOutput,
     ) -> Option<Self> {
+        let fix = Self::try_fix_from_diagnostic(db, diagnostic, encoding);
+
+        match full_diagnostic_output {
+            FullDiagnosticOutput::Enabled => Some(Self::Full(FullDiagnosticData {
+                rendered: diagnostic
+                    .display(
+                        &(db as &dyn ruff_db::Db),
+                        &DisplayDiagnosticConfig::new("ty").color(false),
+                    )
+                    .to_string(),
+                diagnostic_id: diagnostic.id().to_string(),
+                fix,
+            })),
+            FullDiagnosticOutput::Disabled => fix.map(Self::Fix),
+        }
+    }
+
+    fn try_fix_from_diagnostic(
+        db: &dyn Db,
+        diagnostic: &ruff_db::diagnostic::Diagnostic,
+        encoding: PositionEncoding,
+    ) -> Option<DiagnosticFixData> {
         let fix = diagnostic
             .fix()
             .filter(|fix| fix.applies(Applicability::Unsafe))?;
@@ -602,7 +697,7 @@ impl DiagnosticData {
                 });
         }
 
-        Some(Self {
+        Some(DiagnosticFixData {
             fix_title: diagnostic
                 .first_help_text()
                 .map(ToString::to_string)

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -58,9 +58,10 @@ impl Diagnostics {
         if client_capabilities.supports_full_diagnostic_output() {
             // The rendered output includes source snippets that aren't part of the raw diagnostic.
             // Hash each referenced file's source once so that source-only changes invalidate the
-            // result without eagerly rendering every diagnostic. Hashing the entire file is
-            // deliberately conservative: an edit outside the rendered context can cause a full
-            // report, but an edit inside it can never leave stale rendered output on the client.
+            // result without eagerly rendering every diagnostic.
+            // TODO: Hash only the source snippets used by the rendered output. Hashing the entire
+            // file is deliberately conservative: an edit outside the rendered context can cause a
+            // full report, but an edit inside it can never leave stale rendered output on the client.
             let mut hashed_files = FxHashSet::default();
 
             for diagnostic in diagnostics {

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -47,6 +47,11 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
             diagnostic.source.as_deref() == Some(DIAGNOSTIC_NAME)
                 && range_intersect(&diagnostic.range, &params.range)
         }) {
+            let mut diagnostic_id = match &diagnostic.code {
+                Some(Code::String(diagnostic_id)) => Some(Cow::Borrowed(diagnostic_id)),
+                _ => None,
+            };
+
             // If the diagnostic includes fixes, offer those up as options.
             if let Some(data) = diagnostic.data.take() {
                 let data: DiagnosticData = match serde_json::from_value(data) {
@@ -57,21 +62,31 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
                     }
                 };
 
-                actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
-                    title: data.fix_title,
-                    kind: Some(CodeActionKind::QuickFix),
-                    diagnostics: Some(vec![diagnostic.clone()]),
-                    edit: Some(lsp_types::WorkspaceEdit {
-                        changes: Some(data.edits),
-                        document_changes: None,
-                        change_annotations: None,
-                    }),
-                    is_preferred: Some(true),
-                    command: None,
-                    disabled: None,
-                    data: None,
-                    tags: None,
-                }));
+                let fix = match data {
+                    DiagnosticData::Full(full_diagnostic) => {
+                        diagnostic_id = Some(Cow::Owned(full_diagnostic.diagnostic_id));
+                        full_diagnostic.fix
+                    }
+                    DiagnosticData::Fix(fix) => Some(fix),
+                };
+
+                if let Some(fix) = fix {
+                    actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
+                        title: fix.fix_title,
+                        kind: Some(CodeActionKind::QuickFix),
+                        diagnostics: Some(vec![diagnostic.clone()]),
+                        edit: Some(lsp_types::WorkspaceEdit {
+                            changes: Some(fix.edits),
+                            document_changes: None,
+                            change_annotations: None,
+                        }),
+                        is_preferred: Some(true),
+                        command: None,
+                        disabled: None,
+                        data: None,
+                        tags: None,
+                    }));
+                }
             }
 
             // Try to find other applicable actions.
@@ -81,10 +96,10 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
             // which is dubious when you're in the middle of resolving symbols.
             let uri = snapshot.uri();
             let encoding = snapshot.encoding();
-            if let Some(Code::String(diagnostic_id)) = &diagnostic.code
+            if let Some(diagnostic_id) = diagnostic_id
                 && let Some(range) = diagnostic.range.to_text_range(db, file, uri, encoding)
             {
-                for action in code_actions(db, file, range, diagnostic_id) {
+                for action in code_actions(db, file, range, &diagnostic_id) {
                     actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
                         title: action.title,
                         kind: Some(CodeActionKind::QuickFix),

--- a/crates/ty_server/src/server/api/requests/diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/diagnostic.rs
@@ -43,7 +43,7 @@ impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
             return Ok(RelatedFullDocumentDiagnosticReport::default().into());
         };
 
-        let result_id = diagnostics.result_id();
+        let result_id = diagnostics.result_id(db, snapshot.resolved_client_capabilities());
 
         let report = match result_id {
             Some(new_id) if Some(&new_id) == params.previous_result_id.as_ref() => {

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -399,7 +399,12 @@ impl<'a> ResponseWriter<'a> {
             .map(|doc| doc.version())
             .ok();
 
-        let result_id = Diagnostics::result_id_from_hash(diagnostics, unnecessary_hints);
+        let result_id = Diagnostics::result_id_from_hash(
+            db,
+            diagnostics,
+            unnecessary_hints,
+            self.client_capabilities,
+        );
 
         let previous_result_id = self.previous_result_ids.remove(&key).map(|(_uri, id)| id);
 
@@ -488,7 +493,7 @@ impl<'a> ResponseWriter<'a> {
             clippy::iter_over_hash_type,
             reason = "workspace diagnostic reports are independently identified by URI"
         )]
-        for (key, (previous_uri, previous_result_id)) in self.previous_result_ids {
+        for (key, (previous_uri, _)) in self.previous_result_ids {
             // This file had diagnostics before but doesn't now, so we need to report it as having no diagnostics
             let version = self
                 .index
@@ -496,31 +501,15 @@ impl<'a> ResponseWriter<'a> {
                 .ok()
                 .map(crate::session::index::Document::version);
 
-            let new_result_id = Diagnostics::result_id_from_hash(&[], &[]);
-
-            let report = match new_result_id {
-                Some(new_id) if new_id == previous_result_id => {
-                    WorkspaceUnchangedDocumentDiagnosticReport {
-                        uri: previous_uri,
-                        version,
-                        unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
-                            result_id: new_id,
-                        },
-                    }
-                    .into()
-                }
-                new_id => {
-                    WorkspaceFullDocumentDiagnosticReport {
-                        uri: previous_uri,
-                        version,
-                        full_document_diagnostic_report: FullDocumentDiagnosticReport {
-                            result_id: new_id,
-                            items: vec![], // No diagnostics
-                        },
-                    }
-                    .into()
-                }
-            };
+            let report = WorkspaceFullDocumentDiagnosticReport {
+                uri: previous_uri,
+                version,
+                full_document_diagnostic_report: FullDocumentDiagnosticReport {
+                    result_id: None,
+                    items: vec![],
+                },
+            }
+            .into();
 
             items.push(report);
         }

--- a/crates/ty_server/tests/e2e/code_actions.rs
+++ b/crates/ty_server/tests/e2e/code_actions.rs
@@ -157,6 +157,44 @@ x: Literal[1] = 1
     Ok(())
 }
 
+#[test]
+fn code_action_with_full_diagnostic_output_link() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+x: Literal[1] = 1
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(SystemPath::new("ty.toml"), "")?
+        .with_file(foo, foo_content)?
+        .with_full_diagnostic_output()
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+
+    let diagnostics = server.document_diagnostic_request(foo, None);
+    let mut code_action_params =
+        code_actions_at(&server, diagnostics, foo, full_range(foo_content));
+
+    // The ty VS Code extension replaces the diagnostic code with a link label.
+    // The original diagnostic ID in `data` must still drive lazy code actions.
+    for diagnostic in &mut code_action_params.context.diagnostics {
+        diagnostic.code = Some(lsp_types::Code::String(
+            "Click for full diagnostic".to_string(),
+        ));
+    }
+
+    let code_action_id = server.send_request::<CodeActionRequest>(code_action_params);
+    let code_actions = server.await_response::<CodeActionRequest>(&code_action_id);
+
+    assert_eq!(code_actions.as_ref().map(Vec::len), Some(2));
+
+    Ok(())
+}
+
 // Using an unimported decorator `@deprecated`
 #[test]
 fn code_action_undefined_decorator() -> Result<()> {

--- a/crates/ty_server/tests/e2e/code_actions.rs
+++ b/crates/ty_server/tests/e2e/code_actions.rs
@@ -190,7 +190,7 @@ x: Literal[1] = 1
     let code_action_id = server.send_request::<CodeActionRequest>(code_action_params);
     let code_actions = server.await_response::<CodeActionRequest>(&code_action_id);
 
-    assert_eq!(code_actions.as_ref().map(Vec::len), Some(2));
+    insta::assert_json_snapshot!(code_actions);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1378,6 +1378,14 @@ impl TestServerBuilder {
         self
     }
 
+    /// Advertise support for ty's fully rendered diagnostic output.
+    pub(crate) fn with_full_diagnostic_output(mut self) -> Self {
+        self.client_capabilities.experimental = Some(serde_json::json!({
+            "fullDiagnosticOutput": true,
+        }));
+        self
+    }
+
     /// Set custom client capabilities (overrides any previously set capabilities)
     #[expect(dead_code)]
     pub(crate) fn with_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {

--- a/crates/ty_server/tests/e2e/main.rs
+++ b/crates/ty_server/tests/e2e/main.rs
@@ -1483,6 +1483,7 @@ impl TestContext {
             .map_err(|()| anyhow!("Failed to convert root directory to uri"))?;
         settings.add_filter(&tempdir_filter(project_dir.as_str()), "<temp_dir>/");
         settings.add_filter(&tempdir_filter(project_dir_uri.path()), "<temp_dir>/");
+        settings.add_filter(r#"\\\\"#, "/");
         settings.add_filter(
             r#"The system cannot find the file specified."#,
             "No such file or directory",

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -36,6 +36,46 @@ def foo() -> str:
     Ok(())
 }
 
+#[test]
+fn full_diagnostic_output() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content = "\
+def foo() -> str:
+    return 42
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content)?
+        .with_full_diagnostic_output()
+        .enable_pull_diagnostics(false)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content, 1);
+    let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
+    let rendered = diagnostics.diagnostics[0]
+        .data
+        .as_ref()
+        .and_then(|data| data.get("rendered"))
+        .and_then(serde_json::Value::as_str)
+        .expect("diagnostic should include fully rendered output");
+    let diagnostic_id = diagnostics.diagnostics[0]
+        .data
+        .as_ref()
+        .and_then(|data| data.get("diagnostic_id"))
+        .and_then(serde_json::Value::as_str);
+
+    assert_eq!(diagnostic_id, Some("invalid-return-type"));
+    assert!(rendered.contains("Return type does not match returned value"));
+    assert!(rendered.contains("def foo() -> str:"));
+    assert!(rendered.contains("return 42"));
+    assert!(rendered.contains("invalid-return-type"));
+
+    Ok(())
+}
+
 /// Tests that we get diagnostics for a file that is NOT saved to
 /// disk when using `OpenFilesOnly` diagnostic mode.
 #[test]

--- a/crates/ty_server/tests/e2e/publish_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/publish_diagnostics.rs
@@ -55,23 +55,8 @@ def foo() -> str:
 
     server.open_text_document(foo, foo_content, 1);
     let diagnostics = server.await_notification::<PublishDiagnosticsNotification>();
-    let rendered = diagnostics.diagnostics[0]
-        .data
-        .as_ref()
-        .and_then(|data| data.get("rendered"))
-        .and_then(serde_json::Value::as_str)
-        .expect("diagnostic should include fully rendered output");
-    let diagnostic_id = diagnostics.diagnostics[0]
-        .data
-        .as_ref()
-        .and_then(|data| data.get("diagnostic_id"))
-        .and_then(serde_json::Value::as_str);
 
-    assert_eq!(diagnostic_id, Some("invalid-return-type"));
-    assert!(rendered.contains("Return type does not match returned value"));
-    assert!(rendered.contains("def foo() -> str:"));
-    assert!(rendered.contains("return 42"));
-    assert!(rendered.contains("invalid-return-type"));
+    insta::assert_debug_snapshot!(diagnostics);
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -544,6 +544,68 @@ def foo() -> str:
 }
 
 #[test]
+fn document_diagnostic_caching_rendered_source_changed() -> Result<()> {
+    let workspace_root = SystemPath::new("src");
+    let foo = SystemPath::new("src/foo.py");
+    let foo_content_v1 = "\
+def foo() -> str:
+    return 42  # before
+";
+    let foo_content_v2 = "\
+def foo() -> str:
+    return 42  # after!
+";
+
+    let mut server = TestServerBuilder::new()?
+        .with_workspace(workspace_root, None)?
+        .with_file(foo, foo_content_v1)?
+        .with_full_diagnostic_output()
+        .enable_pull_diagnostics(true)
+        .build()
+        .wait_until_workspaces_are_initialized();
+
+    server.open_text_document(foo, foo_content_v1, 1);
+
+    let first_response = server.document_diagnostic_request(foo, None);
+    let result_id = match first_response {
+        DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => report
+            .full_document_diagnostic_report
+            .result_id
+            .expect("First response should have a result ID"),
+        DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
+            panic!("First response should be a full report")
+        }
+    };
+
+    server.change_text_document(
+        foo,
+        vec![
+            lsp_types::TextDocumentContentChangeEvent::TextDocumentContentChangeWholeDocument(
+                TextDocumentContentChangeWholeDocument {
+                    text: foo_content_v2.to_string(),
+                },
+            ),
+        ],
+        2,
+    );
+
+    let second_response = server.document_diagnostic_request(foo, Some(result_id));
+    let DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) = second_response
+    else {
+        panic!("Expected a full report when the rendered source changed");
+    };
+    let rendered = report.full_document_diagnostic_report.items[0]
+        .data
+        .as_ref()
+        .and_then(|data| data.get("rendered"))
+        .and_then(serde_json::Value::as_str)
+        .expect("Diagnostic should include rendered output");
+    assert!(rendered.contains("# after!"));
+
+    Ok(())
+}
+
+#[test]
 fn workspace_diagnostic_caching() -> Result<()> {
     let _filter = filter_result_id();
 

--- a/crates/ty_server/tests/e2e/pull_diagnostics.rs
+++ b/crates/ty_server/tests/e2e/pull_diagnostics.rs
@@ -545,6 +545,8 @@ def foo() -> str:
 
 #[test]
 fn document_diagnostic_caching_rendered_source_changed() -> Result<()> {
+    let _filter = filter_result_id();
+
     let workspace_root = SystemPath::new("src");
     let foo = SystemPath::new("src/foo.py");
     let foo_content_v1 = "\
@@ -567,15 +569,20 @@ def foo() -> str:
     server.open_text_document(foo, foo_content_v1, 1);
 
     let first_response = server.document_diagnostic_request(foo, None);
-    let result_id = match first_response {
+    let result_id = match &first_response {
         DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) => report
             .full_document_diagnostic_report
             .result_id
+            .clone()
             .expect("First response should have a result ID"),
         DocumentDiagnosticReport::RelatedUnchangedDocumentDiagnosticReport(_) => {
             panic!("First response should be a full report")
         }
     };
+    assert_debug_snapshot!(
+        "document_diagnostic_caching_rendered_source_before",
+        first_response
+    );
 
     server.change_text_document(
         foo,
@@ -590,17 +597,10 @@ def foo() -> str:
     );
 
     let second_response = server.document_diagnostic_request(foo, Some(result_id));
-    let DocumentDiagnosticReport::RelatedFullDocumentDiagnosticReport(report) = second_response
-    else {
-        panic!("Expected a full report when the rendered source changed");
-    };
-    let rendered = report.full_document_diagnostic_report.items[0]
-        .data
-        .as_ref()
-        .and_then(|data| data.get("rendered"))
-        .and_then(serde_json::Value::as_str)
-        .expect("Diagnostic should include rendered output");
-    assert!(rendered.contains("# after!"));
+    assert_debug_snapshot!(
+        "document_diagnostic_caching_rendered_source_after",
+        second_response
+    );
 
     Ok(())
 }

--- a/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__code_actions__code_action_with_full_diagnostic_output_link.snap
@@ -1,0 +1,96 @@
+---
+source: crates/ty_server/tests/e2e/code_actions.rs
+expression: code_actions
+---
+[
+  {
+    "title": "import typing.Literal",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 3
+          },
+          "end": {
+            "line": 0,
+            "character": 10
+          }
+        },
+        "severity": 1,
+        "code": "Click for full diagnostic",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `Literal` used when not defined"
+      }
+    ],
+    "isPreferred": true,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 0
+              }
+            },
+            "newText": "from typing import Literal\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Ignore 'unresolved-reference' for this line",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 3
+          },
+          "end": {
+            "line": 0,
+            "character": 10
+          }
+        },
+        "severity": 1,
+        "code": "Click for full diagnostic",
+        "codeDescription": {
+          "href": "https://ty.dev/rules#unresolved-reference"
+        },
+        "source": "ty",
+        "message": "Name `Literal` used when not defined"
+      }
+    ],
+    "isPreferred": false,
+    "edit": {
+      "changes": {
+        "file://<temp_dir>/src/foo.py": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 17
+              },
+              "end": {
+                "line": 0,
+                "character": 17
+              }
+            },
+            "newText": "  # ty:ignore[unresolved-reference]"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__full_diagnostic_output.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__publish_diagnostics__full_diagnostic_output.snap
@@ -1,0 +1,77 @@
+---
+source: crates/ty_server/tests/e2e/publish_diagnostics.rs
+expression: diagnostics
+---
+PublishDiagnosticsParams {
+    uri: Url {
+        scheme: "file",
+        cannot_be_a_base: false,
+        username: "",
+        password: None,
+        host: None,
+        port: None,
+        path: "<temp_dir>/src/foo.py",
+        query: None,
+        fragment: None,
+    },
+    version: Some(
+        1,
+    ),
+    diagnostics: [
+        Diagnostic {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 11,
+                },
+                end: Position {
+                    line: 1,
+                    character: 13,
+                },
+            },
+            severity: Some(
+                Error,
+            ),
+            code: Some(
+                String(
+                    "invalid-return-type",
+                ),
+            ),
+            code_description: Some(
+                CodeDescription {
+                    href: Url {
+                        scheme: "https",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "ty.dev",
+                            ),
+                        ),
+                        port: None,
+                        path: "/rules",
+                        query: None,
+                        fragment: Some(
+                            "invalid-return-type",
+                        ),
+                    },
+                },
+            ),
+            source: Some(
+                "ty",
+            ),
+            message: String(
+                "Return type does not match returned value: expected `str`, found `Literal[42]`",
+            ),
+            tags: None,
+            related_information: None,
+            data: Some(
+                Object {
+                    "diagnostic_id": String("invalid-return-type"),
+                    "rendered": String("error[invalid-return-type]: Return type does not match returned value\n --> src/foo.py:1:14\n  |\n1 | def foo() -> str:\n  |              --- Expected `str` because of return type\n2 |     return 42\n  |            ^^ expected `str`, found `Literal[42]`\n  |\n\n"),
+                },
+            ),
+        },
+    ],
+}

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__document_diagnostic_caching_rendered_source_after.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__document_diagnostic_caching_rendered_source_after.snap
@@ -1,0 +1,71 @@
+---
+source: crates/ty_server/tests/e2e/pull_diagnostics.rs
+expression: second_response
+---
+RelatedFullDocumentDiagnosticReport(
+    RelatedFullDocumentDiagnosticReport {
+        related_documents: None,
+        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+            result_id: Some(
+                "[RESULT_ID]",
+            ),
+            items: [
+                Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 11,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 13,
+                        },
+                    },
+                    severity: Some(
+                        Error,
+                    ),
+                    code: Some(
+                        String(
+                            "invalid-return-type",
+                        ),
+                    ),
+                    code_description: Some(
+                        CodeDescription {
+                            href: Url {
+                                scheme: "https",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: Some(
+                                    Domain(
+                                        "ty.dev",
+                                    ),
+                                ),
+                                port: None,
+                                path: "/rules",
+                                query: None,
+                                fragment: Some(
+                                    "invalid-return-type",
+                                ),
+                            },
+                        },
+                    ),
+                    source: Some(
+                        "ty",
+                    ),
+                    message: String(
+                        "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                    ),
+                    tags: None,
+                    related_information: None,
+                    data: Some(
+                        Object {
+                            "diagnostic_id": String("invalid-return-type"),
+                            "rendered": String("error[invalid-return-type]: Return type does not match returned value\n --> src/foo.py:1:14\n  |\n1 | def foo() -> str:\n  |              --- Expected `str` because of return type\n2 |     return 42  # after!\n  |            ^^ expected `str`, found `Literal[42]`\n  |\n\n"),
+                        },
+                    ),
+                },
+            ],
+        },
+    },
+)

--- a/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__document_diagnostic_caching_rendered_source_before.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__pull_diagnostics__document_diagnostic_caching_rendered_source_before.snap
@@ -1,0 +1,71 @@
+---
+source: crates/ty_server/tests/e2e/pull_diagnostics.rs
+expression: first_response
+---
+RelatedFullDocumentDiagnosticReport(
+    RelatedFullDocumentDiagnosticReport {
+        related_documents: None,
+        full_document_diagnostic_report: FullDocumentDiagnosticReport {
+            result_id: Some(
+                "[RESULT_ID]",
+            ),
+            items: [
+                Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: 1,
+                            character: 11,
+                        },
+                        end: Position {
+                            line: 1,
+                            character: 13,
+                        },
+                    },
+                    severity: Some(
+                        Error,
+                    ),
+                    code: Some(
+                        String(
+                            "invalid-return-type",
+                        ),
+                    ),
+                    code_description: Some(
+                        CodeDescription {
+                            href: Url {
+                                scheme: "https",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: Some(
+                                    Domain(
+                                        "ty.dev",
+                                    ),
+                                ),
+                                port: None,
+                                path: "/rules",
+                                query: None,
+                                fragment: Some(
+                                    "invalid-return-type",
+                                ),
+                            },
+                        },
+                    ),
+                    source: Some(
+                        "ty",
+                    ),
+                    message: String(
+                        "Return type does not match returned value: expected `str`, found `Literal[42]`",
+                    ),
+                    tags: None,
+                    related_information: None,
+                    data: Some(
+                        Object {
+                            "diagnostic_id": String("invalid-return-type"),
+                            "rendered": String("error[invalid-return-type]: Return type does not match returned value\n --> src/foo.py:1:14\n  |\n1 | def foo() -> str:\n  |              --- Expected `str` because of return type\n2 |     return 42  # before\n  |            ^^ expected `str`, found `Literal[42]`\n  |\n\n"),
+                        },
+                    ),
+                },
+            ],
+        },
+    },
+)


### PR DESCRIPTION
## Summary

Fixes https://github.com/astral-sh/ty/issues/1731. See https://github.com/astral-sh/ty-vscode/pull/462 for the companion ty-vscode PR.

This PR implements a parallel to rust-analyzer's "Click for full compiler diagnostic feature" in its VSCode extension. Here's a video of rust-analyzer's feature in action in VSCode:

https://github.com/user-attachments/assets/7c14c7d6-46ea-4716-9f05-4df032cdc913

The feature is implemented by allowing LSP clients to advertise an experimental `fullDiagnosticOutput` capability. For clients that advertise this capability, we include both a plain-text rendering and the original diagnostic identifier in `Diagnostic.data`; otherwise, we retain the existing fix-only payload and avoid the rendering cost.

The one (significant) part of rust-analyzer's feature that is not implemented in this PR is full color rendering of diagnostics. This is left out of scope for this PR, as it would have led to a significant increase in code, and can be done as a followup.

## Prior art in other LSPs

rust-analyzer is the best known LSP that provides this kind of feature. Similar features are also found in [Flow](https://github.com/facebook/flow/blob/main/packages/flow-for-vscode/src/FlowLanguageClient/DetailedDiagnostics.ts) and [wsgl-analyzer](https://github.com/wgsl-analyzer/wgsl-analyzer/blob/main/editors/code/src/client.ts).

Pyrefly has [experimental support for Markdown rendering](https://github.com/facebook/pyrefly/blob/3ca46218e4d5b63f0d079449d93376d535682795/pyrefly/lib/lsp/non_wasm/server.rs#L681-L765) in tooltips, but this is an orthogonal feature. Here's codex's summary of the differences between the two features.

<details>
<summary>Codex comparison</summary>

## Full compiler diagnostics and Markdown diagnostic messages

ty’s full-diagnostic feature and Pyrefly’s Markdown diagnostic-message support improve diagnostic presentation at different layers and are largely complementary.

The ty feature follows the model established by rust-analyzer. The language server preserves the ordinary concise `Diagnostic.message` but attaches a second, substantially richer representation in `Diagnostic.data.rendered`. This rendering can contain source snippets, annotated spans, notes, and other multiline context that would be unwieldy inside a normal diagnostic hover.

ty-vscode detects the additional data and replaces the displayed diagnostic code with a **Click for full diagnostic** link. Following the link opens the rendered report in a read-only virtual document. This requires bespoke client middleware and a virtual-document provider, but clients that do not understand the extension can safely ignore the additional `data` and continue displaying the standard concise diagnostic.

Repurposing `Diagnostic.code` as a link means that ty must preserve the original diagnostic identifier elsewhere. It therefore includes `data.diagnostic_id`, which allows the server to recover identifiers such as `invalid-argument-type` when processing subsequent code-action requests.

The protocol is documented in [ty’s language-server documentation](https://github.com/astral-sh/ruff/blob/9f12f376467bd84e0aff651c09860e5bdbc8fc52/crates/ty_server/README.md#full-diagnostic-output), while the client-side transformation can be seen in [ty-vscode’s diagnostic handling](https://github.com/astral-sh/ty-vscode/blob/48fa1b6567b2deaf923f5724a9d58a6bea2266eb/src/common/diagnostics.ts#L139-L172).

rust-analyzer uses essentially the same client-side design. Its VS Code extension reads a compiler rendering from `Diagnostic.data.rendered`, changes the diagnostic code into a link, and opens the report through a custom URI. The implementation is in [rust-analyzer’s VS Code client](https://github.com/rust-lang/rust-analyzer/blob/master/editors/code/src/client.ts), and the protocol is described under [Colored Diagnostic Output](https://rust-analyzer.github.io/book/contributing/lsp-extensions.html#colored-diagnostic-output). One distinction is that rust-analyzer receives these reports from rustc through check-on-save and can request ANSI styling, whereas ty renders its own diagnostics and the current MVP emits plain text.

Pyrefly’s Markdown diagnostic-message support has a different purpose. Rather than providing a second, expanded representation, it changes the content type of the existing `Diagnostic.message`. When the client advertises `textDocument.diagnostic.markupMessageSupport`, Pyrefly sends the message as:

    {
        "kind": "markdown",
        "value": "..."
    }

This uses the proposed LSP 3.18 extension that permits `Diagnostic.message` to contain `MarkupContent`. A compatible client can render the Markdown directly in its ordinary diagnostic UI without any Pyrefly-specific virtual-document provider. Clients that do not advertise support continue receiving a standard string.

Pyrefly currently uses this mechanism primarily to render backtick-delimited identifiers and types as inline

</details>

## Implementation details

We keep the identifier in `Diagnostic.data` because clients may replace `Diagnostic.code` with a link to the rendered report. We teach code actions to recover the identifier and optional fix from `Diagnostic.data` so replacing the visible diagnostic code with a link does not disable lazy or eager quick fixes.

Rendered reports embed source snippets whereas raw diagnostics do not. We therefore include the source text of every file referenced by diagnostic annotations in pull-diagnostic result IDs for opted-in clients, deduplicating files before hashing. This conservatively invalidates cached reports after source-only edits without rendering every diagnostic merely to compute cache keys. To preserve existing behavior, we continue to omit result IDs from empty workspace reports.

In [the same way that rust-analyzer does](https://rust-analyzer.github.io/book/contributing/lsp-extensions.html#colored-diagnostic-output) (source code [here](https://github.com/rust-lang/rust-analyzer/blob/master/docs/book/src/contributing/lsp-extensions.md#colored-diagnostic-output)), we document the experimental protocol explicitly, describing how clients can declare support for it. 

## Test Plan

Tests have been added covering push and pull output, source-sensitive cache invalidation, and code actions after the visible diagnostic code has been replaced with a link.

And here is a manual test:

https://github.com/user-attachments/assets/ed65ade1-a111-49be-b8a1-ce357286f33e

To reproduce the above manual test, clone https://github.com/AlexWaygood/ty-full-diagnostic-demo and follow the instructions in that repo's README.md.