### PR TITLE
[ty] Model int and str enum value normalization

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -837,8 +837,7 @@ reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
 reveal_type(enum_members(InheritedInt))
 ```
 
-`StrEnum` validates non-string members instead of converting them with `str()`, so rejected values
-must not be normalized into aliases of valid string members:
+`StrEnum` uses the same built-in `str` normalization as an explicit data-type mixin:
 
 ```toml
 [environment]
@@ -850,13 +849,13 @@ from enum import StrEnum
 from ty_extensions import enum_members
 
 class StrictStr(StrEnum):
-    FROM_INT = 1
+    FROM_INT = 1  # TODO: Emit an error for non-string `StrEnum` values.
     FROM_STR = "1"
     OTHER = "other"
 
-reveal_type(StrictStr.FROM_INT.value)  # revealed: Literal[1]
-reveal_type(StrictStr.FROM_STR)  # revealed: Literal[StrictStr.FROM_STR]
-# revealed: tuple[Literal["FROM_INT"], Literal["FROM_STR"], Literal["OTHER"]]
+reveal_type(StrictStr.FROM_INT.value)  # revealed: Literal["1"]
+reveal_type(StrictStr.FROM_STR)  # revealed: Literal[StrictStr.FROM_INT]
+# revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
 reveal_type(enum_members(StrictStr))
 ```
 

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -779,24 +779,6 @@ reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum
 reveal_type(enum_members(InheritedWeirdEnum))
 ```
 
-### Data-type mixin `__init__`
-
-A user-defined `__init__` on an `int` data type can replace `_value_` after `int.__new__` runs.
-Without an explicit `_value_` annotation, `.value` falls back to `Any`:
-
-```py
-from enum import Enum
-
-class BooleanInt(int):
-    def __init__(self, value: int) -> None:
-        self._value_ = False
-
-class BooleanEnum(BooleanInt, Enum):
-    VALUE = False
-
-reveal_type(BooleanEnum.VALUE.value)  # revealed: Any
-```
-
 ### Built-in data types
 
 An enum with an `int` or `str` data type stores the value produced by that type's constructor.
@@ -843,8 +825,9 @@ reveal_type(enum_members(InheritedValues))
 
 ### User-defined data types
 
-For a user-defined subclass of `int`, `.value` has the subclass type. If the subclass inherits
-`int`'s equality and hashing methods, values that normalize to the same integer are aliases:
+User-defined data types remain opaque even when they inherit from `int` or `str` without overriding
+any methods. Their construction, attribute access, equality, and hashing can all differ from the
+built-in type:
 
 ```py
 from enum import Enum
@@ -857,101 +840,9 @@ class CustomValues(CustomInt, Enum):
     FALSE = False
     ZERO = 0
 
-reveal_type(CustomValues.FALSE.value)  # revealed: CustomInt
-# revealed: tuple[Literal["FALSE"]]
+reveal_type(CustomValues.FALSE.value)  # revealed: Any
+# revealed: tuple[Literal["FALSE"], Literal["ZERO"]]
 reveal_type(enum_members(CustomValues))
-```
-
-A separate base class does not become the enum's data type:
-
-```py
-class Behavior:
-    pass
-
-class ValuesWithBehavior(Behavior, int, Enum):
-    FALSE = False
-    ZERO = 0
-
-reveal_type(ValuesWithBehavior.FALSE.value)  # revealed: Literal[0]
-# revealed: tuple[Literal["FALSE"]]
-reveal_type(enum_members(ValuesWithBehavior))
-```
-
-### Custom equality and hashing
-
-If the data type overrides equality or hashing, the assigned literals are not enough to determine
-aliases. We therefore keep both names as possible members:
-
-```py
-from enum import Enum
-from ty_extensions import enum_members
-from typing import Literal
-
-class NeverEqualInt(int):
-    def __eq__(self, other: object) -> Literal[False]:
-        return False
-
-class CustomEquality(NeverEqualInt, Enum):
-    FIRST = 0
-    SECOND = 0
-
-# revealed: tuple[Literal["FIRST"], Literal["SECOND"]]
-reveal_type(enum_members(CustomEquality))
-
-class IdentityHashedInt(int):
-    def __init__(self, value: int) -> None:
-        self.hash_value = id(self)
-
-    def __hash__(self) -> int:
-        return self.hash_value
-
-class CustomHash(IdentityHashedInt, Enum):
-    FIRST = 0
-    SECOND = 0
-
-# revealed: tuple[Literal["FIRST"], Literal["SECOND"]]
-reveal_type(enum_members(CustomHash))
-```
-
-### Dataclass equality
-
-A frozen dataclass generates equality and hashing methods from its fields. In the first example, the
-field records whether the original value was a `bool` or an `int`, so the two members remain
-distinct. With `eq=False`, the subclass instead inherits the methods defined by `int`, and the
-second name becomes an alias:
-
-```py
-from dataclasses import dataclass
-from enum import Enum
-from ty_extensions import enum_members
-
-@dataclass(frozen=True)
-class ComparedInt(int):
-    input_type: type
-
-    def __init__(self, value: int) -> None:
-        object.__setattr__(self, "input_type", type(value))
-
-class GeneratedEquality(ComparedInt, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-
-# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
-reveal_type(enum_members(GeneratedEquality))
-
-@dataclass(eq=False, frozen=True)
-class InheritedEqualityInt(int):
-    input_type: type
-
-    def __init__(self, value: int) -> None:
-        object.__setattr__(self, "input_type", type(value))
-
-class InheritedEquality(InheritedEqualityInt, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-
-# revealed: tuple[Literal["FROM_BOOL"]]
-reveal_type(enum_members(InheritedEquality))
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3014,6 +3014,12 @@ Color = IntEnum("Color", "RED GREEN BLUE")
 
 # revealed: tuple[Literal["RED"], Literal["GREEN"], Literal["BLUE"]]
 reveal_type(enum_members(Color))
+
+Number = IntEnum("Number", {"FALSE": False, "ZERO": 0})
+
+reveal_type(Number.FALSE.value)  # revealed: Literal[0]
+reveal_type(Number.ZERO)  # revealed: Number
+reveal_type(enum_members(Number))  # revealed: tuple[Literal["FALSE"]]
 ```
 
 ### Flag function syntax

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -777,6 +777,35 @@ reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum
 reveal_type(enum_members(InheritedWeirdEnum))
 ```
 
+Known built-in data-type mixins normalize member values before aliases are detected:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class DirectInt(int, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+    OTHER = 2
+
+reveal_type(DirectInt.FROM_BOOL.value)  # revealed: Literal[0]
+reveal_type(DirectInt.FROM_INT)  # revealed: Literal[DirectInt.FROM_BOOL]
+reveal_type(DirectInt.OTHER.value)  # revealed: Literal[2]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
+reveal_type(enum_members(DirectInt))
+
+class DirectStr(str, Enum):
+    FROM_INT = 1
+    FROM_STR = "1"
+    OTHER = "other"
+
+reveal_type(DirectStr.FROM_INT.value)  # revealed: Literal["1"]
+reveal_type(DirectStr.FROM_STR)  # revealed: Literal[DirectStr.FROM_INT]
+reveal_type(DirectStr.OTHER.value)  # revealed: Literal["other"]
+# revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
+reveal_type(enum_members(DirectStr))
+```
+
 ### Assigned `__new__`
 
 Assigning to `__new__` can prevent us from validating members against its signature or inferring
@@ -1318,10 +1347,10 @@ reveal_type(Answer.YES.value)  # revealed: Literal[1]
 reveal_type(Answer.NO.value)  # revealed: Literal[2]
 ```
 
-It's [hard to predict](https://github.com/astral-sh/ruff/pull/20541#discussion_r2381878613) what the
-effect of using `auto()` will be for an arbitrary non-integer mixin, so for anything that isn't a
-`StrEnum` and has a non-`int` mixin, we simply fallback to typeshed's annotation of `Any` for the
-`value` property:
+For a known `str` mixin, the generated value is still normalized to `str`. It's
+[hard to predict](https://github.com/astral-sh/ruff/pull/20541#discussion_r2381878613) what the
+effect of using `auto()` will be for an arbitrary other non-integer mixin, so we fall back to
+typeshed's annotation of `Any` for the `value` property in those cases:
 
 ```python
 from enum import Enum, auto
@@ -1331,7 +1360,7 @@ class A(str, Enum):
     X = auto()
     Y = auto()
 
-reveal_type(A.X.value)  # revealed: Any
+reveal_type(A.X.value)  # revealed: str
 
 class B(bytes, Enum):
     X = auto()

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -3020,6 +3020,13 @@ Number = IntEnum("Number", {"FALSE": False, "ZERO": 0})
 reveal_type(Number.FALSE.value)  # revealed: Literal[0]
 reveal_type(Number.ZERO)  # revealed: Number
 reveal_type(enum_members(Number))  # revealed: tuple[Literal["FALSE"]]
+
+# `int("1")` widens to `int`, but identical raw values still prove that the
+# members are aliases.
+Parsed = IntEnum("Parsed", {"A": "1", "B": "1"})
+
+reveal_type(Parsed.B)  # revealed: Parsed
+reveal_type(enum_members(Parsed))  # revealed: tuple[Literal["A"]]
 ```
 
 ### Flag function syntax

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -853,21 +853,6 @@ reveal_type(InheritedInt.FROM_BOOL.value)  # revealed: Literal[0]
 reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
 # revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
 reveal_type(enum_members(InheritedInt))
-
-# Built-in payload normalization must not override user-defined equality during alias detection.
-class NeverEqualInt(int):
-    def __eq__(self, other: object) -> Literal[False]:
-        return False
-
-class CustomEquality(NeverEqualInt, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-
-reveal_type(CustomEquality.FROM_BOOL.value)  # revealed: Literal[0]
-reveal_type(CustomEquality.FROM_INT.value)  # revealed: Literal[0]
-reveal_type(CustomEquality.FROM_INT)  # revealed: Literal[CustomEquality.FROM_INT]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
-reveal_type(enum_members(CustomEquality))
 ```
 
 `StrEnum` uses the same built-in `str` normalization as an explicit data-type mixin:
@@ -890,6 +875,57 @@ reveal_type(StrictStr.FROM_INT.value)  # revealed: Literal["1"]
 reveal_type(StrictStr.FROM_STR)  # revealed: Literal[StrictStr.FROM_INT]
 # revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
 reveal_type(enum_members(StrictStr))
