### PR TITLE
[ty] Improve specialization of callables in bidirectional inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/bidirectional.md
+++ b/crates/ty_python_semantic/resources/mdtest/bidirectional.md
@@ -710,7 +710,7 @@ If a lambda expression is annotated as a `Callable` type, the body of the lambda
 the annotated return type as type context, and the annotated parameter types are respected:
 
 ```py
-from typing import Callable, TypedDict
+from typing import Any, Callable, Literal, Protocol, TypedDict, overload
 
 class Bar(TypedDict):
     bar: int
@@ -742,6 +742,169 @@ def id_callable[**P, R](x: Callable[P, R]) -> Callable[P, R]:
 f5_paramspec: Callable[[int], int] = id_callable(lambda x: reveal_type(x))  # revealed: int
 reveal_type(f5_paramspec)  # revealed: (x: int) -> int
 
+# Generic callable contexts can be specialized from other arguments, regardless of source order.
+class A:
+    def f(self) -> int:
+        return 1
+
+def g[T, U](x: T, y: Callable[[T], U]) -> U:
+    raise NotImplementedError
+
+reveal_type(g(A(), lambda z: z.f()))  # revealed: int
+
+def h[T, U](y: Callable[[T], U], x: T) -> U:
+    raise NotImplementedError
+
+reveal_type(h(lambda z: z.f(), A()))  # revealed: int
+reveal_type(h(y=lambda z: z.f(), x=A()))  # revealed: int
+
+@overload
+def h_overloaded[T, U](y: Callable[[T], U], x: T) -> U: ...
+@overload
+def h_overloaded(y: Callable[[str], int], *, x: str) -> int: ...
+def h_overloaded(y, x):
+    raise NotImplementedError
+
+reveal_type(h_overloaded(lambda z: z.f(), A()))  # revealed: int
+
+def i[T, S, U](z: Callable[[T, S], U], x: T, y: S) -> U:
+    raise NotImplementedError
+
+reveal_type(i(lambda a, b: a.f() + b, A(), 1))  # revealed: int
+
+def j[T, U](x: list[T], y: Callable[[list[T]], U]) -> U:
+    raise NotImplementedError
+
+reveal_type(j([A()], lambda z: z[0].f()))  # revealed: int
+
+def k[T, U](x: T | None, y: Callable[[T], U]) -> U:
+    raise NotImplementedError
+
+reveal_type(k(A(), lambda z: z.f()))  # revealed: int
+
+type CallableAlias[T, U] = Callable[[T], U]
+
+def l[T, U](x: T, y: CallableAlias[T, U]) -> U:
+    raise NotImplementedError
+
+reveal_type(l(A(), lambda z: z.f()))  # revealed: int
+
+def m[T, U](x: T, y: Callable[[T], U] | None) -> U:
+    raise NotImplementedError
+
+reveal_type(m(A(), lambda z: z.f()))  # revealed: int
+
+type OptionalCallableAlias[T, U] = Callable[[T], U] | None
+
+def n[T, U](x: T, y: OptionalCallableAlias[T, U]) -> U:
+    raise NotImplementedError
+
+reveal_type(n(A(), lambda z: z.f()))  # revealed: int
+
+def callable_or_list[T, U](x: T, y: Callable[[T], U] | list[Literal["a", "b"]]) -> U | None:
+    raise NotImplementedError
+
+reveal_type(callable_or_list(A(), lambda z: z.f()))  # revealed: int | None
+reveal_type(callable_or_list(A(), ["a"]))  # revealed: Unknown | None
+
+def callable_or_dict[T, U](x: T, y: Callable[[T], U] | dict[str | int, str]) -> U | None:
+    raise NotImplementedError
+
+reveal_type(callable_or_dict(A(), lambda z: z.f()))  # revealed: int | None
+reveal_type(callable_or_dict(A(), {"a": "b"}))  # revealed: Unknown | None
+
+def o[T, U](x: T, y: Callable[[T], U] | Callable[[str], U]) -> U:
+    raise NotImplementedError
+
+reveal_type(o(A(), lambda z: z.f()))  # revealed: Unknown
+
+def p[T, U](x: T, y: Callable[[T], U] | Any) -> U:
+    raise NotImplementedError
+
+reveal_type(p(A(), lambda z: z.f()))  # revealed: Unknown
+
+class CallableProtocol[T, U](Protocol):
+    def __call__(self, value: T) -> U: ...
+
+def p_protocol[T, U](x: T, y: CallableProtocol[T, U]) -> U:
+    raise NotImplementedError
+
+# Only explicit `Callable` shapes currently provide argument-derived lambda context.
+# error: [invalid-argument-type]
+reveal_type(p_protocol(A(), lambda z: z.f()))  # revealed: Unknown
+
+type AmbiguousCallableAlias[T, U] = Callable[[T], U] | Callable[[str], U]
+
+def q[T, U](x: T, y: AmbiguousCallableAlias[T, U]) -> U:
+    raise NotImplementedError
+
+reveal_type(q(A(), lambda z: z.f()))  # revealed: Unknown
+
+type NestedAmbiguousCallableAlias[T, U] = Callable[[T], U] | AmbiguousCallableAlias[T, U]
+
+def q_nested[T, U](x: T, y: NestedAmbiguousCallableAlias[T, U] | None) -> U:
+    raise NotImplementedError
+
+reveal_type(q_nested(A(), lambda z: z.f()))  # revealed: Unknown
+
+class Narrow(TypedDict):
+    value: int
+
+def choose[T, U](x: T, y: Callable[[T], U]) -> U:
+    raise NotImplementedError
+
+# Argument-derived specialization should refine the lambda parameter without overriding the
+# return-context solution for `U`.
+narrow: Narrow = choose(1, lambda value: {"value": value})
+reveal_type(narrow)  # revealed: Narrow
+
+# Self-referential aliases.
+type RecursiveCallableAlias = RecursiveCallableAlias | Callable[[int], int]
+
+def rec_direct[T](x: T, y: RecursiveCallableAlias) -> T:
+    raise NotImplementedError
+
+reveal_type(rec_direct(A(), lambda z: z + 1))  # revealed: A
+
+type MutualAliasA = MutualAliasB | None
+type MutualAliasB = MutualAliasA | Callable[[int], int]
+
+def rec_mutual[T](x: T, y: MutualAliasA) -> T:
+    raise NotImplementedError
+
+reveal_type(rec_mutual(A(), lambda z: z + 1))  # revealed: A
+
+# Argument-derived specialization also applies to generic bound methods, where the synthetic
+# `self` argument shifts argument indices.
+class Holder:
+    def apply[T, U](self, x: T, y: Callable[[T], U]) -> U:
+        raise NotImplementedError
+
+    def apply_rev[T, U](self, y: Callable[[T], U], x: T) -> U:
+        raise NotImplementedError
+
+holder = Holder()
+reveal_type(holder.apply(A(), lambda z: z.f()))  # revealed: int
+reveal_type(holder.apply_rev(lambda z: z.f(), A()))  # revealed: int
+
+def solve_from_list[T, U](y: Callable[[T], U], x: list[T]) -> U:
+    raise NotImplementedError
+
+reveal_type(solve_from_list(lambda z: z + 1, [1, 2]))  # revealed: int
+
+# An argument after the lambda is pre-seeded *without* type context, so its seeded type can be
+# less precise than the type inferred with the parameter's context during the final call check
+# (`[]` seeds `list[Unknown]`). Solutions containing dynamic components are therefore discarded
+# rather than used as lambda context, unlike return-context solutions.
+def append_int(x: list[int]) -> None:
+    x.append(1)
+
+reveal_type(solve_from_list(lambda z: append_int([z]), []))  # revealed: None
+
+def _(xs: list[Any]):
+    # The same filtering applies to explicit dynamic components in a sibling argument's type.
+    reveal_type(solve_from_list(lambda z: z, xs))  # revealed: Unknown
+
 # TODO: This should not error once we support `Unpack`.
 # error: [invalid-assignment]
 f6: Callable[[*tuple[int, ...]], None] = lambda x, y, z: None
@@ -766,10 +929,9 @@ reveal_type(f10)  # revealed: (x: str, y: int, z: str) -> tuple[str, int, str]
 f11: Callable[[*tuple[int, ...]], tuple[int, ...]] = lambda *args: reveal_type(args)  # revealed: tuple[Unknown, ...]
 reveal_type(f11)  # revealed: (*args) -> tuple[Unknown, ...]
 
-# TODO: Better generic call inference.
 def _(x: list[int]):
     f12 = list(map(lambda y: y + 1, x))
-    reveal_type(f12)  # revealed: list[Unknown]
+    reveal_type(f12)  # revealed: list[int]
 
 def _() -> Callable[[int], int]:
     return id(lambda x: reveal_type(x))  # revealed: int

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -56,7 +56,7 @@ use crate::types::signatures::{
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
-use crate::types::typevar::{BoundTypeVarIdentity, TypeVarNonceGenerator};
+use crate::types::typevar::{BoundTypeVarIdentity, TypeVarIdentity, TypeVarNonceGenerator};
 use crate::types::visitor::{TypeCollector, TypeVisitor, walk_type_with_recursion_guard};
 use crate::types::{
     BindingContext, BoundMethodType, BoundTypeVarInstance, CallableType, CallableTypes,
@@ -5715,6 +5715,21 @@ struct ParamSpecArgumentContext<'a, 'call, 'db> {
     call_expression_tcx: TypeContext<'db>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct ArgumentTypeContextParams<'a, 'call, 'db> {
+    pub(crate) db: &'db dyn Db,
+    pub(crate) constraints: &'a ConstraintSetBuilder<'db>,
+    pub(crate) binding: &'a CallableBinding<'db>,
+    pub(crate) arguments_types: &'a CallArguments<'call, 'db>,
+    pub(crate) argument_index: usize,
+    pub(crate) call_expression_tcx: TypeContext<'db>,
+    /// Whether the argument is a lambda expression. Lambdas are the only expressions that
+    /// benefit from argument-derived specialization of a callable parameter context, and
+    /// deriving that specialization requires an extra binding check, so it is skipped for
+    /// all other argument expressions.
+    pub(crate) argument_is_lambda: bool,
+}
+
 /// Binding information for one of the overloads of a callable.
 #[derive(Debug, Clone)]
 pub(crate) struct Binding<'db> {
@@ -5849,15 +5864,46 @@ impl<'db> Binding<'db> {
         arguments_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
     ) -> Option<CallableType<'db>> {
+        let Type::Callable(callable) = self
+            .inferred_specialization_from_arguments(
+                db,
+                constraints,
+                binding,
+                arguments_types,
+                call_expression_tcx,
+            )
+            .and_then(|specialization| specialization.get(db, paramspec))?
+        else {
+            return None;
+        };
+
+        (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
+    }
+
+    /// Infers a specialization from call arguments that have already been inferred.
+    ///
+    /// This is used while inferring a later argument's type context. For example, in
+    /// `g(A(), lambda z: z.f())` with `g[T, U](x: T, y: Callable[[T], U]) -> U`, the first
+    /// argument can specialize `T` to `A` before the lambda is inferred, giving the lambda
+    /// parameter the useful context `A`.
+    pub(crate) fn inferred_specialization_from_arguments(
+        &self,
+        db: &'db dyn Db,
+        constraints: &ConstraintSetBuilder<'db>,
+        binding: &CallableBinding<'db>,
+        arguments_types: &CallArguments<'_, 'db>,
+        call_expression_tcx: TypeContext<'db>,
+    ) -> Option<Specialization<'db>> {
         let mut specialized_binding =
             CallableBinding::from_overloads(self.signature_type, [self.signature.clone()]);
         if let Some(bound_type) = binding.bound_type {
             specialized_binding = specialized_binding.with_bound_type(bound_type);
         }
 
-        // Reuse the normal binding checker to infer `P` from the arguments that have already
-        // been inferred. This avoids duplicating specialization logic here; the current
-        // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
+        // Reuse the normal binding checker so argument-derived specialization follows the same
+        // constraint logic as the eventual call check. Arguments that have not been inferred yet
+        // only contribute `Unknown`, which keeps this usable while inferring a later argument's
+        // contextual type.
         let mut specialized_bindings =
             Bindings::from(specialized_binding).match_parameters(db, arguments_types);
         let _ = specialized_bindings.check_types_impl(
@@ -5868,16 +5914,10 @@ impl<'db> Binding<'db> {
             &[],
         );
 
-        let Type::Callable(callable) = specialized_bindings
+        specialized_bindings
             .single_element()
             .and_then(|binding| binding.matching_overloads().exactly_one().ok())
             .and_then(|(_, overload)| overload.specialization())
-            .and_then(|specialization| specialization.get(db, paramspec))?
-        else {
-            return None;
-        };
-
-        (callable.kind(db) == CallableTypeKind::ParamSpecValue).then_some(callable)
     }
 
     /// Returns the specialized wrapped-call parameter type for a forwarded argument.
@@ -5996,6 +6036,111 @@ impl<'db> Binding<'db> {
             .then_some(parameter_type)
     }
 
+    /// Returns true if a source call argument is forwarded through a `ParamSpec` component.
+    pub(crate) fn is_paramspec_component_argument(
+        &self,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+    ) -> bool {
+        let Some((prefix, _)) = self.signature.parameters().as_paramspec_with_prefix() else {
+            return false;
+        };
+
+        self.matched_argument_for_call_argument(binding, argument_index)
+            .is_some_and(|argument| {
+                argument
+                    .parameters
+                    .iter()
+                    .any(|parameter| parameter.index >= prefix.len())
+            })
+    }
+
+    /// Returns true if this argument can use another argument's inferred type to specialize a
+    /// callable parameter context.
+    pub(crate) fn has_specializable_callable_parameter_context(
+        &self,
+        db: &'db dyn Db,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+    ) -> bool {
+        self.matched_argument_for_call_argument(binding, argument_index)
+            .is_some_and(|argument| {
+                argument.parameters.iter().any(|parameter| {
+                    self.signature.parameters()[parameter.index]
+                        .annotated_type()
+                        .single_explicit_callable_alternative(db)
+                        .is_some()
+                })
+            })
+    }
+
+    /// Returns the type variables used by any single explicit callable parameter context in this
+    /// overload.
+    ///
+    /// Signatures rarely have more than a couple such type variables, so this returns a small
+    /// deduplicated `Vec` rather than allocating a hash set per overload.
+    pub(crate) fn callable_parameter_context_typevars(
+        &self,
+        db: &'db dyn Db,
+    ) -> Vec<TypeVarIdentity<'db>> {
+        let Some(generic_context) = self.signature.generic_context else {
+            return Vec::new();
+        };
+
+        let mut callable_context_typevars = Vec::new();
+        for parameter in self.signature.parameters() {
+            let Some(callable) = parameter
+                .annotated_type()
+                .single_explicit_callable_alternative(db)
+            else {
+                continue;
+            };
+
+            for typevar in generic_context.variables(db) {
+                let identity = typevar.typevar(db).identity(db);
+                if !callable_context_typevars.contains(&identity)
+                    && Type::Callable(callable).references_typevar(db, identity)
+                {
+                    callable_context_typevars.push(identity);
+                }
+            }
+        }
+
+        callable_context_typevars
+    }
+
+    /// Returns true if this argument's matched parameter can solve a type variable used by any
+    /// single explicit callable parameter context in this overload.
+    pub(crate) fn can_specialize_callable_parameter_context(
+        &self,
+        db: &'db dyn Db,
+        binding: &CallableBinding<'db>,
+        argument_index: usize,
+        callable_context_typevars: &[TypeVarIdentity<'db>],
+    ) -> bool {
+        if callable_context_typevars.is_empty() {
+            return false;
+        }
+
+        self.matched_argument_for_call_argument(binding, argument_index)
+            .is_some_and(|argument| {
+                argument.parameters.iter().any(|parameter| {
+                    let parameter_type =
+                        self.signature.parameters()[parameter.index].annotated_type();
+                    if parameter_type
+                        .single_explicit_callable_alternative(db)
+                        .is_some()
+                    {
+                        return false;
+                    }
+
+                    callable_context_typevars
+                        .iter()
+                        .any(|typevar| parameter_type.references_typevar(db, *typevar))
+                })
+            })
+    }
+
     /// Returns the type context to use for bidirectional inference of a source call argument.
     ///
     /// This covers the normal parameter annotation path, generic return-context specialization, and
@@ -6009,13 +6154,18 @@ impl<'db> Binding<'db> {
     /// ```
     pub(crate) fn argument_type_context(
         &self,
-        db: &'db dyn Db,
-        constraints: &ConstraintSetBuilder<'db>,
-        binding: &CallableBinding<'db>,
-        arguments_types: &CallArguments<'_, 'db>,
-        argument_index: usize,
-        call_expression_tcx: TypeContext<'db>,
+        context: ArgumentTypeContextParams<'_, '_, 'db>,
     ) -> Option<ArgumentTypeContext<'db>> {
