### PR TITLE
[ty] Infer mismatched literal comparisons

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/integers.md
@@ -12,6 +12,8 @@ reveal_type(1 is 1)  # revealed: bool
 reveal_type(1 is not 1)  # revealed: bool
 reveal_type(1 is 2)  # revealed: Literal[False]
 reveal_type(1 is not 7)  # revealed: Literal[True]
+reveal_type(1 == "")  # revealed: Literal[False]
+reveal_type(1 != "")  # revealed: Literal[True]
 # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `Literal[1]` and `Literal[""]`"
 reveal_type(1 <= "" and 0 < 1)  # revealed: (Unknown & ~AlwaysTruthy) | Literal[True]
 reveal_type(-1 < 0)  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
@@ -17,3 +17,22 @@ def _(x: str):
     # ensure we're not comparing the interned salsa symbols, which compare by order of declaration.
     reveal_type("ab" < "ab_cd")  # revealed: Literal[True]
 ```
+
+## Mismatched literal kinds
+
+Exact built-in literals of different kinds compare unequal. A `LiteralString` can equal any
+particular string literal, so those comparisons remain ambiguous.
+
+```py
+from typing_extensions import LiteralString
+
+reveal_type(True == "")  # revealed: Literal[False]
+reveal_type(True != "")  # revealed: Literal[True]
+reveal_type(b"" == "")  # revealed: Literal[False]
+reveal_type(b"" != "")  # revealed: Literal[True]
+
+def _(value: LiteralString):
+    reveal_type(value == 1)  # revealed: Literal[False]
+    reveal_type(b"" != value)  # revealed: Literal[True]
+    reveal_type(value == "")  # revealed: bool
+```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/strings.md
@@ -35,4 +35,5 @@ def _(value: LiteralString):
     reveal_type(value == 1)  # revealed: Literal[False]
     reveal_type(b"" != value)  # revealed: Literal[True]
     reveal_type(value == "")  # revealed: bool
+    reveal_type(value != "")  # revealed: bool
 ```

