### PR TITLE
[ty] Model non-exhaustive enum member sets

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -145,13 +145,13 @@ error[type-assertion-failure]: Argument does not have asserted type `Baz`
 info: `Baz` and `Foo & Bar` are not equivalent types
 ```
 
-Compact enum complements that are equivalent to a literal union are still spellable.
+When narrowing leaves only one enum member, the inferred type is the corresponding literal.
 
 ```py
-from enum import Flag
+from enum import Enum
 from typing_extensions import assert_type
 
-class F(Flag):
+class F(Enum):
     A = 1
     B = 2
     C = 4

--- a/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
+++ b/crates/ty_python_semantic/resources/mdtest/directives/assert_type.md
@@ -145,7 +145,7 @@ error[type-assertion-failure]: Argument does not have asserted type `Baz`
 info: `Baz` and `Foo & Bar` are not equivalent types
 ```
 
-When narrowing leaves only one enum member, the inferred type is the corresponding literal.
+Compact enum complements that are equivalent to a literal union are still spellable.
 
 ```py
 from enum import Enum

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -247,6 +247,32 @@ def match_non_exhaustive(x: Color):
             assert_never(x)  # error: [type-assertion-failure]
 ```
 
+Matching every named member is not exhaustive for enums that can also have unnamed members.
+
+```py
+from enum import Enum, Flag
+
+class Permission(Flag):
+    READ = 1
+
+class OpenEnum(Enum):
+    ONLY = 1
+
+    @classmethod
+    def _missing_(cls, value: object) -> "OpenEnum":
+        return object.__new__(cls)
+
+def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
+    match value:
+        case Permission.READ:
+            return 1
+
+def match_open_enum(value: OpenEnum) -> int:  # error: [invalid-return-type]
+    match value:
+        case OpenEnum.ONLY:
+            return 1
+```
+
 ## Checks on enum literal subsets
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,88 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+`Flag` and `IntFlag` values can include zero and unnamed combinations, so their named members do not
+cover every possible value:
+
+```py
+from enum import Flag, IntFlag
+from typing import Literal
+
+class Permission(Flag):
+    READ = 1
+
+class Mode(IntFlag):
+    READ = 1
+
+FunctionalPermission = Flag("FunctionalPermission", {"READ": 1})
+
+def compare_flags(left: Permission, right: Permission):
+    reveal_type(left == right)  # revealed: bool
+
+    if left != right:
+        reveal_type(left)  # revealed: Permission
+
+def exclude_declared_flag(value: Permission):
+    if value is Permission.READ:
+        return
+    reveal_type(value)  # revealed: Permission & ~Literal[Permission.READ]
+
+def compare_flag_literals(
+    left: Literal[Permission.READ],
+    right: Literal[Permission.READ],
+):
+    reveal_type(left == right)  # revealed: Literal[True]
+
+def compare_int_flags(left: Mode, right: Mode):
+    reveal_type(left == right)  # revealed: bool
+
+def compare_functional_flags(left: FunctionalPermission, right: FunctionalPermission):
+    reveal_type(left == right)  # revealed: bool
+```
+
+An enum with a custom `_missing_` method can create unnamed members, so two values need not be equal
+even when only one member is declared:
+
+```py
+from enum import Enum
+
+class OpenEnum(Enum):
+    ONLY = 1
+
+    @classmethod
+    def _missing_(cls, value: object) -> "OpenEnum":
+        return object.__new__(cls)
+
+def compare_open_enums(left: OpenEnum, right: OpenEnum):
+    reveal_type(left == right)  # revealed: bool
+
+    if left != right:
+        reveal_type(left)  # revealed: OpenEnum
+
+def exclude_declared_member(value: OpenEnum):
+    if value is OpenEnum.ONLY:
+        return
+    reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+```
+
+A custom enum metaclass can add members that do not appear in the class body. Two values of a
+one-member class therefore need not be equal:
+
+```py
+from enum import Enum, EnumMeta
+
+class InjectingEnumMeta(EnumMeta):
+    def __new__(metacls, name, bases, namespace, **kwargs):
+        namespace["INJECTED"] = 2
+        return super().__new__(metacls, name, bases, namespace, **kwargs)
+
+class TransformedEnum(Enum, metaclass=InjectingEnumMeta):
+    ONLY = 1
+
+def compare_transformed_enums(left: TransformedEnum, right: TransformedEnum):
+    reveal_type(left == right)  # revealed: bool
+```
+
 Unlike plain `Enum` members, `IntEnum` members inherit integer equality. Members of different
 `IntEnum` classes therefore compare equal when they have the same integer value, so both equality
 and inequality narrowing must account for matching members from every class in the union:
@@ -298,9 +380,9 @@ def _(new: Any, init: Any, prepare: Any):
 
     def transformed_by_metaclass(value: Literal[TransformedByMeta.MEMBER] | Literal["member"]):
         if value == "member":
-            reveal_type(value)  # revealed: TransformedByMeta | Literal["member"]
+            reveal_type(value)  # revealed: Literal[TransformedByMeta.MEMBER, "member"]
         else:
-            reveal_type(value)  # revealed: TransformedByMeta
+            reveal_type(value)  # revealed: Literal[TransformedByMeta.MEMBER]
 ```
 
 An opaque `_generate_next_value_` affects `auto()` members, but explicit members still have their

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -310,6 +310,28 @@ def after_excluding_red_mixed(x: Color | int):
         reveal_type(x)  # revealed: Literal[Color.BLUE] | int
 ```
 
+An enum that can have additional runtime members can still be narrowed by a membership test against
+an explicit member. The other branch excludes that member without assuming that the declared members
+are exhaustive.
+
+```py
+from enum import Enum, EnumMeta
+
+class InjectingEnumMeta(EnumMeta):
+    def __new__(metacls, name, bases, namespace, **kwargs):
+        namespace["INJECTED"] = 2
+        return super().__new__(metacls, name, bases, namespace, **kwargs)
+
+class OpenEnum(Enum, metaclass=InjectingEnumMeta):
+    ONLY = 1
+
+def _(value: OpenEnum):
+    if value in (OpenEnum.ONLY,):
+        reveal_type(value)  # revealed: Literal[OpenEnum.ONLY]
+    else:
+        reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+```
+
 ## Union with enum and `int`
 
 ```py

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -209,6 +209,12 @@ pub struct EnumClassLiteral<'db> {
     pub(crate) members: Box<[(Name, Type<'db>)]>,
     #[returns(ref)]
     pub(crate) aliases: Box<[(Name, Name)]>,
+    /// Whether the canonical members exhaust the runtime values of this enum class.
+    ///
+    /// `Flag` classes, transforming metaclasses, and enums with a custom `_missing_` method can
+    /// create runtime members beyond those declared in the class body, so their declared members
+    /// are not a closed value set.
+    pub(crate) members_are_exhaustive: bool,
 }
 
 // The Salsa heap is tracked separately.
@@ -237,13 +243,31 @@ fn enum_class_literal<'db>(
         .map(|(alias, member)| (alias.clone(), member.clone()))
         .collect();
     aliases.sort_unstable();
+    let members_are_exhaustive = !metadata.value_construction.metaclass_may_transform_values
+        && !Type::ClassLiteral(class).is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
+        && !enum_has_custom_missing(db, class);
 
     Some(EnumClassLiteral::new(
         db,
         class,
         members,
         aliases.into_boxed_slice(),
+        members_are_exhaustive,
     ))
+}
+
+/// Return whether enum construction may create pseudo-members through a custom `_missing_` method.
+fn enum_has_custom_missing<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
+    let ClassLiteral::Static(class) = class else {
+        return false;
+    };
+
+    class
+        .iter_mro(db, None)
+        .filter_map(ClassBase::into_class)
+        .take_while(|base| base.known(db) != Some(KnownClass::Enum))
+        .filter_map(|base| base.class_literal(db).as_static())
+        .any(|base| custom_enum_method(db, base.body_scope(db), "_missing_").is_some())
 }
 
 impl<'db> EnumClassLiteral<'db> {
@@ -535,6 +559,9 @@ impl<'db> EnumComplementType<'db> {
         }
 
         let enum_class_literal = enum_class?;
+        if !enum_class_literal.members_are_exhaustive(db) {
+            return None;
+        }
         let mut excluded_names = FxHashSet::default();
         for negative in negative {
             let enum_literal = negative.as_enum_literal()?;
@@ -1229,12 +1256,16 @@ fn resolve_enum_method<'db>(
     }
 }
 