+        let ArgumentTypeContextParams {
+            db,
+            constraints,
+            binding,
+            arguments_types,
+            argument_index,
+            call_expression_tcx,
+            argument_is_lambda,
+        } = context;
+
         let argument_matches = self.matched_argument_for_call_argument(binding, argument_index)?;
         let [parameter] = argument_matches.parameters.as_slice() else {
             return None;
@@ -6083,6 +6233,48 @@ impl<'db> Binding<'db> {
                 }
             }
 
+            let callable_parameter_context = argument_is_lambda
+                && original_parameter_type
+                    .single_explicit_callable_alternative(db)
+                    .is_some();
+
+            // Only lambdas matched to callable parameters benefit from argument-derived
+            // specialization here: the extra precision is used to contextually type the lambda
+            // body, not to change ordinary argument inference for every generic parameter.
+            // Deriving the specialization runs a full extra binding check, so skip it whenever
+            // the expected return type already solved every type variable. Keep return-context
+            // solutions authoritative; argument-derived specialization only fills type variables
+            // that the expected return type did not solve.
+            if callable_parameter_context
+                && generic_context
+                    .variables(db)
+                    .any(|typevar| !return_type_solutions.contains_key(&typevar.identity(db)))
+                && let Some(argument_specialization) = self.inferred_specialization_from_arguments(
+                    db,
+                    constraints,
+                    binding,
+                    arguments_types,
+                    call_expression_tcx,
+                )
+            {
+                for typevar in generic_context.variables(db) {
+                    // Reject solutions with any dynamic or unspecialized component wholesale:
+                    // unlike return-context solutions, these are derived from arguments that may
+                    // not have been inferred yet (contributing `Unknown`), so a partially-dynamic
+                    // solution usually means the solver lacked information rather than that the
+                    // user wrote an explicitly dynamic type.
+                    if let Some(ty) = argument_specialization.get(db, typevar)
+                        && !ty.is_unknown()
+                        && !ty.has_dynamic(db)
+                        && !ty.has_unspecialized_type_var(db)
+                    {
+                        return_type_solutions
+                            .entry(typevar.identity(db))
+                            .or_insert(ty);
+                    }
+                }
+            }
+
             // Default specialize any type variables to a marker type, which will be ignored
             // during argument inference, allowing the concrete subset of the parameter
             // type to still affect argument inference.
