### PR TITLE
[ty] Make reachability call analysis demand-driven

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -4101,7 +4101,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             .add_atom(predicate_id);
 
                         if self.in_function_scope() {
-                            self.record_reachability_constraint_id(predicate_id);
+                            let reachability_constraint = self
+                                .current_reachability_constraints_mut()
+                                .add_source_ordered_atom(predicate_id);
+                            self.current_use_def_map_mut()
+                                .record_reachability_constraint(reachability_constraint);
 
                             // Also gate narrowing by this constraint: if the call returns
                             // `Never`, any narrowing in the current branch should be

--- a/crates/ty_python_core/src/reachability_constraints.rs
+++ b/crates/ty_python_core/src/reachability_constraints.rs
@@ -5,7 +5,7 @@
 use std::cmp::Ordering;
 
 use ruff_index::{Idx, IndexVec};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::predicate::ScopedPredicateId;
 use crate::rank::{RankBitBox, RankBitBoxVec};
@@ -175,6 +175,7 @@ impl ReachabilityConstraints {
 pub struct ReachabilityConstraintsBuilder {
     interiors: IndexVec<ScopedReachabilityConstraintId, InteriorNode>,
     interior_used: RankBitBoxVec,
+    source_ordered_atoms: FxHashSet<ScopedPredicateId>,
     interior_cache: FxHashMap<InteriorNode, ScopedReachabilityConstraintId>,
     not_cache: FxHashMap<ScopedReachabilityConstraintId, ScopedReachabilityConstraintId>,
     and_cache: FxHashMap<
@@ -258,12 +259,21 @@ impl ReachabilityConstraintsBuilder {
         } else if b.is_terminal() {
             Ordering::Less
         } else {
-            // See https://github.com/astral-sh/ruff/pull/20098 for an explanation of why this
-            // ordering is reversed.
-            self.interiors[a]
-                .atom
-                .cmp(&self.interiors[b].atom)
-                .reverse()
+            let a = self.interiors[a].atom;
+            let b = self.interiors[b].atom;
+            match (
+                self.source_ordered_atoms.contains(&a),
+                self.source_ordered_atoms.contains(&b),
+            ) {
+                // Test ordinary control-flow predicates before call predicates. Calls are then
+                // tested in source order, avoiding a backwards type-inference dependency chain.
+                (false, true) => Ordering::Less,
+                (true, false) => Ordering::Greater,
+                (true, true) => a.cmp(&b),
+                // See https://github.com/astral-sh/ruff/pull/20098 for why the default ordering is
+                // reversed.
+                (false, false) => a.cmp(&b).reverse(),
+            }
         }
     }
 
@@ -309,6 +319,19 @@ impl ReachabilityConstraintsBuilder {
                 if_false: ALWAYS_FALSE,
             })
         }
+    }
+
+    /// Adds an atom after marking it as dependency-ordered.
+    ///
+    /// Dependency-ordered atoms are placed below ordinary control-flow predicates and in source
+    /// order relative to each other. This is used for call predicates, whose type inference can
+    /// depend on the reachability of later bindings.
+    pub(crate) fn add_source_ordered_atom(
+        &mut self,
+        predicate: ScopedPredicateId,
+    ) -> ScopedReachabilityConstraintId {
+        self.source_ordered_atoms.insert(predicate);
+        self.add_atom(predicate)
     }
 
     /// Adds a new reachability constraint that is the ternary NOT of an existing one.
@@ -484,5 +507,34 @@ impl ReachabilityConstraintsBuilder {
         });
         self.and_cache.insert((a, b), result);
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn predicate(index: usize) -> ScopedPredicateId {
+        ScopedPredicateId::new(index)
+    }
+
+    #[test]
+    fn source_ordered_atoms_follow_control_flow_predicates() {
+        let mut constraints = ReachabilityConstraintsBuilder::default();
+        let early_call = constraints.add_source_ordered_atom(predicate(0));
+        let late_call = constraints.add_source_ordered_atom(predicate(1));
+        let condition = constraints.add_atom(predicate(2));
+
+        let calls = constraints.add_and_constraint(early_call, late_call);
+        let formula = constraints.add_and_constraint(condition, calls);
+
+        let condition_node = constraints.interiors[formula];
+        assert_eq!(condition_node.atom, predicate(2));
+
+        let early_call_node = constraints.interiors[condition_node.if_true];
+        assert_eq!(early_call_node.atom, predicate(0));
+
+        let late_call_node = constraints.interiors[early_call_node.if_true];
+        assert_eq!(late_call_node.atom, predicate(1));
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -533,11 +533,59 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
 std::thread_local! {
     static ACTIVE_REACHABILITY_EVALUATIONS: ActiveRecursionDetector<salsa::Id> =
         ActiveRecursionDetector::default();
+    static ACTIVE_NON_TERMINAL_CALLS: ActiveNonTerminalCalls = ActiveNonTerminalCalls::default();
 }
 
-fn should_recover_non_terminal_call(db: &dyn Db, predicate: &Predicate) -> bool {
+#[derive(Default)]
+struct ActiveNonTerminalCalls {
+    calls: RefCell<Vec<(salsa::Id, ScopedPredicateId)>>,
+}
+
+impl ActiveNonTerminalCalls {
+    fn visit<R>(&self, scope: salsa::Id, predicate: ScopedPredicateId, f: impl FnOnce() -> R) -> R {
+        self.calls.borrow_mut().push((scope, predicate));
+        let _guard = ActiveNonTerminalCallGuard {
+            calls: &self.calls,
+            expected: (scope, predicate),
+        };
+        f()
+    }
+
+    fn frontier(&self, scope: salsa::Id) -> Option<ScopedPredicateId> {
+        self.calls
+            .borrow()
+            .iter()
+            .rev()
+            .find_map(|(active_scope, predicate)| (*active_scope == scope).then_some(*predicate))
+    }
+}
+
+struct ActiveNonTerminalCallGuard<'a> {
+    calls: &'a RefCell<Vec<(salsa::Id, ScopedPredicateId)>>,
+    expected: (salsa::Id, ScopedPredicateId),
+}
+
+impl Drop for ActiveNonTerminalCallGuard<'_> {
+    fn drop(&mut self) {
+        debug_assert_eq!(self.calls.borrow_mut().pop(), Some(self.expected));
+    }
+}
+
+fn non_terminal_call_recovery_frontier(
+    db: &dyn Db,
+    predicate: &Predicate,
+) -> Option<ScopedPredicateId> {
     let scope = predicate_scope(db, predicate).as_id();
-    ACTIVE_REACHABILITY_EVALUATIONS.with(|active| active.visit(&scope, || true, || false))
+    ACTIVE_NON_TERMINAL_CALLS.with(|active| active.frontier(scope))
+}
+
+fn should_recover_non_terminal_call(
+    db: &dyn Db,
+    predicate_id: ScopedPredicateId,
+    predicate: &Predicate,
+) -> bool {
+    non_terminal_call_recovery_frontier(db, predicate)
+        .is_some_and(|frontier| predicate_id.index() > frontier.index())
 }
 
 /// Infers call predicates reachable from one constraint root in source order.
