### PR TITLE
Record configured `ruff_ranged_value` package

### DIFF
--- a/.known-crates
+++ b/.known-crates
@@ -23,6 +23,7 @@ ruff_python_parser
 ruff_python_semantic
 ruff_python_stdlib
 ruff_python_trivia
+ruff_ranged_value
 ruff_server
 ruff_source_file
 ruff_text_size


### PR DESCRIPTION
## Summary

Record `ruff_ranged_value` as configured for crates.io trusted publishing after #26113 made it publishable.

The bootstrap script uses `.known-crates` as a persistent checkpoint and skips entries on later runs. Checking in the generated result makes subsequent bootstrap runs a no-op until another workspace package becomes publishable.

A dry run confirms that all 37 publishable workspace packages are recorded and no setup work remains.
