### PR TITLE
[ty] Bound recursive inference cycle growth

### DIFF
--- a/crates/ty_python_semantic/resources/corpus/recursive_inference_growth.py
+++ b/crates/ty_python_semantic/resources/corpus/recursive_inference_growth.py
@@ -1,0 +1,227 @@
+# Regression corpus for recursive inference growth from issues #3827 and #3837.
+
+from collections.abc import Callable
+from functools import partial
+from typing import Annotated, TypeIs
+
+
+class Container[T]: ...
+class Other[T]: ...
+
+
+def identity[T](value: T) -> T:
+    return value
+
+
+def is_container[T](x: object, y: T) -> TypeIs[Container[T]]:
+    return True
+
+
+def is_container_or_other[T](x: object, y: T) -> TypeIs[Container[T] | Other[T]]:
+    return True
+
+
+def recursive_iterator_growth():
+    while True:
+        x = iter([[None] + [x]])
+
+
+def recursive_narrowing_distribution():
+    while True:
+        if is_container(x, type(x)):
+            x = [x]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_distribution_inside_a_nested_wrapper():
+    while True:
+        if is_container(x, type(x)):
+            x = [[x]]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_distribution_inside_a_tuple():
+    while True:
+        if is_container(x, type(x)):
+            x = (x,)
+        else:
+            x = {x}
+
+
+def recursive_narrowing_distribution_inside_a_tuple_with_a_stable_element():
+    while True:
+        if is_container(x, type(x)):
+            x = (0, x)
+        else:
+            x = {x}
+
+
+def recursive_narrowing_distribution_in_multiple_tuple_elements():
+    while True:
+        if is_container(x, type(x)):
+            x = (x, x)
+        else:
+            x = {x}
+
+
+def recursive_narrowing_distribution_with_an_initialized_value():
+    x = 1
+    while True:
+        if is_container(x, type(x)):
+            x = [x]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_with_a_stable_previous_arm():
+    x = 0
+    while True:
+        if is_container(x, x):
+            x = [x]
+        else:
+            x = x
+
+
+def recursive_narrowing_distribution_with_multiple_targets():
+    while True:
+        if is_container_or_other(y, type(y)):
+            y = [y]
+        else:
+            y = {y}
+
+
+def recursive_narrowing_with_multiple_growing_frontiers():
+    def test(flag: bool):
+        x = 0
+        while True:
+            if is_container(x, x):
+                x = [x] if flag else (x,)
+            else:
+                x = x
+
+
+def recursive_narrowing_distribution_through_a_bound_method():
+    while True:
+        if is_container(x, type(x)):
+            x = x.__str__
+        else:
+            x = {x}
+
+
+def recursive_narrowing_through_a_negative_bound_method():
+    x = 0
+    while True:
+        if is_container(x, x):
+            x = [x]
+        else:
+            x = x.__str__
+
+
+def recursive_narrowing_through_a_precise_partial():
+    x = 0
+    while True:
+        if is_container(x, x):
+            x = [x]
+        else:
+            x = partial(identity, x)
+
+
+def recursive_type_form_growth_with_a_stable_bound_method():
+    x = int
+    while True:
+        if is_container(x, x):
+            x = list[x]
+        else:
+            x = x.__str__
+
+
+def recursive_narrowing_distribution_through_a_generator_expression():
+    x = 0
+    while True:
+        if is_container(x, x):
+            x = (element for element in (x,))
+        else:
+            x = [x]
+
+
+def recursive_narrowing_distribution_through_a_generator_expression_and_tuple():
+    x = 0
+    while True:
+        if is_container(x, x):
+            x = (element for element in (x,))
+        else:
+            x = (x,)
+
+
+def recursive_narrowing_distribution_through_type():
+    x = 0
+    while True:
+        if is_container(x, type(x)):
+            x = (element for element in (x,))
+        else:
+            x = [x]
+
+
+def recursive_narrowing_through_a_runtime_generic_alias():
+    x = int
+    while True:
+        if is_container(x, type(x)):
+            x = list[x]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_through_a_tuple_generic_alias():
+    x = int
+    while True:
+        if is_container(x, type(x)):
+            x = tuple[x]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_through_a_runtime_callable():
+    x = int
+    while True:
+        if is_container(x, type(x)):
+            x = Callable[[], x]
+        else:
+            x = {x}
+
+
+def recursive_narrowing_through_multiple_runtime_type_forms():
+    x = int
+    while True:
+        if is_container(x, x):
+            x = list[x]
+        else:
+            x = Callable[[], x]
+
+
+def recursive_narrowing_through_same_origin_runtime_type_forms():
+    x = int
+    while True:
+        if is_container(x, x):
+            x = list[x]
+        else:
+            x = list[list[x]]
+
+
+def recursive_narrowing_through_a_runtime_union():
+    x = int
+    while True:
+        if is_container(x, x):
+            x = list[x] | str
+        else:
+            x = {x}
+
+
+def recursive_narrowing_through_a_runtime_annotated_value():
+    x = int
+    while True:
+        if is_container(x, x):
+            x = Annotated[list[x], "metadata"]
+        else:
+            x = {x}

