### PR TITLE
[ty] Support basic usages of `__class__`

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -1,0 +1,90 @@
+# The `__class__` closure cell
+
+Python implicitly creates a closure cell named `__class__` for methods defined in a class body. The
+cell is available in instance methods, static methods, and class methods.
+
+## Method scopes
+
+```py
+class C:
+    def method(self) -> None:
+        reveal_type(__class__)  # revealed: <class 'C'>
+
+    @staticmethod
+    def static_method() -> None:
+        reveal_type(__class__)  # revealed: <class 'C'>
+
+    @classmethod
+    def class_method(cls) -> None:
+        reveal_type(__class__)  # revealed: <class 'C'>
+
+    lambda_method = lambda self: reveal_type(__class__)  # revealed: <class 'C'>
+```
+
+## Class bodies and method defaults
+
+The cell is not available directly in the class body or while evaluating a method's default
+arguments.
+
+```py
+class C:
+    __class__  # error: [unresolved-reference]
+
+    def method(
+        self,
+        value=__class__,  # error: [unresolved-reference]
+    ) -> None: ...
+```
+
+## Nested scopes
+
+The cell is captured by scopes nested inside a method. A method defined in a nested class receives a
+new cell for that class.
+
+```py
+class Outer:
+    def method(self) -> None:
+        def nested() -> None:
+            reveal_type(__class__)  # revealed: <class 'Outer'>
+
+        class Inner:
+            reveal_type(__class__)  # revealed: <class 'Outer'>
+
+            def method(self) -> None:
+                reveal_type(__class__)  # revealed: <class 'Inner'>
+```
+
+## Shadowing
+
+The implicit cell takes precedence over a global with the same name. Local bindings and explicit
+`global` declarations continue to take precedence over the cell.
+
+```py
+__class__ = int
+
+class D:
+    def implicit(self) -> None:
+        reveal_type(__class__)  # revealed: <class 'D'>
+
+    def local(self) -> None:
+        __class__ = str
+        reveal_type(__class__)  # revealed: <class 'str'>
+
+    def explicit_global(self) -> None:
+        global __class__
+        reveal_type(__class__)  # revealed: <class 'int'>
+```
+
+## Generic methods
+
+The type-parameter scope of a generic method can also access the cell.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Generic:
+    def method[T: __class__](self) -> None: ...
+```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -75,7 +75,69 @@ class D:
         reveal_type(__class__)  # revealed: <class 'int'>
 ```
 
-## Generic methods
+## Lexical precedence
+
+The cell is located between the method and class scopes. It takes precedence over bindings outside
+the class, but an intervening `global` declaration redirects lookups to the module scope.
+
+```py
+def outer() -> None:
+    __class__ = int
+
+    class C:
+        def method(self) -> None:
+            reveal_type(__class__)  # revealed: <class 'C'>
+
+__class__ = int
+
+class D:
+    def method(self) -> None:
+        global __class__
+
+        def nested() -> None:
+            reveal_type(__class__)  # revealed: <class 'int'>
+```
+
+## Type alias annotation scopes
+
+PEP 695 type aliases defined in class bodies can access the class namespace. When no class-local
+binding named `__class__` exists, the name refers to the containing class.
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class Direct:
+    type Alias = __class__
+
+def direct(value: Direct.Alias) -> None:
+    reveal_type(value)  # revealed: Direct
+
+class Generic:
+    type Alias[T] = __class__
+
+def generic(value: Generic.Alias[int]) -> None:
+    reveal_type(value)  # revealed: Generic
+
+class Shadowed:
+    __class__ = int
+    type Alias = __class__
+
+def shadowed(value: Shadowed.Alias) -> None:
+    reveal_type(value)  # revealed: int
+
+class Outer:
+    def method(self) -> None:
+        class Inner:
+            type Alias = __class__
+
+        def nested(value: Inner.Alias) -> None:
+            reveal_type(value)  # revealed: Inner
+```
+
+## Generic method bounds
 
 The type-parameter scope of a generic method can also access the cell.
 
@@ -87,4 +149,37 @@ python-version = "3.12"
 ```py
 class Generic:
     def method[T: __class__](self) -> None: ...
+```
+
+## Eager generic method annotations
+
+On Python 3.12 and 3.13, ordinary method annotations are evaluated before the cell is initialized.
+
+```toml
+[environment]
+python-version = "3.13"
+```
+
+```py
+class C:
+    def method[T](
+        self,
+        value: __class__,  # error: [unresolved-reference]
+    ) -> None: ...
+```
+
+## Deferred generic method annotations
+
+Python 3.14 defers annotation evaluation, making the cell available to ordinary annotations as well
+as type-parameter bounds.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class C:
+    def method[T](self, value: __class__) -> __class__:
+        raise NotImplementedError
 ```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -17,8 +17,6 @@ class C:
     @classmethod
     def class_method(cls) -> None:
         reveal_type(__class__)  # revealed: <class 'C'>
