### PR TITLE
[ty] Fix ParamSpec callable signature extraction for callable instances

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/callables.md
@@ -26,6 +26,13 @@ def identity2(c: Callable[P, T]) -> Callable[P, T]:
 reveal_type(generic_context(identity2))
 # revealed: [T](t: T) -> T
 reveal_type(identity2(identity))
+
+class CallableInstance:
+    def __call__(self, value: int, /) -> str:
+        return str(value)
+
+# revealed: (value: int, /) -> str
+reveal_type(identity2(CallableInstance()))
 ```
 
 Generic classes are another example, since you invoke the class to instantiate it:

--- a/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/pep695/callables.md
@@ -28,6 +28,13 @@ def identity2[**P, T](c: Callable[P, T]) -> Callable[P, T]:
 reveal_type(generic_context(identity2))
 # revealed: [T](t: T) -> T
 reveal_type(identity2(identity))
+
+class CallableInstance:
+    def __call__(self, value: int, /) -> str:
+        return str(value)
+
+# revealed: (value: int, /) -> str
+reveal_type(identity2(CallableInstance()))
 ```
 
 Generic classes are another example, since you invoke the class to instantiate it:

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -2880,7 +2880,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 }
             }
 
-            (formal, Type::NominalInstance(actual_nominal)) => {
+            (
+                formal @ (Type::NominalInstance(_) | Type::ProtocolInstance(_)),
+                Type::NominalInstance(actual_nominal),
+            ) => {
                 // Special case: `formal` and `actual` are both tuples.
                 if let (Some(formal_tuple), Some(actual_tuple)) = (
                     formal.tuple_instance_spec(self.db),


### PR DESCRIPTION
## Summary

Preserve signatures from callable instances passed through Callable/ParamSpec functions.

This was just an overly-broad match arm in the old solver (`infer_map_impl`) catching all nominal instances before they hit the callable arm that handles ParamSpec.

## Testing

Added mdtests for both legacy and PEP 695 ParamSpec.

New ecosystem hits represent downstream consequences of actually preserving these signatures rather than collapsing them to `(...) -> Unknown`, as we do on main.