### PR TITLE
[ty] Make class-pattern fallthrough member-aware

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -43,8 +43,9 @@ use crate::place::{
     match_subject_place_expressions,
 };
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
+    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternKind,
+    ClassPatternPredicateKind, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
+    PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
     StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
@@ -2041,29 +2042,29 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             ast::Pattern::MatchClass(pattern) => {
                 let cls = self.add_standalone_expression(&pattern.cls);
 
-                // TODO: A class pattern with only irrefutable subpatterns can still fail if
-                // extracting an attribute named by `__match_args__` or a keyword fails. We retain
-                // this existing approximation because treating all class patterns with arguments
-                // as refutable caused a large ecosystem change. Follow-up work should determine
-                // irrefutability by analyzing the class's attributes and `__match_args__`.
-                PatternPredicateKind::Class(
-                    cls,
-                    if pattern
+                PatternPredicateKind::Class(ClassPatternPredicateKind {
+                    class: cls,
+                    positional: pattern
                         .arguments
                         .patterns
                         .iter()
-                        .all(ast::Pattern::is_irrefutable)
-                        && pattern
-                            .arguments
-                            .keywords
-                            .iter()
-                            .all(|kw| kw.pattern.is_irrefutable())
-                    {
-                        ClassPatternKind::Irrefutable
-                    } else {
-                        ClassPatternKind::Refutable
-                    },
-                )
+                        .map(|pattern| self.predicate_kind(pattern))
+                        .collect(),
+                    positional_irrefutable: pattern
+                        .arguments
+                        .patterns
+                        .iter()
+                        .all(ast::Pattern::is_irrefutable),
+                    keywords: pattern
+                        .arguments
+                        .keywords
+                        .iter()
+                        .map(|keyword| ClassPatternKeywordPredicateKind {
+                            attr: keyword.attr.id.clone(),
+                            pattern: self.predicate_kind(&keyword.pattern),
+                        })
+                        .collect(),
+                })
             }
             ast::Pattern::MatchMapping(pattern) => {
                 // `case {}` and `case {**rest}` match every mapping, while keyed mapping

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -197,7 +197,7 @@ pub struct ClassPatternPredicateKind<'db> {
 }
 
 impl ClassPatternPredicateKind<'_> {
-    pub fn is_argumentless(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.positional.is_empty() && self.keywords.is_empty()
     }
 }

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -187,6 +187,27 @@ impl<'db> SequencePatternPredicateKind<'db> {
     }
 }
 
