### PR TITLE
[ty] Record configured crates.io packages

### DIFF
--- a/.known-crates
+++ b/.known-crates
@@ -28,6 +28,10 @@ ruff_source_file
 ruff_text_size
 ruff_wasm
 ruff_workspace
+ty_combine
 ty_module_resolver
+ty_python_core
+ty_python_semantic
 ty_site_packages
 ty_static
+ty_vendored


### PR DESCRIPTION
## Summary

Record `ty_combine`, `ty_python_core`, `ty_python_semantic`, and `ty_vendored` as configured for crates.io trusted publishing after #26323 made them publishable.

The bootstrap script uses `.known-crates` as a persistent checkpoint and skips entries on later runs. Checking in the generated result makes subsequent bootstrap runs a no-op until another workspace package becomes publishable.

The generated file now matches all 36 publishable workspace packages.
