### PR TITLE
[ty] Avoid expanding same-enum comparisons

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -600,6 +600,100 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
+fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str(
+        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n\n\ndef compare_after_excluding_member(left: LargeEnum, right: LargeEnum):\n    if right == LargeEnum.VALUE_0:\n        return\n    if left and left != right:\n        return\n    return left == right\n",
+    );
+
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
+        &code,
+    );
+}
+
+/// Ensure non-exhaustive enum domains do not fall back to member expansion.
+fn benchmark_open_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut open_code = "from enum import StrEnum\n\nclass OpenLargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut open_code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    open_code.push_str(
+        "\n    @classmethod\n    def _missing_(cls, value: object) -> \"OpenLargeEnum\":\n        return str.__new__(cls, str(value))\n\n\ndef compare(left: OpenLargeEnum, right: OpenLargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
+    );
+
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[open_str_enum_comparison_after_truthiness_narrowing]",
+        &open_code,
+    );
+}
+
+/// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
+fn benchmark_enum_literal_union_comparison(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code =
+        "from enum import StrEnum\nfrom typing import Literal\n\nclass LargeEnum(StrEnum):\n"
+            .to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str("\nLeft = Literal[\n");
+    for index in 0..NUM_ENUM_MEMBERS / 2 {
+        writeln!(&mut code, "    LargeEnum.VALUE_{index},").ok();
+    }
+    code.push_str("]\nRight = Literal[\n");
+    for index in NUM_ENUM_MEMBERS / 2..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    LargeEnum.VALUE_{index},").ok();
+    }
+    code.push_str("]\n\n\ndef compare(left: Left, right: Right):\n    return left == right\n");
+
+    benchmark_enum_comparison(criterion, "ty_micro[enum_literal_union_comparison]", &code);
+}
+
+fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
+    setup_rayon();
+
+    criterion.bench_function(name, |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Ensure the comparison profile is reused instead of scanning every member per expression.
+fn benchmark_repeated_str_enum_comparisons(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 1_024;
+    const NUM_COMPARISONS: usize = 1_000;
+
+    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str("\n\ndef compare(left: LargeEnum, right: LargeEnum):\n");
+    for _ in 0..NUM_COMPARISONS {
+        code.push_str("    left == right\n");
+    }
+
+    benchmark_enum_comparison(criterion, "ty_micro[repeated_str_enum_comparisons]", &code);
+}
+
 /// Micro-benchmark that tests our performance when slicing and unpacking
 /// a very large tuple that has many varied literal strings inside it.
 ///
@@ -1509,6 +1603,10 @@ criterion_group!(
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
+    benchmark_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_open_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_enum_literal_union_comparison,
+    benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_gradual_vararg_call,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -609,32 +609,13 @@ fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Crit
         writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
     }
     code.push_str(
-        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n\n\ndef compare_after_excluding_member(left: LargeEnum, right: LargeEnum):\n    if right == LargeEnum.VALUE_0:\n        return\n    if left and left != right:\n        return\n    return left == right\n",
+        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
     );
 
     benchmark_enum_comparison(
         criterion,
         "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
         &code,
-    );
-}
-
-/// Ensure non-exhaustive enum domains do not fall back to member expansion.
-fn benchmark_open_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
-    const NUM_ENUM_MEMBERS: usize = 256;
-
-    let mut open_code = "from enum import StrEnum\n\nclass OpenLargeEnum(StrEnum):\n".to_string();
-    for index in 0..NUM_ENUM_MEMBERS {
-        writeln!(&mut open_code, "    VALUE_{index} = \"value_{index}\"").ok();
-    }
-    open_code.push_str(
-        "\n    @classmethod\n    def _missing_(cls, value: object) -> \"OpenLargeEnum\":\n        return str.__new__(cls, str(value))\n\n\ndef compare(left: OpenLargeEnum, right: OpenLargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
-    );
-
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[open_str_enum_comparison_after_truthiness_narrowing]",
-        &open_code,
     );
 }
 
@@ -1604,7 +1585,6 @@ criterion_group!(
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
     benchmark_str_enum_comparison_after_truthiness_narrowing,
-    benchmark_open_str_enum_comparison_after_truthiness_narrowing,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -617,7 +617,7 @@ fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) 
 }
 
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
-fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
     let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