-
-    lambda_method = lambda self: reveal_type(__class__)  # revealed: <class 'C'>
 ```
 
 ## Class bodies and method defaults
@@ -34,37 +32,6 @@ class C:
         self,
         value=__class__,  # error: [unresolved-reference]
     ) -> None: ...
-```
-
-## Nested scopes
-
-The cell is captured by scopes nested inside a method. A method defined in a nested class receives a
-new cell for that class.
-
-```py
-class Outer:
-    def method(self) -> None:
-        def nested() -> None:
-            reveal_type(__class__)  # revealed: <class 'Outer'>
-
-        class Inner:
-            reveal_type(__class__)  # revealed: <class 'Outer'>
-
-            def method(self) -> None:
-                reveal_type(__class__)  # revealed: <class 'Inner'>
-```
-
-## Generator expressions
-
-Generator expressions are evaluated lazily and capture the cell when they are defined directly in a
-class body.
-
-```py
-class C:
-    values = (
-        reveal_type(__class__)  # revealed: <class 'C'>
-        for _ in range(1)
-    )
 ```
 
 ## Shadowing
@@ -86,132 +53,4 @@ class D:
     def explicit_global(self) -> None:
         global __class__
         reveal_type(__class__)  # revealed: <class 'int'>
-```
-
-## Lexical precedence
-
-The cell is located between the method and class scopes. It takes precedence over bindings outside
-the class, but an intervening `global` declaration redirects lookups to the module scope.
-
-```py
-def outer() -> None:
-    __class__ = int
-
-    class C:
-        def method(self) -> None:
-            reveal_type(__class__)  # revealed: <class 'C'>
-
-__class__ = int
-
-class D:
-    def method(self) -> None:
-        global __class__
-
-        def nested() -> None:
-            reveal_type(__class__)  # revealed: <class 'int'>
-```
-
-An unbound method-local `__class__` shadows the implicit cell, including from an eager nested scope.
-
-```py
-class C:
-    def method(self) -> None:
-        class Inner:
-            # error: [unresolved-reference]
-            # revealed: Unknown
-            reveal_type(__class__)
-
-        __class__ = int
-```
-
-## Type alias annotation scopes
-
-PEP 695 type aliases defined in class bodies can access the class namespace. When no class-local
-binding named `__class__` exists, the name refers to the containing class.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-class Direct:
-    type Alias = __class__
-
-def direct(value: Direct.Alias) -> None:
-    reveal_type(value)  # revealed: Direct
-
-class Generic:
-    type Alias[T] = __class__
-
-def generic(value: Generic.Alias[int]) -> None:
-    reveal_type(value)  # revealed: Generic
-
-class Shadowed:
-    __class__ = int
-    type Alias = __class__
-
-def shadowed(value: Shadowed.Alias) -> None:
-    reveal_type(value)  # revealed: int
-
-class Outer:
-    def method(self) -> None:
-        class Inner:
-            type Alias = __class__
-
-        def nested(value: Inner.Alias) -> None:
-            reveal_type(value)  # revealed: Inner
-```
-
-## Generic method bounds
-
-The type-parameter scope of a generic method can also access the cell.
-
-```toml
-[environment]
-python-version = "3.12"
-```
-
-```py
-class Generic:
-    def method[T: __class__](self) -> None: ...
-```
-
-## Eager generic method annotations
-
-On Python 3.12 and 3.13, ordinary method annotations are evaluated before the cell is initialized.
-
-```toml
-[environment]
-python-version = "3.13"
-```
-
-```py
-class C:
-    def method[T](
-        self,
-        value: __class__,  # error: [unresolved-reference]
-    ) -> None: ...
-```
-
-## Deferred method annotations
-
-Python 3.14 defers annotation evaluation, making the cell available to ordinary annotations as well
-as type-parameter bounds.
-
-```toml
-[environment]
-python-version = "3.14"
-```
-
-```py
-class C:
-    def method[T](self, value: __class__) -> __class__:
-        raise NotImplementedError
-
-class Outer:
-    def method(self) -> None:
-        class Inner:
-            def annotated(self, value: __class__) -> None:
-                reveal_type(value)  # revealed: Inner
 ```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -54,3 +54,91 @@ class D:
         global __class__
         reveal_type(__class__)  # revealed: <class 'int'>
 ```
+
+## Known limitations
+
+The implicit cell is currently only modeled in direct method bodies. The following valid uses are
+left unresolved until the cell can be represented at the correct lexical scope boundary.
+
+### Nested function and lambda scopes
+
+```py
+class C:
+    def method(self) -> None:
+        def nested() -> None:
+            # TODO: This should reveal `<class 'C'>` without an error.
+            # error: [unresolved-reference]
+            # revealed: Unknown
+            reveal_type(__class__)
+
+    lambda_method = lambda: (
+        # TODO: This should reveal `<class 'C'>` without an error.
+        # error: [unresolved-reference]
+        # revealed: Unknown
+        reveal_type(__class__)
+    )
+```
+
+### Generator expressions
+
+Generator expressions created in a class body capture the cell because they are evaluated lazily.
+
+```py
+class C:
+    values = (
+        # TODO: This should reveal `<class 'C'>` without an error.
+        # error: [unresolved-reference]
+        # revealed: Unknown
+        reveal_type(__class__)
+        for _ in range(1)
+    )
+```
+
+### Type alias annotation scopes
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class C:
+    # TODO: This should resolve to `C` without an error.
+    type Alias = __class__  # error: [unresolved-reference]
+
+    # TODO: This should resolve to `C` without an error.
+    type GenericAlias[T] = __class__  # error: [unresolved-reference]
+```
+
+### Generic method bounds
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+class C:
+    # TODO: The bound should resolve to `C` without an error.
+    def method[T: __class__](self) -> None: ...  # error: [unresolved-reference]
+```
+
+### Deferred method annotations
+
+Python 3.14 defers annotation evaluation, so ordinary method annotations can access the cell.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+class C:
+    def method(
+        self,
+        # TODO: This should resolve to `C` without an error.
+        value: __class__,  # error: [unresolved-reference]
+        # TODO: This should resolve to `C` without an error.
+    ) -> __class__:  # error: [unresolved-reference]
+        raise NotImplementedError
+```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -19,6 +19,17 @@ class C:
         reveal_type(__class__)  # revealed: <class 'C'>
 ```
 
+## Lambda scopes
+
+Lambdas defined directly in a class body also capture the cell. Lambda parameters continue to take
+precedence over it.
+
+```py
+class C:
+    lambda_method = lambda: reveal_type(__class__)  # revealed: <class 'C'>
+    shadowed = lambda __class__: reveal_type(__class__)  # revealed: Unknown
+```
+
 ## Class bodies and method defaults
 
 The cell is not available directly in the class body or while evaluating a method's default
@@ -57,10 +68,11 @@ class D:
 
 ## Known limitations
 
-The implicit cell is currently only modeled in direct method bodies. The following valid uses are
-left unresolved until the cell can be represented at the correct lexical scope boundary.
+The implicit cell is currently only modeled in direct method bodies and lambdas defined directly in
+a class body. The following valid uses are left unresolved until the cell can be represented at the
+correct lexical scope boundary.
 
-### Nested function and lambda scopes
+### Nested function scopes
 
 ```py
 class C:
@@ -70,13 +82,6 @@ class C:
             # error: [unresolved-reference]
             # revealed: Unknown
             reveal_type(__class__)
-
-    lambda_method = lambda: (
-        # TODO: This should reveal `<class 'C'>` without an error.
-        # error: [unresolved-reference]
-        # revealed: Unknown
-        reveal_type(__class__)
-    )
 ```
 
 ### Generator expressions

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -54,6 +54,19 @@ class Outer:
                 reveal_type(__class__)  # revealed: <class 'Inner'>
 ```
 
+## Generator expressions
+
+Generator expressions are evaluated lazily and capture the cell when they are defined directly in a
+class body.
+
+```py
+class C:
+    values = (
+        reveal_type(__class__)  # revealed: <class 'C'>
+        for _ in range(1)
+    )
+```
+
 ## Shadowing
 
 The implicit cell takes precedence over a global with the same name. Local bindings and explicit
@@ -96,6 +109,19 @@ class D:
 
         def nested() -> None:
             reveal_type(__class__)  # revealed: <class 'int'>
+```
+
+An unbound method-local `__class__` shadows the implicit cell, including from an eager nested scope.
+
+```py
+class C:
+    def method(self) -> None:
+        class Inner:
+            # error: [unresolved-reference]
+            # revealed: Unknown
+            reveal_type(__class__)
+
+        __class__ = int
 ```
 
 ## Type alias annotation scopes
@@ -168,7 +194,7 @@ class C:
     ) -> None: ...
 ```
 
-## Deferred generic method annotations
+## Deferred method annotations
 
 Python 3.14 defers annotation evaluation, making the cell available to ordinary annotations as well
 as type-parameter bounds.
@@ -182,4 +208,10 @@ python-version = "3.14"
 class C:
     def method[T](self, value: __class__) -> __class__:
         raise NotImplementedError
+
+class Outer:
+    def method(self) -> None:
+        class Inner:
+            def annotated(self, value: __class__) -> None:
+                reveal_type(value)  # revealed: Inner
 ```

--- a/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
+++ b/crates/ty_python_semantic/resources/mdtest/scopes/dunder_class.md
@@ -30,6 +30,32 @@ class C:
     shadowed = lambda __class__: reveal_type(__class__)  # revealed: Unknown
 ```
 