+/// Structural details for a class pattern.
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternPredicateKind<'db> {
+    pub class: Expression<'db>,
+    pub positional: Box<[PatternPredicateKind<'db>]>,
+    pub positional_irrefutable: bool,
+    pub keywords: Box<[ClassPatternKeywordPredicateKind<'db>]>,
+}
+
+impl ClassPatternPredicateKind<'_> {
+    pub fn is_argumentless(&self) -> bool {
+        self.positional.is_empty() && self.keywords.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct ClassPatternKeywordPredicateKind<'db> {
+    pub attr: Name,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
 /// Pattern structure used for type narrowing, static reachability, and inferring the types of
 /// names bound by a successful match.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
@@ -194,7 +215,7 @@ pub enum PatternPredicateKind<'db> {
     Singleton(Singleton),
     Value(Expression<'db>),
     Or(Box<[PatternPredicateKind<'db>]>),
-    Class(Expression<'db>, ClassPatternKind),
+    Class(ClassPatternPredicateKind<'db>),
     Mapping(ClassPatternKind),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -228,13 +228,6 @@ def _(target: int | str):
             y = 2
 
     reveal_type(y)  # revealed: Literal[1, 2]
-
-def dynamic_attribute_capture_preserves_fallthrough(target: int) -> None:
-    match target:
-        case DynamicClass(real=_):
-            pass
-        case _:
-            target.missing  # error: [unresolved-attribute]
 ```
 
 ### Subclass-of type
@@ -297,20 +290,6 @@ def _(subj: int | abc.Callable[..., str]) -> None:
             y = 3
 
     reveal_type(y)  # revealed: Literal[2, 3]
-
-def callable_then_int(subj: abc.Callable[..., str] | int) -> int:
-    match subj:
-        case abc.Callable():
-            return 1
-        case int():
-            return 2
-
-def int_then_callable(subj: abc.Callable[..., str] | int) -> int:
-    match subj:
-        case int():
-            return 1
-        case abc.Callable():
-            return 2
 ```
 
 ### With arguments
@@ -357,7 +336,7 @@ def _(target: Point | Other):
         case Other():
             reveal_type(target)  # revealed: Other
 
-def ordered_or_class_pattern_preserves_fallthrough(target: Point):
+def missing_attribute_does_not_make_or_pattern_exhaustive(target: Point):
     y = 1
 
     match target:

--- a/crates/ty_python_semantic/resources/mdtest/conditional/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/conditional/match.md
@@ -209,7 +209,8 @@ def _(target: FooSub | str):
 
 ### Dynamic class
 
-A dynamically typed class pattern is not known to match every subject, so later cases remain
+A dynamically typed class expression may match any value, but we cannot prove which values it does
+not match. The failed branch therefore keeps the original subject type, and later cases remain
 reachable.
 
 ```py
@@ -223,10 +224,17 @@ def _(target: int | str):
             reveal_type(target)  # revealed: (int & Any) | (str & Any)
             y = 1
         case _:
-            reveal_type(target)  # revealed: (int & Any) | (str & Any)
+            reveal_type(target)  # revealed: int | str
             y = 2
 
     reveal_type(y)  # revealed: Literal[1, 2]
+
+def dynamic_attribute_capture_preserves_fallthrough(target: int) -> None:
+    match target:
+        case DynamicClass(real=_):
+            pass
+        case _:
+            target.missing  # error: [unresolved-attribute]
 ```
 
 ### Subclass-of type
@@ -289,6 +297,20 @@ def _(subj: int | abc.Callable[..., str]) -> None:
             y = 3
 
     reveal_type(y)  # revealed: Literal[2, 3]
+
+def callable_then_int(subj: abc.Callable[..., str] | int) -> int:
+    match subj:
+        case abc.Callable():
+            return 1
+        case int():
+            return 2
+
+def int_then_callable(subj: abc.Callable[..., str] | int) -> int:
+    match subj:
+        case int():
+            return 1
+        case abc.Callable():
+            return 2
 ```
 
 ### With arguments
@@ -334,6 +356,15 @@ def _(target: Point | Other):
             reveal_type(target)  # revealed: Point
         case Other():
             reveal_type(target)  # revealed: Other
+
+def ordered_or_class_pattern_preserves_fallthrough(target: Point):
+    y = 1
+
+    match target:
+        case Point(missing=_) | Other():
+            y = 2
+
+    reveal_type(y)  # revealed: Literal[1, 2]
 ```
 
 ## Singleton match

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -732,13 +732,214 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
             reveal_type(item)  # revealed: Never
 ```
 
+## Properties and declared attributes
+
+Properties and declared attributes count as present when checking exhaustiveness, even though
+descriptor access can raise `AttributeError` and an annotated attribute can be absent at runtime:
+
+```py
+from typing import Literal
+
+class FallibleProperty:
+    @property
+    def x(self) -> Literal[1]:
+        raise AttributeError
+
+def fallible_property_value_pattern_is_statically_exhaustive(value: FallibleProperty) -> int:
+    match value:
+        case FallibleProperty(x=1):
+            return 1
+
+class DeclaredLiteralAttribute:
+    x: Literal[1]
+
+def declared_literal_attribute_subpattern_is_exhaustive(
+    value: DeclaredLiteralAttribute,
+) -> int:
+    match value:
+        case DeclaredLiteralAttribute(x=1):
+            return 1
+```
+
+## Non-final subclasses
+
+Exhaustiveness follows the static member model, so a member inherited by a non-final subclass is
+treated as present. The same rule applies inside a sequence pattern:
+
+```py
+class BaseWithX:
+    x: int = 0
+
+class NonFinalChild(BaseWithX): ...
+
+def non_final_subclass_member_is_exhaustive(value: NonFinalChild) -> int:
+    match value:
+        case BaseWithX(x=_):
+            return 1
+
+def nested_non_final_subclass_member_is_exhaustive(value: tuple[NonFinalChild]) -> int:
+    match value:
+        case [BaseWithX(x=_)]:
+            return 1
+```
+
+## Runtime-checkable protocol patterns
+
+Runtime-checkable protocol patterns also follow the static member model. A subject that statically
+satisfies the protocol is treated as exhaustive regardless of whether its class is final:
+
+```py
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class RuntimeProtocolWithX(Protocol):
+    x: int
+
+class RuntimeProtocolImplementer:
+    x: int = 0
+
+def runtime_protocol_pattern_is_exhaustive(value: RuntimeProtocolImplementer) -> int:
+    match value:
+        case RuntimeProtocolWithX(x=_):
+            return 1
+
+class DeclaredRuntimeProtocolImplementer:
+    x: int
+
+def argumentless_runtime_protocol_pattern_is_exhaustive(
+    value: DeclaredRuntimeProtocolImplementer,
+) -> int:
+    match value:
+        case RuntimeProtocolWithX():
+            return 1
+
+def nested_argumentless_runtime_protocol_pattern_is_exhaustive(
+    value: tuple[DeclaredRuntimeProtocolImplementer],
+) -> int:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            return 1
+
+def nested_argumentless_runtime_protocol_union_preserves_fallback(
+    value: tuple[DeclaredRuntimeProtocolImplementer | int],
+) -> None:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            pass
+        case [DeclaredRuntimeProtocolImplementer()]:
+            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
+
+def nested_argumentless_runtime_protocol_list_does_not_narrow_fallthrough(
+    value: list[DeclaredRuntimeProtocolImplementer | int],
+) -> None:
+    match value:
+        case [RuntimeProtocolWithX()]:
+            pass
+        case [DeclaredRuntimeProtocolImplementer()]:
+            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer | int
+```
+
+## Subject-class members
+
+A member known on the static subject type can make a base-class pattern exhaustive:
+
+```py
+class BaseWithoutX: ...
+
+class ChildWithX(BaseWithoutX):
+    x: int = 0
+
+def subclass_member_is_exhaustive(value: ChildWithX) -> int:
+    match value:
+        case BaseWithoutX(x=_):
+            return 1
+
+def nested_subclass_member_is_exhaustive(
+    value: tuple[ChildWithX],
+) -> int:
+    match value:
+        case [BaseWithoutX(x=_)]:
+            return 1
+```
+
+## Nested class patterns
+
+Every nested pattern must match all possible values of the attribute it receives:
+
+```py
+from typing import Literal
+
+class Inner:
+    x: int = 0
+
+class Outer:
+    inner: Inner = Inner()
+
+def nested_class_subpattern_is_exhaustive(value: tuple[Outer]) -> int:
+    match value:
+        case [Outer(inner=Inner(x=_))]:
+            return 1
+
+class LiteralAttribute:
+    x: Literal[1] = 1
+
+def literal_attribute_subpattern_is_exhaustive(value: LiteralAttribute) -> int:
+    match value:
+        case LiteralAttribute(x=1):
+            return 1
+```
+
+## Missing class-pattern attributes
+
+A class pattern can fail after its `isinstance` check if a requested attribute is missing. This
+preserves both direct fallthrough and fallthrough from a nested sequence pattern:
+
+```py
+from typing import final
+
+class MissingAttributes: ...
+class OtherClass: ...
+
+def keyword_class_pattern_preserves_direct_fallback(
+    value: MissingAttributes | OtherClass,
+) -> None:
+    match value:
+        case MissingAttributes(missing=_):
+            pass
+        case _:
+            reveal_type(value)  # revealed: MissingAttributes | OtherClass
+
+def attribute_condition() -> bool:
+    return bool()
+
+@final
+class PossiblyMissingAttribute:
+    if attribute_condition():
+        x: int = 0
+
+def possibly_missing_attribute_is_not_exhaustive(
+    value: PossiblyMissingAttribute,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyMissingAttribute(x=_):
+            return 1
+```
+
 ## Sequence exhaustiveness
 
 Sequence patterns also contribute to negative narrowing and exhaustiveness. Exact tuple shapes can
 make a match exhaustive.
 
 ```py
+from typing import final
 from typing_extensions import assert_never
+
+class LengthBase:
+    x: int
+
+@final
+class LengthChild(LengthBase): ...
 
 def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
     match subj:
@@ -769,6 +970,16 @@ def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) 
             return left + right
         case _:
             assert_never(value)
+
+# Checking an element against its subject type does not replace the sequence pattern's length
+# check. This one-element pattern cannot match a two-element tuple.
+def subject_aware_element_keeps_length_check(
+    value: tuple[LengthChild, LengthChild],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case [LengthBase(x=_)]:
+            return 1
 
 def test_match_exact_tuple_element_union_is_exhaustive(x: tuple[int | str]) -> int:
     match x:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -753,7 +753,7 @@ def fallible_property_value_pattern_is_statically_exhaustive(value: FallibleProp
 class DeclaredLiteralAttribute:
     x: Literal[1]
 
-def declared_literal_attribute_subpattern_is_exhaustive(
+def declared_literal_attribute_is_exhaustive(
     value: DeclaredLiteralAttribute,
 ) -> int:
     match value:
@@ -761,32 +761,10 @@ def declared_literal_attribute_subpattern_is_exhaustive(
             return 1
 ```
 
-## Non-final subclasses
-
-Exhaustiveness follows the static member model, so a member inherited by a non-final subclass is
-treated as present. The same rule applies inside a sequence pattern:
-
-```py
-class BaseWithX:
-    x: int = 0
-
-class NonFinalChild(BaseWithX): ...
-
-def non_final_subclass_member_is_exhaustive(value: NonFinalChild) -> int:
-    match value:
-        case BaseWithX(x=_):
-            return 1
-
-def nested_non_final_subclass_member_is_exhaustive(value: tuple[NonFinalChild]) -> int:
-    match value:
-        case [BaseWithX(x=_)]:
-            return 1
-```
-
 ## Runtime-checkable protocol patterns
 
-Runtime-checkable protocol patterns also follow the static member model. A subject that statically
-satisfies the protocol is treated as exhaustive regardless of whether its class is final:
+Runtime-checkable protocols use the same rule. The subject below is known to provide `x`, so the
+pattern is exhaustive even though the subject class is not final:
 
 ```py
 from typing import Protocol, runtime_checkable
@@ -802,46 +780,13 @@ def runtime_protocol_pattern_is_exhaustive(value: RuntimeProtocolImplementer) ->
     match value:
         case RuntimeProtocolWithX(x=_):
             return 1
-
-class DeclaredRuntimeProtocolImplementer:
-    x: int
-
-def argumentless_runtime_protocol_pattern_is_exhaustive(
-    value: DeclaredRuntimeProtocolImplementer,
-) -> int:
-    match value:
-        case RuntimeProtocolWithX():
-            return 1
-
-def nested_argumentless_runtime_protocol_pattern_is_exhaustive(
-    value: tuple[DeclaredRuntimeProtocolImplementer],
-) -> int:
-    match value:
-        case [RuntimeProtocolWithX()]:
-            return 1
-
-def nested_argumentless_runtime_protocol_union_preserves_fallback(
-    value: tuple[DeclaredRuntimeProtocolImplementer | int],
-) -> None:
-    match value:
-        case [RuntimeProtocolWithX()]:
-            pass
-        case [DeclaredRuntimeProtocolImplementer()]:
-            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer
-
-def nested_argumentless_runtime_protocol_list_does_not_narrow_fallthrough(
-    value: list[DeclaredRuntimeProtocolImplementer | int],
-) -> None:
-    match value:
-        case [RuntimeProtocolWithX()]:
-            pass
-        case [DeclaredRuntimeProtocolImplementer()]:
-            reveal_type(value[0])  # revealed: DeclaredRuntimeProtocolImplementer | int
 ```
 
-## Subject-class members
+## Members from the subject type
 
-A member known on the static subject type can make a base-class pattern exhaustive:
+A keyword pattern reads the attribute from the matched value. The subject type can therefore provide
+an attribute that is not declared by the class named in the pattern. This also applies when the
+subject class is not final:
 
 ```py
 class BaseWithoutX: ...
@@ -853,22 +798,14 @@ def subclass_member_is_exhaustive(value: ChildWithX) -> int:
     match value:
         case BaseWithoutX(x=_):
             return 1
-
-def nested_subclass_member_is_exhaustive(
-    value: tuple[ChildWithX],
-) -> int:
-    match value:
-        case [BaseWithoutX(x=_)]:
-            return 1
 ```
 
 ## Nested class patterns
 
-Every nested pattern must match all possible values of the attribute it receives:
+The same rule applies recursively: every nested pattern must match every value allowed for the
+attribute it receives.
 
 ```py
-from typing import Literal
-
 class Inner:
     x: int = 0
 
@@ -879,20 +816,12 @@ def nested_class_subpattern_is_exhaustive(value: tuple[Outer]) -> int:
     match value:
         case [Outer(inner=Inner(x=_))]:
             return 1
-
-class LiteralAttribute:
-    x: Literal[1] = 1
-
-def literal_attribute_subpattern_is_exhaustive(value: LiteralAttribute) -> int:
-    match value:
-        case LiteralAttribute(x=1):
-            return 1
 ```
 
 ## Missing class-pattern attributes
 
-A class pattern can fail after its `isinstance` check if a requested attribute is missing. This
-preserves both direct fallthrough and fallthrough from a nested sequence pattern:
+A class pattern can fail after its `isinstance` check if a requested attribute is missing or only
+conditionally defined. The failed branch therefore keeps the original subject type:
 
 ```py
 from typing import final
@@ -900,7 +829,7 @@ from typing import final
 class MissingAttributes: ...
 class OtherClass: ...
 
-def keyword_class_pattern_preserves_direct_fallback(
+def missing_attribute_keeps_original_subject(
     value: MissingAttributes | OtherClass,
 ) -> None:
     match value:
@@ -932,14 +861,10 @@ Sequence patterns also contribute to negative narrowing and exhaustiveness. Exac
 make a match exhaustive.
 
 ```py
-from typing import final
 from typing_extensions import assert_never
 
-class LengthBase:
-    x: int
-
-@final
-class LengthChild(LengthBase): ...
+class HasX:
+    x: int = 0
 
 def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
     match subj:
@@ -971,14 +896,13 @@ def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) 
         case _:
             assert_never(value)
 
-# Checking an element against its subject type does not replace the sequence pattern's length
-# check. This one-element pattern cannot match a two-element tuple.
-def subject_aware_element_keeps_length_check(
-    value: tuple[LengthChild, LengthChild],
+# Matching the element would succeed, but a one-element pattern cannot match a two-element tuple.
+def sequence_length_is_still_checked(
+    value: tuple[HasX, HasX],
     # error: [invalid-return-type]
 ) -> int:
     match value:
-        case [LengthBase(x=_)]:
+        case [HasX(x=_)]:
             return 1
 
 def test_match_exact_tuple_element_union_is_exhaustive(x: tuple[int | str]) -> int:

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -202,7 +202,8 @@ use crate::{
     types::{
         ActiveRecursionDetector, CallableTypes, EnumClassLiteral, IntersectionBuilder,
         KnownInstanceType, NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType,
-        callable_pattern_type, definite_match_pattern_type, equality_truthiness, expand_type,
+        callable_pattern_type, definite_match_pattern_type,
+        definite_match_pattern_type_for_subject, equality_truthiness, expand_type,
         infer_narrowing_constraints, infer_same_file_expression_type, mapping_pattern_type,
         pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
     },
@@ -494,7 +495,7 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
     }
 
     let truthiness =
-        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty);
+        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty, None);
 
     if truthiness == Truthiness::AlwaysTrue && predicate.guard(db).is_some() {
         // Fall back to ambiguous, the guard might change the result.
@@ -1110,6 +1111,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
+    precomputed_definite_match_ty: Option<Type<'db>>,
 ) -> Truthiness {
     match predicate_kind {
         PatternPredicateKind::Value(value) => {
@@ -1144,9 +1146,20 @@ fn analyze_single_pattern_predicate_kind<'db>(
                         .add_negative(UnionType::from_elements(db, excluded_types.iter()))
                         .build();
 
-                    excluded_types.push(definite_match_pattern_type(db, p));
+                    let definitely_matched =
+                        definite_match_pattern_type_for_subject(db, p, narrowed_subject_ty);
+                    excluded_types.push(definitely_matched);
 
-                    analyze_single_pattern_predicate_kind(db, p, narrowed_subject_ty)
+                    if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
+                        Truthiness::AlwaysTrue
+                    } else {
+                        analyze_single_pattern_predicate_kind(
+                            db,
+                            p,
+                            narrowed_subject_ty,
+                            Some(definitely_matched),
+                        )
+                    }
                 })
                 // this is just a "max", but with a slight optimization:
                 // `AlwaysTrue` is the "greatest" possible element, so we short-circuit if we get there
@@ -1163,34 +1176,28 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 });
             truthiness
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
+        PatternPredicateKind::Class(kind) => {
             let class_ty =
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => {
-                        Some(Type::instance(db, class.top_materialization(db)))
-                    }
+                match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        Some(callable_pattern_type(db))
+                        callable_pattern_type(db)
                     }
-                    _ => None,
+                    _ => return Truthiness::Ambiguous,
                 };
+            let definitely_matched = precomputed_definite_match_ty.unwrap_or_else(|| {
+                definite_match_pattern_type_for_subject(db, predicate_kind, subject_ty)
+            });
 
-            class_ty.map_or(Truthiness::Ambiguous, |class_ty| {
-                if subject_ty.is_subtype_of(db, class_ty) {
-                    if kind.is_irrefutable() {
-                        Truthiness::AlwaysTrue
-                    } else {
-                        // A class pattern like `case Point(x=0, y=0)` is not irrefutable,
-                        // i.e. it does not match all instances of `Point`. This means that
-                        // we can't tell for sure if this pattern will match or not.
-                        Truthiness::Ambiguous
-                    }
-                } else if subject_ty.is_disjoint_from(db, class_ty) {
-                    Truthiness::AlwaysFalse
-                } else {
-                    Truthiness::Ambiguous
-                }
-            })
+            if subject_ty.is_equivalent_to(db, definitely_matched)
+                || subject_ty.is_subtype_of(db, definitely_matched)
+            {
+                Truthiness::AlwaysTrue
+            } else if subject_ty.is_disjoint_from(db, class_ty) {
+                Truthiness::AlwaysFalse
+            } else {
+                Truthiness::Ambiguous
+            }
         }
         PatternPredicateKind::Mapping(kind) => {
             let mapping_ty = mapping_pattern_type(db);
@@ -1222,7 +1229,14 @@ fn analyze_single_pattern_predicate_kind<'db>(
         }
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| analyze_single_pattern_predicate_kind(db, p, subject_ty))
+            .map(|p| {
+                analyze_single_pattern_predicate_kind(
+                    db,
+                    p,
+                    subject_ty,
+                    precomputed_definite_match_ty,
+                )
+            })
             .unwrap_or(Truthiness::AlwaysTrue),
         PatternPredicateKind::Star(_) => Truthiness::AlwaysTrue,
     }

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -35,9 +35,10 @@ pub(crate) use self::infer::{
 pub(crate) use self::iteration::extract_fixed_length_iterable_element_types;
 pub use self::known_instance::KnownInstanceType;
 pub(crate) use self::match_pattern::{
-    callable_pattern_type, definite_match_pattern_type, exact_sequence_pattern_type,
-    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    callable_pattern_type, definite_match_pattern_type, definite_match_pattern_type_for_subject,
+    exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
+    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -192,7 +192,7 @@ fn class_pattern_is_exhaustive(
         return false;
     }
 
-    if kind.is_argumentless() {
+    if kind.is_empty() {
         return true;
     }
 
@@ -335,7 +335,7 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                     }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
-                    if kind.is_argumentless()
+                    if kind.is_empty()
                         && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
                 {
                     return callable_pattern_type(db);
@@ -530,13 +530,11 @@ fn subject_independent_definite_match_pattern_type<'db>(
     match kind {
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
-                Type::ClassLiteral(class) if kind.is_argumentless() => {
+                Type::ClassLiteral(class) if kind.is_empty() => {
                     Some(Type::instance(db, class.top_materialization(db)))
                 }
                 Type::ClassLiteral(_) => None,
-                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
-                    if kind.is_argumentless() =>
-                {
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) if kind.is_empty() => {
                     Some(callable_pattern_type(db))
                 }
                 _ => Some(Type::Never),
@@ -589,12 +587,10 @@ pub(crate) fn definite_match_pattern_type<'db>(
         }
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
-                Type::ClassLiteral(class) if kind.is_argumentless() => {
+                Type::ClassLiteral(class) if kind.is_empty() => {
                     Type::instance(db, class.top_materialization(db))
                 }
-                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
-                    if kind.is_argumentless() =>
-                {
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) if kind.is_empty() => {
                     callable_pattern_type(db)
                 }
                 _ => Type::Never,

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -2,7 +2,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
 use ty_python_core::predicate::{
-    ClassPatternKind, PatternPredicateKind, SequencePatternPredicateKind,
+    ClassPatternPredicateKind, PatternPredicateKind, SequencePatternPredicateKind,
 };
 
 use crate::Db;
@@ -11,8 +11,8 @@ use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    CallableType, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter, Parameters,
-    Signature, SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
+    CallableType, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter,
+    Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
     infer_same_file_expression_type,
 };
 
@@ -167,6 +167,59 @@ pub(crate) fn starred_sequence_pattern_type<'db>(
         .build()
 }
 
+/// Return whether every value in `subject_ty` is statically guaranteed to match this class pattern.
+///
+/// Attribute subpatterns are checked recursively against their statically known member types. The
+/// subject's class can provide members that are absent from the class named in the pattern.
+///
+/// ```python
+/// class Base: ...
+///
+/// class Child(Base):
+///     x: int
+///
+/// # Exhaustive for a `Child` subject because `Child.x` is definitely bound.
+/// case Base(x=_): ...
+/// ```
+fn class_pattern_is_exhaustive(
+    db: &dyn Db,
+    class: ClassLiteral<'_>,
+    subject_ty: Type<'_>,
+    kind: &ClassPatternPredicateKind<'_>,
+) -> bool {
+    let class_instance_ty = Type::instance(db, class.top_materialization(db));
+    if !subject_ty.is_subtype_of(db, class_instance_ty) {
+        return false;
+    }
+
+    if kind.is_argumentless() {
+        return true;
+    }
+
+    if !kind.positional_irrefutable {
+        return false;
+    }
+
+    kind.keywords.iter().all(|keyword| {
+        member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
+    })
+}
+
+/// Return whether `name` is definitely bound and `pattern` consumes its entire static member type.
+fn member_pattern_is_exhaustive(
+    db: &dyn Db,
+    instance_ty: Type<'_>,
+    name: &str,
+    pattern: &PatternPredicateKind<'_>,
+) -> bool {
+    let place = instance_ty.member(db, name).place;
+    place.is_definitely_bound()
+        && place
+            .raw_type()
+            .is_some_and(|member_ty| pattern_is_exhaustive_for_subject(db, pattern, member_ty))
+}
+
+/// Return whether `pattern` is statically guaranteed to match every value in `subject_ty`.
 fn pattern_is_exhaustive_for_subject(
     db: &dyn Db,
     pattern: &PatternPredicateKind<'_>,
@@ -178,6 +231,10 @@ fn pattern_is_exhaustive_for_subject(
     )
 }
 
+/// Return whether an exact tuple subject is fully consumed by a sequence pattern.
+///
+/// Each aligned element is checked with the subject-aware matcher so nested class patterns use the
+/// tuple element's actual static type.
 fn sequence_pattern_is_exhaustive_for_subject(
     db: &dyn Db,
     kind: &SequencePatternPredicateKind<'_>,
@@ -219,46 +276,28 @@ fn sequence_pattern_is_exhaustive_for_subject(
         .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
 }
 
-fn subject_independent_definite_match_pattern_type<'db>(
-    db: &'db dyn Db,
-    kind: &PatternPredicateKind<'db>,
-) -> Option<Type<'db>> {
-    match kind {
-        PatternPredicateKind::Singleton(_)
-        | PatternPredicateKind::Class(_, ClassPatternKind::Irrefutable)
-        | PatternPredicateKind::Mapping(ClassPatternKind::Irrefutable) => {
-            Some(definite_match_pattern_type(db, kind))
-        }
-        PatternPredicateKind::Sequence(sequence) if sequence.is_irrefutable() => {
-            Some(definite_match_pattern_type(db, kind))
-        }
-        PatternPredicateKind::Or(patterns) => {
-            let patterns = patterns
-                .iter()
-                .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
-                .collect::<Option<Vec<_>>>()?;
-            Some(UnionType::from_elements(db, patterns))
-        }
-        PatternPredicateKind::As(Some(pattern), _) => {
-            subject_independent_definite_match_pattern_type(db, pattern)
-        }
-        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => Some(Type::object()),
-        PatternPredicateKind::Value(_)
-        | PatternPredicateKind::Class(_, ClassPatternKind::Refutable)
-        | PatternPredicateKind::Mapping(ClassPatternKind::Refutable)
-        | PatternPredicateKind::Sequence(_) => None,
-    }
-}
-
-/// Return values that are statically guaranteed to match `kind`, using `subject_ty` to recognize
-/// cases where the pattern covers a complete subject arm.
+/// Return the values that are statically guaranteed to match `kind`, using `subject_ty` when the
+/// answer depends on the subject.
 ///
-/// Unlike [`definite_match_pattern_type`], this can recognize guarantees that depend on the
-/// current subject. For example, both `Literal[True]` and `Literal[1]` are guaranteed to match the
-/// value pattern `1` because match value patterns use equality. The returned type can include
-/// values outside `subject_ty`; callers intersect it with the subject before using it for negative
-/// narrowing. Keeping the non-exhaustive part independent of the subject also prevents each case
-/// in a long match statement from embedding all previous negative constraints again.
+/// This is an under-approximation used for negative narrowing and ordered alternatives: callers
+/// may subtract the result from `subject_ty` under ty's static member model. A subject-independent
+/// pattern can return a type wider than `subject_ty`; for example, `case Base()` returns `Base`
+/// even for a `Child` subject. Class patterns need the current subject type when member extraction
+/// depends on the subject's statically known members.
+/// A subject-independent pattern can return its context-free definite-match type directly. A
+/// definitely bound descriptor is treated as successful even though it could raise at runtime.
+/// The same rule is propagated through nested sequence, `or`, and `as` patterns.
+///
+/// ```python
+/// class Base:
+///     x: int
+///
+/// class Child(Base):
+///     pass
+///
+/// # For a `tuple[Child]` subject, this checks `x` on `Child`, not only on `Base`.
+/// case [Base(x=_)]: ...
+/// ```
 pub(crate) fn definite_match_pattern_type_for_subject<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
@@ -284,30 +323,58 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
             if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
-                subject_ty
-            } else {
-                definite_match_pattern_type(db, kind)
+                return subject_ty;
+            }
+        }
+        PatternPredicateKind::Class(kind) => {
+            let class_ty = infer_same_file_expression_type(db, kind.class, TypeContext::default());
+            match class_ty {
+                Type::ClassLiteral(class) => {
+                    if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
+                        return subject_ty;
+                    }
+                    let class_ty = Type::instance(db, class.top_materialization(db));
+                    if kind.is_argumentless() && subject_ty.is_subtype_of(db, class_ty) {
+                        return Type::Never;
+                    }
+                }
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless()
+                        && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
+                {
+                    return callable_pattern_type(db);
+                }
+                _ => {}
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
+            return if sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
                 subject_ty
             } else {
-                definite_sequence_pattern_type(db, kind)
-            }
+                // A nested subject-dependent pattern rejected the context-free approximation.
+                // Reusing that approximation for the surrounding sequence would reintroduce the
+                // values that the recursive analysis deliberately excluded.
+                Type::Never
+            };
         }
-        PatternPredicateKind::Or(patterns) => UnionType::from_elements(
-            db,
-            patterns
-                .iter()
-                .map(|pattern| definite_match_pattern_type_for_subject(db, pattern, subject_ty)),
-        ),
+        PatternPredicateKind::Or(patterns) => {
+            return UnionType::from_elements(
+                db,
+                patterns.iter().map(|pattern| {
+                    definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+                }),
+            );
+        }
         PatternPredicateKind::As(Some(pattern), _) => {
-            definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+            return definite_match_pattern_type_for_subject(db, pattern, subject_ty);
         }
-        PatternPredicateKind::As(None, _) | PatternPredicateKind::Star(_) => subject_ty,
-        _ => definite_match_pattern_type(db, kind),
+        _ => return Type::Never,
     }
+
+    IntersectionBuilder::new(db)
+        .add_positive(subject_ty)
+        .add_positive(definite_match_pattern_type(db, kind))
+        .build()
 }
 
 /// Return the part of `subject_ty` that can reach a later alternative after `kind` fails.
@@ -455,6 +522,55 @@ fn is_same_enum_pattern_domain<'db>(
     }
 }
 
+/// Return the definite-match type when it does not depend on the current subject type.
+///
+/// `None` means that callers must use subject-aware analysis instead of falling back to the
+/// context-free approximation. In particular, attribute class patterns can depend on members of
+/// the static subject type.
+fn subject_independent_definite_match_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+) -> Option<Type<'db>> {
+    match kind {
+        PatternPredicateKind::Class(kind) => {
+            match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                Type::ClassLiteral(class) if kind.is_argumentless() => {
+                    Some(Type::instance(db, class.top_materialization(db)))
+                }
+                Type::ClassLiteral(_) => None,
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless() =>
+                {
+                    Some(callable_pattern_type(db))
+                }
+                _ => Some(Type::Never),
+            }
+        }
+        PatternPredicateKind::Sequence(kind) => {
+            build_definite_sequence_pattern_type(db, kind, |pattern| {
+                subject_independent_definite_match_pattern_type(db, pattern)
+            })
+        }
+        PatternPredicateKind::Mapping(kind) => {
+            if kind.is_irrefutable() {
+                Some(mapping_pattern_type(db))
+            } else {
+                None
+            }
+        }
+        PatternPredicateKind::Or(patterns) => patterns
+            .iter()
+            .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
+            .collect::<Option<Vec<_>>>()
+            .map(|types| UnionType::from_elements(db, types)),
+        PatternPredicateKind::As(Some(pattern), _) => {
+            subject_independent_definite_match_pattern_type(db, pattern)
+        }
+        PatternPredicateKind::Value(_) => None,
+        _ => Some(definite_match_pattern_type(db, kind)),
+    }
+}
+
 /// Return the values that are guaranteed to match `kind`.
 ///
 /// Reachability and negative narrowing can only subtract this under-approximation.