+```
+
+### User-defined data-type mixins
+
+User-defined data-type mixins are opaque for value normalization and alias detection, even when they
+inherit from a known scalar without explicitly overriding its methods. Construction, equality, and
+hashing can all differ from the built-in base:
+
+```py
+from dataclasses import dataclass
+from enum import Enum
+from ty_extensions import enum_members
+from typing import Literal
+
+class CustomInt(int):
+    pass
+
+class CustomIntEnum(CustomInt, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+reveal_type(CustomIntEnum.FROM_BOOL.value)  # revealed: Any
+# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+reveal_type(enum_members(CustomIntEnum))
+
+class NeverEqualInt(int):
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+class CustomEquality(NeverEqualInt, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+reveal_type(CustomEquality.FROM_BOOL.value)  # revealed: Any
+reveal_type(CustomEquality.FROM_INT)  # revealed: Literal[CustomEquality.FROM_INT]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+reveal_type(enum_members(CustomEquality))
+
+@dataclass(frozen=True)
+class TypeSensitiveInt(int):
+    value_type: type
+
+    def __init__(self, value: int) -> None:
+        object.__setattr__(self, "value_type", type(value))
+
+class TypeSensitive(TypeSensitiveInt, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+reveal_type(enum_members(TypeSensitive))
 ```
 
 ### Assigned `__new__`
@@ -1774,6 +1810,25 @@ reveal_type(InheritedCustomNextValueChild.C)  # revealed: Literal[InheritedCusto
 
 def _inherited_mixed_instance(x: InheritedCustomNextValueChild):
     reveal_type(x.value)  # revealed: str | Literal[1]
+```
+
+### Alias RHS state before `auto()`
+
+Aliases still contribute their raw right-hand-side values to the history used by a following
+`auto()` member:
+
+```py
+from enum import Enum, auto
+from ty_extensions import enum_members
+
+class Mixed(int, Enum):
+    ONE = 1
+    TRUE = True
+    AFTER = auto()
+
+reveal_type(Mixed.AFTER.value)  # revealed: Literal[2]
+# revealed: tuple[Literal["ONE"], Literal["AFTER"]]
+reveal_type(enum_members(Mixed))
 ```
 
 ### `member` and `nonmember`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -845,6 +845,21 @@ reveal_type(CustomValues.FALSE.value)  # revealed: Any
 reveal_type(enum_members(CustomValues))
 ```
 
+A separate behavior base does not become the enum's data type:
+
+```py
+class Behavior:
+    pass
+
+class ValuesWithBehavior(Behavior, int, Enum):
+    FALSE = False
+    ZERO = 0
+
+reveal_type(ValuesWithBehavior.FALSE.value)  # revealed: Literal[0]
+# revealed: tuple[Literal["FALSE"]]
+reveal_type(enum_members(ValuesWithBehavior))
+```
+
 ### Assigned `__new__`
 
 Assigning to `__new__` can prevent us from validating members against its signature or inferring

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -879,9 +879,9 @@ reveal_type(enum_members(StrictStr))
 
 ### User-defined data-type mixins
 
-User-defined data-type mixins are opaque for value normalization and alias detection, even when they
-inherit from a known scalar without explicitly overriding its methods. Construction, equality, and
-hashing can all differ from the built-in base:
+User-defined data types that inherit a known scalar retain precise value and alias information when
+their effective equality and hashing methods match the scalar. An independent behavior mixin does
+not become the enum's data type:
 
 ```py
 from dataclasses import dataclass
@@ -895,23 +895,67 @@ class CustomInt(int):
 class CustomIntEnum(CustomInt, Enum):
     FROM_BOOL = False
     FROM_INT = 0
+    OTHER = 1
 
-reveal_type(CustomIntEnum.FROM_BOOL.value)  # revealed: Any
-# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+reveal_type(CustomIntEnum.FROM_BOOL.value)  # revealed: CustomInt
+reveal_type(CustomIntEnum.FROM_INT)  # revealed: Literal[CustomIntEnum.FROM_BOOL]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
 reveal_type(enum_members(CustomIntEnum))
+
+class BehaviorMixin:
+    pass
+
+class IntWithBehavior(BehaviorMixin, int, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+reveal_type(IntWithBehavior.FROM_BOOL.value)  # revealed: Literal[0]
+# revealed: tuple[Literal["FROM_BOOL"]]
+reveal_type(enum_members(IntWithBehavior))
+```
+
+Custom equality or hashing makes alias detection opaque. This includes identical right-hand sides:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+from typing import Literal
 
 class NeverEqualInt(int):
     def __eq__(self, other: object) -> Literal[False]:
         return False
 
 class CustomEquality(NeverEqualInt, Enum):
+    FIRST = 0
+    SECOND = 0
+
+reveal_type(CustomEquality.FIRST.value)  # revealed: NeverEqualInt
+reveal_type(CustomEquality.SECOND)  # revealed: Literal[CustomEquality.SECOND]
+# revealed: tuple[Literal["FIRST"], Literal["SECOND"]]
+reveal_type(enum_members(CustomEquality))
+
+class TypeHashedInt(int):
+    def __init__(self, value: int) -> None:
+        self.value_type = type(value)
+
+    def __hash__(self) -> int:
+        return 0 if self.value_type is bool else 1
+
+class CustomHash(TypeHashedInt, Enum):
     FROM_BOOL = False
     FROM_INT = 0
 
-reveal_type(CustomEquality.FROM_BOOL.value)  # revealed: Any
-reveal_type(CustomEquality.FROM_INT)  # revealed: Literal[CustomEquality.FROM_INT]
 # revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
-reveal_type(enum_members(CustomEquality))
+reveal_type(enum_members(CustomHash))
+```
+
+Synthesized dataclass equality and hashing are treated like explicit custom methods. With
+`eq=False`, the data type retains the inherited scalar semantics:
+
+```py
+from dataclasses import dataclass
+from enum import Enum
+from ty_extensions import enum_members
 
 @dataclass(frozen=True)
 class TypeSensitiveInt(int):
@@ -926,6 +970,20 @@ class TypeSensitive(TypeSensitiveInt, Enum):
 
 # revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
 reveal_type(enum_members(TypeSensitive))
+
+@dataclass(eq=False, frozen=True)
+class TypeInsensitiveInt(int):
+    value_type: type
+
+    def __init__(self, value: int) -> None:
+        object.__setattr__(self, "value_type", type(value))
+
+class TypeInsensitive(TypeInsensitiveInt, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+# revealed: tuple[Literal["FROM_BOOL"]]
+reveal_type(enum_members(TypeInsensitive))
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -823,6 +823,21 @@ reveal_type(InheritedValues.FALSE.value)  # revealed: Literal[0]
 reveal_type(enum_members(InheritedValues))
 ```
 
+Other built-in data types retain exact assigned values when no coercion is needed:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class ByteValues(bytes, Enum):
+    VALUE = b"value"
+    ALIAS = b"value"
+
+reveal_type(ByteValues.VALUE.value)  # revealed: Literal[b"value"]
+# revealed: tuple[Literal["VALUE"]]
+reveal_type(enum_members(ByteValues))
+```
+
 ### User-defined data types
 
 User-defined data types remain opaque even when they inherit from `int` or `str` without overriding

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -22,9 +22,9 @@ reveal_type(Color(1))  # revealed: Color
 reveal_type(Color.RED in Color)  # revealed: bool
 ```
 
-Known standard-library enum constructors preserve precise `.value` types when their built-in
-data-type normalization can be modeled. The inherited `_value_` annotation remains the fallback when
-the result cannot be inferred precisely or when accessing `.value` on the enum class as a whole:
+For standard-library enum classes, we preserve literal `.value` types when we can model how the data
+type constructs each value. The inherited `_value_` annotation remains the fallback when we cannot,
+or when accessing `.value` on the enum class as a whole:
 
 ```py
 from enum import IntEnum, auto
@@ -38,6 +38,7 @@ class Integer(IntEnum):
 reveal_type(Integer.ONE.value)  # revealed: Literal[1]
 reveal_type(Integer.ONE._value_)  # revealed: Literal[1]
 reveal_type(Integer.TRUE.value)  # revealed: Literal[1]
+reveal_type(Integer.TRUE)  # revealed: Literal[Integer.ONE]
 
 def _(value: Integer):
     reveal_type(value.value)  # revealed: int
@@ -780,8 +781,8 @@ reveal_type(enum_members(InheritedWeirdEnum))
 
 ### Data-type mixin `__init__`
 
-A user-defined `__init__` on a data-type mixin can replace `_value_` after the built-in scalar
-constructor runs. Without an explicit `_value_` annotation, `.value` falls back to `Any`:
+A user-defined `__init__` on an `int` data type can replace `_value_` after `int.__new__` runs.
+Without an explicit `_value_` annotation, `.value` falls back to `Any`:
 
 ```py
 from enum import Enum
@@ -796,125 +797,90 @@ class BooleanEnum(BooleanInt, Enum):
 reveal_type(BooleanEnum.VALUE.value)  # revealed: Any
 ```
 
-Known built-in data-type mixins normalize member values before aliases are detected:
+### Built-in data types
+
+An enum with an `int` or `str` data type stores the value produced by that type's constructor.
+Aliases are determined from the constructed values rather than the original assignments:
 
 ```py
-from enum import Enum, IntEnum
-from ty_extensions import enum_members
-from typing import Literal
-
-class DirectInt(int, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-    OTHER = 2
-
-reveal_type(DirectInt.FROM_BOOL.value)  # revealed: Literal[0]
-reveal_type(DirectInt.FROM_INT)  # revealed: Literal[DirectInt.FROM_BOOL]
-reveal_type(DirectInt.OTHER.value)  # revealed: Literal[2]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
-reveal_type(enum_members(DirectInt))
-
-class DirectStr(str, Enum):
-    FROM_INT = 1
-    FROM_STR = "1"
-    OTHER = "other"
-
-reveal_type(DirectStr.FROM_INT.value)  # revealed: Literal["1"]
-reveal_type(DirectStr.FROM_STR)  # revealed: Literal[DirectStr.FROM_INT]
-reveal_type(DirectStr.OTHER.value)  # revealed: Literal["other"]
-# revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
-reveal_type(enum_members(DirectStr))
-
-def union_member_value(value: Literal[1, 2]):
-    class UnionInt(int, Enum):
-        MEMBER = value
-
-    reveal_type(UnionInt.MEMBER.value)  # revealed: Literal[1, 2]
-
-class StandardInt(IntEnum):
-    FROM_BOOL = False
-    FROM_INT = 0
-    OTHER = 2
-
-reveal_type(StandardInt.FROM_BOOL.value)  # revealed: Literal[0]
-reveal_type(StandardInt.FROM_INT)  # revealed: Literal[StandardInt.FROM_BOOL]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
-reveal_type(enum_members(StandardInt))
-
-class EmptyInt(int, Enum):
-    pass
-
-class InheritedInt(EmptyInt):
-    FROM_BOOL = False
-    FROM_INT = 0
-    OTHER = 2
-
-reveal_type(InheritedInt.FROM_BOOL.value)  # revealed: Literal[0]
-reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
-reveal_type(enum_members(InheritedInt))
-```
-
-`StrEnum` uses the same built-in `str` normalization as an explicit data-type mixin:
-
-```toml
-[environment]
-python-version = "3.11"
-```
-
-```py
-from enum import StrEnum
-from ty_extensions import enum_members
-
-class StrictStr(StrEnum):
-    FROM_INT = 1  # TODO: Emit an error for non-string `StrEnum` values.
-    FROM_STR = "1"
-    OTHER = "other"
-
-reveal_type(StrictStr.FROM_INT.value)  # revealed: Literal["1"]
-reveal_type(StrictStr.FROM_STR)  # revealed: Literal[StrictStr.FROM_INT]
-# revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
-reveal_type(enum_members(StrictStr))
-```
-
-### User-defined data-type mixins
-
-User-defined data types that inherit a known scalar retain precise value and alias information when
-their effective equality and hashing methods match the scalar. An independent behavior mixin does
-not become the enum's data type:
-
-```py
-from dataclasses import dataclass
 from enum import Enum
 from ty_extensions import enum_members
 from typing import Literal
 
+class IntegerValues(int, Enum):
+    FALSE = False
+    ZERO = 0
+
+reveal_type(IntegerValues.FALSE.value)  # revealed: Literal[0]
+# revealed: tuple[Literal["FALSE"]]
+reveal_type(enum_members(IntegerValues))
+
+class StringValues(str, Enum):
+    INTEGER = 1
+    STRING = "1"
+
+reveal_type(StringValues.INTEGER.value)  # revealed: Literal["1"]
+# revealed: tuple[Literal["INTEGER"]]
+reveal_type(enum_members(StringValues))
+
+def union_member_value(value: Literal[False, 2]):
+    class UnionValues(int, Enum):
+        MEMBER = value
+
+    reveal_type(UnionValues.MEMBER.value)  # revealed: Literal[0, 2]
+
+class IntegerBase(int, Enum):
+    pass
+
+class InheritedValues(IntegerBase):
+    FALSE = False
+    ZERO = 0
+
+reveal_type(InheritedValues.FALSE.value)  # revealed: Literal[0]
+# revealed: tuple[Literal["FALSE"]]
+reveal_type(enum_members(InheritedValues))
+```
+
+### User-defined data types
+
+For a user-defined subclass of `int`, `.value` has the subclass type. If the subclass inherits
+`int`'s equality and hashing methods, values that normalize to the same integer are aliases:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
 class CustomInt(int):
     pass
 
-class CustomIntEnum(CustomInt, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-    OTHER = 1
+class CustomValues(CustomInt, Enum):
+    FALSE = False
+    ZERO = 0
 
-reveal_type(CustomIntEnum.FROM_BOOL.value)  # revealed: CustomInt
-reveal_type(CustomIntEnum.FROM_INT)  # revealed: Literal[CustomIntEnum.FROM_BOOL]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
-reveal_type(enum_members(CustomIntEnum))
-
-class BehaviorMixin:
-    pass
-
-class IntWithBehavior(BehaviorMixin, int, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
-
-reveal_type(IntWithBehavior.FROM_BOOL.value)  # revealed: Literal[0]
-# revealed: tuple[Literal["FROM_BOOL"]]
-reveal_type(enum_members(IntWithBehavior))
+reveal_type(CustomValues.FALSE.value)  # revealed: CustomInt
+# revealed: tuple[Literal["FALSE"]]
+reveal_type(enum_members(CustomValues))
 ```
 
-Custom equality or hashing makes alias detection opaque. This includes identical right-hand sides:
+A separate base class does not become the enum's data type:
+
+```py
+class Behavior:
+    pass
+
+class ValuesWithBehavior(Behavior, int, Enum):
+    FALSE = False
+    ZERO = 0
+
+reveal_type(ValuesWithBehavior.FALSE.value)  # revealed: Literal[0]
+# revealed: tuple[Literal["FALSE"]]
+reveal_type(enum_members(ValuesWithBehavior))
+```
+
+### Custom equality and hashing
+
+If the data type overrides equality or hashing, the assigned literals are not enough to determine
+aliases. We therefore keep both names as possible members:
 
 ```py
 from enum import Enum
@@ -929,28 +895,30 @@ class CustomEquality(NeverEqualInt, Enum):
     FIRST = 0
     SECOND = 0
 
-reveal_type(CustomEquality.FIRST.value)  # revealed: NeverEqualInt
-reveal_type(CustomEquality.SECOND)  # revealed: Literal[CustomEquality.SECOND]
 # revealed: tuple[Literal["FIRST"], Literal["SECOND"]]
 reveal_type(enum_members(CustomEquality))
 
-class TypeHashedInt(int):
+class IdentityHashedInt(int):
     def __init__(self, value: int) -> None:
-        self.value_type = type(value)
+        self.hash_value = id(self)
 
     def __hash__(self) -> int:
-        return 0 if self.value_type is bool else 1
+        return self.hash_value
 
-class CustomHash(TypeHashedInt, Enum):
-    FROM_BOOL = False
-    FROM_INT = 0
+class CustomHash(IdentityHashedInt, Enum):
+    FIRST = 0
+    SECOND = 0
 
-# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+# revealed: tuple[Literal["FIRST"], Literal["SECOND"]]
 reveal_type(enum_members(CustomHash))
 ```
 
-Synthesized dataclass equality and hashing are treated like explicit custom methods. With
-`eq=False`, the data type retains the inherited scalar semantics:
+### Dataclass equality
+
+A frozen dataclass generates equality and hashing methods from its fields. In the first example, the
+field records whether the original value was a `bool` or an `int`, so the two members remain
+distinct. With `eq=False`, the subclass instead inherits the methods defined by `int`, and the
+second name becomes an alias:
 
 ```py
 from dataclasses import dataclass
@@ -958,32 +926,32 @@ from enum import Enum
 from ty_extensions import enum_members
 
 @dataclass(frozen=True)
-class TypeSensitiveInt(int):
-    value_type: type
+class ComparedInt(int):
+    input_type: type
 
     def __init__(self, value: int) -> None:
-        object.__setattr__(self, "value_type", type(value))
+        object.__setattr__(self, "input_type", type(value))
 
-class TypeSensitive(TypeSensitiveInt, Enum):
+class GeneratedEquality(ComparedInt, Enum):
     FROM_BOOL = False
     FROM_INT = 0
 
 # revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
-reveal_type(enum_members(TypeSensitive))
+reveal_type(enum_members(GeneratedEquality))
 
 @dataclass(eq=False, frozen=True)
-class TypeInsensitiveInt(int):
-    value_type: type
+class InheritedEqualityInt(int):
+    input_type: type
 
     def __init__(self, value: int) -> None:
-        object.__setattr__(self, "value_type", type(value))
+        object.__setattr__(self, "input_type", type(value))
 
-class TypeInsensitive(TypeInsensitiveInt, Enum):
+class InheritedEquality(InheritedEqualityInt, Enum):
     FROM_BOOL = False
     FROM_INT = 0
 
 # revealed: tuple[Literal["FROM_BOOL"]]
-reveal_type(enum_members(TypeInsensitive))
+reveal_type(enum_members(InheritedEquality))
 ```
 
 ### Assigned `__new__`
@@ -1527,10 +1495,10 @@ reveal_type(Answer.YES.value)  # revealed: Literal[1]
 reveal_type(Answer.NO.value)  # revealed: Literal[2]
 ```
 
-For a known `str` mixin, the generated value is still normalized to `str`. It's
-[hard to predict](https://github.com/astral-sh/ruff/pull/20541#discussion_r2381878613) what the
-effect of using `auto()` will be for an arbitrary other non-integer mixin, so we fall back to
-typeshed's annotation of `Any` for the `value` property in those cases:
+For an enum with a `str` data type, the generated value is still normalized to `str`. The result of
+using `auto()` with other non-integer data types is
+[hard to predict](https://github.com/astral-sh/ruff/pull/20541#discussion_r2381878613), so we use
+typeshed's `Any` annotation for `.value` in those cases:
 
 ```python
 from enum import Enum, auto
@@ -1870,10 +1838,11 @@ def _inherited_mixed_instance(x: InheritedCustomNextValueChild):
     reveal_type(x.value)  # revealed: str | Literal[1]
 ```
 
-### Alias RHS state before `auto()`
+### `auto()` after an alias
 
-Aliases still contribute their raw right-hand-side values to the history used by a following
-`auto()` member:
+Even when a declaration becomes an alias, its original value is included in the `last_values` passed
+to `_generate_next_value_`. Here, `TRUE` is an alias of `ONE`, but `AFTER` still receives the value
+`2`:
 
 ```py
 from enum import Enum, auto

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -825,6 +825,24 @@ reveal_type(InheritedValues.FALSE.value)  # revealed: Literal[0]
 reveal_type(enum_members(InheritedValues))
 ```
 
+Non-member declarations do not make alias detection inconclusive:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class ValuesWithHelper(int, Enum):
+    VALUE = 1
+
+    class Helper:
+        pass
+
+    ALIAS = 1
+
+# revealed: tuple[Literal["VALUE"]]
+reveal_type(enum_members(ValuesWithHelper))
+```
+
 When a built-in conversion cannot be modeled precisely, its aliases remain unknown:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -782,6 +782,7 @@ Known built-in data-type mixins normalize member values before aliases are detec
 ```py
 from enum import Enum
 from ty_extensions import enum_members
+from typing import Literal
 
 class DirectInt(int, Enum):
     FROM_BOOL = False
@@ -804,6 +805,12 @@ reveal_type(DirectStr.FROM_STR)  # revealed: Literal[DirectStr.FROM_INT]
 reveal_type(DirectStr.OTHER.value)  # revealed: Literal["other"]
 # revealed: tuple[Literal["FROM_INT"], Literal["OTHER"]]
 reveal_type(enum_members(DirectStr))
+
+def union_member_value(value: Literal[1, 2]):
+    class UnionInt(int, Enum):
+        MEMBER = value
+
+    reveal_type(UnionInt.MEMBER.value)  # revealed: Literal[1, 2]
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -825,6 +825,20 @@ reveal_type(InheritedValues.FALSE.value)  # revealed: Literal[0]
 reveal_type(enum_members(InheritedValues))
 ```
 
+When a built-in conversion cannot be modeled precisely, its aliases remain unknown:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class ParsedIntegerValues(int, Enum):
+    FIRST = "1"
+    SECOND = "1"
+
+reveal_type(ParsedIntegerValues.FIRST is ParsedIntegerValues.SECOND)  # revealed: bool
+reveal_type(enum_members(ParsedIntegerValues))  # revealed: Unknown
+```
+
 Other built-in data types retain exact assigned values when no coercion is needed:
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -837,6 +837,29 @@ reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
 reveal_type(enum_members(InheritedInt))
 ```
 
+`StrEnum` validates non-string members instead of converting them with `str()`, so rejected values
+must not be normalized into aliases of valid string members:
+
+```toml
+[environment]
+python-version = "3.11"
+```
+
+```py
+from enum import StrEnum
+from ty_extensions import enum_members
+
+class StrictStr(StrEnum):
+    FROM_INT = 1
+    FROM_STR = "1"
+    OTHER = "other"
+
+reveal_type(StrictStr.FROM_INT.value)  # revealed: Literal[1]
+reveal_type(StrictStr.FROM_STR)  # revealed: Literal[StrictStr.FROM_STR]
+# revealed: tuple[Literal["FROM_INT"], Literal["FROM_STR"], Literal["OTHER"]]
+reveal_type(enum_members(StrictStr))
+```
+
 ### Assigned `__new__`
 
 Assigning to `__new__` can prevent us from validating members against its signature or inferring

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -775,8 +775,7 @@ class InheritedWeirdEnum(EmptyWeirdEnum):
 
 reveal_type(InheritedWeirdEnum.FROM_BOOL.value)  # revealed: Any
 reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum.FROM_INT]
-# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"], Literal["OTHER"]]
-reveal_type(enum_members(InheritedWeirdEnum))
+reveal_type(enum_members(InheritedWeirdEnum))  # revealed: Unknown
 ```
 
 ### Built-in data types
@@ -800,9 +799,12 @@ reveal_type(enum_members(IntegerValues))
 class StringValues(str, Enum):
     INTEGER = 1
     STRING = "1"
+    BOOLEAN = False
+    BOOLEAN_STRING = "False"
 
 reveal_type(StringValues.INTEGER.value)  # revealed: Literal["1"]
-# revealed: tuple[Literal["INTEGER"]]
+reveal_type(StringValues.BOOLEAN.value)  # revealed: Literal["False"]
+# revealed: tuple[Literal["INTEGER"], Literal["BOOLEAN"]]
 reveal_type(enum_members(StringValues))
 
 def union_member_value(value: Literal[False, 2]):
@@ -838,6 +840,21 @@ reveal_type(ByteValues.VALUE.value)  # revealed: Literal[b"value"]
 reveal_type(enum_members(ByteValues))
 ```
 
+If the data type would coerce the assigned value, its value and aliases remain unknown:
+
+```py
+from enum import Enum
+from ty_extensions import enum_members
+
+class CoercingByteValues(bytes, Enum):
+    FROM_INT = 1
+    FROM_BYTES = b"\0"
+
+reveal_type(CoercingByteValues.FROM_INT.value)  # revealed: Any
+reveal_type(CoercingByteValues.FROM_INT is CoercingByteValues.FROM_BYTES)  # revealed: bool
+reveal_type(enum_members(CoercingByteValues))  # revealed: Unknown
+```
+
 ### User-defined data types
 
 User-defined data types remain opaque even when they inherit from `int` or `str` without overriding
@@ -856,11 +873,13 @@ class CustomValues(CustomInt, Enum):
     ZERO = 0
 
 reveal_type(CustomValues.FALSE.value)  # revealed: Any
-# revealed: tuple[Literal["FALSE"], Literal["ZERO"]]
-reveal_type(enum_members(CustomValues))
+reveal_type(CustomValues.FALSE is CustomValues.ZERO)  # revealed: bool
+reveal_type(CustomValues.ZERO.name)  # revealed: str
+reveal_type(enum_members(CustomValues))  # revealed: Unknown
 ```
 
-A separate behavior base does not become the enum's data type:
+A user-defined behavior base can still affect member construction and attribute access, so it keeps
+the enum's values opaque even when a separate base selects a built-in data type:
 
 ```py
 class Behavior:
@@ -870,9 +889,7 @@ class ValuesWithBehavior(Behavior, int, Enum):
     FALSE = False
     ZERO = 0
 
-reveal_type(ValuesWithBehavior.FALSE.value)  # revealed: Literal[0]
-# revealed: tuple[Literal["FALSE"]]
-reveal_type(enum_members(ValuesWithBehavior))
+reveal_type(ValuesWithBehavior.FALSE.value)  # revealed: Any
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -22,9 +22,9 @@ reveal_type(Color(1))  # revealed: Color
 reveal_type(Color.RED in Color)  # revealed: bool
 ```
 
-Known standard-library enum constructors preserve literal `.value` types when they do not normalize
-the declared value. The inherited `_value_` annotation remains the fallback when construction does
-normalize the value or when accessing `.value` on the enum class as a whole:
+Known standard-library enum constructors preserve precise `.value` types when their built-in
+data-type normalization can be modeled. The inherited `_value_` annotation remains the fallback when
+the result cannot be inferred precisely or when accessing `.value` on the enum class as a whole:
 
 ```py
 from enum import IntEnum, auto
@@ -33,10 +33,11 @@ from typing import Literal
 class Integer(IntEnum):
     ONE = 1
     TRUE = True
+    TWO = 2
 
 reveal_type(Integer.ONE.value)  # revealed: Literal[1]
 reveal_type(Integer.ONE._value_)  # revealed: Literal[1]
-reveal_type(Integer.TRUE.value)  # revealed: int
+reveal_type(Integer.TRUE.value)  # revealed: Literal[1]
 
 def _(value: Integer):
     reveal_type(value.value)  # revealed: int
@@ -780,7 +781,7 @@ reveal_type(enum_members(InheritedWeirdEnum))
 Known built-in data-type mixins normalize member values before aliases are detected:
 
 ```py
-from enum import Enum
+from enum import Enum, IntEnum
 from ty_extensions import enum_members
 from typing import Literal
 
@@ -811,6 +812,29 @@ def union_member_value(value: Literal[1, 2]):
         MEMBER = value
 
     reveal_type(UnionInt.MEMBER.value)  # revealed: Literal[1, 2]
+
+class StandardInt(IntEnum):
+    FROM_BOOL = False
+    FROM_INT = 0
+    OTHER = 2
+
+reveal_type(StandardInt.FROM_BOOL.value)  # revealed: Literal[0]
+reveal_type(StandardInt.FROM_INT)  # revealed: Literal[StandardInt.FROM_BOOL]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
+reveal_type(enum_members(StandardInt))
+
+class EmptyInt(int, Enum):
+    pass
+
+class InheritedInt(EmptyInt):
+    FROM_BOOL = False
+    FROM_INT = 0
+    OTHER = 2
+
+reveal_type(InheritedInt.FROM_BOOL.value)  # revealed: Literal[0]
+reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
+reveal_type(enum_members(InheritedInt))
 ```
 
 ### Assigned `__new__`

--- a/crates/ty_python_semantic/resources/mdtest/enums.md
+++ b/crates/ty_python_semantic/resources/mdtest/enums.md
@@ -778,6 +778,24 @@ reveal_type(InheritedWeirdEnum.FROM_INT)  # revealed: Literal[InheritedWeirdEnum
 reveal_type(enum_members(InheritedWeirdEnum))
 ```
 
+### Data-type mixin `__init__`
+
+A user-defined `__init__` on a data-type mixin can replace `_value_` after the built-in scalar
+constructor runs. Without an explicit `_value_` annotation, `.value` falls back to `Any`:
+
+```py
+from enum import Enum
+
+class BooleanInt(int):
+    def __init__(self, value: int) -> None:
+        self._value_ = False
+
+class BooleanEnum(BooleanInt, Enum):
+    VALUE = False
+
+reveal_type(BooleanEnum.VALUE.value)  # revealed: Any
+```
+
 Known built-in data-type mixins normalize member values before aliases are detected:
 
 ```py
@@ -835,6 +853,21 @@ reveal_type(InheritedInt.FROM_BOOL.value)  # revealed: Literal[0]
 reveal_type(InheritedInt.FROM_INT)  # revealed: Literal[InheritedInt.FROM_BOOL]
 # revealed: tuple[Literal["FROM_BOOL"], Literal["OTHER"]]
 reveal_type(enum_members(InheritedInt))
+
+# Built-in payload normalization must not override user-defined equality during alias detection.
+class NeverEqualInt(int):
+    def __eq__(self, other: object) -> Literal[False]:
+        return False
+
+class CustomEquality(NeverEqualInt, Enum):
+    FROM_BOOL = False
+    FROM_INT = 0
+
+reveal_type(CustomEquality.FROM_BOOL.value)  # revealed: Literal[0]
+reveal_type(CustomEquality.FROM_INT.value)  # revealed: Literal[0]
+reveal_type(CustomEquality.FROM_INT)  # revealed: Literal[CustomEquality.FROM_INT]
+# revealed: tuple[Literal["FROM_BOOL"], Literal["FROM_INT"]]
+reveal_type(enum_members(CustomEquality))
 ```
 
 `StrEnum` uses the same built-in `str` normalization as an explicit data-type mixin:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -206,6 +206,20 @@ reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: Literal[Tr
 reveal_type(CoercingAlias.SECOND == "1")  # revealed: Literal[True]
 ```
 
+When alias detection is inconclusive, equality between different declarations is also unknown. The
+two declarations below are aliases at runtime:
+
+```py
+class Behavior:
+    pass
+
+class OpaqueAliases(Behavior, Enum):
+    FIRST = 1
+    SECOND = 1
+
+reveal_type(OpaqueAliases.FIRST == OpaqueAliases.SECOND)  # revealed: bool
+```
+
 Equality can transfer restrictions on enum members, but other intersection elements must stay on the
 operand where they originated:
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -194,8 +194,8 @@ class RuntimeIntAlias(IntEnum):
 reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Literal[True]
 ```
 
-A scalar mixin can normalize member values before `Enum` checks for aliases. Here, `str` converts
-`1` to `"1"`, so the two members are aliases:
+An enum with a `str` data type constructs its values before checking for aliases. Here, `str`
+converts `1` to `"1"`, so the two members are aliases:
 
 ```py
 class CoercingAlias(str, Enum):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -669,9 +669,22 @@ def _(value: Foo | Shifted):
         reveal_type(value)  # revealed: Literal[Foo.Y] | Shifted
 ```
 
-An explicit `_value_` annotation can make `.value` precise, but it does not describe the scalar
-payload used by inherited comparison methods. We therefore cannot compare members transformed by a
-custom constructor using their annotated values:
+An explicit `_value_` annotation controls the public `.value` type without erasing a concrete
+comparison payload:
+
+```py
+from enum import IntEnum
+
+class AnnotatedInteger(IntEnum):
+    _value_: int
+    ONE = 1
+
+reveal_type(AnnotatedInteger.ONE.value)  # revealed: int
+reveal_type(AnnotatedInteger.ONE == 1)  # revealed: Literal[True]
+```
+
+When a custom constructor transforms the member, however, the annotation does not describe the
+scalar payload used by inherited comparison methods:
 
 ```py
 from enum import IntEnum

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -195,15 +195,14 @@ reveal_type(RuntimeIntAlias.FIRST == RuntimeIntAlias.SECOND)  # revealed: Litera
 ```
 
 A scalar mixin can normalize member values before `Enum` checks for aliases. Here, `str` converts
-`1` to `"1"`, so the two members are aliases at runtime. Since ty does not model this constructor
-call, the comparison remains `bool`:
+`1` to `"1"`, so the two members are aliases:
 
 ```py
 class CoercingAlias(str, Enum):
     FIRST = 1
     SECOND = "1"
 
-reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: bool
+reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: Literal[True]
 ```
 
 Equality can transfer restrictions on enum members, but other intersection elements must stay on the

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -203,6 +203,7 @@ class CoercingAlias(str, Enum):
     SECOND = "1"
 
 reveal_type(CoercingAlias.FIRST == CoercingAlias.SECOND)  # revealed: Literal[True]
+reveal_type(CoercingAlias.SECOND == "1")  # revealed: Literal[True]
 ```
 
 Equality can transfer restrictions on enum members, but other intersection elements must stay on the

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/eq.md
@@ -533,6 +533,12 @@ class IntegerKey(IntEnum):
     ZERO = 0
 
 reveal_type(BooleanKey.FALSE == IntegerKey.ZERO)  # revealed: Literal[True]
+
+class IntegerAliases(IntEnum):
+    ZERO = 0
+    FALSE = False
+
+reveal_type(IntegerAliases.ZERO == IntegerAliases.FALSE)  # revealed: Literal[True]
 ```
 
 Plain enum members from different classes use identity comparison, even when their declared values

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -2065,7 +2065,9 @@ impl<'db> Bindings<'db> {
                             if let [Some(ty)] = overload.parameter_types() {
                                 let return_ty = match ty {
                                     Type::ClassLiteral(class) => {
-                                        if let Some(metadata) = enums::enum_metadata(db, *class) {
+                                        if let Some(metadata) = enums::enum_metadata(db, *class)
+                                            && metadata.aliases_are_known
+                                        {
                                             Type::heterogeneous_tuple(
                                                 db,
                                                 metadata

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -241,14 +241,11 @@ impl<'db> DynamicEnumLiteral<'db> {
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
         let spec = self.spec(db);
         if spec.has_known_members(db)
-            && spec
-                .members(db)
-                .iter()
-                .any(|(member_name, _)| member_name == name)
             && let Some(enum_class) = ClassLiteral::DynamicEnum(self).into_enum_class(db)
+            && let Some(canonical_name) = enum_class.resolve_member(db, &Name::new(name))
         {
             let enum_lit =
-                crate::types::literal::EnumLiteralType::new(db, enum_class, Name::new(name));
+                crate::types::literal::EnumLiteralType::new(db, enum_class, canonical_name.clone());
             return Member::definitely_declared(Type::enum_literal(enum_lit));
         }
         Member::unbound()

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -11,9 +11,10 @@ use crate::{
     },
     reachability::DeclarationsIteratorExtension,
     types::{
-        ClassBase, ClassLiteral, DynamicType, EnumLiteralType, IntersectionType, KnownClass,
-        LiteralValueTypeKind, MemberLookupPolicy, NegativeIntersectionElements, StaticClassLiteral,
-        Type, UnionType, binding_type,
+        ClassBase, ClassLiteral, ClassType, DataclassFlags, DynamicType, EnumLiteralType,
+        IntersectionType, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
+        NegativeIntersectionElements, StaticClassLiteral, Type, UnionType, binding_type,
+        class::CodeGeneratorKind,
         function::FunctionType,
         set_theoretic::{
             RecursivelyDefined,
@@ -47,15 +48,34 @@ pub(super) enum ResolvedEnumMethod<'db> {
 ///     ZERO = 0  # Alias of `FALSE` after `int(False)` produces `0`.
 /// ```
 ///
-/// User-defined data-type mixins are excluded because their construction, equality, and hashing
-/// semantics cannot be inferred from the built-in scalar class later in their MRO.
+/// User-defined subclasses can use this normalization when their construction, equality, and
+/// hashing semantics are known to match the built-in scalar class later in their MRO.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 enum KnownEnumDataTypeMixin {
     Int,
     Str,
 }
 
+/// How enum aliases can be detected from statically inferred member values.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::Update)]
+enum EnumAliasDetection {
+    /// Compare the declared values without applying data-type normalization.
+    #[default]
+    DeclaredValue,
+    /// Apply the known data type's normalization before comparing values.
+    KnownDataType(KnownEnumDataTypeMixin),
+    /// Construction, equality, or hashing prevents reliable alias detection.
+    Opaque,
+}
+
 impl KnownEnumDataTypeMixin {
+    const fn known_class(self) -> KnownClass {
+        match self {
+            Self::Int => KnownClass::Int,
+            Self::Str => KnownClass::Str,
+        }
+    }
+
     /// Returns the scalar payload type after applying the built-in mixin's constructor.
     ///
     /// Literal conversions are preserved precisely, unions are normalized element-wise, and values
@@ -115,7 +135,8 @@ pub(super) struct EnumValueConstruction<'db> {
     pub(super) new: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
     known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
-    data_type_is_opaque: bool,
+    user_defined_data_type_instance: Option<Type<'db>>,
+    alias_detection: EnumAliasDetection,
     pub(super) metaclass_may_transform_values: bool,
 }
 
@@ -128,7 +149,7 @@ impl<'db> EnumValueConstruction<'db> {
     pub(crate) const fn can_validate_with_value_annotation(self) -> bool {
         matches!(self.init, ResolvedEnumMethod::Absent)
             && matches!(self.new, ResolvedEnumMethod::Absent)
-            && !self.data_type_is_opaque
+            && self.user_defined_data_type_instance.is_none()
             && !self.metaclass_may_transform_values
     }
 
@@ -141,7 +162,6 @@ impl<'db> EnumValueConstruction<'db> {
     const fn member_value_may_be_transformed(self, is_auto: bool) -> bool {
         self.init.is_user_defined()
             || self.new.is_user_defined()
-            || self.data_type_is_opaque
             || self.metaclass_may_transform_values
             || (is_auto && self.generate_next_value.is_opaque())
     }
@@ -152,10 +172,7 @@ impl<'db> EnumValueConstruction<'db> {
     /// `_generate_next_value_` is excluded because `value_type` incorporates its return type for
     /// each `auto()` member before the values are combined.
     const fn instance_value_may_be_transformed(self) -> bool {
-        self.init.is_present()
-            || self.new.is_present()
-            || self.data_type_is_opaque
-            || self.metaclass_may_transform_values
+        self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
     }
 
     /// Applies the payload normalization performed by a known built-in data-type mixin.
@@ -178,10 +195,7 @@ impl<'db> EnumValueConstruction<'db> {
         value_ty: Type<'db>,
         is_auto: bool,
     ) -> Option<Type<'db>> {
-        if self.new.is_user_defined()
-            || self.data_type_is_opaque
-            || self.metaclass_may_transform_values
-        {
+        if self.new.is_user_defined() || self.metaclass_may_transform_values {
             return None;
         }
 
@@ -194,7 +208,13 @@ impl<'db> EnumValueConstruction<'db> {
         } else {
             value_ty
         };
-        Some(self.normalize_value(db, value))
+        match self.alias_detection {
+            EnumAliasDetection::DeclaredValue => Some(value),
+            EnumAliasDetection::KnownDataType(data_type) => {
+                Some(data_type.normalize_value(db, value))
+            }
+            EnumAliasDetection::Opaque => None,
+        }
     }
 }
 
@@ -471,8 +491,8 @@ impl<'db> EnumMetadata<'db> {
     /// Returns the type of `.value`/`._value_` for a given enum member.
     ///
     /// A user-defined `_value_` annotation takes priority. Otherwise, values transformed by
-    /// user-defined data types, construction methods, or metaclasses become `Any`. For
-    /// standard-library constructors, known data-type mixins normalize the value directly. A
+    /// construction methods or metaclasses become `Any`. A user-defined data type produces an
+    /// instance of that type, while known built-in data types normalize the value directly. A
     /// literal is preserved when its runtime class matches an inherited `_value_` annotation;
     /// otherwise, the annotation describes the normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
@@ -483,6 +503,9 @@ impl<'db> EnumMetadata<'db> {
         }
         if self.member_value_may_be_transformed(member_name) {
             return Some(Type::Dynamic(DynamicType::Any));
+        }
+        if let Some(data_type_instance) = self.value_construction.user_defined_data_type_instance {
+            return Some(data_type_instance);
         }
 
         let value = if self.auto_members.contains(member_name)
@@ -519,8 +542,8 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// If there is an explicit `_value_` annotation, returns that.
-    /// If there is a user-defined data type, a custom `__init__` or `__new__`, or a custom enum
-    /// metaclass that may transform member values, returns `Any`.
+    /// If there is a custom `__init__` or `__new__`, or a custom enum metaclass that may transform
+    /// member values, returns `Any`.
     /// Otherwise, returns the union of each member's `value_type`, which
     /// applies `_generate_next_value_`'s return type to `auto()` members.
     pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
@@ -936,6 +959,25 @@ pub(crate) fn enum_metadata<'db>(
     // Look up custom construction methods, falling back to parent enum classes. An opaque binding
     // still shadows methods from classes later in the MRO.
     let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
+    let known_data_type = inherited_known_enum_data_type(db, class);
+    let (known_data_type_mixin, user_defined_data_type_instance, alias_detection) =
+        match known_data_type {
+            InheritedKnownEnumDataType::None => (None, None, EnumAliasDetection::DeclaredValue),
+            InheritedKnownEnumDataType::DataType { class, scalar } => {
+                let data_type_instance = class
+                    .class_literal(db)
+                    .known(db)
+                    .is_none()
+                    .then(|| Type::instance(db, class));
+                let alias_detection = if data_type_has_known_alias_semantics(db, class, scalar) {
+                    EnumAliasDetection::KnownDataType(scalar)
+                } else {
+                    EnumAliasDetection::Opaque
+                };
+                (Some(scalar), data_type_instance, alias_detection)
+            }
+            InheritedKnownEnumDataType::Opaque => (None, None, EnumAliasDetection::Opaque),
+        };
     let user_defined_init =
         custom_enum_method(db, scope_id, "__init__").or(inherited_data_type_mixin.init);
     let init = resolve_enum_method(user_defined_init, || {
@@ -960,8 +1002,9 @@ pub(crate) fn enum_metadata<'db>(
         init,
         new,
         generate_next_value,
-        known_data_type_mixin: inherited_data_type_mixin.known,
-        data_type_is_opaque: inherited_data_type_mixin.opaque,
+        known_data_type_mixin,
+        user_defined_data_type_instance,
+        alias_detection,
         metaclass_may_transform_values,
     };
 
@@ -1248,6 +1291,122 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
+/// A selected enum data type that inherits scalar normalization ty can model.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InheritedKnownEnumDataType<'db> {
+    None,
+    DataType {
+        class: ClassType<'db>,
+        scalar: KnownEnumDataTypeMixin,
+    },
+    Opaque,
+}
+
+/// Find the user-defined data type, if any, that precedes a known scalar in a direct base's MRO.
+///
+/// Each direct base is searched independently to avoid treating a separate behavior mixin as the
+/// data type for `class Example(BehaviorMixin, int, Enum)`. Enum classes in the chain are skipped,
+/// which also supports inheriting the data type through a memberless parent enum.
+fn inherited_known_enum_data_type<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> InheritedKnownEnumDataType<'db> {
+    let mut selected = InheritedKnownEnumDataType::None;
+
+    for explicit_base in class.explicit_bases(db) {
+        let Some(explicit_base) = explicit_base.to_class_type(db) else {
+            return InheritedKnownEnumDataType::Opaque;
+        };
+        let mut candidate = None;
+        let mut data_type = None;
+
+        for base in explicit_base.iter_mro(db) {
+            let ClassBase::Class(base) = base else {
+                return InheritedKnownEnumDataType::Opaque;
+            };
+            let Some(base_literal) = base.class_literal(db).as_static() else {
+                return InheritedKnownEnumDataType::Opaque;
+            };
+
+            if base_literal.known(db) == Some(KnownClass::Object)
+                || is_enum_class_by_inheritance(db, base_literal)
+            {
+                continue;
+            }
+
+            let scalar = match base_literal.known(db) {
+                Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
+                Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
+                _ => None,
+            };
+            if let Some(scalar) = scalar {
+                data_type = Some(InheritedKnownEnumDataType::DataType {
+                    class: candidate.unwrap_or(base),
+                    scalar,
+                });
+                break;
+            }
+            candidate.get_or_insert(base);
+        }
+
+        let Some(data_type) = data_type else {
+            continue;
+        };
+        selected = match selected {
+            InheritedKnownEnumDataType::None => data_type,
+            selected if selected == data_type => selected,
+            InheritedKnownEnumDataType::DataType { .. } | InheritedKnownEnumDataType::Opaque => {
+                InheritedKnownEnumDataType::Opaque
+            }
+        };
+    }
+
+    selected
+}
+
+/// Return whether the selected data type provably retains the scalar's alias semantics.
+///
+/// Enum alias registration depends on both equality and hashing. Comparing the effective methods
+/// handles explicit and inherited overrides; dataclass-like generated equality needs a separate
+/// check because it is synthesized by the class transform rather than declared in the class body.
+fn data_type_has_known_alias_semantics<'db>(
+    db: &'db dyn Db,
+    data_type: ClassType<'db>,
+    known_data_type: KnownEnumDataTypeMixin,
+) -> bool {
+    let has_generated_equality = data_type.iter_mro(db).any(|base| {
+        let Some(base) = base
+            .into_class()
+            .and_then(|base| base.class_literal(db).as_static())
+        else {
+            return false;
+        };
+        let Some(policy @ CodeGeneratorKind::DataclassLike(_)) =
+            CodeGeneratorKind::from_class(db, base.into())
+        else {
+            return false;
+        };
+        base.has_dataclass_param(db, policy, DataclassFlags::EQ)
+    });
+    if has_generated_equality {
+        return false;
+    }
+
+    let data_type = Type::instance(db, data_type).to_meta_type(db);
+    let known_data_type = known_data_type.known_class().to_class_literal(db);
+
+    ["__eq__", "__hash__"].into_iter().all(|name| {
+        let lookup = |class: Type<'db>| {
+            class.member_lookup_with_policy(
+                db,
+                Name::new_static(name),
+                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
+            )
+        };
+        lookup(data_type) == lookup(known_data_type)
+    })
+}
+
 #[derive(Clone, Copy)]
 enum EnumMethodBinding<'db> {
     Function(FunctionType<'db>),
@@ -1256,15 +1415,11 @@ enum EnumMethodBinding<'db> {
 
 /// Constructor behavior collected from data-type mixins in MRO order.
 ///
-/// `init` and `new` record the first user-defined constructor methods. `known` records the nearest
-/// built-in scalar mixin whose value normalization ty models, unless an opaque user-defined
-/// data-type mixin precedes it.
+/// `init` and `new` record the first user-defined constructor methods.
 #[derive(Clone, Copy, Default)]
 struct InheritedDataTypeMixin<'db> {
     init: Option<EnumMethodBinding<'db>>,
     new: Option<EnumMethodBinding<'db>>,
-    known: Option<KnownEnumDataTypeMixin>,
-    opaque: bool,
 }
 
 /// Returns the enum method defined in `scope`, including opaque bindings.
@@ -1320,45 +1475,26 @@ fn inherited_user_defined_enum_new<'db>(
 ///
 /// The scan continues through enum bases because a memberless parent enum can itself inherit the
 /// data-type mixin. When no enum class provides a member constructor, `EnumType` uses this method to
-/// construct the scalar payload stored by the enum member. A user-defined non-enum class before the
-/// built-in scalar makes that data type opaque.
+/// construct the scalar payload stored by the enum member.
 fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = InheritedDataTypeMixin::default();
 
-    for base in class.iter_mro(db, None).skip(1) {
-        let Some(base) = base
-            .into_class()
-            .and_then(|class| class.class_literal(db).as_static())
-        else {
-            if result.known.is_none() {
-                result.opaque = true;
-            }
-            continue;
-        };
-
-        match base.known(db) {
-            Some(KnownClass::Int) if result.known.is_none() && !result.opaque => {
-                result.known = Some(KnownEnumDataTypeMixin::Int);
-            }
-            Some(KnownClass::Str) if result.known.is_none() && !result.opaque => {
-                result.known = Some(KnownEnumDataTypeMixin::Str);
-            }
-            None => {
-                let scope = base.body_scope(db);
-                if result.init.is_none() {
-                    result.init = custom_enum_method(db, scope, "__init__");
-                }
-                if result.new.is_none() {
-                    result.new = custom_enum_method(db, scope, "__new__");
-                }
-                if result.known.is_none() && !is_enum_class_by_inheritance(db, base) {
-                    result.opaque = true;
-                }
-            }
-            _ => {}
+    for base in class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.class_literal(db).as_static())
+        .filter(|base| base.known(db).is_none())
+    {
+        let scope = base.body_scope(db);
+        if result.init.is_none() {
+            result.init = custom_enum_method(db, scope, "__init__");
+        }
+        if result.new.is_none() {
+            result.new = custom_enum_method(db, scope, "__new__");
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -47,7 +47,8 @@ pub(super) enum ResolvedEnumMethod<'db> {
 ///     ZERO = 0  # Alias of `FALSE` after `int(False)` produces `0`.
 /// ```
 ///
-/// User-defined mixins are excluded because their constructors can transform values arbitrarily.
+/// Value normalization is only used when user-defined mixins do not replace construction. Alias
+/// detection additionally requires the enum to retain the built-in mixin's equality semantics.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 enum KnownEnumDataTypeMixin {
     Int,
@@ -112,6 +113,7 @@ impl<'db> ResolvedEnumMethod<'db> {
 pub(super) struct EnumValueConstruction<'db> {
     pub(super) init: ResolvedEnumMethod<'db>,
     pub(super) new: ResolvedEnumMethod<'db>,
+    eq: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
     known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
     pub(super) metaclass_may_transform_values: bool,
@@ -165,6 +167,8 @@ impl<'db> EnumValueConstruction<'db> {
     /// Returns `None` when construction can rewrite `_value_` before alias registration, because
     /// the inferred value is not reliable alias evidence in those cases. `__init__` does not affect
     /// this result because alias registration uses the value captured before `__init__` runs.
+    /// Built-in normalization is skipped when member equality is customized, because equal scalar
+    /// payloads may then represent distinct members.
     fn alias_detection_value(
         self,
         db: &'db dyn Db,
@@ -184,7 +188,11 @@ impl<'db> EnumValueConstruction<'db> {
         } else {
             value_ty
         };
-        Some(self.normalize_value(db, value))
+        Some(if self.eq.is_user_defined() {
+            value
+        } else {
+            self.normalize_value(db, value)
+        })
     }
 }
 
@@ -925,20 +933,23 @@ pub(crate) fn enum_metadata<'db>(
 
     // Look up custom construction methods, falling back to parent enum classes. An opaque binding
     // still shadows methods from classes later in the MRO.
-    let user_defined_init = custom_enum_method(db, scope_id, "__init__")
-        .or_else(|| inherited_user_defined_enum_method(db, class, "__init__"));
+    let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
+    let user_defined_init =
+        custom_enum_method(db, scope_id, "__init__").or(inherited_data_type_mixin.init);
     let init = resolve_enum_method(user_defined_init, || {
         inherited_known_enum_method(db, class, "__init__")
     });
     // CPython checks `__new_member__` and then `__new__` on each enum base before continuing
     // through the MRO or falling back to the data-type constructor.
-    let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
     let user_defined_new = custom_enum_method(db, scope_id, "__new__")
         .or_else(|| inherited_user_defined_enum_new(db, class))
         .or(inherited_data_type_mixin.new);
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
+    let user_defined_eq =
+        custom_enum_method(db, scope_id, "__eq__").or(inherited_data_type_mixin.eq);
+    let eq = resolve_enum_method(user_defined_eq, || None);
     let metaclass_may_transform_values = enum_metaclass_may_transform_values(db, class);
     let user_defined_generate_next_value =
         custom_enum_method(db, scope_id, "_generate_next_value_")
@@ -949,6 +960,7 @@ pub(crate) fn enum_metadata<'db>(
     let value_construction = EnumValueConstruction {
         init,
         new,
+        eq,
         generate_next_value,
         known_data_type_mixin: inherited_data_type_mixin.known,
         metaclass_may_transform_values,
@@ -1245,11 +1257,14 @@ enum EnumMethodBinding<'db> {
 
 /// Constructor behavior collected from data-type mixins in MRO order.
 ///
-/// `new` records the first user-defined `__new__`, while `known` records the nearest built-in scalar
-/// mixin whose value normalization ty models.
+/// `init` and `new` record the first user-defined constructor methods, `eq` records the first
+/// user-defined `__eq__` preceding the built-in scalar base, and `known` records the nearest
+/// built-in scalar mixin whose value normalization ty models.
 #[derive(Clone, Copy, Default)]
 struct InheritedDataTypeMixin<'db> {
+    init: Option<EnumMethodBinding<'db>>,
     new: Option<EnumMethodBinding<'db>>,
+    eq: Option<EnumMethodBinding<'db>>,
     known: Option<KnownEnumDataTypeMixin>,
 }
 
@@ -1326,8 +1341,17 @@ fn inherited_data_type_mixin<'db>(
             Some(KnownClass::Str) if result.known.is_none() => {
                 result.known = Some(KnownEnumDataTypeMixin::Str);
             }
-            None if result.new.is_none() => {
-                result.new = custom_enum_method(db, base.body_scope(db), "__new__");
+            None => {
+                let scope = base.body_scope(db);
+                if result.init.is_none() {
+                    result.init = custom_enum_method(db, scope, "__init__");
+                }
+                if result.new.is_none() {
+                    result.new = custom_enum_method(db, scope, "__new__");
+                }
+                if result.known.is_none() && result.eq.is_none() {
+                    result.eq = custom_enum_method(db, scope, "__eq__");
+                }
             }
             _ => {}
         }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -47,8 +47,8 @@ pub(super) enum ResolvedEnumMethod<'db> {
 ///     ZERO = 0  # Alias of `FALSE` after `int(False)` produces `0`.
 /// ```
 ///
-/// Value normalization is only used when user-defined mixins do not replace construction. Alias
-/// detection additionally requires the enum to retain the built-in mixin's equality semantics.
+/// User-defined data-type mixins are excluded because their construction, equality, and hashing
+/// semantics cannot be inferred from the built-in scalar class later in their MRO.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 enum KnownEnumDataTypeMixin {
     Int,
@@ -107,15 +107,15 @@ impl<'db> ResolvedEnumMethod<'db> {
 /// Describes the runtime steps that may transform a declared enum member value.
 ///
 /// Different consumers require different levels of conservatism. Value inference trusts known
-/// standard-library constructors but treats user-defined constructors as possible transformations,
-/// while alias detection follows the value captured before `__init__`.
+/// standard-library data types but treats user-defined data types and constructors as possible
+/// transformations, while alias detection follows the value captured before `__init__`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::Update)]
 pub(super) struct EnumValueConstruction<'db> {
     pub(super) init: ResolvedEnumMethod<'db>,
     pub(super) new: ResolvedEnumMethod<'db>,
-    eq: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
     known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
+    data_type_is_opaque: bool,
     pub(super) metaclass_may_transform_values: bool,
 }
 
@@ -123,23 +123,25 @@ impl<'db> EnumValueConstruction<'db> {
     /// Returns whether a member value can be checked directly against an explicit `_value_`
     /// annotation.
     ///
-    /// Constructor methods have their own call signatures and may replace `_value_`; a custom
-    /// metaclass may rewrite the member value before construction.
+    /// User-defined data types and constructor methods may replace `_value_`; a custom metaclass may
+    /// rewrite the member value before construction.
     pub(crate) const fn can_validate_with_value_annotation(self) -> bool {
         matches!(self.init, ResolvedEnumMethod::Absent)
             && matches!(self.new, ResolvedEnumMethod::Absent)
+            && !self.data_type_is_opaque
             && !self.metaclass_may_transform_values
     }
 
     /// Returns whether the declared value cannot be used as the precise type of `.value`.
     ///
-    /// Standard-library constructors are trusted because their value normalization is either
-    /// modeled directly or reflected in the inherited `_value_` annotation. A resolvable
-    /// `_generate_next_value_` is excluded because its return type can be used for an `auto()`
-    /// member instead.
+    /// Standard-library data types are trusted because their value normalization is either modeled
+    /// directly or reflected in the inherited `_value_` annotation. A resolvable
+    /// `_generate_next_value_` is excluded because its return type can be used for an `auto()` member
+    /// instead.
     const fn member_value_may_be_transformed(self, is_auto: bool) -> bool {
         self.init.is_user_defined()
             || self.new.is_user_defined()
+            || self.data_type_is_opaque
             || self.metaclass_may_transform_values
             || (is_auto && self.generate_next_value.is_opaque())
     }
@@ -150,7 +152,10 @@ impl<'db> EnumValueConstruction<'db> {
     /// `_generate_next_value_` is excluded because `value_type` incorporates its return type for
     /// each `auto()` member before the values are combined.
     const fn instance_value_may_be_transformed(self) -> bool {
-        self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
+        self.init.is_present()
+            || self.new.is_present()
+            || self.data_type_is_opaque
+            || self.metaclass_may_transform_values
     }
 
     /// Applies the payload normalization performed by a known built-in data-type mixin.
@@ -167,15 +172,16 @@ impl<'db> EnumValueConstruction<'db> {
     /// Returns `None` when construction can rewrite `_value_` before alias registration, because
     /// the inferred value is not reliable alias evidence in those cases. `__init__` does not affect
     /// this result because alias registration uses the value captured before `__init__` runs.
-    /// Built-in normalization is skipped when member equality is customized, because equal scalar
-    /// payloads may then represent distinct members.
     fn alias_detection_value(
         self,
         db: &'db dyn Db,
         value_ty: Type<'db>,
         is_auto: bool,
     ) -> Option<Type<'db>> {
-        if self.new.is_user_defined() || self.metaclass_may_transform_values {
+        if self.new.is_user_defined()
+            || self.data_type_is_opaque
+            || self.metaclass_may_transform_values
+        {
             return None;
         }
 
@@ -188,11 +194,7 @@ impl<'db> EnumValueConstruction<'db> {
         } else {
             value_ty
         };
-        Some(if self.eq.is_user_defined() {
-            value
-        } else {
-            self.normalize_value(db, value)
-        })
+        Some(self.normalize_value(db, value))
     }
 }
 
@@ -469,10 +471,10 @@ impl<'db> EnumMetadata<'db> {
     /// Returns the type of `.value`/`._value_` for a given enum member.
     ///
     /// A user-defined `_value_` annotation takes priority. Otherwise, values transformed by
-    /// user-defined construction methods or metaclasses become `Any`. For standard-library
-    /// constructors, known data-type mixins normalize the value directly. A literal is preserved
-    /// when its runtime class matches an inherited `_value_` annotation; otherwise, the annotation
-    /// describes the normalized value.
+    /// user-defined data types, construction methods, or metaclasses become `Any`. For
+    /// standard-library constructors, known data-type mixins normalize the value directly. A
+    /// literal is preserved when its runtime class matches an inherited `_value_` annotation;
+    /// otherwise, the annotation describes the normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
         let declared_value = self.members.get(member_name).copied()?;
 
@@ -517,8 +519,8 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// If there is an explicit `_value_` annotation, returns that.
-    /// If there is a custom `__init__` or `__new__` or a custom enum
-    /// metaclass may transform member values, returns `Any`.
+    /// If there is a user-defined data type, a custom `__init__` or `__new__`, or a custom enum
+    /// metaclass that may transform member values, returns `Any`.
     /// Otherwise, returns the union of each member's `value_type`, which
     /// applies `_generate_next_value_`'s return type to `auto()` members.
     pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
@@ -947,9 +949,6 @@ pub(crate) fn enum_metadata<'db>(
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
-    let user_defined_eq =
-        custom_enum_method(db, scope_id, "__eq__").or(inherited_data_type_mixin.eq);
-    let eq = resolve_enum_method(user_defined_eq, || None);
     let metaclass_may_transform_values = enum_metaclass_may_transform_values(db, class);
     let user_defined_generate_next_value =
         custom_enum_method(db, scope_id, "_generate_next_value_")
@@ -960,9 +959,9 @@ pub(crate) fn enum_metadata<'db>(
     let value_construction = EnumValueConstruction {
         init,
         new,
-        eq,
         generate_next_value,
         known_data_type_mixin: inherited_data_type_mixin.known,
+        data_type_is_opaque: inherited_data_type_mixin.opaque,
         metaclass_may_transform_values,
     };
 
@@ -1103,6 +1102,18 @@ pub(crate) fn enum_metadata<'db>(
                 }
             };
 
+            // Track whether this member's value is a non-literal `int`, so a
+            // following `auto()` knows to widen its result to `int`.
+            prev_value_was_non_literal_int = value_ty.as_int_like_literal().is_none()
+                && value_ty.is_assignable_to(db, KnownClass::Int.to_instance(db));
+            prev_bool_literal =
+                value_ty
+                    .as_literal_value_kind()
+                    .and_then(|literal| match literal {
+                        LiteralValueTypeKind::Bool(value) => Some(value),
+                        _ => None,
+                    });
+
             let alias_value_ty =
                 value_construction.alias_detection_value(db, value_ty, auto_members.contains(name));
             if let Some(alias_value_ty) = alias_value_ty
@@ -1128,18 +1139,6 @@ pub(crate) fn enum_metadata<'db>(
             {
                 return None;
             }
-
-            // Track whether this member's value is a non-literal `int`, so a
-            // following `auto()` knows to widen its result to `int`.
-            prev_value_was_non_literal_int = value_ty.as_int_like_literal().is_none()
-                && value_ty.is_assignable_to(db, KnownClass::Int.to_instance(db));
-            prev_bool_literal =
-                value_ty
-                    .as_literal_value_kind()
-                    .and_then(|literal| match literal {
-                        LiteralValueTypeKind::Bool(value) => Some(value),
-                        _ => None,
-                    });
 
             Some((name.clone(), value_ty))
         })
@@ -1257,15 +1256,15 @@ enum EnumMethodBinding<'db> {
 
 /// Constructor behavior collected from data-type mixins in MRO order.
 ///
-/// `init` and `new` record the first user-defined constructor methods, `eq` records the first
-/// user-defined `__eq__` preceding the built-in scalar base, and `known` records the nearest
-/// built-in scalar mixin whose value normalization ty models.
+/// `init` and `new` record the first user-defined constructor methods. `known` records the nearest
+/// built-in scalar mixin whose value normalization ty models, unless an opaque user-defined
+/// data-type mixin precedes it.
 #[derive(Clone, Copy, Default)]
 struct InheritedDataTypeMixin<'db> {
     init: Option<EnumMethodBinding<'db>>,
     new: Option<EnumMethodBinding<'db>>,
-    eq: Option<EnumMethodBinding<'db>>,
     known: Option<KnownEnumDataTypeMixin>,
+    opaque: bool,
 }
 
 /// Returns the enum method defined in `scope`, including opaque bindings.
@@ -1321,24 +1320,30 @@ fn inherited_user_defined_enum_new<'db>(
 ///
 /// The scan continues through enum bases because a memberless parent enum can itself inherit the
 /// data-type mixin. When no enum class provides a member constructor, `EnumType` uses this method to
-/// construct the scalar payload stored by the enum member.
+/// construct the scalar payload stored by the enum member. A user-defined non-enum class before the
+/// built-in scalar makes that data type opaque.
 fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = InheritedDataTypeMixin::default();
 
-    for base in class
-        .iter_mro(db, None)
-        .skip(1)
-        .filter_map(ClassBase::into_class)
-        .filter_map(|class| class.class_literal(db).as_static())
-    {
+    for base in class.iter_mro(db, None).skip(1) {
+        let Some(base) = base
+            .into_class()
+            .and_then(|class| class.class_literal(db).as_static())
+        else {
+            if result.known.is_none() {
+                result.opaque = true;
+            }
+            continue;
+        };
+
         match base.known(db) {
-            Some(KnownClass::Int) if result.known.is_none() => {
+            Some(KnownClass::Int) if result.known.is_none() && !result.opaque => {
                 result.known = Some(KnownEnumDataTypeMixin::Int);
             }
-            Some(KnownClass::Str) if result.known.is_none() => {
+            Some(KnownClass::Str) if result.known.is_none() && !result.opaque => {
                 result.known = Some(KnownEnumDataTypeMixin::Str);
             }
             None => {
@@ -1349,8 +1354,8 @@ fn inherited_data_type_mixin<'db>(
                 if result.new.is_none() {
                     result.new = custom_enum_method(db, scope, "__new__");
                 }
-                if result.known.is_none() && result.eq.is_none() {
-                    result.eq = custom_enum_method(db, scope, "__eq__");
+                if result.known.is_none() && !is_enum_class_by_inheritance(db, base) {
+                    result.opaque = true;
                 }
             }
             _ => {}

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -954,6 +954,10 @@ pub(crate) fn enum_metadata<'db>(
                     .alias_detection_value(db, *ty, false)
                     .and_then(|alias_value_ty| {
                         try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
+                            // Identical raw literals remain aliases even when normalization widens.
+                            .or_else(|| {
+                                try_register_alias(*ty, name, &mut enum_values, &mut aliases)
+                            })
                     })
                     == Some(true)
                 {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -942,11 +942,21 @@ pub(crate) fn enum_metadata<'db>(
             if !spec.has_known_members(db) {
                 return None;
             }
+            let value_construction = EnumValueConstruction {
+                data_type: inherited_enum_data_type(db, ClassLiteral::DynamicEnum(enum_lit)),
+                ..EnumValueConstruction::default()
+            };
             let mut members = FxIndexMap::default();
             let mut aliases = FxHashMap::default();
             let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
-                if try_register_alias(*ty, name, &mut enum_values, &mut aliases) == Some(true) {
+                if value_construction
+                    .alias_detection_value(db, *ty, false)
+                    .and_then(|alias_value_ty| {
+                        try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
+                    })
+                    == Some(true)
+                {
                     continue;
                 }
                 members.insert(name.clone(), *ty);
@@ -959,7 +969,7 @@ pub(crate) fn enum_metadata<'db>(
                 aliases_are_known: true,
                 auto_members: FxHashSet::default(),
                 value_annotation: None,
-                value_construction: EnumValueConstruction::default(),
+                value_construction,
             });
         }
     };
@@ -990,7 +1000,7 @@ pub(crate) fn enum_metadata<'db>(
 
     // Look up custom construction methods, falling back to parent enum classes. An opaque binding
     // still shadows methods from classes later in the MRO.
-    let data_type = inherited_enum_data_type(db, class);
+    let data_type = inherited_enum_data_type(db, ClassLiteral::Static(class));
     let user_defined_init = custom_enum_method(db, scope_id, "__init__")
         .or_else(|| inherited_user_defined_enum_method(db, class, "__init__"));
     let init = resolve_enum_method(user_defined_init, || {
@@ -1323,7 +1333,7 @@ enum InheritedEnumDataType {
 /// precisely when no user-defined non-enum base can affect member construction or attribute access.
 fn inherited_enum_data_type<'db>(
     db: &'db dyn Db,
-    class: StaticClassLiteral<'db>,
+    class: ClassLiteral<'db>,
 ) -> InheritedEnumDataType {
     let mut selected = InheritedEnumDataType::None;
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -46,13 +46,7 @@ enum KnownEnumDataTypeMixin {
 impl KnownEnumDataTypeMixin {
     fn normalize_value<'db>(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
         if let Type::Union(union) = value {
-            return UnionType::from_elements(
-                db,
-                union
-                    .elements(db)
-                    .iter()
-                    .map(|element| self.normalize_value(db, *element)),
-            );
+            return union.map(db, |element| self.normalize_value(db, *element));
         }
 
         match (self, value.as_literal_value_kind()) {
@@ -923,9 +917,10 @@ pub(crate) fn enum_metadata<'db>(
     });
     // CPython checks `__new_member__` and then `__new__` on each enum base before continuing
     // through the MRO or falling back to the data-type constructor.
+    let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
     let user_defined_new = custom_enum_method(db, scope_id, "__new__")
         .or_else(|| inherited_user_defined_enum_new(db, class))
-        .or_else(|| inherited_user_defined_mixin_new(db, class));
+        .or(inherited_data_type_mixin.new);
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
@@ -940,7 +935,7 @@ pub(crate) fn enum_metadata<'db>(
         init,
         new,
         generate_next_value,
-        known_data_type_mixin: inherited_known_data_type_mixin(db, class),
+        known_data_type_mixin: inherited_data_type_mixin.known,
         metaclass_may_transform_values,
     };
 
@@ -1233,6 +1228,12 @@ enum EnumMethodBinding<'db> {
     Opaque,
 }
 
+#[derive(Clone, Copy, Default)]
+struct InheritedDataTypeMixin<'db> {
+    new: Option<EnumMethodBinding<'db>>,
+    known: Option<KnownEnumDataTypeMixin>,
+}
+
 /// Returns the enum method defined in `scope`, including opaque bindings.
 fn custom_enum_method<'db>(
     db: &'db dyn Db,
@@ -1282,47 +1283,46 @@ fn inherited_user_defined_enum_new<'db>(
         })
 }
 
-/// Looks up a user-defined `__new__` on a data-type mixin anywhere in the MRO, including through an
-/// enum base.
+/// Looks up the constructor behavior inherited from a data-type mixin.
 ///
 /// When no enum class provides a member constructor, `EnumType` uses this method to construct the
-/// scalar payload stored by the enum member.
-fn inherited_user_defined_mixin_new<'db>(
+/// scalar payload stored by the enum member. `StrEnum.__new__` validates that values are already
+/// strings instead of applying `str()`.
+fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
-) -> Option<EnumMethodBinding<'db>> {
-    class
+) -> InheritedDataTypeMixin<'db> {
+    let mut result = InheritedDataTypeMixin::default();
+    let mut has_str_enum_constructor = false;
+
+    for base in class
         .iter_mro(db, None)
         .skip(1)
         .filter_map(ClassBase::into_class)
         .filter_map(|class| class.class_literal(db).as_static())
-        .filter(|base| base.known(db).is_none())
-        .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
-}
+    {
+        match base.known(db) {
+            Some(KnownClass::Int) if result.known.is_none() => {
+                result.known = Some(KnownEnumDataTypeMixin::Int);
+            }
+            Some(KnownClass::Str) if result.known.is_none() => {
+                result.known = Some(KnownEnumDataTypeMixin::Str);
+            }
+            Some(KnownClass::StrEnum) => has_str_enum_constructor = true,
+            None if result.new.is_none() => {
+                result.new = custom_enum_method(db, base.body_scope(db), "__new__");
+            }
+            _ => {}
+        }
+    }
 
-/// Looks up a built-in data-type mixin that coerces member values during construction.
-///
-/// `StrEnum.__new__` validates that values are already strings instead of applying `str()`.
-fn inherited_known_data_type_mixin<'db>(
-    db: &'db dyn Db,
-    class: StaticClassLiteral<'db>,
-) -> Option<KnownEnumDataTypeMixin> {
-    let has_str_enum_constructor = class
-        .iter_mro(db, None)
-        .skip(1)
-        .filter_map(ClassBase::into_class)
-        .any(|base| base.known(db) == Some(KnownClass::StrEnum));
-
-    class
-        .iter_mro(db, None)
-        .skip(1)
-        .filter_map(ClassBase::into_class)
-        .filter_map(|class| class.class_literal(db).as_static())
-        .find_map(|base| match base.known(db) {
-            Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
-            Some(KnownClass::Str) if !has_str_enum_constructor => Some(KnownEnumDataTypeMixin::Str),
-            _ => None,
-        })
+    // Although non-string `StrEnum` members are invalid at runtime, we still model the class for
+    // error recovery. Applying ordinary `str` normalization would incorrectly make values such as
+    // `1` aliases of string members with the value `"1"`.
+    if has_str_enum_constructor && result.known == Some(KnownEnumDataTypeMixin::Str) {
+        result.known = None;
+    }
+    result
 }
 
 /// Looks up a resolvable method inherited from a known enum class.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1300,11 +1300,19 @@ fn inherited_user_defined_mixin_new<'db>(
         .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
 }
 
-/// Looks up a built-in data-type mixin anywhere in the MRO, including through an enum base.
+/// Looks up a built-in data-type mixin that coerces member values during construction.
+///
+/// `StrEnum.__new__` validates that values are already strings instead of applying `str()`.
 fn inherited_known_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> Option<KnownEnumDataTypeMixin> {
+    let has_str_enum_constructor = class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .any(|base| base.known(db) == Some(KnownClass::StrEnum));
+
     class
         .iter_mro(db, None)
         .skip(1)
@@ -1312,7 +1320,7 @@ fn inherited_known_data_type_mixin<'db>(
         .filter_map(|class| class.class_literal(db).as_static())
         .find_map(|base| match base.known(db) {
             Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
-            Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
+            Some(KnownClass::Str) if !has_str_enum_constructor => Some(KnownEnumDataTypeMixin::Str),
             _ => None,
         })
 }

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1251,14 +1251,15 @@ fn inherited_user_defined_value_annotation<'db>(
 enum InheritedEnumDataType {
     #[default]
     None,
+    DeclaredValue(KnownClass),
     Known(KnownEnumDataTypeMixin),
     Opaque,
 }
 
-/// Find the `int` or `str` data type selected for this enum.
+/// Find the data type selected for this enum.
 ///
 /// CPython searches each direct base independently. A user-defined class in the same base chain as
-/// `int` or `str` makes that data type opaque, while an unrelated behavior base does not.
+/// a built-in data type makes that data type opaque, while an unrelated behavior base does not.
 fn inherited_enum_data_type<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1286,23 +1287,22 @@ fn inherited_enum_data_type<'db>(
                 continue;
             }
 
-            let known = match base.known(db) {
-                Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
-                Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
-                _ => {
+            let data_type = match base.known(db) {
+                Some(KnownClass::Int) => InheritedEnumDataType::Known(KnownEnumDataTypeMixin::Int),
+                Some(KnownClass::Str) => InheritedEnumDataType::Known(KnownEnumDataTypeMixin::Str),
+                Some(known) => InheritedEnumDataType::DeclaredValue(known),
+                None => {
                     has_preceding_class = true;
-                    None
+                    has_unsupported_data_type = true;
+                    continue;
                 }
             };
-            if let Some(known) = known {
-                candidate = Some(if has_preceding_class {
-                    InheritedEnumDataType::Opaque
-                } else {
-                    InheritedEnumDataType::Known(known)
-                });
-                break;
-            }
-            has_unsupported_data_type = true;
+            candidate = Some(if has_preceding_class {
+                InheritedEnumDataType::Opaque
+            } else {
+                data_type
+            });
+            break;
         }
 
         let Some(candidate) = candidate else {
@@ -1393,7 +1393,9 @@ fn inherited_data_type_mixin<'db>(
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = match inherited_enum_data_type(db, class) {
-        InheritedEnumDataType::None => InheritedDataTypeMixin::default(),
+        InheritedEnumDataType::None | InheritedEnumDataType::DeclaredValue(_) => {
+            InheritedDataTypeMixin::default()
+        }
         InheritedEnumDataType::Known(known) => InheritedDataTypeMixin {
             known: Some(known),
             ..InheritedDataTypeMixin::default()

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1247,6 +1247,81 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum InheritedEnumDataType {
+    #[default]
+    None,
+    Known(KnownEnumDataTypeMixin),
+    Opaque,
+}
+
+/// Find the `int` or `str` data type selected for this enum.
+///
+/// CPython searches each direct base independently. A user-defined class in the same base chain as
+/// `int` or `str` makes that data type opaque, while an unrelated behavior base does not.
+fn inherited_enum_data_type<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> InheritedEnumDataType {
+    let mut selected = InheritedEnumDataType::None;
+    let mut has_unsupported_data_type = false;
+
+    for explicit_base in class.explicit_bases(db) {
+        let Some(explicit_base) = explicit_base.to_class_type(db) else {
+            return InheritedEnumDataType::Opaque;
+        };
+        let mut has_preceding_class = false;
+        let mut candidate = None;
+
+        for base in explicit_base.iter_mro(db) {
+            let Some(base) = base
+                .into_class()
+                .and_then(|base| base.class_literal(db).as_static())
+            else {
+                return InheritedEnumDataType::Opaque;
+            };
+
+            if base.known(db) == Some(KnownClass::Object) || is_enum_class_by_inheritance(db, base)
+            {
+                continue;
+            }
+
+            let known = match base.known(db) {
+                Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
+                Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
+                _ => {
+                    has_preceding_class = true;
+                    None
+                }
+            };
+            if let Some(known) = known {
+                candidate = Some(if has_preceding_class {
+                    InheritedEnumDataType::Opaque
+                } else {
+                    InheritedEnumDataType::Known(known)
+                });
+                break;
+            }
+            has_unsupported_data_type = true;
+        }
+
+        let Some(candidate) = candidate else {
+            continue;
+        };
+        selected = match (selected, candidate) {
+            (InheritedEnumDataType::None, candidate) => candidate,
+            (selected, candidate) if selected == candidate => selected,
+            _ => InheritedEnumDataType::Opaque,
+        };
+    }
+
+    if matches!(selected, InheritedEnumDataType::None) && has_unsupported_data_type {
+        InheritedEnumDataType::Opaque
+    } else {
+        selected
+    }
+}
+
 #[derive(Clone, Copy)]
 enum EnumMethodBinding<'db> {
     Function(FunctionType<'db>),
@@ -1317,40 +1392,27 @@ fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
-    let mut result = InheritedDataTypeMixin::default();
+    let mut result = match inherited_enum_data_type(db, class) {
+        InheritedEnumDataType::None => InheritedDataTypeMixin::default(),
+        InheritedEnumDataType::Known(known) => InheritedDataTypeMixin {
+            known: Some(known),
+            ..InheritedDataTypeMixin::default()
+        },
+        InheritedEnumDataType::Opaque => InheritedDataTypeMixin {
+            opaque: true,
+            ..InheritedDataTypeMixin::default()
+        },
+    };
 
-    for base in class.iter_mro(db, None).skip(1) {
-        let Some(base) = base
-            .into_class()
-            .and_then(|class| class.class_literal(db).as_static())
-        else {
-            if result.known.is_none() {
-                result.opaque = true;
-            }
-            continue;
-        };
-
-        if base.known(db) == Some(KnownClass::Object) || is_enum_class_by_inheritance(db, base) {
-            continue;
-        }
-
-        match base.known(db) {
-            Some(KnownClass::Int) if result.known.is_none() && !result.opaque => {
-                result.known = Some(KnownEnumDataTypeMixin::Int);
-            }
-            Some(KnownClass::Str) if result.known.is_none() && !result.opaque => {
-                result.known = Some(KnownEnumDataTypeMixin::Str);
-            }
-            None => {
-                if result.new.is_none() {
-                    result.new = custom_enum_method(db, base.body_scope(db), "__new__");
-                }
-                if result.known.is_none() {
-                    result.opaque = true;
-                }
-            }
-            Some(_) if result.known.is_none() => result.opaque = true,
-            Some(_) => {}
+    for base in class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.class_literal(db).as_static())
+        .filter(|base| base.known(db).is_none())
+    {
+        if result.new.is_none() {
+            result.new = custom_enum_method(db, base.body_scope(db), "__new__");
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1300,7 +1300,7 @@ fn inherited_user_defined_mixin_new<'db>(
         .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
 }
 
-/// Looks up a built-in data-type mixin before the first parent enum.
+/// Looks up a built-in data-type mixin anywhere in the MRO, including through an enum base.
 fn inherited_known_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1310,7 +1310,6 @@ fn inherited_known_data_type_mixin<'db>(
         .skip(1)
         .filter_map(ClassBase::into_class)
         .filter_map(|class| class.class_literal(db).as_static())
-        .take_while(|base| !is_enum_class_by_inheritance(db, *base))
         .find_map(|base| match base.known(db) {
             Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
             Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1156,8 +1156,10 @@ pub(crate) fn enum_metadata<'db>(
                         _ => None,
                     });
 
-            let data_type_aliases_may_be_unknown = value_construction.data_type_is_opaque
-                || value_construction.exact_data_type.is_some();
+            let data_type_aliases_may_be_unknown =
+                value_construction.known_data_type_mixin.is_some()
+                    || value_construction.data_type_is_opaque
+                    || value_construction.exact_data_type.is_some();
             match value_construction
                 .alias_detection_value(db, value_ty, auto_members.contains(name))
                 .and_then(|alias_value_ty| {

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -115,6 +115,7 @@ pub(super) struct EnumValueConstruction<'db> {
     pub(super) new: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
     known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
+    exact_data_type: Option<KnownClass>,
     data_type_is_opaque: bool,
     pub(super) metaclass_may_transform_values: bool,
 }
@@ -158,10 +159,16 @@ impl<'db> EnumValueConstruction<'db> {
             || self.metaclass_may_transform_values
     }
 
-    /// Applies the payload normalization performed by a known built-in data-type mixin.
-    fn normalize_value(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
-        self.known_data_type_mixin
-            .map_or(value, |mixin| mixin.normalize_value(db, value))
+    /// Returns the payload after known built-in data-type construction, or `None` when the
+    /// constructor may coerce it in a way that ty does not model.
+    fn normalize_value(self, db: &'db dyn Db, value: Type<'db>) -> Option<Type<'db>> {
+        if let Some(mixin) = self.known_data_type_mixin {
+            return Some(mixin.normalize_value(db, value));
+        }
+        if let Some(data_type) = self.exact_data_type {
+            return value_has_exact_known_class(db, value, data_type).then_some(value);
+        }
+        Some(value)
     }
 
     /// Returns the value to use when checking whether an enum member is an alias.
@@ -194,7 +201,7 @@ impl<'db> EnumValueConstruction<'db> {
         } else {
             value_ty
         };
-        Some(self.normalize_value(db, value))
+        self.normalize_value(db, value)
     }
 }
 
@@ -218,6 +225,9 @@ impl<'db> EnumValueAnnotation<'db> {
 pub(crate) struct EnumMetadata<'db> {
     pub(crate) members: FxIndexMap<Name, Type<'db>>,
     pub(crate) aliases: FxHashMap<Name, Name>,
+
+    /// Whether alias detection was precise for every member declaration.
+    pub(crate) aliases_are_known: bool,
 
     /// Members whose values were defined using `auto()`.
     pub(crate) auto_members: FxHashSet<Name>,
@@ -275,6 +285,8 @@ pub struct EnumClassLiteral<'db> {
     pub(crate) members: Box<[(Name, Type<'db>)]>,
     #[returns(ref)]
     pub(crate) aliases: Box<[(Name, Name)]>,
+    /// Whether the canonical member and alias sets are known exactly.
+    pub(crate) aliases_are_known: bool,
     /// Whether the canonical members exhaust the runtime values of this enum class.
     ///
     /// `Flag` classes, transforming metaclasses, and enums with a custom `_missing_` method can
@@ -318,6 +330,7 @@ fn enum_class_literal<'db>(
         class,
         members,
         aliases.into_boxed_slice(),
+        metadata.aliases_are_known,
         members_are_exhaustive,
     ))
 }
@@ -366,8 +379,12 @@ impl<'db> EnumClassLiteral<'db> {
 
     /// Returns the type of `.name`/`._name_` for a given enum member.
     ///
-    /// This is always a string literal of the member name.
+    /// This is the canonical member name when alias detection is precise, or `str` when the
+    /// declaration may be an alias of another member.
     pub(crate) fn name_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
+        if !self.aliases_are_known(db) {
+            return Some(KnownClass::Str.to_instance(db));
+        }
         self.resolve_member(db, name)
             .map(|name| Type::string_literal(db, name.as_str()))
     }
@@ -457,11 +474,34 @@ fn known_constructor_preserves_value_type<'db>(
     }
 }
 
+/// Return whether constructing `data_type` from `value` preserves the value's inferred runtime
+/// class. This deliberately requires an exact known class rather than accepting subclasses whose
+/// constructor may return an instance of the built-in base.
+fn value_has_exact_known_class<'db>(
+    db: &'db dyn Db,
+    value: Type<'db>,
+    data_type: KnownClass,
+) -> bool {
+    match value.resolve_type_alias(db) {
+        Type::Union(union) => union
+            .elements(db)
+            .iter()
+            .all(|element| value_has_exact_known_class(db, *element, data_type)),
+        Type::LiteralValue(literal) => match literal.fallback_instance(db) {
+            Type::NominalInstance(instance) => instance.has_known_class(db, data_type),
+            _ => false,
+        },
+        Type::NominalInstance(instance) => instance.has_known_class(db, data_type),
+        _ => false,
+    }
+}
+
 impl<'db> EnumMetadata<'db> {
     fn empty() -> Self {
         EnumMetadata {
             members: FxIndexMap::default(),
             aliases: FxHashMap::default(),
+            aliases_are_known: false,
             auto_members: FxHashSet::default(),
             value_annotation: None,
             value_construction: EnumValueConstruction::default(),
@@ -495,7 +535,9 @@ impl<'db> EnumMetadata<'db> {
         } else {
             declared_value
         };
-        let value = self.value_construction.normalize_value(db, value);
+        let Some(value) = self.value_construction.normalize_value(db, value) else {
+            return Some(Type::Dynamic(DynamicType::Any));
+        };
 
         if let Some(EnumValueAnnotation::StandardLibrary(annotation)) = self.value_annotation
             && !known_constructor_preserves_value_type(db, value, annotation)
@@ -832,19 +874,17 @@ pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -
     }
 }
 
-/// If `value_ty` has the same supported literal kind and payload as a value in `enum_values`, record
-/// it as an alias and return `true`. Otherwise track it as canonical. Literal metadata does not
-/// affect enum aliasing at runtime, so the map is keyed by [`LiteralValueTypeKind`] rather than
-/// [`Type`].
+/// If `value_ty` has a supported literal value, record it as canonical or as an alias of an existing
+/// value. Returns `None` when the value is not precise enough for alias detection. Literal metadata
+/// does not affect enum aliasing at runtime, so the map is keyed by [`LiteralValueTypeKind`] rather
+/// than [`Type`].
 fn try_register_alias<'db>(
     value_ty: Type<'db>,
     name: &Name,
     enum_values: &mut FxHashMap<LiteralValueTypeKind<'db>, Name>,
     aliases: &mut FxHashMap<Name, Name>,
-) -> bool {
-    let Some(value) = value_ty.as_literal_value_kind() else {
-        return false;
-    };
+) -> Option<bool> {
+    let value = value_ty.as_literal_value_kind()?;
     if !matches!(
         value,
         LiteralValueTypeKind::Bool(_)
@@ -852,14 +892,14 @@ fn try_register_alias<'db>(
             | LiteralValueTypeKind::String(_)
             | LiteralValueTypeKind::Bytes(_)
     ) {
-        return false;
+        return None;
     }
     if let Some(canonical) = enum_values.get(&value) {
         aliases.insert(name.clone(), canonical.clone());
-        return true;
+        return Some(true);
     }
     enum_values.insert(value, name.clone());
-    false
+    Some(false)
 }
 
 /// List all members of an enum.
@@ -892,7 +932,7 @@ pub(crate) fn enum_metadata<'db>(
             let mut aliases = FxHashMap::default();
             let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
-                if try_register_alias(*ty, name, &mut enum_values, &mut aliases) {
+                if try_register_alias(*ty, name, &mut enum_values, &mut aliases) == Some(true) {
                     continue;
                 }
                 members.insert(name.clone(), *ty);
@@ -902,6 +942,7 @@ pub(crate) fn enum_metadata<'db>(
             return Some(EnumMetadata {
                 members,
                 aliases,
+                aliases_are_known: true,
                 auto_members: FxHashSet::default(),
                 value_annotation: None,
                 value_construction: EnumValueConstruction::default(),
@@ -928,6 +969,7 @@ pub(crate) fn enum_metadata<'db>(
     let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
     let mut auto_counter = 0;
     let mut auto_members = FxHashSet::default();
+    let mut aliases_are_known = true;
     let mut prev_value_was_non_literal_int = false;
     let mut prev_bool_literal = None;
     let ignored_names = enum_ignored_names(db, scope_id);
@@ -960,6 +1002,7 @@ pub(crate) fn enum_metadata<'db>(
         new,
         generate_next_value,
         known_data_type_mixin: inherited_data_type_mixin.known,
+        exact_data_type: inherited_data_type_mixin.exact,
         data_type_is_opaque: inherited_data_type_mixin.opaque,
         metaclass_may_transform_values,
     };
@@ -1113,12 +1156,17 @@ pub(crate) fn enum_metadata<'db>(
                         _ => None,
                     });
 
-            let alias_value_ty =
-                value_construction.alias_detection_value(db, value_ty, auto_members.contains(name));
-            if let Some(alias_value_ty) = alias_value_ty
-                && try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
-            {
-                return None;
+            let data_type_aliases_may_be_unknown = value_construction.data_type_is_opaque
+                || value_construction.exact_data_type.is_some();
+            match value_construction
+                .alias_detection_value(db, value_ty, auto_members.contains(name))
+                .and_then(|alias_value_ty| {
+                    try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
+                }) {
+                Some(true) => return None,
+                Some(false) => {}
+                None if data_type_aliases_may_be_unknown => aliases_are_known = false,
+                None => {}
             }
 
             let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
@@ -1163,6 +1211,7 @@ pub(crate) fn enum_metadata<'db>(
     Some(EnumMetadata {
         members,
         aliases,
+        aliases_are_known,
         auto_members,
         value_annotation,
         value_construction,
@@ -1258,8 +1307,8 @@ enum InheritedEnumDataType {
 
 /// Find the data type selected for this enum.
 ///
-/// CPython searches each direct base independently. A user-defined class in the same base chain as
-/// a built-in data type makes that data type opaque, while an unrelated behavior base does not.
+/// CPython searches each direct base independently. We only model a selected built-in data type
+/// precisely when no user-defined non-enum base can affect member construction or attribute access.
 fn inherited_enum_data_type<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
@@ -1271,14 +1320,17 @@ fn inherited_enum_data_type<'db>(
         let Some(explicit_base) = explicit_base.to_class_type(db) else {
             return InheritedEnumDataType::Opaque;
         };
-        let mut has_preceding_class = false;
         let mut candidate = None;
 
         for base in explicit_base.iter_mro(db) {
-            let Some(base) = base
-                .into_class()
-                .and_then(|base| base.class_literal(db).as_static())
-            else {
+            let Some(base) = base.into_class() else {
+                return InheritedEnumDataType::Opaque;
+            };
+            let base = base.class_literal(db);
+            if matches!(base, ClassLiteral::DynamicEnum(_)) {
+                continue;
+            }
+            let Some(base) = base.as_static() else {
                 return InheritedEnumDataType::Opaque;
             };
 
@@ -1292,16 +1344,11 @@ fn inherited_enum_data_type<'db>(
                 Some(KnownClass::Str) => InheritedEnumDataType::Known(KnownEnumDataTypeMixin::Str),
                 Some(known) => InheritedEnumDataType::DeclaredValue(known),
                 None => {
-                    has_preceding_class = true;
                     has_unsupported_data_type = true;
                     continue;
                 }
             };
-            candidate = Some(if has_preceding_class {
-                InheritedEnumDataType::Opaque
-            } else {
-                data_type
-            });
+            candidate = Some(data_type);
             break;
         }
 
@@ -1315,7 +1362,7 @@ fn inherited_enum_data_type<'db>(
         };
     }
 
-    if matches!(selected, InheritedEnumDataType::None) && has_unsupported_data_type {
+    if has_unsupported_data_type {
         InheritedEnumDataType::Opaque
     } else {
         selected
@@ -1333,6 +1380,7 @@ enum EnumMethodBinding<'db> {
 struct InheritedDataTypeMixin<'db> {
     new: Option<EnumMethodBinding<'db>>,
     known: Option<KnownEnumDataTypeMixin>,
+    exact: Option<KnownClass>,
     opaque: bool,
 }
 
@@ -1387,15 +1435,17 @@ fn inherited_user_defined_enum_new<'db>(
 
 /// Looks up data-type behavior across the full MRO, including through an enum base.
 ///
-/// A user-defined non-enum class before `int` or `str` makes the data type opaque.
+/// Any user-defined non-enum class makes the data type opaque.
 fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = match inherited_enum_data_type(db, class) {
-        InheritedEnumDataType::None | InheritedEnumDataType::DeclaredValue(_) => {
-            InheritedDataTypeMixin::default()
-        }
+        InheritedEnumDataType::None => InheritedDataTypeMixin::default(),
+        InheritedEnumDataType::DeclaredValue(exact) => InheritedDataTypeMixin {
+            exact: Some(exact),
+            ..InheritedDataTypeMixin::default()
+        },
         InheritedEnumDataType::Known(known) => InheritedDataTypeMixin {
             known: Some(known),
             ..InheritedDataTypeMixin::default()

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1156,6 +1156,24 @@ pub(crate) fn enum_metadata<'db>(
                 }
             };
 
+            let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
+
+            if !explicit_member_wrapper
+                && declarations.clone().any_reachable(db, |declaration| {
+                    declaration.is_defined_and(|declaration| {
+                        !matches!(
+                            declaration.kind(db),
+                            DefinitionKind::AnnotatedAssignment(assignment)
+                                if assignment
+                                    .value(&parsed_module(db, declaration.file(db)).load(db))
+                                    .is_some()
+                        )
+                    })
+                })
+            {
+                return None;
+            }
+
             // Track whether this member's value is a non-literal `int`, so a
             // following `auto()` knows to widen its result to `int`.
             prev_value_was_non_literal_int = value_ty.as_int_like_literal().is_none()
@@ -1179,24 +1197,6 @@ pub(crate) fn enum_metadata<'db>(
                     aliases_are_known = false;
                 }
                 None => {}
-            }
-
-            let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
-
-            if !explicit_member_wrapper
-                && declarations.clone().any_reachable(db, |declaration| {
-                    declaration.is_defined_and(|declaration| {
-                        !matches!(
-                            declaration.kind(db),
-                            DefinitionKind::AnnotatedAssignment(assignment)
-                                if assignment
-                                    .value(&parsed_module(db, declaration.file(db)).load(db))
-                                    .is_some()
-                        )
-                    })
-                })
-            {
-                return None;
             }
 
             Some((name.clone(), value_ty))

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -114,9 +114,7 @@ pub(super) struct EnumValueConstruction<'db> {
     pub(super) init: ResolvedEnumMethod<'db>,
     pub(super) new: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
-    known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
-    exact_data_type: Option<KnownClass>,
-    data_type_is_opaque: bool,
+    data_type: InheritedEnumDataType,
     pub(super) metaclass_may_transform_values: bool,
 }
 
@@ -129,7 +127,7 @@ impl<'db> EnumValueConstruction<'db> {
     pub(crate) const fn can_validate_with_value_annotation(self) -> bool {
         matches!(self.init, ResolvedEnumMethod::Absent)
             && matches!(self.new, ResolvedEnumMethod::Absent)
-            && !self.data_type_is_opaque
+            && !matches!(self.data_type, InheritedEnumDataType::Opaque)
             && !self.metaclass_may_transform_values
     }
 
@@ -142,7 +140,7 @@ impl<'db> EnumValueConstruction<'db> {
     const fn member_value_may_be_transformed(self, is_auto: bool) -> bool {
         self.init.is_user_defined()
             || self.new.is_user_defined()
-            || self.data_type_is_opaque
+            || matches!(self.data_type, InheritedEnumDataType::Opaque)
             || self.metaclass_may_transform_values
             || (is_auto && self.generate_next_value.is_opaque())
     }
@@ -155,20 +153,21 @@ impl<'db> EnumValueConstruction<'db> {
     const fn instance_value_may_be_transformed(self) -> bool {
         self.init.is_present()
             || self.new.is_present()
-            || self.data_type_is_opaque
+            || matches!(self.data_type, InheritedEnumDataType::Opaque)
             || self.metaclass_may_transform_values
     }
 
     /// Returns the payload after known built-in data-type construction, or `None` when the
     /// constructor may coerce it in a way that ty does not model.
     fn normalize_value(self, db: &'db dyn Db, value: Type<'db>) -> Option<Type<'db>> {
-        if let Some(mixin) = self.known_data_type_mixin {
-            return Some(mixin.normalize_value(db, value));
+        match self.data_type {
+            InheritedEnumDataType::None => Some(value),
+            InheritedEnumDataType::DeclaredValue(data_type) => {
+                value_has_exact_known_class(db, value, data_type).then_some(value)
+            }
+            InheritedEnumDataType::Known(mixin) => Some(mixin.normalize_value(db, value)),
+            InheritedEnumDataType::Opaque => None,
         }
-        if let Some(data_type) = self.exact_data_type {
-            return value_has_exact_known_class(db, value, data_type).then_some(value);
-        }
-        Some(value)
     }
 
     /// Returns the value to use when checking whether an enum member is an alias.
@@ -186,7 +185,7 @@ impl<'db> EnumValueConstruction<'db> {
         is_auto: bool,
     ) -> Option<Type<'db>> {
         if self.new.is_user_defined()
-            || self.data_type_is_opaque
+            || matches!(self.data_type, InheritedEnumDataType::Opaque)
             || self.metaclass_may_transform_values
         {
             return None;
@@ -227,7 +226,7 @@ pub(crate) struct EnumMetadata<'db> {
     pub(crate) aliases: FxHashMap<Name, Name>,
 
     /// Whether alias detection was precise for every member declaration.
-    pub(crate) aliases_are_known: bool,
+    pub(super) aliases_are_known: bool,
 
     /// Members whose values were defined using `auto()`.
     pub(crate) auto_members: FxHashSet<Name>,
@@ -286,7 +285,7 @@ pub struct EnumClassLiteral<'db> {
     #[returns(ref)]
     pub(crate) aliases: Box<[(Name, Name)]>,
     /// Whether the canonical member and alias sets are known exactly.
-    pub(crate) aliases_are_known: bool,
+    pub(super) aliases_are_known: bool,
     /// Whether the canonical members exhaust the runtime values of this enum class.
     ///
     /// `Flag` classes, transforming metaclasses, and enums with a custom `_missing_` method can
@@ -540,7 +539,7 @@ impl<'db> EnumMetadata<'db> {
     ///
     /// Unlike [`Self::value_type`], this does not substitute a `_value_` annotation for the
     /// concrete payload.
-    pub(crate) fn concrete_value_type(
+    pub(super) fn concrete_value_type(
         &self,
         db: &'db dyn Db,
         member_name: &Name,
@@ -566,7 +565,7 @@ impl<'db> EnumMetadata<'db> {
     /// Return whether enum construction may replace the value declared for `member_name`.
     ///
     /// An opaque `_generate_next_value_` only affects members declared with `auto()`.
-    pub(crate) fn member_value_may_be_transformed(&self, member_name: &Name) -> bool {
+    fn member_value_may_be_transformed(&self, member_name: &Name) -> bool {
         self.value_construction
             .member_value_may_be_transformed(self.auto_members.contains(member_name))
     }
@@ -991,7 +990,7 @@ pub(crate) fn enum_metadata<'db>(
 
     // Look up custom construction methods, falling back to parent enum classes. An opaque binding
     // still shadows methods from classes later in the MRO.
-    let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
+    let data_type = inherited_enum_data_type(db, class);
     let user_defined_init = custom_enum_method(db, scope_id, "__init__")
         .or_else(|| inherited_user_defined_enum_method(db, class, "__init__"));
     let init = resolve_enum_method(user_defined_init, || {
@@ -1001,7 +1000,7 @@ pub(crate) fn enum_metadata<'db>(
     // through the MRO or falling back to the data-type constructor.
     let user_defined_new = custom_enum_method(db, scope_id, "__new__")
         .or_else(|| inherited_user_defined_enum_new(db, class))
-        .or(inherited_data_type_mixin.new);
+        .or_else(|| inherited_user_defined_mixin_new(db, class));
     let new = resolve_enum_method(user_defined_new, || {
         inherited_known_enum_method(db, class, "__new__")
     });
@@ -1016,9 +1015,7 @@ pub(crate) fn enum_metadata<'db>(
         init,
         new,
         generate_next_value,
-        known_data_type_mixin: inherited_data_type_mixin.known,
-        exact_data_type: inherited_data_type_mixin.exact,
-        data_type_is_opaque: inherited_data_type_mixin.opaque,
+        data_type,
         metaclass_may_transform_values,
     };
 
@@ -1171,10 +1168,6 @@ pub(crate) fn enum_metadata<'db>(
                         _ => None,
                     });
 
-            let data_type_aliases_may_be_unknown =
-                value_construction.known_data_type_mixin.is_some()
-                    || value_construction.data_type_is_opaque
-                    || value_construction.exact_data_type.is_some();
             match value_construction
                 .alias_detection_value(db, value_ty, auto_members.contains(name))
                 .and_then(|alias_value_ty| {
@@ -1182,7 +1175,9 @@ pub(crate) fn enum_metadata<'db>(
                 }) {
                 Some(true) => return None,
                 Some(false) => {}
-                None if data_type_aliases_may_be_unknown => aliases_are_known = false,
+                None if value_construction.data_type != InheritedEnumDataType::None => {
+                    aliases_are_known = false;
+                }
                 None => {}
             }
 
@@ -1313,7 +1308,7 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::Update)]
 enum InheritedEnumDataType {
     #[default]
     None,
@@ -1331,7 +1326,6 @@ fn inherited_enum_data_type<'db>(
     class: StaticClassLiteral<'db>,
 ) -> InheritedEnumDataType {
     let mut selected = InheritedEnumDataType::None;
-    let mut has_unsupported_data_type = false;
 
     for explicit_base in class.explicit_bases(db) {
         let Some(explicit_base) = explicit_base.to_class_type(db) else {
@@ -1360,10 +1354,7 @@ fn inherited_enum_data_type<'db>(
                 Some(KnownClass::Int) => InheritedEnumDataType::Known(KnownEnumDataTypeMixin::Int),
                 Some(KnownClass::Str) => InheritedEnumDataType::Known(KnownEnumDataTypeMixin::Str),
                 Some(known) => InheritedEnumDataType::DeclaredValue(known),
-                None => {
-                    has_unsupported_data_type = true;
-                    continue;
-                }
+                None => return InheritedEnumDataType::Opaque,
             };
             candidate = Some(data_type);
             break;
@@ -1375,30 +1366,17 @@ fn inherited_enum_data_type<'db>(
         selected = match (selected, candidate) {
             (InheritedEnumDataType::None, candidate) => candidate,
             (selected, candidate) if selected == candidate => selected,
-            _ => InheritedEnumDataType::Opaque,
+            _ => return InheritedEnumDataType::Opaque,
         };
     }
 
-    if has_unsupported_data_type {
-        InheritedEnumDataType::Opaque
-    } else {
-        selected
-    }
+    selected
 }
 
 #[derive(Clone, Copy)]
 enum EnumMethodBinding<'db> {
     Function(FunctionType<'db>),
     Opaque,
-}
-
-/// Constructor and normalization behavior inherited from data-type mixins.
-#[derive(Clone, Copy, Default)]
-struct InheritedDataTypeMixin<'db> {
-    new: Option<EnumMethodBinding<'db>>,
-    known: Option<KnownEnumDataTypeMixin>,
-    exact: Option<KnownClass>,
-    opaque: bool,
 }
 
 /// Returns the enum method defined in `scope`, including opaque bindings.
@@ -1450,42 +1428,22 @@ fn inherited_user_defined_enum_new<'db>(
         })
 }
 
-/// Looks up data-type behavior across the full MRO, including through an enum base.
+/// Looks up a user-defined `__new__` on a data-type mixin anywhere in the MRO, including through an
+/// enum base.
 ///
-/// Any user-defined non-enum class makes the data type opaque.
-fn inherited_data_type_mixin<'db>(
+/// When no enum class provides a member constructor, `EnumType` uses this method to construct the
+/// scalar payload stored by the enum member.
+fn inherited_user_defined_mixin_new<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
-) -> InheritedDataTypeMixin<'db> {
-    let mut result = match inherited_enum_data_type(db, class) {
-        InheritedEnumDataType::None => InheritedDataTypeMixin::default(),
-        InheritedEnumDataType::DeclaredValue(exact) => InheritedDataTypeMixin {
-            exact: Some(exact),
-            ..InheritedDataTypeMixin::default()
-        },
-        InheritedEnumDataType::Known(known) => InheritedDataTypeMixin {
-            known: Some(known),
-            ..InheritedDataTypeMixin::default()
-        },
-        InheritedEnumDataType::Opaque => InheritedDataTypeMixin {
-            opaque: true,
-            ..InheritedDataTypeMixin::default()
-        },
-    };
-
-    for base in class
+) -> Option<EnumMethodBinding<'db>> {
+    class
         .iter_mro(db, None)
         .skip(1)
         .filter_map(ClassBase::into_class)
         .filter_map(|class| class.class_literal(db).as_static())
         .filter(|base| base.known(db).is_none())
-    {
-        if result.new.is_none() {
-            result.new = custom_enum_method(db, base.body_scope(db), "__new__");
-        }
-    }
-
-    result
+        .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
 }
 
 /// Looks up a resolvable method inherited from a known enum class.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -37,6 +37,17 @@ pub(super) enum ResolvedEnumMethod<'db> {
     Opaque,
 }
 
+/// A built-in enum data-type mixin whose runtime value normalization ty models.
+///
+/// ```python
+/// from enum import Enum
+///
+/// class Number(int, Enum):
+///     FALSE = False
+///     ZERO = 0  # Alias of `FALSE` after `int(False)` produces `0`.
+/// ```
+///
+/// User-defined mixins are excluded because their constructors can transform values arbitrarily.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 enum KnownEnumDataTypeMixin {
     Int,
@@ -44,6 +55,10 @@ enum KnownEnumDataTypeMixin {
 }
 
 impl KnownEnumDataTypeMixin {
+    /// Returns the scalar payload type after applying the built-in mixin's constructor.
+    ///
+    /// Literal conversions are preserved precisely, unions are normalized element-wise, and values
+    /// whose conversion cannot be modeled precisely fall back to the mixin's instance type.
     fn normalize_value<'db>(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
         if let Type::Union(union) = value {
             return union.map(db, |element| self.normalize_value(db, *element));
@@ -1228,6 +1243,10 @@ enum EnumMethodBinding<'db> {
     Opaque,
 }
 
+/// Constructor behavior collected from data-type mixins in MRO order.
+///
+/// `new` records the first user-defined `__new__`, while `known` records the nearest built-in scalar
+/// mixin whose value normalization ty models.
 #[derive(Clone, Copy, Default)]
 struct InheritedDataTypeMixin<'db> {
     new: Option<EnumMethodBinding<'db>>,
@@ -1283,17 +1302,16 @@ fn inherited_user_defined_enum_new<'db>(
         })
 }
 