@@ -575,7 +623,11 @@ fn analyze_non_terminal_call_worklist<'db>(
     calls.sort_unstable_by_key(|predicate| predicate.index());
     calls.dedup();
     for predicate in calls {
-        analyze_single(db, &predicates[predicate]);
+        let predicate_data = &predicates[predicate];
+        let scope = predicate_scope(db, predicate_data).as_id();
+        ACTIVE_NON_TERMINAL_CALLS.with(|active| {
+            active.visit(scope, predicate, || analyze_single(db, predicate_data));
+        });
     }
 }
 
@@ -584,7 +636,7 @@ fn evaluate_reachability_constraint<'db>(
     constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     mut id: ScopedReachabilityConstraintId,
-    recover_call_cycle: bool,
+    recovery_frontier: Option<ScopedPredicateId>,
 ) -> Truthiness {
     type Id = ScopedReachabilityConstraintId;
 
@@ -596,7 +648,8 @@ fn evaluate_reachability_constraint<'db>(
             _ => constraints.get_interior_node(id),
         };
         let predicate = &predicates[node.atom()];
-        let truthiness = if recover_call_cycle
+        let truthiness = if recovery_frontier
+            .is_some_and(|frontier| node.atom().index() > frontier.index())
             && matches!(predicate.node, PredicateNode::IsNonTerminalCall(_))
         {
             // Match `analyze_non_terminal_call`'s conservative cycle-initial value. The future
@@ -636,7 +689,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
         if id.is_terminal() {
-            return evaluate_reachability_constraint(db, self, predicates, id, false);
+            return evaluate_reachability_constraint(db, self, predicates, id, None);
         }
 
         let predicate = &predicates[self.get_interior_node(id).atom()];
@@ -648,11 +701,17 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
                     // The outer evaluation is already inferring calls in source order. Reentering
                     // that work through a later implicit-attribute binding would otherwise
                     // recreate the reverse query chain that the worklist is meant to avoid.
-                    evaluate_reachability_constraint(db, self, predicates, id, true)
+                    evaluate_reachability_constraint(
+                        db,
+                        self,
+                        predicates,
+                        id,
+                        non_terminal_call_recovery_frontier(db, predicate),
+                    )
                 },
                 || {
                     analyze_non_terminal_call_worklist(db, self, predicates, id);
-                    evaluate_reachability_constraint(db, self, predicates, id, false)
+                    evaluate_reachability_constraint(db, self, predicates, id, None)
                 },
             )
         })
@@ -976,9 +1035,10 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-                    // Call predicates also gate narrowing. Apply the same recovery as reachability
-                    // so projection cannot reenter the active source-order worklist backwards.
-                    let branch = if should_recover_non_terminal_call(self.db, &predicate) {
+                    // Call predicates also gate narrowing. Recover future calls while a worklist
+                    // is active, but retain precise results for calls it has already processed.
+                    let branch = if should_recover_non_terminal_call(self.db, node.atom, &predicate)
+                    {
                         node.if_true
                     } else {
                         match analyze_single(self.db, &predicate) {
@@ -1588,10 +1648,13 @@ impl<'db> DeclarationsIteratorExtension<'db> for DeclarationsIterator<'_, 'db> {
 mod tests {
     use super::*;
     use crate::db::tests::setup_db;
+    use crate::types::check_types;
+    use ruff_db::diagnostic::DiagnosticId;
     use ruff_db::files::system_path_to_file;
     use ruff_db::system::DbWithWritableSystem as _;
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
+    use ty_python_core::scope::ScopeKind;
     use ty_python_core::semantic_index;
 
     #[test]
@@ -1654,5 +1717,69 @@ mod tests {
             })?;
 
         handle.join().expect("projection thread panicked")
+    }
+
+    #[test]
+    fn resolved_never_call_is_preserved_during_scope_reentry() -> anyhow::Result<()> {
+        let mut db = setup_db();
+        db.write_files([
+            ("/src/package/__init__.py", ""),
+            (
+                "/src/package/ui.py",
+                r#"from typing_extensions import Never
+
+def abort() -> Never: ...
+
+class Ui:
+    def setup(self, value: int | None):
+        if value is None:
+            abort()
+        self.target.bit_length()
+        self.target = value
+"#,
+            ),
+            (
+                "/src/package/consumer.py",
+                r#"from typing_extensions import reveal_type
+from .ui import Ui
+
+class Form(Ui):
+    def target_value(self) -> int:
+        reveal_type(self.target)
+        return self.target
+"#,
+            ),
+        ])?;
+
+        let ui_file = system_path_to_file(&db, "/src/package/ui.py").unwrap();
+        let index = semantic_index(&db, ui_file);
+        let class_scope = index
+            .child_scopes(FileScopeId::global())
+            .find(|(scope, _)| index.scope(*scope).kind() == ScopeKind::Class)
+            .unwrap()
+            .0;
+        let method_scope = index.child_scopes(class_scope).next().unwrap().0;
+        let scope = method_scope.to_scope_id(&db, ui_file).as_id();
+        let consumer_file = system_path_to_file(&db, "/src/package/consumer.py").unwrap();
+
+        ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
+            active.visit(
+                &scope,
+                || panic!("test unexpectedly reentered its synthetic outer evaluation"),
+                || {
+                    let diagnostics = check_types(&db, consumer_file);
+                    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+                    assert_eq!(diagnostics[0].id(), DiagnosticId::RevealedType);
+                    assert_eq!(
+                        diagnostics[0]
+                            .primary_annotation()
+                            .and_then(|annotation| annotation.get_message()),
+                        Some("`int`")
+                    );
+                },
+            );
+        });
+
+        Ok(())
     }
 }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -518,10 +518,6 @@ fn accumulate_constraint<'db>(
     }
 }
 
-std::thread_local! {
-    static ACTIVE_NON_TERMINAL_CALL_PREFIXES: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
-}
-
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -534,54 +530,91 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
     }
 }
 
-/// Infers preceding call predicates in source order.
+std::thread_local! {
+    static ACTIVE_REACHABILITY_EVALUATIONS: ActiveRecursionDetector<salsa::Id> =
+        ActiveRecursionDetector::default();
+}
+
+fn should_recover_non_terminal_call(db: &dyn Db, predicate: &Predicate) -> bool {
+    let scope = predicate_scope(db, predicate).as_id();
+    ACTIVE_REACHABILITY_EVALUATIONS.with(|active| active.visit(&scope, || true, || false))
+}
+
+/// Infers call predicates reachable from one constraint root in source order.
 ///
 /// Predicate IDs are assigned in source order, but the decision diagrams intentionally order
-/// predicates in reverse to reduce their size. Inferring a later call can depend on the
-/// reachability of all preceding calls, which otherwise creates a deeply recursive Salsa query
-/// chain. Inferring the expressions in source order turns that chain into cache lookups while
-/// preserving normal reachability and narrowing during every inference.
-///
-/// Because the prefix is based on predicate indices rather than graph reachability, branch-heavy
-/// code can warm calls from earlier source branches that this evaluation would not otherwise visit.
-/// A demand-driven graph walk could avoid that work, but would require a more complex work list. We
-/// accept the broader eager pass because it keeps the ordering simple, and checking a scope will
-/// typically exercise most of its predicates eventually.
-///
-/// Reentrant analysis of the same predicate graph skips the prefix pass: because the outer pass is
-/// proceeding in source order, any preceding call needed by the current expression has already
-/// been inferred. A different predicate graph performs its own pass, which is necessary when
-/// inferring a call crosses into another large scope.
-fn analyze_non_terminal_call_prefix<'db>(
+/// predicates in reverse to reduce their size. Walking the requested graph and inferring its calls
+/// in source order turns a deeply recursive query chain into cache lookups without analyzing calls
+/// from unrelated control-flow paths.
+fn analyze_non_terminal_call_worklist<'db>(
     db: &'db dyn Db,
