### PR TITLE
[ty] Publish semantic crates to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "ty_combine"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "ordermap",
  "ruff_db",
@@ -4705,7 +4705,7 @@ dependencies = [
 
 [[package]]
 name = "ty_python_core"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "ty_python_semantic"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4881,7 +4881,7 @@ dependencies = [
 
 [[package]]
 name = "ty_vendored"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
  "path-slash",
  "ruff_db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,19 +44,19 @@ ruff_text_size = { version = "0.0.2", path = "crates/ruff_text_size" }
 ruff_workspace = { version = "0.0.2", path = "crates/ruff_workspace" }
 
 ty = { path = "crates/ty" }
-ty_combine = { path = "crates/ty_combine" }
+ty_combine = { version = "0.0.1", path = "crates/ty_combine" }
 ty_completion_bench = { path = "crates/ty_completion_bench" }
 ty_completion_eval = { path = "crates/ty_completion_eval" }
 ty_ide = { path = "crates/ty_ide" }
 ty_module_resolver = { version = "0.0.2", path = "crates/ty_module_resolver" }
 ty_project = { path = "crates/ty_project", default-features = false }
-ty_python_semantic = { path = "crates/ty_python_semantic" }
-ty_python_core = { path = "crates/ty_python_core" }
+ty_python_semantic = { version = "0.0.1", path = "crates/ty_python_semantic" }
+ty_python_core = { version = "0.0.1", path = "crates/ty_python_core" }
 ty_server = { path = "crates/ty_server" }
 ty_site_packages = { version = "0.0.2", path = "crates/ty_site_packages" }
 ty_static = { version = "0.0.2", path = "crates/ty_static" }
 ty_test = { path = "crates/ty_test" }
-ty_vendored = { path = "crates/ty_vendored" }
+ty_vendored = { version = "0.0.1", path = "crates/ty_vendored" }
 
 mdtest = { path = "crates/mdtest" }
 

--- a/crates/ruff/README.md
+++ b/crates/ruff/README.md
@@ -42,9 +42,13 @@ The following Ruff workspace members are also available:
 - [ruff_text_size](https://crates.io/crates/ruff_text_size)
 - [ruff_wasm](https://crates.io/crates/ruff_wasm)
 - [ruff_workspace](https://crates.io/crates/ruff_workspace)
+- [ty_combine](https://crates.io/crates/ty_combine)
 - [ty_module_resolver](https://crates.io/crates/ty_module_resolver)
+- [ty_python_core](https://crates.io/crates/ty_python_core)
+- [ty_python_semantic](https://crates.io/crates/ty_python_semantic)
 - [ty_site_packages](https://crates.io/crates/ty_site_packages)
 - [ty_static](https://crates.io/crates/ty_static)
+- [ty_vendored](https://crates.io/crates/ty_vendored)
 
 Ruff's workspace members are considered internal and will have frequent breaking changes.
 

--- a/crates/ty_combine/Cargo.toml
+++ b/crates/ty_combine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ty_combine"
-version = "0.0.0"
-publish = false
+version = "0.0.1"
+description = "This is an internal component crate of Ruff"
 edition.workspace = true
 rust-version.workspace = true
 homepage.workspace = true

--- a/crates/ty_combine/README.md
+++ b/crates/ty_combine/README.md
@@ -1,0 +1,12 @@
+<!-- This file is generated. DO NOT EDIT -->
+
+# ty_combine
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.1) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ty_combine).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ty_python_core"
-version = "0.0.0"
-publish = false
+version = "0.0.1"
+description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ty_python_core/README.md
+++ b/crates/ty_python_core/README.md
@@ -1,0 +1,12 @@
+<!-- This file is generated. DO NOT EDIT -->
+
+# ty_python_core
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.1) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ty_python_core).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ty_python_semantic"
-version = "0.0.0"
-publish = false
+version = "0.0.1"
+description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ty_python_semantic/README.md
+++ b/crates/ty_python_semantic/README.md
@@ -1,0 +1,12 @@
+<!-- This file is generated. DO NOT EDIT -->
+
+# ty_python_semantic
+
+This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
+here is unstable and will have frequent breaking changes.
+
+This version (0.0.1) is a component of [Ruff 0.15.19](https://crates.io/crates/ruff/0.15.19). The
+source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.19/crates/ty_python_semantic).
+
+See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for
+details on versioning.

--- a/crates/ty_vendored/Cargo.toml
+++ b/crates/ty_vendored/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ty_vendored"
-version = "0.0.0"
-publish = false
+version = "0.0.1"
+description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/ty_vendored/src/lib.rs
+++ b/crates/ty_vendored/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 
 /// The source commit of the vendored typeshed.
 pub const SOURCE_COMMIT: &str =
-    include_str!("../../../crates/ty_vendored/vendor/typeshed/source_commit.txt").trim_ascii_end();
+    include_str!("../vendor/typeshed/source_commit.txt").trim_ascii_end();
 
 static_assertions::const_assert_eq!(SOURCE_COMMIT.len(), 40);
 


### PR DESCRIPTION
## Summary

- Make `ty_python_semantic`, `ty_python_core`, and `ty_vendored` publishable; `ty_module_resolver` is already in the publishing set and remains unchanged.
- Publish `ty_combine` as the required runtime dependency of `ty_python_core`. All other ty crates remain excluded from crates.io publishing.
- Add the generated crate READMEs and make `ty_vendored`'s source-commit include package-relative so the packaged crate verifies outside the Ruff workspace.

The complete new dependency chain passes Cargo's publish dry run, all 774 affected crate tests pass, and the repository hooks and dependency checks pass.
