### PR TITLE
[ty] Avoid string allocations in implicit attribute queries

### DIFF
--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -2295,7 +2295,7 @@ pub(super) struct AbstractMethod<'db> {
 }
 
 /// The decorator category for a method-like function.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, get_size2::GetSize)]
 pub enum MethodDecorator {
     /// An instance method with an implicit instance receiver, conventionally named `self`.
     #[default]

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -2201,7 +2201,7 @@ impl<'db> StaticClassLiteral<'db> {
         Self::implicit_attribute_inner(
             db,
             class_body_scope,
-            name.to_string(),
+            Name::new(name),
             target_method_decorator,
         )
     }
@@ -2216,7 +2216,7 @@ impl<'db> StaticClassLiteral<'db> {
     pub(super) fn implicit_attribute_inner(
         db: &'db dyn Db,
         class_body_scope: ScopeId<'db>,
-        name: String,
+        name: Name,
         target_method_decorator: MethodDecorator,
     ) -> Member<'db> {
         // If we do not see any declarations of an attribute, neither in the class body nor in
@@ -3206,7 +3206,7 @@ fn implicit_attribute_cycle_recover<'db>(
     previous_member: &Member<'db>,
     member: Member<'db>,
     _class_body_scope: ScopeId<'db>,
-    _name: String,
+    _name: Name,
     _target_method_decorator: MethodDecorator,
 ) -> Member<'db> {
     let inner = member

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -1,3 +1,4 @@
+use compact_str::CompactString;
 use itertools::{Either, Itertools};
 use ruff_db::{
     diagnostic::Span,
@@ -2200,25 +2201,25 @@ impl<'db> StaticClassLiteral<'db> {
 
         Self::implicit_attribute_inner(
             db,
-            class_body_scope,
-            Name::new(name),
-            target_method_decorator,
+            ImplicitAttributeName::new(db, class_body_scope, name, target_method_decorator),
         )
     }
 
     #[salsa::tracked(
         cycle_fn=implicit_attribute_cycle_recover,
-        cycle_initial=|_, id, _, _, _| Member {
+        cycle_initial=|_, id, _| Member {
             inner: Place::bound(Type::divergent(id)).into(),
         },
         heap_size=ruff_memory_usage::heap_size,
     )]
-    pub(super) fn implicit_attribute_inner(
+    fn implicit_attribute_inner(
         db: &'db dyn Db,
-        class_body_scope: ScopeId<'db>,
-        name: Name,
-        target_method_decorator: MethodDecorator,
+        attribute: ImplicitAttributeName<'db>,
     ) -> Member<'db> {
+        let class_body_scope = attribute.class_body_scope(db);
+        let name = attribute.name(db);
+        let target_method_decorator = attribute.target_method_decorator(db);
+
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of the raw types inferred from all bindings of that
         // attribute, then apply public-type promotion to the final union.
@@ -2277,7 +2278,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         // First check declarations
         for (attribute_declarations, method_scope_id) in
-            attribute_declarations(db, class_body_scope, &name)
+            attribute_declarations(db, class_body_scope, name)
         {
             let method_scope = index.scope(method_scope_id);
             if !is_valid_scope(method_scope) {
@@ -2337,7 +2338,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         for (attribute_assignments, attribute_binding_scope_id) in
-            attribute_assignments(db, class_body_scope, &name)
+            attribute_assignments(db, class_body_scope, name)
         {
             let binding_scope = index.scope(attribute_binding_scope_id);
             if !is_valid_scope(binding_scope) {
@@ -3181,6 +3182,17 @@ fn explicit_bases_cycle_fn<'db>(
     }
 }
 
+#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+struct ImplicitAttributeName<'db> {
+    class_body_scope: ScopeId<'db>,
+    #[returns(deref)]
+    name: CompactString,
+    target_method_decorator: MethodDecorator,
+}
+
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for ImplicitAttributeName<'_> {}
+
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>) -> Box<[Name]> {
     let index = semantic_index(db, class_body_scope.file(db));
@@ -3205,9 +3217,7 @@ fn implicit_attribute_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous_member: &Member<'db>,
     member: Member<'db>,
-    _class_body_scope: ScopeId<'db>,
-    _name: Name,
-    _target_method_decorator: MethodDecorator,
+    _attribute: ImplicitAttributeName<'db>,
 ) -> Member<'db> {
     let inner = member
         .inner


### PR DESCRIPTION
## Summary

Use `Name` for implicit attribute query keys instead of allocating a `String` for every lookup. This keeps typical attribute names inline and makes cached input clones allocation-free.

## Test Plan

Testing: Passed targeted semantic tests and repository hooks.
