### PR TITLE
Add versioning sections to custom crate READMEs

### DIFF
--- a/crates/ruff_python_formatter/README.md
+++ b/crates/ruff_python_formatter/README.md
@@ -24,3 +24,18 @@ For details, see [Style Guide](https://docs.astral.sh/ruff/formatter/#style-guid
 ## Getting started
 
 Head to [The Ruff Formatter](https://docs.astral.sh/ruff/formatter/) for usage instructions and a comparison to Black.
+
+## Versioning
+
+<!-- BEGIN GENERATED CRATE VERSIONING -->
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.2) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ruff_python_formatter).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.
+
+<!-- END GENERATED CRATE VERSIONING -->

--- a/crates/ruff_server/README.md
+++ b/crates/ruff_server/README.md
@@ -16,3 +16,18 @@ Contributions are welcome and highly appreciated. To get started, check out the
 [**contributing guidelines**](https://docs.astral.sh/ruff/contributing/).
 
 You can also join us on [**Discord**](https://discord.com/invite/astral-sh).
+
+## Versioning
+
+<!-- BEGIN GENERATED CRATE VERSIONING -->
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.2) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ruff_server).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.
+
+<!-- END GENERATED CRATE VERSIONING -->

--- a/crates/ruff_wasm/README.md
+++ b/crates/ruff_wasm/README.md
@@ -19,33 +19,46 @@ There are multiple versions for the different wasm-pack targets. See [here](http
 This example uses the wasm-pack web target and is known to work with Vite.
 
 ```ts
-import init, { Workspace, type Diagnostic, PositionEncoding } from '@astral-sh/ruff-wasm-web';
+import init, { Workspace, type Diagnostic, PositionEncoding } from "@astral-sh/ruff-wasm-web";
 
-const exampleDocument = `print('hello'); print("world")`
+const exampleDocument = `print('hello'); print("world")`;
 
 await init(); // Initializes WASM module
 
 // These are default settings just to illustrate configuring Ruff
 // Settings info: https://docs.astral.sh/ruff/settings
-const workspace = new Workspace({
-  'line-length': 88,
-  'indent-width': 4,
-  format: {
-    'indent-style': 'space',
-    'quote-style': 'double',
+const workspace = new Workspace(
+  {
+    "line-length": 88,
+    "indent-width": 4,
+    format: {
+      "indent-style": "space",
+      "quote-style": "double",
+    },
+    lint: {
+      select: ["E4", "E7", "E9", "F"],
+    },
   },
-  lint: {
-    select: [
-      'E4',
-      'E7',
-      'E9',
-      'F'
-    ],
-  },
-}, PositionEncoding.UTF16);
+  PositionEncoding.UTF16,
+);
 
 // Will contain 1 diagnostic code for E702: Multiple statements on one line
 const diagnostics: Diagnostic[] = workspace.check(exampleDocument);
 
 const formatted = workspace.format(exampleDocument);
 ```
+
+## Versioning
+
+<!-- BEGIN GENERATED CRATE VERSIONING -->
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.15.19) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ruff_wasm).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.
+
+<!-- END GENERATED CRATE VERSIONING -->


### PR DESCRIPTION
## Summary

Adds generated versioning sections to three handwritten crate READMEs.

Follow-up to [ruff#26315](https://github.com/astral-sh/ruff/pull/26315).

I've skipped `ruff_annotate_snippets` for now as it's a fork of the original crate.
