### PR TITLE
[ty] Derive `Update` instead of manual implementation

### DIFF
--- a/crates/ty_python_core/src/ast_node_ref.rs
+++ b/crates/ty_python_core/src/ast_node_ref.rs
@@ -32,7 +32,7 @@ use ruff_text_size::Ranged;
 /// This means that changes to expressions in other scopes don't invalidate the expression's id, giving
 /// us some form of scope-stable identity for expressions. Only queries accessing the node field
 /// run on every AST change. All other queries only run when the expression's identity changes.
-#[derive(Clone)]
+#[derive(Clone, salsa::Update)]
 pub struct AstNodeRef<T> {
     /// The index of the node in the AST.
     index: NodeIndex,
@@ -48,6 +48,9 @@ pub struct AstNodeRef<T> {
     #[cfg(debug_assertions)]
     file: File,
 
+    // Always consider the node changed because its identity also depends on the module address,
+    // which is omitted in release builds. Customizing this field avoids requiring `T: Update`.
+    #[update(unsafe(with(|_, _| true)))]
     _node: PhantomData<T>,
 }
 
@@ -98,20 +101,6 @@ where
             .try_into()
             .ok()
             .expect("AST indices should never change within the same revision")
-    }
-}
-
-#[expect(unsafe_code)]
-unsafe impl<T> salsa::Update for AstNodeRef<T> {
-    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
-        let old_ref = unsafe { &mut (*old_pointer) };
-
-        // The equality of an `AstNodeRef` depends on both the module address and the node index,
-        // but the former is not stored in release builds to save memory. As such, AST nodes
-        // are always considered change when the AST is reparsed, which is acceptable because
-        // any change to the AST is likely to invalidate most node indices anyways.
-        *old_ref = new_value;
-        true
     }
 }
 

--- a/crates/ty_python_core/src/rank.rs
+++ b/crates/ty_python_core/src/rank.rs
@@ -23,9 +23,10 @@ use get_size2::GetSize;
 ///
 /// This trick adds O(1.5) bits of overhead per large vector element on 64-bit platforms, and O(2)
 /// bits of overhead on 32-bit platforms.
-#[derive(Clone, Debug, Eq, Hash, PartialEq, GetSize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, GetSize, salsa::Update)]
 pub struct RankBitBox {
     #[get_size(size_fn = bit_box_size)]
+    #[update(fallback)]
     bits: RankBitBoxStorage,
     chunk_ranks: Box<[u32]>,
 }
@@ -44,21 +45,6 @@ type Chunk = u64;
 type Chunk = u32;
 
 const CHUNK_SIZE: usize = Chunk::BITS as usize;
-
-// SAFETY: This is the standard pattern for implementing salsa::Update. Salsa ensures that the
-// `old_pointer` we are provided can safely be used as a mutable reference to the old value.
-#[expect(unsafe_code)]
-unsafe impl salsa::Update for RankBitBox {
-    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
-        let old_ref = unsafe { &mut *old_pointer };
-        if *old_ref != new_value {
-            *old_ref = new_value;
-            true
-        } else {
-            false
-        }
-    }
-}
 
 impl RankBitBox {
     pub fn bits_with_capacity(cap: usize) -> RankBitBoxVec {


### PR DESCRIPTION
## Summary

Replace the remaining manual `Update` implementations in ty with Salsa's field-customizable derive.
This removes unsafe trait implementations while preserving `AstNodeRef`'s always-changed behavior and `RankBitBox`'s fallback equality.

## Test Plan

Testing: Ran the `ty_python_core` tests, focused Clippy, and repository hooks.
