### PR TITLE
[ty] Widen inferred class-valued instance attributes

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
+++ b/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
@@ -21,6 +21,68 @@ class Counter:
 reveal_type(Counter().value)  # revealed: int
 ```
 
+Class literals stored in inferred attributes are widened when accessed through an instance. A
+subclass can override an undeclared class attribute, so a method that accesses the attribute through
+`self` cannot assume that it still holds the original class object. Direct access on a specific
+class object remains exact:
+
+```py
+from typing import Final
+
+class Response: ...
+class HtmlResponse(Response): ...
+
+class TestResponse:
+    response_class = Response
+
+    def check(self) -> None:
+        reveal_type(self.response_class)  # revealed: type[Response]
+
+class TestHtmlResponse(TestResponse):
+    response_class = HtmlResponse
+
+reveal_type(TestResponse.response_class)  # revealed: <class 'Response'>
+
+class AnnotatedResponse:
+    response_class: type[Response] = Response
+
+    def check(self) -> None:
+        reveal_type(self.response_class)  # revealed: type[Response]
+
+class FixedResponse:
+    response_class: Final = Response
+
+    def check(self) -> None:
+        reveal_type(self.response_class)  # revealed: <class 'Response'>
+```
+
+The same widening applies to undeclared instance attributes assigned in methods:
+
+```py
+class InstanceResponse: ...
+
+class Wrapper:
+    def __init__(self) -> None:
+        self.response_class = InstanceResponse
+
+reveal_type(Wrapper().response_class)  # revealed: type[InstanceResponse]
+```
+
+Widening distributes over unions of class literals:
+
+```py
+class UnionA: ...
+class UnionB: ...
+
+def get_flag() -> bool:
+    return bool()
+
+class EitherClass:
+    value = UnionA if get_flag() else UnionB
+
+reveal_type(EitherClass().value)  # revealed: type[UnionA | UnionB]
+```
+
 ## Widening of non-literal singleton types
 
 It's similarly unlikely that an unannotated attribute initialized to a singleton type (like `None`)

--- a/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
+++ b/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
@@ -35,14 +35,17 @@ class HtmlResponse(Response): ...
 
 class TestResponse:
     response_class = Response
+    response_classes = (Response,)
 
     def check(self) -> None:
         reveal_type(self.response_class)  # revealed: type[Response]
+        reveal_type(self.response_classes)  # revealed: tuple[type[Response]]
 
 class TestHtmlResponse(TestResponse):
     response_class = HtmlResponse
 
 reveal_type(TestResponse.response_class)  # revealed: <class 'Response'>
+reveal_type(TestResponse.response_classes)  # revealed: tuple[<class 'Response'>]
 
 def check_type(response: type[TestResponse]) -> None:
     reveal_type(response.response_class)  # revealed: type[Response]

--- a/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
+++ b/crates/ty_python_semantic/resources/mdtest/doc/public_type_undeclared_symbols.md
@@ -27,7 +27,8 @@ subclass can override an undeclared class attribute, so a method that accesses t
 class object remains exact:
 
 ```py
-from typing import Final
+from typing import Final, NewType, TypeVar, final
+from typing_extensions import assert_never
 
 class Response: ...
 class HtmlResponse(Response): ...
@@ -42,6 +43,46 @@ class TestHtmlResponse(TestResponse):
     response_class = HtmlResponse
 
 reveal_type(TestResponse.response_class)  # revealed: <class 'Response'>
+
+def check_type(response: type[TestResponse]) -> None:
+    reveal_type(response.response_class)  # revealed: type[Response]
+
+T = TypeVar("T", bound=TestResponse)
+
+def check_typevar(response: T) -> None:
+    reveal_type(response.response_class)  # revealed: type[Response]
+
+TClass = TypeVar("TClass", bound=type[TestResponse])
+
+def check_typevar_class(response: TClass) -> None:
+    reveal_type(response.response_class)  # revealed: type[Response]
+
+@final
+class FinalTestResponse:
+    response_class = Response
+
+    @classmethod
+    def check(cls) -> None:
+        if cls.response_class is not Response:
+            assert_never(cls.response_class)
+
+TFinal = TypeVar("TFinal", bound=FinalTestResponse)
+
+def check_final_typevar(response: type[TFinal]) -> None:
+    reveal_type(response.response_class)  # revealed: <class 'Response'>
+
+NewTestResponse = NewType("NewTestResponse", TestResponse)
+
+def check_newtype(response: NewTestResponse) -> None:
+    reveal_type(response.response_class)  # revealed: type[Response]
+
+class ResponseMeta(type):
+    response_class = Response
+
+NewResponseMeta = NewType("NewResponseMeta", ResponseMeta)
+
+def check_newtype_class(response: NewResponseMeta) -> None:
+    reveal_type(response.response_class)  # revealed: type[Response]
 
 class AnnotatedResponse:
     response_class: type[Response] = Response

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3549,6 +3549,25 @@ impl<'db> Type<'db> {
             policy: MemberLookupPolicy,
             receiver: Option<Type<'db>>,
         ) -> PlaceAndQualifiers<'db> {
