### PR TITLE
[ty] Preserve stable union arms during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -628,6 +628,17 @@ def f() -> JSON_OBJECT:
     return {"hello": 23}
 ```
 
+### Aliased union in a self-recursive type alias
+
+Regression test for <https://github.com/astral-sh/ty/issues/3835>.
+
+```py
+from collections.abc import Sequence
+
+type JSONScalar = str | int
+type JSONValue = JSONScalar | Sequence[JSONValue] | dict[str, JSONValue]
+```
+
 ### Recursive dict alias in method return
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1234,16 +1234,22 @@ impl<'db> Type<'db> {
         div: Self,
     ) -> Option<Self> {
         if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
+            let current_elements = current.elements(db);
             let previous_elements = previous.elements(db);
+            let same_nominal_class = |left: Type<'db>, right: Type<'db>| {
+                left.as_nominal_instance()
+                    .zip(right.as_nominal_instance())
+                    .is_some_and(|(left, right)| left.class_literal(db) == right.class_literal(db))
+            };
 
             // Multiple union arms may each grow by wrapping the entire previous union. Normalize
-            // only when every previous arm is nominal and at least two changed current arms are
-            // nominal wrappers; arms shared with the previous union remain unchanged.
+            // only when every previous arm is nominal, at least two changed current arms are
+            // nominal wrappers, and each previous arm either remains unchanged or has a changed
+            // wrapper with the same nominal class.
             if previous_elements
                 .iter()
                 .all(|element| matches!(element, Type::NominalInstance(_)))
-                && let Some(replacements) = current
-                    .elements(db)
+                && let Some(replacements) = current_elements
                     .iter()
                     .copied()
                     .filter(|element| !previous_elements.contains(element))
@@ -1258,6 +1264,12 @@ impl<'db> Type<'db> {
                     })
                     .collect::<Option<smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]>>>()
                 && replacements.len() > 1
+                && previous_elements.iter().all(|previous_element| {
+                    current_elements.contains(previous_element)
+                        || replacements.iter().any(|(current_element, _)| {
+                            same_nominal_class(*current_element, *previous_element)
+                        })
+                })
             {
                 return Some(current.map_leave_aliases(db, |element| {
                     replacements


### PR DESCRIPTION
## Summary

A recursive PEP 695 type alias can temporarily omit a stable union arm while Salsa evaluates redundancy through a named alias:

```python
from collections.abc import Sequence

type JSONScalar = str | int
type JSONValue = JSONScalar | Sequence[JSONValue] | dict[str, JSONValue]
```

The multi-arm recursive-growth recovery assumed that every previous union arm either remained in the current result or was represented by a growing wrapper. When the named alias caused `str` to disappear temporarily, recovery rebuilt the current union without it. The arm returned on the next iteration, producing an oscillation that eventually exhausted Salsa's cycle limit.

This requires each previous arm to remain unchanged or have a changed wrapper with the same nominal class before applying multi-arm normalization. If that invariant does not hold, we use the existing monotonic union recovery instead. This prevents the panic while preserving the recursive `TypeOf` cases that require multi-arm normalization.

Closes https://github.com/astral-sh/ty/issues/3835.
