### PR TITLE
[ty] Revert recursive `TypeOf` cycle recovery

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/cycle.md
+++ b/crates/ty_python_semantic/resources/mdtest/cycle.md
@@ -244,31 +244,6 @@ min(Y)
 T = f()
 ```
 
-## Type replacement with a lazy function signature
-
-Type replacement while recovering the first `function` definition must not evaluate its lazy
-signature. The definition's reachability depends on the enclosing loop header through the match
-pattern. Evaluating the signature during `infer_definition_types` cycle recovery would therefore
-introduce a new `loop_header_reachability` dependency, which Salsa rejects.
-
-```toml
-[environment]
-python-version = "3.10"
-```
-
-```py
-lambda: function
-for factory in (lambda: (function for _ in factory),):  # error: [not-iterable]
-    match 0:
-        case missing():  # error: [unresolved-reference]
-            def function(): ...
-
-        case factory():  # error: [invalid-match-pattern]
-            ...
-        case 0:
-            def function(): ...
-```
-
 ## Lazy cached property behind `hasattr`
 
 This pattern used to panic with "too many cycle iterations".

--- a/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
+++ b/crates/ty_python_semantic/resources/mdtest/regression/3827_nested_iterable_types.md
@@ -1,9 +1,0 @@
-# Nested iterable types
-
-Regression test for <https://github.com/astral-sh/ty/issues/3827>.
-
-```py
-while 1:
-    x = iter([[None] + [x]])  # error: [possibly-unresolved-reference]
-    reveal_type(x)  # revealed: Iterator[Divergent]
-```

--- a/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
+++ b/crates/ty_python_semantic/resources/mdtest/ty_extensions.md
@@ -493,8 +493,7 @@ def foo(x: "TypeOf[foo]"):
     reveal_type(x)  # revealed: def foo(x: def foo(...)) -> Unknown
 ```
 