@@ -475,17 +591,17 @@ pub(crate) fn definite_match_pattern_type<'db>(
                 Type::Never
             }
         }
-        PatternPredicateKind::Class(class_expr, kind) => {
-            if kind.is_irrefutable() {
-                match infer_same_file_expression_type(db, *class_expr, TypeContext::default()) {
-                    Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
-                    Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(db)
-                    }
-                    _ => Type::Never,
+        PatternPredicateKind::Class(kind) => {
+            match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                Type::ClassLiteral(class) if kind.is_argumentless() => {
+                    Type::instance(db, class.top_materialization(db))
                 }
-            } else {
-                Type::Never
+                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
+                    if kind.is_argumentless() =>
+                {
+                    callable_pattern_type(db)
+                }
+                _ => Type::Never,
             }
         }
         PatternPredicateKind::Mapping(kind) => {
@@ -511,36 +627,51 @@ pub(crate) fn definite_match_pattern_type<'db>(
 }
 
 /// Return the values that are guaranteed to match a sequence pattern.
-pub(crate) fn definite_sequence_pattern_type<'db>(
+fn definite_sequence_pattern_type<'db>(
     db: &'db dyn Db,
     kind: &SequencePatternPredicateKind<'db>,
 ) -> Type<'db> {
+    build_definite_sequence_pattern_type(db, kind, |pattern| {
+        Some(definite_match_pattern_type(db, pattern))
+    })
+    .unwrap_or(Type::Never)
+}
+
+fn build_definite_sequence_pattern_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    mut element_type: impl FnMut(&PatternPredicateKind<'db>) -> Option<Type<'db>>,
+) -> Option<Type<'db>> {
     if kind.is_irrefutable() {
-        return sequence_pattern_type_builder(db).build();
+        return Some(sequence_pattern_type_builder(db).build());
     }
 
     if let Some((prefix, suffix)) = kind.split_around_star() {
-        return Type::tuple(TupleType::mixed(
+        let prefix_types = prefix
+            .iter()
+            .map(&mut element_type)
+            .collect::<Option<Vec<_>>>()?;
+        let suffix_types = suffix
+            .iter()
+            .map(&mut element_type)
+            .collect::<Option<Vec<_>>>()?;
+        return Some(Type::tuple(TupleType::mixed(
             db,
-            prefix
-                .iter()
-                .map(|pattern| definite_match_pattern_type(db, pattern)),
+            prefix_types,
             Type::object(),
-            suffix
-                .iter()
-                .map(|pattern| definite_match_pattern_type(db, pattern)),
-        ));
+            suffix_types,
+        )));
     }
 
     let element_types: Vec<_> = kind
         .patterns
         .iter()
