### PR TITLE
[ty] Avoid relation queries during cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -92,6 +92,35 @@ while isinstance(x, B):
 class A: ...
 ```
 
+## Literal widening during cycle recovery
+
+Once a recursively growing group of integer literals widens to `int`, later iterations must not
+reintroduce individual literals. Otherwise, the inferred type continues changing and the cycle never
+converges. This is a reduced regression test from SciPy's iterative sparse solvers.
+
+```py
+def solve(maxiter, a, b, c, d, e):
+    iteration = 0
+    stop = 0
+    while iteration < maxiter:
+        iteration = iteration + 1
+        if iteration >= maxiter:
+            stop = 7
+        if a:
+            stop = 6
+        if b:
+            stop = 5
+        if c:
+            stop = 4
+        if d:
+            stop = 3
+        if e:
+            stop = 2
+        if stop > 0:
+            break
+    return stop
+```
+
 ## Self-referential bare type alias
 
 ```toml

--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -46,6 +46,52 @@ while 1:
     y = (y, *y)
 ```
 
+## Literal reduction during cycle recovery
+
+This is a regression test for <https://github.com/astral-sh/ty/issues/3851>. Constructing a union
+during cycle recovery must not run redundancy checks between a literal and a protocol instance.
+Resolving the protocol interface can depend on the expression inference query that is already being
+recovered, which would introduce a new Salsa cycle.
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```py
+from typing import Protocol, runtime_checkable
+
+_: Any
+
+@property
+def prop(self) -> A:
+    raise NotImplementedError
+
+@runtime_checkable
+class B(Protocol):
+    _: A
+
+x = 5
+
+while isinstance(x, B):
+    x = B()  # error: [call-non-callable]
+
+type(x)
+x = 2
+
+from typing import Any, assert_type
+
+assert_type(prop, property)
+
+if bool:
+    x = 5
+
+while isinstance(x, B):
+    x = B()  # error: [call-non-callable]
+
+class A: ...
+```
+
 ## Self-referential bare type alias
 
 ```toml

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -381,7 +381,8 @@ impl<'db> UnionElement<'db> {
         cycle_recovery: bool,
     ) -> ReduceResult<'db> {
         if cycle_recovery {
-            // Preserve literal widening using exact class identity without running relation queries.
+            // A widened literal group must absorb matching literals from later iterations for
+            // recovery to converge. Preserve that exact fallback reduction without relation queries.
             return match self {
                 UnionElement::Type(existing) => ReduceResult::Type(*existing),
                 UnionElement::IntLiterals(_) => {
@@ -982,7 +983,7 @@ impl<'db> UnionBuilder<'db> {
                 }
             }
             // Adding `object` to a union results in `object`.
-            ty if ty.is_object() => self.collapse_to_object(),
+            ty if ty.is_object() && !cycle_recovery => self.collapse_to_object(),
             _ => self.push_type(ty, seen_aliases),
         }
     }
@@ -1028,7 +1029,7 @@ impl<'db> UnionBuilder<'db> {
             }
 
             // `object` already contains every possible union element.
-            if element_type == Type::object() {
+            if !self.cycle_recovery && element_type == Type::object() {
                 return;
             }
 
@@ -1045,10 +1046,11 @@ impl<'db> UnionBuilder<'db> {
                 continue;
             }
 
-            if element_type
-                .as_literal_value_kind()
-                .zip(bool_pair(ty))
-                .is_some_and(|(element, pair)| element == pair)
+            if !self.cycle_recovery
+                && element_type
+                    .as_literal_value_kind()
+                    .zip(bool_pair(ty))
+                    .is_some_and(|(element, pair)| element == pair)
             {
                 self.add_in_place_impl(KnownClass::Bool.to_instance(self.db), seen_aliases);
                 return;
@@ -2008,6 +2010,29 @@ mod tests {
             enum_literal,
             enum_literal.expect_enum_literal().enum_class_instance(&db),
         );
+    }
+
+    #[test]
+    fn cycle_recovery_skips_other_redundancy_simplification() {
+        let db = setup_db();
+
+        for (left, right) in [
+            (Type::string_literal(&db, "literal"), Type::literal_string()),
+            (Type::bool_literal(true), KnownClass::Bool.to_instance(&db)),
+            (Type::int_literal(1), Type::object()),
+            (Type::bool_literal(true), Type::bool_literal(false)),
+        ] {
+            for (first, second) in [(left, right), (right, left)] {
+                let union = UnionBuilder::new(&db)
+                    .cycle_recovery(true)
+                    .add(first)
+                    .add(second)
+                    .build()
+                    .expect_union();
+                assert!(union.elements(&db).contains(&left));
+                assert!(union.elements(&db).contains(&right));
+            }
+        }
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -374,7 +374,33 @@ impl<'db> UnionElement<'db> {
     }
 
     /// Try reducing this `UnionElement` given the presence in the same union of `other_type`.
-    fn try_reduce(&mut self, db: &'db dyn Db, other_type: Type<'db>) -> ReduceResult<'db> {
+    fn try_reduce(
+        &mut self,
+        db: &'db dyn Db,
+        other_type: Type<'db>,
+        cycle_recovery: bool,
+    ) -> ReduceResult<'db> {
+        if cycle_recovery {
+            // Preserve literal widening using exact class identity without running relation queries.
+            return match self {
+                UnionElement::Type(existing) => ReduceResult::Type(*existing),
+                UnionElement::IntLiterals(_) => {
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Int))
+                }
+                UnionElement::StringLiterals(_) => {
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Str))
+                }
+                UnionElement::BytesLiterals(_) => {
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Bytes))
+                }
+                UnionElement::EnumLiterals { enum_class, .. } => ReduceResult::KeepIf(
+                    other_type
+                        .as_nominal_instance()
+                        .is_none_or(|instance| instance.class_literal(db) != *enum_class),
+                ),
+            };
+        }
+
         let mut other_type_negated_cache = None;
 
         let mut collapse = false;
