### PR TITLE
[ty] Avoid stack overflows in reachability analysis

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/post_if_statement.md
@@ -160,6 +160,31 @@ def _(val: int | None):
     reveal_type(val)  # revealed: int
 ```
 
+Narrowing from the terminal branch is also preserved when deciding whether a later overloaded call
+returns:
+
+```py
+from typing import Literal, overload
+from typing_extensions import Never
+
+def abort() -> Never:
+    raise RuntimeError
+
+@overload
+def terminal(value: Literal[0]) -> Never: ...
+@overload
+def terminal(value: Literal[1]) -> None: ...
+def terminal(value: Literal[0, 1]) -> None:
+    if value == 0:
+        raise RuntimeError
+
+def _(value: Literal[0, 1]) -> None:
+    if value == 1:
+        abort()
+    terminal(value)
+    return "unreachable"
+```
+
 This also works when the `NoReturn` function is called in the else branch:
 
 ```py

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -598,6 +598,28 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
     ) -> Truthiness {
         type Id = ScopedReachabilityConstraintId;
 
+        // Analyze statement-level calls through this root one by one in source order, so any
+        // earlier call needed while inferring a later one is already cached instead of deepening
+        // the Salsa query stack. This avoids growing an excessive stack for deeply nested
+        // reachability queries.
+        //
+        // Without this prefix analysis, given:
+        //
+        //   call_a()  # predicate 0
+        //   call_b()  # predicate 1
+        //   call_c()  # predicate 2
+        //
+        // we'd analyze them backwards:
+        //
+        //   analyze call_c
+        //   └─ analyze call_b
+        //      └─ analyze call_a
+        //
+        // The prefix pass explicitly analyzes them forwards:
+        //
+        //   analyze call_a  → cached
+        //   analyze call_b  → call_a is already cached
+        //   analyze call_c  → call_b is already cached
         if !id.is_terminal() {
             let root_predicate = self.get_interior_node(id).atom();
             analyze_non_terminal_call_prefix(db, predicates, root_predicate);

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -634,9 +634,6 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         _ => {}
     }
 
-    let root_predicate = constraints.get_interior_node(id).atom;
-    analyze_non_terminal_call_prefix(db, predicates, root_predicate);
-
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -542,6 +542,12 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 /// chain. Inferring the expressions in source order turns that chain into cache lookups while
 /// preserving normal reachability and narrowing during every inference.
 ///
+/// Because the prefix is based on predicate indices rather than graph reachability, branch-heavy
+/// code can warm calls from earlier source branches that this evaluation would not otherwise visit.
+/// A demand-driven graph walk could avoid that work, but would require a more complex work list. We
+/// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
+/// typically exercise most of its predicates eventually.
+///
 /// Reentrant analysis of the same predicate graph skips the prefix pass: because the outer pass is
 /// proceeding in source order, any preceding call needed by the current expression has already
 /// been inferred. A different predicate graph performs its own pass, which is necessary when

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -200,9 +200,9 @@ use crate::{
     dunder_all::dunder_all_names,
     place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
     types::{
-        CallableTypes, EnumClassLiteral, IntersectionBuilder, NarrowingConstraint, SpecialFormType,
-        Type, TypeContext, UnionType, callable_pattern_type, definite_match_pattern_type,
-        equality_truthiness, expand_type, infer_narrowing_constraints,
+        ActiveRecursionDetector, CallableTypes, EnumClassLiteral, IntersectionBuilder,
+        NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
+        definite_match_pattern_type, equality_truthiness, expand_type, infer_narrowing_constraints,
         infer_same_file_expression_type, mapping_pattern_type, pattern_binding_fallthrough_type,
         sequence_pattern_type_builder, singleton_pattern_type,
     },
@@ -211,11 +211,13 @@ use ruff_index::{Idx, IndexSlice};
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
+use salsa::plumbing::AsId;
 use smallvec::SmallVec;
 use ty_python_core::{
     BindingWithConstraints, DeclarationWithConstraint, DeclarationsIterator, FileScopeId,
     ScopedDefinitionId, SemanticIndex, Truthiness, UseDefMap,
     definition::DefinitionState,
+    expression::Expression,
     narrowing_constraints::{NarrowingConstraints, ScopedNarrowingConstraint},
     place::ScopedPlaceId,
     place_table,
@@ -516,6 +518,66 @@ fn accumulate_constraint<'db>(
     }
 }
 
+std::thread_local! {
+    static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
+}
+
+fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
+    match predicate.node {
+        PredicateNode::Expression(expression) => expression.scope(db),
+        PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
+            callable.scope(db)
+        }
+        PredicateNode::Pattern(pattern) => pattern.scope(db),
+        PredicateNode::SubjectElementPattern(subject_element) => subject_element.pattern.scope(db),
+        PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
+    }
+}
+
+/// Infers preceding call predicates in source order.
+///
+/// Predicate IDs are assigned in source order, but the decision diagrams intentionally order
+/// predicates in reverse to reduce their size. Inferring a later call can depend on the
+/// reachability of all preceding calls, which otherwise creates a deeply recursive Salsa query
+/// chain. Inferring the expressions in source order turns that chain into cache lookups while
+/// preserving normal reachability and narrowing during every inference.
+///
+/// Reentrant analysis of the same predicate graph skips the prefix pass: because the outer pass is
+/// proceeding in source order, any preceding call needed by the current expression has already
+/// been inferred. A different predicate graph performs its own pass, which is necessary when
+/// inferring a call crosses into another large scope.
+fn analyze_non_terminal_call_prefix<'db>(
+    db: &'db dyn Db,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    root_predicate: ScopedPredicateId,
+) {
+    let range = 0..=root_predicate.index();
+    if !range.clone().any(|index| {
+        matches!(
+            predicates[ScopedPredicateId::new(index)].node,
+            PredicateNode::IsNonTerminalCall(_)
+        )
+    }) {
+        return;
+    }
+
+    let key = predicate_scope(db, &predicates[root_predicate]).as_id();
+    ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
+        active.visit(
+            &key,
+            || {},
+            || {
+                for index in range {
+                    let predicate = &predicates[ScopedPredicateId::new(index)];
+                    if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
+                        analyze_single(db, predicate);
+                    }
+                }
+            },
+        );
+    });
+}
+
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
     /// Analyze the statically known reachability for a given constraint.
     fn evaluate(
@@ -535,6 +597,11 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         mut id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
         type Id = ScopedReachabilityConstraintId;
+
+        if !id.is_terminal() {
+            let root_predicate = self.get_interior_node(id).atom();
+            analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+        }
 
         loop {
             let node = match id {
@@ -566,6 +633,9 @@ pub(crate) fn narrow_type_by_constraint<'db>(
         ScopedNarrowingConstraint::ALWAYS_FALSE => return Type::Never,
         _ => {}
     }
+
+    let root_predicate = constraints.get_interior_node(id).atom;
+    analyze_non_terminal_call_prefix(db, predicates, root_predicate);
 
     let mut projector = NarrowingProjector::new(db, constraints, predicates, place);
     let projected_root = projector.project(id);
@@ -1132,6 +1202,74 @@ fn analyze_single_pattern_predicate_kind<'db>(
     }
 }
 