+/// Return the enum's canonical member literals when they exhaust its runtime domain.
 pub(crate) fn enum_member_literals<'a, 'db: 'a>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
     exclude_member: Option<&'a Name>,
 ) -> Option<impl Iterator<Item = Type<'a>> + 'a> {
     let enum_class_literal = class.into_enum_class(db)?;
+    if !enum_class_literal.members_are_exhaustive(db) {
+        return None;
+    }
     Some(
         enum_class_literal
             .member_names(db)
@@ -1245,8 +1276,11 @@ pub(crate) fn enum_member_literals<'a, 'db: 'a>(
     )
 }
 
+/// Return whether the enum has exactly one possible runtime value.
 pub(crate) fn is_single_member_enum<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> bool {
-    enum_metadata(db, class).is_some_and(|metadata| metadata.members.len() == 1)
+    class.into_enum_class(db).is_some_and(|enum_class| {
+        enum_class.members_are_exhaustive(db) && enum_class.member_count(db) == 1
+    })
 }
 
 pub(crate) fn is_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -15,6 +15,10 @@ use super::{
     enums::{enum_member_literals, enum_metadata},
 };
 
+mod enums;
+
+pub(super) use self::enums::enum_membership_constraint;
+
 /// The result of evaluating a runtime comparison between two types.
 ///
 /// Definite truthiness is represented separately from a constraint for the operand currently being

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,0 +1,77 @@
+//! Equality reasoning for values from the same enum class.
+
+use crate::Db;
+use crate::types::{EnumClassLiteral, IntersectionBuilder, LiteralValueTypeKind, Type};
+
+/// Return the enum class when `ty` represents an open enum domain.
+fn open_enum_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<EnumClassLiteral<'db>> {
+    match ty.resolve_type_alias(db) {
+        Type::NominalInstance(instance) => {
+            let enum_class = instance.class_literal(db).into_enum_class(db)?;
+            (!enum_class.members_are_exhaustive(db)).then_some(enum_class)
+        }
+        Type::Intersection(intersection) => {
+            let mut enum_classes = intersection
+                .positive(db)
+                .iter()
+                .filter_map(|positive| open_enum_class(db, *positive));
+            let enum_class = enum_classes.next()?;
+            enum_classes
+                .all(|other| other == enum_class)
+                .then_some(enum_class)
+        }
+        _ => None,
+    }
+}
+
+/// Return the enum class when `ty` is an exact set of literals from one enum.
+fn exact_enum_member_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<EnumClassLiteral<'db>> {
+    match ty.resolve_type_alias(db) {
+        Type::LiteralValue(literal) => {
+            let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                return None;
+            };
+            Some(literal.enum_class_literal(db))
+        }
+        Type::Union(union) => {
+            let mut enum_classes = union
+                .elements(db)
+                .iter()
+                .map(|element| exact_enum_member_class(db, *element));
+            let enum_class = enum_classes.next()??;
+            enum_classes
+                .all(|other| other == Some(enum_class))
+                .then_some(enum_class)
+        }
+        _ => None,
+    }
+}
+
+/// Return the constraint established by membership in an exact set of open-enum members.
+pub(in crate::types) fn enum_membership_constraint<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    members: Type<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    let enum_class = open_enum_class(db, target)?;
+    if exact_enum_member_class(db, members)? != enum_class {
+        return None;
+    }
+
+    let enum_instance = enum_class.class_literal(db).to_non_generic_instance(db);
+    if enum_instance.overrides_equality(db) {
+        return None;
+    }
+
+    if is_positive {
+        Some(members)
+    } else {
+        Some(
+            IntersectionBuilder::new(db)
+                .add_positive(enum_instance)
+                .add_negative(members)
+                .build(),
+        )
+    }
+}

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -34,8 +34,10 @@ use ruff_python_ast::name::Name;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use super::UnionType;
-use super::enums::{enum_member_literals, enum_metadata};
-use super::equality::{evaluate_type_equality, evaluate_type_inequality};
+use super::enums::enum_member_literals;
+use super::equality::{
+    enum_membership_constraint, evaluate_type_equality, evaluate_type_inequality,
+};
 use itertools::Itertools;
 use ruff_python_ast as ast;
 use ruff_python_ast::{BoolOp, ExprBoolOp};
