### PR TITLE
[ty] Optimize enum comparisons in equality evaluation

### DIFF
--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -654,7 +654,7 @@ fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) 
 }
 
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
-fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+fn benchmark_narrowed_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
     let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
@@ -665,11 +665,7 @@ fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Crit
         "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
     );
 
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
-        &code,
-    );
+    benchmark_enum_comparison(criterion, "ty_micro[narrowed_str_enum_comparison]", &code);
 }
 
 /// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
@@ -1678,7 +1674,7 @@ criterion_group!(
     benchmark_gradual_vararg_call,
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
-    benchmark_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_narrowed_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -637,6 +637,22 @@ fn benchmark_large_enum_membership(criterion: &mut Criterion) {
     });
 }
 
+fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
+    setup_rayon();
+
+    criterion.bench_function(name, |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
 /// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
 fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
@@ -677,22 +693,6 @@ fn benchmark_enum_literal_union_comparison(criterion: &mut Criterion) {
     code.push_str("]\n\n\ndef compare(left: Left, right: Right):\n    return left == right\n");
 
     benchmark_enum_comparison(criterion, "ty_micro[enum_literal_union_comparison]", &code);
-}
-
-fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
-    setup_rayon();
-
-    criterion.bench_function(name, |b| {
-        b.iter_batched_ref(
-            || setup_micro_case(code),
-            |case| {
-                let Case { db, .. } = case;
-                let result = db.check();
-                assert_eq!(result.len(), 0);
-            },
-            BatchSize::SmallInput,
-        );
-    });
 }
 
 /// Ensure the comparison profile is reused instead of scanning every member per expression.

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -708,6 +708,62 @@ fn benchmark_repeated_str_enum_comparisons(criterion: &mut Criterion) {
     benchmark_enum_comparison(criterion, "ty_micro[repeated_str_enum_comparisons]", &code);
 }
 
+/// Ensure comparison constraints between two large scalar enums do not compare every member pair.
+fn benchmark_cross_str_enum_comparison(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code = "from enum import StrEnum\n\nclass Left(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str("\n\nclass Right(StrEnum):\n");
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str(
+        "\n\ndef compare(left: Left, right: Right):\n    if left != right:\n        return\n    return left == right\n",
+    );
+
+    benchmark_enum_comparison(criterion, "ty_micro[cross_str_enum_comparison]", &code);
+}
+
+/// Ensure comparisons of unions spanning several scalar enum classes avoid member-pair expansion.
+fn benchmark_mixed_str_enum_comparison(criterion: &mut Criterion) {
+    const NUM_ENUM_CLASSES: usize = 8;
+    const NUM_ENUM_MEMBERS: usize = 32;
+
+    let mut code = "from enum import StrEnum\n".to_string();
+    for side in ["Left", "Right"] {
+        for class_index in 0..NUM_ENUM_CLASSES {
+            writeln!(&mut code, "\nclass {side}{class_index}(StrEnum):").ok();
+            for member_index in 0..NUM_ENUM_MEMBERS {
+                writeln!(
+                    &mut code,
+                    "    VALUE_{member_index} = \"class_{class_index}_value_{member_index}\""
+                )
+                .ok();
+            }
+        }
+    }
+    code.push_str("\ndef compare(left: ");
+    for class_index in 0..NUM_ENUM_CLASSES {
+        if class_index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Left{class_index}").ok();
+    }
+    code.push_str(", right: ");
+    for class_index in 0..NUM_ENUM_CLASSES {
+        if class_index > 0 {
+            code.push_str(" | ");
+        }
+        write!(&mut code, "Right{class_index}").ok();
+    }
+    code.push_str("):\n    if left != right:\n        return\n    return left == right\n");
+
+    benchmark_enum_comparison(criterion, "ty_micro[mixed_str_enum_comparison]", &code);
+}
+
 /// Micro-benchmark that tests our performance when slicing and unpacking
 /// a very large tuple that has many varied literal strings inside it.
 ///
@@ -1677,6 +1733,8 @@ criterion_group!(
     benchmark_narrowed_str_enum_comparison,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
+    benchmark_cross_str_enum_comparison,
+    benchmark_mixed_str_enum_comparison,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_vararg_parameter_type_accumulation,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -712,13 +712,12 @@ fn benchmark_repeated_str_enum_comparisons(criterion: &mut Criterion) {
 fn benchmark_cross_str_enum_comparison(criterion: &mut Criterion) {
     const NUM_ENUM_MEMBERS: usize = 256;
 
-    let mut code = "from enum import StrEnum\n\nclass Left(StrEnum):\n".to_string();
-    for index in 0..NUM_ENUM_MEMBERS {
-        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
-    }
-    code.push_str("\n\nclass Right(StrEnum):\n");
-    for index in 0..NUM_ENUM_MEMBERS {
-        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    let mut code = "from enum import StrEnum\n".to_string();
+    for side in ["Left", "Right"] {
+        writeln!(&mut code, "\nclass {side}(StrEnum):").ok();
+        for index in 0..NUM_ENUM_MEMBERS {
+            writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+        }
     }
     code.push_str(
         "\n\ndef compare(left: Left, right: Right):\n    if left != right:\n        return\n    return left == right\n",
@@ -745,21 +744,19 @@ fn benchmark_mixed_str_enum_comparison(criterion: &mut Criterion) {
             }
         }
     }
-    code.push_str("\ndef compare(left: ");
-    for class_index in 0..NUM_ENUM_CLASSES {
-        if class_index > 0 {
-            code.push_str(" | ");
-        }
-        write!(&mut code, "Left{class_index}").ok();
-    }
-    code.push_str(", right: ");
-    for class_index in 0..NUM_ENUM_CLASSES {
-        if class_index > 0 {
-            code.push_str(" | ");
-        }
-        write!(&mut code, "Right{class_index}").ok();
-    }
-    code.push_str("):\n    if left != right:\n        return\n    return left == right\n");
+    let class_union = |side| {
+        (0..NUM_ENUM_CLASSES)
+            .map(|index| format!("{side}{index}"))
+            .collect::<Vec<_>>()
+            .join(" | ")
+    };
+    writeln!(
+        &mut code,
+        "\ndef compare(left: {}, right: {}):\n    if left != right:\n        return\n    return left == right",
+        class_union("Left"),
+        class_union("Right"),
+    )
+    .ok();
 
     benchmark_enum_comparison(criterion, "ty_micro[mixed_str_enum_comparison]", &code);
 }

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -646,32 +646,13 @@ fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Crit
         writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
     }
     code.push_str(
-        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n\n\ndef compare_after_excluding_member(left: LargeEnum, right: LargeEnum):\n    if right == LargeEnum.VALUE_0:\n        return\n    if left and left != right:\n        return\n    return left == right\n",
+        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
     );
 
     benchmark_enum_comparison(
         criterion,
         "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
         &code,
-    );
-}
-
-/// Ensure non-exhaustive enum domains do not fall back to member expansion.
-fn benchmark_open_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
-    const NUM_ENUM_MEMBERS: usize = 256;
-
-    let mut open_code = "from enum import StrEnum\n\nclass OpenLargeEnum(StrEnum):\n".to_string();
-    for index in 0..NUM_ENUM_MEMBERS {
-        writeln!(&mut open_code, "    VALUE_{index} = \"value_{index}\"").ok();
-    }
-    open_code.push_str(
-        "\n    @classmethod\n    def _missing_(cls, value: object) -> \"OpenLargeEnum\":\n        return str.__new__(cls, str(value))\n\n\ndef compare(left: OpenLargeEnum, right: OpenLargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
-    );
-
-    benchmark_enum_comparison(
-        criterion,
-        "ty_micro[open_str_enum_comparison_after_truthiness_narrowing]",
-        &open_code,
     );
 }
 
@@ -1698,7 +1679,6 @@ criterion_group!(
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
     benchmark_str_enum_comparison_after_truthiness_narrowing,
-    benchmark_open_str_enum_comparison_after_truthiness_narrowing,
     benchmark_enum_literal_union_comparison,
     benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,

--- a/crates/ruff_benchmark/benches/ty.rs
+++ b/crates/ruff_benchmark/benches/ty.rs
@@ -637,6 +637,100 @@ fn benchmark_large_enum_membership(criterion: &mut Criterion) {
     });
 }
 