+## Generator expression scopes
+
+The body of a generator expression defined directly in a class captures the cell because it is
+evaluated lazily. The first iterable is evaluated eagerly in the class body, where the cell is not
+yet available. Eager comprehension bodies likewise cannot access the cell.
+
+```py
+class C:
+    values = (
+        reveal_type(__class__)  # revealed: <class 'C'>
+        for _ in range(1)
+    )
+
+    first_iterable = (
+        value
+        for value in (
+            __class__,  # error: [unresolved-reference]
+        )
+    )
+
+    eager_comprehension = [
+        __class__  # error: [unresolved-reference]
+        for _ in range(1)
+    ]
+```
+
 ## Class bodies and method defaults
 
 The cell is not available directly in the class body or while evaluating a method's default
@@ -68,9 +94,9 @@ class D:
 
 ## Known limitations
 
-The implicit cell is currently only modeled in direct method bodies and lambdas defined directly in
-a class body. The following valid uses are left unresolved until the cell can be represented at the
-correct lexical scope boundary.
+The implicit cell is currently only modeled in direct method bodies and lazy scopes defined directly
+in a class body. The following valid uses are left unresolved until the cell can be represented at
+the correct lexical scope boundary.
 
 ### Nested function scopes
 
@@ -82,21 +108,6 @@ class C:
             # error: [unresolved-reference]
             # revealed: Unknown
             reveal_type(__class__)
