### PR TITLE
Match `noqa` shebang handling in `ruff:ignore` comments

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -1069,11 +1069,3 @@ select = ["D100"]
 #!/usr/bin/env python
 # ruff:ignore[D100]
 ```
-
-An intervening blank line should keep the ignore from applying to the shebang:
-
-```py
-#!/usr/bin/env python  # error: [undocumented-public-module]
-
-# ruff:ignore[D100]
-```

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -1053,3 +1053,27 @@ help: Remove unused suppression
   |
 note: This is an unsafe fix and may change runtime behavior
 ```
+
+## Empty diagnostic range before a shebang
+
+An ignore comment at the start of the second line should suppress diagnostics with an empty range
+at offset zero, as with `noqa`.
+
+```toml
+[lint]
+preview = true
+select = ["D100"]
+```
+
+```py
+#!/usr/bin/env python
+# ruff:ignore[D100]
+```
+
+An intervening blank line should keep the ignore from applying to the shebang:
+
+```py
+#!/usr/bin/env python  # error: [undocumented-public-module]
+
+# ruff:ignore[D100]
+```

--- a/crates/ruff_linter/src/comments/shebang.rs
+++ b/crates/ruff_linter/src/comments/shebang.rs
@@ -1,6 +1,9 @@
 use std::ops::Deref;
 
+use ruff_python_ast::token::{TokenKind, Tokens};
 use ruff_python_trivia::Cursor;
+use ruff_source_file::LineRanges;
+use ruff_text_size::{Ranged, TextRange, TextSlice};
 
 /// A shebang directive (e.g., `#!/usr/bin/env python3`).
 #[derive(Debug, PartialEq, Eq)]
@@ -30,6 +33,21 @@ impl Deref for ShebangDirective<'_> {
     fn deref(&self) -> &Self::Target {
         self.0
     }
+}
+
+/// Return the range of a shebang at the start of a file, including its line ending.
+pub(crate) fn leading_shebang_range(source: &str, tokens: &Tokens) -> Option<TextRange> {
+    let first_token = tokens.first()?;
+    if first_token.kind() != TokenKind::Comment
+        || ShebangDirective::try_extract(source.slice(first_token)).is_none()
+    {
+        return None;
+    }
+
+    Some(TextRange::new(
+        first_token.start(),
+        source.full_line_end(first_token.end()),
+    ))
 }
 
 #[cfg(test)]

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -12,7 +12,7 @@ use ruff_source_file::LineRanges;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
 use crate::Locator;
-use crate::comments::shebang::ShebangDirective;
+use crate::comments::shebang::leading_shebang_range;
 use crate::noqa::NoqaMapping;
 use crate::settings::LinterSettings;
 
@@ -125,16 +125,7 @@ fn extract_noqa_line_for(tokens: &Tokens, locator: &Locator, indexer: &Indexer) 
         }
     }
 
-    let mut shebang_mapping = None;
-    if let Some(first_token) = tokens.first()
-        && first_token.kind() == TokenKind::Comment
-        && ShebangDirective::try_extract(locator.slice(first_token)).is_some()
-    {
-        shebang_mapping = Some(TextRange::new(
-            first_token.start(),
-            locator.full_line_end(first_token.end()),
-        ));
-    }
+    let shebang_mapping = leading_shebang_range(locator.contents(), tokens);
 
     // The capacity allocated here might be more than we need if there are
     // nested interpolated strings.

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -17,6 +17,7 @@ use smallvec::{SmallVec, smallvec};
 
 use crate::checkers::ast::{DiagnosticGuard, LintContext};
 use crate::codes::Rule;
+use crate::comments::shebang::leading_shebang_range;
 use crate::fix::edits::delete_comment;
 use crate::preview::{is_human_readable_names_enabled, is_ruff_ignore_enabled};
 use crate::rule_redirects::get_redirect_target;
@@ -782,7 +783,17 @@ impl<'a> SuppressionsBuilder<'a> {
                         .is_some()
                     {
                         // own-line ignore
-                        Self::standalone_comment_range(suppression.range, before, after)
+                        let mut range =
+                            Self::standalone_comment_range(suppression.range, before, after);
+
+                        // Allow an ignore to suppress diagnostics on a leading shebang.
+                        if let Some(shebang) = leading_shebang_range(self.source, tokens)
+                            && shebang.end() == self.source.line_start(suppression.range.start())
+                        {
+                            range = shebang.cover(range);
+                        }
+
+                        range
                     } else {
                         // trailing ignore
                         self.trailing_comment_range(suppression.token_range, before)


### PR DESCRIPTION
Summary
--

This addresses another discrepancy Codex noticed between `noqa` and `ruff:ignore` while reviewing my
`--add-ignore` PR. `noqa` had special handling for shebang lines, which allowed it to suppress a
diagnostic with a 0..0 range, like `D100`, even when a shebang was present that prevented putting
the suppression on the first line:

```py
 #!/usr/bin/python
 # noqa: D100
```

[Playground](https://play.ruff.rs/5381b897-06d1-4d41-900b-cc85a40b2740)

This was previously not the case for `ruff:ignore`.

```py
 #!/usr/bin/python
 # ruff:ignore[D100]
```

[Playground](https://play.ruff.rs/1d3dde25-2692-43f3-a6fb-54b2e156ba66)

Test Plan
--

A new mdtest covering this scenario
