### PR TITLE
[ty] Fix divergent recursive tuple cycle handling in ty

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -32,6 +32,20 @@ reveal_type(p.x)  # revealed: int
 reveal_type(p.y)  # revealed: int
 ```
 
+## Unpacking a recursively growing tuple
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/3838>.
+
+```py
+while 1:
+    # error: [possibly-unresolved-reference]
+    # error: [possibly-unresolved-reference]
+    x = (*x, x)
+
+while 1:
+    y = (y, *y)
+```
+
 ## Self-referential bare type alias
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -516,6 +516,14 @@ nested: list[tuple[TypeOf[nested]]]
 nested = [(1,)]
 reveal_type(nested)  # revealed: list[Divergent]
 
+variadic_tuple: tuple[TypeOf[variadic_tuple], ...]
+variadic_tuple = (1,)
+reveal_type(variadic_tuple)  # revealed: tuple[Literal[1]]
+
+mixed_variadic_tuple: tuple[TypeOf[mixed_variadic_tuple], *tuple[int, ...]]
+mixed_variadic_tuple = (1,)
+reveal_type(mixed_variadic_tuple)  # revealed: tuple[Literal[1]]
+
 optional: list[TypeOf[optional]] | None
 optional = [1]
 reveal_type(optional)  # revealed: list[Divergent]

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1335,16 +1335,28 @@ impl<'db> Type<'db> {
         wrapped: Self,
         div: Self,
     ) -> Option<Self> {
+        // A variadic tuple can flatten the previous cycle result before the result appears again
+        // as a fixed element, as in `x = (*x, x)`. If the fixed prefix or suffix grows between
+        // iterations, replacing only that nested occurrence would leave the flattened prefix
+        // growing by one element on every iteration. Variadic tuples with stable fixed elements
+        // still need nominal growth recovery for recursive `TypeOf` references.
+        if let Some(current_tuple) = current.own_tuple_spec(db)
+            && current_tuple.is_variadic()
+            && let Some(previous_tuple) = wrapped.exact_tuple_instance_spec(db)
+            && current_tuple.fixed_elements().count() > previous_tuple.fixed_elements().count()
+        {
+            return None;
+        }
+
+        let type_mapping = TypeMapping::ReplaceType {
+            from: wrapped,
+            to: div,
+        };
+
         let current_class = current.class(db);
         let alias = current_class.into_generic_alias()?;
         let original_specialization = alias.specialization(db);
-        let specialization = original_specialization.apply_type_mapping(
-            db,
-            &TypeMapping::ReplaceType {
-                from: wrapped,
-                to: div,
-            },
-        );
+        let specialization = original_specialization.apply_type_mapping(db, &type_mapping);
         if specialization == original_specialization {
             return None;
         }


### PR DESCRIPTION
## Summary

Avoid replacing the recursive occurrence when the current type is already a variadic tuple, which prevents unbounded growth in cases like `x = (*x, x)`.

Closes https://github.com/astral-sh/ty/issues/3838

## Testing

Added mdtest.