@@ -6134,6 +6326,14 @@ impl<'db> Binding<'db> {
             }
 
             parameter_type = parameter_type.apply_specialization(db, specialization);
+            // Preserve an optional/non-callable fallback around the parameter while solving
+            // typevars, but infer lambdas against the single callable alternative when that
+            // alternative remains unambiguous after specialization.
+            if callable_parameter_context
+                && let Some(callable) = parameter_type.single_explicit_callable_alternative(db)
+            {
+                parameter_type = Type::Callable(callable);
+            }
         }
 
         Some(ArgumentTypeContext::standard(

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -9,7 +9,8 @@ use crate::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
         FunctionType, InternedType, KnownBoundMethodType, KnownClass, KnownInstanceType,
         LiteralValueTypeKind, MemberLookupPolicy, Parameter, Parameters, Signature,
-        SubclassOfInner, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, UnionType,
+        SubclassOfInner, Type, TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+        UnionType,
         constraints::{ConstraintSet, IteratorConstraintsExtension},
         known_instance::FunctoolsPartialInstance,
         relation::{TypeRelation, TypeRelationChecker},
@@ -43,6 +44,66 @@ impl<'db> Type<'db> {
 
     pub(crate) fn try_upcast_to_callable(self, db: &'db dyn Db) -> Option<CallableTypes<'db>> {
         self.try_upcast_to_callable_with_policy(db, UpcastPolicy::default())
+    }
+
+    /// Returns the single explicit callable alternative in this type, allowing non-callable union
+    /// alternatives and aliases.
+    ///
+    /// This only recognizes callable shapes that are already represented as [`Type::Callable`]. It
+    /// does not synthesize callables from class objects, `__call__` members, or other
+    /// call-compatible runtime values.
+    pub(crate) fn single_explicit_callable_alternative(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<CallableType<'db>> {
+        self.single_explicit_callable_alternative_impl(db, &mut FxHashSet::default())
+            .into_option()
+    }
+
+    fn single_explicit_callable_alternative_impl(
+        self,
+        db: &'db dyn Db,
+        seen_aliases: &mut FxHashSet<TypeAliasType<'db>>,
+    ) -> SingleCallableAlternative<'db> {
+        // Resolve aliases one level at a time, tracking which aliases have already been
+        // expanded. A self-referential alias (e.g. `type A = A | Callable[[int], int]`) can
+        // reference itself through a union element; expanding it again contributes no new
+        // alternatives, so treat the back-reference as `None` rather than recursing forever.
+        let mut ty = self;
+        while let Type::TypeAlias(alias) = ty {
+            if !seen_aliases.insert(alias) {
+                return SingleCallableAlternative::None;
+            }
+            ty = alias.value_type(db);
+        }
+
+        match ty {
+            Type::Callable(callable) => SingleCallableAlternative::One(callable),
+            Type::Union(union) => {
+                let mut single_callable = None;
+                for element in union.elements(db) {
+                    let callable =
+                        match element.single_explicit_callable_alternative_impl(db, seen_aliases) {
+                            SingleCallableAlternative::One(callable) => callable,
+                            SingleCallableAlternative::None => continue,
+                            SingleCallableAlternative::Ambiguous => {
+                                return SingleCallableAlternative::Ambiguous;
+                            }
+                        };
+
+                    if single_callable.replace(callable).is_some() {
+                        return SingleCallableAlternative::Ambiguous;
+                    }
+                }
+
+                single_callable.map_or(
+                    SingleCallableAlternative::None,
+                    SingleCallableAlternative::One,
+                )
+            }
+            Type::Dynamic(_) | Type::Divergent(_) => SingleCallableAlternative::Ambiguous,
+            _ => SingleCallableAlternative::None,
+        }
     }
 
     pub(crate) fn try_upcast_to_callable_with_recursive_fallback(
@@ -388,6 +449,24 @@ pub(crate) enum UpcastPolicy {
     /// `Callable[<constructor signature of T>, T`.
     #[default]
     Unsound,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SingleCallableAlternative<'db> {
+    One(CallableType<'db>),
+    None,
+    // A dynamic element or multiple callable alternatives makes contextual typing unsafe: picking
+    // one callable shape would hide a real ambiguity from lambda/body inference.
+    Ambiguous,
+}
+
+impl<'db> SingleCallableAlternative<'db> {
+    fn into_option(self) -> Option<CallableType<'db>> {
+        match self {
+            Self::One(callable) => Some(callable),
+            Self::None | Self::Ambiguous => None,
+        }
+    }
 }
 
 impl From<TypeRelation> for UpcastPolicy {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -39,7 +39,7 @@ use crate::place::{
 };
 use crate::reachability::{ReachabilityEvaluationCache, evaluate_reachability_with_cache};
 use crate::types::add_inferred_python_version_hint_to_diagnostic;
-use crate::types::call::bind::MatchingOverloadIndex;
+use crate::types::call::bind::{ArgumentTypeContextParams, MatchingOverloadIndex};
 use crate::types::call::{Binding, Bindings, CallArguments, CallError, CallErrorKind};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::class::{ClassLiteral, CodeGeneratorKind, MethodDecorator};
@@ -5785,6 +5785,135 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             add_overloads_from_binding(&mut overloads_with_binding, binding);
         });
 
+        // Generic callable argument context can depend on type variables solved by other arguments,
+        // regardless of source order. Seed only arguments matched to parameters that mention a
+        // type variable used by a callable context, and only when that callable context is needed
+        // for a lambda argument. The callable argument itself is inferred later with the
+        // specialized context.
+        //
+        // Only lambda arguments benefit from this analysis, so find the first lambda up front and
+        // skip the more expensive signature analysis entirely for calls without one. Arguments
+        // before the first lambda never need pre-seeding: the main inference loop below processes
+        // arguments in source order and records each inferred type in `arguments_types`, so those
+        // types are already available when a later lambda's context is computed.
+        let first_lambda_argument_index =
+            ast_arguments
+                .clone()
+                .enumerate()
+                .find_map(|(argument_index, ast_argument)| {
+                    (!ast_argument.is_variadic()
+                        && matches!(ast_argument.value(), ast::Expr::Lambda(_)))
+                    .then_some(argument_index)
+                });
+
+        let mut arguments_to_seed = Vec::new();
+        if let Some(first_lambda_argument_index) = first_lambda_argument_index
+            && overloads_with_binding
+                .iter()
+                .any(|(overload, _)| overload.signature.generic_context.is_some())
+        {
+            let overload_has_eligible_callable_context: Vec<bool> = overloads_with_binding
+                .iter()
+                .map(|(overload, binding)| {
+                    ast_arguments
+                        .clone()
+                        .enumerate()
+                        .any(|(argument_index, ast_argument)| {
+                            !ast_argument.is_variadic()
+                                && matches!(ast_argument.value(), ast::Expr::Lambda(_))
+                                && overload.has_specializable_callable_parameter_context(
+                                    db,
+                                    binding,
+                                    argument_index,
+                                )
+                        })
+                })
+                .collect();
+
+            if overload_has_eligible_callable_context
+                .iter()
+                .any(|eligible| *eligible)
+            {
+                let callable_context_typevars: Vec<_> = overloads_with_binding
+                    .iter()
+                    .zip(&overload_has_eligible_callable_context)
+                    .map(|((overload, _), eligible)| {
+                        if *eligible {
+                            overload.callable_parameter_context_typevars(db)
+                        } else {
+                            Vec::new()
+                        }
+                    })
+                    .collect();
+
+                for (argument_index, ast_argument) in ast_arguments
+                    .clone()
+                    .enumerate()
+                    .skip(first_lambda_argument_index + 1)
+                {
+                    // Splatted arguments are inferred before parameter matching to determine
+                    // their length, so there is no default expression type to pre-seed here.
+                    if ast_argument.is_variadic() {
+                        continue;
+                    }
+
+                    let has_default_type = matches!(
+                        arguments_types.argument_types(argument_index),
+                        Some(argument_types) if argument_types.get_default().is_some()
+                    );
+                    if has_default_type {
+                        continue;
+                    }
+
+                    // In an overloaded call, the same source argument can be forwarded through
+                    // `P.args` for one overload and still solve an ordinary `T` for another. Only
+                    // skip pre-seeding when no candidate overload can use the argument as a normal
+                    // solver.
+                    let can_seed_any_overload = overloads_with_binding
+                        .iter()
+                        .zip(&overload_has_eligible_callable_context)
+                        .zip(&callable_context_typevars)
+                        .any(
+                            |(((overload, binding), eligible), callable_context_typevars)| {
+                                *eligible
+                                    && overload.can_specialize_callable_parameter_context(
+                                        db,
+                                        binding,
+                                        argument_index,
+                                        callable_context_typevars,
+                                    )
+                                    && !overload
+                                        .is_paramspec_component_argument(binding, argument_index)
+                            },
+                        );
+
+                    if can_seed_any_overload {
+                        arguments_to_seed.push((argument_index, ast_argument));
+                    }
+                }
+            }
+        }
+
+        if !arguments_to_seed.is_empty() {
+            // The cache is torn down again before the main inference loop below: real (non-
+            // speculative) inference must not be short-circuited by speculatively cached results,
+            // or it would skip recording sub-expression types and emitting diagnostics.
+            let teardown = self.setup_expression_cache();
+
+            for (argument_index, ast_argument) in arguments_to_seed {
+                let mut speculative_builder = self.speculate_without_diagnostics();
+                let inferred_ty = infer_argument_ty(
+                    &mut speculative_builder,
+                    (argument_index, ast_argument.value(), TypeContext::default()),
+                );
+                arguments_types.insert_type(argument_index, TypeContext::default(), inferred_ty);
+            }
+
+            if teardown {
+                self.teardown_expression_cache();
+            }
+        }
+
         // A keyword argument matched to `**P.kwargs` can appear before the keyword argument that
         // binds `P`, e.g. `wrapper(TagSet=[...], func=put_object)`. Seed those binder argument
         // types first so the normal ParamSpec context path below is not source-order dependent.
@@ -5830,14 +5959,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             let parameter_tcx = |overload: &'bindings Binding<'db>,
                                  binding: &CallableBinding<'db>| {
-                overload.argument_type_context(
+                overload.argument_type_context(ArgumentTypeContextParams {
                     db,
-                    &constraints,
+                    constraints: &constraints,
                     binding,
                     arguments_types,
                     argument_index,
                     call_expression_tcx,
-                )
+                    argument_is_lambda: matches!(ast_argument, ast::Expr::Lambda(_)),
+                })
             };
 
             // If there is only a single binding and overload, we can infer the argument directly with


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

When inferring argument types for a generic callable, seed argument
types before applying parameter context.  This lets type variables solved
by one argument specialize the callable context used for another
argument, regardless of definition order.

Fixes this:

    def _(x: list[int]):
        f12 = list(map(lambda y: y + 1, x))
        reveal_type(f12)  # revealed: list[int]

We drill through type aliases and unions in case the callable spec is
nested, but stil unambiguous, `Callable[...] | None` being the most
trivial example.

## Test Plan

Added new tests to `bidirectional.md`.