@@ -628,11 +628,7 @@ fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Crit
         "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
     );
 
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
-        &code,
-    );
+    benchmark_enum_comparison(criterion, "ty_micro[narrowed_str_enum_comparison]", &code);
 }
 
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
@@ -1584,7 +1580,7 @@ criterion_group!(
     benchmark_complex_constrained_attributes_2,
     benchmark_complex_constrained_attributes_3,
     benchmark_many_enum_members,
-    benchmark_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_narrowed_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -600,6 +600,22 @@ fn benchmark_many_enum_members(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
+    setup_rayon();
+
+    criterion.bench_function(name, |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
 fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
@@ -640,22 +656,6 @@ fn benchmark_enum_literal_union_comparison(criterion: &mut Criterion) {
     code.push_str("]\n\n\ndef compare(left: Left, right: Right):\n    return left == right\n");
 
     benchmark_enum_comparison(criterion, "ty_micro[enum_literal_union_comparison]", &code);
-}
-
-fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
-    setup_rayon();
-
-    criterion.bench_function(name, |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
 }
 
 /// Ensure the comparison profile is reused instead of scanning every member per expression.

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -255,11 +255,11 @@ from enum import Enum, Flag
 class Permission(Flag):
     READ = 1
 
-class OpenEnum(Enum):
+class MissingValueEnum(Enum):
     ONLY = 1
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenEnum":
+    def _missing_(cls, value: object) -> "MissingValueEnum":
         return object.__new__(cls)
 
 def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
@@ -267,9 +267,9 @@ def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
         case Permission.READ:
             return 1
 
-def match_open_enum(value: OpenEnum) -> int:  # error: [invalid-return-type]
+def match_open_enum(value: MissingValueEnum) -> int:  # error: [invalid-return-type]
     match value:
-        case OpenEnum.ONLY:
+        case MissingValueEnum.ONLY:
             return 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,89 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+Comparisons between values of the same enum preserve existing narrowing. They can also narrow to
+members shared by both operands, or determine that groups with no members in common are unequal:
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+class Choice(StrEnum):
+    FIRST = "first"
+    SECOND = "second"
+    THIRD = "third"
+    FOURTH = "fourth"
+
+def compare_after_truthiness_check(left: Choice, right: Choice):
+    if right and left != right:
+        reveal_type(right)  # revealed: Choice & ~AlwaysFalsy
+        return
+
+    reveal_type(right)  # revealed: Choice
+
+def compare_with_narrowed_right(left: Choice, right: Choice):
+    if right == Choice.FIRST:
+        return
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Choice.SECOND, Choice.THIRD, Choice.FOURTH]
+
+def compare_non_overlapping_narrowed_values(left: Choice, right: Choice):
+    if left == Choice.FIRST or left == Choice.SECOND:
+        return
+    if right == Choice.THIRD or right == Choice.FOURTH:
+        return
+
+    reveal_type(left == right)  # revealed: Literal[False]
+
+def compare_literal_unions(
+    left: Literal[Choice.FIRST, Choice.SECOND],
+    right: Literal[Choice.SECOND, Choice.THIRD],
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Choice.SECOND]
+        reveal_type(right)  # revealed: Literal[Choice.SECOND]
+
+def compare_non_overlapping_literal_unions(
+    left: Literal[Choice.FIRST, Choice.SECOND],
+    right: Literal[Choice.THIRD, Choice.FOURTH],
+):
+    reveal_type(left == right)  # revealed: Literal[False]
+```
+
+Equality narrowing must not copy unrelated parts of one operand's type to the other:
+
+```py
+from enum import StrEnum
+from typing import Any, NewType
+from ty_extensions import Intersection
+
+class Response(StrEnum):
+    ACCEPT = "accept"
+    REJECT = "reject"
+
+Tag = NewType("Tag", str)
+
+def compare_any(left: Response, right: Any):
+    if isinstance(right, Response):
+        if left != right:
+            return
+        left.does_not_exist  # error: [unresolved-attribute]
+
+def compare_narrowed_any(left: Response, right: Any):
+    if isinstance(right, Response):
+        if right == Response.ACCEPT:
+            return
+        if left != right:
+            return
+        reveal_type(left)  # revealed: Literal[Response.REJECT]
+        reveal_type(right)  # revealed: Response & Any & ~Literal[Response.ACCEPT]
+
+def compare_newtype(left: Response, right: Intersection[Response, Tag]):
+    if left != right:
+        return
+    reveal_type(left)  # revealed: Response
+```
+
 `Flag` and `IntFlag` values can include zero and unnamed combinations, so their named members do not
 cover every possible value:
 
@@ -201,6 +284,54 @@ class TransformedEnum(Enum, metaclass=InjectingEnumMeta):
     ONLY = 1
 
 def compare_transformed_enums(left: TransformedEnum, right: TransformedEnum):
+    reveal_type(left == right)  # revealed: bool
+```
+
+A custom comparison method determines the result even when both operands have the same enum type:
+
+```py
+from enum import Enum
+from typing import Literal
+
+class NeverEqual(Enum):
+    FIRST = 1
+    SECOND = 2
+    THIRD = 3
+
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+def compare_custom(left: NeverEqual, right: NeverEqual):
+    reveal_type(left == right)  # revealed: Literal[False]
+
+    if left is NeverEqual.FIRST:
+        return
+    reveal_type(left == right)  # revealed: Literal[False]
+
+def compare_custom_subsets(
+    left: Literal[NeverEqual.FIRST, NeverEqual.SECOND],
+    right: Literal[NeverEqual.SECOND, NeverEqual.THIRD],
+):
+    reveal_type(left == right)  # revealed: Literal[False]
+```
+
+When member values are not known statically, two different members may still compare equal:
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+def runtime_value(value: str) -> str:
+    return value
+
+class UnknownValues(StrEnum):
+    FIRST = runtime_value("first")
+    SECOND = runtime_value("second")
+
+def compare_unknown_values(
+    left: Literal[UnknownValues.FIRST],
+    right: Literal[UnknownValues.SECOND],
+):
     reveal_type(left == right)  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ Comparisons between values of the same enum preserve existing narrowing. They ca
 members shared by both operands, or determine that groups with no members in common are unequal:
 
 ```py
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Literal
 
 class Choice(StrEnum):
@@ -169,6 +169,26 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+
+def make_value() -> Literal["value"]:
+    return "value"
+
+class RuntimeAlias(StrEnum):
+    FIRST = make_value()
+    SECOND = "value"
+
+# These members have equal runtime values, but the inferred value literals have different
+# promotability. We therefore cannot conclude that the members compare unequal.
+reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: bool
+
+def make_int_value() -> Literal[1]:
+    return 1
+
+class RuntimeIntAlias(IntEnum):
+    FIRST = make_int_value()
+    SECOND = 1
+
+reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
 ```
 
 Equality narrowing must not copy unrelated parts of one operand's type to the other:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ Comparisons between values of the same enum preserve existing narrowing. They ca
 members shared by both operands, or determine that groups with no members in common are unequal:
 
 ```py
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import Literal
 
 class Choice(StrEnum):
@@ -189,6 +189,13 @@ class RuntimeIntAlias(IntEnum):
     SECOND = 1
 
 reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
+
+class CoercingAlias(str, Enum):
+    FIRST = 1
+    SECOND = "1"
+
+# `str.__new__` normalizes both declared values to the same runtime string.
+reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
 Equality narrowing must not copy unrelated parts of one operand's type to the other:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -194,8 +194,9 @@ class RuntimeIntAlias(IntEnum):
 reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Literal[True]
 ```
 
-Scalar mixins can also coerce different class-body values to the same runtime value. Here, both
-declarations become aliases at runtime, so the comparison cannot be assumed false:
+A scalar mixin can normalize member values before `Enum` checks for aliases. Here, `str` converts
+`1` to `"1"`, so the two members are aliases at runtime. Since ty does not model this constructor
+call, the comparison remains `bool`:
 
 ```py
 class CoercingAlias(str, Enum):
@@ -205,12 +206,12 @@ class CoercingAlias(str, Enum):
 reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
-Equality narrowing must not transfer `Any` or an unrelated `NewType` constraint from one operand to
-the other:
+Equality can transfer restrictions on enum members, but other intersection elements must stay on the
+operand where they originated:
 
 ```py
 from enum import StrEnum
-from typing import Any, NewType
+from typing import Any, Literal, NewType
 from ty_extensions import Intersection
 
 class Response(StrEnum):
@@ -219,14 +220,14 @@ class Response(StrEnum):
 
 Tag = NewType("Tag", str)
 
-def compare_narrowed_any(left: Response, right: Any):
-    if isinstance(right, Response):
-        if right == Response.ACCEPT:
-            return
-        if left != right:
-            return
-        reveal_type(left)  # revealed: Literal[Response.REJECT]
-        reveal_type(right)  # revealed: Response & Any & ~Literal[Response.ACCEPT]
+def compare_any(
+    left: Response,
+    right: Intersection[Literal[Response.REJECT], Any],
+):
+    if left != right:
+        return
+    reveal_type(left)  # revealed: Literal[Response.REJECT]
+    reveal_type(right)  # revealed: Literal[Response.REJECT] & Any
 
 def compare_newtype(left: Response, right: Intersection[Response, Tag]):
     if left != right:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,8 +122,8 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
-Comparisons between values of the same enum preserve existing narrowing. They can also narrow to
-members shared by both operands, or determine that groups with no members in common are unequal:
+When both operands are restricted to members of the same enum, equality narrows each operand to the
+members allowed by both. If the restrictions do not overlap, the comparison is always false:
 
 ```py
 from enum import Enum, IntEnum, StrEnum
@@ -169,7 +169,12 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+```
 
+Members with the same known value are aliases, even when one value comes from a function call.
+Comparisons between their canonical members are always true:
+
+```py
 def make_value() -> Literal["value"]:
     return "value"
 
@@ -177,9 +182,7 @@ class RuntimeAlias(StrEnum):
     FIRST = make_value()
     SECOND = "value"
 
-# These members have equal runtime values, but the inferred value literals have different
-# promotability. We therefore cannot conclude that the members compare unequal.
-reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: bool
+reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: Literal[True]
 
 def make_int_value() -> Literal[1]:
     return 1
@@ -188,17 +191,22 @@ class RuntimeIntAlias(IntEnum):
     FIRST = make_int_value()
     SECOND = 1
 
-reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
+reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Literal[True]
+```
 
+Scalar mixins can also coerce different class-body values to the same runtime value. Here, both
+declarations become aliases at runtime, so the comparison cannot be assumed false:
+
+```py
 class CoercingAlias(str, Enum):
     FIRST = 1
     SECOND = "1"
 
-# `str.__new__` normalizes both declared values to the same runtime string.
 reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
-Equality narrowing must not copy unrelated parts of one operand's type to the other:
+Equality narrowing must not transfer `Any` or an unrelated `NewType` constraint from one operand to
+the other:
 
 ```py
 from enum import StrEnum
@@ -210,12 +218,6 @@ class Response(StrEnum):
     REJECT = "reject"
 
 Tag = NewType("Tag", str)
-
-def compare_any(left: Response, right: Any):
-    if isinstance(right, Response):
-        if left != right:
-            return
-        left.does_not_exist  # error: [unresolved-attribute]
 
 def compare_narrowed_any(left: Response, right: Any):
     if isinstance(right, Response):
@@ -277,23 +279,18 @@ even when only one member is declared:
 ```py
 from enum import Enum
 
-class OpenEnum(Enum):
+class MissingValueEnum(Enum):
     ONLY = 1
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenEnum":
+    def _missing_(cls, value: object) -> "MissingValueEnum":
         return object.__new__(cls)
 
-def compare_open_enums(left: OpenEnum, right: OpenEnum):
+def compare_open_enums(left: MissingValueEnum, right: MissingValueEnum):
     reveal_type(left == right)  # revealed: bool
 
     if left != right:
-        reveal_type(left)  # revealed: OpenEnum
-
-def exclude_declared_member(value: OpenEnum):
-    if value is OpenEnum.ONLY:
-        return
-    reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+        reveal_type(left)  # revealed: MissingValueEnum
 ```
 
 A custom enum metaclass can add members that do not appear in the class body. Two values of a
@@ -333,12 +330,6 @@ def compare_custom(left: NeverEqual, right: NeverEqual):
 
     if left is NeverEqual.FIRST:
         return
-    reveal_type(left == right)  # revealed: Literal[False]
-
-def compare_custom_subsets(
-    left: Literal[NeverEqual.FIRST, NeverEqual.SECOND],
-    right: Literal[NeverEqual.SECOND, NeverEqual.THIRD],
-):
     reveal_type(left == right)  # revealed: Literal[False]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -281,6 +281,7 @@ def _(x: LiteralString | int):
 
 ```py
 from enum import Enum
+from typing import Literal
 
 class Color(Enum):
     RED = "red"
@@ -308,6 +309,21 @@ def after_excluding_red_mixed(x: Color | int):
         reveal_type(x)  # revealed: Literal[Color.GREEN] | int
     else:
         reveal_type(x)  # revealed: Literal[Color.BLUE] | int
+
+SelectedColor = Literal[Color.RED, Color.GREEN]
+SELECTED_COLORS: tuple[SelectedColor, ...] = (Color.RED, Color.GREEN)
+
+def selected_colors(colors: list[Color]) -> list[SelectedColor]:
+    result: list[SelectedColor] = []
+    result.extend([color for color in colors if color in SELECTED_COLORS])
+    return result
+
+def _(colors: list[Color]):
+    annotated = [color for color in colors if color in SELECTED_COLORS]
+    reveal_type(annotated)  # revealed: list[Literal[Color.RED, Color.GREEN]]
+
+    inline = [color for color in colors if color in (Color.RED, Color.GREEN)]
+    reveal_type(inline)  # revealed: list[Color]
 ```
 
 An enum that can have additional runtime members can still be narrowed by a membership test against

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -309,7 +309,13 @@ def after_excluding_red_mixed(x: Color | int):
         reveal_type(x)  # revealed: Literal[Color.GREEN] | int
     else:
         reveal_type(x)  # revealed: Literal[Color.BLUE] | int
+```
 
+When the container's element type is a union of enum literals, membership narrows to that union.
+Without the annotation, the tuple's elements are widened to `Color`, so the comprehension remains
+`list[Color]`:
+
+```py
 SelectedColor = Literal[Color.RED, Color.GREEN]
 SELECTED_COLORS: tuple[SelectedColor, ...] = (Color.RED, Color.GREEN)
 
@@ -319,9 +325,6 @@ def selected_colors(colors: list[Color]) -> list[SelectedColor]:
     return result
 
 def _(colors: list[Color]):
-    annotated = [color for color in colors if color in SELECTED_COLORS]
-    reveal_type(annotated)  # revealed: list[Literal[Color.RED, Color.GREEN]]
-
     inline = [color for color in colors if color in (Color.RED, Color.GREEN)]
     reveal_type(inline)  # revealed: list[Color]
 ```
@@ -338,14 +341,14 @@ class InjectingEnumMeta(EnumMeta):
         namespace["INJECTED"] = 2
         return super().__new__(metacls, name, bases, namespace, **kwargs)
 
-class OpenEnum(Enum, metaclass=InjectingEnumMeta):
+class InjectedEnum(Enum, metaclass=InjectingEnumMeta):
     ONLY = 1
 
-def _(value: OpenEnum):
-    if value in (OpenEnum.ONLY,):
-        reveal_type(value)  # revealed: Literal[OpenEnum.ONLY]
+def _(value: InjectedEnum):
+    if value in (InjectedEnum.ONLY,):
+        reveal_type(value)  # revealed: Literal[InjectedEnum.ONLY]
     else:
-        reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+        reveal_type(value)  # revealed: InjectedEnum & ~Literal[InjectedEnum.ONLY]
 ```
 
 ## Union with enum and `int`

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -778,30 +778,33 @@ pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -
     }
 }
 