-A `TypeOf` self-reference nested in a nominal specialization forms a recursive type. Cycle recovery
-preserves the outer nominal structure and replaces the recursive argument with `Divergent`:
+A direct self-reference in a variable annotation is resolved from the later assignment:
 
 ```toml
 [environment]
@@ -507,41 +506,6 @@ from ty_extensions import TypeOf
 direct: TypeOf[direct]
 direct = 1
 reveal_type(direct)  # revealed: Literal[1]
-
-x: list[TypeOf[x]]
-x = [1]
-reveal_type(x)  # revealed: list[Divergent]
-
-nested: list[tuple[TypeOf[nested]]]
-nested = [(1,)]
-reveal_type(nested)  # revealed: list[Divergent]
-
-variadic_tuple: tuple[TypeOf[variadic_tuple], ...]
-variadic_tuple = (1,)
-reveal_type(variadic_tuple)  # revealed: tuple[Literal[1]]
-
-mixed_variadic_tuple: tuple[TypeOf[mixed_variadic_tuple], *tuple[int, ...]]
-mixed_variadic_tuple = (1,)
-reveal_type(mixed_variadic_tuple)  # revealed: tuple[Literal[1]]
-
-optional: list[TypeOf[optional]] | None
-optional = [1]
-reveal_type(optional)  # revealed: list[Divergent]
-
-class Container[T]: ...
-
-y: Container[TypeOf[y]]
-y = 1  # error: [invalid-assignment]
-reveal_type(y)  # revealed: Container[Divergent]
-
-# Regression test for https://github.com/astral-sh/ty/issues/3837.
-union: list[TypeOf[union]] | Container[TypeOf[union]]
-union = [1]
-reveal_type(union)  # revealed: list[Divergent]
-
-stable_union: list[TypeOf[stable_union]] | Container[TypeOf[stable_union]] | None
-stable_union = [1]
-reveal_type(stable_union)  # revealed: list[Divergent]
 ```
 
 ## Recursive `TypeOf` in returned callables

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -1181,14 +1181,6 @@ impl<'db> Type<'db> {
         // So we avoid unioning in the first couple iterations, and just use the later iteration's
         // result directly. We still ensure monotonicity after the first couple iterations, which
         // still ensures convergence in cases that are prone to oscillation.
-        if cycle.iteration() > crate::TAINTED_CYCLES
-            && let Some(normalized) = cycle.head_ids().find_map(|id| {
-                self.recursive_nominal_growth_normalized(db, previous, Type::divergent(id))
-            })
-        {
-            return normalized.recursive_type_normalized(db, cycle);
-        }
-
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
                 any_over_type(db, self, false, |ty| {
@@ -1216,155 +1208,6 @@ impl<'db> Type<'db> {
             UnionType::from_elements_cycle_recovery(db, [previous, self])
         }
         .recursive_type_normalized(db, cycle)
-    }
-
-    /// Normalizes nominal growth that wraps the previous cycle result in one or more
-    /// specializations, either directly or beneath an unambiguous union wrapper.
-    ///
-    /// For example, an inference cycle can otherwise grow indefinitely as
-    /// `C[int]`, `C[C[int]]`, `C[C[C[int]]]`, and so on. Once fixed-point iteration has passed its
-    /// tainted cycles, replace the recursive type argument with the cycle's `Divergent` marker so
-    /// that the existing recursive-type normalization can converge on `C[Divergent]`.
-    /// Class-backed protocol instances participate through their nominal representation;
-    /// synthesized protocols are excluded.
-    fn recursive_nominal_growth_normalized(
-        self,
-        db: &'db dyn Db,
-        previous: Self,
-        div: Self,
-    ) -> Option<Self> {
-        if let (Type::Union(current), Type::Union(previous)) = (self, previous) {
-            let previous_elements = previous.elements(db);
-
-            // Multiple union arms may each grow by wrapping the entire previous union. Normalize
-            // only when every previous arm is nominal and at least two changed current arms are
-            // nominal wrappers; arms shared with the previous union remain unchanged.
-            if previous_elements
-                .iter()
-                .all(|element| matches!(element, Type::NominalInstance(_)))
-                && let Some(replacements) = current
-                    .elements(db)
-                    .iter()
-                    .copied()
-                    .filter(|element| !previous_elements.contains(element))
-                    .map(|element| {
-                        Self::nominal_wrapper_normalized(
-                            db,
-                            element.as_nominal_instance()?,
-                            Type::Union(previous),
-                            div,
-                        )
-                        .map(|normalized| (element, normalized))
-                    })
-                    .collect::<Option<smallvec::SmallVec<[(Type<'db>, Type<'db>); 2]>>>()
-                && replacements.len() > 1
-            {
-                let normalized = current.map_leave_aliases(db, |element| {
-                    replacements
-                        .iter()
-                        .find_map(|(original, normalized)| {
-                            (*original == *element).then_some(*normalized)
-                        })
-                        .unwrap_or(*element)
-                });
-
-                // Multi-arm matching cannot prove a one-to-one correspondence between previous
-                // and growing current arms. Union with the entire previous result to keep recovery
-                // monotonic when a stable arm shares a nominal class with a wrapper.
-                return Some(UnionType::from_elements_cycle_recovery(
-                    db,
-                    [Type::Union(previous), normalized],
-                ));
-            }
-
-            // Only align unions when each iteration has exactly one changed arm. With multiple
-            // unmatched arms, pairing is ambiguous and can destabilize otherwise-convergent
-            // recursive cycles.
-            let current_element = current
-                .elements(db)
-                .iter()
-                .copied()
-                .filter(|element| !previous.elements(db).contains(element))
-                .exactly_one()
-                .ok()?;
-            let previous_element = previous
-                .elements(db)
-                .iter()
-                .copied()
-                .filter(|element| !current.elements(db).contains(element))
-                .exactly_one()
-                .ok()?;
-            let normalized_element =
-                current_element.recursive_nominal_growth_normalized(db, previous_element, div)?;
-            return Some(current.map_leave_aliases(db, |element| {
-                if *element == current_element {
-                    normalized_element
-                } else {
-                    *element
-                }
-            }));
-        }
-
-        let (current, previous_instance) = match (self, previous) {
-            (Type::NominalInstance(current), Type::NominalInstance(previous)) => {
-                (current, previous)
-            }
-            (Type::ProtocolInstance(current), Type::ProtocolInstance(previous)) => {
-                // A class-backed protocol shares a nominal specialization with its runtime class.
-                // `nominal_wrapper_normalized` reconstructs the result through `Type::instance`,
-                // which recognizes the protocol class and restores a protocol instance.
-                (
-                    current.to_nominal_instance()?,
-                    previous.to_nominal_instance()?,
-                )
-            }
-            _ => return None,
-        };
-
-        if current.class(db).class_literal(db) != previous_instance.class_literal(db) {
-            return None;
-        }
-
-        Self::nominal_wrapper_normalized(db, current, previous, div)
-    }
-
-    /// Replaces `wrapped` beneath the outer nominal specialization in `current`.
-    fn nominal_wrapper_normalized(
-        db: &'db dyn Db,
-        current: NominalInstanceType<'db>,
-        wrapped: Self,
-        div: Self,
-    ) -> Option<Self> {
-        // A variadic tuple can flatten the previous cycle result before the result appears again
-        // as a fixed element, as in `x = (*x, x)`. If the fixed prefix or suffix grows between
-        // iterations, replacing only that nested occurrence would leave the flattened prefix
-        // growing by one element on every iteration. Variadic tuples with stable fixed elements
-        // still need nominal growth recovery for recursive `TypeOf` references.
-        if let Some(current_tuple) = current.own_tuple_spec(db)
-            && current_tuple.is_variadic()
-            && let Some(previous_tuple) = wrapped.exact_tuple_instance_spec(db)
-            && current_tuple.fixed_elements().count() > previous_tuple.fixed_elements().count()
-        {
-            return None;
-        }
-
-        let type_mapping = TypeMapping::ReplaceType {
-            from: wrapped,
-            to: div,
-        };
-
-        let current_class = current.class(db);
-        let alias = current_class.into_generic_alias()?;
-        let original_specialization = alias.specialization(db);
-        let specialization = original_specialization.apply_type_mapping(db, &type_mapping);
-        if specialization == original_specialization {
-            return None;
-        }
-
-        Some(Type::instance(
-            db,
-            ClassType::Generic(GenericAlias::new(db, alias.origin(db), specialization)),
-        ))
     }
 
     pub fn is_none(&self, db: &'db dyn Db) -> bool {
@@ -6297,12 +6140,6 @@ impl<'db> Type<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
-        if let TypeMapping::ReplaceType { from, to } = type_mapping
-            && self == *from
-        {
-            return *to;
-        }
-
         // If we are binding `typing.Self`, and this type is what we are binding `Self` to, return
         // early. This is not just an optimization, it also prevents us from infinitely expanding
         // the type, if it's something that can contain a `Self` reference.
@@ -6558,7 +6395,6 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf { .. } |
                 TypeMapping::ReplaceSelf { .. } |
-                TypeMapping::ReplaceType { .. } |
                 TypeMapping::Materialize(_) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -6575,7 +6411,6 @@ impl<'db> Type<'db> {
                 TypeMapping::FreshenBoundTypeVars { .. } |
                 TypeMapping::BindSelf(..) |
                 TypeMapping::ReplaceSelf { .. } |
-                TypeMapping::ReplaceType { .. } |
                 TypeMapping::Promote(..) |
                 TypeMapping::ReplaceParameterDefaults |
                 TypeMapping::EagerExpansion |
@@ -7628,8 +7463,6 @@ pub enum TypeMapping<'a, 'db> {
     BindSelf(SelfBinding<'db>),
     /// Replaces occurrences of `typing.Self` with a new `Self` type variable with the given upper bound.
     ReplaceSelf { new_upper_bound: Type<'db> },
-    /// Replaces occurrences of one specific type with another.
-    ReplaceType { from: Type<'db>, to: Type<'db> },
     /// Create the top or bottom materialization of a type.
     Materialize(MaterializationKind),
     /// Replace default types in parameters of callables with `Unknown`. This is used to avoid infinite
@@ -7682,7 +7515,6 @@ impl<'db> TypeMapping<'_, 'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::BindLegacyTypevars(_)
-            | TypeMapping::ReplaceType { .. }
             | TypeMapping::Materialize(_)
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
@@ -7730,7 +7562,6 @@ impl<'db> TypeMapping<'_, 'db> {
             | TypeMapping::FreshenBoundTypeVars { .. }
             | TypeMapping::BindSelf(..)
             | TypeMapping::ReplaceSelf { .. }
-            | TypeMapping::ReplaceType { .. }
             | TypeMapping::ReplaceParameterDefaults
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => self.clone(),

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1099,21 +1099,18 @@ impl<'db> FunctionType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
-        // Type replacement during cycle recovery, returned-callable rescoping, and type-alias
-        // specialization should not rebuild signatures from the function literal; doing so can
-        // re-enter recursive type inference.
+        // Returned-callable rescoping and type-alias specialization should not rebuild signatures from the
+        // function literal; doing so can re-enter recursive `TypeOf` evaluation.
         let literal = self.literal(db);
         let (updated_signature, updated_implementation_signature) = if matches!(
             type_mapping,
-            TypeMapping::ReplaceType { .. }
-                | TypeMapping::ApplySpecialization(
-                    ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
-                )
-                | TypeMapping::ApplySpecializationWithMaterialization {
-                    specialization: ApplySpecialization::ReturnCallables(_)
-                        | ApplySpecialization::TypeAlias(_),
-                    ..
-                }
+            TypeMapping::ApplySpecialization(
+                ApplySpecialization::ReturnCallables(_) | ApplySpecialization::TypeAlias(_)
+            ) | TypeMapping::ApplySpecializationWithMaterialization {
+                specialization: ApplySpecialization::ReturnCallables(_)
+                    | ApplySpecialization::TypeAlias(_),
+                ..
+            }
         ) {
             (
                 self.updated_signature(db).map(|signature| {

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -375,7 +375,6 @@ impl<'db> KnownInstanceType<'db> {
                 | TypeMapping::FreshenBoundTypeVars { .. }
                 | TypeMapping::BindSelf(..)
                 | TypeMapping::ReplaceSelf { .. }
-                | TypeMapping::ReplaceType { .. }
                 | TypeMapping::Materialize(_)
                 | TypeMapping::ReplaceParameterDefaults
                 | TypeMapping::EagerExpansion

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -1144,7 +1144,6 @@ impl<'db> BoundTypeVarInstance<'db> {
             }
             TypeMapping::Promote(..)
             | TypeMapping::ReplaceParameterDefaults
-            | TypeMapping::ReplaceType { .. }
             | TypeMapping::BindLegacyTypevars(_)
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => Type::TypeVar(self),


### PR DESCRIPTION
## Summary

This reverts #26163 and its follow-up changes in #26230, #26246, #26274, #26275, and #26316.

The recursive nominal-growth recovery replaces a previous cycle result nested inside a specialization with `Divergent`. The follow-up regressions show that this local replacement is not structurally safe: multi-arm union recovery can lose stable arms, and variadic tuple growth can continue after replacement. Addressing those cases required increasingly shape-specific alignment and guards without a general way to establish correspondence between fixed-point iterations.

This restores the cycle-recovery behavior from before #26163. The direct self-referential `TypeOf` case and the regression coverage for astral-sh/ty#3835 and astral-sh/ty#3838 continue to pass without the heuristic and are retained. We remove only the cases that no longer converge: `TypeOf` references nested in nominal specializations and the nested-iterable case from astral-sh/ty#3827. The independent `Divergent` constraint fixes from #26288 and #26334, including the regression coverage for astral-sh/ty#3836, are also retained.