+            fn promote_inferred_attribute_class_literals<'db>(
+                db: &'db dyn Db,
+                result: PlaceAndQualifiers<'db>,
+            ) -> PlaceAndQualifiers<'db> {
+                let should_promote = matches!(
+                    result.place,
+                    Place::Defined(DefinedPlace {
+                        origin: TypeOrigin::Inferred,
+                        ..
+                    })
+                ) && !result.qualifiers.contains(TypeQualifiers::FINAL);
+
+                if should_promote {
+                    result.map_type(|ty| ty.promote_class_literals(db))
+                } else {
+                    result
+                }
+            }
+
             fn instance_like_member_lookup<'db>(
                 db: &'db dyn Db,
                 this: Type<'db>,
@@ -3598,23 +3617,8 @@ impl<'db> Type<'db> {
                 let result = this.fallback_to_getattr(db, name, result, policy);
                 // An inferred attribute accessed through an instance can resolve to an override
                 // on a subclass, so an exact class object is not a safe public type here.
-                let should_promote_class_literals =
-                    matches!(
-                        result.place,
-                        Place::Defined(DefinedPlace {
-                            origin: TypeOrigin::Inferred,
-                            ..
-                        })
-                    ) && !result.qualifiers.contains(TypeQualifiers::FINAL);
-
-                result.map_type(|ty| {
-                    let ty = ty.bind_self_typevars(db, receiver);
-                    if should_promote_class_literals {
-                        ty.promote_class_literals(db)
-                    } else {
-                        ty
-                    }
-                })
+                let result = result.map_type(|ty| ty.bind_self_typevars(db, receiver));
+                promote_inferred_attribute_class_literals(db, result)
             }
 
             tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);
@@ -4099,6 +4103,15 @@ impl<'db> Type<'db> {
                     // class. `try_call_dunder` adds `NO_INSTANCE_FALLBACK`, which causes the
                     // lookup to hit the catch-all that only checks the meta-type (the metaclass).
                     let result = this.fallback_to_getattr(db, &name, result, policy);
+                    // Unlike a specific class literal, `type[C]` can represent any subclass of
+                    // `C`, unless a `TypeVar` upper bound normalizes to a final class.
+                    let result = if let Type::SubclassOf(subclass_of) = this
+                        && subclass_of.exact_typevar_upper_bound(db).is_none()
+                    {
+                        promote_inferred_attribute_class_literals(db, result)
+                    } else {
+                        result
+                    };
 
                     // `type[Any]`/`type[Unknown]` are gradual forms with an unknown metaclass
                     // (which is at least `type`). Attributes resolved via `type`'s descriptors

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2088,19 +2088,17 @@ impl<'db> Type<'db> {
         self.promote_singletons_impl(db)
     }
 
-    /// Promote top-level class literals to the class objects represented by `type[...]`.
+    /// Promote class literals to the class objects represented by `type[...]`.
     ///
     /// This is intentionally separate from regular promotion. Applying it during collection
     /// inference would lose useful precision for local and module-level collections of class
     /// objects.
     pub(crate) fn promote_class_literals(self, db: &'db dyn Db) -> Type<'db> {
-        match self {
-            Type::ClassLiteral(class) => SubclassOfType::from(db, class.default_specialization(db)),
-            Type::Union(union) => {
-                union.map_leave_aliases(db, |element| element.promote_class_literals(db))
-            }
-            _ => self,
-        }
+        self.apply_type_mapping(
+            db,
+            &TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly),
+            TypeContext::default(),
+        )
     }
 
     /// Recursively promote singleton types (like `None`, `EllipsisType`) to
@@ -6203,6 +6201,15 @@ impl<'db> Type<'db> {
             return self;
         }
 
+        if let Type::ClassLiteral(class) = self
+            && matches!(
+                type_mapping,
+                TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly)
+            )
+        {
+            return SubclassOfType::from(db, class.default_specialization(db));
+        }
+
         match self {
             Type::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, type_mapping, visitor),
             Type::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
