### PR TITLE
[ty] Revert multi-arm TypeOf cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
+++ b/crates/ty_python_semantic/resources/mdtest/pep695_type_aliases.md
@@ -628,6 +628,17 @@ def f() -> JSON_OBJECT:
     return {"hello": 23}
 ```
 
+### Aliased union in a self-recursive type alias
+
+Regression test for <https://github.com/astral-sh/ty/issues/3835>.
+
+```py
+from collections.abc import Sequence
+
+type JSONScalar = str | int
+type JSONValue = JSONScalar | Sequence[JSONValue] | dict[str, JSONValue]
+```
+
 ### Recursive dict alias in method return
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -525,14 +525,6 @@ class Container[T]: ...
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
-
-union: list[TypeOf[union]] | Container[TypeOf[union]]
-union = [1]
-reveal_type(union)  # revealed: list[Divergent]
-
-stable_union: list[TypeOf[stable_union]] | Container[TypeOf[stable_union]] | None
-stable_union = [1]
-reveal_type(stable_union)  # revealed: list[Divergent]
 ```
 
 ## Recursive `TypeOf` in returned callables

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1218,8 +1218,8 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
-    /// Normalizes nominal growth that wraps the previous cycle result in one or more
-    /// specializations, either directly or beneath an unambiguous union wrapper.
+    /// Normalizes nominal growth that wraps the previous cycle result in a specialization, either
+    /// directly or beneath an unambiguous union wrapper.
     ///
     /// For example, an inference cycle can otherwise grow indefinitely as
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
@@ -1234,41 +1234,6 @@ impl<'db> Type<'db> {
         div: Self,
     ) -> Option<Self> {
         if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
-            let previous_elements = previous.elements(db);
-
-            // Multiple union arms may each grow by wrapping the entire previous union. Normalize
-            // only when every previous arm is nominal and at least two changed current arms are
-            // nominal wrappers; arms shared with the previous union remain unchanged.
-            if previous_elements
-                .iter()
-                .all(|element| matches!(element, Type::NominalInstance(_)))
-                && let Some(replacements) = current
-                    .elements(db)
-                    .iter()
-                    .copied()
-                    .filter(|element| !previous_elements.contains(element))
-                    .map(|element| {
-                        Self::nominal_wrapper_normalized(
-                            db,
-                            element.as_nominal_instance()?,
-                            Type::Union(previous),
-                            div,
-                        )
-                        .map(|normalized| (element, normalized))
-                    })
-                    .collect::<Option<smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]>>>()
-                && replacements.len() > 1
-            {
-                return Some(current.map_leave_aliases(db, |element| {
-                    replacements
-                        .iter()
-                        .find_map(|(original, normalized)| {
-                            (*original == *element).then_some(*normalized)
-                        })
-                        .unwrap_or(*element)
-                }));
-            }
-
             // Only align unions when each iteration has exactly one changed arm. With multiple
             // unmatched arms, pairing is ambiguous and can destabilize otherwise-convergent
             // recursive cycles.
@@ -1303,8 +1268,8 @@ impl<'db> Type<'db> {
             }
             (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => {
                 // A class-backed protocol shares a nominal specialization with its runtime class.
-                // `nominal_wrapper_normalized` reconstructs the result through `Type::instance`,
-                // which recognizes the protocol class and restores a protocol instance.
+                // Reconstructing the result through `Type::instance` recognizes the protocol class
+                // and restores a protocol instance.
                 (
                     current.to_nominal_instance()?,
                     previous.to_nominal_instance()?,
@@ -1313,27 +1278,17 @@ impl<'db> Type<'db> {
             _ => return None,
         };
 
-        if current.class(db).class_literal(db) != previous_instance.class_literal(db) {
+        let current_class = current.class(db);
+        if current_class.class_literal(db) != previous_instance.class_literal(db) {
             return None;
         }
 
-        Self::nominal_wrapper_normalized(db, current, previous, div)
-    }
-
-    /// Replaces `wrapped` beneath the outer nominal specialization in `current`.
-    fn nominal_wrapper_normalized(
-        db: &'db dyn Db,
-        current: NominalInstanceType<'db>,
-        wrapped: Self,
-        div: Self,
-    ) -> Option<Self> {
-        let current_class = current.class(db);
         let alias = current_class.into_generic_alias()?;
         let original_specialization = alias.specialization(db);
         let specialization = original_specialization.apply_type_mapping(
             db,
             &TypeMapping::ReplaceType {
-                from: wrapped,
+                from: previous,
                 to: div,
             },
         );


### PR DESCRIPTION
## Summary

This reverts #26230, which normalized recursive `TypeOf` growth across multiple union arms.

That recovery assumed that previous union arms absent from the current iteration were represented by growing recursive wrappers. A named union alias can instead cause a stable arm to disappear temporarily during redundancy checking:

```python
from collections.abc import Sequence

type JSONScalar = str | int
type JSONValue = JSONScalar | Sequence[JSONValue] | dict[str, JSONValue]
```

The recovery rebuilt the current union without the temporarily absent `str` arm. The arm returned on the next iteration, producing an oscillation that eventually exhausted Salsa's cycle limit.

Reverting restores the behavior from ty 0.0.51 and adds regression coverage for the recursive JSON alias. This knowingly restores the unsupported multi-arm `TypeOf` case from #26230; a follow-up should address grouped recursive growth with a stronger alignment model rather than another local heuristic.

Closes https://github.com/astral-sh/ty/issues/3835.