-/// If `value_ty` is a hashable literal and already exists in `enum_values`,
-/// record it as an alias and return `true`. Otherwise track it as canonical.
+/// If `value_ty` has the same supported literal kind and payload as a value in `enum_values`, record
+/// it as an alias and return `true`. Otherwise track it as canonical. Literal metadata does not
+/// affect enum aliasing at runtime, so the map is keyed by [`LiteralValueTypeKind`] rather than
+/// [`Type`].
 fn try_register_alias<'db>(
     value_ty: Type<'db>,
     name: &Name,
-    enum_values: &mut FxHashMap<Type<'db>, Name>,
+    enum_values: &mut FxHashMap<LiteralValueTypeKind<'db>, Name>,
     aliases: &mut FxHashMap<Name, Name>,
 ) -> bool {
+    let Some(value) = value_ty.as_literal_value_kind() else {
+        return false;
+    };
     if !matches!(
-        value_ty.as_literal_value_kind(),
-        Some(
-            LiteralValueTypeKind::Bool(_)
-                | LiteralValueTypeKind::Int(_)
-                | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_)
-        )
+        value,
+        LiteralValueTypeKind::Bool(_)
+            | LiteralValueTypeKind::Int(_)
+            | LiteralValueTypeKind::String(_)
+            | LiteralValueTypeKind::Bytes(_)
     ) {
         return false;
     }
-    if let Some(canonical) = enum_values.get(&value_ty) {
+    if let Some(canonical) = enum_values.get(&value) {
         aliases.insert(name.clone(), canonical.clone());
         return true;
     }
-    enum_values.insert(value_ty, name.clone());
+    enum_values.insert(value, name.clone());
     false
 }
 
@@ -833,7 +836,7 @@ pub(crate) fn enum_metadata<'db>(
             }
             let mut members = FxIndexMap::default();
             let mut aliases = FxHashMap::default();