@@ -113,15 +115,8 @@ fn finite_single_valued_union_alternatives<'db>(
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => {
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
         }
-        Type::NominalInstance(instance)
-            if enum_metadata(db, instance.class_literal(db)).is_some()
-                && !ty.overrides_equality(db) =>
-        {
-            Some(
-                enum_member_literals(db, instance.class_literal(db), None)
-                    .expect("Calling `enum_member_literals` on an enum class")
-                    .collect(),
-            )
+        Type::NominalInstance(instance) if !ty.overrides_equality(db) => {
+            enum_member_literals(db, instance.class_literal(db), None).map(Iterator::collect)
         }
         _ => None,
     }
@@ -140,12 +135,8 @@ fn has_finite_single_valued_union_alternatives<'db>(db: &'db dyn Db, ty: Type<'d
             .enum_complement(db)
             .is_some_and(|complement| complement.has_finite_single_valued_alternatives(db)),
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Bool) => true,
-        Type::NominalInstance(instance)
-            if enum_metadata(db, instance.class_literal(db))
-                .is_some_and(|metadata| !metadata.members.is_empty())
-                && !ty.overrides_equality(db) =>
-        {
-            true
+        Type::NominalInstance(instance) if !ty.overrides_equality(db) => {
+            enum_member_literals(db, instance.class_literal(db), None).is_some()
         }
         _ => false,
     }