+    constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    root_predicate: ScopedPredicateId,
+    root: ScopedReachabilityConstraintId,
 ) {
-    let range = 0..=root_predicate.index();
-    if !range.clone().any(|index| {
-        matches!(
-            predicates[ScopedPredicateId::new(index)].node,
+    let mut pending = vec![root];
+    let mut visited = FxHashSet::default();
+    let mut calls = Vec::new();
+
+    while let Some(id) = pending.pop() {
+        if id.is_terminal() || !visited.insert(id) {
+            continue;
+        }
+
+        let node = constraints.get_interior_node(id);
+        if matches!(
+            predicates[node.atom()].node,
             PredicateNode::IsNonTerminalCall(_)
-        )
-    }) {
-        return;
+        ) {
+            calls.push(node.atom());
+        }
+
+        pending.extend([node.if_true(), node.if_ambiguous(), node.if_false()]);
     }
 
-    let key = predicate_scope(db, &predicates[root_predicate]).as_id();
-    ACTIVE_NON_TERMINAL_CALL_PREFIXES.with(|active| {
-        active.visit(
-            &key,
-            || {},
-            || {
-                for index in range {
-                    let predicate = &predicates[ScopedPredicateId::new(index)];
-                    if matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)) {
-                        analyze_single(db, predicate);
-                    }
-                }
-            },
-        );
-    });
+    calls.sort_unstable_by_key(|predicate| predicate.index());
+    calls.dedup();
+    for predicate in calls {
+        analyze_single(db, &predicates[predicate]);
+    }
+}
+
+fn evaluate_reachability_constraint<'db>(
+    db: &'db dyn Db,
+    constraints: &ReachabilityConstraints,
+    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
+    mut id: ScopedReachabilityConstraintId,
+    recover_call_cycle: bool,
+) -> Truthiness {
+    type Id = ScopedReachabilityConstraintId;
+
+    loop {
+        let node = match id {
+            Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+            Id::AMBIGUOUS => return Truthiness::Ambiguous,
+            Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+            _ => constraints.get_interior_node(id),
+        };
+        let predicate = &predicates[node.atom()];
+        let truthiness = if recover_call_cycle
+            && matches!(predicate.node, PredicateNode::IsNonTerminalCall(_))
+        {
+            // Match `analyze_non_terminal_call`'s conservative cycle-initial value. The future
+            // call can affect whether a later implicit-attribute binding is reachable, but it
+            // cannot make the current source position reachable if it was not already. Assuming
+            // that it returns therefore avoids false unreachable results while breaking the
+            // backwards inference cycle.
+            Truthiness::AlwaysTrue.negate_if(!predicate.is_positive)
+        } else {
+            analyze_single(db, predicate)
+        };
+
+        match truthiness {
+            Truthiness::AlwaysTrue => id = node.if_true(),
+            Truthiness::Ambiguous => id = node.if_ambiguous(),
+            Truthiness::AlwaysFalse => id = node.if_false(),
+        }
+    }
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -600,51 +633,29 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         &self,
         db: &'db dyn Db,
         predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        mut id: ScopedReachabilityConstraintId,
+        id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
-        type Id = ScopedReachabilityConstraintId;
-
-        // Analyze statement-level calls through this root one by one in source order, so any
-        // earlier call needed while inferring a later one is already cached instead of deepening
-        // the Salsa query stack. This avoids growing an excessive stack for deeply nested
-        // reachability queries.
-        //
-        // Without this prefix analysis, given:
-        //
-        //   call_a()  # predicate 0
-        //   call_b()  # predicate 1
-        //   call_c()  # predicate 2
-        //
-        // we'd analyze them backwards:
-        //
-        //   analyze call_c
-        //   └─ analyze call_b
-        //      └─ analyze call_a
-        //
-        // The prefix pass explicitly analyzes them forwards:
-        //
-        //   analyze call_a  → cached
-        //   analyze call_b  → call_a is already cached
-        //   analyze call_c  → call_b is already cached
-        if !id.is_terminal() {
-            let root_predicate = self.get_interior_node(id).atom();
-            analyze_non_terminal_call_prefix(db, predicates, root_predicate);
+        if id.is_terminal() {
+            return evaluate_reachability_constraint(db, self, predicates, id, false);
         }
 
-        loop {
-            let node = match id {
-                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
-                Id::AMBIGUOUS => return Truthiness::Ambiguous,
-                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
-                _ => self.get_interior_node(id),
-            };
-            let predicate = &predicates[node.atom()];
-            match analyze_single(db, predicate) {
-                Truthiness::AlwaysTrue => id = node.if_true(),
-                Truthiness::Ambiguous => id = node.if_ambiguous(),
-                Truthiness::AlwaysFalse => id = node.if_false(),
-            }
-        }
+        let predicate = &predicates[self.get_interior_node(id).atom()];
+        let scope = predicate_scope(db, predicate).as_id();
+        ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
+            active.visit(
+                &scope,
+                || {
+                    // The outer evaluation is already inferring calls in source order. Reentering
+                    // that work through a later implicit-attribute binding would otherwise
+                    // recreate the reverse query chain that the worklist is meant to avoid.
+                    evaluate_reachability_constraint(db, self, predicates, id, true)
+                },
+                || {
+                    analyze_non_terminal_call_worklist(db, self, predicates, id);
+                    evaluate_reachability_constraint(db, self, predicates, id, false)
+                },
+            )
+        })
     }
 }
 