+/// Determines whether a statement-level call can return.
+///
+/// Only a call known to return `Never` is treated as terminal. Unsupported or uncertain callable
+/// forms are conservatively treated as returning so that subsequent code remains reachable.
+///
+/// Cycle recovery conservatively treats the call as returning so that a cyclic type inference
+/// dependency cannot make subsequent code unreachable.
+#[salsa::tracked(
+    cycle_initial = |_, _, _, _, _| Truthiness::AlwaysTrue,
+    heap_size = get_size2::GetSize::get_heap_size
+)]
+fn analyze_non_terminal_call<'db>(
+    db: &'db dyn Db,
+    callable: Expression<'db>,
+    call_expr: Expression<'db>,
+    is_await: bool,
+) -> Truthiness {
+    // We first infer just the type of the callable. In the most likely case that the function is
+    // not marked with `NoReturn`, or that it always returns `NoReturn`, doing so allows us to avoid
+    // the more expensive work of inferring the entire call expression (which could involve
+    // inferring argument types to possibly run the overload selection algorithm). Avoiding this on
+    // the happy path is important because these constraints can be very large in number, since we
+    // add them on all statement-level function calls.
+    let ty = infer_same_file_expression_type(db, callable, TypeContext::default());
+
+    // Short-circuit for well-known types that are known not to return `Never` when called. Without
+    // the short-circuit, we've seen that threads keep blocking each other because they all try to
+    // acquire Salsa's `CallableType` lock that ensures each type is only interned once. The lock is
+    // so heavily congested because there are only very few dynamic types, in which case Salsa's
+    // sharding the locks by value doesn't help much. See <https://github.com/astral-sh/ty/issues/968>.
+    if matches!(ty, Type::Dynamic(_)) {
+        return Truthiness::AlwaysTrue;
+    }
+
+    let overloads_iterator = if let Some(callable) = ty
+        .try_upcast_to_callable(db)
+        .and_then(CallableTypes::exactly_one)
+    {
+        callable.signatures(db).overloads.iter()
+    } else {
+        return Truthiness::AlwaysTrue;
+    };
+
+    let mut no_overloads_return_never = true;
+    let mut all_overloads_return_never = true;
+    let mut any_overload_is_generic = false;
+
+    for overload in overloads_iterator {
+        let returns_never = overload.return_ty.is_equivalent_to(db, Type::Never);
+        no_overloads_return_never &= !returns_never;
+        all_overloads_return_never &= returns_never;
+        any_overload_is_generic |= overload.return_ty.has_typevar(db);
+    }
+
+    if no_overloads_return_never && !any_overload_is_generic && !is_await {
+        Truthiness::AlwaysTrue
+    } else if all_overloads_return_never {
+        Truthiness::AlwaysFalse
+    } else {
+        let call_expr_ty = infer_same_file_expression_type(db, call_expr, TypeContext::default());
+        if call_expr_ty.is_equivalent_to(db, Type::Never) {
+            Truthiness::AlwaysFalse
+        } else {
+            Truthiness::AlwaysTrue
+        }
+    }
+}
+
 fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
     let _span = tracing::trace_span!("analyze_single", ?predicate).entered();
 