@@ -6211,7 +6218,7 @@ impl<'db> Type<'db> {
                 match type_mapping {
                     // Promote the types within the signature before promoting the signature to its
                     // callable form.
-                    TypeMapping::Promote(PromotionMode::On, _) => {
+                    TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => {
                         Type::FunctionLiteral(function.apply_type_mapping_impl(
                             db,
                             type_mapping,
@@ -6328,9 +6335,12 @@ impl<'db> Type<'db> {
                     builder =
                         builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
                 }
-                // Promotion should remove negative contributions from intersections,
-                // so we don't preserve them here when promotion is enabled.
-                if !matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, _)) {
+                // Regular promotion should remove negative contributions from intersections,
+                // so we don't preserve them here when regular promotion is enabled.
+                if !matches!(
+                    type_mapping,
+                    TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)
+                ) {
                     for negative in intersection.negative(db) {
                         builder = builder.add_negative(
                             negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
@@ -6445,6 +6455,7 @@ impl<'db> Type<'db> {
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) |
                 TypeMapping::Promote(PromotionMode::Off, _) |
+                TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly) |
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly) => self,
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => self.promote_impl(db),
             }
@@ -7382,6 +7393,8 @@ impl PromotionMode {
 pub enum PromotionKind {
     /// Default promotion behaviour: recurse into nested types
     Regular,
+    /// Promote class literals recursively without promoting other literal types.
+    ClassLiteralsOnly,
     /// Singleton-only promotion recursively descends through nominal instances
     /// without recursing into unions or non-nominal types.
     SingletonsOnly,

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2088,6 +2088,21 @@ impl<'db> Type<'db> {
         self.promote_singletons_impl(db)
     }
 
+    /// Promote top-level class literals to the class objects represented by `type[...]`.
+    ///
+    /// This is intentionally separate from regular promotion. Applying it during collection
+    /// inference would lose useful precision for local and module-level collections of class
+    /// objects.
+    pub(crate) fn promote_class_literals(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Type::ClassLiteral(class) => SubclassOfType::from(db, class.default_specialization(db)),
+            Type::Union(union) => {
+                union.map_leave_aliases(db, |element| element.promote_class_literals(db))
+            }
+            _ => self,
+        }
+    }
+
     /// Recursively promote singleton types (like `None`, `EllipsisType`) to
     /// `T | Unknown` within nominal type parameters, without recursing into unions.
     /// Used for collection literal inference so that `[None]` is inferred as
@@ -3581,8 +3596,25 @@ impl<'db> Type<'db> {
                 }
 
                 let result = this.fallback_to_getattr(db, name, result, policy);
+                // An inferred attribute accessed through an instance can resolve to an override
+                // on a subclass, so an exact class object is not a safe public type here.
+                let should_promote_class_literals =
+                    matches!(
+                        result.place,
+                        Place::Defined(DefinedPlace {
+                            origin: TypeOrigin::Inferred,
+                            ..
+                        })
+                    ) && !result.qualifiers.contains(TypeQualifiers::FINAL);
 
-                result.map_type(|ty| ty.bind_self_typevars(db, receiver))
+                result.map_type(|ty| {
+                    let ty = ty.bind_self_typevars(db, receiver);
+                    if should_promote_class_literals {
+                        ty.promote_class_literals(db)
+                    } else {
+                        ty
+                    }
+                })
             }
 
             tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -6455,8 +6455,10 @@ impl<'db> Type<'db> {
                 TypeMapping::EagerExpansion |
                 TypeMapping::RescopeReturnCallables(_) |
                 TypeMapping::Promote(PromotionMode::Off, _) |
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly) |
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly) => self,
+                TypeMapping::Promote(
+                    PromotionMode::On,
+                    PromotionKind::ClassLiteralsOnly | PromotionKind::SingletonsOnly,
+                ) => self,
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => self.promote_impl(db),
             }
 

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -976,11 +976,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source_subclass: SubclassOfType<'db>,
         target: Type<'db>,
     ) -> bool {
-        let is_exact_upper_bound = source_subclass.into_type_var().is_some_and(|source_i| {
-            source_i.typevar(db).upper_bound(db).and_then(|bound| {
-                SubclassOfType::try_from_instance(db, bound.resolve_type_alias(db))
-            }) == Some(target)
-        });
+        let is_exact_upper_bound = source_subclass.exact_typevar_upper_bound(db) == Some(target);
 
         (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_)) || is_exact_upper_bound)
             && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -135,6 +135,18 @@ impl<'db> SubclassOfType<'db> {
         self.subclass_of.into_type_var()
     }
 
+    /// Return the exact class-object type of this `type[T]` `TypeVar`'s upper bound, if it has one.
+    ///
+    /// This can only succeed when the upper bound normalizes to a final class.
+    pub(crate) fn exact_typevar_upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        self.into_type_var()
+            .and_then(|typevar| typevar.typevar(db).upper_bound(db))
+            .and_then(|bound| {
+                let bound = Self::try_from_instance(db, bound.resolve_type_alias(db))?;
+                matches!(bound, Type::ClassLiteral(_) | Type::GenericAlias(_)).then_some(bound)
+            })
+    }
+
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,


### PR DESCRIPTION
## Summary

Unannotated attributes use public-type promotion when accessed through an instance, but class literals were left exact. This meant an inherited method could treat `self.response_class` as exactly `Response`, even though a subclass can override that attribute with another response class.

This widens inferred class-valued attributes to `type[...]` during instance member lookup, distributing over unions of class literals. Direct access on a specific class object remains exact, as do attributes declared with `Final`. The widening is kept separate from regular literal promotion so local and module-level collections of class objects retain the precision needed for exhaustiveness checks.

```python
class Response: ...
class HtmlResponse(Response): ...

class Base:
    response_class = Response

    def check(self):
        reveal_type(self.response_class)  # type[Response]

class Child(Base):
    response_class = HtmlResponse
```