--- a/crates/ty_python_semantic/resources/mdtest/attributes.md
+++ b/crates/ty_python_semantic/resources/mdtest/attributes.md
@@ -3111,6 +3111,34 @@ class ManyCycles:
         reveal_type(self.x6)  # revealed: int
         reveal_type(self.x7)  # revealed: int
 
+# A wide finite cycle needs more than the minimum iteration budget to converge.
+class WideCycle:
+    def __init__(self):
+        self.x1 = 0
+        self.x2 = 0
+        self.x3 = 0
+        self.x4 = 0
+        self.x5 = 0
+        self.x6 = 0
+        self.x7 = 0
+        self.x8 = 0
+        self.x9 = 0
+        self.x10 = 1
+
+    def update(self):
+        self.x1 = self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x2 = self.x1 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x3 = self.x1 + self.x2 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x4 = self.x1 + self.x2 + self.x3 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x5 = self.x1 + self.x2 + self.x3 + self.x4 + self.x6 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x6 = self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x7 + self.x8 + self.x9 + self.x10
+        self.x7 = self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x8 + self.x9 + self.x10
+        self.x8 = self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x9 + self.x10
+        self.x9 = self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x10
+        self.x10 = self.x1 + self.x2 + self.x3 + self.x4 + self.x5 + self.x6 + self.x7 + self.x8 + self.x9
+
+        reveal_type(self.x1)  # revealed: int
+
 class ManyCycles2:
     def __init__(self: "ManyCycles2"):
         self.x1 = [0]

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -51,12 +51,14 @@ use rustc_hash::FxHashMap;
 use salsa;
 use salsa::plumbing::AsId;
 use std::borrow::Cow;
+use std::cell::Cell;
 pub(super) use ty_python_core::frozen::{FrozenMap, FrozenSet, FrozenValueMap};
 
 use crate::types::diagnostic::TypeCheckDiagnostics;
 use crate::types::function::{FunctionDecorators, FunctionType};
 use crate::types::generics::Specialization;
 use crate::types::unpacker::{UnpackResult, Unpacker};
+use crate::types::visitor::any_over_type;
 use crate::types::{
     ClassLiteral, KnownClass, StaticClassLiteral, Type, TypeAndQualifiers, TypeQualifiers,
 };
@@ -94,6 +96,15 @@ struct TypeAndRange<'db> {
 }
 
 type CollectionUseConstraints<'db> = FxHashMap<Definition<'db>, FxIndexSet<Type<'db>>>;
+
+/// Returns `true` if the eagerly available graph for `ty` contains more than `limit` nodes.
+fn type_exceeds_node_limit<'db>(db: &'db dyn Db, ty: Type<'db>, limit: usize) -> bool {
+    let count = Cell::new(0usize);
+    any_over_type(db, ty, false, |_| {
+        count.set(count.get().saturating_add(1));
+        count.get() > limit
+    })
+}
 
 /// Extends the current collection-use constraints with those from the previous cycle iteration.
 ///
