### PR TITLE
[ty] Use borrowed values for Salsa interned lookups

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -4112,7 +4112,7 @@ impl<'db> Type<'db> {
                         return Place::bound(Type::enum_literal(EnumLiteralType::new(
                             db,
                             enum_class,
-                            resolved_name.clone(),
+                            resolved_name,
                         )))
                         .into();
                     }

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -524,8 +524,8 @@ impl<'db> DynamicClassLiteral<'db> {
     ) -> Self {
         Self::new(
             db,
-            self.name(db).clone(),
-            self.anchor(db).clone(),
+            self.name(db),
+            self.anchor(db),
             self.members(db),
             self.has_dynamic_namespace(db),
             dataclass_params,
@@ -560,7 +560,7 @@ impl<'db> DynamicClassLiteral<'db> {
 
         Some(Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             anchor,
             members,
             self.has_dynamic_namespace(db),

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -119,7 +119,7 @@ impl<'db> DynamicEnumLiteral<'db> {
 
         Some(Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
             self.base_class(db),

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -170,7 +170,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     ) -> Option<Self> {
         Some(Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
         ))

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -158,7 +158,7 @@ impl<'db> StaticClassLiteral<'db> {
     ) -> Self {
         Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.body_scope(db),
             self.known(db),
             self.deprecated(db),
@@ -2073,7 +2073,7 @@ impl<'db> StaticClassLiteral<'db> {
                     default_ty = field.default_type(db);
                     init = field.init(db);
                     kw_only = field.kw_only(db);
-                    alias = field.alias(db);
+                    alias.clone_from(field.alias(db));
                     converter = field.converter(db);
                 }
 

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -854,7 +854,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     ) -> Option<Self> {
         Some(Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.anchor(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
         ))

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -636,7 +636,7 @@ impl<'db> EnumComplementType<'db> {
     /// Expand this complement to the enum literals that remain possible.
     pub fn remaining_literal_types(self, db: &'db dyn Db) -> Vec<Type<'db>> {
         self.remaining_member_names(db)
-            .map(|name| self.remaining_literal_type(db, name.clone()))
+            .map(|name| self.remaining_literal_type(db, name))
             .collect()
     }
 
@@ -658,7 +658,7 @@ impl<'db> EnumComplementType<'db> {
     }
 
     /// Build the type for one remaining canonical member, preserving any positive rest components.
-    fn remaining_literal_type(self, db: &'db dyn Db, name: Name) -> Type<'db> {
+    fn remaining_literal_type(self, db: &'db dyn Db, name: &Name) -> Type<'db> {
         let literal =
             Type::enum_literal(EnumLiteralType::new(db, self.enum_class_literal(db), name));
         if self.rest(db).is_empty() {
@@ -740,7 +740,7 @@ impl<'db> EnumComplementType<'db> {
             negative.insert(Type::enum_literal(EnumLiteralType::new(
                 db,
                 self.enum_class_literal(db),
-                name.clone(),
+                name,
             )));
         }
 
@@ -1271,7 +1271,7 @@ pub(crate) fn enum_member_literals<'a, 'db: 'a>(
             .member_names(db)
             .filter(move |name| Some(*name) != exclude_member)
             .map(move |name| {
-                Type::enum_literal(EnumLiteralType::new(db, enum_class_literal, name.clone()))
+                Type::enum_literal(EnumLiteralType::new(db, enum_class_literal, name))
             }),
     )
 }

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -289,7 +289,7 @@ impl<'db> OverloadLiteral<'db> {
     fn with_deprecated(self, db: &'db dyn Db, deprecated: DeprecatedInstance<'db>) -> Self {
         Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.known(db),
             self.body_scope(db),
             self.decorators(db),
@@ -306,7 +306,7 @@ impl<'db> OverloadLiteral<'db> {
     ) -> Self {
         Self::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.known(db),
             self.body_scope(db),
             self.decorators(db),
@@ -1032,7 +1032,7 @@ impl<'db> UpdatedFunctionSignatures<'db> {
 pub struct FunctionType<'db> {
     pub(crate) literal: FunctionLiteral<'db>,
 
-    #[returns(as_ref)]
+    #[returns(ref)]
     updated_signatures: Option<Box<UpdatedFunctionSignatures<'db>>>,
 }
 
@@ -1058,11 +1058,13 @@ pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Siz
 impl<'db> FunctionType<'db> {
     fn updated_signature(self, db: &'db dyn Db) -> Option<&'db CallableSignature<'db>> {
         self.updated_signatures(db)
+            .as_deref()
             .and_then(|updated| updated.signature.as_ref())
     }
 
     fn updated_implementation_signature(self, db: &'db dyn Db) -> Option<&'db Signature<'db>> {
         self.updated_signatures(db)
+            .as_deref()
             .and_then(|updated| updated.implementation_signature.as_ref())
     }
 
@@ -1178,7 +1180,7 @@ impl<'db> FunctionType<'db> {
             last_definition: literal.last_definition.with_deprecated(db, deprecated),
             ..literal
         };
-        Self::new(db, literal, self.updated_signatures(db).cloned())
+        Self::new(db, literal, self.updated_signatures(db))
     }
 
     /// Returns the [`File`] in which this function is defined.

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -4022,7 +4022,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Some(repr_arg) = repr_arg else {
             return Some(Type::KnownInstance(KnownInstanceType::Sentinel(
-                SentinelInstance::new(self.db(), target_name.clone(), definition),
+                SentinelInstance::new(self.db(), target_name, definition),
             )));
         };
 
@@ -4031,7 +4031,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         Some(Type::KnownInstance(KnownInstanceType::Sentinel(
-            SentinelInstance::new(self.db(), target_name.clone(), definition),
+            SentinelInstance::new(self.db(), target_name, definition),
         )))
     }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -147,7 +147,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => Type::from(StaticClassLiteral::new(
                     db,
-                    name.id.clone(),
+                    &name.id,
                     body_scope,
                     maybe_known_class,
                     deprecated,

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -147,7 +147,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let has_exec_body = exec_body_arg.is_some_and(|arg| !arg.is_none_literal_expr());
         let members: Box<[(ast::name::Name, Type<'db>)]> = Box::new([]);
         let dynamic_class =
-            DynamicClassLiteral::new(db, name.clone(), anchor, members, has_exec_body, None);
+            DynamicClassLiteral::new(db, &name, anchor, members, has_exec_body, None);
 
         // For dangling calls, validate bases eagerly. For assigned calls, validation is
         // deferred along with bases inference.

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -253,14 +253,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
         };
 
-        let dynamic_class = DynamicClassLiteral::new(
-            db,
-            name.clone(),
-            anchor,
-            members,
-            has_dynamic_namespace,
-            None,
-        );
+        let dynamic_class =
+            DynamicClassLiteral::new(db, &name, anchor, members, has_dynamic_namespace, None);
 
         // For dangling calls, validate bases eagerly. For assigned calls, validation is
         // deferred along with bases inference.

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -914,7 +914,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let identity = TypeVarIdentity::new(
             db,
-            target_name.clone(),
+            target_name,
             Some(definition),
             TypeVarKind::LegacyParamSpec,
         );
@@ -1252,7 +1252,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let identity = TypeVarIdentity::new(
             db,
-            target_name.clone(),
+            target_name,
             Some(definition),
             TypeVarKind::LegacyTypeVar,
         );

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -473,6 +473,7 @@ pub struct FieldInstance<'db> {
     pub kw_only: Option<bool>,
 
     /// This name is used to provide an alternative parameter name in the synthesized `__init__` method.
+    #[returns(ref)]
     pub alias: Option<Box<str>>,
 
     /// The converter types for this field, if a `converter` argument was provided.

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -144,14 +144,14 @@ impl<'db> NewType<'db> {
                     for inner_newtype in inner_newtype_stack.into_iter().rev() {
                         mapped_base = NewTypeBase::NewType(NewType::new(
                             db,
-                            inner_newtype.name(db).clone(),
+                            inner_newtype.name(db),
                             inner_newtype.definition(db),
                             Some(mapped_base),
                         ));
                     }
                     return Some(NewType::new(
                         db,
-                        self.name(db).clone(),
+                        self.name(db),
                         self.definition(db),
                         Some(mapped_base),
                     ));
@@ -189,7 +189,7 @@ impl<'db> NewType<'db> {
 
         Some(NewType::new(
             db,
-            self.name(db).clone(),
+            self.name(db),
             self.definition(db),
             eager_base,
         ))

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -275,7 +275,7 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
                 builder = builder.add_negative(Type::enum_literal(EnumLiteralType::new(
                     db,
                     complement.enum_class_literal(db),
-                    name.clone(),
+                    name,
                 )));
             }
             types[complement_index] = builder.build();


### PR DESCRIPTION
## Summary

Pass borrowed names and cached values to Salsa interned constructors so `Lookup` only clones on cache misses.