-            let mut enum_values: FxHashMap<Type<'db>, Name> = FxHashMap::default();
+            let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
                 if try_register_alias(*ty, name, &mut enum_values, &mut aliases) {
                     continue;
@@ -868,7 +871,7 @@ pub(crate) fn enum_metadata<'db>(
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
-    let mut enum_values: FxHashMap<Type<'db>, Name> = FxHashMap::default();
+    let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
     let mut auto_counter = 0;
     let mut auto_members = FxHashSet::default();
     let mut prev_value_was_non_literal_int = false;

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -18,6 +18,8 @@ use super::{
 mod enums;
 
 pub(super) use self::enums::enum_membership_constraint;
+use self::enums::evaluate_same_enum_domains;
+pub(super) use self::enums::{EnumComparison, compact_enum_comparison};
 
 /// The result of evaluating a runtime comparison between two types.
 ///
@@ -315,6 +317,10 @@ fn evaluate_comparison_once<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
+
+    if let Some(result) = evaluate_same_enum_domains(db, left, right, branch, operator) {
+        return result;
+    }
 
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -19,7 +19,7 @@ mod enums;
 
 pub(super) use self::enums::enum_membership_constraint;
 use self::enums::evaluate_same_enum_domains;
-pub(super) use self::enums::{EnumComparison, compact_enum_comparison};
+pub(super) use self::enums::{EnumComparison, same_enum_comparison};
 
 /// The result of evaluating a runtime comparison between two types.
 ///

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,77 +1,444 @@
-//! Equality reasoning for values from the same enum class.
+//! Compact equality reasoning for values from the same enum class.
 
-use crate::Db;
-use crate::types::{EnumClassLiteral, IntersectionBuilder, LiteralValueTypeKind, Type};
+use ruff_python_ast::name::Name;
+use rustc_hash::FxHashSet;
+use ty_python_core::Truthiness;
 
-/// Return the enum class when `ty` represents an open enum domain.
-fn open_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<EnumClassLiteral<'db>> {
-    match ty.resolve_type_alias(db) {
-        Type::NominalInstance(instance) => {
-            let enum_class = instance.class_literal(db).into_enum_class(db)?;
-            (!enum_class.members_are_exhaustive(db)).then_some(enum_class)
+use crate::types::{
+    EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
+    LiteralValueTypeKind, Type, UnionBuilder,
+};
+use crate::{Db, FxOrderSet};
+
+use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
+
+/// Compare two compact domains from the same enum without expanding their members.
+pub(super) fn evaluate_same_enum_domains<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    other: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    let comparison = SameEnumComparison::from_types(db, target, other, operator)?;
+    match comparison.truthiness(db, operator)? {
+        Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
+        Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
+        Truthiness::Ambiguous if !comparison.supports_domain_narrowing() => {
+            Some(ComparisonResult::Ambiguous)
         }
-        Type::Intersection(intersection) => {
-            let mut enum_classes = intersection
-                .positive(db)
-                .iter()
-                .filter_map(|positive| open_enum_class(db, *positive));
-            let enum_class = enum_classes.next()?;
-            enum_classes
-                .all(|other| other == enum_class)
-                .then_some(enum_class)
-        }
-        _ => None,
+        Truthiness::Ambiguous if operator.condition_expects_equality(branch) => Some(
+            ComparisonResult::CanNarrow(comparison.right.restriction_type(db)),
+        ),
+        Truthiness::Ambiguous => Some(comparison.right.singleton_type(db).map_or(
+            ComparisonResult::Ambiguous,
+            |singleton| {
+                ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(comparison.left.restriction_type(db))
+                        .add_negative(singleton)
+                        .build(),
+                )
+            },
+        )),
     }
 }
 
-/// Return the enum class when `ty` is an exact set of literals from one enum.
-fn exact_enum_member_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<EnumClassLiteral<'db>> {
-    match ty.resolve_type_alias(db) {
-        Type::LiteralValue(literal) => {
-            let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
-                return None;
-            };
-            Some(literal.enum_class_literal(db))
-        }
-        Type::Union(union) => {
-            let mut enum_classes = union
-                .elements(db)
-                .iter()
-                .map(|element| exact_enum_member_class(db, *element));
-            let enum_class = enum_classes.next()??;
-            enum_classes
-                .all(|other| other == Some(enum_class))
-                .then_some(enum_class)
-        }
-        _ => None,
-    }
+/// The result of comparing two compact domains from the same enum.
+pub(in crate::types) enum EnumComparison {
+    /// The comparison method is modeled and has the given truthiness.
+    Known(Truthiness),
+    /// A custom or otherwise unmodeled comparison method must be called directly.
+    Unmodeled,
 }
 
-/// Return the constraint established by membership in an exact set of open-enum members.
+/// Compare two compact domains from the same enum without expanding either operand.
+///
+/// `None` means that an operand is not structurally an enum domain.
+pub(in crate::types) fn compact_enum_comparison<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_equality: bool,
+) -> Option<EnumComparison> {
+    let operator = if is_equality {
+        ComparisonOperator::Equality
+    } else {
+        ComparisonOperator::Inequality
+    };
+    let comparison = SameEnumComparison::from_types(db, left, right, operator)?;
+    Some(
+        comparison
+            .truthiness(db, operator)
+            .map_or(EnumComparison::Unmodeled, EnumComparison::Known),
+    )
+}
+
+/// Return the constraint established by membership in an exact set of members from the same enum.
 pub(in crate::types) fn enum_membership_constraint<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
     members: Type<'db>,
     is_positive: bool,
 ) -> Option<Type<'db>> {