@@ -1261,6 +1272,86 @@ impl<'db> DefinitionInferenceExtra<'db> {
 }
 
 impl<'db> DefinitionInference<'db> {
+    /// Maximum size of an unstable type graph retained during cycle recovery, regardless of the
+    /// number of cycle heads.
+    const MAX_PRECISE_CYCLE_TYPE_NODES: usize = 128;
+    const PRECISE_CYCLE_TYPE_NODES_PER_HEAD: usize = 8;
+
+    /// Maximum number of iterations for which definition inference preserves a precise result,
+    /// regardless of the number of cycle heads.
+    ///
+    /// Some recursive definitions form an infinite ascending chain by wrapping the previous
+    /// result in another structural layer. Salsa requires cycle recovery to converge, so after a
+    /// bounded precision phase we return the deterministic cycle-initial result instead. Applying
+    /// the same widening on every later iteration guarantees convergence without trying to align
+    /// unrelated structural positions between successive results.
+    const MAX_PRECISE_CYCLE_ITERATIONS: u32 = 128;
+    const PRECISE_CYCLE_ITERATIONS_PER_HEAD: u32 = 2;
+
+    fn cycle_head_count(cycle: &salsa::Cycle) -> usize {
+        cycle.head_ids().count().max(2)
+    }
+
+    fn max_precise_cycle_type_nodes(cycle: &salsa::Cycle) -> usize {
+        Self::cycle_head_count(cycle)
+            .saturating_mul(Self::PRECISE_CYCLE_TYPE_NODES_PER_HEAD)
+            .min(Self::MAX_PRECISE_CYCLE_TYPE_NODES)
+    }
+
+    fn max_precise_cycle_iterations(cycle: &salsa::Cycle) -> u32 {
+        let cycle_heads = u32::try_from(Self::cycle_head_count(cycle))
+            .unwrap_or(Self::MAX_PRECISE_CYCLE_ITERATIONS);
+        let topology_allowance =
+            cycle_heads.saturating_mul(Self::PRECISE_CYCLE_ITERATIONS_PER_HEAD);
+        crate::TAINTED_CYCLES
+            .saturating_add(topology_allowance)
+            .min(Self::MAX_PRECISE_CYCLE_ITERATIONS)
+    }
+
+    fn exceeds_cycle_type_node_limit(
+        &self,
+        db: &'db dyn Db,
+        previous: &Self,
+        owner: Definition<'db>,
+        node_limit: usize,
+    ) -> bool {
+        let previous_fallback = previous.fallback_type();
+
+        for (definition, current) in self.types.bindings(owner) {
+            if let Some(previous) = previous
+                .types
+                .binding_type(owner, definition)
+                .or(previous_fallback)
+                && current != previous
+                && type_exceeds_node_limit(db, current, node_limit)
+            {
+                return true;
+            }
+        }
+
+        for (definition, current) in self.types.declarations(owner) {
+            if let Some(previous) = previous
+                .types
+                .declaration_type(owner, definition)
+                .map(|ty| ty.inner_type())
+                .or(previous_fallback)
+                && current.inner_type() != previous
+                && type_exceeds_node_limit(db, current.inner_type(), node_limit)
+            {
+                return true;
+            }
+        }
+
+        for (expression, current) in &self.expressions {
+            let previous = previous.expression_type(*expression);
+            if *current != previous && type_exceeds_node_limit(db, *current, node_limit) {
+                return true;
+            }
+        }
+
+        false
+    }
+
     fn cycle_initial(
         db: &'db dyn Db,
         definition: Definition<'db>,
@@ -1312,6 +1403,12 @@ impl<'db> DefinitionInference<'db> {
         cycle: &salsa::Cycle,
         definition: Definition<'db>,
     ) -> DefinitionInference<'db> {
+        // Once an unstable cycle result has been widened, keep returning the same deterministic
+        // seed. Otherwise, later iterations can start growing again from `Unknown`.
+        if previous_inference.fallback_type() == Some(Type::unknown()) {
+            return Self::cycle_initial(db, definition, Type::unknown());
+        }
+
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous_inference.expression_type(*expr);
             *ty = ty.cycle_normalized(db, previous_ty, cycle);
@@ -1322,6 +1419,17 @@ impl<'db> DefinitionInference<'db> {
             cycle,
             definition,
         );
+
+        if cycle.iteration() > crate::TAINTED_CYCLES + 1
+            && self.exceeds_cycle_type_node_limit(
+                db,
+                previous_inference,
+                definition,
+                Self::max_precise_cycle_type_nodes(cycle),
+            )
+        {
+            return Self::cycle_initial(db, definition, Type::unknown());
+        }
 
         if cycle.iteration() > crate::TAINTED_CYCLES
             && let Some(previous_constraints) = previous_inference
@@ -1341,6 +1449,12 @@ impl<'db> DefinitionInference<'db> {
                 previous_constraints,
             );
             self.extra = Some(Box::new(DefinitionInferenceExtra::Other(Box::new(extra))));
+        }
+
+        if cycle.iteration() > Self::max_precise_cycle_iterations(cycle)
+            && self != *previous_inference
+        {
+            return Self::cycle_initial(db, definition, Type::unknown());
         }
 
         self


### PR DESCRIPTION
## Summary

Type inference cycle recovery currently relies on structural normalization and monotonic unions to reach a fixed point. Some recursive definitions instead form an infinite ascending chain: `TypeIs` can distribute a narrowing across every loop-carried arm, while nested iterable construction repeatedly wraps the previous result. These continue until Salsa exhausts its cycle-iteration limit and panics.

This adds a query-level widening boundary for definition inference. After the tainted iterations, we retain precise results within budgets scaled to the number of Salsa cycle heads: eight eager type nodes and two iterations per head, both capped at 128. If an unstable result crosses either budget, we replace it with a deterministic `Unknown` cycle seed and keep that seed absorbing for later iterations. The node budget examines every changed binding, declaration, and expression rather than trying to establish structural correspondence between successive nested types.

Scaling the precision window by cycle topology lets wide but finite dependency cycles continue to their exact fixed point. This avoids the shape-specific replacement assumptions that caused the regressions in the reverted implementation while still bounding both recursive depth and recursive breadth.

The no-panic corpus covers all 23 non-`TypeOf` `TypeIs` cases linked from https://github.com/astral-sh/ty/issues/3837, including the `TypeIs` reproducer from https://github.com/astral-sh/ty/issues/3826, along with the nested-iterable reproducer. A separate precision regression verifies that a ten-attribute finite cycle still converges to `int`, and the 13 independent projection cases exposed by the reverted implementation continue to terminate.

Closes https://github.com/astral-sh/ty/issues/3827.