@@ -965,11 +976,19 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-                    let branch = match analyze_single(self.db, &predicate) {
-                        Truthiness::AlwaysTrue => node.if_true,
-                        Truthiness::AlwaysFalse => node.if_false,
-                        Truthiness::Ambiguous => {
-                            unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
+                    // Call predicates also gate narrowing. Apply the same recovery as reachability
+                    // so projection cannot reenter the active source-order worklist backwards.
+                    let branch = if should_recover_non_terminal_call(self.db, &predicate) {
+                        node.if_true
+                    } else {
+                        match analyze_single(self.db, &predicate) {
+                            Truthiness::AlwaysTrue => node.if_true,
+                            Truthiness::AlwaysFalse => node.if_false,
+                            Truthiness::Ambiguous => {
+                                unreachable!(
+                                    "`IsNonTerminalCall` predicates should never be Ambiguous"
+                                )
+                            }
                         }
                     };
 

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -539,16 +539,32 @@ std::thread_local! {
 #[derive(Default)]
 struct ActiveNonTerminalCalls {
     calls: RefCell<Vec<(salsa::Id, ScopedPredicateId)>>,
+    sessions: RefCell<Vec<(salsa::Id, FxHashSet<ScopedPredicateId>)>>,
 }
 
 impl ActiveNonTerminalCalls {
-    fn visit<R>(&self, scope: salsa::Id, predicate: ScopedPredicateId, f: impl FnOnce() -> R) -> R {
-        self.calls.borrow_mut().push((scope, predicate));
-        let _guard = ActiveNonTerminalCallGuard {
-            calls: &self.calls,
-            expected: (scope, predicate),
+    fn visit_scope<R>(&self, scope: salsa::Id, f: impl FnOnce() -> R) -> R {
+        self.sessions
+            .borrow_mut()
+            .push((scope, FxHashSet::default()));
+        let _guard = ActiveNonTerminalCallSessionGuard {
+            sessions: &self.sessions,
+            expected_scope: scope,
         };
         f()
+    }
+
+    fn visit<R>(&self, scope: salsa::Id, predicate: ScopedPredicateId, f: impl FnOnce() -> R) -> R {
+        self.calls.borrow_mut().push((scope, predicate));
+        let result = {
+            let _guard = ActiveNonTerminalCallGuard {
+                calls: &self.calls,
+                expected: (scope, predicate),
+            };
+            f()
+        };
+        self.mark_prepared(scope, predicate);
+        result
     }
 
     fn frontier(&self, scope: salsa::Id) -> Option<ScopedPredicateId> {
@@ -557,6 +573,41 @@ impl ActiveNonTerminalCalls {
             .iter()
             .rev()
             .find_map(|(active_scope, predicate)| (*active_scope == scope).then_some(*predicate))
+    }
+
+    fn is_prepared(&self, scope: salsa::Id, predicate: ScopedPredicateId) -> bool {
+        self.sessions
+            .borrow()
+            .iter()
+            .rev()
+            .find_map(|(active_scope, prepared)| {
+                (*active_scope == scope).then(|| prepared.contains(&predicate))
+            })
+            .unwrap_or(false)
+    }
+
+    fn mark_prepared(&self, scope: salsa::Id, predicate: ScopedPredicateId) {
+        let mut sessions = self.sessions.borrow_mut();
+        let session = sessions
+            .iter_mut()
+            .rev()
+            .find(|(active_scope, _)| *active_scope == scope);
+        debug_assert!(session.is_some(), "an active call needs a worklist session");
+        if let Some((_, prepared)) = session {
+            prepared.insert(predicate);
+        }
+    }
+}
+
+struct ActiveNonTerminalCallSessionGuard<'a> {
+    sessions: &'a RefCell<Vec<(salsa::Id, FxHashSet<ScopedPredicateId>)>>,
+    expected_scope: salsa::Id,
+}
+
+impl Drop for ActiveNonTerminalCallSessionGuard<'_> {
+    fn drop(&mut self) {
+        let scope = self.sessions.borrow_mut().pop().map(|(scope, _)| scope);
+        debug_assert_eq!(scope, Some(self.expected_scope));
     }
 }
 
@@ -594,11 +645,15 @@ fn should_recover_non_terminal_call(
 /// predicates in reverse to reduce their size. Walking the requested graph and inferring its calls
 /// in source order turns a deeply recursive query chain into cache lookups without analyzing calls
 /// from unrelated control-flow paths.
+///
+/// During reentry, calls at or beyond the active frontier cannot be prepared without recreating
+/// the cycle. Calls before it are safe to prepare unless the active scope session already did so.
 fn analyze_non_terminal_call_worklist<'db>(
     db: &'db dyn Db,
     constraints: &ReachabilityConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     root: ScopedReachabilityConstraintId,
+    recovery_frontier: Option<ScopedPredicateId>,
 ) {
     let mut pending = vec![root];
     let mut visited = FxHashSet::default();
@@ -623,10 +678,16 @@ fn analyze_non_terminal_call_worklist<'db>(
     calls.sort_unstable_by_key(|predicate| predicate.index());
     calls.dedup();
     for predicate in calls {
+        if recovery_frontier.is_some_and(|frontier| predicate.index() >= frontier.index()) {
+            continue;
+        }
+
         let predicate_data = &predicates[predicate];
         let scope = predicate_scope(db, predicate_data).as_id();
         ACTIVE_NON_TERMINAL_CALLS.with(|active| {
-            active.visit(scope, predicate, || analyze_single(db, predicate_data));
+            if !active.is_prepared(scope, predicate) {
+                active.visit(scope, predicate, || analyze_single(db, predicate_data));
+            }
         });
     }
 }
@@ -698,20 +759,20 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
             active.visit(
                 &scope,
                 || {
-                    // The outer evaluation is already inferring calls in source order. Reentering
-                    // that work through a later implicit-attribute binding would otherwise
-                    // recreate the reverse query chain that the worklist is meant to avoid.
-                    evaluate_reachability_constraint(
-                        db,
-                        self,
-                        predicates,
-                        id,
-                        non_terminal_call_recovery_frontier(db, predicate),
-                    )
+                    let recovery_frontier = non_terminal_call_recovery_frontier(db, predicate);
+                    // This graph can contain earlier calls from a control-flow path that is absent
+                    // from the outer graph. Prepare those calls in source order before evaluating
+                    // the graph, while leaving the active and future calls to cycle recovery.
+                    analyze_non_terminal_call_worklist(db, self, predicates, id, recovery_frontier);
+                    evaluate_reachability_constraint(db, self, predicates, id, recovery_frontier)
                 },
                 || {
-                    analyze_non_terminal_call_worklist(db, self, predicates, id);
-                    evaluate_reachability_constraint(db, self, predicates, id, None)
+                    ACTIVE_NON_TERMINAL_CALLS.with(|calls| {
+                        calls.visit_scope(scope, || {
+                            analyze_non_terminal_call_worklist(db, self, predicates, id, None);
+                            evaluate_reachability_constraint(db, self, predicates, id, None)
+                        })
+                    })
                 },
             )
         })
@@ -1762,22 +1823,26 @@ class Form(Ui):
         let scope = method_scope.to_scope_id(&db, ui_file).as_id();
         let consumer_file = system_path_to_file(&db, "/src/package/consumer.py").unwrap();
 
-        ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
-            active.visit(
-                &scope,
-                || panic!("test unexpectedly reentered its synthetic outer evaluation"),
-                || {
-                    let diagnostics = check_types(&db, consumer_file);
-                    assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
-                    assert_eq!(diagnostics[0].id(), DiagnosticId::RevealedType);
-                    assert_eq!(
-                        diagnostics[0]
-                            .primary_annotation()
-                            .and_then(|annotation| annotation.get_message()),
-                        Some("`int`")
+        ACTIVE_NON_TERMINAL_CALLS.with(|calls| {
+            calls.visit_scope(scope, || {
+                ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
+                    active.visit(
+                        &scope,
+                        || panic!("test unexpectedly reentered its synthetic outer evaluation"),
+                        || {
+                            let diagnostics = check_types(&db, consumer_file);
+                            assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+                            assert_eq!(diagnostics[0].id(), DiagnosticId::RevealedType);
+                            assert_eq!(
+                                diagnostics[0]
+                                    .primary_annotation()
+                                    .and_then(|annotation| annotation.get_message()),
+                                Some("`int`")
+                            );
+                        },
                     );
-                },
-            );
+                });
+            });
         });
 
         Ok(())

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -195,6 +195,8 @@
 
 use std::cell::RefCell;
 
+use ruff_db::parsed::parsed_module;
+
 use crate::{
     Db,
     dunder_all::dunder_all_names,
@@ -208,6 +210,7 @@ use crate::{
     },
 };
 use ruff_index::{Idx, IndexSlice};
+use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -227,6 +230,7 @@ use ty_python_core::{
     },
     reachability_constraints::{ReachabilityConstraints, ScopedReachabilityConstraintId},
     scope::ScopeId,
+    use_def_map,
 };
 
 /// Narrow `subject_ty` by all preceding unguarded match patterns.
