### PR TITLE
[ty] Correct enum alias detection and scalar constructors

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -702,6 +702,7 @@ dynamic when we cannot model the transformation:
 
 ```py
 from enum import Enum
+from ty_extensions import enum_members
 
 class OffsetInt(int):
     def __new__(cls, value: int) -> "OffsetInt":
@@ -712,6 +713,23 @@ class OffsetEnum(OffsetInt, Enum):
     INVALID = "not an int"  # error: [invalid-assignment]
 
 reveal_type(OffsetEnum.VALID.value)  # revealed: Any
+
+class WeirdInt(int):
+    def __new__(cls, value: int) -> "WeirdInt":
+        return int.__new__(cls, 100 if value is False else value)
+
+class EmptyWeirdEnum(WeirdInt, Enum):
+    pass
+
+class InheritedWeirdEnum(EmptyWeirdEnum):
+    FROM_BOOL = False
+    FROM_INT = 0
+    OTHER = 2
+
+reveal_type(InheritedWeirdEnum.FROM_BOOL.value)  # revealed: Any
+reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum.FROM_INT]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"], Literal["OTHER"]]
+reveal_type(enum_members(InheritedWeirdEnum))
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -694,6 +694,26 @@ class Child(Base):
     GITHUB = "github"  # error: [invalid-assignment]
 ```
 
+### Data-type mixin `__new__`
+
+A user-defined `__new__` on a data-type mixin constructs the scalar payload and can transform the
+declared member value. Members are validated against its signature, and their `.value` types remain
+dynamic when we cannot model the transformation:
+
+```py
+from enum import Enum
+
+class OffsetInt(int):
+    def __new__(cls, value: int) -> "OffsetInt":
+        return int.__new__(cls, value + 1)
+
+class OffsetEnum(OffsetInt, Enum):
+    VALID = 1
+    INVALID = "not an int"  # error: [invalid-assignment]
+
+reveal_type(OffsetEnum.VALID.value)  # revealed: Any
+```
+
 ### Assigned `__new__`
 
 Assigning to `__new__` can prevent us from validating members against its signature or inferring
@@ -1017,6 +1037,26 @@ reveal_type(enum_members(Color))
 
 # revealed: Literal[Color.RED]
 reveal_type(Color.red)
+```
+
+Literal metadata does not affect aliasing at runtime. A value returned from a function is therefore
+still an alias of the same literal written directly in the class body:
+
+```py
+from enum import Enum
+from typing import Literal
+from ty_extensions import enum_members
+
+def make_alias_value() -> Literal["value"]:
+    return "value"
+
+class RuntimeAlias(Enum):
+    FIRST = make_alias_value()
+    SECOND = "value"
+
+# revealed: tuple[Literal["FIRST"]]
+reveal_type(enum_members(RuntimeAlias))
+reveal_type(RuntimeAlias.SECOND)  # revealed: RuntimeAlias
 ```
 
 Multiple aliases to the same member are also supported. This is a regression test for

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -712,16 +712,16 @@ class ShiftedInt(int):
     def __new__(cls, value: int) -> "ShiftedInt":
         return int.__new__(cls, value + 1)
 
-class Shifted(ShiftedInt, Enum):
+class MixinShifted(ShiftedInt, Enum):
     MEMBER = 1
 
 class Normal(IntEnum):
     MEMBER = 2
 
-reveal_type(Shifted.MEMBER == Normal.MEMBER)  # revealed: bool
+reveal_type(MixinShifted.MEMBER == Normal.MEMBER)  # revealed: bool
 
-if Shifted.MEMBER == Normal.MEMBER:
-    reveal_type(Shifted.MEMBER)  # revealed: Shifted
+if MixinShifted.MEMBER == Normal.MEMBER:
+    reveal_type(MixinShifted.MEMBER)  # revealed: MixinShifted
 ```
 
 The return value of `_generate_next_value_` is not necessarily the final value of an `IntEnum`

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1216,7 +1216,8 @@ fn inherited_user_defined_enum_method<'db>(
         .find_map(|base| custom_enum_method(db, base.body_scope(db), name))
 }
 
-/// Looks up a user-defined `__new__` on a data-type mixin before the first parent enum.
+/// Looks up a user-defined `__new__` on a data-type mixin anywhere in the MRO, including through an
+/// enum base.
 ///
 /// When no enum class provides a member constructor, `EnumType` uses this method to construct the
 /// scalar payload stored by the enum member.
@@ -1229,7 +1230,6 @@ fn inherited_user_defined_mixin_new<'db>(
         .skip(1)
         .filter_map(ClassBase::into_class)
         .filter_map(|class| class.class_literal(db).as_static())
-        .take_while(|base| !is_enum_class_by_inheritance(db, *base))
         .filter(|base| base.known(db).is_none())
         .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
 }


### PR DESCRIPTION
## Summary

Enum member metadata currently uses full `Type` values when identifying duplicate-value aliases. Literal metadata such as promotability is therefore treated as part of runtime identity, so equivalent values can incorrectly remain separate canonical members.

We also only look for value-transforming `__new__` implementations on enum classes. Python's `EnumType` can instead use a user-defined `__new__` from a non-enum data-type mixin to construct the member's scalar payload. Ignoring that constructor can leave `.value` as the declared literal, skip constructor argument validation, and mark a runtime-reachable equality branch as unreachable.

This keys alias detection by runtime literal kind and payload, and includes user-defined data-type mixin constructors in enum value-construction metadata:

```python
from enum import Enum

class OffsetInt(int):
    def __new__(cls, value: int) -> "OffsetInt":
        return int.__new__(cls, value + 1)

class Offset(OffsetInt, Enum):
    VALUE = 1

reveal_type(Offset.VALUE.value)  # Any
```

Enum aliases now resolve to the same canonical member even when their inferred literal types differ only in metadata, while transformed scalar-mixin values remain conservative unless we can model the constructor.