@@ -1145,62 +1283,8 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
             callable,
             call_expr,
             is_await,
-        }) => {
-            // We first infer just the type of the callable. In the most likely case that the
-            // function is not marked with `NoReturn`, or that it always returns `NoReturn`,
-            // doing so allows us to avoid the more expensive work of inferring the entire call
-            // expression (which could involve inferring argument types to possibly run the overload
-            // selection algorithm).
-            // Avoiding this on the happy-path is important because these constraints can be
-            // very large in number, since we add them on all statement level function calls.
-            let ty = infer_same_file_expression_type(db, callable, TypeContext::default());
-
-            // Short-circuit for well known types that are known not to return `Never` when called.
-            // Without the short-circuit, we've seen that threads keep blocking each other
-            // because they all try to acquire Salsa's `CallableType` lock that ensures each type
-            // is only interned once. The lock is so heavily congested because there are only
-            // very few dynamic types, in which case Salsa's sharding the locks by value
-            // doesn't help much.
-            // See <https://github.com/astral-sh/ty/issues/968>.
-            if matches!(ty, Type::Dynamic(_)) {
-                return Truthiness::AlwaysTrue.negate_if(!predicate.is_positive);
-            }
-
-            let overloads_iterator = if let Some(callable) = ty
-                .try_upcast_to_callable(db)
-                .and_then(CallableTypes::exactly_one)
-            {
-                callable.signatures(db).overloads.iter()
-            } else {
-                return Truthiness::AlwaysTrue.negate_if(!predicate.is_positive);
-            };
-
-            let mut no_overloads_return_never = true;
-            let mut all_overloads_return_never = true;
-            let mut any_overload_is_generic = false;
-
-            for overload in overloads_iterator {
-                let returns_never = overload.return_ty.is_equivalent_to(db, Type::Never);
-                no_overloads_return_never &= !returns_never;
-                all_overloads_return_never &= returns_never;
-                any_overload_is_generic |= overload.return_ty.has_typevar(db);
-            }
-
-            if no_overloads_return_never && !any_overload_is_generic && !is_await {
-                Truthiness::AlwaysTrue
-            } else if all_overloads_return_never {
-                Truthiness::AlwaysFalse
-            } else {
-                let call_expr_ty =
-                    infer_same_file_expression_type(db, call_expr, TypeContext::default());
-                if call_expr_ty.is_equivalent_to(db, Type::Never) {
-                    Truthiness::AlwaysFalse
-                } else {
-                    Truthiness::AlwaysTrue
-                }
-            }
-            .negate_if(!predicate.is_positive)
-        }
+        }) => analyze_non_terminal_call(db, callable, call_expr, is_await)
+            .negate_if(!predicate.is_positive),
         PredicateNode::Pattern(inner) => analyze_pattern_predicate(db, inner),
         PredicateNode::SubjectElementPattern(subject_element) => {
             analyze_pattern_predicate(db, subject_element.pattern)
@@ -1351,17 +1435,7 @@ impl<'db> ReachabilityEvaluationCache<'db> {
 
         let predicate = predicates[constraints.get_interior_node(id).atom()];
         let constraints_key = std::ptr::from_ref(constraints).addr();
-        let scope = match predicate.node {
-            PredicateNode::Expression(expression) => expression.scope(db),
-            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
-                callable.scope(db)
-            }
-            PredicateNode::Pattern(pattern) => pattern.scope(db),
-            PredicateNode::SubjectElementPattern(subject_element) => {
-                subject_element.pattern.scope(db)
-            }
-            PredicateNode::StarImportPlaceholder(star_import) => star_import.scope(db),
-        };
+        let scope = predicate_scope(db, &predicate);
 
         if scope != self.primary_scope || constraints_key != self.primary_constraints {
             let key = (constraints_key, id);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -24,7 +24,7 @@ use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
-pub(crate) use self::cyclic::TypeTransformer;
+pub(crate) use self::cyclic::{ActiveRecursionDetector, TypeTransformer};
 pub(crate) use self::diagnostic::register_lints;
 pub use self::diagnostic::{TypeCheckDiagnostics, UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
 pub(crate) use self::infer::{

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -3,7 +3,7 @@ use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
 use crate::place::{ConsideredDefinitions, Place, global_symbol};
 use crate::types::{KnownClass, KnownInstanceType, check_types};
-use ruff_db::diagnostic::Diagnostic;
+use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
@@ -53,6 +53,23 @@ fn assert_file_diagnostics(db: &TestDb, filename: &str, expected: &[&str]) {
     let diagnostics = check_types(db, file);
 
     assert_diagnostic_messages(&diagnostics, expected);
+}
+
+#[track_caller]
+fn assert_revealed_type(db: &TestDb, filename: &str, expected: &str) {
+    let file = system_path_to_file(db, filename).unwrap();
+    let diagnostics = check_types(db, file);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+
+    let diagnostic = &diagnostics[0];
+    assert_eq!(diagnostic.id(), DiagnosticId::RevealedType);
+    let expected = format!("`{expected}`");
+    assert_eq!(
+        diagnostic
+            .primary_annotation()
+            .and_then(|annotation| annotation.get_message()),
+        Some(expected.as_str())
+    );
 }
 
 #[test]
@@ -325,6 +342,288 @@ fn unbound_symbol_no_reachability_constraint_check() {
     });
     let expected: Vec<String> = vec![];
     assert_eq!(cycles, expected);
+}
+
+const MANY_WIDGETS: usize = 400;
+const MANY_NON_TERMINAL_CALLS: usize = 1_100;
+const FEW_NON_TERMINAL_CALLS: usize = 80;
+
+#[test]
+fn implicit_attribute_after_many_non_terminal_calls() -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name("implicit-attribute-stack-test".into())
+        // Match the stack size used by ty's production worker threads.
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(|| {
+            let mut db = setup_db();
+            let mut ui = String::from(
+                r#"from widgets import Widget
+
+class Ui:
+    def setup(self):
+"#,
+            );
+
+            for index in 0..MANY_WIDGETS {
+                ui.push_str(&format!(
+                    concat!(
+                        "        self.widget_{index} = Widget()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                    ),
+                    index = index,
+                ));
+            }
+            ui.push_str("        self.target = Widget()\n");
+
+            db.write_files([
+                (
+                    "/src/widgets.py",
+                    r#"class Widget:
+    def configure(self) -> None: ...
+"#,
+                ),
+                ("/src/ui.py", &ui),
+                (
+                    "/src/consumer.py",
+                    r#"from typing_extensions import reveal_type
+from ui import Ui
+from widgets import Widget
+
+class Form(Ui):
+    def target_widget(self) -> Widget:
+        reveal_type(self.target)
+        return self.target
+"#,
+                ),
+            ])?;
+
+            assert_revealed_type(&db, "/src/consumer.py", "Widget");
+
+            Ok(())
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn implicit_attribute_binding_forms_after_many_non_terminal_calls() -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name("implicit-attribute-binding-forms-stack-test".into())
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(|| {
+            let mut db = setup_db();
+            let mut ui = String::from(
+                r#"from widgets import Widget
+
+def noop() -> None: ...
+
+class Ui:
+    def setup(self):
+"#,
+            );
+            for _ in 0..FEW_NON_TERMINAL_CALLS {
+                ui.push_str("        noop()\n");
+            }
+            ui.push_str(
+                r#"        self.annotated_target: Widget = Widget()
+        self.unpacking_target, = (Widget(),)
+        for self.for_target in [Widget()]:
+            pass
+"#,
+            );
+
+            db.write_files([
+                ("/src/widgets.py", "class Widget: ...\n"),
+                ("/src/ui.py", &ui),
+                (
+                    "/src/annotated_consumer.py",
+                    r#"from typing_extensions import reveal_type
+from ui import Ui
+
+reveal_type(Ui().annotated_target)
+"#,
+                ),
+                (
+                    "/src/unpacking_consumer.py",
+                    r#"from typing_extensions import reveal_type
+from ui import Ui
+
+reveal_type(Ui().unpacking_target)
+"#,
+                ),
+                (
+                    "/src/for_consumer.py",
+                    r#"from typing_extensions import reveal_type
+from ui import Ui
+
+reveal_type(Ui().for_target)
+"#,
+                ),
+            ])?;
+
+            assert_revealed_type(&db, "/src/annotated_consumer.py", "Widget");
+            assert_revealed_type(&db, "/src/unpacking_consumer.py", "Widget");
+            assert_revealed_type(&db, "/src/for_consumer.py", "Widget");
+
+            Ok(())
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn nested_implicit_attribute_graphs_do_not_overflow_stack() -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name("nested-implicit-attribute-stack-test".into())
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(|| {
+            let mut db = setup_db();
+            let mut inner = String::from(
+                r#"from widgets import Widget
+
+class Inner:
+    def setup(self):
+"#,
+            );
+            for index in 0..MANY_WIDGETS {
+                inner.push_str(&format!(
+                    concat!(
+                        "        self.widget_{index} = Widget()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                    ),
+                    index = index,
+                ));
+            }
+            inner.push_str("        self.target = Widget()\n");
+
+            let mut outer = String::from(
+                r#"from inner import Inner
+
+def noop() -> None: ...
+
+class Outer:
+    def setup(self, inner: Inner, flag: bool):
+"#,
+            );
+            for _ in 0..FEW_NON_TERMINAL_CALLS {
+                outer.push_str("        noop()\n");
+            }
+            outer.push_str(
+                r#"        if flag:
+            inner.target.configure()
+        self.target = inner
+"#,
+            );
+
+            db.write_files([
+                (
+                    "/src/widgets.py",
+                    r#"class Widget:
+    def configure(self) -> None: ...
+"#,
+                ),
+                ("/src/inner.py", &inner),
+                ("/src/outer.py", &outer),
+                (
+                    "/src/consumer.py",
+                    r#"from typing_extensions import reveal_type
+from inner import Inner
+from outer import Outer
+
+class Form(Outer):
+    def target_inner(self) -> Inner:
+        reveal_type(self.target)
+        return self.target
+"#,
+                ),
+            ])?;
+
+            assert_revealed_type(&db, "/src/consumer.py", "Inner");
+
+            Ok(())
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn implicit_attribute_preserves_terminal_narrowing_after_many_calls() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let mut ui = String::from(
+        r#"import sys
+
+def noop() -> None: ...
+
+class Ui:
+    def setup(self, value: int | None):
+"#,
+    );
+    for _ in 0..MANY_NON_TERMINAL_CALLS {
+        ui.push_str("        noop()\n");
+    }
+    ui.push_str(
+        r#"        if value is None:
+            sys.exit()
+        self.target = value
+"#,
+    );
+
+    db.write_files([
+        ("/src/package/__init__.py", ""),
+        ("/src/package/ui.py", &ui),
+        (
+            "/src/package/consumer.py",
+            r#"from typing_extensions import reveal_type
+from .ui import Ui
+
+class Form(Ui):
+    def target_value(self) -> int:
+        reveal_type(self.target)
+        return self.target
+"#,
+        ),
+    ])?;
+
+    assert_revealed_type(&db, "/src/package/consumer.py", "int");
+
+    Ok(())
+}
+
+#[test]
+fn implicit_attribute_literal_after_many_calls() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    let mut ui = String::from(
+        r#"def noop() -> None: ...
+
+class Ui:
+    def setup(self):
+"#,
+    );
+    for _ in 0..MANY_NON_TERMINAL_CALLS {
+        ui.push_str("        noop()\n");
+    }
+    ui.push_str("        self.target = 1\n");
+
+    db.write_files([
+        ("/src/ui.py", ui.as_str()),
+        (
+            "/src/consumer.py",
+            r#"from ui import Ui
+
+class Form(Ui):
+    def target_value(self) -> int:
+        return self.target
+"#,
+        ),
+    ])?;
+
+    assert_file_diagnostics(&db, "/src/consumer.py", &[]);
+
+    Ok(())
 }
 
 // Incremental inference tests

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -408,72 +408,6 @@ class Form(Ui):
 }
 
 #[test]
-fn implicit_attribute_binding_forms_after_many_non_terminal_calls() -> anyhow::Result<()> {
-    let handle = std::thread::Builder::new()
-        .name("implicit-attribute-binding-forms-stack-test".into())
-        .stack_size(ruff_db::STACK_SIZE)
-        .spawn(|| {
-            let mut db = setup_db();
-            let mut ui = String::from(
-                r#"from widgets import Widget
-
-def noop() -> None: ...
-
-class Ui:
-    def setup(self):
-"#,
-            );
-            for _ in 0..FEW_NON_TERMINAL_CALLS {
-                ui.push_str("        noop()\n");
-            }
-            ui.push_str(
-                r#"        self.annotated_target: Widget = Widget()
-        self.unpacking_target, = (Widget(),)
-        for self.for_target in [Widget()]:
-            pass
-"#,
-            );
-
-            db.write_files([
-                ("/src/widgets.py", "class Widget: ...\n"),
-                ("/src/ui.py", &ui),
-                (
-                    "/src/annotated_consumer.py",
-                    r#"from typing_extensions import reveal_type
-from ui import Ui
-
-reveal_type(Ui().annotated_target)
-"#,
-                ),
-                (
-                    "/src/unpacking_consumer.py",
-                    r#"from typing_extensions import reveal_type
-from ui import Ui
-
-reveal_type(Ui().unpacking_target)
-"#,
-                ),
-                (
-                    "/src/for_consumer.py",
-                    r#"from typing_extensions import reveal_type
-from ui import Ui
-
-reveal_type(Ui().for_target)
-"#,
-                ),
-            ])?;
-
-            assert_revealed_type(&db, "/src/annotated_consumer.py", "Widget");
-            assert_revealed_type(&db, "/src/unpacking_consumer.py", "Widget");
-            assert_revealed_type(&db, "/src/for_consumer.py", "Widget");
-
-            Ok(())
-        })?;
-
-    handle.join().expect("regression test thread panicked")
-}
-
-#[test]
 fn nested_implicit_attribute_graphs_do_not_overflow_stack() -> anyhow::Result<()> {
     let handle = std::thread::Builder::new()
         .name("nested-implicit-attribute-stack-test".into())
@@ -589,39 +523,6 @@ class Form(Ui):
     ])?;
 
     assert_revealed_type(&db, "/src/package/consumer.py", "int");
-
-    Ok(())
-}
-
-#[test]
-fn implicit_attribute_literal_after_many_calls() -> anyhow::Result<()> {
-    let mut db = setup_db();
-    let mut ui = String::from(
-        r#"def noop() -> None: ...
-
-class Ui:
-    def setup(self):
-"#,
-    );
-    for _ in 0..MANY_NON_TERMINAL_CALLS {
-        ui.push_str("        noop()\n");
-    }
-    ui.push_str("        self.target = 1\n");
-
-    db.write_files([
-        ("/src/ui.py", ui.as_str()),
-        (
-            "/src/consumer.py",
-            r#"from ui import Ui
-
-class Form(Ui):
-    def target_value(self) -> int:
-        return self.target
-"#,
-        ),
-    ])?;
-
-    assert_file_diagnostics(&db, "/src/consumer.py", &[]);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

We record a reachability predicate for every statement-level call because the call may return `Never`. Predicate IDs follow source order, but reachability decision diagrams put later predicates before earlier ones. In a large generated method, analyzing a late call could infer its receiver, re-enter reachability for the preceding call, and continue backward through thousands of calls until the worker stack overflowed.

For example, given:

```python
call_a()  # predicate 0
call_b()  # predicate 1
call_c()  # predicate 2
```

Reachability previously discovered the dependencies backward:

```text
analyze call_c
└─ analyze call_b
   └─ analyze call_a
```

Before evaluating a reachability constraint, we now force analysis to process the relevant statement-level calls one by one in source order:

```text
analyze call_a → cached
analyze call_b → call_a is already cached
analyze call_c → call_b is already cached
```

Non-terminal-call analysis is a tracked Salsa query, so each result is cached. When inferring a later call asks about an earlier call, it gets that cached result instead of adding another nested inference and reachability frame.

Inferring a call can itself re-enter reachability, so a scope-keyed guard prevents the same source-order pass from starting again. A nested scope is still allowed to perform its own pass. The ordinary decision-diagram evaluation and `Never`-based narrowing behavior remain unchanged.

The exact PySide6 reproduction now completes successfully instead of aborting with a stack overflow.

Closes https://github.com/astral-sh/ty/issues/3822.