-```
-
-### Generator expressions
-
-Generator expressions created in a class body capture the cell because they are evaluated lazily.
-
-```py
-class C:
-    values = (
-        # TODO: This should reveal `<class 'C'>` without an error.
-        # error: [unresolved-reference]
-        # revealed: Unknown
-        reveal_type(__class__)
-        for _ in range(1)
-    )
 ```
 
 ### Type alias annotation scopes

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1685,52 +1685,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
-    /// Returns the type of the implicit `__class__` cell at a method/class scope boundary.
-    fn dunder_class_cell_type(
-        &self,
-        inner: &NodeWithScopeKind,
-        outer: &NodeWithScopeKind,
-        inside_generic_method_body: bool,
-    ) -> Option<Type<'db>> {
-        let cell_is_visible = match inner {
-            NodeWithScopeKind::Function(_)
-            | NodeWithScopeKind::Lambda(_)
-            | NodeWithScopeKind::GeneratorExpression(_) => true,
-            NodeWithScopeKind::FunctionTypeParameters(_) => {
-                inside_generic_method_body || self.is_deferred()
-            }
-            NodeWithScopeKind::TypeAlias(_) | NodeWithScopeKind::TypeAliasTypeParameters(_) => true,
-            _ => false,
-        };
-        if !cell_is_visible {
-            return None;
-        }
-
-        let class = outer.as_class()?;
-        let definition = self.index.expect_single_definition(class);
-        original_class_type(self.db(), definition).map(Type::ClassLiteral)
-    }
-
-    /// Returns the implicit `__class__` cell used to evaluate a deferred method annotation.
-    fn deferred_method_annotation_class_type(&self) -> Option<Type<'db>> {
-        if !self.is_deferred()
-            || !self.inference_flags().intersects(
-                InferenceFlags::IN_PARAMETER_ANNOTATION | InferenceFlags::IN_RETURN_TYPE,
-            )
-        {
-            return None;
-        }
-
-        let InferenceRegion::Deferred(definition) = self.region else {
-            return None;
-        };
-        let DefinitionKind::Function(function) = definition.kind(self.db()) else {
-            return None;
-        };
-        let function_scope = self
-            .index
-            .node_scope(NodeWithScopeRef::Function(function.node(self.module())));
-        let class_definition = self.index.class_definition_of_method(function_scope)?;
+    /// Returns the type of the implicit `__class__` cell in the current direct method body.
+    fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
+        let current_scope_id = self.scope().file_scope_id(self.db());
+        let class_definition = self.index.class_definition_of_method(current_scope_id)?;
         original_class_type(self.db(), class_definition).map(Type::ClassLiteral)
     }
 
@@ -9596,10 +9554,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Place::Undefined.into();
             }
 
-            let is_dunder_class = place_expr
+            if place_expr
                 .as_symbol()
-                .is_some_and(|symbol| symbol.name() == "__class__");
-            if is_dunder_class && let Some(ty) = self.deferred_method_annotation_class_type() {
+                .is_some_and(|symbol| symbol.name() == "__class__")
+                && let Some(ty) = self.dunder_class_cell_type()
+            {
                 return Place::bound(ty).into();
             }
 
@@ -9666,70 +9625,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // cases we're being too deferential to local bindings. Unfortunately the fully sound
             // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
             // which is too frustrating for users in practice.
-            let mut inside_generic_method_body = false;
-            let mut dunder_class_shadowed_by_local = false;
-            for ((_, inner_scope), (enclosing_scope_file_id, enclosing_scope)) in
-                self.index.ancestor_scopes(file_scope_id).tuple_windows()
-            {
+            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
                 // If the current enclosing scope is global, no place lookup is performed here,
                 // instead falling back to the module's explicit global lookup below.
                 if enclosing_scope_file_id.is_global() {
                     break;
                 }
 
-                if matches!(inner_scope.node(), NodeWithScopeKind::Function(_))
-                    && matches!(
-                        enclosing_scope.node(),
-                        NodeWithScopeKind::FunctionTypeParameters(_)
-                    )
-                {
-                    inside_generic_method_body = true;
-                }
-
-                if is_dunder_class
-                    && enclosing_scope.kind().is_function_like()
-                    && let Some(symbol) = self
-                        .index
-                        .place_table(enclosing_scope_file_id)
-                        .symbol_by_name("__class__")
-                    && symbol.is_local()
-                {
-                    dunder_class_shadowed_by_local = true;
-                }
-
-                let dunder_class_cell_type = is_dunder_class
-                    .then(|| {
-                        self.dunder_class_cell_type(
-                            inner_scope.node(),
-                            enclosing_scope.node(),
-                            inside_generic_method_body,
-                        )
-                    })
-                    .flatten();
-                let resolve_dunder_class_cell = |ty| -> PlaceAndQualifiers<'db> {
-                    if dunder_class_shadowed_by_local {
-                        Place::Undefined.into()
-                    } else {
-                        Place::bound(ty).into()
-                    }
-                };
-
                 // Class scopes are not visible to nested scopes, and we need to handle global
                 // scope differently (because an unbound name there falls back to builtins), so
                 // check only function-like scopes.
                 // There is one exception to this rule: annotation scopes can see
                 // names defined in an immediately-enclosing class scope.
-                let is_immediately_enclosing_scope = inner_scope.kind().is_annotation()
-                    && !inside_generic_method_body
-                    && enclosing_scope.kind().is_class();
+                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
 
-                // For methods, the cell sits inside the class namespace and therefore takes
-                // precedence over class and outer-scope bindings. Annotation scopes can access
-                // the class namespace itself, so their explicit class bindings take precedence
-                // over the cell.
-                if !is_immediately_enclosing_scope && let Some(ty) = dunder_class_cell_type {
-                    return resolve_dunder_class_cell(ty);
-                }
+                let is_immediately_enclosing_scope = scope.is_annotation(db)
+                    && scope
+                        .scope(db)
+                        .parent()
+                        .is_some_and(|parent| parent == enclosing_scope_file_id);
 
                 let has_root_place_been_reassigned = || {
                     let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
@@ -9792,9 +9706,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if has_root_place_been_reassigned() {
                                 return Place::Undefined.into();
                             }
-                            if let Some(ty) = dunder_class_cell_type {
-                                return resolve_dunder_class_cell(ty);
-                            }
                             continue;
                         }
                         EnclosingSnapshotResult::NoLongerInEagerContext => {
@@ -9811,9 +9722,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
                 let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                    if let Some(ty) = dunder_class_cell_type {
-                        return resolve_dunder_class_cell(ty);
-                    }
                     continue;
                 };
 
@@ -9837,9 +9745,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
                     // Note that this check includes members like `x.y` and `x[0]`, which aren't
                     // symbols and can't be explicitly `nonlocal`.
-                    if let Some(ty) = dunder_class_cell_type {
-                        return resolve_dunder_class_cell(ty);
-                    }
                     continue;
                 }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1693,7 +1693,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         inside_generic_method_body: bool,
     ) -> Option<Type<'db>> {
         let cell_is_visible = match inner {
-            NodeWithScopeKind::Function(_) | NodeWithScopeKind::Lambda(_) => true,
+            NodeWithScopeKind::Function(_)
+            | NodeWithScopeKind::Lambda(_)
+            | NodeWithScopeKind::GeneratorExpression(_) => true,
             NodeWithScopeKind::FunctionTypeParameters(_) => {
                 inside_generic_method_body || self.is_deferred()
             }
@@ -1707,6 +1709,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class = outer.as_class()?;
         let definition = self.index.expect_single_definition(class);
         original_class_type(self.db(), definition).map(Type::ClassLiteral)
+    }
+
+    /// Returns the implicit `__class__` cell used to evaluate a deferred method annotation.
+    fn deferred_method_annotation_class_type(&self) -> Option<Type<'db>> {
+        if !self.is_deferred()
+            || !self.inference_flags().intersects(
+                InferenceFlags::IN_PARAMETER_ANNOTATION | InferenceFlags::IN_RETURN_TYPE,
+            )
+        {
+            return None;
+        }
+
+        let InferenceRegion::Deferred(definition) = self.region else {
+            return None;
+        };
+        let DefinitionKind::Function(function) = definition.kind(self.db()) else {
+            return None;
+        };
+        let function_scope = self
+            .index
+            .node_scope(NodeWithScopeRef::Function(function.node(self.module())));
+        let class_definition = self.index.class_definition_of_method(function_scope)?;
+        original_class_type(self.db(), class_definition).map(Type::ClassLiteral)
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9571,6 +9596,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Place::Undefined.into();
             }
 
+            let is_dunder_class = place_expr
+                .as_symbol()
+                .is_some_and(|symbol| symbol.name() == "__class__");
+            if is_dunder_class && let Some(ty) = self.deferred_method_annotation_class_type() {
+                return Place::bound(ty).into();
+            }
+
             for parent_id in place_table.parents(place_expr) {
                 let parent_expr = place_table.place(parent_id);
                 let mut expr_ref = expr_ref;
@@ -9635,6 +9667,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
             // which is too frustrating for users in practice.
             let mut inside_generic_method_body = false;
+            let mut dunder_class_shadowed_by_local = false;
             for ((_, inner_scope), (enclosing_scope_file_id, enclosing_scope)) in
                 self.index.ancestor_scopes(file_scope_id).tuple_windows()
             {
@@ -9653,16 +9686,33 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     inside_generic_method_body = true;
                 }
 
-                let dunder_class_cell_type = place_expr
-                    .as_symbol()
-                    .filter(|symbol| symbol.name() == "__class__")
-                    .and_then(|_| {
+                if is_dunder_class
+                    && enclosing_scope.kind().is_function_like()
+                    && let Some(symbol) = self
+                        .index
+                        .place_table(enclosing_scope_file_id)
+                        .symbol_by_name("__class__")
+                    && symbol.is_local()
+                {
+                    dunder_class_shadowed_by_local = true;
+                }
+
+                let dunder_class_cell_type = is_dunder_class
+                    .then(|| {
                         self.dunder_class_cell_type(
                             inner_scope.node(),
                             enclosing_scope.node(),
                             inside_generic_method_body,
                         )
-                    });
+                    })
+                    .flatten();
+                let resolve_dunder_class_cell = |ty| -> PlaceAndQualifiers<'db> {
+                    if dunder_class_shadowed_by_local {
+                        Place::Undefined.into()
+                    } else {
+                        Place::bound(ty).into()
+                    }
+                };
 
                 // Class scopes are not visible to nested scopes, and we need to handle global
                 // scope differently (because an unbound name there falls back to builtins), so
@@ -9678,7 +9728,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // the class namespace itself, so their explicit class bindings take precedence
                 // over the cell.
                 if !is_immediately_enclosing_scope && let Some(ty) = dunder_class_cell_type {
-                    return Place::bound(ty).into();
+                    return resolve_dunder_class_cell(ty);
                 }
 
                 let has_root_place_been_reassigned = || {
@@ -9743,7 +9793,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 return Place::Undefined.into();
                             }
                             if let Some(ty) = dunder_class_cell_type {
-                                return Place::bound(ty).into();
+                                return resolve_dunder_class_cell(ty);
                             }
                             continue;
                         }
@@ -9762,7 +9812,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
                 let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
                     if let Some(ty) = dunder_class_cell_type {
-                        return Place::bound(ty).into();
+                        return resolve_dunder_class_cell(ty);
                     }
                     continue;
                 };
@@ -9788,7 +9838,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // Note that this check includes members like `x.y` and `x[0]`, which aren't
                     // symbols and can't be explicitly `nonlocal`.
                     if let Some(ty) = dunder_class_cell_type {
-                        return Place::bound(ty).into();
+                        return resolve_dunder_class_cell(ty);
                     }
                     continue;
                 }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1685,6 +1685,29 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
+    /// Returns the type of the implicit `__class__` closure cell visible from the current scope.
+    fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
+        self.index
+            .ancestor_scopes(self.scope().file_scope_id(self.db()))
+            .tuple_windows()
+            .find_map(|((_, inner), (_, outer))| {
+                if !outer.kind().is_class()
+                    || !matches!(
+                        inner.node(),
+                        NodeWithScopeKind::Function(_)
+                            | NodeWithScopeKind::FunctionTypeParameters(_)
+                            | NodeWithScopeKind::Lambda(_)
+                    )
+                {
+                    return None;
+                }
+
+                let class = outer.node().as_class()?;
+                let definition = self.index.expect_single_definition(class);
+                original_class_type(self.db(), definition).map(Type::ClassLiteral)
+            })
+    }
+
     /// If the current scope is a (non-lambda) function, return that function's AST node.
     ///
     /// If the current scope is not a function (or it is a lambda function), return `None`.
@@ -9771,6 +9794,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                             });
                         }
+                    }
+                    Place::Undefined.into()
+                })
+                // Methods receive an implicit `__class__` closure cell. The cell is also visible
+                // from nested scopes and takes precedence over a global with the same name.
+                .or_fall_back_to(db, || {
+                    if place_expr
+                        .as_symbol()
+                        .is_some_and(|symbol| symbol.name() == "__class__")
+                        && let Some(ty) = self.dunder_class_cell_type()
+                    {
+                        return Place::bound(ty).into();
                     }
                     Place::Undefined.into()
                 })

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1686,7 +1686,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     /// Returns the type of the implicit `__class__` cell in the current direct method body or
-    /// class-body lambda.
+    /// lazy scope defined directly in a class body.
     fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
         let class_definition =
@@ -1694,7 +1694,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 definition
             } else {
                 let current_scope = self.index.scope(current_scope_id);
-                if !matches!(current_scope.node(), NodeWithScopeKind::Lambda(_)) {
+                if !matches!(
+                    current_scope.node(),
+                    NodeWithScopeKind::Lambda(_) | NodeWithScopeKind::GeneratorExpression(_)
+                ) {
                     return None;
                 }
                 let class = self

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1685,9 +1685,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
-    /// Returns the type of the implicit `__class__` cell in the current direct method body or
+    /// Returns the implicit `__class__` cell in the current direct method body or
     /// lazy scope defined directly in a class body.
-    fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
+    fn dunder_class_cell_type(&self) -> Option<ClassLiteral<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
         let class_definition =
             if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
@@ -1707,7 +1707,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .as_class()?;
                 self.index.expect_single_definition(class)
             };
-        original_class_type(self.db(), class_definition).map(Type::ClassLiteral)
+        original_class_type(self.db(), class_definition)
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9572,12 +9572,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return Place::Undefined.into();
             }
 
-            if place_expr
-                .as_symbol()
-                .is_some_and(|symbol| symbol.name() == "__class__")
-                && let Some(ty) = self.dunder_class_cell_type()
+            if let PlaceExprRef::Symbol(symbol) = place_expr
+                && symbol.name() == "__class__"
+                && let Some(class) = self.dunder_class_cell_type()
             {
-                return Place::bound(ty).into();
+                return Place::bound(class).into();
             }
 
             for parent_id in place_table.parents(place_expr) {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1685,10 +1685,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
-    /// Returns the type of the implicit `__class__` cell in the current direct method body.
+    /// Returns the type of the implicit `__class__` cell in the current direct method body or
+    /// class-body lambda.
     fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
         let current_scope_id = self.scope().file_scope_id(self.db());
-        let class_definition = self.index.class_definition_of_method(current_scope_id)?;
+        let class_definition =
+            if let Some(definition) = self.index.class_definition_of_method(current_scope_id) {
+                definition
+            } else {
+                let current_scope = self.index.scope(current_scope_id);
+                if !matches!(current_scope.node(), NodeWithScopeKind::Lambda(_)) {
+                    return None;
+                }
+                let class = self
+                    .index
+                    .parent_scope(current_scope_id)?
+                    .node()
+                    .as_class()?;
+                self.index.expect_single_definition(class)
+            };
         original_class_type(self.db(), class_definition).map(Type::ClassLiteral)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -1685,27 +1685,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .map(|class_literal| class_literal.default_specialization(self.db()))
     }
 
-    /// Returns the type of the implicit `__class__` closure cell visible from the current scope.
-    fn dunder_class_cell_type(&self) -> Option<Type<'db>> {
-        self.index
-            .ancestor_scopes(self.scope().file_scope_id(self.db()))
-            .tuple_windows()
-            .find_map(|((_, inner), (_, outer))| {
-                if !outer.kind().is_class()
-                    || !matches!(
-                        inner.node(),
-                        NodeWithScopeKind::Function(_)
-                            | NodeWithScopeKind::FunctionTypeParameters(_)
-                            | NodeWithScopeKind::Lambda(_)
-                    )
-                {
-                    return None;
-                }
+    /// Returns the type of the implicit `__class__` cell at a method/class scope boundary.
+    fn dunder_class_cell_type(
+        &self,
+        inner: &NodeWithScopeKind,
+        outer: &NodeWithScopeKind,
+        inside_generic_method_body: bool,
+    ) -> Option<Type<'db>> {
+        let cell_is_visible = match inner {
+            NodeWithScopeKind::Function(_) | NodeWithScopeKind::Lambda(_) => true,
+            NodeWithScopeKind::FunctionTypeParameters(_) => {
+                inside_generic_method_body || self.is_deferred()
+            }
+            NodeWithScopeKind::TypeAlias(_) | NodeWithScopeKind::TypeAliasTypeParameters(_) => true,
+            _ => false,
+        };
+        if !cell_is_visible {
+            return None;
+        }
 
-                let class = outer.node().as_class()?;
-                let definition = self.index.expect_single_definition(class);
-                original_class_type(self.db(), definition).map(Type::ClassLiteral)
-            })
+        let class = outer.as_class()?;
+        let definition = self.index.expect_single_definition(class);
+        original_class_type(self.db(), definition).map(Type::ClassLiteral)
     }
 
     /// If the current scope is a (non-lambda) function, return that function's AST node.
@@ -9633,25 +9634,52 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // cases we're being too deferential to local bindings. Unfortunately the fully sound
             // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
             // which is too frustrating for users in practice.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
+            let mut inside_generic_method_body = false;
+            for ((_, inner_scope), (enclosing_scope_file_id, enclosing_scope)) in
+                self.index.ancestor_scopes(file_scope_id).tuple_windows()
+            {
                 // If the current enclosing scope is global, no place lookup is performed here,
                 // instead falling back to the module's explicit global lookup below.
                 if enclosing_scope_file_id.is_global() {
                     break;
                 }
 
+                if matches!(inner_scope.node(), NodeWithScopeKind::Function(_))
+                    && matches!(
+                        enclosing_scope.node(),
+                        NodeWithScopeKind::FunctionTypeParameters(_)
+                    )
+                {
+                    inside_generic_method_body = true;
+                }
+
+                let dunder_class_cell_type = place_expr
+                    .as_symbol()
+                    .filter(|symbol| symbol.name() == "__class__")
+                    .and_then(|_| {
+                        self.dunder_class_cell_type(
+                            inner_scope.node(),
+                            enclosing_scope.node(),
+                            inside_generic_method_body,
+                        )
+                    });
+
                 // Class scopes are not visible to nested scopes, and we need to handle global
                 // scope differently (because an unbound name there falls back to builtins), so
                 // check only function-like scopes.
                 // There is one exception to this rule: annotation scopes can see
                 // names defined in an immediately-enclosing class scope.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
+                let is_immediately_enclosing_scope = inner_scope.kind().is_annotation()
+                    && !inside_generic_method_body
+                    && enclosing_scope.kind().is_class();
 
-                let is_immediately_enclosing_scope = scope.is_annotation(db)
-                    && scope
-                        .scope(db)
-                        .parent()
-                        .is_some_and(|parent| parent == enclosing_scope_file_id);
+                // For methods, the cell sits inside the class namespace and therefore takes
+                // precedence over class and outer-scope bindings. Annotation scopes can access
+                // the class namespace itself, so their explicit class bindings take precedence
+                // over the cell.
+                if !is_immediately_enclosing_scope && let Some(ty) = dunder_class_cell_type {
+                    return Place::bound(ty).into();
+                }
 
                 let has_root_place_been_reassigned = || {
                     let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
@@ -9714,6 +9742,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if has_root_place_been_reassigned() {
                                 return Place::Undefined.into();
                             }
+                            if let Some(ty) = dunder_class_cell_type {
+                                return Place::bound(ty).into();
+                            }
                             continue;
                         }
                         EnclosingSnapshotResult::NoLongerInEagerContext => {
@@ -9730,6 +9761,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
                 let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
+                    if let Some(ty) = dunder_class_cell_type {
+                        return Place::bound(ty).into();
+                    }
                     continue;
                 };
 
@@ -9753,6 +9787,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
                     // Note that this check includes members like `x.y` and `x[0]`, which aren't
                     // symbols and can't be explicitly `nonlocal`.
+                    if let Some(ty) = dunder_class_cell_type {
+                        return Place::bound(ty).into();
+                    }
                     continue;
                 }
 
@@ -9794,18 +9831,6 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 )
                             });
                         }
-                    }
-                    Place::Undefined.into()
-                })
-                // Methods receive an implicit `__class__` closure cell. The cell is also visible
-                // from nested scopes and takes precedence over a global with the same name.
-                .or_fall_back_to(db, || {
-                    if place_expr
-                        .as_symbol()
-                        .is_some_and(|symbol| symbol.name() == "__class__")
-                        && let Some(ty) = self.dunder_class_cell_type()
-                    {
-                        return Place::bound(ty).into();
                     }
                     Place::Undefined.into()
                 })


### PR DESCRIPTION
## Summary

When Python creates a function or lazy generator directly in a class body, it provides an implicit `__class__` closure cell that refers to the class where the scope was defined. We previously treated loads from this cell as unresolved references, including in instance methods, static methods, class methods, lambdas, and generator expressions.

This recognizes `__class__` after normal local and `global` resolution when the current scope is a direct method body or a lambda or generator expression whose immediate parent is the class, and infers the original class literal. The immediate-parent restriction avoids approximating the cell across more complex lexical boundaries. Generator expressions remain distinct from eager comprehensions, and their first iterable remains in the eager class-body scope.

The mdtest covers the supported method and lazy-scope forms, eager class-body contexts, and local and global shadowing. It also records the currently unsupported nested scopes, type aliases, generic bounds, and deferred annotations as explicit TODO cases.

The full `ty_python_semantic` suite and workspace Clippy pass.

Closes https://github.com/astral-sh/ty/issues/3122.
