### PR TITLE
[ty] Use assignability for divergent constraints

### DIFF
--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -436,16 +436,17 @@ impl<'db> Type<'db> {
             return false;
         }
 
-        // A top-level `Divergent` must be handled by lazy constraint-set assignability.
-        if self.is_divergent() || target.is_divergent() {
-            return false;
-        }
-
         match (self, target) {
             (Type::Never | Type::Dynamic(_), _) | (_, Type::Dynamic(_)) => true,
             (_, Type::NominalInstance(target)) if target.is_object() => true,
-            (_, Type::Union(union)) => union.elements(db).contains(&self),
-            (Type::Intersection(intersection), _) => intersection.positive(db).contains(&target),
+            (_, Type::Union(union)) => {
+                self.materialized_divergent_fallback().is_none()
+                    && union.elements(db).contains(&self)
+            }
+            (Type::Intersection(intersection), _) => {
+                target.materialized_divergent_fallback().is_none()
+                    && intersection.positive(db).contains(&target)
+            }
             _ => false,
         }
     }
@@ -1126,7 +1127,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // but this is not true for divergent types (and moving this case any lower down appears to cause
             // "too many cycle iterations" panics).
             (Type::Divergent(_), _) | (_, Type::Divergent(_)) => {
-                ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
+                ConstraintSet::from_bool(self.constraints, self.relation.is_assignability())
             }
 
             // Instances of classes that inherit from an explicit `Any` base retain their nominal

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -325,7 +325,7 @@ fn divergent_type() {
     assert_eq!(union.display(&db).to_string(), "Divergent | int");
     for (source, target) in [(div, union), (div, Type::unknown()), (Type::unknown(), div)] {
         let when = source.when_constraint_set_assignable_to_owned(&db, target);
-        assert!(when.query(|_builder, when| when.is_never_satisfied(&db)));
+        assert!(when.query(|_builder, when| when.is_always_satisfied(&db)));
     }
     let normalized = union
         .recursive_type_normalized_impl(&db, div, false)


### PR DESCRIPTION
## Summary

#26288 fixed a crash by preventing `when_constraint_set_assignable_to_owned`
from returning a trivial `always` result for top-level `Divergent` pairs. The
underlying issue was that the owned fast path and the lazy relation checker
could disagree: the fast path treated some `Divergent` assignability checks as
always satisfied, while the lazy relation checker treated top-level `Divergent`
as never assignable.

This patch resolves the inconsistency in the relation checker instead.
Unmaterialized `Divergent` is assignability-compatible in both eager and lazy
assignability, while it is still not a subtype of arbitrary types and still must
not be eliminated by redundancy/union simplification.

With the lazy relation checker aligned with the fast path, we no longer need the
top-level `Divergent` exclusion in `is_trivially_constraint_set_assignable_to`.
The regression test from #26288 still passes, and the unit test now asserts that
constraint-set assignability treats `Divergent` consistently.
## Test Plan

unit test updated
