### PR TITLE
[`pydocstyle`] Skip `overload-with-docstring` in stub files (`D418`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D418.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D418.pyi
@@ -1,12 +1,3 @@
-"""Regression fixture for D418 (`OverloadWithDocstring`) on stub files.
-
-D418 should not fire in stub files (`.pyi`). Stubs have no non-overloaded
-implementation that could carry a shared docstring, so the docstring must
-live on one of the overloads.
-
-See https://github.com/astral-sh/ruff/issues/26153.
-"""
-
 from typing import overload
 
 
@@ -15,20 +6,3 @@ def overloaded_func(a: int) -> str: ...
 @overload
 def overloaded_func(a: str) -> str:
     """Return the string form of ``a``."""
-
-
-class C:
-    @overload
-    def overloaded_method(self, a: int) -> str: ...
-    @overload
-    def overloaded_method(self, a: str) -> str:
-        """Return the string form of ``a``."""
-
-
-# Nested function with `@overload`, also inside a stub file.
-def outer() -> None:
-    @overload
-    def inner(a: int) -> str: ...
-    @overload
-    def inner(a: str) -> str:
-        """Return the string form of ``a``."""

--- a/crates/ruff_linter/resources/test/fixtures/pydocstyle/D418.pyi
+++ b/crates/ruff_linter/resources/test/fixtures/pydocstyle/D418.pyi
@@ -1,0 +1,34 @@
+"""Regression fixture for D418 (`OverloadWithDocstring`) on stub files.
+
+D418 should not fire in stub files (`.pyi`). Stubs have no non-overloaded
+implementation that could carry a shared docstring, so the docstring must
+live on one of the overloads.
+
+See https://github.com/astral-sh/ruff/issues/26153.
+"""
+
+from typing import overload
+
+
+@overload
+def overloaded_func(a: int) -> str: ...
+@overload
+def overloaded_func(a: str) -> str:
+    """Return the string form of ``a``."""
+
+
+class C:
+    @overload
+    def overloaded_method(self, a: int) -> str: ...
+    @overload
+    def overloaded_method(self, a: str) -> str:
+        """Return the string form of ``a``."""
+
+
+# Nested function with `@overload`, also inside a stub file.
+def outer() -> None:
+    @overload
+    def inner(a: int) -> str: ...
+    @overload
+    def inner(a: str) -> str:
+        """Return the string form of ``a``."""

--- a/crates/ruff_linter/src/rules/pydocstyle/mod.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/mod.rs
@@ -90,6 +90,7 @@ mod tests {
     #[test_case(Rule::MismatchedSectionUnderlineLength, Path::new("sections.py"))]
     #[test_case(Rule::OverindentedSectionUnderline, Path::new("sections.py"))]
     #[test_case(Rule::OverloadWithDocstring, Path::new("D.py"))]
+    #[test_case(Rule::OverloadWithDocstring, Path::new("D418.pyi"))]
     #[test_case(Rule::EscapeSequenceInDocstring, Path::new("D.py"))]
     #[test_case(Rule::EscapeSequenceInDocstring, Path::new("D301.py"))]
     #[test_case(Rule::PropertyDocstringStartsWithVerb, Path::new("D421.py"))]

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
@@ -67,6 +67,14 @@ use crate::docstrings::Docstring;
 ///
 /// - `lint.pydocstyle.ignore-decorators`
 ///
+/// ## Stub files
+///
+/// This rule is not enforced in stub files (`.pyi`). Overloaded functions in
+/// stub files have no non-overloaded implementation to attach a shared
+/// docstring to, so the docstring can only live on one of the overloads.
+/// Type checkers such as mypy and zuban actually reject non-overloaded
+/// implementations in stub files.
+///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [Python documentation: `typing.overload`](https://docs.python.org/3/library/typing.html#typing.overload)
@@ -83,6 +91,13 @@ impl Violation for OverloadWithDocstring {
 
 /// D418
 pub(crate) fn if_needed(checker: &Checker, docstring: &Docstring) {
+    // Stub files (`.pyi`) cannot have a non-overloaded implementation to host
+    // the docstring, so the docstring must live on one of the overloads.
+    // See https://github.com/astral-sh/ruff/issues/26153.
+    if checker.source_type.is_stub() {
+        return;
+    }
+
     let Some(function) = docstring.definition.as_function_def() else {
         return;
     };

--- a/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
+++ b/crates/ruff_linter/src/rules/pydocstyle/rules/if_needed.rs
@@ -19,6 +19,8 @@ use crate::docstrings::Docstring;
 /// the docstring should be placed on the non-decorated definition that contains
 /// the implementation.
 ///
+/// This rule does not apply to stub files, which don't contain implementations.
+///
 /// ## Example
 ///
 /// ```python
@@ -67,14 +69,6 @@ use crate::docstrings::Docstring;
 ///
 /// - `lint.pydocstyle.ignore-decorators`
 ///
-/// ## Stub files
-///
-/// This rule is not enforced in stub files (`.pyi`). Overloaded functions in
-/// stub files have no non-overloaded implementation to attach a shared
-/// docstring to, so the docstring can only live on one of the overloads.
-/// Type checkers such as mypy and zuban actually reject non-overloaded
-/// implementations in stub files.
-///
 /// ## References
 /// - [PEP 257 – Docstring Conventions](https://peps.python.org/pep-0257/)
 /// - [Python documentation: `typing.overload`](https://docs.python.org/3/library/typing.html#typing.overload)
@@ -91,9 +85,6 @@ impl Violation for OverloadWithDocstring {
 
 /// D418
 pub(crate) fn if_needed(checker: &Checker, docstring: &Docstring) {
-    // Stub files (`.pyi`) cannot have a non-overloaded implementation to host
-    // the docstring, so the docstring must live on one of the overloads.
-    // See https://github.com/astral-sh/ruff/issues/26153.
     if checker.source_type.is_stub() {
         return;
     }

--- a/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D418_D418.pyi.snap
+++ b/crates/ruff_linter/src/rules/pydocstyle/snapshots/ruff_linter__rules__pydocstyle__tests__D418_D418.pyi.snap
@@ -1,0 +1,3 @@
+---
+source: crates/ruff_linter/src/rules/pydocstyle/mod.rs
+---


### PR DESCRIPTION

Closes #26153.

`D418` (`overload-with-docstring`) currently fires inside stub files (`.pyi`),
but stubs do not have a non-overloaded "implementation" definition that could
carry the shared docstring — type checkers such as mypy and zuban actively
reject that pattern in stubs. The only place the docstring can live is on one
of the overloads, so flagging it as a violation is a false positive.

This change adds a stub-file early-exit to the `D418` entry point, matching
the established pattern used elsewhere in `ruff_linter` (e.g. `S401`–`S413`,
`B006`, `FBT001`, `FBT002`, and many `flake8_pyi` rules).

This matches the maintainer steer in the issue thread:

> Huh. I think Ruff should probably just refrain from enforcing this rule on
> stub files. Overloaded functions never have implementations in stub files.
> Mypy and zuban actually emit errors if you try to do so […]
>
> — @AlexWaygood

## Test plan

- Added a fixture `D418.pyi` containing module-level, method, and nested
  overloaded functions, each with a docstring on the last overload.
- Added a corresponding `#[test_case]` and an empty insta snapshot.
- The pre-existing `D.py` fixture / snapshot are unchanged — `.py` behaviour
  is identical, no regression.

```text
$ cargo test -p ruff_linter --lib \
    "pydocstyle::tests::rules::rule_overloadwithdocstring"
running 2 tests
test rules::pydocstyle::tests::rules::rule_overloadwithdocstring_path_new_d418_pyi_expects ... ok
test rules::pydocstyle::tests::rules::rule_overloadwithdocstring_path_new_d_py_expects ... ok
test result: ok. 2 passed; 0 failed