@@ -518,6 +522,11 @@ fn accumulate_constraint<'db>(
     }
 }
 
+std::thread_local! {
+    static ACTIVE_SCOPE_CALL_PREPARATIONS: ActiveRecursionDetector<salsa::Id> = ActiveRecursionDetector::default();
+    static ACTIVE_IMPLICIT_ATTRIBUTE_SCOPES: RefCell<Vec<salsa::Id>> = const { RefCell::new(Vec::new()) };
+}
+
 fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<'db> {
     match predicate.node {
         PredicateNode::Expression(expression) => expression.scope(db),
@@ -530,205 +539,104 @@ fn predicate_scope<'db>(db: &'db dyn Db, predicate: &Predicate<'db>) -> ScopeId<
     }
 }
 
-std::thread_local! {
-    static ACTIVE_REACHABILITY_EVALUATIONS: ActiveRecursionDetector<salsa::Id> =
-        ActiveRecursionDetector::default();
-    static ACTIVE_NON_TERMINAL_CALLS: ActiveNonTerminalCalls = ActiveNonTerminalCalls::default();
-}
+/// Prepares context-independent call predicates in a scope in source order.
+#[salsa::tracked]
+fn prepare_non_terminal_calls_in_scope<'db>(db: &'db dyn Db, scope: ScopeId<'db>) {
+    let use_def = use_def_map(db, scope);
+    let predicates = use_def.predicates();
+    let module = parsed_module(db, scope.file(db)).load(db);
 
-#[derive(Default)]
-struct ActiveNonTerminalCalls {
-    calls: RefCell<Vec<(salsa::Id, ScopedPredicateId)>>,
-    sessions: RefCell<Vec<(salsa::Id, FxHashSet<ScopedPredicateId>)>>,
-}
-
-impl ActiveNonTerminalCalls {
-    fn visit_scope<R>(&self, scope: salsa::Id, f: impl FnOnce() -> R) -> R {
-        self.sessions
-            .borrow_mut()
-            .push((scope, FxHashSet::default()));
-        let _guard = ActiveNonTerminalCallSessionGuard {
-            sessions: &self.sessions,
-            expected_scope: scope,
+    for predicate in predicates.iter() {
+        let PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) = predicate.node
+        else {
+            continue;
         };
-        f()
-    }
-
-    fn visit<R>(&self, scope: salsa::Id, predicate: ScopedPredicateId, f: impl FnOnce() -> R) -> R {
-        self.calls.borrow_mut().push((scope, predicate));
-        let result = {
-            let _guard = ActiveNonTerminalCallGuard {
-                calls: &self.calls,
-                expected: (scope, predicate),
-            };
-            f()
-        };
-        self.mark_prepared(scope, predicate);
-        result
-    }
-
-    fn frontier(&self, scope: salsa::Id) -> Option<ScopedPredicateId> {
-        self.calls
-            .borrow()
-            .iter()
-            .rev()
-            .find_map(|(active_scope, predicate)| (*active_scope == scope).then_some(*predicate))
-    }
-
-    fn is_prepared(&self, scope: salsa::Id, predicate: ScopedPredicateId) -> bool {
-        self.sessions
-            .borrow()
-            .iter()
-            .rev()
-            .find_map(|(active_scope, prepared)| {
-                (*active_scope == scope).then(|| prepared.contains(&predicate))
-            })
-            .unwrap_or(false)
-    }
-
-    fn mark_prepared(&self, scope: salsa::Id, predicate: ScopedPredicateId) {
-        let mut sessions = self.sessions.borrow_mut();
-        let session = sessions
-            .iter_mut()
-            .rev()
-            .find(|(active_scope, _)| *active_scope == scope);
-        debug_assert!(session.is_some(), "an active call needs a worklist session");
-        if let Some((_, prepared)) = session {
-            prepared.insert(predicate);
+        if callable_is_context_independent(callable.node_ref(db).node(&module)) {
+            analyze_single(db, predicate);
         }
     }
 }
 
-struct ActiveNonTerminalCallSessionGuard<'a> {
-    sessions: &'a RefCell<Vec<(salsa::Id, FxHashSet<ScopedPredicateId>)>>,
-    expected_scope: salsa::Id,
-}
-
-impl Drop for ActiveNonTerminalCallSessionGuard<'_> {
-    fn drop(&mut self) {
-        let scope = self.sessions.borrow_mut().pop().map(|(scope, _)| scope);
-        debug_assert_eq!(scope, Some(self.expected_scope));
+fn callable_is_context_independent(callable: &ast::Expr) -> bool {
+    match callable {
+        ast::Expr::Name(_) => true,
+        ast::Expr::Attribute(attribute) => matches!(attribute.value.as_ref(), ast::Expr::Name(_)),
+        _ => false,
     }
 }
 
-struct ActiveNonTerminalCallGuard<'a> {
-    calls: &'a RefCell<Vec<(salsa::Id, ScopedPredicateId)>>,
-    expected: (salsa::Id, ScopedPredicateId),
-}
-
-impl Drop for ActiveNonTerminalCallGuard<'_> {
-    fn drop(&mut self) {
-        debug_assert_eq!(self.calls.borrow_mut().pop(), Some(self.expected));
-    }
-}
-
-fn non_terminal_call_recovery_frontier(
-    db: &dyn Db,
-    predicate: &Predicate,
-) -> Option<ScopedPredicateId> {
-    let scope = predicate_scope(db, predicate).as_id();
-    ACTIVE_NON_TERMINAL_CALLS.with(|active| active.frontier(scope))
-}
-
-fn should_recover_non_terminal_call(
-    db: &dyn Db,
-    predicate_id: ScopedPredicateId,
-    predicate: &Predicate,
-) -> bool {
-    non_terminal_call_recovery_frontier(db, predicate)
-        .is_some_and(|frontier| predicate_id.index() > frontier.index())
-}
-
-/// Infers call predicates reachable from one constraint root in source order.
-///
-/// Predicate IDs are assigned in source order, but the decision diagrams intentionally order
-/// predicates in reverse to reduce their size. Walking the requested graph and inferring its calls
-/// in source order turns a deeply recursive query chain into cache lookups without analyzing calls
-/// from unrelated control-flow paths.
-///
-/// During reentry, calls at or beyond the active frontier cannot be prepared without recreating
-/// the cycle. Calls before it are safe to prepare unless the active scope session already did so.
-fn analyze_non_terminal_call_worklist<'db>(
+pub(crate) fn with_implicit_attribute_call_recovery<'db, R>(
     db: &'db dyn Db,
