### PR TITLE
Update `ruff_python_parser` README for crates.io

### DIFF
--- a/crates/ruff_python_parser/README.md
+++ b/crates/ruff_python_parser/README.md
@@ -1,18 +1,11 @@
 # Ruff Python Parser
 
 Ruff's Python parser is a hand-written [recursive descent parser] which can parse
-Python source code into an Abstract Syntax Tree (AST). It also utilizes the [Pratt
+Python source code into an [Abstract Syntax Tree (AST)](https://crates.io/crates/ruff_python_ast). It also utilizes the [Pratt
 parsing](https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html)
 technique to parse expressions with different [precedence](https://docs.python.org/3/reference/expressions.html#operator-precedence).
 
 Try out the parser in the [playground](https://play.ruff.rs/?secondary=AST).
-
-## Python version support
-
-The parser supports the latest Python syntax, which is currently Python 3.12.
-It does not throw syntax errors if it encounters a syntax feature that is not
-supported by the [`target-version`](https://docs.astral.sh/ruff/settings/#target-version).
-This will be fixed in a future release (see <https://github.com/astral-sh/ruff/issues/6591>).
 
 ## Contributing
 

--- a/crates/ruff_python_parser/README.md
+++ b/crates/ruff_python_parser/README.md
@@ -12,4 +12,19 @@ Try out the parser in the [playground](https://play.ruff.rs/?secondary=AST).
 Refer to the [contributing guidelines](./CONTRIBUTING.md) to get started and GitHub issues with the
 [parser label](https://github.com/astral-sh/ruff/issues?q=is:open+is:issue+label:parser) for issues that need help.
 
+## Versioning
+
+<!-- BEGIN GENERATED CRATE VERSIONING -->
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.2) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ruff_python_parser).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.
+
+<!-- END GENERATED CRATE VERSIONING -->
+
 [recursive descent parser]: https://en.wikipedia.org/wiki/Recursive_descent_parser

--- a/scripts/generate-crate-readmes.py
+++ b/scripts/generate-crate-readmes.py
@@ -10,6 +10,8 @@ import pathlib
 import subprocess
 
 GENERATED_HEADER = "<!-- This file is generated. DO NOT EDIT -->"
+GENERATED_SECTION_START = "<!-- BEGIN GENERATED CRATE VERSIONING -->"
+GENERATED_SECTION_END = "<!-- END GENERATED CRATE VERSIONING -->"
 
 RUFF_TEMPLATE = """{GENERATED_HEADER}
 
@@ -36,10 +38,7 @@ details on versioning.
 """
 
 
-MEMBER_TEMPLATE = """{GENERATED_HEADER}
-
-# {name}
-
+MEMBER_VERSIONING_TEMPLATE = """\
 This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
@@ -50,9 +49,31 @@ See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#cra
 details on versioning.
 """
 
+MEMBER_TEMPLATE = """{GENERATED_HEADER}
+
+# {name}
+
+{versioning}"""
+
 
 REPO_URL = "https://github.com/astral-sh/ruff"
 PRETTIER_VERSION = "3.8.3"
+
+
+def replace_generated_section(readme: str, generated_content: str) -> str:
+    start = readme.find(GENERATED_SECTION_START)
+    end = readme.find(GENERATED_SECTION_END, start)
+    if start == -1 or end == -1:
+        raise ValueError("README has an incomplete generated crate versioning section")
+
+    content_start = start + len(GENERATED_SECTION_START)
+    return (
+        readme[:content_start]
+        + "\n\n"
+        + generated_content.strip()
+        + "\n\n"
+        + readme[end:]
+    )
 
 
 def main() -> None:
@@ -124,26 +145,40 @@ def main() -> None:
         crate_dir = manifest_path.parent
         member_readme_path = crate_dir / "README.md"
 
-        # Preserve hand-written crate READMEs.
+        handwritten_readme = None
+        # Preserve hand-written crate READMEs unless they opt in to a generated versioning section.
         if member_readme_path.exists():
             existing_content = member_readme_path.read_text()
             if not existing_content.startswith(GENERATED_HEADER):
-                print(f"Skipping {name}: existing README without generated header")
-                continue
+                if (
+                    GENERATED_SECTION_START not in existing_content
+                    and GENERATED_SECTION_END not in existing_content
+                ):
+                    print(f"Skipping {name}: existing README without generated header")
+                    continue
+                handwritten_readme = existing_content
 
         crate_version = package["version"]
         relative_crate_path = crate_dir.relative_to(workspace_root)
         source_url = f"{REPO_URL}/blob/{ruff_version}/{relative_crate_path}"
 
         ruff_crates_io_url = f"https://crates.io/crates/ruff/{ruff_version}"
-        member_readme_content = MEMBER_TEMPLATE.format(
-            GENERATED_HEADER=GENERATED_HEADER,
-            name=name,
+        member_versioning_content = MEMBER_VERSIONING_TEMPLATE.format(
             crate_version=crate_version,
             ruff_version=ruff_version,
             ruff_crates_io_url=ruff_crates_io_url,
             source_url=source_url,
         )
+        if handwritten_readme is None:
+            member_readme_content = MEMBER_TEMPLATE.format(
+                GENERATED_HEADER=GENERATED_HEADER,
+                name=name,
+                versioning=member_versioning_content,
+            )
+        else:
+            member_readme_content = replace_generated_section(
+                handwritten_readme, member_versioning_content
+            )
         member_readme_path.write_text(member_readme_content)
         generated_paths.append(member_readme_path)
 


### PR DESCRIPTION
## Summary

This PR updates the parser README to:
1. Link the parser README's AST reference to the published `ruff_python_ast` crate
2. Remove the obsolete "Python version support" section now that version specific syntax errors are implemented

Additionally, I've also updated the README generator to add a "Versioning" section while preserving the rest of the handwritten README and updated the generator to refresh marker-delimited versioning sections. Maybe this is not worth doing, let me know if that's the case.

### Review

- https://github.com/astral-sh/ruff/pull/26315/commits/5a4145a37436872c197c7de9771a04e91f4f0500 - updates the README manually as mentioned in (1) and (2) above
- https://github.com/astral-sh/ruff/pull/26315/commits/dcb59253c41ecbebacd919defcbb725461a95478 - updates the README generator to add the versioning section

## Test plan

Here's the [Rendered README](https://github.com/astral-sh/ruff/blob/dcb59253c41ecbebacd919defcbb725461a95478/crates/ruff_python_parser/README.md) for preview.

Ran `uv run --script scripts/generate-crate-readmes.py` twice and verified idempotent output