-/// Looks up the constructor behavior inherited from a data-type mixin.
+/// Looks up constructor behavior inherited from data-type mixins across the full MRO.
 ///
-/// When no enum class provides a member constructor, `EnumType` uses this method to construct the
-/// scalar payload stored by the enum member. `StrEnum.__new__` validates that values are already
-/// strings instead of applying `str()`.
+/// The scan continues through enum bases because a memberless parent enum can itself inherit the
+/// data-type mixin. When no enum class provides a member constructor, `EnumType` uses this method to
+/// construct the scalar payload stored by the enum member.
 fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = InheritedDataTypeMixin::default();
-    let mut has_str_enum_constructor = false;
 
     for base in class
         .iter_mro(db, None)
@@ -1308,7 +1326,6 @@ fn inherited_data_type_mixin<'db>(
             Some(KnownClass::Str) if result.known.is_none() => {
                 result.known = Some(KnownEnumDataTypeMixin::Str);
             }
-            Some(KnownClass::StrEnum) => has_str_enum_constructor = true,
             None if result.new.is_none() => {
                 result.new = custom_enum_method(db, base.body_scope(db), "__new__");
             }
@@ -1316,12 +1333,6 @@ fn inherited_data_type_mixin<'db>(
         }
     }
 
-    // Although non-string `StrEnum` members are invalid at runtime, we still model the class for
-    // error recovery. Applying ordinary `str` normalization would incorrectly make values such as
-    // `1` aliases of string members with the value `"1"`.
-    if has_str_enum_constructor && result.known == Some(KnownEnumDataTypeMixin::Str) {
-        result.known = None;
-    }
     result
 }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -45,6 +45,16 @@ enum KnownEnumDataTypeMixin {
 
 impl KnownEnumDataTypeMixin {
     fn normalize_value<'db>(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
+        if let Type::Union(union) = value {
+            return UnionType::from_elements(
+                db,
+                union
+                    .elements(db)
+                    .iter()
+                    .map(|element| self.normalize_value(db, *element)),
+            );
+        }
+
         match (self, value.as_literal_value_kind()) {
             (Self::Int, Some(LiteralValueTypeKind::Int(_)))
             | (Self::Str, Some(LiteralValueTypeKind::String(_))) => value,

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -1159,7 +1159,7 @@ pub(crate) fn enum_metadata<'db>(
             let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
 
             if !explicit_member_wrapper
-                && declarations.clone().any_reachable(db, |declaration| {
+                && declarations.any_reachable(db, |declaration| {
                     declaration.is_defined_and(|declaration| {
                         !matches!(
                             declaration.kind(db),

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -516,13 +516,38 @@ impl<'db> EnumMetadata<'db> {
     /// matches an inherited `_value_` annotation; otherwise, the annotation describes the
     /// normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
-        let declared_value = self.members.get(member_name).copied()?;
+        if !self.members.contains_key(member_name) {
+            return None;
+        }
 
         if let Some(EnumValueAnnotation::UserDefined(annotation)) = self.value_annotation {
             return Some(annotation);
         }
-        if self.member_value_may_be_transformed(member_name) {
+        let Some(value) = self.concrete_value_type(db, member_name) else {
             return Some(Type::Dynamic(DynamicType::Any));
+        };
+
+        if let Some(EnumValueAnnotation::StandardLibrary(annotation)) = self.value_annotation
+            && !known_constructor_preserves_value_type(db, value, annotation)
+        {
+            Some(annotation)
+        } else {
+            Some(value)
+        }
+    }
+
+    /// Returns the normalized member payload when construction is known not to transform it.
+    ///
+    /// Unlike [`Self::value_type`], this does not substitute a `_value_` annotation for the
+    /// concrete payload.
+    pub(crate) fn concrete_value_type(
+        &self,
+        db: &'db dyn Db,
+        member_name: &Name,
+    ) -> Option<Type<'db>> {
+        let declared_value = self.members.get(member_name).copied()?;
+        if self.member_value_may_be_transformed(member_name) {
+            return None;
         }
         let value = if self.auto_members.contains(member_name)
             && self
@@ -535,17 +560,7 @@ impl<'db> EnumMetadata<'db> {
         } else {
             declared_value
         };
-        let Some(value) = self.value_construction.normalize_value(db, value) else {
-            return Some(Type::Dynamic(DynamicType::Any));
-        };
-
-        if let Some(EnumValueAnnotation::StandardLibrary(annotation)) = self.value_annotation
-            && !known_constructor_preserves_value_type(db, value, annotation)
-        {
-            Some(annotation)
-        } else {
-            Some(value)
-        }
+        self.value_construction.normalize_value(db, value)
     }
 
     /// Return whether enum construction may replace the value declared for `member_name`.

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -11,10 +11,9 @@ use crate::{
     },
     reachability::DeclarationsIteratorExtension,
     types::{
-        ClassBase, ClassLiteral, ClassType, DataclassFlags, DynamicType, EnumLiteralType,
-        IntersectionType, KnownClass, LiteralValueTypeKind, MemberLookupPolicy,
-        NegativeIntersectionElements, StaticClassLiteral, Type, UnionType, binding_type,
-        class::CodeGeneratorKind,
+        ClassBase, ClassLiteral, DynamicType, EnumLiteralType, IntersectionType, KnownClass,
+        LiteralValueTypeKind, MemberLookupPolicy, NegativeIntersectionElements, StaticClassLiteral,
+        Type, UnionType, binding_type,
         function::FunctionType,
         set_theoretic::{
             RecursivelyDefined,
@@ -48,34 +47,15 @@ pub(super) enum ResolvedEnumMethod<'db> {
 ///     ZERO = 0  # Alias of `FALSE` after `int(False)` produces `0`.
 /// ```
 ///
-/// User-defined subclasses can use this normalization when their construction, equality, and
-/// hashing semantics are known to match the built-in scalar class later in their MRO.
+/// User-defined data types are excluded because their construction, attribute access, equality, and
+/// hashing semantics can differ from the built-in scalar later in their MRO.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
 enum KnownEnumDataTypeMixin {
     Int,
     Str,
 }
 
-/// How enum aliases can be detected from statically inferred member values.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::Update)]
-enum EnumAliasDetection {
-    /// Compare the declared values without applying data-type normalization.
-    #[default]
-    DeclaredValue,
-    /// Apply the known data type's normalization before comparing values.
-    KnownDataType(KnownEnumDataTypeMixin),
-    /// Construction, equality, or hashing prevents reliable alias detection.
-    Opaque,
-}
-
 impl KnownEnumDataTypeMixin {
-    const fn known_class(self) -> KnownClass {
-        match self {
-            Self::Int => KnownClass::Int,
-            Self::Str => KnownClass::Str,
-        }
-    }
-
     /// Returns the scalar payload type after applying the built-in mixin's constructor.
     ///
     /// Literal conversions are preserved precisely, unions are normalized element-wise, and values
@@ -135,8 +115,7 @@ pub(super) struct EnumValueConstruction<'db> {
     pub(super) new: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
     known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
-    user_defined_data_type_instance: Option<Type<'db>>,
-    alias_detection: EnumAliasDetection,
+    data_type_is_opaque: bool,
     pub(super) metaclass_may_transform_values: bool,
 }
 
@@ -149,7 +128,7 @@ impl<'db> EnumValueConstruction<'db> {
     pub(crate) const fn can_validate_with_value_annotation(self) -> bool {
         matches!(self.init, ResolvedEnumMethod::Absent)
             && matches!(self.new, ResolvedEnumMethod::Absent)
-            && self.user_defined_data_type_instance.is_none()
+            && !self.data_type_is_opaque
             && !self.metaclass_may_transform_values
     }
 
@@ -162,6 +141,7 @@ impl<'db> EnumValueConstruction<'db> {
     const fn member_value_may_be_transformed(self, is_auto: bool) -> bool {
         self.init.is_user_defined()
             || self.new.is_user_defined()
+            || self.data_type_is_opaque
             || self.metaclass_may_transform_values
             || (is_auto && self.generate_next_value.is_opaque())
     }
@@ -172,7 +152,10 @@ impl<'db> EnumValueConstruction<'db> {
     /// `_generate_next_value_` is excluded because `value_type` incorporates its return type for
     /// each `auto()` member before the values are combined.
     const fn instance_value_may_be_transformed(self) -> bool {
-        self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
+        self.init.is_present()
+            || self.new.is_present()
+            || self.data_type_is_opaque
+            || self.metaclass_may_transform_values
     }
 
     /// Applies the payload normalization performed by a known built-in data-type mixin.
@@ -195,7 +178,10 @@ impl<'db> EnumValueConstruction<'db> {
         value_ty: Type<'db>,
         is_auto: bool,
     ) -> Option<Type<'db>> {
-        if self.new.is_user_defined() || self.metaclass_may_transform_values {
+        if self.new.is_user_defined()
+            || self.data_type_is_opaque
+            || self.metaclass_may_transform_values
+        {
             return None;
         }
 
@@ -208,13 +194,7 @@ impl<'db> EnumValueConstruction<'db> {
         } else {
             value_ty
         };
-        match self.alias_detection {
-            EnumAliasDetection::DeclaredValue => Some(value),
-            EnumAliasDetection::KnownDataType(data_type) => {
-                Some(data_type.normalize_value(db, value))
-            }
-            EnumAliasDetection::Opaque => None,
-        }
+        Some(self.normalize_value(db, value))
     }
 }
 
@@ -491,10 +471,10 @@ impl<'db> EnumMetadata<'db> {
     /// Returns the type of `.value`/`._value_` for a given enum member.
     ///
     /// A user-defined `_value_` annotation takes priority. Otherwise, values transformed by
-    /// construction methods or metaclasses become `Any`. A user-defined data type produces an
-    /// instance of that type, while known built-in data types normalize the value directly. A
-    /// literal is preserved when its runtime class matches an inherited `_value_` annotation;
-    /// otherwise, the annotation describes the normalized value.
+    /// user-defined data types, construction methods, or metaclasses become `Any`. Known built-in
+    /// data types normalize the value directly. A literal is preserved when its runtime class
+    /// matches an inherited `_value_` annotation; otherwise, the annotation describes the
+    /// normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
         let declared_value = self.members.get(member_name).copied()?;
 
@@ -504,10 +484,6 @@ impl<'db> EnumMetadata<'db> {
         if self.member_value_may_be_transformed(member_name) {
             return Some(Type::Dynamic(DynamicType::Any));
         }
-        if let Some(data_type_instance) = self.value_construction.user_defined_data_type_instance {
-            return Some(data_type_instance);
-        }
-
         let value = if self.auto_members.contains(member_name)
             && self
                 .value_construction
@@ -542,8 +518,8 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// If there is an explicit `_value_` annotation, returns that.
-    /// If there is a custom `__init__` or `__new__`, or a custom enum metaclass that may transform
-    /// member values, returns `Any`.
+    /// If there is a user-defined data type, a custom `__init__` or `__new__`, or a custom enum
+    /// metaclass that may transform member values, returns `Any`.
     /// Otherwise, returns the union of each member's `value_type`, which
     /// applies `_generate_next_value_`'s return type to `auto()` members.
     pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
@@ -959,27 +935,8 @@ pub(crate) fn enum_metadata<'db>(
     // Look up custom construction methods, falling back to parent enum classes. An opaque binding
     // still shadows methods from classes later in the MRO.
     let inherited_data_type_mixin = inherited_data_type_mixin(db, class);
-    let known_data_type = inherited_known_enum_data_type(db, class);
-    let (known_data_type_mixin, user_defined_data_type_instance, alias_detection) =
-        match known_data_type {
-            InheritedKnownEnumDataType::None => (None, None, EnumAliasDetection::DeclaredValue),
-            InheritedKnownEnumDataType::DataType { class, scalar } => {
-                let data_type_instance = class
-                    .class_literal(db)
-                    .known(db)
-                    .is_none()
-                    .then(|| Type::instance(db, class));
-                let alias_detection = if data_type_has_known_alias_semantics(db, class, scalar) {
-                    EnumAliasDetection::KnownDataType(scalar)
-                } else {
-                    EnumAliasDetection::Opaque
-                };
-                (Some(scalar), data_type_instance, alias_detection)
-            }
-            InheritedKnownEnumDataType::Opaque => (None, None, EnumAliasDetection::Opaque),
-        };
-    let user_defined_init =
-        custom_enum_method(db, scope_id, "__init__").or(inherited_data_type_mixin.init);
+    let user_defined_init = custom_enum_method(db, scope_id, "__init__")
+        .or_else(|| inherited_user_defined_enum_method(db, class, "__init__"));
     let init = resolve_enum_method(user_defined_init, || {
         inherited_known_enum_method(db, class, "__init__")
     });
@@ -1002,9 +959,8 @@ pub(crate) fn enum_metadata<'db>(
         init,
         new,
         generate_next_value,
-        known_data_type_mixin,
-        user_defined_data_type_instance,
-        alias_detection,
+        known_data_type_mixin: inherited_data_type_mixin.known,
+        data_type_is_opaque: inherited_data_type_mixin.opaque,
         metaclass_may_transform_values,
     };
 
@@ -1291,135 +1247,18 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
-/// A selected enum data type that inherits scalar normalization ty can model.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum InheritedKnownEnumDataType<'db> {
-    None,
-    DataType {
-        class: ClassType<'db>,
-        scalar: KnownEnumDataTypeMixin,
-    },
-    Opaque,
-}
-
-/// Find the user-defined data type, if any, that precedes a known scalar in a direct base's MRO.
-///
-/// Each direct base is searched independently to avoid treating a separate behavior mixin as the
-/// data type for `class Example(BehaviorMixin, int, Enum)`. Enum classes in the chain are skipped,
-/// which also supports inheriting the data type through a memberless parent enum.
-fn inherited_known_enum_data_type<'db>(
-    db: &'db dyn Db,
-    class: StaticClassLiteral<'db>,
-) -> InheritedKnownEnumDataType<'db> {
-    let mut selected = InheritedKnownEnumDataType::None;
-
-    for explicit_base in class.explicit_bases(db) {
-        let Some(explicit_base) = explicit_base.to_class_type(db) else {
-            return InheritedKnownEnumDataType::Opaque;
-        };
-        let mut candidate = None;
-        let mut data_type = None;
-
-        for base in explicit_base.iter_mro(db) {
-            let ClassBase::Class(base) = base else {
-                return InheritedKnownEnumDataType::Opaque;
-            };
-            let Some(base_literal) = base.class_literal(db).as_static() else {
-                return InheritedKnownEnumDataType::Opaque;
-            };
-
-            if base_literal.known(db) == Some(KnownClass::Object)
-                || is_enum_class_by_inheritance(db, base_literal)
-            {
-                continue;
-            }
-
-            let scalar = match base_literal.known(db) {
-                Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
-                Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
-                _ => None,
-            };
-            if let Some(scalar) = scalar {
-                data_type = Some(InheritedKnownEnumDataType::DataType {
-                    class: candidate.unwrap_or(base),
-                    scalar,
-                });
-                break;
-            }
-            candidate.get_or_insert(base);
-        }
-
-        let Some(data_type) = data_type else {
-            continue;
-        };
-        selected = match selected {
-            InheritedKnownEnumDataType::None => data_type,
-            selected if selected == data_type => selected,
-            InheritedKnownEnumDataType::DataType { .. } | InheritedKnownEnumDataType::Opaque => {
-                InheritedKnownEnumDataType::Opaque
-            }
-        };
-    }
-
-    selected
-}
-
-/// Return whether the selected data type provably retains the scalar's alias semantics.
-///
-/// Enum alias registration depends on both equality and hashing. Comparing the effective methods
-/// handles explicit and inherited overrides; dataclass-like generated equality needs a separate
-/// check because it is synthesized by the class transform rather than declared in the class body.
-fn data_type_has_known_alias_semantics<'db>(
-    db: &'db dyn Db,
-    data_type: ClassType<'db>,
-    known_data_type: KnownEnumDataTypeMixin,
-) -> bool {
-    let has_generated_equality = data_type.iter_mro(db).any(|base| {
-        let Some(base) = base
-            .into_class()
-            .and_then(|base| base.class_literal(db).as_static())
-        else {
-            return false;
-        };
-        let Some(policy @ CodeGeneratorKind::DataclassLike(_)) =
-            CodeGeneratorKind::from_class(db, base.into())
-        else {
-            return false;
-        };
-        base.has_dataclass_param(db, policy, DataclassFlags::EQ)
-    });
-    if has_generated_equality {
-        return false;
-    }
-
-    let data_type = Type::instance(db, data_type).to_meta_type(db);
-    let known_data_type = known_data_type.known_class().to_class_literal(db);
-
-    ["__eq__", "__hash__"].into_iter().all(|name| {
-        let lookup = |class: Type<'db>| {
-            class.member_lookup_with_policy(
-                db,
-                Name::new_static(name),
-                MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
-            )
-        };
-        lookup(data_type) == lookup(known_data_type)
-    })
-}
-
 #[derive(Clone, Copy)]
 enum EnumMethodBinding<'db> {
     Function(FunctionType<'db>),
     Opaque,
 }
 
-/// Constructor behavior collected from data-type mixins in MRO order.
-///
-/// `init` and `new` record the first user-defined constructor methods.
+/// Constructor and normalization behavior inherited from data-type mixins.
 #[derive(Clone, Copy, Default)]
 struct InheritedDataTypeMixin<'db> {
-    init: Option<EnumMethodBinding<'db>>,
     new: Option<EnumMethodBinding<'db>>,
+    known: Option<KnownEnumDataTypeMixin>,
+    opaque: bool,
 }
 
 /// Returns the enum method defined in `scope`, including opaque bindings.
@@ -1471,30 +1310,47 @@ fn inherited_user_defined_enum_new<'db>(
         })
 }
 
-/// Looks up constructor behavior inherited from data-type mixins across the full MRO.
+/// Looks up data-type behavior across the full MRO, including through an enum base.
 ///
-/// The scan continues through enum bases because a memberless parent enum can itself inherit the
-/// data-type mixin. When no enum class provides a member constructor, `EnumType` uses this method to
-/// construct the scalar payload stored by the enum member.
+/// A user-defined non-enum class before `int` or `str` makes the data type opaque.
 fn inherited_data_type_mixin<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> InheritedDataTypeMixin<'db> {
     let mut result = InheritedDataTypeMixin::default();
 
-    for base in class
-        .iter_mro(db, None)
-        .skip(1)
-        .filter_map(ClassBase::into_class)
-        .filter_map(|class| class.class_literal(db).as_static())
-        .filter(|base| base.known(db).is_none())
-    {
-        let scope = base.body_scope(db);
-        if result.init.is_none() {
-            result.init = custom_enum_method(db, scope, "__init__");
+    for base in class.iter_mro(db, None).skip(1) {
+        let Some(base) = base
+            .into_class()
+            .and_then(|class| class.class_literal(db).as_static())
+        else {
+            if result.known.is_none() {
+                result.opaque = true;
+            }
+            continue;
+        };
+
+        if base.known(db) == Some(KnownClass::Object) || is_enum_class_by_inheritance(db, base) {
+            continue;
         }
-        if result.new.is_none() {
-            result.new = custom_enum_method(db, scope, "__new__");
+
+        match base.known(db) {
+            Some(KnownClass::Int) if result.known.is_none() && !result.opaque => {
+                result.known = Some(KnownEnumDataTypeMixin::Int);
+            }
+            Some(KnownClass::Str) if result.known.is_none() && !result.opaque => {
+                result.known = Some(KnownEnumDataTypeMixin::Str);
+            }
+            None => {
+                if result.new.is_none() {
+                    result.new = custom_enum_method(db, base.body_scope(db), "__new__");
+                }
+                if result.known.is_none() {
+                    result.opaque = true;
+                }
+            }
+            Some(_) if result.known.is_none() => result.opaque = true,
+            Some(_) => {}
         }
     }
 

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -37,6 +37,32 @@ pub(super) enum ResolvedEnumMethod<'db> {
     Opaque,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update)]
+enum KnownEnumDataTypeMixin {
+    Int,
+    Str,
+}
+
+impl KnownEnumDataTypeMixin {
+    fn normalize_value<'db>(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
+        match (self, value.as_literal_value_kind()) {
+            (Self::Int, Some(LiteralValueTypeKind::Int(_)))
+            | (Self::Str, Some(LiteralValueTypeKind::String(_))) => value,
+            (Self::Int, Some(LiteralValueTypeKind::Bool(value))) => {
+                Type::int_literal(i64::from(value))
+            }
+            (Self::Str, Some(LiteralValueTypeKind::Int(value))) => {
+                Type::string_literal(db, &value.to_string())
+            }
+            (Self::Str, Some(LiteralValueTypeKind::Bool(value))) => {
+                Type::string_literal(db, if value { "True" } else { "False" })
+            }
+            (Self::Int, _) => KnownClass::Int.to_instance(db),
+            (Self::Str, _) => KnownClass::Str.to_instance(db),
+        }
+    }
+}
+
 impl<'db> ResolvedEnumMethod<'db> {
     pub(super) const fn function(self) -> Option<FunctionType<'db>> {
         match self {
@@ -68,6 +94,7 @@ pub(super) struct EnumValueConstruction<'db> {
     pub(super) init: ResolvedEnumMethod<'db>,
     pub(super) new: ResolvedEnumMethod<'db>,
     generate_next_value: ResolvedEnumMethod<'db>,
+    known_data_type_mixin: Option<KnownEnumDataTypeMixin>,
     pub(super) metaclass_may_transform_values: bool,
 }
 
@@ -85,9 +112,10 @@ impl<'db> EnumValueConstruction<'db> {
 
     /// Returns whether the declared value cannot be used as the precise type of `.value`.
     ///
-    /// Standard-library constructors are trusted because their value normalization is reflected in
-    /// the inherited `_value_` annotation. A resolvable `_generate_next_value_` is excluded because
-    /// its return type can be used for an `auto()` member instead.
+    /// Standard-library constructors are trusted because their value normalization is either
+    /// modeled directly or reflected in the inherited `_value_` annotation. A resolvable
+    /// `_generate_next_value_` is excluded because its return type can be used for an `auto()`
+    /// member instead.
     const fn member_value_may_be_transformed(self, is_auto: bool) -> bool {
         self.init.is_user_defined()
             || self.new.is_user_defined()
@@ -102,6 +130,12 @@ impl<'db> EnumValueConstruction<'db> {
     /// each `auto()` member before the values are combined.
     const fn instance_value_may_be_transformed(self) -> bool {
         self.init.is_present() || self.new.is_present() || self.metaclass_may_transform_values
+    }
+
+    /// Applies the payload normalization performed by a known built-in data-type mixin.
+    fn normalize_value(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
+        self.known_data_type_mixin
+            .map_or(value, |mixin| mixin.normalize_value(db, value))
     }
 
     /// Returns the value to use when checking whether an enum member is an alias.
@@ -119,16 +153,19 @@ impl<'db> EnumValueConstruction<'db> {
         is_auto: bool,
     ) -> Option<Type<'db>> {
         if self.new.is_user_defined() || self.metaclass_may_transform_values {
-            None
-        } else if !is_auto {
-            Some(value_ty)
-        } else if self.generate_next_value.is_opaque() {
-            None
-        } else if let Some(function) = self.generate_next_value.function() {
-            Some(function.signature(db).overload_return_type_or_unknown(db))
-        } else {
-            Some(value_ty)
+            return None;
         }
+
+        let value = if !is_auto {
+            value_ty
+        } else if self.generate_next_value.is_opaque() {
+            return None;
+        } else if let Some(function) = self.generate_next_value.function() {
+            function.signature(db).overload_return_type_or_unknown(db)
+        } else {
+            value_ty
+        };
+        Some(self.normalize_value(db, value))
     }
 }
 
@@ -406,8 +443,9 @@ impl<'db> EnumMetadata<'db> {
     ///
     /// A user-defined `_value_` annotation takes priority. Otherwise, values transformed by
     /// user-defined construction methods or metaclasses become `Any`. For standard-library
-    /// constructors, a literal is preserved when its runtime class matches the inherited `_value_`
-    /// annotation; otherwise, the annotation describes the normalized value.
+    /// constructors, known data-type mixins normalize the value directly. A literal is preserved
+    /// when its runtime class matches an inherited `_value_` annotation; otherwise, the annotation
+    /// describes the normalized value.
     pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
         let declared_value = self.members.get(member_name).copied()?;
 
@@ -429,6 +467,7 @@ impl<'db> EnumMetadata<'db> {
         } else {
             declared_value
         };
+        let value = self.value_construction.normalize_value(db, value);
 
         if let Some(EnumValueAnnotation::StandardLibrary(annotation)) = self.value_annotation
             && !known_constructor_preserves_value_type(db, value, annotation)
@@ -891,6 +930,7 @@ pub(crate) fn enum_metadata<'db>(
         init,
         new,
         generate_next_value,
+        known_data_type_mixin: inherited_known_data_type_mixin(db, class),
         metaclass_may_transform_values,
     };
 
@@ -1248,6 +1288,24 @@ fn inherited_user_defined_mixin_new<'db>(
         .filter_map(|class| class.class_literal(db).as_static())
         .filter(|base| base.known(db).is_none())
         .find_map(|base| custom_enum_method(db, base.body_scope(db), "__new__"))
+}
+
+/// Looks up a built-in data-type mixin before the first parent enum.
+fn inherited_known_data_type_mixin<'db>(
+    db: &'db dyn Db,
+    class: StaticClassLiteral<'db>,
+) -> Option<KnownEnumDataTypeMixin> {
+    class
+        .iter_mro(db, None)
+        .skip(1)
+        .filter_map(ClassBase::into_class)
+        .filter_map(|class| class.class_literal(db).as_static())
+        .take_while(|base| !is_enum_class_by_inheritance(db, *base))
+        .find_map(|base| match base.known(db) {
+            Some(KnownClass::Int) => Some(KnownEnumDataTypeMixin::Int),
+            Some(KnownClass::Str) => Some(KnownEnumDataTypeMixin::Str),
+            _ => None,
+        })
 }
 
 /// Looks up a resolvable method inherited from a known enum class.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1532,10 +1532,7 @@ fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Op
     let enum_class_literal = literal.enum_class_literal(db);
     let metadata = enum_metadata(db, enum_class_literal.class_literal(db))?;
     let name = enum_class_literal.resolve_member(db, literal.name(db))?;
-    if metadata.member_value_may_be_transformed(name) {
-        return None;
-    }
-    metadata.value_type(db, name)
+    metadata.concrete_value_type(db, name)
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1535,11 +1535,7 @@ fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Op
     if metadata.member_value_may_be_transformed(name) {
         return None;
     }
-    if metadata.auto_members.contains(name) {
-        metadata.value_type(db, name)
-    } else {
-        metadata.members.get(name).copied()
-    }
+    metadata.value_type(db, name)
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -1485,6 +1485,10 @@ fn known_literal_equality<'db>(
             if same_enum_member(db, left, right) {
                 return Some(true);
             }
+            let enum_class = left.enum_class_literal(db);
+            if enum_class == right.enum_class_literal(db) && !enum_class.aliases_are_known(db) {
+                return None;
+            }
             if left_semantics == KnownComparisonSemantics::Object {
                 return Some(false);
             }

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -848,6 +848,9 @@ fn same_enum_comparison_profile<'db>(
     let profile = enum_class_key_profile(db, enum_class, operator);
     let (comparison_keys, members_compare_by_identity) = match profile.semantics {
         None => (None, false),
+        Some(KnownComparisonSemantics::Object) if !enum_class.aliases_are_known(db) => {
+            (Some(SameEnumComparisonKeys::UnknownOrRepeated), true)
+        }
         Some(KnownComparisonSemantics::Object) => (Some(SameEnumComparisonKeys::Distinct), true),
         Some(
             KnownComparisonSemantics::Int

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2685,6 +2685,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (Type::LiteralValue(left), Type::LiteralValue(right))
+                if let (Some(left), Some(right)) = (left.as_enum(), right.as_enum())
+                    && left.enum_class_literal(db) == right.enum_class_literal(db)
+                    && !left.enum_class_literal(db).aliases_are_known(db) =>
+            {
+                self.never()
+            }
+
+            (Type::LiteralValue(left), Type::LiteralValue(right))
                 if left.is_literal_string() && right.is_literal_string()
                     || (left.is_string() && right.is_literal_string())
                     || (left.is_literal_string() && right.is_string()) =>

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2685,14 +2685,6 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (Type::LiteralValue(left), Type::LiteralValue(right))
-                if let (Some(left), Some(right)) = (left.as_enum(), right.as_enum())
-                    && left.enum_class_literal(db) == right.enum_class_literal(db)
-                    && !left.enum_class_literal(db).aliases_are_known(db) =>
-            {
-                self.never()
-            }
-
-            (Type::LiteralValue(left), Type::LiteralValue(right))
                 if left.is_literal_string() && right.is_literal_string()
                     || (left.is_string() && right.is_literal_string())
                     || (left.is_literal_string() && right.is_string()) =>
@@ -2701,7 +2693,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (Type::LiteralValue(left), Type::LiteralValue(right)) => {
-                ConstraintSet::from_bool(self.constraints, left.kind() != right.kind())
+                if let (Some(left), Some(right)) = (left.as_enum(), right.as_enum())
+                    && left.enum_class_literal(db) == right.enum_class_literal(db)
+                    && !left.enum_class_literal(db).aliases_are_known(db)
+                {
+                    self.never()
+                } else {
+                    ConstraintSet::from_bool(self.constraints, left.kind() != right.kind())
+                }
             }
 
             (Type::PropertyInstance(left), Type::PropertyInstance(right)) => {


### PR DESCRIPTION
## Summary

For enums that inherit from `int` or `str`, Python converts each assigned value before storing it.

For example:

```python
class Number(int, Enum):
    FALSE = False
    ZERO = 0
```

Python converts `False` to `0`. Therefore:

- `Number.FALSE.value` is `0`, not `False`.
- `Number.ZERO` is another name for `Number.FALSE`, not a separate member.

Previously, we reasoned from the values as written (`False` and `0`) and could incorrectly treat them as different members. We now account for the conversion performed by `int` or `str`. And when we can't reliably predict it, we return a less precise type.