-    constraints: &ReachabilityConstraints,
-    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    root: ScopedReachabilityConstraintId,
-    recovery_frontier: Option<ScopedPredicateId>,
-) {
-    let mut pending = vec![root];
-    let mut visited = FxHashSet::default();
-    let mut calls = Vec::new();
+    scopes: impl IntoIterator<Item = ScopeId<'db>>,
+    f: impl FnOnce() -> R,
+) -> R {
+    // Preparing calls can affect which Salsa cycle participant supplies the initial value. Keep
+    // the workaround below the query depth at which it is needed, so ordinary functions retain
+    // their existing inference order. The problematic dependency chain grows with call predicates,
+    // not with the total number of control-flow predicates in the scope.
+    const MIN_CALLS_TO_PREPARE: usize = 512;
 
-    while let Some(id) = pending.pop() {
-        if id.is_terminal() || !visited.insert(id) {
-            continue;
-        }
-
-        let node = constraints.get_interior_node(id);
-        if matches!(
-            predicates[node.atom()].node,
-            PredicateNode::IsNonTerminalCall(_)
-        ) {
-            calls.push(node.atom());
-        }
-
-        pending.extend([node.if_true(), node.if_ambiguous(), node.if_false()]);
+    let scopes = scopes
+        .into_iter()
+        .filter(|scope| {
+            use_def_map(db, *scope)
+                .predicates()
+                .iter()
+                .filter(|predicate| matches!(predicate.node, PredicateNode::IsNonTerminalCall(_)))
+                .take(MIN_CALLS_TO_PREPARE)
+                .count()
+                == MIN_CALLS_TO_PREPARE
+        })
+        .collect::<Vec<_>>();
+    if scopes.is_empty() {
+        return f();
     }
 
-    calls.sort_unstable_by_key(|predicate| predicate.index());
-    calls.dedup();
-    for predicate in calls {
-        if recovery_frontier.is_some_and(|frontier| predicate.index() >= frontier.index()) {
-            continue;
-        }
-
-        let predicate_data = &predicates[predicate];
-        let scope = predicate_scope(db, predicate_data).as_id();
-        ACTIVE_NON_TERMINAL_CALLS.with(|active| {
-            if !active.is_prepared(scope, predicate) {
-                active.visit(scope, predicate, || analyze_single(db, predicate_data));
-            }
+    for &scope in &scopes {
+        let key = scope.as_id();
+        ACTIVE_SCOPE_CALL_PREPARATIONS.with(|active| {
+            active.visit(
+                &key,
+                || {},
+                || prepare_non_terminal_calls_in_scope(db, scope),
+            );
         });
     }
+
+    ACTIVE_IMPLICIT_ATTRIBUTE_SCOPES.with(|active| {
+        let original_len = active.borrow().len();
+        active.borrow_mut().extend(scopes.iter().map(AsId::as_id));
+        let _guard = ImplicitAttributeScopesGuard {
+            active,
+            original_len,
+        };
+        f()
+    })
 }
 
-fn evaluate_reachability_constraint<'db>(
-    db: &'db dyn Db,
-    constraints: &ReachabilityConstraints,
-    predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-    mut id: ScopedReachabilityConstraintId,
-    recovery_frontier: Option<ScopedPredicateId>,
-) -> Truthiness {
-    type Id = ScopedReachabilityConstraintId;
+struct ImplicitAttributeScopesGuard<'a> {
+    active: &'a RefCell<Vec<salsa::Id>>,
+    original_len: usize,
+}
 
-    loop {
-        let node = match id {
-            Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
-            Id::AMBIGUOUS => return Truthiness::Ambiguous,
-            Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
-            _ => constraints.get_interior_node(id),
-        };
-        let predicate = &predicates[node.atom()];
-        let truthiness = if recovery_frontier
-            .is_some_and(|frontier| node.atom().index() > frontier.index())
-            && matches!(predicate.node, PredicateNode::IsNonTerminalCall(_))
-        {
-            // Match `analyze_non_terminal_call`'s conservative cycle-initial value. The future
-            // call can affect whether a later implicit-attribute binding is reachable, but it
-            // cannot make the current source position reachable if it was not already. Assuming
-            // that it returns therefore avoids false unreachable results while breaking the
-            // backwards inference cycle.
-            Truthiness::AlwaysTrue.negate_if(!predicate.is_positive)
-        } else {
-            analyze_single(db, predicate)
-        };
-
-        match truthiness {
-            Truthiness::AlwaysTrue => id = node.if_true(),
-            Truthiness::Ambiguous => id = node.if_ambiguous(),
-            Truthiness::AlwaysFalse => id = node.if_false(),
-        }
+impl Drop for ImplicitAttributeScopesGuard<'_> {
+    fn drop(&mut self) {
+        self.active.borrow_mut().truncate(self.original_len);
     }
+}
+
+fn should_recover_implicit_attribute_call(db: &dyn Db, predicate: &Predicate) -> bool {
+    let PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) = predicate.node
+    else {
+        return false;
+    };
+    let scope = callable.scope(db);
+    if !ACTIVE_IMPLICIT_ATTRIBUTE_SCOPES.with(|active| active.borrow().contains(&scope.as_id())) {
+        return false;
+    }
+
+    let module = parsed_module(db, scope.file(db)).load(db);
+    !callable_is_context_independent(callable.node_ref(db).node(&module))
 }
 
 pub(crate) trait ReachabilityConstraintsExtension<'db> {
@@ -747,35 +655,24 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
         &self,
         db: &'db dyn Db,
         predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
-        id: ScopedReachabilityConstraintId,
+        mut id: ScopedReachabilityConstraintId,
     ) -> Truthiness {
-        if id.is_terminal() {
-            return evaluate_reachability_constraint(db, self, predicates, id, None);
-        }
+        type Id = ScopedReachabilityConstraintId;
 
-        let predicate = &predicates[self.get_interior_node(id).atom()];
-        let scope = predicate_scope(db, predicate).as_id();
-        ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
-            active.visit(
-                &scope,
-                || {
-                    let recovery_frontier = non_terminal_call_recovery_frontier(db, predicate);
-                    // This graph can contain earlier calls from a control-flow path that is absent
-                    // from the outer graph. Prepare those calls in source order before evaluating
-                    // the graph, while leaving the active and future calls to cycle recovery.
-                    analyze_non_terminal_call_worklist(db, self, predicates, id, recovery_frontier);
-                    evaluate_reachability_constraint(db, self, predicates, id, recovery_frontier)
-                },
-                || {
-                    ACTIVE_NON_TERMINAL_CALLS.with(|calls| {
-                        calls.visit_scope(scope, || {
-                            analyze_non_terminal_call_worklist(db, self, predicates, id, None);
-                            evaluate_reachability_constraint(db, self, predicates, id, None)
-                        })
-                    })
-                },
-            )
-        })
+        loop {
+            let node = match id {
+                Id::ALWAYS_TRUE => return Truthiness::AlwaysTrue,
+                Id::AMBIGUOUS => return Truthiness::Ambiguous,
+                Id::ALWAYS_FALSE => return Truthiness::AlwaysFalse,
+                _ => self.get_interior_node(id),
+            };
+            let predicate = &predicates[node.atom()];
+            match analyze_single(db, predicate) {
+                Truthiness::AlwaysTrue => id = node.if_true(),
+                Truthiness::Ambiguous => id = node.if_ambiguous(),
+                Truthiness::AlwaysFalse => id = node.if_false(),
+            }
+        }
     }
 }
 
