### PR TITLE
[ty] Make multi-arm TypeOf cycle recovery monotonic

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -525,6 +525,15 @@ class Container[T]: ...
 y: Container[TypeOf[y]]
 y = 1  # error: [invalid-assignment]
 reveal_type(y)  # revealed: Container[Divergent]
+
+# Regression test for https://github.com/astral-sh/ty/issues/3837.
+union: list[TypeOf[union]] | Container[TypeOf[union]]
+union = [1]
+reveal_type(union)  # revealed: list[Divergent]
+
+stable_union: list[TypeOf[stable_union]] | Container[TypeOf[stable_union]] | None
+stable_union = [1]
+reveal_type(stable_union)  # revealed: list[Divergent]
 ```
 
 ## Recursive `TypeOf` in returned callables

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1218,8 +1218,8 @@ impl<'db> Type<'db> {
         .recursive_type_normalized(db, cycle)
     }
 
-    /// Normalizes nominal growth that wraps the previous cycle result in a specialization, either
-    /// directly or beneath an unambiguous union wrapper.
+    /// Normalizes nominal growth that wraps the previous cycle result in one or more
+    /// specializations, either directly or beneath an unambiguous union wrapper.
     ///
     /// For example, an inference cycle can otherwise grow indefinitely as
     /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
@@ -1234,6 +1234,49 @@ impl<'db> Type<'db> {
         div: Self,
     ) -> Option<Self> {
         if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
+            let previous_elements = previous.elements(db);
+
+            // Multiple union arms may each grow by wrapping the entire previous union. Normalize
+            // only when every previous arm is nominal and at least two changed current arms are
+            // nominal wrappers; arms shared with the previous union remain unchanged.
+            if previous_elements
+                .iter()
+                .all(|element| matches!(element, Type::NominalInstance(_)))
+                && let Some(replacements) = current
+                    .elements(db)
+                    .iter()
+                    .copied()
+                    .filter(|element| !previous_elements.contains(element))
+                    .map(|element| {
+                        Self::nominal_wrapper_normalized(
+                            db,
+                            element.as_nominal_instance()?,
+                            Type::Union(previous),
+                            div,
+                        )
+                        .map(|normalized| (element, normalized))
+                    })
+                    .collect::<Option<smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]>>>()
+                && replacements.len() > 1
+            {
+                let normalized = current.map_leave_aliases(db, |element| {
+                    replacements
+                        .iter()
+                        .find_map(|(original, normalized)| {
+                            (*original == *element).then_some(*normalized)
+                        })
+                        .unwrap_or(*element)
+                });
+
+                // Multi-arm matching cannot prove a one-to-one correspondence between previous
+                // and growing current arms. Union with the entire previous result to keep recovery
+                // monotonic when a stable arm shares a nominal class with a wrapper.
+                return Some(UnionType::from_elements_cycle_recovery(
+                    db,
+                    [Type::Union(previous), normalized],
+                ));
+            }
+
             // Only align unions when each iteration has exactly one changed arm. With multiple
             // unmatched arms, pairing is ambiguous and can destabilize otherwise-convergent
             // recursive cycles.
@@ -1268,8 +1311,8 @@ impl<'db> Type<'db> {
             }
             (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => {
                 // A class-backed protocol shares a nominal specialization with its runtime class.
-                // Reconstructing the result through `Type::instance` recognizes the protocol class
-                // and restores a protocol instance.
+                // `nominal_wrapper_normalized` reconstructs the result through `Type::instance`,
+                // which recognizes the protocol class and restores a protocol instance.
                 (
                     current.to_nominal_instance()?,
                     previous.to_nominal_instance()?,
@@ -1278,17 +1321,27 @@ impl<'db> Type<'db> {
             _ => return None,
         };
 
-        let current_class = current.class(db);
-        if current_class.class_literal(db) != previous_instance.class_literal(db) {
+        if current.class(db).class_literal(db) != previous_instance.class_literal(db) {
             return None;
         }
 
+        Self::nominal_wrapper_normalized(db, current, previous, div)
+    }
+
+    /// Replaces `wrapped` beneath the outer nominal specialization in `current`.
+    fn nominal_wrapper_normalized(
+        db: &'db dyn Db,
+        current: NominalInstanceType<'db>,
+        wrapped: Self,
+        div: Self,
+    ) -> Option<Self> {
+        let current_class = current.class(db);
         let alias = current_class.into_generic_alias()?;
         let original_specialization = alias.specialization(db);
         let specialization = original_specialization.apply_type_mapping(
             db,
             &TypeMapping::ReplaceType {
-                from: previous,
+                from: wrapped,
                 to: div,
             },
         );


### PR DESCRIPTION
## Summary

Restore cycle recovery for recursive `TypeOf` expressions that grow through multiple union arms:

```python
from ty_extensions import TypeOf

class Container[T]: ...

x: list[TypeOf[x]] | Container[TypeOf[x]] | None
x = [1]
```

The original multi-arm recovery in #26230 normalized each growing wrapper, but it could drop an unmatched arm from the previous cycle result. For example, nominal-class matching can mistake `list[previous]` for the replacement of a stable `list[int]` arm:

```text
previous = str | list[int]
current  = str | list[previous] | dict[str, previous]
```

Returning only the normalized current result is not monotonic in this case. The missing arm can reappear in the next iteration, which caused the recursive alias in https://github.com/astral-sh/ty/issues/3837 to oscillate until Salsa exhausted its cycle limit.

This keeps the multi-arm normalization, but unions its result with the entire previous cycle value before recursive normalization. Recovery therefore remains monotonic even when correspondence between union arms is ambiguous, while the existing single-arm recovery path remains unchanged.

Closes https://github.com/astral-sh/ty/issues/3837.
