### PR TITLE
[ty] Resolve positional class-pattern exhaustiveness

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2050,11 +2050,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         .iter()
                         .map(|pattern| self.predicate_kind(pattern))
                         .collect(),
-                    positional_irrefutable: pattern
-                        .arguments
-                        .patterns
-                        .iter()
-                        .all(ast::Pattern::is_irrefutable),
                     keywords: pattern
                         .arguments
                         .keywords

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -192,7 +192,6 @@ impl<'db> SequencePatternPredicateKind<'db> {
 pub struct ClassPatternPredicateKind<'db> {
     pub class: Expression<'db>,
     pub positional: Box<[PatternPredicateKind<'db>]>,
-    pub positional_irrefutable: bool,
     pub keywords: Box<[ClassPatternKeywordPredicateKind<'db>]>,
 }
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -735,7 +735,8 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
 ## Exhaustive positional patterns for built-in classes
 
 Python defines a fixed set of built-in classes whose single positional subpattern receives the
-entire subject. This example checks every such class, including nested sequence and `or` patterns:
+entire subject. The `float` element also handles `int`, which is assignable to `float` but is not a
+`float` instance at runtime:
 
 ```py
 def builtin_positional_patterns_are_exhaustive(
@@ -800,75 +801,22 @@ def builtin_subclass_positional_pattern_is_exhaustive(value: MyInt) -> int:
         case MyInt(_):
             return 1
 
-def builtin_base_positional_pattern_is_exhaustive_for_subclass(value: MyInt) -> int:
-    match value:
-        case int(_):
-            return 1
-
-def nested_builtin_positional_pattern_is_exhaustive_for_subclass(
-    value: tuple[MyInt],
-) -> int:
-    match value:
-        case [int(_)]:
-            return 1
-
 def builtin_positional_literal_is_not_exhaustive(
     value: MyInt,
     # error: [invalid-return-type]
 ) -> int:
     match value:
-        case int(0):
+        case MyInt(0):
             return 1
 ```
 
 ## Resolving `__match_args__`
 
-For other positional class patterns, Python reads `__match_args__` from the pattern class. The
-attribute must be definitely present and must be a fixed tuple of literal attribute names. The
-selected attributes must also be definitely present on the subject:
+For other positional class patterns, Python reads `__match_args__` from the pattern class. A fixed
+tuple of attribute names makes the corresponding positional patterns exhaustive when every selected
+attribute is present on the subject:
 
 ```py
-class MyIntWithDefinitelyBoundMatchArgs(int):
-    __match_args__ = ("real",)
-
-def builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
-    value: MyIntWithDefinitelyBoundMatchArgs,
-) -> int:
-    match value:
-        case MyIntWithDefinitelyBoundMatchArgs(_):
-            return 1
-
-def nested_builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
-    value: tuple[MyIntWithDefinitelyBoundMatchArgs],
-) -> int:
-    match value:
-        case [MyIntWithDefinitelyBoundMatchArgs(_)]:
-            return 1
-
-class MyIntWithMissingMatchArg(int):
-    __match_args__ = ("missing",)
-
-def builtin_subclass_with_missing_match_arg_is_not_exhaustive(
-    value: MyIntWithMissingMatchArg,
-    # error: [invalid-return-type]
-) -> int:
-    match value:
-        case MyIntWithMissingMatchArg(_):
-            return 1
-
-class MatchArgsMeta(type):
-    __match_args__ = ("missing",)
-
-class MyIntWithMetaclassMatchArgs(int, metaclass=MatchArgsMeta): ...
-
-def builtin_subclass_with_metaclass_match_args_is_not_exhaustive(
-    value: MyIntWithMetaclassMatchArgs,
-    # error: [invalid-return-type]
-) -> int:
-    match value:
-        case MyIntWithMetaclassMatchArgs(_):
-            return 1
-
 class KnownAttributes:
     __match_args__ = ("x", "y")
     x: int = 0
@@ -878,12 +826,42 @@ def fixed_match_args_are_exhaustive(value: KnownAttributes) -> int:
     match value:
         case KnownAttributes(_, _):
             return 1
+```
+
+The pattern is not exhaustive when a selected attribute is missing, an explicit annotation widens
+the tuple type, or a conditional definition can override a built-in class's usual positional
+behavior. A metaclass can also provide `__match_args__` that selects a missing attribute:
+
+```py
+class IntWithMissingMatchArg(int):
+    __match_args__ = ("missing",)
+
+def missing_match_arg_is_not_exhaustive(
+    value: IntWithMissingMatchArg,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case IntWithMissingMatchArg(_):
+            return 1
+
+class MatchArgsMeta(type):
+    __match_args__ = ("missing",)
+
+class IntWithMetaclassMatchArgs(int, metaclass=MatchArgsMeta): ...
+
+def metaclass_match_args_is_not_exhaustive(
+    value: IntWithMetaclassMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case IntWithMetaclassMatchArgs(_):
+            return 1
 
 class WidenedMatchArgs:
     __match_args__: tuple[str, ...] = ("x",)
     x: int = 0
 
-def widened_match_args_does_not_identify_an_attribute(
+def widened_match_args_is_not_exhaustive(
     value: WidenedMatchArgs,
     # error: [invalid-return-type]
 ) -> int:
@@ -891,45 +869,21 @@ def widened_match_args_does_not_identify_an_attribute(
         case WidenedMatchArgs(_):
             return 1
 
-class AnnotatedMatchArgs(int):
-    __match_args__: tuple[str, ...]
-
-def annotated_match_args_is_not_exhaustive(
-    value: AnnotatedMatchArgs,
-    # error: [invalid-return-type]
-) -> int:
-    match value:
-        case AnnotatedMatchArgs(_):
-            return 1
-
 def condition() -> bool:
     return bool()
 
 flag = condition()
 
-class PossiblyBoundMatchArgs:
-    if flag:
-        __match_args__ = ("x",)
-    x: int = 0
-
-def possibly_bound_match_args_is_not_exhaustive(
-    value: PossiblyBoundMatchArgs,
-    # error: [invalid-return-type]
-) -> int:
-    match value:
-        case PossiblyBoundMatchArgs(_):
-            return 1
-
-class PossiblyBoundIntMatchArgs(int):
+class ConditionalIntMatchArgs(int):
     if flag:
         __match_args__ = ("missing",)
 
-def possibly_bound_match_args_does_not_enable_match_self(
-    value: PossiblyBoundIntMatchArgs,
+def conditional_match_args_disables_builtin_behavior(
+    value: ConditionalIntMatchArgs,
     # error: [invalid-return-type]
 ) -> int:
     match value:
-        case PossiblyBoundIntMatchArgs(_):
+        case ConditionalIntMatchArgs(_):
             return 1
 ```
 
@@ -942,16 +896,9 @@ descriptor access can raise `AttributeError` and an annotated attribute can be a
 from typing import Literal
 
 class FallibleProperty:
-    __match_args__ = ("x",)
-
     @property
     def x(self) -> Literal[1]:
         raise AttributeError
-
-def direct_fallible_property_is_statically_exhaustive(value: FallibleProperty) -> int:
-    match value:
-        case FallibleProperty(_):
-            return 1
 
 def fallible_property_value_pattern_is_statically_exhaustive(value: FallibleProperty) -> int:
     match value:
@@ -1006,7 +953,14 @@ def subclass_member_is_exhaustive(value: ChildWithX) -> int:
     match value:
         case BaseWithoutX(x=_):
             return 1
+```
 
+## Positional behavior comes from the pattern class
+
+Only the class named in the pattern determines what a positional subpattern receives. Although
+`IntPlainChild` also inherits from `int`, `PlainBase(_)` does not receive the whole value:
+
+```py
 class PlainBase: ...
 class IntPlainChild(int, PlainBase): ...
 
@@ -1040,7 +994,8 @@ def nested_class_subpattern_is_exhaustive(value: tuple[Outer]) -> int:
 ## Missing class-pattern attributes
 
 A class pattern can fail after its `isinstance` check if a requested attribute is missing or only
-conditionally defined. The failed branch therefore keeps the original subject type:
+conditionally defined. This applies to both keyword and positional attributes, including inside a
+sequence. The failed branch therefore keeps the original subject type:
 
 ```py
 from typing import final
@@ -1060,7 +1015,7 @@ def missing_attribute_keeps_original_subject(
         case _:
             reveal_type(value)  # revealed: MissingAttributes | OtherClass
 
-def keyword_class_pattern_in_sequence_preserves_fallback(
+def missing_positional_attribute_keeps_sequence_possible(
     value: tuple[MissingAttributes],
 ) -> None:
     match value:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -732,6 +732,207 @@ def test_match_class_alias_rejects_disjoint_final_class(value: FinalA) -> None:
             reveal_type(item)  # revealed: Never
 ```
 
+## Exhaustive positional patterns for built-in classes
+
+Python defines a fixed set of built-in classes whose single positional subpattern receives the
+entire subject. This example checks every such class, including nested sequence and `or` patterns:
+
+```py
+def builtin_positional_patterns_are_exhaustive(
+    value: tuple[
+        bool,
+        bytearray,
+        bytes,
+        dict[object, object],
+        float,
+        frozenset[object],
+        int,
+        list[object],
+        set[object],
+        str,
+        tuple[object, ...],
+    ],
+) -> int:
+    match value:
+        case (
+            bool(_),
+            bytearray(_),
+            bytes(_),
+            dict(_),
+            (int(_) | float(_)),
+            frozenset(_),
+            int(_),
+            list(_),
+            set(_),
+            str(_),
+            tuple(_),
+        ):
+            return 1
+```
+
+## `NamedTuple` positional patterns
+
+A `NamedTuple` provides a generated `__match_args__` tuple containing all of its fields:
+
+```py
+from typing import NamedTuple
+
+class NamedPoint(NamedTuple):
+    x: int
+    label: str
+
+def named_tuple_positional_pattern_is_exhaustive(value: NamedPoint) -> int:
+    match value:
+        case NamedPoint(_, _):
+            return 1
+```
+
+## Positional patterns for built-in subclasses
+
+Subclasses inherit this positional behavior. The positional subpattern still needs to match the
+entire value, so a literal subpattern is not exhaustive:
+
+```py
+class MyInt(int): ...
+
+def builtin_subclass_positional_pattern_is_exhaustive(value: MyInt) -> int:
+    match value:
+        case MyInt(_):
+            return 1
+
+def builtin_base_positional_pattern_is_exhaustive_for_subclass(value: MyInt) -> int:
+    match value:
+        case int(_):
+            return 1
+
+def nested_builtin_positional_pattern_is_exhaustive_for_subclass(
+    value: tuple[MyInt],
+) -> int:
+    match value:
+        case [int(_)]:
+            return 1
+
+def builtin_positional_literal_is_not_exhaustive(
+    value: MyInt,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case int(0):
+            return 1
+```
+
+## Resolving `__match_args__`
+
+For other positional class patterns, Python reads `__match_args__` from the pattern class. The
+attribute must be definitely present and must be a fixed tuple of literal attribute names. The
+selected attributes must also be definitely present on the subject:
+
+```py
+class MyIntWithDefinitelyBoundMatchArgs(int):
+    __match_args__ = ("real",)
+
+def builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
+    value: MyIntWithDefinitelyBoundMatchArgs,
+) -> int:
+    match value:
+        case MyIntWithDefinitelyBoundMatchArgs(_):
+            return 1
+
+def nested_builtin_subclass_with_definitely_bound_match_args_is_exhaustive(
+    value: tuple[MyIntWithDefinitelyBoundMatchArgs],
+) -> int:
+    match value:
+        case [MyIntWithDefinitelyBoundMatchArgs(_)]:
+            return 1
+
+class MyIntWithMissingMatchArg(int):
+    __match_args__ = ("missing",)
+
+def builtin_subclass_with_missing_match_arg_is_not_exhaustive(
+    value: MyIntWithMissingMatchArg,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case MyIntWithMissingMatchArg(_):
+            return 1
+
+class MatchArgsMeta(type):
+    __match_args__ = ("missing",)
+
+class MyIntWithMetaclassMatchArgs(int, metaclass=MatchArgsMeta): ...
+
+def builtin_subclass_with_metaclass_match_args_is_not_exhaustive(
+    value: MyIntWithMetaclassMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case MyIntWithMetaclassMatchArgs(_):
+            return 1
+
+class KnownAttributes:
+    __match_args__ = ("x", "y")
+    x: int = 0
+    y: int = 0
+
+def fixed_match_args_are_exhaustive(value: KnownAttributes) -> int:
+    match value:
+        case KnownAttributes(_, _):
+            return 1
+
+class WidenedMatchArgs:
+    __match_args__: tuple[str, ...] = ("x",)
+    x: int = 0
+
+def widened_match_args_does_not_identify_an_attribute(
+    value: WidenedMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case WidenedMatchArgs(_):
+            return 1
+
+class AnnotatedMatchArgs(int):
+    __match_args__: tuple[str, ...]
+
+def annotated_match_args_is_not_exhaustive(
+    value: AnnotatedMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case AnnotatedMatchArgs(_):
+            return 1
+
+def condition() -> bool:
+    return bool()
+
+flag = condition()
+
+class PossiblyBoundMatchArgs:
+    if flag:
+        __match_args__ = ("x",)
+    x: int = 0
+
+def possibly_bound_match_args_is_not_exhaustive(
+    value: PossiblyBoundMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyBoundMatchArgs(_):
+            return 1
+
+class PossiblyBoundIntMatchArgs(int):
+    if flag:
+        __match_args__ = ("missing",)
+
+def possibly_bound_match_args_does_not_enable_match_self(
+    value: PossiblyBoundIntMatchArgs,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PossiblyBoundIntMatchArgs(_):
+            return 1
+```
+
 ## Properties and declared attributes
 
 Properties and declared attributes count as present when checking exhaustiveness, even though
@@ -741,9 +942,16 @@ descriptor access can raise `AttributeError` and an annotated attribute can be a
 from typing import Literal
 
 class FallibleProperty:
+    __match_args__ = ("x",)
+
     @property
     def x(self) -> Literal[1]:
         raise AttributeError
+
+def direct_fallible_property_is_statically_exhaustive(value: FallibleProperty) -> int:
+    match value:
+        case FallibleProperty(_):
+            return 1
 
 def fallible_property_value_pattern_is_statically_exhaustive(value: FallibleProperty) -> int:
     match value:
@@ -798,6 +1006,17 @@ def subclass_member_is_exhaustive(value: ChildWithX) -> int:
     match value:
         case BaseWithoutX(x=_):
             return 1
+
+class PlainBase: ...
+class IntPlainChild(int, PlainBase): ...
+
+def builtin_positional_behavior_comes_from_pattern_class(
+    value: IntPlainChild,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case PlainBase(_):
+            return 1
 ```
 
 ## Nested class patterns
@@ -826,7 +1045,10 @@ conditionally defined. The failed branch therefore keeps the original subject ty
 ```py
 from typing import final
 
-class MissingAttributes: ...
+class MissingAttributes:
+    __match_args__ = ("x", "missing")
+    x: int = 0
+
 class OtherClass: ...
 
 def missing_attribute_keeps_original_subject(
@@ -837,6 +1059,15 @@ def missing_attribute_keeps_original_subject(
             pass
         case _:
             reveal_type(value)  # revealed: MissingAttributes | OtherClass
+
+def keyword_class_pattern_in_sequence_preserves_fallback(
+    value: tuple[MissingAttributes],
+) -> None:
+    match value:
+        case [MissingAttributes(_, _)]:
+            pass
+        case _:
+            reveal_type(value)  # revealed: tuple[MissingAttributes]
 
 def attribute_condition() -> bool:
     return bool()

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -826,6 +826,17 @@ def fixed_match_args_are_exhaustive(value: KnownAttributes) -> int:
     match value:
         case KnownAttributes(_, _):
             return 1
+
+class ValidMatchArgsMeta(type):
+    __match_args__ = ("x",)
+
+class WithMetaclassMatchArgs(metaclass=ValidMatchArgsMeta):
+    x: int = 0
+
+def metaclass_match_args_is_exhaustive(value: WithMetaclassMatchArgs) -> int:
+    match value:
+        case WithMetaclassMatchArgs(_):
+            return 1
 ```
 
 The pattern is not exhaustive when a selected attribute is missing, an explicit annotation widens

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -218,15 +218,26 @@ fn class_pattern_is_exhaustive(
         })
 }
 
+/// The static lookup result for a pattern class's `__match_args__` member.
+///
+/// `PossiblyUndefined` is distinct from `Undefined` because a conditional definition can take
+/// precedence over match-self behavior at runtime, so that behavior cannot be assumed.
 enum ClassMatchArgs<'db> {
+    /// The class and its metaclass hierarchy do not define `__match_args__`.
     Undefined,
+    /// `__match_args__` is definitely bound with this type.
     Defined(Type<'db>),
+    /// `__match_args__` is defined along some control-flow paths but not others.
     PossiblyUndefined,
 }
 
+/// The value supplied to one positional subpattern in a class pattern.
 enum ClassPatternPositionalSource {
+    /// The complete subject, as used by Python's special built-in class patterns.
     MatchSelf,
+    /// The named attribute extracted from the subject according to `__match_args__`.
     Attribute(Name),
+    /// No value source can be determined statically, so the subpattern is not exhaustive.
     Unknown,
 }
 
@@ -256,6 +267,11 @@ fn class_match_args_type<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> Clas
     }
 }
 
+/// Return whether `class` inherits Python's special match-self class-pattern behavior.
+///
+/// Callers must first establish that `__match_args__` is statically absent. A definite definition
+/// overrides match-self behavior, while a conditional definition makes it runtime-dependent;
+/// neither case should consult this flag.
 fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
     class
         .iter_mro(db)
@@ -280,6 +296,26 @@ fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
         })
 }
 
+/// Resolve the value supplied to each positional subpattern, preserving source order and length.
+///
+/// A fixed tuple of string literals in `__match_args__` maps positions to subject attributes.
+/// Python's special built-in classes map only the first position to the complete subject. Missing,
+/// extra, widened, or conditionally defined positions resolve to
+/// [`ClassPatternPositionalSource::Unknown`].
+///
+/// ```python
+/// class Point:
+///     __match_args__ = ("x",)
+///     x: int
+///
+/// match point:
+///     case Point(_):  # The positional subpattern receives `point.x`.
+///         pass
+///
+/// match number:
+///     case int(_):  # The positional subpattern receives `number` itself.
+///         pass
+/// ```
 fn class_pattern_positional_sources(
     db: &dyn Db,
     class: ClassLiteral<'_>,

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -6,14 +6,15 @@ use ty_python_core::predicate::{
 };
 
 use crate::Db;
+use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
-    CallableType, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass, Parameter,
-    Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, equality_truthiness,
-    infer_same_file_expression_type,
+    CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
+    Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, binding_type,
+    equality_truthiness, infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -196,13 +197,124 @@ fn class_pattern_is_exhaustive(
         return true;
     }
 
-    if !kind.positional_irrefutable {
+    let positional_sources = class_pattern_positional_sources(db, class, kind.positional.len());
+    if !kind.keywords.iter().all(|keyword| {
+        member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
+    }) {
         return false;
     }
 
-    kind.keywords.iter().all(|keyword| {
-        member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
-    })
+    kind.positional
+        .iter()
+        .zip(positional_sources)
+        .all(|(pattern, source)| match source {
+            ClassPatternPositionalSource::MatchSelf => {
+                pattern_is_exhaustive_for_subject(db, pattern, subject_ty)
+            }
+            ClassPatternPositionalSource::Attribute(name) => {
+                member_pattern_is_exhaustive(db, subject_ty, name.as_str(), pattern)
+            }
+            ClassPatternPositionalSource::Unknown => false,
+        })
+}
+
+enum ClassMatchArgs<'db> {
+    Undefined,
+    Defined(Type<'db>),
+    PossiblyUndefined,
+}
+
+enum ClassPatternPositionalSource {
+    MatchSelf,
+    Attribute(Name),
+    Unknown,
+}
+
+/// Resolve `__match_args__` through the pattern class, including its metaclass.
+///
+/// Inferred assignments retain their literal binding type, while an explicit annotation remains
+/// authoritative. `PossiblyUndefined` is distinct from `Undefined` because only a truly absent
+/// `__match_args__` enables match-self behavior.
+fn class_match_args_type<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> ClassMatchArgs<'db> {
+    match Type::ClassLiteral(class).member(db, "__match_args__").place {
+        Place::Defined(
+            place @ DefinedPlace {
+                ty,
+                origin,
+                provenance,
+                ..
+            },
+        ) if place.is_definitely_defined() => ClassMatchArgs::Defined(if origin.is_declared() {
+            ty
+        } else {
+            provenance
+                .definition()
+                .map_or(ty, |definition| binding_type(db, definition))
+        }),
+        Place::Defined(_) => ClassMatchArgs::PossiblyUndefined,
+        Place::Undefined => ClassMatchArgs::Undefined,
+    }
+}
+
+fn class_has_match_self_flag(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+    class
+        .iter_mro(db)
+        .filter_map(ClassBase::into_class)
+        .any(|base| {
+            matches!(
+                base.class_literal(db).known(db),
+                Some(
+                    KnownClass::Bool
+                        | KnownClass::Bytearray
+                        | KnownClass::Bytes
+                        | KnownClass::Dict
+                        | KnownClass::Float
+                        | KnownClass::FrozenSet
+                        | KnownClass::Int
+                        | KnownClass::List
+                        | KnownClass::Set
+                        | KnownClass::Str
+                        | KnownClass::Tuple
+                )
+            )
+        })
+}
+
+fn class_pattern_positional_sources(
+    db: &dyn Db,
+    class: ClassLiteral<'_>,
+    positional_count: usize,
+) -> Vec<ClassPatternPositionalSource> {
+    let fixed = match class_match_args_type(db, class) {
+        ClassMatchArgs::Undefined if class_has_match_self_flag(db, class) => {
+            return (0..positional_count)
+                .map(|index| {
+                    if index == 0 {
+                        ClassPatternPositionalSource::MatchSelf
+                    } else {
+                        ClassPatternPositionalSource::Unknown
+                    }
+                })
+                .collect();
+        }
+        ClassMatchArgs::Defined(match_args) => match_args
+            .exact_tuple_instance_spec(db)
+            .and_then(|tuple| tuple.as_fixed_length().cloned()),
+        ClassMatchArgs::Undefined | ClassMatchArgs::PossiblyUndefined => None,
+    };
+
+    (0..positional_count)
+        .map(|index| {
+            fixed
+                .as_ref()
+                .and_then(|tuple| tuple.elements_slice().get(index))
+                .and_then(|ty| ty.as_string_literal())
+                .map(|literal| {
+                    ClassPatternPositionalSource::Attribute(Name::new(literal.value(db)))
+                })
+                .unwrap_or(ClassPatternPositionalSource::Unknown)
+        })
+        .collect()
 }
 
 /// Return whether `name` is definitely bound and `pattern` consumes its entire static member type.

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -197,13 +197,13 @@ fn class_pattern_is_exhaustive(
         return true;
     }
 
-    let positional_sources = class_pattern_positional_sources(db, class, kind.positional.len());
     if !kind.keywords.iter().all(|keyword| {
         member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
     }) {
         return false;
     }
 
+    let positional_sources = class_pattern_positional_sources(db, class, kind.positional.len());
     kind.positional
         .iter()
         .zip(positional_sources)


### PR DESCRIPTION
## Summary

This is the second of three stacked PRs split from #26010. It is based on #26283.

The first PR makes keyword class-pattern exhaustiveness subject-aware, but positional patterns still use a syntax-only approximation: any positional capture is treated as irrefutable without determining which value Python passes to it. That can classify a pattern as exhaustive when `__match_args__` is missing, uncertain, widened, or names an absent attribute.

This resolves each positional source from the class named in the pattern. For ordinary classes, we require a definitely bound fixed tuple of literal names from `__match_args__` and check each selected member recursively. For Python's match-self builtins, including their subclasses, the first positional pattern receives the complete subject. Generated `NamedTuple.__match_args__` values follow the same path.