@@ -1096,20 +993,17 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
                 Action::AnalyzeNonTerminal(id) => {
                     let node = self.constraints.get_interior_node(id);
                     let predicate = self.predicates[node.atom];
-                    // Call predicates also gate narrowing. Recover future calls while a worklist
-                    // is active, but retain precise results for calls it has already processed.
-                    let branch = if should_recover_non_terminal_call(self.db, node.atom, &predicate)
+                    let truthiness = if should_recover_implicit_attribute_call(self.db, &predicate)
                     {
-                        node.if_true
+                        Truthiness::AlwaysTrue.negate_if(!predicate.is_positive)
                     } else {
-                        match analyze_single(self.db, &predicate) {
-                            Truthiness::AlwaysTrue => node.if_true,
-                            Truthiness::AlwaysFalse => node.if_false,
-                            Truthiness::Ambiguous => {
-                                unreachable!(
-                                    "`IsNonTerminalCall` predicates should never be Ambiguous"
-                                )
-                            }
+                        analyze_single(self.db, &predicate)
+                    };
+                    let branch = match truthiness {
+                        Truthiness::AlwaysTrue => node.if_true,
+                        Truthiness::AlwaysFalse => node.if_false,
+                        Truthiness::Ambiguous => {
+                            unreachable!("`IsNonTerminalCall` predicates should never be Ambiguous")
                         }
                     };
 
@@ -1715,7 +1609,6 @@ mod tests {
     use ruff_db::system::DbWithWritableSystem as _;
     use ty_python_core::narrowing_constraints::InteriorNode;
     use ty_python_core::predicate::Predicates;
-    use ty_python_core::scope::ScopeKind;
     use ty_python_core::semantic_index;
 
     #[test]
@@ -1781,7 +1674,7 @@ mod tests {
     }
 
     #[test]
-    fn resolved_never_call_is_preserved_during_scope_reentry() -> anyhow::Result<()> {
+    fn never_call_narrowing_is_preserved_during_implicit_attribute_lookup() -> anyhow::Result<()> {
         let mut db = setup_db();
         db.write_files([
             ("/src/package/__init__.py", ""),
@@ -1812,38 +1705,16 @@ class Form(Ui):
             ),
         ])?;
 
-        let ui_file = system_path_to_file(&db, "/src/package/ui.py").unwrap();
-        let index = semantic_index(&db, ui_file);
-        let class_scope = index
-            .child_scopes(FileScopeId::global())
-            .find(|(scope, _)| index.scope(*scope).kind() == ScopeKind::Class)
-            .unwrap()
-            .0;
-        let method_scope = index.child_scopes(class_scope).next().unwrap().0;
-        let scope = method_scope.to_scope_id(&db, ui_file).as_id();
         let consumer_file = system_path_to_file(&db, "/src/package/consumer.py").unwrap();
-
-        ACTIVE_NON_TERMINAL_CALLS.with(|calls| {
-            calls.visit_scope(scope, || {
-                ACTIVE_REACHABILITY_EVALUATIONS.with(|active| {
-                    active.visit(
-                        &scope,
-                        || panic!("test unexpectedly reentered its synthetic outer evaluation"),
-                        || {
-                            let diagnostics = check_types(&db, consumer_file);
-                            assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
-                            assert_eq!(diagnostics[0].id(), DiagnosticId::RevealedType);
-                            assert_eq!(
-                                diagnostics[0]
-                                    .primary_annotation()
-                                    .and_then(|annotation| annotation.get_message()),
-                                Some("`int`")
-                            );
-                        },
-                    );
-                });
-            });
-        });
+        let diagnostics = check_types(&db, consumer_file);
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:#?}");
+        assert_eq!(diagnostics[0].id(), DiagnosticId::RevealedType);
+        assert_eq!(
+            diagnostics[0]
+                .primary_annotation()
+                .and_then(|annotation| annotation.get_message()),
+            Some("`int`")
+        );
 
         Ok(())
     }

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -16,7 +16,9 @@ use crate::{
         DefinedPlace, Definedness, Place, PlaceAndQualifiers, Provenance, PublicTypePolicy,
         TypeOrigin, place_from_bindings, place_from_declarations,
     },
-    reachability::{DeclarationsIteratorExtension, binding_reachability},
+    reachability::{
+        DeclarationsIteratorExtension, binding_reachability, with_implicit_attribute_call_recovery,
+    },
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, CallArguments, CallableType, ClassBase,
         ClassLiteral, ClassType, DATACLASS_FLAGS, DataclassFlags, DataclassParams, GenericAlias,
@@ -2199,10 +2201,15 @@ impl<'db> StaticClassLiteral<'db> {
             return Member::unbound();
         }
 
-        Self::implicit_attribute_inner(
-            db,
-            ImplicitAttributeName::new(db, class_body_scope, name, target_method_decorator),
-        )
+        let file = class_body_scope.file(db);
+        let method_scopes = attribute_assignments(db, class_body_scope, name)
+            .map(|(_, method_scope)| method_scope.to_scope_id(db, file));
+        with_implicit_attribute_call_recovery(db, method_scopes, || {
+            Self::implicit_attribute_inner(
+                db,
+                ImplicitAttributeName::new(db, class_body_scope, name, target_method_decorator),
+            )
+        })
     }
 
     #[salsa::tracked(

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -346,6 +346,7 @@ fn unbound_symbol_no_reachability_constraint_check() {
 }
 
 const MANY_WIDGETS: usize = 400;
+const MANY_BRANCH_NON_TERMINAL_CALLS: usize = 5_000;
 const MANY_NON_TERMINAL_CALLS: usize = 1_100;
 const FEW_NON_TERMINAL_CALLS: usize = 80;
 
@@ -530,6 +531,67 @@ class Form(Ui):
             ])?;
 
             assert_revealed_type(&db, "/src/consumer.py", "Widget");