@@ -2204,6 +2195,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_expr_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
 
+        if let Ok(iterable) = rhs_ty.try_iterate(self.db)
+            && let Some(constraint) = enum_membership_constraint(
+                self.db,
+                lhs_ty,
+                iterable.homogeneous_element_type(self.db),
+                true,
+            )
+        {
+            return Some(constraint);
+        }
+
         if is_union_of_single_valued(self.db, lhs_ty) {
             rhs_ty
                 .try_iterate(self.db)
@@ -2242,6 +2244,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_expr_not_in(&mut self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         let lhs_ty = lhs_ty.resolve_type_alias(self.db);
         let rhs_values = self.exact_fixed_length_membership_values(rhs_ty)?;
+
+        if let Some(constraint) = enum_membership_constraint(self.db, lhs_ty, rhs_values, false) {
+            return Some(constraint);
+        }
 
         if is_union_of_single_valued(self.db, lhs_ty) {
             // Exclude the RHS values from the entire (single-valued) LHS domain.

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -848,8 +848,10 @@ impl<'db> UnionBuilder<'db> {
                         let enum_class_literal = enum_member_to_add.enum_class_literal(self.db);
                         let enum_class = enum_class_literal.class_literal(self.db);
                         let enum_member_count = enum_class_literal.member_count(self.db);
+                        let members_are_exhaustive =
+                            enum_class_literal.members_are_exhaustive(self.db);
 
-                        if enum_member_count == 1 {
+                        if members_are_exhaustive && enum_member_count == 1 {
                             self.add_in_place_impl(
                                 enum_member_to_add.enum_class_instance(self.db),
                                 seen_aliases,
@@ -902,7 +904,7 @@ impl<'db> UnionBuilder<'db> {
                                 ordermap::map::Entry::Vacant(entry) => {
                                     entry.insert(literal.is_promotable());
 
-                                    if found.len() == enum_member_count {
+                                    if members_are_exhaustive && found.len() == enum_member_count {
                                         self.add_in_place_impl(
                                             enum_member_to_add.enum_class_instance(self.db),
                                             seen_aliases,
@@ -1356,6 +1358,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
             let Some(enum_class_literal) = instance.class_literal(db).into_enum_class(db) else {
                 continue;
             };
+            if !enum_class_literal.members_are_exhaustive(db) {
+                continue;
+            }
 
             let mut excluded_names = FxHashSet::default();
             for negative in &self.negative {


### PR DESCRIPTION
## Summary

We currently treat the members declared on every enum as its complete runtime domain. That assumption does not hold for `Flag` and `IntFlag`, which also have zero and unnamed combinations, or for enums whose custom `_missing_` method or metaclass can create additional members. As a result, we can incorrectly treat a one-member enum as a singleton, widen all declared members to the nominal enum, erase a non-empty complement, or consider a `match` over the declared members exhaustive.

This adds a `members_are_exhaustive` property to `EnumClassLiteral` and uses it wherever we rely on an enum being a finite set: complement construction, union simplification, singleton detection, finite-alternative narrowing, and match exhaustiveness. Open enums retain the nominal remainder after known members are excluded.

Explicit membership tests remain precise when the enum uses identity comparison. For example, a metaclass may add `INJECTED`, but testing against `ONLY` still establishes that exact member on the positive branch and excludes only that member on the negative branch:

```python
class OpenEnum(Enum, metaclass=InjectingEnumMeta):
    ONLY = 1

def check(value: OpenEnum):
    if value in (OpenEnum.ONLY,):
        reveal_type(value)  # Literal[OpenEnum.ONLY]
    else:
        reveal_type(value)  # OpenEnum & ~Literal[OpenEnum.ONLY]
```

This is the semantic foundation split out of #26270; that PR adds the compact same-enum comparison path on top.