-        .map(|pattern| definite_match_pattern_type(db, pattern))
-        .collect();
+        .map(element_type)
+        .collect::<Option<_>>()?;
 
     if element_types.iter().any(Type::is_never) {
-        Type::Never
+        Some(Type::Never)
     } else {
-        exact_sequence_pattern_type(db, element_types.into_iter())
+        Some(exact_sequence_pattern_type(db, element_types.into_iter()))
     }
 }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -333,10 +333,6 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                     if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
                         return subject_ty;
                     }
-                    let class_ty = Type::instance(db, class.top_materialization(db));
-                    if kind.is_argumentless() && subject_ty.is_subtype_of(db, class_ty) {
-                        return Type::Never;
-                    }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_argumentless()

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -15,9 +15,10 @@ use crate::types::{
     CallableType, ClassLiteral, ClassType, IntersectionBuilder, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueTypeKind, Parameter, Parameters, Signature, SpecialFormType,
     SubclassOfInner, SubclassOfType, Truthiness, Type, TypeContext, TypeVarBoundOrConstraints,
-    UnionBuilder, callable_pattern_type, exact_sequence_pattern_type, infer_expression_types,
-    mapping_pattern_type, pattern_binding_fallthrough_type, pattern_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    UnionBuilder, callable_pattern_type, definite_match_pattern_type_for_subject,
+    exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
+    pattern_binding_fallthrough_type, pattern_fallthrough_type, sequence_pattern_type_builder,
+    singleton_pattern_type, starred_sequence_pattern_type,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -1051,9 +1052,9 @@ fn necessary_match_pattern_type<'db>(
 ) -> Type<'db> {
     match pattern {
         PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
-        PatternPredicateKind::Class(cls, _) => positive_class_pattern_type(
+        PatternPredicateKind::Class(kind) => positive_class_pattern_type(
             db,
-            infer_same_file_expression_type(db, *cls, TypeContext::default()),
+            infer_same_file_expression_type(db, kind.class, TypeContext::default()),
         )
         .unwrap_or_else(Type::object),
         PatternPredicateKind::Mapping(_) => mapping_pattern_type(db),
@@ -1262,9 +1263,14 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
             PatternPredicateKind::Singleton(singleton) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_singleton(subject, *singleton, is_positive),
             ),
-            PatternPredicateKind::Class(cls, kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_class(subject, *cls, *kind, is_positive),
-            ),
+            PatternPredicateKind::Class(kind) => {
+                PatternNarrowingResult::Possible(self.evaluate_match_pattern_class(
+                    subject,
+                    kind.class,
+                    pattern_predicate_kind,
+                    is_positive,
+                ))
+            }
             PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
                 self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
             ),