+
+            Ok(())
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn branch_local_calls_reentered_by_implicit_attribute_do_not_overflow_stack() -> anyhow::Result<()>
+{
+    let handle = std::thread::Builder::new()
+        .name("branch-local-call-stack-test".into())
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(|| {
+            let mut db = setup_db();
+            let mut ui = String::from(
+                r#"from helpers import noop
+from widgets import Widget
+
+class Ui:
+    def setup(self, flag: bool):
+        if flag:
+"#,
+            );
+            for _ in 0..MANY_BRANCH_NON_TERMINAL_CALLS {
+                ui.push_str("            noop()\n");
+            }
+            ui.push_str(
+                r#"            self.target = Widget()
+            return
+        self.target.configure()
+"#,
+            );
+
+            db.write_files([
+                ("/src/helpers.py", "def noop() -> None: ...\n"),
+                (
+                    "/src/widgets.py",
+                    r#"class Widget:
+    def configure(self) -> None: ...
+"#,
+                ),
+                ("/src/ui.py", &ui),
+            ])?;
+
+            let file = system_path_to_file(&db, "/src/ui.py").unwrap();
+            let index = semantic_index(&db, file);
+            let class_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+            let function_scope = index.child_scopes(class_scope).next().unwrap().0;
+            let use_def = index.use_def_map(function_scope);
+            // The fallthrough graph only contains the call on the non-returning branch. Inferring
+            // its receiver reenters the assignment graph on the returning branch, whose calls
+            // therefore have not been prepared by the outer worklist.
+            assert_eq!(
+                use_def.reachability_constraints().evaluate(
+                    &db,
+                    use_def.predicates(),
+                    use_def.end_of_scope_reachability(),
+                ),
+                Truthiness::Ambiguous,
+            );
 
             Ok(())
         })?;

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -2,6 +2,7 @@ use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
 use crate::place::{ConsideredDefinitions, Place, global_symbol};
+use crate::reachability::ReachabilityConstraintsExtension;
 use crate::types::{KnownClass, KnownInstanceType, check_types};
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::{File, system_path_to_file};
@@ -9,7 +10,7 @@ use ruff_db::system::DbWithWritableSystem as _;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
 use ty_python_core::definition::Definition;
 use ty_python_core::scope::FileScopeId;
-use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
+use ty_python_core::{Truthiness, global_scope, place_table, semantic_index, use_def_map};
 
 use super::*;
 
@@ -349,6 +350,72 @@ const MANY_NON_TERMINAL_CALLS: usize = 1_100;
 const FEW_NON_TERMINAL_CALLS: usize = 80;
 
 #[test]
+fn non_terminal_call_worklist_skips_non_reaching_branch() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented(
+        "/src/test.py",
+        r#"
+        def f(flag: bool) -> None:
+            if flag:
+                print()
+                return
+            len(())
+        "#,
+    )?;
+
+    let file = system_path_to_file(&db, "/src/test.py").unwrap();
+    db.clear_salsa_events();
+    {
+        let index = semantic_index(&db, file);
+        let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
+        let use_def = index.use_def_map(function_scope);
+        assert_eq!(
+            use_def.reachability_constraints().evaluate(
+                &db,
+                use_def.predicates(),
+                use_def.end_of_scope_reachability(),
+            ),
+            Truthiness::Ambiguous,
+        );
+    }
+    let events = db.take_salsa_events();
+
+    let module = parsed_module(&db, file).load(&db);
+    let function = module.syntax().body[0].as_function_def_stmt().unwrap();
+    let if_statement = function.body[0].as_if_stmt().unwrap();
+    let print_call = if_statement.body[0]
+        .as_expr_stmt()
+        .unwrap()
+        .value
+        .as_call_expr()
+        .unwrap();
+    let len_call = function.body[1]
+        .as_expr_stmt()
+        .unwrap()
+        .value
+        .as_call_expr()
+        .unwrap();
+    let index = semantic_index(&db, file);
+    let print_expression = index.expression(print_call.func.as_ref());
+    let len_expression = index.expression(len_call.func.as_ref());
+
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(print_expression),
+        &events,
+    );
+    assert_function_query_was_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(len_expression),
+        &events,
+    );
+
+    Ok(())
+}
+
+#[test]
 fn implicit_attribute_after_many_non_terminal_calls() -> anyhow::Result<()> {
     let handle = std::thread::Builder::new()
         .name("implicit-attribute-stack-test".into())
@@ -395,6 +462,69 @@ class Form(Ui):
     def target_widget(self) -> Widget:
         reveal_type(self.target)
         return self.target
+"#,
+                ),
+            ])?;
+
+            assert_revealed_type(&db, "/src/consumer.py", "Widget");
+
+            Ok(())
+        })?;
+
+    handle.join().expect("regression test thread panicked")
+}
+
+#[test]
+fn early_call_reentering_late_implicit_attribute_does_not_overflow_stack() -> anyhow::Result<()> {
+    let handle = std::thread::Builder::new()
+        .name("early-late-implicit-attribute-stack-test".into())
+        .stack_size(ruff_db::STACK_SIZE)
+        .spawn(|| {
+            let mut db = setup_db();
+            let mut ui = String::from(
+                r#"from widgets import Widget
+
+class Ui:
+    def __init__(self):
+        self.target = Widget()
+
+    def setup(self):
+        self.target.configure()
+        self.early = Widget()
+"#,
+            );
+
+            for index in 0..MANY_WIDGETS {
+                ui.push_str(&format!(
+                    concat!(
+                        "        self.widget_{index} = Widget()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                        "        self.widget_{index}.configure()\n",
+                    ),
+                    index = index,
+                ));
+            }
+            ui.push_str("        self.target = Widget()\n");
+
+            db.write_files([
+                (
+                    "/src/widgets.py",
+                    r#"class Widget:
+    def configure(self) -> None: ...
+"#,
+                ),
+                ("/src/ui.py", &ui),
+                (
+                    "/src/consumer.py",
+                    r#"from typing_extensions import reveal_type
+from ui import Ui
+from widgets import Widget
+
+class Form(Ui):
+    def early_widget(self) -> Widget:
+        reveal_type(self.early)
+        return self.early
 "#,
                 ),
             ])?;

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -351,7 +351,7 @@ const MANY_NON_TERMINAL_CALLS: usize = 1_100;
 const FEW_NON_TERMINAL_CALLS: usize = 80;
 
 #[test]
-fn non_terminal_call_worklist_skips_non_reaching_branch() -> anyhow::Result<()> {
+fn reachability_skips_call_on_non_reaching_branch() -> anyhow::Result<()> {
     let mut db = setup_db();
     db.write_dedented(
         "/src/test.py",
@@ -582,8 +582,7 @@ class Ui:
             let function_scope = index.child_scopes(class_scope).next().unwrap().0;
             let use_def = index.use_def_map(function_scope);
             // The fallthrough graph only contains the call on the non-returning branch. Inferring
-            // its receiver reenters the assignment graph on the returning branch, whose calls
-            // therefore have not been prepared by the outer worklist.
+            // its receiver reenters the assignment graph on the returning branch.
             assert_eq!(
                 use_def.reachability_constraints().evaluate(
                     &db,


### PR DESCRIPTION
## Summary

This is a follow-up to https://github.com/astral-sh/ruff/pull/26272.

We record a reachability predicate for every statement-level call because the call may return `Never`. The previous implementation prevented a reverse Salsa dependency chain by eagerly inferring every preceding call, including calls on control-flow paths that the query did not need. Scope-wide work-list variants also made reentrant implicit-attribute inference order-dependent: recovering every call could discard resolved `Never` narrowing, while leaving calls unprepared in a nested graph could restore the stack overflow.

This change moves the primary ordering rule into reachability-diagram construction. Ordinary control-flow predicates remain ahead of statement-level call predicates, while call predicates are ordered by source position. Evaluation therefore remains demand-driven—calls on unreachable branches are not inferred—but calls along the selected path cannot form a backward dependency chain.

Implicit-attribute lookup is the exceptional entry point because it can begin from a late assignment before ordinary reachability evaluation has prepared earlier calls. For method scopes with at least 512 call predicates, we prepare context-independent calls in source order before entering the implicit-attribute query and conservatively recover context-dependent receiver calls during reentry. The threshold confines the query-order change to graphs deep enough to threaten the worker stack, while direct functions and name-based attributes such as `sys.exit` retain their resolved `Never` result.

The regressions cover the original large implicit-attribute case, early calls that reenter a later assignment, calls isolated on another control-flow branch, nested implicit-attribute graphs, preservation of `Never` narrowing, and avoiding inference on an unreachable branch. The full semantic/core suite and Clippy pass. In the local `attrs` project benchmark, this implementation takes roughly 293 ms, compared with roughly 1008 ms for the scope-wide work-list implementation and 259 ms on `main`.