### PR TITLE
[ty] Avoid bypassing lazy constraints for Divergent

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -1767,6 +1767,20 @@ reveal_type(node)  # revealed: Node
 reveal_type(node.next)  # revealed: Node | None
 ```
 
+### Nested collection cycles do not panic
+
+Regression test for [#3836](https://github.com/astral-sh/ty/issues/3836).
+
+```py
+def distance() -> None:
+    previous = [0]
+    for _ in [0]:
+        row = []
+        for _ in [0]:
+            row.append(previous[0])
+        previous = row
+```
+
 ### `global` and `nonlocal` keywords in a loop
 
 We need to make sure that the loop header definition doesn't count as a "use" prior to the

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -436,17 +436,16 @@ impl<'db> Type<'db> {
             return false;
         }
 
+        // A top-level `Divergent` must be handled by lazy constraint-set assignability.
+        if self.is_divergent() || target.is_divergent() {
+            return false;
+        }
+
         match (self, target) {
             (Type::Never | Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => true,
             (_, Type::NominalInstance(target)) if target.is_object() => true,
-            (_, Type::Union(union)) => {
-                self.materialized_divergent_fallback().is_none()
-                    && union.elements(db).contains(&self)
-            }
-            (Type::Intersection(intersection), _) => {
-                target.materialized_divergent_fallback().is_none()
-                    && intersection.positive(db).contains(&target)
-            }
+            (_, Type::Union(union)) => union.elements(db).contains(&self),
+            (Type::Intersection(intersection), _) => intersection.positive(db).contains(&target),
             _ => false,
         }
     }

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -323,6 +323,10 @@ fn divergent_type() {
 
     let union = UnionType::from_elements(&db, [div, KnownClass::Int.to_instance(&db)]);
     assert_eq!(union.display(&db).to_string(), "Divergent | int");
+    for (source, target) in [(div, union), (div, Type::unknown()), (Type::unknown(), div)] {
+        let when = source.when_constraint_set_assignable_to_owned(&db, target);
+        assert!(when.query(|_builder, when| when.is_never_satisfied(&db)));
+    }
     let normalized = union
         .recursive_type_normalized_impl(&db, div, false)
         .unwrap();


### PR DESCRIPTION
## Summary

`when_constraint_set_assignable_to_owned` avoids entering its tracked Salsa query when a relation appears to be unconditionally satisfied. The shortcut used `materialized_divergent_fallback().is_none()` to guard the union and intersection cases, but an unmaterialized `Divergent` marker also has no fallback.

During recursive inference, that allowed the shortcut to return an always-satisfied constraint set for relations such as `Divergent` to `int | Divergent`. Lazy constraint-set assignability intentionally handles a top-level `Divergent` differently, so bypassing the query could admit an inconsistent bound and eventually trigger a debug assertion in constraint solving.

This keeps the exact-equality fast path, but routes every other relation involving a top-level `Divergent` through the tracked query. It also adds direct coverage for union and dynamic relations alongside the original nested-loop reproducer:

```python
def distance() -> None:
    previous = [0]
    for _ in [0]:
        row = []
        for _ in [0]:
            row.append(previous[0])
        previous = row
```

Closes https://github.com/astral-sh/ty/issues/3836.