@@ -1404,10 +1410,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     bindings: BTreeMap::new(),
                 }
             }
-            PatternPredicateKind::Class(class_expr, _) => {
+            PatternPredicateKind::Class(kind) => {
                 let class_ty = necessary_match_pattern_type(self.db, pattern);
                 let class =
-                    infer_same_file_expression_type(self.db, *class_expr, TypeContext::default())
+                    infer_same_file_expression_type(self.db, kind.class, TypeContext::default())
                         .as_class_literal();
                 let matched_subject_ty =
                     self.match_class_pattern_subject_type(class, class_ty, subject_ty, false);
@@ -1451,18 +1457,6 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         evaluate_type_equality(self.db, subject_ty, value_ty, true)
             .map(|constraint| self.intersect_types(subject_ty, constraint))
             .unwrap_or(subject_ty)
-    }
-
-    fn contains_class_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
-        match pattern {
-            PatternPredicateKind::Class(..) => true,
-            PatternPredicateKind::Sequence(kind) => {
-                kind.patterns.iter().any(Self::contains_class_pattern)
-            }
-            PatternPredicateKind::Or(patterns) => patterns.iter().any(Self::contains_class_pattern),
-            PatternPredicateKind::As(Some(pattern), _) => Self::contains_class_pattern(pattern),
-            _ => false,
-        }
     }
 
     fn contains_unsupported_binding_pattern(pattern: &PatternPredicateKind<'_>) -> bool {
@@ -1528,13 +1522,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let mut previous_pattern = first_pattern;
 
         for pattern in patterns {
-            remaining_subject_ty = if Self::contains_class_pattern(previous_pattern) {
-                // Attribute extraction can still fail after the runtime class check. The next PR
-                // refines this with subject-aware class-pattern exhaustiveness.
-                remaining_subject_ty
-            } else {
-                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty)
-            };
+            remaining_subject_ty =
+                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty);
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
             binding_subject_types.add_in_place(alternative.binding_subject_ty);
