### PR TITLE
[ty] Prove TypedDict structural patterns exhaustive

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -43,9 +43,9 @@ use crate::place::{
     match_subject_place_expressions,
 };
 use crate::predicate::{
-    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternKind,
-    ClassPatternPredicateKind, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
-    PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
+    CallableAndCallExpr, ClassPatternKeywordPredicateKind, ClassPatternPredicateKind,
+    MappingPatternEntryPredicateKind, PatternPredicate, PatternPredicateKind, Predicate,
+    PredicateNode, PredicateOrLiteral, ScopedPredicateId, SequencePatternPredicateKind,
     StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
 use crate::program::Program;
@@ -2062,13 +2062,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 })
             }
             ast::Pattern::MatchMapping(pattern) => {
-                // `case {}` and `case {**rest}` match every mapping, while keyed mapping
-                // patterns are refutable (`case {"x": _}` may fail for some mappings).
-                PatternPredicateKind::Mapping(if pattern.keys.is_empty() {
-                    ClassPatternKind::Irrefutable
-                } else {
-                    ClassPatternKind::Refutable
-                })
+                // Retain keyed entries for subject-aware exhaustiveness analysis.
+                PatternPredicateKind::Mapping(
+                    pattern
+                        .keys
+                        .iter()
+                        .zip(&pattern.patterns)
+                        .map(|(key, pattern)| MappingPatternEntryPredicateKind {
+                            key: self.add_standalone_expression(key),
+                            pattern: self.predicate_kind(pattern),
+                        })
+                        .collect(),
+                )
             }
             ast::Pattern::MatchSequence(pattern) => {
                 PatternPredicateKind::Sequence(SequencePatternPredicateKind {

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -149,18 +149,6 @@ pub struct SubjectElementPatternPredicate<'db> {
     pub target: ExpressionNodeKey,
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-pub enum ClassPatternKind {
-    Irrefutable,
-    Refutable,
-}
-
-impl ClassPatternKind {
-    pub fn is_irrefutable(self) -> bool {
-        matches!(self, ClassPatternKind::Irrefutable)
-    }
-}
-
 /// Structural details for sequence patterns that affect narrowing and reachability.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
 pub struct SequencePatternPredicateKind<'db> {
@@ -207,6 +195,12 @@ pub struct ClassPatternKeywordPredicateKind<'db> {
     pub pattern: PatternPredicateKind<'db>,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
+pub struct MappingPatternEntryPredicateKind<'db> {
+    pub key: Expression<'db>,
+    pub pattern: PatternPredicateKind<'db>,
+}
+
 /// Pattern structure used for type narrowing, static reachability, and inferring the types of
 /// names bound by a successful match.
 #[derive(Debug, Clone, Hash, PartialEq, salsa::Update, get_size2::GetSize)]
@@ -215,7 +209,7 @@ pub enum PatternPredicateKind<'db> {
     Value(Expression<'db>),
     Or(Box<[PatternPredicateKind<'db>]>),
     Class(ClassPatternPredicateKind<'db>),
-    Mapping(ClassPatternKind),
+    Mapping(Box<[MappingPatternEntryPredicateKind<'db>]>),
     Sequence(SequencePatternPredicateKind<'db>),
     As(Option<Box<PatternPredicateKind<'db>>>, Option<Name>),
     Star(Option<Name>),

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -774,14 +774,24 @@ def builtin_positional_patterns_are_exhaustive(
 ## `TypedDict` class patterns at runtime
 
 A `TypedDict` value is a dictionary at runtime, so argumentless `dict` and `Mapping` patterns always
-match it. The positional `dict` pattern does as well:
+match it. The positional `dict` pattern does as well. This also applies when the subject is a
+truthiness-narrowed intersection or a type variable bounded by or constrained to `TypedDict`s:
 
 ```py
 from collections.abc import Mapping
-from typing import TypedDict
+from typing import TypeVar, TypedDict
 
 class Movie(TypedDict):
     title: str
+
+class OptionalMovie(TypedDict, total=False):
+    title: str
+
+class Series(TypedDict):
+    seasons: int
+
+T = TypeVar("T", bound=Movie)
+U = TypeVar("U", Movie, Series)
 
 def argumentless_dict_pattern_is_exhaustive(value: Movie) -> int:
     match value:
@@ -796,6 +806,23 @@ def mapping_pattern_is_exhaustive(value: Movie) -> int:
 def positional_dict_pattern_is_exhaustive(value: Movie) -> int:
     match value:
         case dict(_):
+            return 1
+
+def narrowed_typed_dict_pattern_is_exhaustive(value: OptionalMovie) -> int:
+    if not value:
+        return 0
+    match value:
+        case dict():
+            return 1
+
+def bounded_typed_dict_pattern_is_exhaustive(value: T) -> int:
+    match value:
+        case dict():
+            return 1
+
+def constrained_typed_dict_pattern_is_exhaustive(value: U) -> int:
+    match value:
+        case dict():
             return 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -771,6 +771,80 @@ def builtin_positional_patterns_are_exhaustive(
             return 1
 ```
 
+## Runtime dictionary class patterns
+
+A `TypedDict` value is a dictionary at runtime, so argumentless `dict` and `Mapping` patterns always
+match it. The positional `dict` pattern does as well:
+
+```py
+from collections.abc import Mapping
+from typing import TypedDict
+
+class Movie(TypedDict):
+    title: str
+
+def typed_dict_argumentless_dict_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case dict():
+            return 1
+
+def typed_dict_mapping_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case Mapping():
+            return 1
+
+def typed_dict_positional_dict_pattern_is_exhaustive(value: Movie) -> int:
+    match value:
+        case dict(_):
+            return 1
+```
+
+## Required `TypedDict` keys
+
+A mapping pattern is exhaustive for a `TypedDict` when every key in the pattern names a required
+field and every nested pattern accepts the field's complete type. Optional, absent, and non-string
+keys are not guaranteed to be present.
+
+```py
+from typing import Literal, TypedDict
+
+class RequiredPayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class OptionalPayload(TypedDict, total=False):
+    value: int
+
+def required_keys_are_exhaustive(value: RequiredPayload) -> int:
+    match value:
+        case {"tag": "int", "value": int()}:
+            return 1
+
+def optional_key_is_not_exhaustive(
+    value: OptionalPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {"value": _}:
+            return 1
+
+def absent_key_is_not_exhaustive(
+    value: RequiredPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {"missing": _}:
+            return 1
+
+def non_string_key_is_not_exhaustive(
+    value: RequiredPayload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case {1: _}:
+            return 1
+```
+
 ## `NamedTuple` positional patterns
 
 A `NamedTuple` provides a generated `__match_args__` tuple containing all of its fields:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -833,7 +833,8 @@ field and every value pattern matches all values allowed for that field. The neg
 exercise three separate checks: an optional field, an unknown key, and a non-string key.
 
 ```py
-from typing import Literal, TypedDict
+from typing import Any, Literal, TypedDict
+from ty_extensions import Unknown
 
 class RequiredPayload(TypedDict):
     tag: Literal["int"]
@@ -842,9 +843,18 @@ class RequiredPayload(TypedDict):
 class OptionalPayload(TypedDict, total=False):
     value: int
 
+class DynamicPayload(TypedDict):
+    any_value: Any
+    unknown_value: Unknown
+
 def required_typed_dict_keys_are_exhaustive(value: RequiredPayload) -> int:
     match value:
         case {"tag": "int", "value": int()}:
+            return 1
+
+def universal_nested_patterns_are_exhaustive(value: DynamicPayload) -> int:
+    match value:
+        case {"any_value": object(), "unknown_value": object()}:
             return 1
 
 def optional_key_is_not_exhaustive(

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -771,7 +771,7 @@ def builtin_positional_patterns_are_exhaustive(
             return 1
 ```
 
-## Runtime dictionary class patterns
+## `TypedDict` class patterns at runtime
 
 A `TypedDict` value is a dictionary at runtime, so argumentless `dict` and `Mapping` patterns always
 match it. The positional `dict` pattern does as well:
@@ -783,17 +783,17 @@ from typing import TypedDict
 class Movie(TypedDict):
     title: str
 
-def typed_dict_argumentless_dict_pattern_is_exhaustive(value: Movie) -> int:
+def argumentless_dict_pattern_is_exhaustive(value: Movie) -> int:
     match value:
         case dict():
             return 1
 
-def typed_dict_mapping_pattern_is_exhaustive(value: Movie) -> int:
+def mapping_pattern_is_exhaustive(value: Movie) -> int:
     match value:
         case Mapping():
             return 1
 
-def typed_dict_positional_dict_pattern_is_exhaustive(value: Movie) -> int:
+def positional_dict_pattern_is_exhaustive(value: Movie) -> int:
     match value:
         case dict(_):
             return 1
@@ -802,8 +802,8 @@ def typed_dict_positional_dict_pattern_is_exhaustive(value: Movie) -> int:
 ## Required `TypedDict` keys
 
 A mapping pattern is exhaustive for a `TypedDict` when every key in the pattern names a required
-field and every nested pattern accepts the field's complete type. Optional, absent, and non-string
-keys are not guaranteed to be present.
+field and every value pattern matches all values allowed for that field. The negative cases below
+exercise three separate checks: an optional field, an unknown key, and a non-string key.
 
 ```py
 from typing import Literal, TypedDict
@@ -815,7 +815,7 @@ class RequiredPayload(TypedDict):
 class OptionalPayload(TypedDict, total=False):
     value: int
 
-def required_keys_are_exhaustive(value: RequiredPayload) -> int:
+def required_typed_dict_keys_are_exhaustive(value: RequiredPayload) -> int:
     match value:
         case {"tag": "int", "value": int()}:
             return 1

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -833,8 +833,8 @@ field and every value pattern matches all values allowed for that field. The neg
 exercise three separate checks: an optional field, an unknown key, and a non-string key.
 
 ```py
-from typing import Any, Literal, TypedDict
-from ty_extensions import Unknown
+from typing import Any, Literal, Protocol, TypeVar, TypedDict
+from ty_extensions import Intersection, Unknown
 
 class RequiredPayload(TypedDict):
     tag: Literal["int"]
@@ -847,6 +847,16 @@ class DynamicPayload(TypedDict):
     any_value: Any
     unknown_value: Unknown
 
+class AlternatePayload(TypedDict):
+    tag: Literal["int"]
+    value: int
+
+class Marker(Protocol):
+    marker: int
+
+P = TypeVar("P", bound=RequiredPayload)
+Q = TypeVar("Q", RequiredPayload, AlternatePayload)
+
 def required_typed_dict_keys_are_exhaustive(value: RequiredPayload) -> int:
     match value:
         case {"tag": "int", "value": int()}:
@@ -855,6 +865,23 @@ def required_typed_dict_keys_are_exhaustive(value: RequiredPayload) -> int:
 def universal_nested_patterns_are_exhaustive(value: DynamicPayload) -> int:
     match value:
         case {"any_value": object(), "unknown_value": object()}:
+            return 1
+
+def bounded_typed_dict_mapping_is_exhaustive(value: P) -> int:
+    match value:
+        case {"tag": "int", "value": int()}:
+            return 1
+
+def constrained_typed_dict_mapping_is_exhaustive(value: Q) -> int:
+    match value:
+        case {"tag": "int", "value": int()}:
+            return 1
+
+def intersected_typed_dict_mapping_is_exhaustive(
+    value: Intersection[RequiredPayload, Marker],
+) -> int:
+    match value:
+        case {"tag": "int", "value": int()}:
             return 1
 
 def optional_key_is_not_exhaustive(

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -1202,7 +1202,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Mapping(kind) => {
             let mapping_ty = mapping_pattern_type(db);
             if subject_ty.is_subtype_of(db, mapping_ty) {
-                if kind.is_irrefutable() {
+                if kind.is_empty() {
                     Truthiness::AlwaysTrue
                 } else {
                     Truthiness::Ambiguous

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -2538,7 +2538,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     rest,
                 } = match_mapping;
                 for key in keys {
-                    self.infer_expression(key, TypeContext::default());
+                    self.infer_maybe_standalone_expression(key, TypeContext::default());
                 }
                 for pattern in patterns {
                     self.infer_nested_match_pattern(pattern);

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -2,7 +2,8 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ty_python_core::Truthiness;
 use ty_python_core::predicate::{
-    ClassPatternPredicateKind, PatternPredicateKind, SequencePatternPredicateKind,
+    ClassPatternPredicateKind, MappingPatternEntryPredicateKind, PatternPredicateKind,
+    SequencePatternPredicateKind,
 };
 
 use crate::Db;
@@ -33,6 +34,19 @@ pub(crate) fn mapping_pattern_type(db: &dyn Db) -> Type<'_> {
 
 pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
     Type::Callable(CallableType::unknown(db)).top_materialization(db)
+}
+
+/// Return whether every runtime value represented by a `TypedDict` satisfies `class`.
+///
+/// `TypedDict` is not a nominal subtype of `dict` in the static type system, but every runtime
+/// value is a dictionary. A `TypedDict` therefore matches class patterns such as `dict()`,
+/// `Mapping()`, and `MutableMapping()`.
+fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
+    let Some(dict) = KnownClass::Dict.to_class_literal(db).as_class_literal() else {
+        return false;
+    };
+    Type::instance(db, dict.top_materialization(db))
+        .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
 }
 
 pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
@@ -189,7 +203,9 @@ fn class_pattern_is_exhaustive(
     kind: &ClassPatternPredicateKind<'_>,
 ) -> bool {
     let class_instance_ty = Type::instance(db, class.top_materialization(db));
-    if !subject_ty.is_subtype_of(db, class_instance_ty) {
+    let is_typed_dict_match =
+        matches!(subject_ty, Type::TypedDict(_)) && typed_dict_matches_class_pattern(db, class);
+    if !is_typed_dict_match && !subject_ty.is_subtype_of(db, class_instance_ty) {
         return false;
     }
 
@@ -379,6 +395,36 @@ fn pattern_is_exhaustive_for_subject(
     )
 }
 
+/// Return whether every value in `subject_ty` is guaranteed to match a mapping pattern.
+///
+/// A nonempty mapping pattern is exhaustive for a `TypedDict` only when every key names a required
+/// field and every nested pattern exhausts that field's declared type. Other mapping types do not
+/// guarantee that a particular key is present.
+fn mapping_pattern_is_exhaustive(
+    db: &dyn Db,
+    entries: &[MappingPatternEntryPredicateKind<'_>],
+    subject_ty: Type<'_>,
+) -> bool {
+    if entries.is_empty() {
+        return subject_ty.is_subtype_of(db, mapping_pattern_type(db));
+    }
+
+    let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(db) else {
+        return false;
+    };
+
+    entries.iter().all(|entry| {
+        let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
+        let Some(key) = key_ty.as_string_literal() else {
+            return false;
+        };
+        typed_dict.item(db, key.value(db)).is_some_and(|field| {
+            field.is_required()
+                && pattern_is_exhaustive_for_subject(db, &entry.pattern, field.declared_ty)
+        })
+    })
+}
+
 /// Return whether an exact tuple subject is fully consumed by a sequence pattern.
 ///
 /// Each aligned element is checked with the subject-aware matcher so nested class patterns use the
@@ -433,8 +479,11 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// even for a `Child` subject. Class patterns need the current subject type when member extraction
 /// depends on the subject's statically known members.
 /// A subject-independent pattern can return its context-free definite-match type directly. A
-/// definitely bound descriptor is treated as successful even though it could raise at runtime.
-/// The same rule is propagated through nested sequence, `or`, and `as` patterns.
+/// mapping pattern can use required `TypedDict` fields to establish that every subject value
+/// contains its keys.
+/// This treats access to a definitely bound descriptor as successful even though the descriptor
+/// could raise at runtime. The same rule is propagated through nested sequence, `or`, and `as`
+/// patterns.
 ///
 /// ```python
 /// class Base:
@@ -498,6 +547,13 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                 // A nested subject-dependent pattern rejected the context-free approximation.
                 // Reusing that approximation for the surrounding sequence would reintroduce the
                 // values that the recursive analysis deliberately excluded.
+                Type::Never
+            };
+        }
+        PatternPredicateKind::Mapping(kind) => {
+            return if mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
+                subject_ty
+            } else {
                 Type::Never
             };
         }
@@ -678,7 +734,9 @@ fn subject_independent_definite_match_pattern_type<'db>(
     match kind {
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
-                Type::ClassLiteral(class) if kind.is_empty() => {
+                Type::ClassLiteral(class)
+                    if kind.is_empty() && !typed_dict_matches_class_pattern(db, class) =>
+                {
                     Some(Type::instance(db, class.top_materialization(db)))
                 }
                 Type::ClassLiteral(_) => None,
@@ -694,7 +752,7 @@ fn subject_independent_definite_match_pattern_type<'db>(
             })
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_irrefutable() {
+            if kind.is_empty() {
                 Some(mapping_pattern_type(db))
             } else {
                 None
@@ -745,7 +803,7 @@ pub(crate) fn definite_match_pattern_type<'db>(
             }
         }
         PatternPredicateKind::Mapping(kind) => {
-            if kind.is_irrefutable() {
+            if kind.is_empty() {
                 mapping_pattern_type(db)
             } else {
                 Type::Never

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -405,10 +405,6 @@ fn mapping_pattern_is_exhaustive(
     entries: &[MappingPatternEntryPredicateKind<'_>],
     subject_ty: Type<'_>,
 ) -> bool {
-    if entries.is_empty() {
-        return subject_ty.is_subtype_of(db, mapping_pattern_type(db));
-    }
-
     let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(db) else {
         return false;
     };

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -757,10 +757,12 @@ fn subject_independent_definite_match_pattern_type<'db>(
     match kind {
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
-                Type::ClassLiteral(class)
-                    if kind.is_empty() && !typed_dict_matches_class_pattern(db, class) =>
-                {
-                    Some(Type::instance(db, class.top_materialization(db)))
+                Type::ClassLiteral(class) if kind.is_empty() => {
+                    let class_instance_ty = Type::instance(db, class.top_materialization(db));
+                    let typed_dict_adds_runtime_matches =
+                        typed_dict_matches_class_pattern(db, class)
+                            && !Type::object().is_subtype_of(db, class_instance_ty);
+                    (!typed_dict_adds_runtime_matches).then_some(class_instance_ty)
                 }
                 Type::ClassLiteral(_) => None,
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) if kind.is_empty() => {

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -15,7 +15,7 @@ use crate::types::tuple::TupleType;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
     Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext,
-    TypeVarBoundOrConstraints, UnionType, binding_type, equality_truthiness,
+    TypeVarBoundOrConstraints, TypedDictType, UnionType, binding_type, equality_truthiness,
     infer_same_file_expression_type,
 };
 
@@ -50,30 +50,39 @@ fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> boo
         .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
 }
 
-/// Return whether every value in `ty` is represented by a `TypedDict` schema at runtime.
-fn is_typed_dict_pattern_domain(db: &dyn Db, ty: Type<'_>) -> bool {
+/// Return whether every value in `ty` belongs to a `TypedDict` domain accepted by `predicate`.
+fn typed_dict_pattern_domain_satisfies<'db>(
+    db: &'db dyn Db,
+    ty: Type<'db>,
+    predicate: &impl Fn(TypedDictType<'db>) -> bool,
+) -> bool {
     match ty.resolve_type_alias(db) {
-        Type::TypedDict(_) => true,
+        Type::TypedDict(typed_dict) => predicate(typed_dict),
         Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                is_typed_dict_pattern_domain(db, bound)
+                typed_dict_pattern_domain_satisfies(db, bound, predicate)
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                 .elements(db)
                 .iter()
-                .all(|constraint| is_typed_dict_pattern_domain(db, *constraint)),
+                .all(|constraint| typed_dict_pattern_domain_satisfies(db, *constraint, predicate)),
             None => false,
         },
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| is_typed_dict_pattern_domain(db, *element)),
+            .all(|element| typed_dict_pattern_domain_satisfies(db, *element, predicate)),
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| is_typed_dict_pattern_domain(db, *element)),
+            .any(|element| typed_dict_pattern_domain_satisfies(db, *element, predicate)),
         _ => false,
     }
+}
+
+/// Return whether every value in `ty` is represented by a `TypedDict` schema at runtime.
+fn is_typed_dict_pattern_domain(db: &dyn Db, ty: Type<'_>) -> bool {
+    typed_dict_pattern_domain_satisfies(db, ty, &|_| true)
 }
 
 pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
@@ -432,18 +441,16 @@ fn mapping_pattern_is_exhaustive(
     entries: &[MappingPatternEntryPredicateKind<'_>],
     subject_ty: Type<'_>,
 ) -> bool {
-    let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(db) else {
-        return false;
-    };
-
-    entries.iter().all(|entry| {
-        let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
-        let Some(key) = key_ty.as_string_literal() else {
-            return false;
-        };
-        typed_dict.item(db, key.value(db)).is_some_and(|field| {
-            field.is_required()
-                && pattern_is_exhaustive_for_subject(db, &entry.pattern, field.declared_ty)
+    typed_dict_pattern_domain_satisfies(db, subject_ty, &|typed_dict| {
+        entries.iter().all(|entry| {
+            let key_ty = infer_same_file_expression_type(db, entry.key, TypeContext::default());
+            let Some(key) = key_ty.as_string_literal() else {
+                return false;
+            };
+            typed_dict.item(db, key.value(db)).is_some_and(|field| {
+                field.is_required()
+                    && pattern_is_exhaustive_for_subject(db, &entry.pattern, field.declared_ty)
+            })
         })
     })
 }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -14,8 +14,9 @@ use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
-    Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext, UnionType, binding_type,
-    equality_truthiness, infer_same_file_expression_type,
+    Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext,
+    TypeVarBoundOrConstraints, UnionType, binding_type, equality_truthiness,
+    infer_same_file_expression_type,
 };
 
 pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
@@ -47,6 +48,32 @@ fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> boo
     };
     Type::instance(db, dict.top_materialization(db))
         .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
+}
+
+/// Return whether every value in `ty` is represented by a `TypedDict` schema at runtime.
+fn is_typed_dict_pattern_domain(db: &dyn Db, ty: Type<'_>) -> bool {
+    match ty.resolve_type_alias(db) {
+        Type::TypedDict(_) => true,
+        Type::TypeVar(typevar) => match typevar.typevar(db).bound_or_constraints(db) {
+            Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                is_typed_dict_pattern_domain(db, bound)
+            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                .elements(db)
+                .iter()
+                .all(|constraint| is_typed_dict_pattern_domain(db, *constraint)),
+            None => false,
+        },
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| is_typed_dict_pattern_domain(db, *element)),
+        Type::Intersection(intersection) => intersection
+            .positive(db)
+            .iter()
+            .any(|element| is_typed_dict_pattern_domain(db, *element)),
+        _ => false,
+    }
 }
 
 pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
@@ -204,7 +231,7 @@ fn class_pattern_is_exhaustive(
 ) -> bool {
     let class_instance_ty = Type::instance(db, class.top_materialization(db));
     let is_typed_dict_match =
-        matches!(subject_ty, Type::TypedDict(_)) && typed_dict_matches_class_pattern(db, class);
+        is_typed_dict_pattern_domain(db, subject_ty) && typed_dict_matches_class_pattern(db, class);
     if !is_typed_dict_match && !subject_ty.is_subtype_of(db, class_instance_ty) {
         return false;
     }

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2981,13 +2981,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject_place);
-        let mapping_type = ClassInfoConstraintFunction::IsInstance
-            .generate_constraint(
-                self.db,
-                KnownClass::Mapping.to_class_literal(self.db),
-                is_positive,
-            )?
-            .negate_if(self.db, !is_positive);
+        let mapping_type = ClassInfoConstraintFunction::IsInstance.generate_constraint(
+            self.db,
+            KnownClass::Mapping.to_class_literal(self.db),
+            true,
+        )?;
 
         Some(NarrowingConstraints::from_iter([(
             place,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -24,8 +24,8 @@ use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
 use ty_python_core::place::{PlaceExpr, PlaceTable, ScopedPlaceId};
 use ty_python_core::predicate::{
-    CallableAndCallExpr, ClassPatternKind, PatternPredicate, PatternPredicateKind, Predicate,
-    PredicateNode, SequencePatternPredicateKind, SubjectElementPatternPredicate,
+    CallableAndCallExpr, PatternPredicate, PatternPredicateKind, Predicate, PredicateNode,
+    SequencePatternPredicateKind, SubjectElementPatternPredicate,
 };
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{ExpressionNodeKey, NarrowingEvaluator, place_table, semantic_index};
@@ -1271,8 +1271,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     is_positive,
                 ))
             }
-            PatternPredicateKind::Mapping(kind) => PatternNarrowingResult::Possible(
-                self.evaluate_match_pattern_mapping(subject, *kind, is_positive),
+            PatternPredicateKind::Mapping(_) => PatternNarrowingResult::Possible(
+                self.evaluate_match_pattern_mapping(subject, pattern_predicate_kind, is_positive),
             ),
             PatternPredicateKind::Sequence(kind) => {
                 self.evaluate_match_pattern_sequence(subject, kind, is_positive)
@@ -2955,21 +2955,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
         if !is_positive {
-            let subject_place =
-                PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-            let place = self.expect_place(&subject_place);
-            let subject_ty =
-                infer_same_file_expression_type(self.db, subject, TypeContext::default());
-            let definitely_matched =
-                definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
-            if definitely_matched.is_never() {
-                return None;
-            }
-
-            return Some(NarrowingConstraints::from_iter([(
-                place,
-                NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
-            )]));
+            return self.evaluate_negative_match_pattern(subject, pattern);
         }
 
         let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
@@ -2986,15 +2972,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn evaluate_match_pattern_mapping(
         &mut self,
         subject: Expression<'db>,
-        kind: ClassPatternKind,
+        pattern: &PatternPredicateKind<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
-        if !kind.is_irrefutable() && !is_positive {
-            return None;
+        if !is_positive {
+            return self.evaluate_negative_match_pattern(subject, pattern);
         }
 
-        let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
-        let place = self.expect_place(&subject);
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
         let mapping_type = ClassInfoConstraintFunction::IsInstance
             .generate_constraint(
                 self.db,
@@ -3006,6 +2992,26 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         Some(NarrowingConstraints::from_iter([(
             place,
             NarrowingConstraint::intersection(mapping_type),
+        )]))
+    }
+
+    fn evaluate_negative_match_pattern(
+        &self,
+        subject: Expression<'db>,
+        pattern: &PatternPredicateKind<'db>,
+    ) -> Option<NarrowingConstraints<'db>> {
+        let subject_place = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
+        let place = self.expect_place(&subject_place);
+        let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
+        let definitely_matched =
+            definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+        if definitely_matched.is_never() {
+            return None;
+        }
+
+        Some(NarrowingConstraints::from_iter([(
+            place,
+            NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
         )]))
     }
 


### PR DESCRIPTION
## Summary

This is the third and final stacked PR split from #26010. It is based on #26284.

Prior to this change, we retained only whether a mapping pattern was empty or nonempty. That is enough to recognize `case {}` as exhaustive for a mapping, but it cannot prove that a keyed pattern matches every value of a `TypedDict`. We also model `TypedDict` structurally rather than as a nominal `dict` subtype, even though every `TypedDict` value is a dictionary at runtime.

This retains each mapping key and nested pattern for subject-aware exhaustiveness. A keyed mapping pattern is exhaustive for a `TypedDict` only when every key is a string literal naming a required field and every nested pattern exhausts that field's declared type. Optional, absent, and non-string keys remain refutable.

The same runtime representation rule lets argumentless `dict` and `Mapping` class patterns, along with the positional `dict` match-self pattern, exhaust a `TypedDict` subject. Negative narrowing reuses the resulting definite-match type instead of treating every nonempty mapping pattern as opaque.