-    let enum_class = open_enum_class(db, target)?;
-    if exact_enum_member_class(db, members)? != enum_class {
+    let comparison =
+        SameEnumComparison::from_types(db, target, members, ComparisonOperator::Equality)?;
+    if !comparison.supports_domain_narrowing() {
         return None;
     }
 
-    let enum_instance = enum_class.class_literal(db).to_non_generic_instance(db);
-    if enum_instance.overrides_equality(db) {
-        return None;
-    }
-
+    let members = comparison.right.restriction_type(db);
     if is_positive {
         Some(members)
     } else {
         Some(
             IntersectionBuilder::new(db)
-                .add_positive(enum_instance)
+                .add_positive(comparison.left.restriction_type(db))
                 .add_negative(members)
                 .build(),
         )
     }
+}
+
+struct SameEnumComparison<'db> {
+    left: EnumValueSet<'db>,
+    right: EnumValueSet<'db>,
+    profile: EnumComparisonProfile,
+}
+
+impl<'db> SameEnumComparison<'db> {
+    fn from_types(
+        db: &'db dyn Db,
+        left: Type<'db>,
+        right: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        let left = EnumValueSet::from_type(db, left)?;
+        let right = EnumValueSet::from_type(db, right)?;
+        if left.enum_class != right.enum_class {
+            return None;
+        }
+        let enum_class = left.enum_class;
+
+        Some(Self {
+            left,
+            right,
+            profile: enum_comparison_profile(db, enum_class, operator),
+        })
+    }
+
+    /// Return `None` only when comparison behavior is custom or otherwise unmodeled.
+    fn truthiness(&self, db: &'db dyn Db, operator: ComparisonOperator) -> Option<Truthiness> {
+        let comparison_keys = self.profile.comparison_keys?;
+        let members_are_exhaustive = self.profile.members_are_exhaustive;
+        let domains_are_closed = self.left.is_closed(members_are_exhaustive)
+            && self.right.is_closed(members_are_exhaustive);
+        let equality = if domains_are_closed
+            && comparison_keys == EnumComparisonKeys::Distinct
+            && !self.left.overlaps(&self.right, db)
+        {
+            Truthiness::AlwaysFalse
+        } else if self.left.is_singleton(db, members_are_exhaustive)
+            && self.right.is_singleton(db, members_are_exhaustive)
+            && self.left.overlaps(&self.right, db)
+        {
+            Truthiness::AlwaysTrue
+        } else {
+            Truthiness::Ambiguous
+        };
+
+        Some(equality.negate_if(operator == ComparisonOperator::Inequality))
+    }
+
+    fn supports_domain_narrowing(&self) -> bool {
+        matches!(
+            self.profile.comparison_keys,
+            Some(EnumComparisonKeys::Distinct)
+        ) && self.right.is_closed(self.profile.members_are_exhaustive)
+            && (self.left.is_closed(self.profile.members_are_exhaustive)
+                || self.profile.members_compare_by_identity)
+    }
+}
+
+/// The enum-member values represented by an operand, excluding non-enum intersection state.
+///
+/// This is an upper bound on the operand's enum values. Gradual and nominal rest components can
+/// make the operand more specific, but they must never be transferred to the other operand by an
+/// equality constraint.
+struct EnumValueSet<'db> {
+    enum_class: EnumClassLiteral<'db>,
+    members: EnumValueSetMembers<'db>,
+}
+
+enum EnumValueSetMembers<'db> {
+    All,
+    One(&'db Name),
+    Included(FxOrderSet<&'db Name>),
+    AllExcept(EnumComplementType<'db>),
+}
+
+impl<'db> EnumValueSet<'db> {
+    /// Extract only structural enum membership facts from `ty`.
+    ///
+    /// This deliberately does not use subtyping: a `NewType` over an enum is a subtype of the
+    /// enum but remains disjoint from the enum's literal members.
+    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        let value_set = match ty.resolve_type_alias(db) {
+            Type::LiteralValue(literal) => {
+                let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                    return None;
+                };
+                let enum_class = literal.enum_class_literal(db);
+                let name = enum_class.resolve_member(db, literal.name(db))?;
+                Self {
+                    enum_class,
+                    members: EnumValueSetMembers::One(name),
+                }
+            }
+            Type::NominalInstance(instance) => Self {
+                enum_class: instance.class_literal(db).into_enum_class(db)?,
+                members: EnumValueSetMembers::All,
+            },
+            Type::EnumComplement(complement) => Self {
+                enum_class: complement.enum_class_literal(db),
+                members: EnumValueSetMembers::AllExcept(complement),
+            },
+            Type::Union(union) => Self::from_union(db, union.elements(db))?,
+            Type::Intersection(intersection) => Self::from_intersection(db, intersection)?,
+            _ => return None,
+        };
+        (value_set.member_count(db) > 0).then_some(value_set)
+    }
+
+    fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
+        let mut enum_class = None;
+        let mut included = FxOrderSet::default();
+        for element in elements {
+            let value_set = Self::from_type(db, *element)?;
+            if let Some(enum_class) = enum_class
+                && enum_class != value_set.enum_class
+            {
+                return None;
+            }
+            enum_class = Some(value_set.enum_class);
+            match value_set.members {
+                EnumValueSetMembers::One(name) => {
+                    included.insert(name);
+                }
+                EnumValueSetMembers::Included(names) => included.extend(names),
+                EnumValueSetMembers::All | EnumValueSetMembers::AllExcept(_) => return None,
+            }
+        }
+
+        let enum_class = enum_class?;
+        let members = if included.len() == 1 {
+            EnumValueSetMembers::One(included.into_iter().next()?)
+        } else {
+            EnumValueSetMembers::Included(included)
+        };
+        Some(Self {
+            enum_class,
+            members,
+        })
+    }
+
+    fn from_intersection(db: &'db dyn Db, intersection: IntersectionType<'db>) -> Option<Self> {
+        if let Some(complement) = intersection.enum_complement(db) {
+            return Self::from_type(db, Type::EnumComplement(complement));
+        }
+
+        // Other intersection components can only reduce the represented enum values. Ignoring
+        // them therefore preserves a safe upper bound without transferring them during narrowing.
+        let mut value_sets = intersection
+            .positive(db)
+            .iter()
+            .filter_map(|positive| Self::from_type(db, *positive));
+        let value_set = value_sets.next()?;
+        value_sets
+            .all(|other| other.enum_class == value_set.enum_class)
+            .then_some(value_set)
+    }
+
+    fn member_count(&self, db: &'db dyn Db) -> usize {
+        match &self.members {
+            EnumValueSetMembers::All => self.enum_class.member_count(db),
+            EnumValueSetMembers::One(_) => 1,
+            EnumValueSetMembers::Included(names) => names.len(),
+            EnumValueSetMembers::AllExcept(complement) => {
+                self.enum_class.member_count(db) - complement.excluded_names(db).len()
+            }
+        }
+    }
+
+    fn is_closed(&self, members_are_exhaustive: bool) -> bool {
+        members_are_exhaustive
+            || matches!(
+                self.members,
+                EnumValueSetMembers::One(_) | EnumValueSetMembers::Included(_)
+            )
+    }
+
+    fn is_singleton(&self, db: &'db dyn Db, members_are_exhaustive: bool) -> bool {
+        self.member_count(db) == 1 && self.is_closed(members_are_exhaustive)
+    }
+
+    fn overlaps(&self, other: &Self, db: &'db dyn Db) -> bool {
+        debug_assert_eq!(self.enum_class, other.enum_class);
+        match (&self.members, &other.members) {
+            (EnumValueSetMembers::All, _) | (_, EnumValueSetMembers::All) => true,
+            (EnumValueSetMembers::One(left), EnumValueSetMembers::One(right)) => left == right,
+            (EnumValueSetMembers::One(name), EnumValueSetMembers::Included(names))
+            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One(name)) => {
+                names.contains(name)
+            }
+            (EnumValueSetMembers::Included(left), EnumValueSetMembers::Included(right)) => {
+                let (smaller, larger) = if left.len() < right.len() {
+                    (left, right)
+                } else {
+                    (right, left)
+                };
+                smaller.iter().any(|name| larger.contains(name))
+            }
+            (EnumValueSetMembers::One(name), EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One(name)) => {
+                !complement.excluded_names(db).contains(*name)
+            }
+            (EnumValueSetMembers::Included(names), EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::Included(names)) => {
+                names
+                    .iter()
+                    .any(|name| !complement.excluded_names(db).contains(*name))
+            }
+            (EnumValueSetMembers::AllExcept(left), EnumValueSetMembers::AllExcept(right)) => {
+                let left = left.excluded_names(db);
+                let right = right.excluded_names(db);
+                let excluded =
+                    left.len() + right.iter().filter(|name| !left.contains(*name)).count();
+                excluded < self.enum_class.member_count(db)
+            }
+        }
+    }
+
+    /// Reconstruct a constraint containing only this enum value restriction.
+    fn restriction_type(&self, db: &'db dyn Db) -> Type<'db> {
+        match &self.members {
+            EnumValueSetMembers::All => self
+                .enum_class
+                .class_literal(db)
+                .to_non_generic_instance(db),
+            EnumValueSetMembers::One(name) => {
+                Type::enum_literal(EnumLiteralType::new(db, self.enum_class, (*name).clone()))
+            }
+            EnumValueSetMembers::Included(names) => names
+                .iter()
+                .fold(UnionBuilder::new(db), |builder, name| {
+                    builder.add(Type::enum_literal(EnumLiteralType::new(
+                        db,
+                        self.enum_class,
+                        (*name).clone(),
+                    )))
+                })
+                .build(),
+            EnumValueSetMembers::AllExcept(complement) => {
+                if complement.rest(db).is_empty() {
+                    Type::EnumComplement(*complement)
+                } else {
+                    Type::EnumComplement(EnumComplementType::new(
+                        db,
+                        self.enum_class,
+                        complement.excluded_names(db).clone(),
+                        FxOrderSet::default(),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn singleton_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if self.member_count(db) != 1 {
+            return None;
+        }
+        let name = match &self.members {
+            EnumValueSetMembers::All => self.enum_class.member_names(db).next()?,
+            EnumValueSetMembers::One(name) => name,
+            EnumValueSetMembers::Included(names) => names.first()?,
+            EnumValueSetMembers::AllExcept(complement) => self
+                .enum_class
+                .member_names(db)
+                .find(|name| !complement.excluded_names(db).contains(*name))?,
+        };
+        Some(Type::enum_literal(EnumLiteralType::new(
+            db,
+            self.enum_class,
+            (*name).clone(),
+        )))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+enum EnumComparisonKeys {
+    Distinct,
+    UnknownOrRepeated,
+}
+
+/// Class-wide facts required to compare enum value sets without member expansion.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct EnumComparisonProfile {
+    members_are_exhaustive: bool,
+    /// Whether distinct enum members compare by identity, including members created at runtime.
+    members_compare_by_identity: bool,
+    /// `None` means comparison behavior is custom or otherwise unmodeled.
+    comparison_keys: Option<EnumComparisonKeys>,
+}
+
+/// Compute and cache the class-wide work needed for repeated comparisons of the same enum.
+#[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+fn enum_comparison_profile<'db>(
+    db: &'db dyn Db,
+    enum_class: EnumClassLiteral<'db>,
+    operator: ComparisonOperator,
+) -> EnumComparisonProfile {
+    let semantics = KnownComparisonSemantics::of_instance(
+        db,
+        enum_class.class_literal(db).to_non_generic_instance(db),
+        operator,
+    );
+    let (comparison_keys, members_compare_by_identity) = match semantics {
+        None => (None, false),
+        Some(KnownComparisonSemantics::Object) => (Some(EnumComparisonKeys::Distinct), true),
+        Some(
+            KnownComparisonSemantics::Int
+            | KnownComparisonSemantics::Str
+            | KnownComparisonSemantics::Bytes,
+        ) if enum_members_have_distinct_value_keys(db, enum_class) => {
+            (Some(EnumComparisonKeys::Distinct), false)
+        }
+        Some(_) => (Some(EnumComparisonKeys::UnknownOrRepeated), false),
+    };
+    EnumComparisonProfile {
+        members_are_exhaustive: enum_class.members_are_exhaustive(db),
+        members_compare_by_identity,
+        comparison_keys,
+    }
+}
+
+fn enum_members_have_distinct_value_keys<'db>(
+    db: &'db dyn Db,
+    enum_class: EnumClassLiteral<'db>,
+) -> bool {
+    let mut keys = FxHashSet::default();
+    enum_class.members(db).iter().all(|(_, value)| {
+        let key = match value.as_literal_value_kind() {
+            Some(LiteralValueTypeKind::Bool(value)) => Type::int_literal(i64::from(value)),
+            Some(
+                LiteralValueTypeKind::Int(_)
+                | LiteralValueTypeKind::String(_)
+                | LiteralValueTypeKind::Bytes(_),
+            ) => *value,
+            Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
+                return false;
+            }
+        };
+        keys.insert(key)
+    })
 }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -6,9 +6,9 @@ use ty_python_core::Truthiness;
 
 use crate::types::{
     EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
-    LiteralValueTypeKind, Type, UnionBuilder,
+    LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder,
 };
-use crate::{Db, FxOrderSet};
+use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
@@ -185,10 +185,10 @@ struct EnumValueSet<'db> {
 enum EnumValueSetMembers<'db> {
     /// The entire enum domain, including undeclared runtime values when the enum is open.
     All,
-    /// One canonical member name after resolving aliases.
-    One(&'db Name),
-    /// An exact set of canonical member names.
-    Included(FxOrderSet<&'db Name>),
+    /// One canonical member name after resolving aliases, and whether its literal is promotable.
+    One { name: &'db Name, promotable: bool },
+    /// An exact set of canonical member names and their literal promotability.
+    Included(FxOrderMap<&'db Name, bool>),
     /// The enum domain except for the declared members excluded by an enum complement.
     AllExcept(EnumComplementType<'db>),
 }
@@ -201,14 +201,17 @@ impl<'db> EnumValueSet<'db> {
     fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         let value_set = match ty.resolve_type_alias(db) {
             Type::LiteralValue(literal) => {
-                let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                let LiteralValueTypeKind::Enum(enum_literal) = literal.kind() else {
                     return None;
                 };
-                let enum_class = literal.enum_class_literal(db);
-                let name = enum_class.resolve_member(db, literal.name(db))?;
+                let enum_class = enum_literal.enum_class_literal(db);
+                let name = enum_class.resolve_member(db, enum_literal.name(db))?;
                 Self {
                     enum_class,
-                    members: EnumValueSetMembers::One(name),
+                    members: EnumValueSetMembers::One {
+                        name,
+                        promotable: literal.is_promotable(),
+                    },
                 }
             }
             Type::NominalInstance(instance) => Self {
@@ -231,7 +234,7 @@ impl<'db> EnumValueSet<'db> {
     /// Whole-domain and complement arms are rejected because they are not exact included sets.
     fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
         let mut enum_class = None;
-        let mut included = FxOrderSet::default();
+        let mut included = FxOrderMap::default();
         for element in elements {
             let value_set = Self::from_type(db, *element)?;
             if let Some(enum_class) = enum_class
@@ -241,17 +244,22 @@ impl<'db> EnumValueSet<'db> {
             }
             enum_class = Some(value_set.enum_class);
             match value_set.members {
-                EnumValueSetMembers::One(name) => {
-                    included.insert(name);
+                EnumValueSetMembers::One { name, promotable } => {
+                    Self::insert_member(&mut included, name, promotable);
                 }
-                EnumValueSetMembers::Included(names) => included.extend(names),
+                EnumValueSetMembers::Included(members) => {
+                    for (name, promotable) in members {
+                        Self::insert_member(&mut included, name, promotable);
+                    }
+                }
                 EnumValueSetMembers::All | EnumValueSetMembers::AllExcept(_) => return None,
             }
         }
 
         let enum_class = enum_class?;
         let members = if included.len() == 1 {
-            EnumValueSetMembers::One(included.into_iter().next()?)
+            let (name, promotable) = included.into_iter().next()?;
+            EnumValueSetMembers::One { name, promotable }
         } else {
             EnumValueSetMembers::Included(included)
         };
@@ -259,6 +267,22 @@ impl<'db> EnumValueSet<'db> {
             enum_class,
             members,
         })
+    }
+
+    /// Insert a member, preserving unpromotable literal provenance if either occurrence has it.
+    fn insert_member(
+        included: &mut FxOrderMap<&'db Name, bool>,
+        name: &'db Name,
+        promotable: bool,
+    ) {
+        match included.entry(name) {
+            ordermap::map::Entry::Vacant(entry) => {
+                entry.insert(promotable);
+            }
+            ordermap::map::Entry::Occupied(mut entry) => {
+                *entry.get_mut() &= promotable;
+            }
+        }
     }
 
     /// Extract the enum restriction while discarding unrelated positive intersection state.
@@ -282,7 +306,7 @@ impl<'db> EnumValueSet<'db> {
     fn member_count(&self, db: &'db dyn Db) -> usize {
         match &self.members {
             EnumValueSetMembers::All => self.enum_class.member_count(db),
-            EnumValueSetMembers::One(_) => 1,
+            EnumValueSetMembers::One { .. } => 1,
             EnumValueSetMembers::Included(names) => names.len(),
             EnumValueSetMembers::AllExcept(complement) => {
                 self.enum_class.member_count(db) - complement.excluded_names(db).len()
@@ -298,7 +322,7 @@ impl<'db> EnumValueSet<'db> {
         members_are_exhaustive
             || matches!(
                 self.members,
-                EnumValueSetMembers::One(_) | EnumValueSetMembers::Included(_)
+                EnumValueSetMembers::One { .. } | EnumValueSetMembers::Included(_)
             )
     }
 
@@ -310,10 +334,13 @@ impl<'db> EnumValueSet<'db> {
         debug_assert_eq!(self.enum_class, other.enum_class);
         match (&self.members, &other.members) {
             (EnumValueSetMembers::All, _) | (_, EnumValueSetMembers::All) => true,
-            (EnumValueSetMembers::One(left), EnumValueSetMembers::One(right)) => left == right,
-            (EnumValueSetMembers::One(name), EnumValueSetMembers::Included(names))
-            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One(name)) => {
-                names.contains(name)
+            (
+                EnumValueSetMembers::One { name: left, .. },
+                EnumValueSetMembers::One { name: right, .. },
+            ) => left == right,
+            (EnumValueSetMembers::One { name, .. }, EnumValueSetMembers::Included(names))
+            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One { name, .. }) => {
+                names.contains_key(name)
             }
             (EnumValueSetMembers::Included(left), EnumValueSetMembers::Included(right)) => {
                 let (smaller, larger) = if left.len() < right.len() {
@@ -321,16 +348,16 @@ impl<'db> EnumValueSet<'db> {
                 } else {
                     (right, left)
                 };
-                smaller.iter().any(|name| larger.contains(name))
+                smaller.keys().any(|name| larger.contains_key(name))
             }
-            (EnumValueSetMembers::One(name), EnumValueSetMembers::AllExcept(complement))
-            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One(name)) => {
+            (EnumValueSetMembers::One { name, .. }, EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One { name, .. }) => {
                 !complement.excluded_names(db).contains(*name)
             }
             (EnumValueSetMembers::Included(names), EnumValueSetMembers::AllExcept(complement))
             | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::Included(names)) => {
                 names
-                    .iter()
+                    .keys()
                     .any(|name| !complement.excluded_names(db).contains(*name))
             }
             (EnumValueSetMembers::AllExcept(left), EnumValueSetMembers::AllExcept(right)) => {
@@ -350,17 +377,13 @@ impl<'db> EnumValueSet<'db> {
                 .enum_class
                 .class_literal(db)
                 .to_non_generic_instance(db),
-            EnumValueSetMembers::One(name) => {
-                Type::enum_literal(EnumLiteralType::new(db, self.enum_class, (*name).clone()))
+            EnumValueSetMembers::One { name, promotable } => {
+                self.member_type(db, name, *promotable)
             }
-            EnumValueSetMembers::Included(names) => names
+            EnumValueSetMembers::Included(members) => members
                 .iter()
-                .fold(UnionBuilder::new(db), |builder, name| {
-                    builder.add(Type::enum_literal(EnumLiteralType::new(
-                        db,
-                        self.enum_class,
-                        (*name).clone(),
-                    )))
+                .fold(UnionBuilder::new(db), |builder, (name, promotable)| {
+                    builder.add(self.member_type(db, name, *promotable))
                 })
                 .build(),
             EnumValueSetMembers::AllExcept(complement) => {
@@ -386,20 +409,29 @@ impl<'db> EnumValueSet<'db> {
         if self.member_count(db) != 1 {
             return None;
         }
-        let name = match &self.members {
-            EnumValueSetMembers::All => self.enum_class.member_names(db).next()?,
-            EnumValueSetMembers::One(name) => name,
-            EnumValueSetMembers::Included(names) => names.first()?,
-            EnumValueSetMembers::AllExcept(complement) => self
-                .enum_class
-                .member_names(db)
-                .find(|name| !complement.excluded_names(db).contains(*name))?,
+        let (name, promotable) = match &self.members {
+            EnumValueSetMembers::All => (self.enum_class.member_names(db).next()?, true),
+            EnumValueSetMembers::One { name, promotable } => (*name, *promotable),
+            EnumValueSetMembers::Included(members) => {
+                let (name, promotable) = members.first()?;
+                (*name, *promotable)
+            }
+            EnumValueSetMembers::AllExcept(complement) => (
+                self.enum_class
+                    .member_names(db)
+                    .find(|name| !complement.excluded_names(db).contains(*name))?,
+                true,
+            ),
         };
-        Some(Type::enum_literal(EnumLiteralType::new(
-            db,
-            self.enum_class,
-            (*name).clone(),
-        )))
+        Some(self.member_type(db, name, promotable))
+    }
+
+    fn member_type(&self, db: &'db dyn Db, name: &Name, promotable: bool) -> Type<'db> {
+        LiteralValueType::new(
+            EnumLiteralType::new(db, self.enum_class, name.clone()),
+            promotable,
+        )
+        .into()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -13,6 +13,9 @@ use crate::{Db, FxOrderSet};
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
 /// Compare two compact domains from the same enum without expanding their members.
+///
+/// Any narrowing constraint produced here contains only enum-membership facts. In particular,
+/// equality never transfers gradual or nominal intersection state from one operand to the other.
 pub(super) fn evaluate_same_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
@@ -100,6 +103,10 @@ pub(in crate::types) fn enum_membership_constraint<'db>(
     }
 }
 
+/// Two non-empty value domains from the same enum and the semantics used to compare them.
+///
+/// Keeping the operands compact avoids constructing and pairwise comparing unions of every
+/// declared member.
 struct SameEnumComparison<'db> {
     left: EnumValueSet<'db>,
     right: EnumValueSet<'db>,
@@ -150,6 +157,10 @@ impl<'db> SameEnumComparison<'db> {
         Some(equality.negate_if(operator == ComparisonOperator::Inequality))
     }
 
+    /// Return whether equality can soundly transfer the right-hand enum restriction to the left.
+    ///
+    /// The right domain must be closed, and the left must either be closed as well or use identity
+    /// comparison, for which undeclared runtime members cannot equal a declared member.
     fn supports_domain_narrowing(&self) -> bool {
         matches!(
             self.profile.comparison_keys,
@@ -170,10 +181,15 @@ struct EnumValueSet<'db> {
     members: EnumValueSetMembers<'db>,
 }
 
+/// Compact representation of the member names admitted by an [`EnumValueSet`].
 enum EnumValueSetMembers<'db> {
+    /// The entire enum domain, including undeclared runtime values when the enum is open.
     All,
+    /// One canonical member name after resolving aliases.
     One(&'db Name),
+    /// An exact set of canonical member names.
     Included(FxOrderSet<&'db Name>),
+    /// The enum domain except for the declared members excluded by an enum complement.
     AllExcept(EnumComplementType<'db>),
 }
 
@@ -210,6 +226,9 @@ impl<'db> EnumValueSet<'db> {
         (value_set.member_count(db) > 0).then_some(value_set)
     }
 
+    /// Extract an exact included-member set from a union of enum domains.
+    ///
+    /// Whole-domain and complement arms are rejected because they are not exact included sets.
     fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
         let mut enum_class = None;
         let mut included = FxOrderSet::default();
@@ -242,6 +261,7 @@ impl<'db> EnumValueSet<'db> {
         })
     }
 
+    /// Extract the enum restriction while discarding unrelated positive intersection state.
     fn from_intersection(db: &'db dyn Db, intersection: IntersectionType<'db>) -> Option<Self> {
         if let Some(complement) = intersection.enum_complement(db) {
             return Self::from_type(db, Type::EnumComplement(complement));
@@ -270,6 +290,10 @@ impl<'db> EnumValueSet<'db> {
         }
     }
 
+    /// Return whether this set excludes every value not named by its representation.
+    ///
+    /// A whole-domain or complement representation is not closed for an enum that can create
+    /// undeclared members at runtime.
     fn is_closed(&self, members_are_exhaustive: bool) -> bool {
         members_are_exhaustive
             || matches!(
@@ -354,6 +378,10 @@ impl<'db> EnumValueSet<'db> {
         }
     }
 
+    /// Reconstruct the only declared member left in this set.
+    ///
+    /// The caller must separately establish that the domain is closed before treating this as the
+    /// operand's only possible runtime value.
     fn singleton_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self.member_count(db) != 1 {
             return None;
@@ -375,9 +403,12 @@ impl<'db> EnumValueSet<'db> {
     }
 }
 
+/// Whether distinct declared members are known to have distinct runtime comparison keys.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 enum EnumComparisonKeys {
+    /// Different member names cannot compare equal.
     Distinct,
+    /// Values are unknown or repeated, so different member names may compare equal.
     UnknownOrRepeated,
 }
 
@@ -422,6 +453,9 @@ fn enum_comparison_profile<'db>(
     }
 }
 
+/// Return whether every declared member has a unique modeled runtime comparison key.
+///
+/// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
     enum_class: EnumClassLiteral<'db>,

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,4 +1,4 @@
-//! Compact equality reasoning for values from the same enum class.
+//! Equality reasoning for values from the same enum class without expanding member unions.
 
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
@@ -13,7 +13,7 @@ use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
-/// Compare two compact domains from the same enum without expanding their members.
+/// Compare two value domains from the same enum without comparing every pair of members.
 ///
 /// Any narrowing constraint produced here contains only enum-membership facts. In particular,
 /// equality never transfers gradual or nominal intersection state from one operand to the other.
@@ -48,7 +48,7 @@ pub(super) fn evaluate_same_enum_domains<'db>(
     }
 }
 
-/// The result of comparing two compact domains from the same enum.
+/// The result of comparing two value domains from the same enum.
 pub(in crate::types) enum EnumComparison {
     /// The comparison method is modeled and has the given truthiness.
     Known(Truthiness),
@@ -56,10 +56,10 @@ pub(in crate::types) enum EnumComparison {
     Unmodeled,
 }
 
-/// Compare two compact domains from the same enum without expanding either operand.
+/// Compare two value domains from the same enum without comparing every pair of members.
 ///
 /// `None` means that an operand is not structurally an enum domain.
-pub(in crate::types) fn compact_enum_comparison<'db>(
+pub(in crate::types) fn same_enum_comparison<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
@@ -106,8 +106,8 @@ pub(in crate::types) fn enum_membership_constraint<'db>(
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
 ///
-/// Keeping the operands compact avoids constructing and pairwise comparing unions of every
-/// declared member.
+/// This representation avoids constructing and pairwise comparing unions of every declared
+/// member.
 struct SameEnumComparison<'db> {
     left: EnumValueSet<'db>,
     right: EnumValueSet<'db>,

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -471,10 +471,10 @@ fn enum_comparison_profile<'db>(
         None => (None, false),
         Some(KnownComparisonSemantics::Object) => (Some(EnumComparisonKeys::Distinct), true),
         Some(
-            KnownComparisonSemantics::Int
+            semantics @ (KnownComparisonSemantics::Int
             | KnownComparisonSemantics::Str
-            | KnownComparisonSemantics::Bytes,
-        ) if enum_members_have_distinct_value_keys(db, enum_class) => {
+            | KnownComparisonSemantics::Bytes),
+        ) if enum_members_have_distinct_value_keys(db, enum_class, semantics) => {
             (Some(EnumComparisonKeys::Distinct), false)
         }
         Some(_) => (Some(EnumComparisonKeys::UnknownOrRepeated), false),
@@ -488,26 +488,27 @@ fn enum_comparison_profile<'db>(
 
 /// Return whether every declared member has a unique modeled runtime comparison key.
 ///
+/// A value is only used when its literal kind matches the inherited scalar semantics; other values
+/// may be normalized by the scalar constructor before enum alias detection.
 /// Keys exclude literal metadata such as promotability, which does not affect runtime equality.
 /// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
     enum_class: EnumClassLiteral<'db>,
+    semantics: KnownComparisonSemantics,
 ) -> bool {
     let mut keys = FxHashSet::default();
     enum_class.members(db).iter().all(|(_, value)| {
-        let key = match value.as_literal_value_kind() {
-            Some(LiteralValueTypeKind::Bool(value)) => {
+        let key = match (semantics, value.as_literal_value_kind()) {
+            (KnownComparisonSemantics::Int, Some(LiteralValueTypeKind::Bool(value))) => {
                 LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value)))
             }
-            Some(
-                kind @ (LiteralValueTypeKind::Int(_)
-                | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_)),
-            ) => kind,
-            Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
-                return false;
+            (KnownComparisonSemantics::Int, Some(kind @ LiteralValueTypeKind::Int(_)))
+            | (KnownComparisonSemantics::Str, Some(kind @ LiteralValueTypeKind::String(_)))
+            | (KnownComparisonSemantics::Bytes, Some(kind @ LiteralValueTypeKind::Bytes(_))) => {
+                kind
             }
+            _ => return false,
         };
         keys.insert(key)
     })

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -4,6 +4,7 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 use ty_python_core::Truthiness;
 
+use crate::types::literal::IntLiteralType;
 use crate::types::{
     EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
     LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder,
@@ -487,6 +488,7 @@ fn enum_comparison_profile<'db>(
 
 /// Return whether every declared member has a unique modeled runtime comparison key.
 ///
+/// Keys exclude literal metadata such as promotability, which does not affect runtime equality.
 /// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
@@ -495,12 +497,14 @@ fn enum_members_have_distinct_value_keys<'db>(
     let mut keys = FxHashSet::default();
     enum_class.members(db).iter().all(|(_, value)| {
         let key = match value.as_literal_value_kind() {
-            Some(LiteralValueTypeKind::Bool(value)) => Type::int_literal(i64::from(value)),
+            Some(LiteralValueTypeKind::Bool(value)) => {
+                LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value)))
+            }
             Some(
-                LiteralValueTypeKind::Int(_)
+                kind @ (LiteralValueTypeKind::Int(_)
                 | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_),
-            ) => *value,
+                | LiteralValueTypeKind::Bytes(_)),
+            ) => kind,
             Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
                 return false;
             }

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -7,6 +7,7 @@ use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
+use crate::types::equality::{EnumComparison, compact_enum_comparison};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
@@ -169,6 +170,19 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
         }
     };
+
+    if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
+        && let Some(comparison) = compact_enum_comparison(db, left, right, op == ast::CmpOp::Eq)
+    {
+        return match comparison {
+            EnumComparison::Known(truthiness) => Ok(match truthiness {
+                Truthiness::AlwaysTrue => Type::bool_literal(true),
+                Truthiness::AlwaysFalse => Type::bool_literal(false),
+                Truthiness::Ambiguous => KnownClass::Bool.to_instance(db),
+            }),
+            EnumComparison::Unmodeled => try_dunder(MemberLookupPolicy::default()),
+        };
+    }
 
     let comparison_result = match (left, right) {
         (Type::EnumComplement(complement), right) => Some(infer_binary_type_comparison(

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -7,7 +7,7 @@ use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
-use crate::types::equality::{EnumComparison, compact_enum_comparison};
+use crate::types::equality::{EnumComparison, same_enum_comparison};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
@@ -172,7 +172,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
     };
 
     if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq)
-        && let Some(comparison) = compact_enum_comparison(db, left, right, op == ast::CmpOp::Eq)
+        && let Some(comparison) = same_enum_comparison(db, left, right, op == ast::CmpOp::Eq)
     {
         return match comparison {
             EnumComparison::Known(truthiness) => Ok(match truthiness {


### PR DESCRIPTION
## Summary

When comparing two narrowed values of the same enum, we materialize the remaining members and compare their cross-product, which is extremely slow for a large enum.

This PR adds a compact representation for operands from the same enum: all members, one member, an included set, or all members except a known set. We compare those sets directly to determine overlap, truthiness, and safe branch constraints without expanding member pairs.

This also makes comparison expressions more precise when the enum's comparison behavior and member values are known. Previously, comparisons between ordinary `Enum` members could produce `Literal[True]` or `Literal[False]`, while `StrEnum`, `IntEnum`, and other scalar-mixin enums generally fell back to a dunder method whose annotated return type was only `bool`. We now use the same modeled runtime values and comparison semantics for both narrowing and expression inference:

```python
from enum import StrEnum
from typing import Literal

class Choice(StrEnum):
    FIRST = "first"
    SECOND = "second"
    THIRD = "third"
    FOURTH = "fourth"

def compare(
    left: Literal[Choice.FIRST, Choice.SECOND],
    right: Literal[Choice.THIRD, Choice.FOURTH],
):
    reveal_type(left == right)  # Literal[False]
```

Closes https://github.com/astral-sh/ty/issues/3830.