@@ -2962,35 +2951,31 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         &mut self,
         subject: Expression<'db>,
         cls: Expression<'db>,
-        kind: ClassPatternKind,
+        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
-            // A class pattern like `case Point(x=0, y=0)` is not irrefutable. In the positive case,
-            // we can still narrow the type of the match subject to `Point`. But in the negative case,
-            // we cannot exclude `Point` as a possibility.
-            return None;
+        if !is_positive {
+            let subject_place =
+                PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+            let place = self.expect_place(&subject_place);
+            let subject_ty =
+                infer_same_file_expression_type(self.db, subject, TypeContext::default());
+            let definitely_matched =
+                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+            if definitely_matched.is_never() {
+                return None;
+            }
+
+            return Some(NarrowingConstraints::from_iter([(
+                place,
+                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+            )]));
         }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject);
-
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
         let class_type = infer_same_file_expression_type(self.db, cls, TypeContext::default());
-
-        let narrowed_type = if is_positive {
-            positive_class_pattern_type(self.db, class_type)?
-        } else {
-            match class_type {
-                Type::ClassLiteral(class) => {
-                    Type::instance(self.db, class.top_materialization(self.db)).negate(self.db)
-                }
-                Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                    callable_pattern_type(self.db).negate(self.db)
-                }
-                dynamic @ Type::Dynamic(_) => dynamic,
-                _ => return None,
-            }
-        };
+        let narrowed_type = positive_class_pattern_type(self.db, class_type)?;
 
         Some(NarrowingConstraints::from_iter([(
             place,
@@ -3010,7 +2995,6 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
-
         let mapping_type = ClassInfoConstraintFunction::IsInstance
             .generate_constraint(
                 self.db,
@@ -3049,7 +3033,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
 
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
-        let Some(subject) = PlaceExpr::try_from_expr(subject_node) else {
+        let Some(subject_place) = PlaceExpr::try_from_expr(subject_node) else {
             return PatternNarrowingResult::Possible(None);
         };
 
@@ -3066,7 +3050,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return PatternNarrowingResult::Possible(None);
         }
 
-        let place = self.expect_place(&subject);
+        let place = self.expect_place(&subject_place);
 
         PatternNarrowingResult::Possible(Some(NarrowingConstraints::from_iter([(
             place,


### PR DESCRIPTION
## Summary

This is the first of three stacked PRs split from #26010.

On `main`, we consider a class pattern exhaustive whenever its subpatterns are irrefutable. We do not check whether the attributes requested by the pattern are actually present:

```python
class Base: ...

class Child(Base):
    x: int = 0

def missing_attribute(value: Base) -> int:
    match value:
        case Base(x=_):
            return 1

def subject_attribute(value: Child) -> int:
    match value:
        case Base(x=_):
            return 1
```

`main` accepts both functions. This is wrong for `missing_attribute`: a `Base` instance may not have `x`, so the pattern can fail and the function can return `None`. However, `subject_attribute` is exhaustive because its static subject type is `Child`, which guarantees that `x` is present.

(This isn't exactly right -- Pyright requires that `Child` is `@final`, but I think this is more consistent with our semantics elsewhere.)

This PR retains the attributes requested by a class pattern and checks them against the static subject type. With this change, `missing_attribute` reports `invalid-return-type`, while `subject_attribute` remains accepted. Nested attribute patterns use the same check recursively, including inside sequence, `or`, and `as` patterns.