--- a/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
@@ -88,11 +88,9 @@ If two tuples contain types that do not support comparison, the result may be `U
 a = (1, 2)
 b = (1, "hello")
 
-# TODO: should be Literal[False], once we implement (in)equality for mismatched literals
-reveal_type(a == b)  # revealed: bool
+reveal_type(a == b)  # revealed: Literal[False]
 
-# TODO: should be Literal[True], once we implement (in)equality for mismatched literals
-reveal_type(a != b)  # revealed: bool
+reveal_type(a != b)  # revealed: Literal[True]
 
 # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
 reveal_type(a < b)  # revealed: Unknown
@@ -325,10 +323,8 @@ c = (1, 2, 3)
 reveal_type(a is (1, 2))  # revealed: bool
 reveal_type(a is not (1, 2))  # revealed: bool
 
-# TODO should be Literal[False] once we implement comparison of mismatched literal types
-reveal_type(a is b)  # revealed: bool
-# TODO should be Literal[True] once we implement comparison of mismatched literal types
-reveal_type(a is not b)  # revealed: bool
+reveal_type(a is b)  # revealed: Literal[False]
+reveal_type(a is not b)  # revealed: Literal[True]
 
 reveal_type(a is c)  # revealed: Literal[False]
 reveal_type(a is not c)  # revealed: Literal[True]

--- a/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Heterogeneous_-_Value_Comparisons_-_Comparison_Unsupport…_(966dd82bd3668d0e).snap
+++ b/crates/ty_python_semantic/resources/mdtest/snapshots/tuples.md_-_Comparison___Tuples_-_Heterogeneous_-_Value_Comparisons_-_Comparison_Unsupport…_(966dd82bd3668d0e).snap
@@ -16,55 +16,53 @@ mdtest path: crates/ty_python_semantic/resources/mdtest/comparison/tuples.md
  1 | a = (1, 2)
  2 | b = (1, "hello")
  3 | 
- 4 | # TODO: should be Literal[False], once we implement (in)equality for mismatched literals
- 5 | reveal_type(a == b)  # revealed: bool
- 6 | 
- 7 | # TODO: should be Literal[True], once we implement (in)equality for mismatched literals
- 8 | reveal_type(a != b)  # revealed: bool
- 9 | 
-10 | # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
-11 | reveal_type(a < b)  # revealed: Unknown
-12 | # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
-13 | reveal_type(a <= b)  # revealed: Unknown
-14 | # error: [unsupported-operator] "Operator `>` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
-15 | reveal_type(a > b)  # revealed: Unknown
-16 | # error: [unsupported-operator] "Operator `>=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
-17 | reveal_type(a >= b)  # revealed: Unknown
-18 | # error: [unsupported-operator]
-19 | # error: [unsupported-operator]
-20 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
-21 | a = (1, 2)
-22 | b = (999999, "hello")
-23 | 
-24 | reveal_type(a == b)  # revealed: Literal[False]
-25 | reveal_type(a != b)  # revealed: Literal[True]
-26 | reveal_type(a < b)  # revealed: Literal[True]
-27 | reveal_type(a <= b)  # revealed: Literal[True]
-28 | reveal_type(a > b)  # revealed: Literal[False]
-29 | reveal_type(a >= b)  # revealed: Literal[False]
+ 4 | reveal_type(a == b)  # revealed: Literal[False]
+ 5 | 
+ 6 | reveal_type(a != b)  # revealed: Literal[True]
+ 7 | 
+ 8 | # error: [unsupported-operator] "Operator `<` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
+ 9 | reveal_type(a < b)  # revealed: Unknown
+10 | # error: [unsupported-operator] "Operator `<=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
+11 | reveal_type(a <= b)  # revealed: Unknown
+12 | # error: [unsupported-operator] "Operator `>` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
+13 | reveal_type(a > b)  # revealed: Unknown
+14 | # error: [unsupported-operator] "Operator `>=` is not supported between objects of type `tuple[Literal[1], Literal[2]]` and `tuple[Literal[1], Literal["hello"]]`"
+15 | reveal_type(a >= b)  # revealed: Unknown
+16 | # error: [unsupported-operator]
+17 | # error: [unsupported-operator]
+18 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
+19 | a = (1, 2)
+20 | b = (999999, "hello")
+21 | 
+22 | reveal_type(a == b)  # revealed: Literal[False]
+23 | reveal_type(a != b)  # revealed: Literal[True]
+24 | reveal_type(a < b)  # revealed: Literal[True]
+25 | reveal_type(a <= b)  # revealed: Literal[True]
+26 | reveal_type(a > b)  # revealed: Literal[False]
+27 | reveal_type(a >= b)  # revealed: Literal[False]
 ```
 
 # Diagnostics
 
 ```
 error[unsupported-operator]: Unsupported `<` operation
-  --> src/mdtest_snippet.py:11:13
-   |
-11 | reveal_type(a < b)  # revealed: Unknown
-   |             -^^^-
-   |             |   |
-   |             |   Has type `tuple[Literal[1], Literal["hello"]]`
-   |             Has type `tuple[Literal[1], Literal[2]]`
-   |
+ --> src/mdtest_snippet.py:9:13
+  |
+9 | reveal_type(a < b)  # revealed: Unknown
+  |             -^^^-
+  |             |   |
+  |             |   Has type `tuple[Literal[1], Literal["hello"]]`
+  |             Has type `tuple[Literal[1], Literal[2]]`
+  |
 info: Operation fails because operator `<` is not supported between the tuple elements at index 2 (of type `Literal[2]` and `Literal["hello"]`)
 
 ```
 
 ```
 error[unsupported-operator]: Unsupported `<=` operation
-  --> src/mdtest_snippet.py:13:13
+  --> src/mdtest_snippet.py:11:13
    |
-13 | reveal_type(a <= b)  # revealed: Unknown
+11 | reveal_type(a <= b)  # revealed: Unknown
    |             -^^^^-
    |             |    |
    |             |    Has type `tuple[Literal[1], Literal["hello"]]`
@@ -76,9 +74,9 @@ info: Operation fails because operator `<=` is not supported between the tuple e
 
 ```
 error[unsupported-operator]: Unsupported `>` operation
-  --> src/mdtest_snippet.py:15:13
+  --> src/mdtest_snippet.py:13:13
    |
-15 | reveal_type(a > b)  # revealed: Unknown
+13 | reveal_type(a > b)  # revealed: Unknown
    |             -^^^-
    |             |   |
    |             |   Has type `tuple[Literal[1], Literal["hello"]]`
@@ -90,9 +88,9 @@ info: Operation fails because operator `>` is not supported between the tuple el
 
 ```
 error[unsupported-operator]: Unsupported `>=` operation