@@ -506,9 +532,8 @@ pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
     db: &'db dyn Db,
     unpack_aliases: bool,
-    /// This is enabled when joining types in a `cycle_recovery` function.
-    /// Since a cycle cannot be created within a `cycle_recovery` function,
-    /// execution of `is_redundant_with` is skipped.
+    /// This is enabled when joining types in a `cycle_recovery` function. Because recovery cannot
+    /// introduce a new cycle, relation-based union simplifications are skipped in this mode.
     cycle_recovery: bool,
     recursively_defined: RecursivelyDefined,
 }
@@ -713,7 +738,7 @@ impl<'db> UnionBuilder<'db> {
                                     found = Some(literals);
                                     continue;
                                 }
-                                UnionElement::Type(existing) => {
+                                UnionElement::Type(existing) if !cycle_recovery => {
                                     // e.g. `existing` could be `Literal[""] & Any`,
                                     // and `ty` could be `Literal[""]`
                                     if ty.is_redundant_with(self.db, *existing) {
@@ -760,7 +785,7 @@ impl<'db> UnionBuilder<'db> {
                                     found = Some(literals);
                                     continue;
                                 }
-                                UnionElement::Type(existing) => {
+                                UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
                                         return;
                                     }
@@ -809,7 +834,7 @@ impl<'db> UnionBuilder<'db> {
                                     found = Some(literals);
                                     continue;
                                 }
-                                UnionElement::Type(existing) => {
+                                UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
                                         return;
                                     }
@@ -879,7 +904,7 @@ impl<'db> UnionBuilder<'db> {
                                     found = Some(literals);
                                     continue;
                                 }
-                                UnionElement::Type(existing) => {
+                                UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
                                         return;
                                     }
@@ -957,7 +982,7 @@ impl<'db> UnionBuilder<'db> {
         let mut to_remove = SmallVec::<[usize; 2]>::new();
 
         for (i, element) in self.elements.iter_mut().enumerate() {
-            let element_type = match element.try_reduce(self.db, ty) {
+            let element_type = match element.try_reduce(self.db, ty, self.cycle_recovery) {
                 ReduceResult::KeepIf(keep) => {
                     if !keep {
                         to_remove.push(i);
@@ -983,12 +1008,14 @@ impl<'db> UnionBuilder<'db> {
                 return;
             }
 
-            if should_preserve_hashable_union(self.db, ty, element_type) {
+            if !self.cycle_recovery && should_preserve_hashable_union(self.db, ty, element_type) {
                 continue;
             }
 
             // Fold `(T & ~AlwaysTruthy) | (T & ~AlwaysFalsy)` to `T`.
-            if let Some(merged_type) = merge_truthiness_guarded_pair(self.db, ty, element_type) {
+            if !self.cycle_recovery
+                && let Some(merged_type) = merge_truthiness_guarded_pair(self.db, ty, element_type)
+            {
                 to_remove.push(i);
                 ty = merged_type;
                 continue;
@@ -1868,7 +1895,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
 #[cfg(test)]
 mod tests {
     use super::{
-        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, Type, UnionBuilder, UnionType,
+        IntersectionBuilder, MAX_NON_RECURSIVE_UNION_LITERALS, MAX_RECURSIVE_UNION_LITERALS,
+        RecursivelyDefined, Type, UnionBuilder, UnionType,
     };
 
     use crate::db::tests::{TestDb, setup_db};
@@ -1906,6 +1934,53 @@ mod tests {
         let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
 
         assert_eq!(union.elements(&db), &[t0, t1]);
+    }
+
+    #[test]
+    fn cycle_recovery_widens_recursive_literal_union() {
+        let db = setup_db();
+        let literal_limit =
+            i64::try_from(MAX_RECURSIVE_UNION_LITERALS).expect("literal limit fits in i64");
+
+        let union = (0..=literal_limit).map(Type::int_literal).fold(
+            UnionBuilder::new(&db)
+                .cycle_recovery(true)
+                .recursively_defined(RecursivelyDefined::Yes),
+            UnionBuilder::add,
+        );
+
+        assert_eq!(union.build(), KnownClass::Int.to_instance(&db));
+
+        let assert_widens = |literal, instance| {
+            let union = UnionBuilder::new(&db)
+                .cycle_recovery(true)
+                .add(literal)
+                .add(instance)
+                .build();
+            assert_eq!(union, instance);
+        };
+
+        assert_widens(
+            Type::string_literal(&db, "literal"),
+            KnownClass::Str.to_instance(&db),
+        );
+        assert_widens(
+            Type::bytes_literal(&db, b"literal"),
+            KnownClass::Bytes.to_instance(&db),
+        );
+
+        let safe_uuid_class = known_module_symbol(&db, KnownModule::Uuid, "SafeUUID")
+            .place
+            .expect_type()
+            .expect_class_literal();
+        let enum_literal = enum_member_literals(&db, safe_uuid_class, None)
+            .expect("SafeUUID is an enum")
+            .next()
+            .expect("SafeUUID has members");
+        assert_widens(
+            enum_literal,
+            enum_literal.expect_enum_literal().enum_class_instance(&db),
+        );
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -738,6 +738,12 @@ impl<'db> UnionBuilder<'db> {
                                     found = Some(literals);
                                     continue;
                                 }
+                                UnionElement::Type(existing)
+                                    if cycle_recovery
+                                        && literal.fallback_instance(self.db) == *existing =>
+                                {
+                                    return;
+                                }
                                 UnionElement::Type(existing) if !cycle_recovery => {
                                     // e.g. `existing` could be `Literal[""] & Any`,
                                     // and `ty` could be `Literal[""]`
@@ -784,6 +790,12 @@ impl<'db> UnionBuilder<'db> {
                                     }
                                     found = Some(literals);
                                     continue;
+                                }
+                                UnionElement::Type(existing)
+                                    if cycle_recovery
+                                        && literal.fallback_instance(self.db) == *existing =>
+                                {
+                                    return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
@@ -833,6 +845,12 @@ impl<'db> UnionBuilder<'db> {
                                     }
                                     found = Some(literals);
                                     continue;
+                                }
+                                UnionElement::Type(existing)
+                                    if cycle_recovery
+                                        && literal.fallback_instance(self.db) == *existing =>
+                                {
+                                    return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
@@ -903,6 +921,12 @@ impl<'db> UnionBuilder<'db> {
                                     }
                                     found = Some(literals);
                                     continue;
+                                }
+                                UnionElement::Type(existing)
+                                    if cycle_recovery
+                                        && literal.fallback_instance(self.db) == *existing =>
+                                {
+                                    return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
                                     if ty.is_redundant_with(self.db, *existing) {
@@ -1952,14 +1976,17 @@ mod tests {
         assert_eq!(union.build(), KnownClass::Int.to_instance(&db));
 
         let assert_widens = |literal, instance| {
-            let union = UnionBuilder::new(&db)
-                .cycle_recovery(true)
-                .add(literal)
-                .add(instance)
-                .build();
-            assert_eq!(union, instance);
+            for (first, second) in [(literal, instance), (instance, literal)] {
+                let union = UnionBuilder::new(&db)
+                    .cycle_recovery(true)
+                    .add(first)
+                    .add(second)
+                    .build();
+                assert_eq!(union, instance);
+            }
         };
 
+        assert_widens(Type::int_literal(1), KnownClass::Int.to_instance(&db));
         assert_widens(
             Type::string_literal(&db, "literal"),
             KnownClass::Str.to_instance(&db),


### PR DESCRIPTION
## Summary

Union construction during Salsa cycle recovery already skips the final full-reduction block, but literal insertion and grouped-literal reduction could still ask semantic type-relation questions. Comparing a literal with a runtime-checkable protocol instance could therefore resolve protocol members, re-enter the expression inference query being recovered, and panic with a new Salsa cycle.

This skips relation-based simplification throughout cycle-recovery union construction. The regression coverage reproduces the Python 3.14 crash and separately protects widening for integer, string, bytes, and enum literals.

Closes https://github.com/astral-sh/ty/issues/3851.