+/// Regression benchmark for <https://github.com/astral-sh/ty/issues/3830>.
+fn benchmark_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str(
+        "\n\ndef compare(left: LargeEnum, right: LargeEnum):\n    if right and left != right:\n        return\n    return left == right\n\n\ndef compare_after_excluding_member(left: LargeEnum, right: LargeEnum):\n    if right == LargeEnum.VALUE_0:\n        return\n    if left and left != right:\n        return\n    return left == right\n",
+    );
+
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[str_enum_comparison_after_truthiness_narrowing]",
+        &code,
+    );
+}
+
+/// Ensure non-exhaustive enum domains do not fall back to member expansion.
+fn benchmark_open_str_enum_comparison_after_truthiness_narrowing(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut open_code = "from enum import StrEnum\n\nclass OpenLargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut open_code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    open_code.push_str(
+        "\n    @classmethod\n    def _missing_(cls, value: object) -> \"OpenLargeEnum\":\n        return str.__new__(cls, str(value))\n\n\ndef compare(left: OpenLargeEnum, right: OpenLargeEnum):\n    if right and left != right:\n        return\n    return left == right\n",
+    );
+
+    benchmark_enum_comparison(
+        criterion,
+        "ty_micro[open_str_enum_comparison_after_truthiness_narrowing]",
+        &open_code,
+    );
+}
+
+/// Ensure explicit enum-literal unions are compared as value sets, not member pairs.
+fn benchmark_enum_literal_union_comparison(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 256;
+
+    let mut code =
+        "from enum import StrEnum\nfrom typing import Literal\n\nclass LargeEnum(StrEnum):\n"
+            .to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str("\nLeft = Literal[\n");
+    for index in 0..NUM_ENUM_MEMBERS / 2 {
+        writeln!(&mut code, "    LargeEnum.VALUE_{index},").ok();
+    }
+    code.push_str("]\nRight = Literal[\n");
+    for index in NUM_ENUM_MEMBERS / 2..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    LargeEnum.VALUE_{index},").ok();
+    }
+    code.push_str("]\n\n\ndef compare(left: Left, right: Right):\n    return left == right\n");
+
+    benchmark_enum_comparison(criterion, "ty_micro[enum_literal_union_comparison]", &code);
+}
+
+fn benchmark_enum_comparison(criterion: &mut Criterion, name: &str, code: &str) {
+    setup_rayon();
+
+    criterion.bench_function(name, |b| {
+        b.iter_batched_ref(
+            || setup_micro_case(code),
+            |case| {
+                let Case { db, .. } = case;
+                let result = db.check();
+                assert_eq!(result.len(), 0);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+/// Ensure the comparison profile is reused instead of scanning every member per expression.
+fn benchmark_repeated_str_enum_comparisons(criterion: &mut Criterion) {
+    const NUM_ENUM_MEMBERS: usize = 1_024;
+    const NUM_COMPARISONS: usize = 1_000;
+
+    let mut code = "from enum import StrEnum\n\nclass LargeEnum(StrEnum):\n".to_string();
+    for index in 0..NUM_ENUM_MEMBERS {
+        writeln!(&mut code, "    VALUE_{index} = \"value_{index}\"").ok();
+    }
+    code.push_str("\n\ndef compare(left: LargeEnum, right: LargeEnum):\n");
+    for _ in 0..NUM_COMPARISONS {
+        code.push_str("    left == right\n");
+    }
+
+    benchmark_enum_comparison(criterion, "ty_micro[repeated_str_enum_comparisons]", &code);
+}
+
 /// Micro-benchmark that tests our performance when slicing and unpacking
 /// a very large tuple that has many varied literal strings inside it.
 ///
@@ -1603,6 +1697,10 @@ criterion_group!(
     benchmark_gradual_vararg_call,
     benchmark_large_enum_membership,
     benchmark_many_enum_members,
+    benchmark_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_open_str_enum_comparison_after_truthiness_narrowing,
+    benchmark_enum_literal_union_comparison,
+    benchmark_repeated_str_enum_comparisons,
     benchmark_many_enum_members_2,
     benchmark_many_protocol_members_mismatch,
     benchmark_vararg_parameter_type_accumulation,

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -255,11 +255,11 @@ from enum import Enum, Flag
 class Permission(Flag):
     READ = 1
 
-class OpenEnum(Enum):
+class MissingValueEnum(Enum):
     ONLY = 1
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenEnum":
+    def _missing_(cls, value: object) -> "MissingValueEnum":
         return object.__new__(cls)
 
 def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
@@ -267,9 +267,9 @@ def match_flag(value: Permission) -> int:  # error: [invalid-return-type]
         case Permission.READ:
             return 1
 
-def match_open_enum(value: OpenEnum) -> int:  # error: [invalid-return-type]
+def match_open_enum(value: MissingValueEnum) -> int:  # error: [invalid-return-type]
     match value:
-        case OpenEnum.ONLY:
+        case MissingValueEnum.ONLY:
             return 1
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,6 +122,89 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
+Comparisons between values of the same enum preserve existing narrowing. They can also narrow to
+members shared by both operands, or determine that groups with no members in common are unequal:
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+class Choice(StrEnum):
+    FIRST = "first"
+    SECOND = "second"
+    THIRD = "third"
+    FOURTH = "fourth"
+
+def compare_after_truthiness_check(left: Choice, right: Choice):
+    if right and left != right:
+        reveal_type(right)  # revealed: Choice & ~AlwaysFalsy
+        return
+
+    reveal_type(right)  # revealed: Choice
+
+def compare_with_narrowed_right(left: Choice, right: Choice):
+    if right == Choice.FIRST:
+        return
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Choice.SECOND, Choice.THIRD, Choice.FOURTH]
+
+def compare_non_overlapping_narrowed_values(left: Choice, right: Choice):
+    if left == Choice.FIRST or left == Choice.SECOND:
+        return
+    if right == Choice.THIRD or right == Choice.FOURTH:
+        return
+
+    reveal_type(left == right)  # revealed: Literal[False]
+
+def compare_literal_unions(
+    left: Literal[Choice.FIRST, Choice.SECOND],
+    right: Literal[Choice.SECOND, Choice.THIRD],
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Choice.SECOND]
+        reveal_type(right)  # revealed: Literal[Choice.SECOND]
+
+def compare_non_overlapping_literal_unions(
+    left: Literal[Choice.FIRST, Choice.SECOND],
+    right: Literal[Choice.THIRD, Choice.FOURTH],
+):
+    reveal_type(left == right)  # revealed: Literal[False]
+```
+
+Equality narrowing must not copy unrelated parts of one operand's type to the other:
+
+```py
+from enum import StrEnum
+from typing import Any, NewType
+from ty_extensions import Intersection
+
+class Response(StrEnum):
+    ACCEPT = "accept"
+    REJECT = "reject"
+
+Tag = NewType("Tag", str)
+
+def compare_any(left: Response, right: Any):
+    if isinstance(right, Response):
+        if left != right:
+            return
+        left.does_not_exist  # error: [unresolved-attribute]
+
+def compare_narrowed_any(left: Response, right: Any):
+    if isinstance(right, Response):
+        if right == Response.ACCEPT:
+            return
+        if left != right:
+            return
+        reveal_type(left)  # revealed: Literal[Response.REJECT]
+        reveal_type(right)  # revealed: Response & Any & ~Literal[Response.ACCEPT]
+
+def compare_newtype(left: Response, right: Intersection[Response, Tag]):
+    if left != right:
+        return
+    reveal_type(left)  # revealed: Response
+```
+
 `Flag` and `IntFlag` values can include zero and unnamed combinations, so their named members do not
 cover every possible value:
 
@@ -201,6 +284,54 @@ class TransformedEnum(Enum, metaclass=InjectingEnumMeta):
     ONLY = 1
 
 def compare_transformed_enums(left: TransformedEnum, right: TransformedEnum):
+    reveal_type(left == right)  # revealed: bool
+```
+
+A custom comparison method determines the result even when both operands have the same enum type:
+
+```py
+from enum import Enum
+from typing import Literal
+
+class NeverEqual(Enum):
+    FIRST = 1
+    SECOND = 2
+    THIRD = 3
+
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+def compare_custom(left: NeverEqual, right: NeverEqual):
+    reveal_type(left == right)  # revealed: Literal[False]
+
+    if left is NeverEqual.FIRST:
+        return
+    reveal_type(left == right)  # revealed: Literal[False]
+
+def compare_custom_subsets(
+    left: Literal[NeverEqual.FIRST, NeverEqual.SECOND],
+    right: Literal[NeverEqual.SECOND, NeverEqual.THIRD],
+):
+    reveal_type(left == right)  # revealed: Literal[False]
+```
+
+When member values are not known statically, two different members may still compare equal:
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+def runtime_value(value: str) -> str:
+    return value
+
+class UnknownValues(StrEnum):
+    FIRST = runtime_value("first")
+    SECOND = runtime_value("second")
+
+def compare_unknown_values(
+    left: Literal[UnknownValues.FIRST],
+    right: Literal[UnknownValues.SECOND],
+):
     reveal_type(left == right)  # revealed: bool
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -702,6 +702,28 @@ reveal_type(AnnotatedInitialized.MEMBER.value)  # revealed: Literal[2]
 reveal_type(AnnotatedInitialized.MEMBER == Other.MEMBER)  # revealed: bool
 ```
 
+A scalar data-type mixin can also transform a declared value before it becomes the enum member's
+comparison payload. Such a value is not a safe comparison key:
+
+```py
+from enum import Enum, IntEnum
+
+class ShiftedInt(int):
+    def __new__(cls, value: int) -> "ShiftedInt":
+        return int.__new__(cls, value + 1)
+
+class Shifted(ShiftedInt, Enum):
+    MEMBER = 1
+
+class Normal(IntEnum):
+    MEMBER = 2
+
+reveal_type(Shifted.MEMBER == Normal.MEMBER)  # revealed: bool
+
+if Shifted.MEMBER == Normal.MEMBER:
+    reveal_type(Shifted.MEMBER)  # revealed: Shifted
+```
+
 The return value of `_generate_next_value_` is not necessarily the final value of an `IntEnum`
 member. Here, the inherited `int.__new__` converts the generated string `"1"` to the integer `1`.
 Because the generated value's exact conversion is not modeled, we cannot use it to decide whether

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -673,6 +673,45 @@ def _(value: Foo | Shifted):
         reveal_type(value)  # revealed: Literal[Foo.Y] | Shifted
 ```
 
+An explicit `_value_` annotation can make `.value` precise, but it does not describe the scalar
+payload used by inherited comparison methods. We therefore cannot compare members transformed by a
+custom constructor using their annotated values:
+
+```py
+from enum import IntEnum
+from typing import Literal
+
+class AnnotatedShifted(IntEnum):
+    _value_: Literal[1]
+
+    def __new__(cls, value: int) -> "AnnotatedShifted":
+        member = int.__new__(cls, value + 1)
+        member._value_ = 1
+        return member
+
+    MEMBER = 1
+
+class Other(IntEnum):
+    MEMBER = 1
+
+reveal_type(AnnotatedShifted.MEMBER.value)  # revealed: Literal[1]
+reveal_type(AnnotatedShifted.MEMBER == Other.MEMBER)  # revealed: bool
+
+if AnnotatedShifted.MEMBER != Other.MEMBER:
+    reveal_type(AnnotatedShifted.MEMBER)  # revealed: AnnotatedShifted
+
+class AnnotatedInitialized(IntEnum):
+    _value_: Literal[2]
+
+    def __init__(self, value: int) -> None:
+        self._value_ = 2
+
+    MEMBER = 1
+
+reveal_type(AnnotatedInitialized.MEMBER.value)  # revealed: Literal[2]
+reveal_type(AnnotatedInitialized.MEMBER == Other.MEMBER)  # revealed: bool
+```
+
 The return value of `_generate_next_value_` is not necessarily the final value of an `IntEnum`
 member. Here, the inherited `int.__new__` converts the generated string `"1"` to the integer `1`.
 Because the generated value's exact conversion is not modeled, we cannot use it to decide whether

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -383,6 +383,218 @@ def _(value: Foo | Bar):
         reveal_type(value)  # revealed: Literal[Foo.X, Bar.A]
 ```
 
+`StrEnum` domains from different classes are compared by their string values. Equality retains the
+members whose values occur in both domains; inequality against a singleton excludes the matching
+member. Exact member comparisons are true or false when both values are known:
+
+```py
+from enum import StrEnum
+from typing import Literal
+
+class Left(StrEnum):
+    A = "a"
+    SHARED = "shared"
+    C = "c"
+
+class Right(StrEnum):
+    SHARED = "shared"
+    B = "b"
+    D = "d"
+
+reveal_type(Left.SHARED == Right.SHARED)  # revealed: Literal[True]
+reveal_type(Left.A == Right.B)  # revealed: Literal[False]
+reveal_type(Left.SHARED != Right.SHARED)  # revealed: Literal[False]
+
+def compare_domains(left: Left, right: Right):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+    else:
+        reveal_type(left)  # revealed: Left
+        reveal_type(right)  # revealed: Right
+
+    if left != right:
+        reveal_type(left)  # revealed: Left
+        reveal_type(right)  # revealed: Right
+    else:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+
+def compare_singleton(left: Left, right: Literal[Right.SHARED]):
+    if left != right:
+        reveal_type(left)  # revealed: Literal[Left.A, Left.C]
+    else:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+
+def compare_subsets(
+    left: Literal[Left.A, Left.SHARED],
+    right: Literal[Right.SHARED, Right.B],
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[Left.SHARED]
+        reveal_type(right)  # revealed: Literal[Right.SHARED]
+```
+
+The same comparison-key projection applies when each operand spans several enum classes. This
+example represents 16 possible values on the left and 20 on the right, so comparing every member
+pair would exceed the finite-comparison budget:
+
+```py
+from enum import IntEnum
+
+class MixedLeft0(IntEnum):
+    A = 0
+    B = 1
+    C = 2
+    D = 3
+
+class MixedLeft1(IntEnum):
+    A = 4
+    B = 5
+    C = 6
+    D = 7
+
+class MixedLeft2(IntEnum):
+    A = 8
+    B = 9
+    C = 10
+    D = 11
+
+class MixedLeft3(IntEnum):
+    A = 12
+    B = 13
+    C = 14
+    D = 15
+
+class MixedRight0(IntEnum):
+    A = 0
+    B = 1
+    C = 2
+    D = 3
+
+class MixedRight1(IntEnum):
+    A = 4
+    B = 5
+    C = 6
+    D = 7
+
+class MixedRight2(IntEnum):
+    A = 8
+    B = 9
+    C = 10
+    D = 11
+
+class MixedRight3(IntEnum):
+    A = 16
+    B = 17
+    C = 18
+    D = 19
+
+class MixedRight4(IntEnum):
+    A = 20
+    B = 21
+    C = 22
+    D = 23
+
+def compare_mixed_domains(
+    left: MixedLeft0 | MixedLeft1 | MixedLeft2 | MixedLeft3,
+    right: MixedRight0 | MixedRight1 | MixedRight2 | MixedRight3 | MixedRight4,
+):
+    if left == right:
+        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | MixedLeft2
+        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | MixedRight2
+```
+
+An open identity-comparing enum can still be narrowed to all of its declared members. Undeclared
+runtime members are not retained merely because every declared member matches:
+
+```py
+from enum import Enum
+from typing import Literal
+
+class OpenIdentity(Enum):
+    A = "a"
+    B = "b"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "OpenIdentity":
+        raise ValueError
+
+class OtherIdentity(Enum):
+    C = "c"
+
+def compare_open_identity(
+    left: OpenIdentity | OtherIdentity,
+    right: Literal[OpenIdentity.A, OpenIdentity.B],
+):
+    if left == right:
+        reveal_type(left)  # revealed: Literal[OpenIdentity.A, OpenIdentity.B]
+```
+
+Integer comparison keys normalize booleans in the same way as Python equality:
+
+```py
+from enum import Enum, IntEnum
+
+class BooleanKey(int, Enum):
+    FALSE = False
+
+class IntegerKey(IntEnum):
+    ZERO = 0
+
+reveal_type(BooleanKey.FALSE == IntegerKey.ZERO)  # revealed: Literal[True]
+```
+
+Plain enum members from different classes use identity comparison, even when their declared values
+are equal. Custom comparison methods and open scalar enums remain ambiguous:
+
+```py
+from enum import Enum, StrEnum
+
+class PlainLeft(Enum):
+    MEMBER = "shared"
+
+class PlainRight(Enum):
+    MEMBER = "shared"
+
+reveal_type(PlainLeft.MEMBER == PlainRight.MEMBER)  # revealed: Literal[False]
+
+def compare_plain(left: PlainLeft, right: PlainRight):
+    if left == right:
+        reveal_type(left)  # revealed: Never
+
+class CustomLeft(StrEnum):
+    MEMBER = "shared"
+
+    def __eq__(self, other: object) -> bool:
+        return False
+
+class CustomRight(StrEnum):
+    MEMBER = "shared"
+
+reveal_type(CustomLeft.MEMBER == CustomRight.MEMBER)  # revealed: bool
+
+class CustomNeLeft(StrEnum):
+    MEMBER = "shared"
+
+    def __ne__(self, other: object) -> bool:
+        return False
+
+reveal_type(CustomNeLeft.MEMBER == CustomRight.MEMBER)  # revealed: Literal[True]
+reveal_type(CustomNeLeft.MEMBER != CustomRight.MEMBER)  # revealed: bool
+
+class OpenLeft(StrEnum):
+    MEMBER = "shared"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "OpenLeft":
+        raise ValueError
+
+def compare_open(left: OpenLeft, right: CustomRight):
+    if left == right:
+        reveal_type(left)  # revealed: OpenLeft
+```
+
 The same narrowing applies when comparing enum members directly with their inherited integer or
 string values. The negative constraint excludes both the builtin literal and every enum member known
 to compare equal to it:
@@ -481,6 +693,7 @@ class Other(IntEnum):
     ONE = 1
 
 reveal_type(Generated.ONE.value)  # revealed: int
+reveal_type(Generated.ONE == Other.ONE)  # revealed: bool
 
 def _(value: Generated | Other):
     if value == Generated.ONE:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ Comparisons between values of the same enum preserve existing narrowing. They ca
 members shared by both operands, or determine that groups with no members in common are unequal:
 
 ```py
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Literal
 
 class Choice(StrEnum):
@@ -169,6 +169,26 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+
+def make_value() -> Literal["value"]:
+    return "value"
+
+class RuntimeAlias(StrEnum):
+    FIRST = make_value()
+    SECOND = "value"
+
+# These members have equal runtime values, but the inferred value literals have different
+# promotability. We therefore cannot conclude that the members compare unequal.
+reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: bool
+
+def make_int_value() -> Literal[1]:
+    return 1
+
+class RuntimeIntAlias(IntEnum):
+    FIRST = make_int_value()
+    SECOND = 1
+
+reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
 ```
 
 Equality narrowing must not copy unrelated parts of one operand's type to the other:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -126,7 +126,7 @@ Comparisons between values of the same enum preserve existing narrowing. They ca
 members shared by both operands, or determine that groups with no members in common are unequal:
 
 ```py
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum, StrEnum
 from typing import Literal
 
 class Choice(StrEnum):
@@ -189,6 +189,13 @@ class RuntimeIntAlias(IntEnum):
     SECOND = 1
 
 reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
+
+class CoercingAlias(str, Enum):
+    FIRST = 1
+    SECOND = "1"
+
+# `str.__new__` normalizes both declared values to the same runtime string.
+reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
 Equality narrowing must not copy unrelated parts of one operand's type to the other:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -436,8 +436,8 @@ def compare_subsets(
 ```
 
 The same comparison-key projection applies when each operand spans several enum classes. This
-example represents 16 possible values on the left and 20 on the right, so comparing every member
-pair would exceed the finite-comparison budget:
+example represents 18 possible values on each side, which would otherwise require 324 pairwise
+comparisons:
 
 ```py
 from enum import IntEnum
@@ -447,62 +447,52 @@ class MixedLeft0(IntEnum):
     B = 1
     C = 2
     D = 3
+    E = 4
+    F = 5
+    G = 6
+    H = 7
+    I = 8
 
 class MixedLeft1(IntEnum):
-    A = 4
-    B = 5
-    C = 6
-    D = 7
-
-class MixedLeft2(IntEnum):
-    A = 8
-    B = 9
-    C = 10
-    D = 11
-
-class MixedLeft3(IntEnum):
-    A = 12
-    B = 13
-    C = 14
-    D = 15
+    A = 9
+    B = 10
+    C = 11
+    D = 12
+    E = 13
+    F = 14
+    G = 15
+    H = 16
+    I = 17
 
 class MixedRight0(IntEnum):
     A = 0
     B = 1
     C = 2
     D = 3
+    E = 4
+    F = 5
+    G = 6
+    H = 7
+    I = 8
 
 class MixedRight1(IntEnum):
-    A = 4
-    B = 5
-    C = 6
-    D = 7
-
-class MixedRight2(IntEnum):
-    A = 8
-    B = 9
-    C = 10
-    D = 11
-
-class MixedRight3(IntEnum):
-    A = 16
-    B = 17
-    C = 18
-    D = 19
-
-class MixedRight4(IntEnum):
-    A = 20
-    B = 21
-    C = 22
-    D = 23
+    A = 18
+    B = 19
+    C = 20
+    D = 21
+    E = 22
+    F = 23
+    G = 24
+    H = 25
+    I = 26
 
 def compare_mixed_domains(
-    left: MixedLeft0 | MixedLeft1 | MixedLeft2 | MixedLeft3,
-    right: MixedRight0 | MixedRight1 | MixedRight2 | MixedRight3 | MixedRight4,
+    left: MixedLeft0 | MixedLeft1,
+    right: MixedRight0 | MixedRight1,
 ):
     if left == right:
-        reveal_type(left)  # revealed: MixedLeft0 | MixedLeft1 | MixedLeft2
-        reveal_type(right)  # revealed: MixedRight0 | MixedRight1 | MixedRight2
+        reveal_type(left)  # revealed: MixedLeft0
+        reveal_type(right)  # revealed: MixedRight0
 ```
 
 An open identity-comparing enum can still be narrowed to all of its declared members. Undeclared

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -913,6 +913,28 @@ def _(answer: CoupledInequality):
         reveal_type(answer)  # revealed: CoupledInequality
 ```
 
+## Recursive aliases containing enum domains
+
+Enum domains nested in a recursive alias fall back to general comparison inference:
+
+```toml
+[environment]
+python-version = "3.12"
+```
+
+```py
+from enum import Enum
+
+class EnumValue(Enum):
+    VALUE = 1
+    OTHER = 2
+
+type Recursive = EnumValue | Recursive
+
+def _(left: Recursive, right: EnumValue):
+    reveal_type(left == right)  # revealed: bool
+```
+
 ## Known built-in equality behavior
 
 `bool`, `LiteralString`, `TypedDict`, and final classes that inherit `object.__eq__` have known

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -194,8 +194,9 @@ class RuntimeIntAlias(IntEnum):
 reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Literal[True]
 ```
 
-Scalar mixins can also coerce different class-body values to the same runtime value. Here, both
-declarations become aliases at runtime, so the comparison cannot be assumed false:
+A scalar mixin can normalize member values before `Enum` checks for aliases. Here, `str` converts
+`1` to `"1"`, so the two members are aliases at runtime. Since ty does not model this constructor
+call, the comparison remains `bool`:
 
 ```py
 class CoercingAlias(str, Enum):
@@ -205,12 +206,12 @@ class CoercingAlias(str, Enum):
 reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
-Equality narrowing must not transfer `Any` or an unrelated `NewType` constraint from one operand to
-the other:
+Equality can transfer restrictions on enum members, but other intersection elements must stay on the
+operand where they originated:
 
 ```py
 from enum import StrEnum
-from typing import Any, NewType
+from typing import Any, Literal, NewType
 from ty_extensions import Intersection
 
 class Response(StrEnum):
@@ -219,14 +220,14 @@ class Response(StrEnum):
 
 Tag = NewType("Tag", str)
 
-def compare_narrowed_any(left: Response, right: Any):
-    if isinstance(right, Response):
-        if right == Response.ACCEPT:
-            return
-        if left != right:
-            return
-        reveal_type(left)  # revealed: Literal[Response.REJECT]
-        reveal_type(right)  # revealed: Response & Any & ~Literal[Response.ACCEPT]
+def compare_any(
+    left: Response,
+    right: Intersection[Literal[Response.REJECT], Any],
+):
+    if left != right:
+        return
+    reveal_type(left)  # revealed: Literal[Response.REJECT]
+    reveal_type(right)  # revealed: Literal[Response.REJECT] & Any
 
 def compare_newtype(left: Response, right: Intersection[Response, Tag]):
     if left != right:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -122,8 +122,8 @@ def enum_complement_rhs(x: Color, y: Intersection[Color, Not[Literal[Color.RED]]
         reveal_type(x)  # revealed: Literal[Color.GREEN, Color.BLUE]
 ```
 
-Comparisons between values of the same enum preserve existing narrowing. They can also narrow to
-members shared by both operands, or determine that groups with no members in common are unequal:
+When both operands are restricted to members of the same enum, equality narrows each operand to the
+members allowed by both. If the restrictions do not overlap, the comparison is always false:
 
 ```py
 from enum import Enum, IntEnum, StrEnum
@@ -169,7 +169,12 @@ def compare_non_overlapping_literal_unions(
     right: Literal[Choice.THIRD, Choice.FOURTH],
 ):
     reveal_type(left == right)  # revealed: Literal[False]
+```
 
+Members with the same known value are aliases, even when one value comes from a function call.
+Comparisons between their canonical members are always true:
+
+```py
 def make_value() -> Literal["value"]:
     return "value"
 
@@ -177,9 +182,7 @@ class RuntimeAlias(StrEnum):
     FIRST = make_value()
     SECOND = "value"
 
-# These members have equal runtime values, but the inferred value literals have different
-# promotability. We therefore cannot conclude that the members compare unequal.
-reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: bool
+reveal_type(RuntimeAlias.FIRST == RuntimeAlias.SECOND)  # revealed: Literal[True]
 
 def make_int_value() -> Literal[1]:
     return 1
@@ -188,17 +191,22 @@ class RuntimeIntAlias(IntEnum):
     FIRST = make_int_value()
     SECOND = 1
 
-reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: bool
+reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Literal[True]
+```
 
+Scalar mixins can also coerce different class-body values to the same runtime value. Here, both
+declarations become aliases at runtime, so the comparison cannot be assumed false:
+
+```py
 class CoercingAlias(str, Enum):
     FIRST = 1
     SECOND = "1"
 
-# `str.__new__` normalizes both declared values to the same runtime string.
 reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
 ```
 
-Equality narrowing must not copy unrelated parts of one operand's type to the other:
+Equality narrowing must not transfer `Any` or an unrelated `NewType` constraint from one operand to
+the other:
 
 ```py
 from enum import StrEnum
@@ -210,12 +218,6 @@ class Response(StrEnum):
     REJECT = "reject"
 
 Tag = NewType("Tag", str)
-
-def compare_any(left: Response, right: Any):
-    if isinstance(right, Response):
-        if left != right:
-            return
-        left.does_not_exist  # error: [unresolved-attribute]
 
 def compare_narrowed_any(left: Response, right: Any):
     if isinstance(right, Response):
@@ -277,23 +279,18 @@ even when only one member is declared:
 ```py
 from enum import Enum
 
-class OpenEnum(Enum):
+class MissingValueEnum(Enum):
     ONLY = 1
 
     @classmethod
-    def _missing_(cls, value: object) -> "OpenEnum":
+    def _missing_(cls, value: object) -> "MissingValueEnum":
         return object.__new__(cls)
 
-def compare_open_enums(left: OpenEnum, right: OpenEnum):
+def compare_open_enums(left: MissingValueEnum, right: MissingValueEnum):
     reveal_type(left == right)  # revealed: bool
 
     if left != right:
-        reveal_type(left)  # revealed: OpenEnum
-
-def exclude_declared_member(value: OpenEnum):
-    if value is OpenEnum.ONLY:
-        return
-    reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+        reveal_type(left)  # revealed: MissingValueEnum
 ```
 
 A custom enum metaclass can add members that do not appear in the class body. Two values of a
@@ -333,12 +330,6 @@ def compare_custom(left: NeverEqual, right: NeverEqual):
 
     if left is NeverEqual.FIRST:
         return
-    reveal_type(left == right)  # revealed: Literal[False]
-
-def compare_custom_subsets(
-    left: Literal[NeverEqual.FIRST, NeverEqual.SECOND],
-    right: Literal[NeverEqual.SECOND, NeverEqual.THIRD],
-):
     reveal_type(left == right)  # revealed: Literal[False]
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -479,6 +479,7 @@ def _(x: LiteralString | int):
 
 ```py
 from enum import Enum
+from typing import Literal
 
 class Color(Enum):
     RED = "red"
@@ -506,6 +507,21 @@ def after_excluding_red_mixed(x: Color | int):
         reveal_type(x)  # revealed: Literal[Color.GREEN] | int
     else:
         reveal_type(x)  # revealed: Literal[Color.BLUE] | int
+
+SelectedColor = Literal[Color.RED, Color.GREEN]
+SELECTED_COLORS: tuple[SelectedColor, ...] = (Color.RED, Color.GREEN)
+
+def selected_colors(colors: list[Color]) -> list[SelectedColor]:
+    result: list[SelectedColor] = []
+    result.extend([color for color in colors if color in SELECTED_COLORS])
+    return result
+
+def _(colors: list[Color]):
+    annotated = [color for color in colors if color in SELECTED_COLORS]
+    reveal_type(annotated)  # revealed: list[Literal[Color.RED, Color.GREEN]]
+
+    inline = [color for color in colors if color in (Color.RED, Color.GREEN)]
+    reveal_type(inline)  # revealed: list[Color]
 ```
 
 An enum that can have additional runtime members can still be narrowed by a membership test against

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -507,7 +507,13 @@ def after_excluding_red_mixed(x: Color | int):
         reveal_type(x)  # revealed: Literal[Color.GREEN] | int
     else:
         reveal_type(x)  # revealed: Literal[Color.BLUE] | int
+```
 
+When the container's element type is a union of enum literals, membership narrows to that union.
+Without the annotation, the tuple's elements are widened to `Color`, so the comprehension remains
+`list[Color]`:
+
+```py
 SelectedColor = Literal[Color.RED, Color.GREEN]
 SELECTED_COLORS: tuple[SelectedColor, ...] = (Color.RED, Color.GREEN)
 
@@ -517,9 +523,6 @@ def selected_colors(colors: list[Color]) -> list[SelectedColor]:
     return result
 
 def _(colors: list[Color]):
-    annotated = [color for color in colors if color in SELECTED_COLORS]
-    reveal_type(annotated)  # revealed: list[Literal[Color.RED, Color.GREEN]]
-
     inline = [color for color in colors if color in (Color.RED, Color.GREEN)]
     reveal_type(inline)  # revealed: list[Color]
 ```
@@ -536,14 +539,14 @@ class InjectingEnumMeta(EnumMeta):
         namespace["INJECTED"] = 2
         return super().__new__(metacls, name, bases, namespace, **kwargs)
 
-class OpenEnum(Enum, metaclass=InjectingEnumMeta):
+class InjectedEnum(Enum, metaclass=InjectingEnumMeta):
     ONLY = 1
 
-def _(value: OpenEnum):
-    if value in (OpenEnum.ONLY,):
-        reveal_type(value)  # revealed: Literal[OpenEnum.ONLY]
+def _(value: InjectedEnum):
+    if value in (InjectedEnum.ONLY,):
+        reveal_type(value)  # revealed: Literal[InjectedEnum.ONLY]
     else:
-        reveal_type(value)  # revealed: OpenEnum & ~Literal[OpenEnum.ONLY]
+        reveal_type(value)  # revealed: InjectedEnum & ~Literal[InjectedEnum.ONLY]
 ```
 
 ## Union with enum and `int`

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -765,30 +765,33 @@ pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -
     }
 }
 
-/// If `value_ty` is a hashable literal and already exists in `enum_values`,
-/// record it as an alias and return `true`. Otherwise track it as canonical.
+/// If `value_ty` has the same supported literal kind and payload as a value in `enum_values`, record
+/// it as an alias and return `true`. Otherwise track it as canonical. Literal metadata does not
+/// affect enum aliasing at runtime, so the map is keyed by [`LiteralValueTypeKind`] rather than
+/// [`Type`].
 fn try_register_alias<'db>(
     value_ty: Type<'db>,
     name: &Name,
-    enum_values: &mut FxHashMap<Type<'db>, Name>,
+    enum_values: &mut FxHashMap<LiteralValueTypeKind<'db>, Name>,
     aliases: &mut FxHashMap<Name, Name>,
 ) -> bool {
+    let Some(value) = value_ty.as_literal_value_kind() else {
+        return false;
+    };
     if !matches!(
-        value_ty.as_literal_value_kind(),
-        Some(
-            LiteralValueTypeKind::Bool(_)
-                | LiteralValueTypeKind::Int(_)
-                | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_)
-        )
+        value,
+        LiteralValueTypeKind::Bool(_)
+            | LiteralValueTypeKind::Int(_)
+            | LiteralValueTypeKind::String(_)
+            | LiteralValueTypeKind::Bytes(_)
     ) {
         return false;
     }
-    if let Some(canonical) = enum_values.get(&value_ty) {
+    if let Some(canonical) = enum_values.get(&value) {
         aliases.insert(name.clone(), canonical.clone());
         return true;
     }
-    enum_values.insert(value_ty, name.clone());
+    enum_values.insert(value, name.clone());
     false
 }
 
@@ -820,7 +823,7 @@ pub(crate) fn enum_metadata<'db>(
             }
             let mut members = FxIndexMap::default();
             let mut aliases = FxHashMap::default();
-            let mut enum_values: FxHashMap<Type<'db>, Name> = FxHashMap::default();
+            let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
                 if try_register_alias(*ty, name, &mut enum_values, &mut aliases) {
                     continue;
@@ -855,7 +858,7 @@ pub(crate) fn enum_metadata<'db>(
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
-    let mut enum_values: FxHashMap<Type<'db>, Name> = FxHashMap::default();
+    let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
     let mut auto_counter = 0;
     let mut auto_members = FxHashSet::default();
     let mut prev_value_was_non_literal_int = false;

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -873,7 +873,8 @@ pub(crate) fn enum_metadata<'db>(
         inherited_known_enum_method(db, class, "__init__")
     });
     let user_defined_new = custom_enum_method(db, scope_id, "__new__")
-        .or_else(|| inherited_user_defined_enum_method(db, class, "__new__"));
+        .or_else(|| inherited_user_defined_enum_method(db, class, "__new__"))
+        .or_else(|| inherited_user_defined_mixin_new(db, class));
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
@@ -1213,6 +1214,24 @@ fn inherited_user_defined_enum_method<'db>(
     iter_parent_enum_classes(db, class)
         .filter(|base| base.known(db).is_none())
         .find_map(|base| custom_enum_method(db, base.body_scope(db), name))
+}
+
+/// Looks up a user-defined `__new__` on a data-type mixin before the first parent enum.
+///
+/// When no enum class provides a member constructor, `EnumType` uses this method to construct the
+/// scalar payload stored by the enum member.
+fn inherited_user_defined_mixin_new<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<EnumMethodBinding<'db>> {
+    class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.class_literal(db).as_static())
+        .take_while(|base| !is_enum_class_by_inheritance(db, *base))
+        .filter(|base| base.known(db).is_none())
+        .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
 }
 
 /// Looks up a resolvable method inherited from a known enum class.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -15,6 +15,12 @@ use super::{
     enums::{enum_member_literals, enum_metadata},
 };
 
+mod enums;
+
+pub(super) use self::enums::enum_membership_constraint;
+use self::enums::evaluate_same_enum_domains;
+pub(super) use self::enums::{EnumComparison, compact_enum_comparison};
+
 /// The result of evaluating a runtime comparison between two types.
 ///
 /// Definite truthiness is represented separately from a constraint for the operand currently being
@@ -392,6 +398,10 @@ fn evaluate_comparison_once<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
+
+    if let Some(result) = evaluate_same_enum_domains(db, left, right, branch, operator) {
+        return result;
+    }
 
     if let Some(alternatives) = finite_alternatives(db, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -20,7 +20,7 @@ mod enums;
 
 pub(super) use self::enums::enum_membership_constraint;
 use self::enums::evaluate_same_enum_domains;
-pub(super) use self::enums::{EnumComparison, compact_enum_comparison};
+pub(super) use self::enums::{EnumComparison, same_enum_comparison};
 
 /// The result of evaluating a runtime comparison between two types.
 ///

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -10,8 +10,9 @@ use rustc_hash::FxHashSet;
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
-    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueTypeKind,
-    MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints, UnionBuilder,
+    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueType,
+    LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints,
+    UnionBuilder,
     enums::{enum_member_literals, enum_metadata},
 };
 
@@ -734,7 +735,10 @@ fn enum_literal_constraint<'db>(
     operator: ComparisonOperator,
     condition_expects_equality: bool,
 ) -> Option<Type<'db>> {
-    let LiteralValueTypeKind::Enum(right) = right.as_literal_value_kind()? else {
+    let Type::LiteralValue(right_literal) = right.resolve_type_alias(db) else {
+        return None;
+    };
+    let LiteralValueTypeKind::Enum(right) = right_literal.kind() else {
         return None;
     };
     if !is_same_enum_domain(db, left, right)
@@ -748,7 +752,10 @@ fn enum_literal_constraint<'db>(
     let name = enum_class_literal
         .resolve_member(db, right.name(db))?
         .clone();
-    let equal_to_right = Type::enum_literal(EnumLiteralType::new(db, enum_class_literal, name));
+    let equal_to_right = Type::from(LiteralValueType::new(
+        EnumLiteralType::new(db, enum_class_literal, name),
+        right_literal.is_promotable(),
+    ));
     Some(equal_to_right.negate_if(db, !condition_expects_equality))
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -18,9 +18,7 @@ use super::{
 
 mod enums;
 
-pub(super) use self::enums::enum_membership_constraint;
-use self::enums::evaluate_same_enum_domains;
-pub(super) use self::enums::{EnumComparison, same_enum_comparison};
+use self::enums::evaluate_enum_domains;
 
 /// The result of evaluating a runtime comparison between two types.
 ///
@@ -150,6 +148,10 @@ pub(super) fn evaluate_type_equality<'db>(
             ComparisonOperator::Equality,
             condition_expects_equality,
         )
+    })
+    .or_else(|| {
+        evaluate_enum_domains(db, left, right, branch, ComparisonOperator::Equality)
+            .and_then(|result| result.constraint(branch))
     })
     .or_else(|| {
         if comparison_domain(db, left, right, ComparisonOperator::Equality)
@@ -400,7 +402,7 @@ fn evaluate_comparison_once<'db>(
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
 
-    if let Some(result) = evaluate_same_enum_domains(db, left, right, branch, operator) {
+    if let Some(result) = evaluate_enum_domains(db, left, right, branch, operator) {
         return result;
     }
 
@@ -1255,7 +1257,7 @@ impl ComparisonOperator {
 ///
 /// Two types with different known semantics cannot compare equal. Types with custom or otherwise
 /// unknown comparison methods are not assigned a value of this enum.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 enum KnownComparisonSemantics {
     Object,
     Int,

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -195,45 +195,71 @@ impl<'db> EnumValueSet<'db> {
     ///
     /// This deliberately does not use subtyping: a `NewType` over an enum is a subtype of the
     /// enum but remains disjoint from the enum's literal members.
-    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
-        let value_set = match ty.resolve_type_alias(db) {
-            Type::LiteralValue(literal) => {
-                let LiteralValueTypeKind::Enum(enum_literal) = literal.kind() else {
-                    return None;
-                };
-                let enum_class = enum_literal.enum_class_literal(db);
-                let name = enum_class.resolve_member(db, enum_literal.name(db))?;
-                Self {
-                    enum_class,
-                    members: EnumValueSetMembers::One {
-                        name,
-                        promotable: literal.is_promotable(),
-                    },
+    fn from_type(
+        db: &'db dyn Db,
+        ty: Type<'db>,
+        active_types: &mut FxHashSet<Type<'db>>,
+    ) -> Option<Self> {
+        fn from_type_inner<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            active_types: &mut FxHashSet<Type<'db>>,
+        ) -> Option<EnumValueSet<'db>> {
+            let value_set = match ty.resolve_type_alias(db) {
+                Type::LiteralValue(literal) => {
+                    let LiteralValueTypeKind::Enum(enum_literal) = literal.kind() else {
+                        return None;
+                    };
+                    let enum_class = enum_literal.enum_class_literal(db);
+                    let name = enum_class.resolve_member(db, enum_literal.name(db))?;
+                    EnumValueSet {
+                        enum_class,
+                        members: EnumValueSetMembers::One {
+                            name,
+                            promotable: literal.is_promotable(),
+                        },
+                    }
                 }
-            }
-            Type::NominalInstance(instance) => Self {
-                enum_class: instance.class_literal(db).into_enum_class(db)?,
-                members: EnumValueSetMembers::All,
-            },
-            Type::EnumComplement(complement) => Self {
-                enum_class: complement.enum_class_literal(db),
-                members: EnumValueSetMembers::AllExcept(complement),
-            },
-            Type::Union(union) => Self::from_union(db, union.elements(db))?,
-            Type::Intersection(intersection) => Self::from_intersection(db, intersection)?,
-            _ => return None,
-        };
-        (value_set.member_count(db) > 0).then_some(value_set)
+                Type::NominalInstance(instance) => EnumValueSet {
+                    enum_class: instance.class_literal(db).into_enum_class(db)?,
+                    members: EnumValueSetMembers::All,
+                },
+                Type::EnumComplement(complement) => EnumValueSet {
+                    enum_class: complement.enum_class_literal(db),
+                    members: EnumValueSetMembers::AllExcept(complement),
+                },
+                Type::Union(union) => {
+                    EnumValueSet::from_union(db, union.elements(db), active_types)?
+                }
+                Type::Intersection(intersection) => {
+                    EnumValueSet::from_intersection(db, intersection, active_types)?
+                }
+                _ => return None,
+            };
+            (value_set.member_count(db) > 0).then_some(value_set)
+        }
+
+        // A cycle prevents extracting a finite enum domain, so fall back to general comparison.
+        if !active_types.insert(ty) {
+            return None;
+        }
+        let value_set = from_type_inner(db, ty, active_types);
+        active_types.remove(&ty);
+        value_set
     }
 
     /// Extract an exact included-member set from a union of enum domains.
     ///
     /// Whole-domain and complement arms are rejected because they are not exact included sets.
-    fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
+    fn from_union(
+        db: &'db dyn Db,
+        elements: &[Type<'db>],
+        active_types: &mut FxHashSet<Type<'db>>,
+    ) -> Option<Self> {
         let mut enum_class = None;
         let mut included = FxOrderMap::default();
         for element in elements {
-            let value_set = Self::from_type(db, *element)?;
+            let value_set = Self::from_type(db, *element, active_types)?;
             if let Some(enum_class) = enum_class
                 && enum_class != value_set.enum_class
             {
@@ -292,9 +318,13 @@ impl<'db> EnumValueSet<'db> {
     }
 
     /// Extract the enum restriction while discarding unrelated positive intersection state.
-    fn from_intersection(db: &'db dyn Db, intersection: IntersectionType<'db>) -> Option<Self> {
+    fn from_intersection(
+        db: &'db dyn Db,
+        intersection: IntersectionType<'db>,
+        active_types: &mut FxHashSet<Type<'db>>,
+    ) -> Option<Self> {
         if let Some(complement) = intersection.enum_complement(db) {
-            return Self::from_type(db, Type::EnumComplement(complement));
+            return Self::from_type(db, Type::EnumComplement(complement), active_types);
         }
 
         // Other intersection components can only reduce the represented enum values. Ignoring
@@ -302,7 +332,7 @@ impl<'db> EnumValueSet<'db> {
         let mut value_sets = intersection
             .positive(db)
             .iter()
-            .filter_map(|positive| Self::from_type(db, *positive));
+            .filter_map(|positive| Self::from_type(db, *positive, active_types));
         let value_set = value_sets.next()?;
         value_sets
             .all(|other| other.enum_class == value_set.enum_class)
@@ -466,23 +496,39 @@ impl<'db> EnumDomainSet<'db> {
             db: &'db dyn Db,
             ty: Type<'db>,
             domains: &mut Vec<EnumValueSet<'db>>,
+            active_types: &mut FxHashSet<Type<'db>>,
         ) -> Option<()> {
-            if let Some(domain) = EnumValueSet::from_type(db, ty) {
+            if let Some(domain) = EnumValueSet::from_type(db, ty, active_types) {
                 domains.push(domain);
                 return Some(());
             }
 
+            if !active_types.insert(ty) {
+                return None;
+            }
+            let result = collect_union(db, ty, domains, active_types);
+            active_types.remove(&ty);
+            result
+        }
+
+        fn collect_union<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            domains: &mut Vec<EnumValueSet<'db>>,
+            active_types: &mut FxHashSet<Type<'db>>,
+        ) -> Option<()> {
             let Type::Union(union) = ty.resolve_type_alias(db) else {
                 return None;
             };
             for element in union.elements(db) {
-                collect(db, *element, domains)?;
+                collect(db, *element, domains, active_types)?;
             }
             Some(())
         }
 
         let mut domains = Vec::new();
-        collect(db, ty, &mut domains)?;
+        let mut active_types = FxHashSet::default();
+        collect(db, ty, &mut domains, &mut active_types)?;
         (!domains.is_empty()).then_some(Self { domains })
     }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -6,9 +6,9 @@ use ty_python_core::Truthiness;
 
 use crate::types::{
     EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
-    LiteralValueTypeKind, Type, UnionBuilder,
+    LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder,
 };
-use crate::{Db, FxOrderSet};
+use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
@@ -185,10 +185,10 @@ struct EnumValueSet<'db> {
 enum EnumValueSetMembers<'db> {
     /// The entire enum domain, including undeclared runtime values when the enum is open.
     All,
-    /// One canonical member name after resolving aliases.
-    One(&'db Name),
-    /// An exact set of canonical member names.
-    Included(FxOrderSet<&'db Name>),
+    /// One canonical member name after resolving aliases, and whether its literal is promotable.
+    One { name: &'db Name, promotable: bool },
+    /// An exact set of canonical member names and their literal promotability.
+    Included(FxOrderMap<&'db Name, bool>),
     /// The enum domain except for the declared members excluded by an enum complement.
     AllExcept(EnumComplementType<'db>),
 }
@@ -201,14 +201,17 @@ impl<'db> EnumValueSet<'db> {
     fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
         let value_set = match ty.resolve_type_alias(db) {
             Type::LiteralValue(literal) => {
-                let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                let LiteralValueTypeKind::Enum(enum_literal) = literal.kind() else {
                     return None;
                 };
-                let enum_class = literal.enum_class_literal(db);
-                let name = enum_class.resolve_member(db, literal.name(db))?;
+                let enum_class = enum_literal.enum_class_literal(db);
+                let name = enum_class.resolve_member(db, enum_literal.name(db))?;
                 Self {
                     enum_class,
-                    members: EnumValueSetMembers::One(name),
+                    members: EnumValueSetMembers::One {
+                        name,
+                        promotable: literal.is_promotable(),
+                    },
                 }
             }
             Type::NominalInstance(instance) => Self {
@@ -231,7 +234,7 @@ impl<'db> EnumValueSet<'db> {
     /// Whole-domain and complement arms are rejected because they are not exact included sets.
     fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
         let mut enum_class = None;
-        let mut included = FxOrderSet::default();
+        let mut included = FxOrderMap::default();
         for element in elements {
             let value_set = Self::from_type(db, *element)?;
             if let Some(enum_class) = enum_class
@@ -241,17 +244,22 @@ impl<'db> EnumValueSet<'db> {
             }
             enum_class = Some(value_set.enum_class);
             match value_set.members {
-                EnumValueSetMembers::One(name) => {
-                    included.insert(name);
+                EnumValueSetMembers::One { name, promotable } => {
+                    Self::insert_member(&mut included, name, promotable);
                 }
-                EnumValueSetMembers::Included(names) => included.extend(names),
+                EnumValueSetMembers::Included(members) => {
+                    for (name, promotable) in members {
+                        Self::insert_member(&mut included, name, promotable);
+                    }
+                }
                 EnumValueSetMembers::All | EnumValueSetMembers::AllExcept(_) => return None,
             }
         }
 
         let enum_class = enum_class?;
         let members = if included.len() == 1 {
-            EnumValueSetMembers::One(included.into_iter().next()?)
+            let (name, promotable) = included.into_iter().next()?;
+            EnumValueSetMembers::One { name, promotable }
         } else {
             EnumValueSetMembers::Included(included)
         };
@@ -259,6 +267,22 @@ impl<'db> EnumValueSet<'db> {
             enum_class,
             members,
         })
+    }
+
+    /// Insert a member, preserving unpromotable literal provenance if either occurrence has it.
+    fn insert_member(
+        included: &mut FxOrderMap<&'db Name, bool>,
+        name: &'db Name,
+        promotable: bool,
+    ) {
+        match included.entry(name) {
+            ordermap::map::Entry::Vacant(entry) => {
+                entry.insert(promotable);
+            }
+            ordermap::map::Entry::Occupied(mut entry) => {
+                *entry.get_mut() &= promotable;
+            }
+        }
     }
 
     /// Extract the enum restriction while discarding unrelated positive intersection state.
@@ -282,7 +306,7 @@ impl<'db> EnumValueSet<'db> {
     fn member_count(&self, db: &'db dyn Db) -> usize {
         match &self.members {
             EnumValueSetMembers::All => self.enum_class.member_count(db),
-            EnumValueSetMembers::One(_) => 1,
+            EnumValueSetMembers::One { .. } => 1,
             EnumValueSetMembers::Included(names) => names.len(),
             EnumValueSetMembers::AllExcept(complement) => {
                 self.enum_class.member_count(db) - complement.excluded_names(db).len()
@@ -298,7 +322,7 @@ impl<'db> EnumValueSet<'db> {
         members_are_exhaustive
             || matches!(
                 self.members,
-                EnumValueSetMembers::One(_) | EnumValueSetMembers::Included(_)
+                EnumValueSetMembers::One { .. } | EnumValueSetMembers::Included(_)
             )
     }
 
@@ -310,10 +334,13 @@ impl<'db> EnumValueSet<'db> {
         debug_assert_eq!(self.enum_class, other.enum_class);
         match (&self.members, &other.members) {
             (EnumValueSetMembers::All, _) | (_, EnumValueSetMembers::All) => true,
-            (EnumValueSetMembers::One(left), EnumValueSetMembers::One(right)) => left == right,
-            (EnumValueSetMembers::One(name), EnumValueSetMembers::Included(names))
-            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One(name)) => {
-                names.contains(name)
+            (
+                EnumValueSetMembers::One { name: left, .. },
+                EnumValueSetMembers::One { name: right, .. },
+            ) => left == right,
+            (EnumValueSetMembers::One { name, .. }, EnumValueSetMembers::Included(names))
+            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One { name, .. }) => {
+                names.contains_key(name)
             }
             (EnumValueSetMembers::Included(left), EnumValueSetMembers::Included(right)) => {
                 let (smaller, larger) = if left.len() < right.len() {
@@ -321,16 +348,16 @@ impl<'db> EnumValueSet<'db> {
                 } else {
                     (right, left)
                 };
-                smaller.iter().any(|name| larger.contains(name))
+                smaller.keys().any(|name| larger.contains_key(name))
             }
-            (EnumValueSetMembers::One(name), EnumValueSetMembers::AllExcept(complement))
-            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One(name)) => {
+            (EnumValueSetMembers::One { name, .. }, EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One { name, .. }) => {
                 !complement.excluded_names(db).contains(*name)
             }
             (EnumValueSetMembers::Included(names), EnumValueSetMembers::AllExcept(complement))
             | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::Included(names)) => {
                 names
-                    .iter()
+                    .keys()
                     .any(|name| !complement.excluded_names(db).contains(*name))
             }
             (EnumValueSetMembers::AllExcept(left), EnumValueSetMembers::AllExcept(right)) => {
@@ -350,17 +377,13 @@ impl<'db> EnumValueSet<'db> {
                 .enum_class
                 .class_literal(db)
                 .to_non_generic_instance(db),
-            EnumValueSetMembers::One(name) => {
-                Type::enum_literal(EnumLiteralType::new(db, self.enum_class, (*name).clone()))
+            EnumValueSetMembers::One { name, promotable } => {
+                self.member_type(db, name, *promotable)
             }
-            EnumValueSetMembers::Included(names) => names
+            EnumValueSetMembers::Included(members) => members
                 .iter()
-                .fold(UnionBuilder::new(db), |builder, name| {
-                    builder.add(Type::enum_literal(EnumLiteralType::new(
-                        db,
-                        self.enum_class,
-                        (*name).clone(),
-                    )))
+                .fold(UnionBuilder::new(db), |builder, (name, promotable)| {
+                    builder.add(self.member_type(db, name, *promotable))
                 })
                 .build(),
             EnumValueSetMembers::AllExcept(complement) => {
@@ -386,20 +409,29 @@ impl<'db> EnumValueSet<'db> {
         if self.member_count(db) != 1 {
             return None;
         }
-        let name = match &self.members {
-            EnumValueSetMembers::All => self.enum_class.member_names(db).next()?,
-            EnumValueSetMembers::One(name) => name,
-            EnumValueSetMembers::Included(names) => names.first()?,
-            EnumValueSetMembers::AllExcept(complement) => self
-                .enum_class
-                .member_names(db)
-                .find(|name| !complement.excluded_names(db).contains(*name))?,
+        let (name, promotable) = match &self.members {
+            EnumValueSetMembers::All => (self.enum_class.member_names(db).next()?, true),
+            EnumValueSetMembers::One { name, promotable } => (*name, *promotable),
+            EnumValueSetMembers::Included(members) => {
+                let (name, promotable) = members.first()?;
+                (*name, *promotable)
+            }
+            EnumValueSetMembers::AllExcept(complement) => (
+                self.enum_class
+                    .member_names(db)
+                    .find(|name| !complement.excluded_names(db).contains(*name))?,
+                true,
+            ),
         };
-        Some(Type::enum_literal(EnumLiteralType::new(
-            db,
-            self.enum_class,
-            (*name).clone(),
-        )))
+        Some(self.member_type(db, name, promotable))
+    }
+
+    fn member_type(&self, db: &'db dyn Db, name: &Name, promotable: bool) -> Type<'db> {
+        LiteralValueType::new(
+            EnumLiteralType::new(db, self.enum_class, name.clone()),
+            promotable,
+        )
+        .into()
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -13,6 +13,9 @@ use crate::{Db, FxOrderSet};
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
 /// Compare two compact domains from the same enum without expanding their members.
+///
+/// Any narrowing constraint produced here contains only enum-membership facts. In particular,
+/// equality never transfers gradual or nominal intersection state from one operand to the other.
 pub(super) fn evaluate_same_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
@@ -100,6 +103,10 @@ pub(in crate::types) fn enum_membership_constraint<'db>(
     }
 }
 
+/// Two non-empty value domains from the same enum and the semantics used to compare them.
+///
+/// Keeping the operands compact avoids constructing and pairwise comparing unions of every
+/// declared member.
 struct SameEnumComparison<'db> {
     left: EnumValueSet<'db>,
     right: EnumValueSet<'db>,
@@ -150,6 +157,10 @@ impl<'db> SameEnumComparison<'db> {
         Some(equality.negate_if(operator == ComparisonOperator::Inequality))
     }
 
+    /// Return whether equality can soundly transfer the right-hand enum restriction to the left.
+    ///
+    /// The right domain must be closed, and the left must either be closed as well or use identity
+    /// comparison, for which undeclared runtime members cannot equal a declared member.
     fn supports_domain_narrowing(&self) -> bool {
         matches!(
             self.profile.comparison_keys,
@@ -170,10 +181,15 @@ struct EnumValueSet<'db> {
     members: EnumValueSetMembers<'db>,
 }
 
+/// Compact representation of the member names admitted by an [`EnumValueSet`].
 enum EnumValueSetMembers<'db> {
+    /// The entire enum domain, including undeclared runtime values when the enum is open.
     All,
+    /// One canonical member name after resolving aliases.
     One(&'db Name),
+    /// An exact set of canonical member names.
     Included(FxOrderSet<&'db Name>),
+    /// The enum domain except for the declared members excluded by an enum complement.
     AllExcept(EnumComplementType<'db>),
 }
 
@@ -210,6 +226,9 @@ impl<'db> EnumValueSet<'db> {
         (value_set.member_count(db) > 0).then_some(value_set)
     }
 
+    /// Extract an exact included-member set from a union of enum domains.
+    ///
+    /// Whole-domain and complement arms are rejected because they are not exact included sets.
     fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
         let mut enum_class = None;
         let mut included = FxOrderSet::default();
@@ -242,6 +261,7 @@ impl<'db> EnumValueSet<'db> {
         })
     }
 
+    /// Extract the enum restriction while discarding unrelated positive intersection state.
     fn from_intersection(db: &'db dyn Db, intersection: IntersectionType<'db>) -> Option<Self> {
         if let Some(complement) = intersection.enum_complement(db) {
             return Self::from_type(db, Type::EnumComplement(complement));
@@ -270,6 +290,10 @@ impl<'db> EnumValueSet<'db> {
         }
     }
 
+    /// Return whether this set excludes every value not named by its representation.
+    ///
+    /// A whole-domain or complement representation is not closed for an enum that can create
+    /// undeclared members at runtime.
     fn is_closed(&self, members_are_exhaustive: bool) -> bool {
         members_are_exhaustive
             || matches!(
@@ -354,6 +378,10 @@ impl<'db> EnumValueSet<'db> {
         }
     }
 
+    /// Reconstruct the only declared member left in this set.
+    ///
+    /// The caller must separately establish that the domain is closed before treating this as the
+    /// operand's only possible runtime value.
     fn singleton_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
         if self.member_count(db) != 1 {
             return None;
@@ -375,9 +403,12 @@ impl<'db> EnumValueSet<'db> {
     }
 }
 
+/// Whether distinct declared members are known to have distinct runtime comparison keys.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 enum EnumComparisonKeys {
+    /// Different member names cannot compare equal.
     Distinct,
+    /// Values are unknown or repeated, so different member names may compare equal.
     UnknownOrRepeated,
 }
 
@@ -422,6 +453,9 @@ fn enum_comparison_profile<'db>(
     }
 }
 
+/// Return whether every declared member has a unique modeled runtime comparison key.
+///
+/// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
     enum_class: EnumClassLiteral<'db>,

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,4 +1,4 @@
-//! Compact equality reasoning for values from the same enum class.
+//! Equality reasoning for values from the same enum class without expanding member unions.
 
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
@@ -13,7 +13,7 @@ use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
-/// Compare two compact domains from the same enum without expanding their members.
+/// Compare two value domains from the same enum without comparing every pair of members.
 ///
 /// Any narrowing constraint produced here contains only enum-membership facts. In particular,
 /// equality never transfers gradual or nominal intersection state from one operand to the other.
@@ -48,7 +48,7 @@ pub(super) fn evaluate_same_enum_domains<'db>(
     }
 }
 
-/// The result of comparing two compact domains from the same enum.
+/// The result of comparing two value domains from the same enum.
 pub(in crate::types) enum EnumComparison {
     /// The comparison method is modeled and has the given truthiness.
     Known(Truthiness),
@@ -56,10 +56,10 @@ pub(in crate::types) enum EnumComparison {
     Unmodeled,
 }
 
-/// Compare two compact domains from the same enum without expanding either operand.
+/// Compare two value domains from the same enum without comparing every pair of members.
 ///
 /// `None` means that an operand is not structurally an enum domain.
-pub(in crate::types) fn compact_enum_comparison<'db>(
+pub(in crate::types) fn same_enum_comparison<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
@@ -106,8 +106,8 @@ pub(in crate::types) fn enum_membership_constraint<'db>(
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
 ///
-/// Keeping the operands compact avoids constructing and pairwise comparing unions of every
-/// declared member.
+/// This representation avoids constructing and pairwise comparing unions of every declared
+/// member.
 struct SameEnumComparison<'db> {
     left: EnumValueSet<'db>,
     right: EnumValueSet<'db>,

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -20,6 +20,8 @@ use super::{
 ///
 /// Any narrowing constraint produced here contains only enum-membership facts. In particular,
 /// equality never transfers gradual or nominal intersection state from one operand to the other.
+/// Same-class domains compare compact member sets directly, while comparisons spanning multiple
+/// classes project their members onto runtime comparison keys.
 pub(super) fn evaluate_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
@@ -27,50 +29,16 @@ pub(super) fn evaluate_enum_domains<'db>(
     branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> Option<ComparisonResult<'db>> {
-    EnumDomainComparison::from_types(db, target, other, operator)?.evaluate(db, branch, operator)
-}
-
-/// A comparison of one or more enum domains, using the narrowest applicable representation.
-enum EnumDomainComparison<'db> {
-    SameClass(SameEnumComparison<'db>),
-    Projected(ProjectedEnumComparison<'db>),
-}
-
-impl<'db> EnumDomainComparison<'db> {
-    fn from_types(
-        db: &'db dyn Db,
-        left: Type<'db>,
-        right: Type<'db>,
-        operator: ComparisonOperator,
-    ) -> Option<Self> {
-        let left = EnumDomainSet::from_type(db, left)?;
-        let right = EnumDomainSet::from_type(db, right)?;
-        if let (Some(left), Some(right)) = (left.single(), right.single())
-            && left.enum_class == right.enum_class
-        {
-            return Some(Self::SameClass(SameEnumComparison::new(
-                db,
-                left.clone(),
-                right.clone(),
-                operator,
-            )));
-        }
-        Some(Self::Projected(ProjectedEnumComparison::new(
-            db, left, &right, operator,
-        )?))
+    let target = EnumDomainSet::from_type(db, target)?;
+    let other = EnumDomainSet::from_type(db, other)?;
+    if let (Some(target), Some(other)) = (target.single(), other.single())
+        && target.enum_class == other.enum_class
+    {
+        return SameEnumComparison::new(db, target.clone(), other.clone(), operator)
+            .evaluate(db, branch, operator);
     }
 
-    fn evaluate(
-        &self,
-        db: &'db dyn Db,
-        branch: ComparisonBranch,
-        operator: ComparisonOperator,
-    ) -> Option<ComparisonResult<'db>> {
-        match self {
-            Self::SameClass(comparison) => comparison.evaluate(db, branch, operator),
-            Self::Projected(comparison) => comparison.evaluate(db, branch, operator),
-        }
-    }
+    ProjectedEnumComparison::new(db, target, &other, operator)?.evaluate(db, branch, operator)
 }
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -11,7 +11,10 @@ use crate::types::{
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 
-use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
+use super::{
+    ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics,
+    enum_literal_value,
+};
 
 /// Compare two enum value domains without comparing every pair of members.
 ///
@@ -794,10 +797,13 @@ fn enum_class_key_profile<'db>(
     let members: Box<[(Name, Option<LiteralValueTypeKind<'db>>)]> = enum_class
         .members(db)
         .iter()
-        .map(|(name, value)| {
+        .map(|(name, _)| {
             (
                 name.clone(),
-                semantics.and_then(|semantics| enum_comparison_key(semantics, *value)),
+                semantics.and_then(|semantics| {
+                    enum_literal_value(db, EnumLiteralType::new(db, enum_class, name.clone()))
+                        .and_then(|value| enum_comparison_key(semantics, value))
+                }),
             )
         })
         .collect();

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -253,7 +253,16 @@ impl<'db> EnumValueSet<'db> {
             }
         }
 
-        let enum_class = enum_class?;
+        Self::from_included(enum_class?, included)
+    }
+
+    fn from_included(
+        enum_class: EnumClassLiteral<'db>,
+        included: FxOrderMap<&'db Name, bool>,
+    ) -> Option<Self> {
+        if included.is_empty() {
+            return None;
+        }
         let members = if included.len() == 1 {
             let (name, promotable) = included.into_iter().next()?;
             EnumValueSetMembers::One { name, promotable }
@@ -458,21 +467,18 @@ impl<'db> EnumDomainSet<'db> {
             ty: Type<'db>,
             domains: &mut Vec<EnumValueSet<'db>>,
         ) -> Option<()> {
-            match ty.resolve_type_alias(db) {
-                Type::Union(union) => {
-                    for element in union.elements(db) {
-                        collect(db, *element, domains)?;
-                    }
-                }
-                ty => domains.push(EnumValueSet::from_type(db, ty)?),
+            if let Some(domain) = EnumValueSet::from_type(db, ty) {
+                domains.push(domain);
+                return Some(());
+            }
+
+            let Type::Union(union) = ty.resolve_type_alias(db) else {
+                return None;
+            };
+            for element in union.elements(db) {
+                collect(db, *element, domains)?;
             }
             Some(())
-        }
-
-        if let Some(domain) = EnumValueSet::from_type(db, ty) {
-            return Some(Self {
-                domains: vec![domain],
-            });
         }
 
         let mut domains = Vec::new();
@@ -575,8 +581,10 @@ impl<'db> ProjectedEnumComparison<'db> {
     fn truthiness(&self, operator: ComparisonOperator) -> Truthiness {
         let equality = if !self.left_projection.may_overlap(&self.right_projection) {
             Truthiness::AlwaysFalse
-        } else if self.left_projection.single_key().is_some()
-            && self.left_projection.single_key() == self.right_projection.single_key()
+        } else if let (Some(left), Some(right)) = (
+            self.left_projection.single_key(),
+            self.right_projection.single_key(),
+        ) && left == right
         {
             Truthiness::AlwaysTrue
         } else {
@@ -701,8 +709,7 @@ impl<'db> EnumValueSet<'db> {
         operator: ComparisonOperator,
         projection: &mut EnumKeyProjection<'db>,
     ) -> Option<()> {
-        let profile: &'db EnumClassKeyProfile<'db> =
-            enum_class_key_profile(db, self.enum_class, operator);
+        let profile = enum_class_key_profile(db, self.enum_class, operator);
         let semantics = profile.semantics?;
         let key_domain = EnumComparisonKeyDomain::new(self.enum_class, semantics);
 
@@ -737,8 +744,7 @@ impl<'db> EnumValueSet<'db> {
         operator: ComparisonOperator,
         keys: &FxHashSet<EnumComparisonKey<'db>>,
     ) -> Result<Option<Self>, ()> {
-        let profile: &'db EnumClassKeyProfile<'db> =
-            enum_class_key_profile(db, self.enum_class, operator);
+        let profile = enum_class_key_profile(db, self.enum_class, operator);
         let semantics = profile.semantics.ok_or(())?;
         let mut included = FxOrderMap::default();
         for (name, scalar_key) in &profile.members {
@@ -754,24 +760,12 @@ impl<'db> EnumValueSet<'db> {
                 Self::insert_member(&mut included, name, promotable);
             }
         }
-        if included.is_empty() {
-            return Ok(None);
-        }
         if included.len() == self.member_count(db) && self.is_closed(profile.members_are_exhaustive)
         {
             return Ok(Some(self.clone()));
         }
 
-        let members = if included.len() == 1 {
-            let (name, promotable) = included.into_iter().next().ok_or(())?;
-            EnumValueSetMembers::One { name, promotable }
-        } else {
-            EnumValueSetMembers::Included(included)
-        };
-        Ok(Some(Self {
-            enum_class: self.enum_class,
-            members,
-        }))
+        Ok(Self::from_included(self.enum_class, included))
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,0 +1,444 @@
+//! Compact equality reasoning for values from the same enum class.
+
+use ruff_python_ast::name::Name;
+use rustc_hash::FxHashSet;
+use ty_python_core::Truthiness;
+
+use crate::types::{
+    EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
+    LiteralValueTypeKind, Type, UnionBuilder,
+};
+use crate::{Db, FxOrderSet};
+
+use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
+
+/// Compare two compact domains from the same enum without expanding their members.
+pub(super) fn evaluate_same_enum_domains<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    other: Type<'db>,
+    branch: ComparisonBranch,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    let comparison = SameEnumComparison::from_types(db, target, other, operator)?;
+    match comparison.truthiness(db, operator)? {
+        Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
+        Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
+        Truthiness::Ambiguous if !comparison.supports_domain_narrowing() => {
+            Some(ComparisonResult::Ambiguous)
+        }
+        Truthiness::Ambiguous if operator.condition_expects_equality(branch) => Some(
+            ComparisonResult::CanNarrow(comparison.right.restriction_type(db)),
+        ),
+        Truthiness::Ambiguous => Some(comparison.right.singleton_type(db).map_or(
+            ComparisonResult::Ambiguous,
+            |singleton| {
+                ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(comparison.left.restriction_type(db))
+                        .add_negative(singleton)
+                        .build(),
+                )
+            },
+        )),
+    }
+}
+
+/// The result of comparing two compact domains from the same enum.
+pub(in crate::types) enum EnumComparison {
+    /// The comparison method is modeled and has the given truthiness.
+    Known(Truthiness),
+    /// A custom or otherwise unmodeled comparison method must be called directly.
+    Unmodeled,
+}
+
+/// Compare two compact domains from the same enum without expanding either operand.
+///
+/// `None` means that an operand is not structurally an enum domain.
+pub(in crate::types) fn compact_enum_comparison<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+    is_equality: bool,
+) -> Option<EnumComparison> {
+    let operator = if is_equality {
+        ComparisonOperator::Equality
+    } else {
+        ComparisonOperator::Inequality
+    };
+    let comparison = SameEnumComparison::from_types(db, left, right, operator)?;
+    Some(
+        comparison
+            .truthiness(db, operator)
+            .map_or(EnumComparison::Unmodeled, EnumComparison::Known),
+    )
+}
+
+/// Return the constraint established by membership in an exact set of members from the same enum.
+pub(in crate::types) fn enum_membership_constraint<'db>(
+    db: &'db dyn Db,
+    target: Type<'db>,
+    members: Type<'db>,
+    is_positive: bool,
+) -> Option<Type<'db>> {
+    let comparison =
+        SameEnumComparison::from_types(db, target, members, ComparisonOperator::Equality)?;
+    if !comparison.supports_domain_narrowing() {
+        return None;
+    }
+
+    let members = comparison.right.restriction_type(db);
+    if is_positive {
+        Some(members)
+    } else {
+        Some(
+            IntersectionBuilder::new(db)
+                .add_positive(comparison.left.restriction_type(db))
+                .add_negative(members)
+                .build(),
+        )
+    }
+}
+
+struct SameEnumComparison<'db> {
+    left: EnumValueSet<'db>,
+    right: EnumValueSet<'db>,
+    profile: EnumComparisonProfile,
+}
+
+impl<'db> SameEnumComparison<'db> {
+    fn from_types(
+        db: &'db dyn Db,
+        left: Type<'db>,
+        right: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        let left = EnumValueSet::from_type(db, left)?;
+        let right = EnumValueSet::from_type(db, right)?;
+        if left.enum_class != right.enum_class {
+            return None;
+        }
+        let enum_class = left.enum_class;
+
+        Some(Self {
+            left,
+            right,
+            profile: enum_comparison_profile(db, enum_class, operator),
+        })
+    }
+
+    /// Return `None` only when comparison behavior is custom or otherwise unmodeled.
+    fn truthiness(&self, db: &'db dyn Db, operator: ComparisonOperator) -> Option<Truthiness> {
+        let comparison_keys = self.profile.comparison_keys?;
+        let members_are_exhaustive = self.profile.members_are_exhaustive;
+        let domains_are_closed = self.left.is_closed(members_are_exhaustive)
+            && self.right.is_closed(members_are_exhaustive);
+        let equality = if domains_are_closed
+            && comparison_keys == EnumComparisonKeys::Distinct
+            && !self.left.overlaps(&self.right, db)
+        {
+            Truthiness::AlwaysFalse
+        } else if self.left.is_singleton(db, members_are_exhaustive)
+            && self.right.is_singleton(db, members_are_exhaustive)
+            && self.left.overlaps(&self.right, db)
+        {
+            Truthiness::AlwaysTrue
+        } else {
+            Truthiness::Ambiguous
+        };
+
+        Some(equality.negate_if(operator == ComparisonOperator::Inequality))
+    }
+
+    fn supports_domain_narrowing(&self) -> bool {
+        matches!(
+            self.profile.comparison_keys,
+            Some(EnumComparisonKeys::Distinct)
+        ) && self.right.is_closed(self.profile.members_are_exhaustive)
+            && (self.left.is_closed(self.profile.members_are_exhaustive)
+                || self.profile.members_compare_by_identity)
+    }
+}
+
+/// The enum-member values represented by an operand, excluding non-enum intersection state.
+///
+/// This is an upper bound on the operand's enum values. Gradual and nominal rest components can
+/// make the operand more specific, but they must never be transferred to the other operand by an
+/// equality constraint.
+struct EnumValueSet<'db> {
+    enum_class: EnumClassLiteral<'db>,
+    members: EnumValueSetMembers<'db>,
+}
+
+enum EnumValueSetMembers<'db> {
+    All,
+    One(&'db Name),
+    Included(FxOrderSet<&'db Name>),
+    AllExcept(EnumComplementType<'db>),
+}
+
+impl<'db> EnumValueSet<'db> {
+    /// Extract only structural enum membership facts from `ty`.
+    ///
+    /// This deliberately does not use subtyping: a `NewType` over an enum is a subtype of the
+    /// enum but remains disjoint from the enum's literal members.
+    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        let value_set = match ty.resolve_type_alias(db) {
+            Type::LiteralValue(literal) => {
+                let LiteralValueTypeKind::Enum(literal) = literal.kind() else {
+                    return None;
+                };
+                let enum_class = literal.enum_class_literal(db);
+                let name = enum_class.resolve_member(db, literal.name(db))?;
+                Self {
+                    enum_class,
+                    members: EnumValueSetMembers::One(name),
+                }
+            }
+            Type::NominalInstance(instance) => Self {
+                enum_class: instance.class_literal(db).into_enum_class(db)?,
+                members: EnumValueSetMembers::All,
+            },
+            Type::EnumComplement(complement) => Self {
+                enum_class: complement.enum_class_literal(db),
+                members: EnumValueSetMembers::AllExcept(complement),
+            },
+            Type::Union(union) => Self::from_union(db, union.elements(db))?,
+            Type::Intersection(intersection) => Self::from_intersection(db, intersection)?,
+            _ => return None,
+        };
+        (value_set.member_count(db) > 0).then_some(value_set)
+    }
+
+    fn from_union(db: &'db dyn Db, elements: &[Type<'db>]) -> Option<Self> {
+        let mut enum_class = None;
+        let mut included = FxOrderSet::default();
+        for element in elements {
+            let value_set = Self::from_type(db, *element)?;
+            if let Some(enum_class) = enum_class
+                && enum_class != value_set.enum_class
+            {
+                return None;
+            }
+            enum_class = Some(value_set.enum_class);
+            match value_set.members {
+                EnumValueSetMembers::One(name) => {
+                    included.insert(name);
+                }
+                EnumValueSetMembers::Included(names) => included.extend(names),
+                EnumValueSetMembers::All | EnumValueSetMembers::AllExcept(_) => return None,
+            }
+        }
+
+        let enum_class = enum_class?;
+        let members = if included.len() == 1 {
+            EnumValueSetMembers::One(included.into_iter().next()?)
+        } else {
+            EnumValueSetMembers::Included(included)
+        };
+        Some(Self {
+            enum_class,
+            members,
+        })
+    }
+
+    fn from_intersection(db: &'db dyn Db, intersection: IntersectionType<'db>) -> Option<Self> {
+        if let Some(complement) = intersection.enum_complement(db) {
+            return Self::from_type(db, Type::EnumComplement(complement));
+        }
+
+        // Other intersection components can only reduce the represented enum values. Ignoring
+        // them therefore preserves a safe upper bound without transferring them during narrowing.
+        let mut value_sets = intersection
+            .positive(db)
+            .iter()
+            .filter_map(|positive| Self::from_type(db, *positive));
+        let value_set = value_sets.next()?;
+        value_sets
+            .all(|other| other.enum_class == value_set.enum_class)
+            .then_some(value_set)
+    }
+
+    fn member_count(&self, db: &'db dyn Db) -> usize {
+        match &self.members {
+            EnumValueSetMembers::All => self.enum_class.member_count(db),
+            EnumValueSetMembers::One(_) => 1,
+            EnumValueSetMembers::Included(names) => names.len(),
+            EnumValueSetMembers::AllExcept(complement) => {
+                self.enum_class.member_count(db) - complement.excluded_names(db).len()
+            }
+        }
+    }
+
+    fn is_closed(&self, members_are_exhaustive: bool) -> bool {
+        members_are_exhaustive
+            || matches!(
+                self.members,
+                EnumValueSetMembers::One(_) | EnumValueSetMembers::Included(_)
+            )
+    }
+
+    fn is_singleton(&self, db: &'db dyn Db, members_are_exhaustive: bool) -> bool {
+        self.member_count(db) == 1 && self.is_closed(members_are_exhaustive)
+    }
+
+    fn overlaps(&self, other: &Self, db: &'db dyn Db) -> bool {
+        debug_assert_eq!(self.enum_class, other.enum_class);
+        match (&self.members, &other.members) {
+            (EnumValueSetMembers::All, _) | (_, EnumValueSetMembers::All) => true,
+            (EnumValueSetMembers::One(left), EnumValueSetMembers::One(right)) => left == right,
+            (EnumValueSetMembers::One(name), EnumValueSetMembers::Included(names))
+            | (EnumValueSetMembers::Included(names), EnumValueSetMembers::One(name)) => {
+                names.contains(name)
+            }
+            (EnumValueSetMembers::Included(left), EnumValueSetMembers::Included(right)) => {
+                let (smaller, larger) = if left.len() < right.len() {
+                    (left, right)
+                } else {
+                    (right, left)
+                };
+                smaller.iter().any(|name| larger.contains(name))
+            }
+            (EnumValueSetMembers::One(name), EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::One(name)) => {
+                !complement.excluded_names(db).contains(*name)
+            }
+            (EnumValueSetMembers::Included(names), EnumValueSetMembers::AllExcept(complement))
+            | (EnumValueSetMembers::AllExcept(complement), EnumValueSetMembers::Included(names)) => {
+                names
+                    .iter()
+                    .any(|name| !complement.excluded_names(db).contains(*name))
+            }
+            (EnumValueSetMembers::AllExcept(left), EnumValueSetMembers::AllExcept(right)) => {
+                let left = left.excluded_names(db);
+                let right = right.excluded_names(db);
+                let excluded =
+                    left.len() + right.iter().filter(|name| !left.contains(*name)).count();
+                excluded < self.enum_class.member_count(db)
+            }
+        }
+    }
+
+    /// Reconstruct a constraint containing only this enum value restriction.
+    fn restriction_type(&self, db: &'db dyn Db) -> Type<'db> {
+        match &self.members {
+            EnumValueSetMembers::All => self
+                .enum_class
+                .class_literal(db)
+                .to_non_generic_instance(db),
+            EnumValueSetMembers::One(name) => {
+                Type::enum_literal(EnumLiteralType::new(db, self.enum_class, (*name).clone()))
+            }
+            EnumValueSetMembers::Included(names) => names
+                .iter()
+                .fold(UnionBuilder::new(db), |builder, name| {
+                    builder.add(Type::enum_literal(EnumLiteralType::new(
+                        db,
+                        self.enum_class,
+                        (*name).clone(),
+                    )))
+                })
+                .build(),
+            EnumValueSetMembers::AllExcept(complement) => {
+                if complement.rest(db).is_empty() {
+                    Type::EnumComplement(*complement)
+                } else {
+                    Type::EnumComplement(EnumComplementType::new(
+                        db,
+                        self.enum_class,
+                        complement.excluded_names(db).clone(),
+                        FxOrderSet::default(),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn singleton_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+        if self.member_count(db) != 1 {
+            return None;
+        }
+        let name = match &self.members {
+            EnumValueSetMembers::All => self.enum_class.member_names(db).next()?,
+            EnumValueSetMembers::One(name) => name,
+            EnumValueSetMembers::Included(names) => names.first()?,
+            EnumValueSetMembers::AllExcept(complement) => self
+                .enum_class
+                .member_names(db)
+                .find(|name| !complement.excluded_names(db).contains(*name))?,
+        };
+        Some(Type::enum_literal(EnumLiteralType::new(
+            db,
+            self.enum_class,
+            (*name).clone(),
+        )))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+enum EnumComparisonKeys {
+    Distinct,
+    UnknownOrRepeated,
+}
+
+/// Class-wide facts required to compare enum value sets without member expansion.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct EnumComparisonProfile {
+    members_are_exhaustive: bool,
+    /// Whether distinct enum members compare by identity, including members created at runtime.
+    members_compare_by_identity: bool,
+    /// `None` means comparison behavior is custom or otherwise unmodeled.
+    comparison_keys: Option<EnumComparisonKeys>,
+}
+
+/// Compute and cache the class-wide work needed for repeated comparisons of the same enum.
+#[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
+fn enum_comparison_profile<'db>(
+    db: &'db dyn Db,
+    enum_class: EnumClassLiteral<'db>,
+    operator: ComparisonOperator,
+) -> EnumComparisonProfile {
+    let semantics = KnownComparisonSemantics::of_instance(
+        db,
+        enum_class.class_literal(db).to_non_generic_instance(db),
+        operator,
+    );
+    let (comparison_keys, members_compare_by_identity) = match semantics {
+        None => (None, false),
+        Some(KnownComparisonSemantics::Object) => (Some(EnumComparisonKeys::Distinct), true),
+        Some(
+            KnownComparisonSemantics::Int
+            | KnownComparisonSemantics::Str
+            | KnownComparisonSemantics::Bytes,
+        ) if enum_members_have_distinct_value_keys(db, enum_class) => {
+            (Some(EnumComparisonKeys::Distinct), false)
+        }
+        Some(_) => (Some(EnumComparisonKeys::UnknownOrRepeated), false),
+    };
+    EnumComparisonProfile {
+        members_are_exhaustive: enum_class.members_are_exhaustive(db),
+        members_compare_by_identity,
+        comparison_keys,
+    }
+}
+
+fn enum_members_have_distinct_value_keys<'db>(
+    db: &'db dyn Db,
+    enum_class: EnumClassLiteral<'db>,
+) -> bool {
+    let mut keys = FxHashSet::default();
+    enum_class.members(db).iter().all(|(_, value)| {
+        let key = match value.as_literal_value_kind() {
+            Some(LiteralValueTypeKind::Bool(value)) => Type::int_literal(i64::from(value)),
+            Some(
+                LiteralValueTypeKind::Int(_)
+                | LiteralValueTypeKind::String(_)
+                | LiteralValueTypeKind::Bytes(_),
+            ) => *value,
+            Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
+                return false;
+            }
+        };
+        keys.insert(key)
+    })
+}

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -471,10 +471,10 @@ fn enum_comparison_profile<'db>(
         None => (None, false),
         Some(KnownComparisonSemantics::Object) => (Some(EnumComparisonKeys::Distinct), true),
         Some(
-            KnownComparisonSemantics::Int
+            semantics @ (KnownComparisonSemantics::Int
             | KnownComparisonSemantics::Str
-            | KnownComparisonSemantics::Bytes,
-        ) if enum_members_have_distinct_value_keys(db, enum_class) => {
+            | KnownComparisonSemantics::Bytes),
+        ) if enum_members_have_distinct_value_keys(db, enum_class, semantics) => {
             (Some(EnumComparisonKeys::Distinct), false)
         }
         Some(_) => (Some(EnumComparisonKeys::UnknownOrRepeated), false),
@@ -488,26 +488,27 @@ fn enum_comparison_profile<'db>(
 
 /// Return whether every declared member has a unique modeled runtime comparison key.
 ///
+/// A value is only used when its literal kind matches the inherited scalar semantics; other values
+/// may be normalized by the scalar constructor before enum alias detection.
 /// Keys exclude literal metadata such as promotability, which does not affect runtime equality.
 /// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
     enum_class: EnumClassLiteral<'db>,
+    semantics: KnownComparisonSemantics,
 ) -> bool {
     let mut keys = FxHashSet::default();
     enum_class.members(db).iter().all(|(_, value)| {
-        let key = match value.as_literal_value_kind() {
-            Some(LiteralValueTypeKind::Bool(value)) => {
+        let key = match (semantics, value.as_literal_value_kind()) {
+            (KnownComparisonSemantics::Int, Some(LiteralValueTypeKind::Bool(value))) => {
                 LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value)))
             }
-            Some(
-                kind @ (LiteralValueTypeKind::Int(_)
-                | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_)),
-            ) => kind,
-            Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
-                return false;
+            (KnownComparisonSemantics::Int, Some(kind @ LiteralValueTypeKind::Int(_)))
+            | (KnownComparisonSemantics::Str, Some(kind @ LiteralValueTypeKind::String(_)))
+            | (KnownComparisonSemantics::Bytes, Some(kind @ LiteralValueTypeKind::Bytes(_))) => {
+                kind
             }
+            _ => return false,
         };
         keys.insert(key)
     })

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -1,4 +1,4 @@
-//! Equality reasoning for values from the same enum class without expanding member unions.
+//! Equality reasoning for enum value domains without expanding member unions.
 
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
@@ -13,94 +13,60 @@ use crate::{Db, FxOrderMap, FxOrderSet};
 
 use super::{ComparisonBranch, ComparisonOperator, ComparisonResult, KnownComparisonSemantics};
 
-/// Compare two value domains from the same enum without comparing every pair of members.
+/// Compare two enum value domains without comparing every pair of members.
 ///
 /// Any narrowing constraint produced here contains only enum-membership facts. In particular,
 /// equality never transfers gradual or nominal intersection state from one operand to the other.
-pub(super) fn evaluate_same_enum_domains<'db>(
+pub(super) fn evaluate_enum_domains<'db>(
     db: &'db dyn Db,
     target: Type<'db>,
     other: Type<'db>,
     branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> Option<ComparisonResult<'db>> {
-    let comparison = SameEnumComparison::from_types(db, target, other, operator)?;
-    match comparison.truthiness(db, operator)? {
-        Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
-        Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
-        Truthiness::Ambiguous if !comparison.supports_domain_narrowing() => {
-            Some(ComparisonResult::Ambiguous)
+    EnumDomainComparison::from_types(db, target, other, operator)?.evaluate(db, branch, operator)
+}
+
+/// A comparison of one or more enum domains, using the narrowest applicable representation.
+enum EnumDomainComparison<'db> {
+    SameClass(SameEnumComparison<'db>),
+    Projected(ProjectedEnumComparison<'db>),
+}
+
+impl<'db> EnumDomainComparison<'db> {
+    fn from_types(
+        db: &'db dyn Db,
+        left: Type<'db>,
+        right: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        let left = EnumDomainSet::from_type(db, left)?;
+        let right = EnumDomainSet::from_type(db, right)?;
+        if let (Some(left), Some(right)) = (left.single(), right.single())
+            && left.enum_class == right.enum_class
+        {
+            return Some(Self::SameClass(SameEnumComparison::new(
+                db,
+                left.clone(),
+                right.clone(),
+                operator,
+            )));
         }
-        Truthiness::Ambiguous if operator.condition_expects_equality(branch) => Some(
-            ComparisonResult::CanNarrow(comparison.right.restriction_type(db)),
-        ),
-        Truthiness::Ambiguous => Some(comparison.right.singleton_type(db).map_or(
-            ComparisonResult::Ambiguous,
-            |singleton| {
-                ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
-                        .add_positive(comparison.left.restriction_type(db))
-                        .add_negative(singleton)
-                        .build(),
-                )
-            },
-        )),
-    }
-}
-
-/// The result of comparing two value domains from the same enum.
-pub(in crate::types) enum EnumComparison {
-    /// The comparison method is modeled and has the given truthiness.
-    Known(Truthiness),
-    /// A custom or otherwise unmodeled comparison method must be called directly.
-    Unmodeled,
-}
-
-/// Compare two value domains from the same enum without comparing every pair of members.
-///
-/// `None` means that an operand is not structurally an enum domain.
-pub(in crate::types) fn same_enum_comparison<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-    is_equality: bool,
-) -> Option<EnumComparison> {
-    let operator = if is_equality {
-        ComparisonOperator::Equality
-    } else {
-        ComparisonOperator::Inequality
-    };
-    let comparison = SameEnumComparison::from_types(db, left, right, operator)?;
-    Some(
-        comparison
-            .truthiness(db, operator)
-            .map_or(EnumComparison::Unmodeled, EnumComparison::Known),
-    )
-}
-
-/// Return the constraint established by membership in an exact set of members from the same enum.
-pub(in crate::types) fn enum_membership_constraint<'db>(
-    db: &'db dyn Db,
-    target: Type<'db>,
-    members: Type<'db>,
-    is_positive: bool,
-) -> Option<Type<'db>> {
-    let comparison =
-        SameEnumComparison::from_types(db, target, members, ComparisonOperator::Equality)?;
-    if !comparison.supports_domain_narrowing() {
-        return None;
+        Some(Self::Projected(ProjectedEnumComparison::new(
+            db, left, &right, operator,
+        )?))
     }
 
-    let members = comparison.right.restriction_type(db);
-    if is_positive {
-        Some(members)
-    } else {
-        Some(
-            IntersectionBuilder::new(db)
-                .add_positive(comparison.left.restriction_type(db))
-                .add_negative(members)
-                .build(),
-        )
+    fn evaluate(
+        &self,
+        db: &'db dyn Db,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> Option<ComparisonResult<'db>> {
+        match self {
+            Self::SameClass(comparison) => comparison.evaluate(db, branch, operator),
+            Self::Projected(comparison) => comparison.evaluate(db, branch, operator),
+        }
     }
 }
 
@@ -111,28 +77,24 @@ pub(in crate::types) fn enum_membership_constraint<'db>(
 struct SameEnumComparison<'db> {
     left: EnumValueSet<'db>,
     right: EnumValueSet<'db>,
-    profile: EnumComparisonProfile,
+    profile: SameEnumComparisonProfile,
 }
 
 impl<'db> SameEnumComparison<'db> {
-    fn from_types(
+    fn new(
         db: &'db dyn Db,
-        left: Type<'db>,
-        right: Type<'db>,
+        left: EnumValueSet<'db>,
+        right: EnumValueSet<'db>,
         operator: ComparisonOperator,
-    ) -> Option<Self> {
-        let left = EnumValueSet::from_type(db, left)?;
-        let right = EnumValueSet::from_type(db, right)?;
-        if left.enum_class != right.enum_class {
-            return None;
-        }
+    ) -> Self {
+        debug_assert_eq!(left.enum_class, right.enum_class);
         let enum_class = left.enum_class;
 
-        Some(Self {
+        Self {
             left,
             right,
-            profile: enum_comparison_profile(db, enum_class, operator),
-        })
+            profile: same_enum_comparison_profile(db, enum_class, operator),
+        }
     }
 
     /// Return `None` only when comparison behavior is custom or otherwise unmodeled.
@@ -142,7 +104,7 @@ impl<'db> SameEnumComparison<'db> {
         let domains_are_closed = self.left.is_closed(members_are_exhaustive)
             && self.right.is_closed(members_are_exhaustive);
         let equality = if domains_are_closed
-            && comparison_keys == EnumComparisonKeys::Distinct
+            && comparison_keys == SameEnumComparisonKeys::Distinct
             && !self.left.overlaps(&self.right, db)
         {
             Truthiness::AlwaysFalse
@@ -158,6 +120,35 @@ impl<'db> SameEnumComparison<'db> {
         Some(equality.negate_if(operator == ComparisonOperator::Inequality))
     }
 
+    fn evaluate(
+        &self,
+        db: &'db dyn Db,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> Option<ComparisonResult<'db>> {
+        match self.truthiness(db, operator)? {
+            Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
+            Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
+            Truthiness::Ambiguous if !self.supports_domain_narrowing() => {
+                Some(ComparisonResult::Ambiguous)
+            }
+            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => {
+                Some(ComparisonResult::CanNarrow(self.right.restriction_type(db)))
+            }
+            Truthiness::Ambiguous => Some(self.right.singleton_type(db).map_or(
+                ComparisonResult::Ambiguous,
+                |singleton| {
+                    ComparisonResult::CanNarrow(
+                        IntersectionBuilder::new(db)
+                            .add_positive(self.left.restriction_type(db))
+                            .add_negative(singleton)
+                            .build(),
+                    )
+                },
+            )),
+        }
+    }
+
     /// Return whether equality can soundly transfer the right-hand enum restriction to the left.
     ///
     /// The right domain must be closed, and the left must either be closed as well or use identity
@@ -165,7 +156,7 @@ impl<'db> SameEnumComparison<'db> {
     fn supports_domain_narrowing(&self) -> bool {
         matches!(
             self.profile.comparison_keys,
-            Some(EnumComparisonKeys::Distinct)
+            Some(SameEnumComparisonKeys::Distinct)
         ) && self.right.is_closed(self.profile.members_are_exhaustive)
             && (self.left.is_closed(self.profile.members_are_exhaustive)
                 || self.profile.members_compare_by_identity)
@@ -177,12 +168,14 @@ impl<'db> SameEnumComparison<'db> {
 /// This is an upper bound on the operand's enum values. Gradual and nominal rest components can
 /// make the operand more specific, but they must never be transferred to the other operand by an
 /// equality constraint.
+#[derive(Clone)]
 struct EnumValueSet<'db> {
     enum_class: EnumClassLiteral<'db>,
     members: EnumValueSetMembers<'db>,
 }
 
 /// Compact representation of the member names admitted by an [`EnumValueSet`].
+#[derive(Clone)]
 enum EnumValueSetMembers<'db> {
     /// The entire enum domain, including undeclared runtime values when the enum is open.
     All,
@@ -331,6 +324,20 @@ impl<'db> EnumValueSet<'db> {
         self.member_count(db) == 1 && self.is_closed(members_are_exhaustive)
     }
 
+    fn member_promotability(&self, db: &'db dyn Db, name: &Name) -> Option<bool> {
+        match &self.members {
+            EnumValueSetMembers::All => Some(true),
+            EnumValueSetMembers::One {
+                name: member,
+                promotable,
+            } => (*member == name).then_some(*promotable),
+            EnumValueSetMembers::Included(members) => members.get(name).copied(),
+            EnumValueSetMembers::AllExcept(complement) => {
+                (!complement.excluded_names(db).contains(name)).then_some(true)
+            }
+        }
+    }
+
     fn overlaps(&self, other: &Self, db: &'db dyn Db) -> bool {
         debug_assert_eq!(self.enum_class, other.enum_class);
         match (&self.members, &other.members) {
@@ -436,80 +443,439 @@ impl<'db> EnumValueSet<'db> {
     }
 }
 
+/// One or more enum-class domains represented by an operand.
+struct EnumDomainSet<'db> {
+    domains: Vec<EnumValueSet<'db>>,
+}
+
+impl<'db> EnumDomainSet<'db> {
+    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+        fn collect<'db>(
+            db: &'db dyn Db,
+            ty: Type<'db>,
+            domains: &mut Vec<EnumValueSet<'db>>,
+        ) -> Option<()> {
+            match ty.resolve_type_alias(db) {
+                Type::Union(union) => {
+                    for element in union.elements(db) {
+                        collect(db, *element, domains)?;
+                    }
+                }
+                ty => domains.push(EnumValueSet::from_type(db, ty)?),
+            }
+            Some(())
+        }
+
+        if let Some(domain) = EnumValueSet::from_type(db, ty) {
+            return Some(Self {
+                domains: vec![domain],
+            });
+        }
+
+        let mut domains = Vec::new();
+        collect(db, ty, &mut domains)?;
+        (!domains.is_empty()).then_some(Self { domains })
+    }
+
+    fn single(&self) -> Option<&EnumValueSet<'db>> {
+        let [domain] = self.domains.as_slice() else {
+            return None;
+        };
+        Some(domain)
+    }
+
+    fn key_projection(
+        &self,
+        db: &'db dyn Db,
+        operator: ComparisonOperator,
+    ) -> Option<EnumKeyProjection<'db>> {
+        let mut projection = EnumKeyProjection::default();
+        for domain in &self.domains {
+            domain.add_keys_to_projection(db, operator, &mut projection)?;
+        }
+        Some(projection)
+    }
+
+    fn restriction_type(&self, db: &'db dyn Db) -> Type<'db> {
+        self.domains
+            .iter()
+            .fold(UnionBuilder::new(db), |builder, domain| {
+                builder.add(domain.restriction_type(db))
+            })
+            .build()
+    }
+
+    fn restrict_for_equality(
+        &self,
+        db: &'db dyn Db,
+        operator: ComparisonOperator,
+        other: &EnumKeyProjection<'db>,
+    ) -> Option<Type<'db>> {
+        let mut builder = UnionBuilder::new(db);
+        for domain in &self.domains {
+            let mut projection = EnumKeyProjection::default();
+            domain.add_keys_to_projection(db, operator, &mut projection)?;
+            if projection.unknowns_may_overlap(other) {
+                builder = builder.add(domain.restriction_type(db));
+            } else if let Some(retained) = domain.retain_keys(db, operator, &other.keys).ok()? {
+                builder = builder.add(retained.restriction_type(db));
+            }
+        }
+        Some(builder.build())
+    }
+
+    /// Return the known subset of `self` that compares equal to `other`'s single key.
+    fn known_equal_type(
+        &self,
+        db: &'db dyn Db,
+        operator: ComparisonOperator,
+        other: &EnumKeyProjection<'db>,
+    ) -> Option<Type<'db>> {
+        let mut builder = UnionBuilder::new(db);
+        for domain in &self.domains {
+            let mut projection = EnumKeyProjection::default();
+            domain.add_keys_to_projection(db, operator, &mut projection)?;
+            if projection.unknowns_may_overlap(other) {
+                continue;
+            }
+            if let Some(retained) = domain.retain_keys(db, operator, &other.keys).ok()? {
+                builder = builder.add(retained.restriction_type(db));
+            }
+        }
+        Some(builder.build())
+    }
+}
+
+/// A comparison of operands that span more than one enum class.
+struct ProjectedEnumComparison<'db> {
+    left: EnumDomainSet<'db>,
+    left_projection: EnumKeyProjection<'db>,
+    right_projection: EnumKeyProjection<'db>,
+}
+
+impl<'db> ProjectedEnumComparison<'db> {
+    fn new(
+        db: &'db dyn Db,
+        left: EnumDomainSet<'db>,
+        right: &EnumDomainSet<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
+        let left_projection = left.key_projection(db, operator)?;
+        let right_projection = right.key_projection(db, operator)?;
+        Some(Self {
+            left,
+            left_projection,
+            right_projection,
+        })
+    }
+
+    fn truthiness(&self, operator: ComparisonOperator) -> Truthiness {
+        let equality = if !self.left_projection.may_overlap(&self.right_projection) {
+            Truthiness::AlwaysFalse
+        } else if self.left_projection.single_key().is_some()
+            && self.left_projection.single_key() == self.right_projection.single_key()
+        {
+            Truthiness::AlwaysTrue
+        } else {
+            Truthiness::Ambiguous
+        };
+        equality.negate_if(operator == ComparisonOperator::Inequality)
+    }
+
+    fn evaluate(
+        &self,
+        db: &'db dyn Db,
+        branch: ComparisonBranch,
+        operator: ComparisonOperator,
+    ) -> Option<ComparisonResult<'db>> {
+        match self.truthiness(operator) {
+            Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
+            Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
+            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => {
+                Some(ComparisonResult::CanNarrow(
+                    self.left
+                        .restrict_for_equality(db, operator, &self.right_projection)?,
+                ))
+            }
+            Truthiness::Ambiguous if self.right_projection.single_key().is_some() => {
+                let equal_left =
+                    self.left
+                        .known_equal_type(db, operator, &self.right_projection)?;
+                Some(ComparisonResult::CanNarrow(
+                    IntersectionBuilder::new(db)
+                        .add_positive(self.left.restriction_type(db))
+                        .add_negative(equal_left)
+                        .build(),
+                ))
+            }
+            Truthiness::Ambiguous => Some(ComparisonResult::Ambiguous),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+enum EnumComparisonKey<'db> {
+    Object(EnumClassLiteral<'db>, &'db Name),
+    Scalar(LiteralValueTypeKind<'db>),
+}
+
+impl<'db> EnumComparisonKey<'db> {
+    fn domain(self) -> Option<EnumComparisonKeyDomain<'db>> {
+        match self {
+            Self::Object(enum_class, _) => Some(EnumComparisonKeyDomain::Object(enum_class)),
+            Self::Scalar(LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_)) => {
+                Some(EnumComparisonKeyDomain::Int)
+            }
+            Self::Scalar(LiteralValueTypeKind::String(_)) => Some(EnumComparisonKeyDomain::Str),
+            Self::Scalar(LiteralValueTypeKind::Bytes(_)) => Some(EnumComparisonKeyDomain::Bytes),
+            Self::Scalar(_) => None,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+enum EnumComparisonKeyDomain<'db> {
+    Object(EnumClassLiteral<'db>),
+    Int,
+    Str,
+    Bytes,
+    Tuple,
+    Dict,
+}
+
+impl<'db> EnumComparisonKeyDomain<'db> {
+    fn new(enum_class: EnumClassLiteral<'db>, semantics: KnownComparisonSemantics) -> Self {
+        match semantics {
+            KnownComparisonSemantics::Object => Self::Object(enum_class),
+            KnownComparisonSemantics::Int => Self::Int,
+            KnownComparisonSemantics::Str => Self::Str,
+            KnownComparisonSemantics::Bytes => Self::Bytes,
+            KnownComparisonSemantics::Tuple => Self::Tuple,
+            KnownComparisonSemantics::Dict => Self::Dict,
+        }
+    }
+
+    const fn unknown_overlaps_known(self) -> bool {
+        !matches!(self, Self::Object(_))
+    }
+}
+
+#[derive(Default)]
+struct EnumKeyProjection<'db> {
+    keys: FxHashSet<EnumComparisonKey<'db>>,
+    known_domains: FxHashSet<EnumComparisonKeyDomain<'db>>,
+    unknown_domains: FxHashSet<EnumComparisonKeyDomain<'db>>,
+}
+
+impl<'db> EnumKeyProjection<'db> {
+    fn may_overlap(&self, other: &Self) -> bool {
+        !self.keys.is_disjoint(&other.keys) || self.unknowns_may_overlap(other)
+    }
+
+    fn unknowns_may_overlap(&self, other: &Self) -> bool {
+        !self.unknown_domains.is_disjoint(&other.unknown_domains)
+            || self.unknown_domains.iter().any(|domain| {
+                domain.unknown_overlaps_known() && other.known_domains.contains(domain)
+            })
+            || other.unknown_domains.iter().any(|domain| {
+                domain.unknown_overlaps_known() && self.known_domains.contains(domain)
+            })
+    }
+
+    fn single_key(&self) -> Option<EnumComparisonKey<'db>> {
+        if self.unknown_domains.is_empty() && self.keys.len() == 1 {
+            self.keys.iter().copied().next()
+        } else {
+            None
+        }
+    }
+}
+
+impl<'db> EnumValueSet<'db> {
+    fn add_keys_to_projection(
+        &self,
+        db: &'db dyn Db,
+        operator: ComparisonOperator,
+        projection: &mut EnumKeyProjection<'db>,
+    ) -> Option<()> {
+        let profile: &'db EnumClassKeyProfile<'db> =
+            enum_class_key_profile(db, self.enum_class, operator);
+        let semantics = profile.semantics?;
+        let key_domain = EnumComparisonKeyDomain::new(self.enum_class, semantics);
+
+        for (name, scalar_key) in &profile.members {
+            if self.member_promotability(db, name).is_none() {
+                continue;
+            }
+            let key = if semantics == KnownComparisonSemantics::Object {
+                Some(EnumComparisonKey::Object(self.enum_class, name))
+            } else {
+                scalar_key.map(EnumComparisonKey::Scalar)
+            };
+            if let Some(key) = key
+                && let Some(domain) = key.domain()
+            {
+                projection.known_domains.insert(domain);
+                projection.keys.insert(key);
+            } else {
+                projection.unknown_domains.insert(key_domain);
+            }
+        }
+
+        if !self.is_closed(profile.members_are_exhaustive) {
+            projection.unknown_domains.insert(key_domain);
+        }
+        Some(())
+    }
+
+    fn retain_keys(
+        &self,
+        db: &'db dyn Db,
+        operator: ComparisonOperator,
+        keys: &FxHashSet<EnumComparisonKey<'db>>,
+    ) -> Result<Option<Self>, ()> {
+        let profile: &'db EnumClassKeyProfile<'db> =
+            enum_class_key_profile(db, self.enum_class, operator);
+        let semantics = profile.semantics.ok_or(())?;
+        let mut included = FxOrderMap::default();
+        for (name, scalar_key) in &profile.members {
+            let Some(promotable) = self.member_promotability(db, name) else {
+                continue;
+            };
+            let key = if semantics == KnownComparisonSemantics::Object {
+                Some(EnumComparisonKey::Object(self.enum_class, name))
+            } else {
+                scalar_key.map(EnumComparisonKey::Scalar)
+            };
+            if key.is_some_and(|key| keys.contains(&key)) {
+                Self::insert_member(&mut included, name, promotable);
+            }
+        }
+        if included.is_empty() {
+            return Ok(None);
+        }
+        if included.len() == self.member_count(db) && self.is_closed(profile.members_are_exhaustive)
+        {
+            return Ok(Some(self.clone()));
+        }
+
+        let members = if included.len() == 1 {
+            let (name, promotable) = included.into_iter().next().ok_or(())?;
+            EnumValueSetMembers::One { name, promotable }
+        } else {
+            EnumValueSetMembers::Included(included)
+        };
+        Ok(Some(Self {
+            enum_class: self.enum_class,
+            members,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
+struct EnumClassKeyProfile<'db> {
+    members_are_exhaustive: bool,
+    semantics: Option<KnownComparisonSemantics>,
+    members: Box<[(Name, Option<LiteralValueTypeKind<'db>>)]>,
+}
+
+/// Cache each class's modeled comparison keys independently of any particular operand pair.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+fn enum_class_key_profile<'db>(
+    db: &'db dyn Db,
+    enum_class: EnumClassLiteral<'db>,
+    operator: ComparisonOperator,
+) -> EnumClassKeyProfile<'db> {
+    let semantics = KnownComparisonSemantics::of_instance(
+        db,
+        enum_class.class_literal(db).to_non_generic_instance(db),
+        operator,
+    );
+    let members: Box<[(Name, Option<LiteralValueTypeKind<'db>>)]> = enum_class
+        .members(db)
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.clone(),
+                semantics.and_then(|semantics| enum_comparison_key(semantics, *value)),
+            )
+        })
+        .collect();
+    EnumClassKeyProfile {
+        members_are_exhaustive: enum_class.members_are_exhaustive(db),
+        semantics,
+        members,
+    }
+}
+
 /// Whether distinct declared members are known to have distinct runtime comparison keys.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-enum EnumComparisonKeys {
+enum SameEnumComparisonKeys {
     /// Different member names cannot compare equal.
     Distinct,
     /// Values are unknown or repeated, so different member names may compare equal.
     UnknownOrRepeated,
 }
 
-/// Class-wide facts required to compare enum value sets without member expansion.
+/// Same-class facts that are unnecessary when projecting keys across different classes.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
-struct EnumComparisonProfile {
+struct SameEnumComparisonProfile {
     members_are_exhaustive: bool,
-    /// Whether distinct enum members compare by identity, including members created at runtime.
     members_compare_by_identity: bool,
-    /// `None` means comparison behavior is custom or otherwise unmodeled.
-    comparison_keys: Option<EnumComparisonKeys>,
+    comparison_keys: Option<SameEnumComparisonKeys>,
 }
 
-/// Compute and cache the class-wide work needed for repeated comparisons of the same enum.
 #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
-fn enum_comparison_profile<'db>(
+fn same_enum_comparison_profile<'db>(
     db: &'db dyn Db,
     enum_class: EnumClassLiteral<'db>,
     operator: ComparisonOperator,
-) -> EnumComparisonProfile {
-    let semantics = KnownComparisonSemantics::of_instance(
-        db,
-        enum_class.class_literal(db).to_non_generic_instance(db),
-        operator,
-    );
-    let (comparison_keys, members_compare_by_identity) = match semantics {
+) -> SameEnumComparisonProfile {
+    let profile = enum_class_key_profile(db, enum_class, operator);
+    let (comparison_keys, members_compare_by_identity) = match profile.semantics {
         None => (None, false),
-        Some(KnownComparisonSemantics::Object) => (Some(EnumComparisonKeys::Distinct), true),
+        Some(KnownComparisonSemantics::Object) => (Some(SameEnumComparisonKeys::Distinct), true),
         Some(
-            semantics @ (KnownComparisonSemantics::Int
+            KnownComparisonSemantics::Int
             | KnownComparisonSemantics::Str
-            | KnownComparisonSemantics::Bytes),
-        ) if enum_members_have_distinct_value_keys(db, enum_class, semantics) => {
-            (Some(EnumComparisonKeys::Distinct), false)
+            | KnownComparisonSemantics::Bytes,
+        ) => {
+            let mut keys = FxHashSet::default();
+            let keys_are_distinct = profile
+                .members
+                .iter()
+                .all(|(_, key)| key.is_some_and(|key| keys.insert(key)));
+            (
+                Some(if keys_are_distinct {
+                    SameEnumComparisonKeys::Distinct
+                } else {
+                    SameEnumComparisonKeys::UnknownOrRepeated
+                }),
+                false,
+            )
         }
-        Some(_) => (Some(EnumComparisonKeys::UnknownOrRepeated), false),
+        Some(_) => (Some(SameEnumComparisonKeys::UnknownOrRepeated), false),
     };
-    EnumComparisonProfile {
-        members_are_exhaustive: enum_class.members_are_exhaustive(db),
+    SameEnumComparisonProfile {
+        members_are_exhaustive: profile.members_are_exhaustive,
         members_compare_by_identity,
         comparison_keys,
     }
 }
 
-/// Return whether every declared member has a unique modeled runtime comparison key.
-///
-/// A value is only used when its literal kind matches the inherited scalar semantics; other values
-/// may be normalized by the scalar constructor before enum alias detection.
-/// Keys exclude literal metadata such as promotability, which does not affect runtime equality.
-/// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
-fn enum_members_have_distinct_value_keys<'db>(
-    db: &'db dyn Db,
-    enum_class: EnumClassLiteral<'db>,
+fn enum_comparison_key(
     semantics: KnownComparisonSemantics,
-) -> bool {
-    let mut keys = FxHashSet::default();
-    enum_class.members(db).iter().all(|(_, value)| {
-        let key = match (semantics, value.as_literal_value_kind()) {
-            (KnownComparisonSemantics::Int, Some(LiteralValueTypeKind::Bool(value))) => {
-                LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value)))
-            }
-            (KnownComparisonSemantics::Int, Some(kind @ LiteralValueTypeKind::Int(_)))
-            | (KnownComparisonSemantics::Str, Some(kind @ LiteralValueTypeKind::String(_)))
-            | (KnownComparisonSemantics::Bytes, Some(kind @ LiteralValueTypeKind::Bytes(_))) => {
-                kind
-            }
-            _ => return false,
-        };
-        keys.insert(key)
-    })
+    value: Type<'_>,
+) -> Option<LiteralValueTypeKind<'_>> {
+    match (semantics, value.as_literal_value_kind()) {
+        (KnownComparisonSemantics::Int, Some(LiteralValueTypeKind::Bool(value))) => Some(
+            LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value))),
+        ),
+        (KnownComparisonSemantics::Int, Some(kind @ LiteralValueTypeKind::Int(_)))
+        | (KnownComparisonSemantics::Str, Some(kind @ LiteralValueTypeKind::String(_)))
+        | (KnownComparisonSemantics::Bytes, Some(kind @ LiteralValueTypeKind::Bytes(_))) => {
+            Some(kind)
+        }
+        _ => None,
+    }
 }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -4,6 +4,7 @@ use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 use ty_python_core::Truthiness;
 
+use crate::types::literal::IntLiteralType;
 use crate::types::{
     EnumClassLiteral, EnumComplementType, EnumLiteralType, IntersectionBuilder, IntersectionType,
     LiteralValueType, LiteralValueTypeKind, Type, UnionBuilder,
@@ -487,6 +488,7 @@ fn enum_comparison_profile<'db>(
 
 /// Return whether every declared member has a unique modeled runtime comparison key.
 ///
+/// Keys exclude literal metadata such as promotability, which does not affect runtime equality.
 /// Boolean keys are normalized to integers because Python considers `False == 0` and `True == 1`.
 fn enum_members_have_distinct_value_keys<'db>(
     db: &'db dyn Db,
@@ -495,12 +497,14 @@ fn enum_members_have_distinct_value_keys<'db>(
     let mut keys = FxHashSet::default();
     enum_class.members(db).iter().all(|(_, value)| {
         let key = match value.as_literal_value_kind() {
-            Some(LiteralValueTypeKind::Bool(value)) => Type::int_literal(i64::from(value)),
+            Some(LiteralValueTypeKind::Bool(value)) => {
+                LiteralValueTypeKind::Int(IntLiteralType::from_i64(i64::from(value)))
+            }
             Some(
-                LiteralValueTypeKind::Int(_)
+                kind @ (LiteralValueTypeKind::Int(_)
                 | LiteralValueTypeKind::String(_)
-                | LiteralValueTypeKind::Bytes(_),
-            ) => *value,
+                | LiteralValueTypeKind::Bytes(_)),
+            ) => kind,
             Some(LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_)) | None => {
                 return false;
             }


### PR DESCRIPTION
## Summary

Since #25955 and #26337, equality narrowing, match reachability, membership compatibility, and ordinary `==` and `!=` result inference all use the same comparison evaluator, within which comparing large enums ends up performing a large member cross-product operation.

This PR adds a fast path for enums, whereby same-class operands use compact member sets and cross-class / multi-class unions project members onto cached runtime comparison keys. The cache is per enum class and comparison operator, so repeated comparisons reuse the class-wide scan instead of repeating it for every type pair or expression. Because it's in the shared evaluator, this optimization applies consistently to equality and inequality narrowing, definite comparison results and resulting reachability, value-pattern narrowing, and membership compatibility.

(Note: `SameEnumComparison` is a fast path within the fast path for enums of the same class. Within the same class, we can just compare member-name sets; for different classes, we need project down to a value.)

In quick local benchmarks against current `main`, the original astral-sh/ty#3830 reproducer drops from roughly 14.4 s to 9.3 ms, a comparison between two 256-member `StrEnum`s drops from roughly 242 ms to 10.8 ms, and a comparison between unions spanning 16 enum classes drops from roughly 296 ms to 10.9 ms.

Closes https://github.com/astral-sh/ty/issues/3830.