-  --> src/mdtest_snippet.py:17:13
+  --> src/mdtest_snippet.py:15:13
    |
-17 | reveal_type(a >= b)  # revealed: Unknown
+15 | reveal_type(a >= b)  # revealed: Unknown
    |             -^^^^-
    |             |    |
    |             |    Has type `tuple[Literal[1], Literal["hello"]]`
@@ -104,9 +102,9 @@ info: Operation fails because operator `>=` is not supported between the tuple e
 
 ```
 error[unsupported-operator]: Unsupported `<` operation
-  --> src/mdtest_snippet.py:20:13
+  --> src/mdtest_snippet.py:18:13
    |
-20 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
+18 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
    |             -----------^^^-----------
    |             |
    |             Both operands have type `tuple[object]`
@@ -117,9 +115,9 @@ info: Operation fails because operator `<` is not supported between the tuple el
 
 ```
 error[unsupported-operator]: Unsupported `<` operation
-  --> src/mdtest_snippet.py:20:27
+  --> src/mdtest_snippet.py:18:27
    |
-20 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
+18 | reveal_type((object(),) < (object(),) < (object(),))  # revealed: Unknown
    |                           -----------^^^-----------
    |                           |
    |                           Both operands have type `tuple[object]`

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -545,6 +545,21 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     Some(Ok(result))
                 }
 
+                // Same-kind literals and the special relationship between `int` and `bool` are
+                // handled above. Any remaining pair of exact builtin literals compares unequal.
+                (
+                    LiteralValueTypeKind::Int(_)
+                    | LiteralValueTypeKind::Bool(_)
+                    | LiteralValueTypeKind::String(_)
+                    | LiteralValueTypeKind::Bytes(_),
+                    LiteralValueTypeKind::Int(_)
+                    | LiteralValueTypeKind::Bool(_)
+                    | LiteralValueTypeKind::String(_)
+                    | LiteralValueTypeKind::Bytes(_),
+                ) if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq) => {
+                    Some(Ok(Type::bool_literal(op == ast::CmpOp::NotEq)))
+                }
+
                 (LiteralValueTypeKind::Enum(literal_1), LiteralValueTypeKind::Enum(literal_2))
                     if op == ast::CmpOp::Eq =>
                 {

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -545,8 +545,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     Some(Ok(result))
                 }
 
-                // Same-kind literals and the special relationship between `int` and `bool` are
-                // handled above. Any remaining pair of exact builtin literals compares unequal.
+                // Same-kind exact literals and the special relationship between `int` and `bool`
+                // are handled above. Any remaining pair of exact builtin literals compares
+                // unequal. `LiteralString` also compares unequal to non-string literals, but its
+                // comparison with an exact string literal remains ambiguous.
                 (
                     LiteralValueTypeKind::Int(_)
                     | LiteralValueTypeKind::Bool(_)
@@ -556,6 +558,18 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     | LiteralValueTypeKind::Bool(_)
                     | LiteralValueTypeKind::String(_)
                     | LiteralValueTypeKind::Bytes(_),
+                )
+                | (
+                    LiteralValueTypeKind::LiteralString,
+                    LiteralValueTypeKind::Int(_)
+                    | LiteralValueTypeKind::Bool(_)
+                    | LiteralValueTypeKind::Bytes(_),
+                )
+                | (
+                    LiteralValueTypeKind::Int(_)
+                    | LiteralValueTypeKind::Bool(_)
+                    | LiteralValueTypeKind::Bytes(_),
+                    LiteralValueTypeKind::LiteralString,
                 ) if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq) => {
                     Some(Ok(Type::bool_literal(op == ast::CmpOp::NotEq)))
                 }


### PR DESCRIPTION
## Summary

We already infer equality results for literal values of the same kind, but mismatched literal kinds fell through to dunder lookup and produced `bool`. As a result, direct comparisons such as `1 == ""` remained ambiguous, as did tuple comparisons whose corresponding elements had different literal kinds.

This adds a narrow expression-inference case for mismatched built-in `int`, `bool`, `str`, and `bytes` literals. It also handles `LiteralString` compared with non-string literals while preserving `bool` for `LiteralString` compared with a particular string literal, since those values may be equal.

```python
reveal_type(1 == "")  # Literal[False]
reveal_type(True != "")  # Literal[True]

left = (1, 2)
right = (1, "two")
reveal_type(left == right)  # Literal[False]
```

