### PR TITLE
[ty] Compact semantic node lookup tables

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -140,6 +140,12 @@ pub(crate) mod node_key {
     )]
     pub struct ExpressionNodeKey(NodeKey);
 
+    impl ExpressionNodeKey {
+        pub(crate) fn index(self) -> ast::NodeIndex {
+            self.0.index()
+        }
+    }
+
     impl From<ast::ExprRef<'_>> for ExpressionNodeKey {
         fn from(value: ast::ExprRef<'_>) -> Self {
             Self(NodeKey::from_node(value))

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -38,6 +38,7 @@ use crate::definition::{
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
+use crate::node_key::NodeIndexMap;
 use crate::place::{
     PlaceExpr, PlaceTableBuilder, PossiblyNarrowedPlacesBuilder, ScopedPlaceId,
     match_subject_place_expressions,
@@ -2637,9 +2638,17 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             place_tables: place_tables.into(),
             scopes: self.scopes.into(),
             definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
-            expressions_by_node: self.expressions_by_node,
+            expressions_by_node: NodeIndexMap::from_entries(
+                self.expressions_by_node
+                    .into_iter()
+                    .map(|(key, expression)| (key.index(), expression)),
+            ),
             unpacks_by_target: FrozenMap::from(self.unpacks_by_target),
-            statements_by_node: self.statements_by_node,
+            statements_by_node: NodeIndexMap::from_entries(
+                self.statements_by_node
+                    .into_iter()
+                    .map(|(key, statement)| (key.index(), statement)),
+            ),
             scope_ids_by_scope: self.scope_ids_by_scope.into(),
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -1604,6 +1604,10 @@ pub struct NestedBindingsDefinitionKind {
 pub struct DefinitionNodeKey(NodeKey);
 
 impl DefinitionNodeKey {
+    pub(crate) fn index(self) -> ast::NodeIndex {
+        self.0.index()
+    }
+
     pub(crate) fn from_node_ref(node: ast::AnyNodeRef<'_>) -> Self {
         match node {
             ast::AnyNodeRef::ParameterWithDefault(parameter) => parameter.into(),

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -27,6 +27,7 @@ use builder::SemanticIndexBuilder;
 use definition::{Definition, DefinitionNodeKey, Definitions};
 use expression::Expression;
 use narrowing_constraints::ScopedNarrowingConstraint;
+use node_key::NodeIndexMap;
 pub use place::{PlaceExprRef, PlaceTable};
 pub use reachability_constraints::ReachabilityConstraintsBuilder;
 pub use scope::FileScopeId;
@@ -237,7 +238,7 @@ pub enum EnclosingSnapshotResult<'map, 'db> {
 
 #[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
 struct DefinitionsByNode<'db> {
-    single: FrozenMap<DefinitionNodeKey, Definition<'db>>,
+    single: NodeIndexMap<Definition<'db>>,
     non_single: FrozenMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
 }
 
@@ -263,14 +264,18 @@ impl<'db> DefinitionsByNode<'db> {
         }
 
         Self {
-            single: FrozenMap::from_entries(single),
+            single: NodeIndexMap::from_entries(
+                single
+                    .into_iter()
+                    .map(|(key, definition)| (key.index(), definition)),
+            ),
             non_single: FrozenMap::from_entries(non_single),
         }
     }
 
     fn get(&self, key: DefinitionNodeKey) -> Option<&[Definition<'db>]> {
         self.single
-            .get(&key)
+            .get(key.index())
             .map(std::slice::from_ref)
             .or_else(|| self.non_single.get(&key).map(AsRef::as_ref))
     }
@@ -292,13 +297,13 @@ pub struct SemanticIndex<'db> {
     definitions_by_node: DefinitionsByNode<'db>,
 
     /// Map from a standalone expression to its [`Expression`] ingredient.
-    expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
+    expressions_by_node: NodeIndexMap<Expression<'db>>,
 
     /// Map from an unpacking target to its [`unpack::Unpack`] ingredient.
     unpacks_by_target: FrozenMap<ExpressionNodeKey, unpack::Unpack<'db>>,
 
     /// Map from a standalone statement to its [`Statement`] ingredient.
-    statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
+    statements_by_node: NodeIndexMap<Statement<'db>>,
 
     /// Map from nodes that create a scope to the scope they create.
     scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
@@ -634,9 +639,10 @@ impl<'db> SemanticIndex<'db> {
         &self,
         definition_key: impl Into<DefinitionNodeKey>,
     ) -> Option<Definition<'db>> {
+        let definition_key = definition_key.into();
         self.definitions_by_node
             .single
-            .get(&definition_key.into())
+            .get(definition_key.index())
             .copied()
     }
 
@@ -646,7 +652,7 @@ impl<'db> SemanticIndex<'db> {
     /// `SemanticIndexBuilder`.
     #[track_caller]
     pub fn expression(&self, expression_key: impl Into<ExpressionNodeKey>) -> Expression<'db> {
-        self.expressions_by_node[&expression_key.into()]
+        self.expressions_by_node[expression_key.into().index()]
     }
 
     pub fn try_expression(
@@ -654,7 +660,7 @@ impl<'db> SemanticIndex<'db> {
         expression_key: impl Into<ExpressionNodeKey>,
     ) -> Option<Expression<'db>> {
         self.expressions_by_node
-            .get(&expression_key.into())
+            .get(expression_key.into().index())
             .copied()
     }
 
@@ -665,14 +671,16 @@ impl<'db> SemanticIndex<'db> {
 
     pub fn is_standalone_expression(&self, expression_key: impl Into<ExpressionNodeKey>) -> bool {
         self.expressions_by_node
-            .contains_key(&expression_key.into())
+            .contains_key(expression_key.into().index())
     }
 
     pub fn try_statement(
         &self,
         statement_key: impl Into<StatementNodeKey>,
     ) -> Option<Statement<'db>> {
-        self.statements_by_node.get(&statement_key.into()).copied()
+        self.statements_by_node
+            .get(statement_key.into().index())
+            .copied()
     }
 
     /// Returns the id of the scope that `node` creates.

--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -1,6 +1,8 @@
-use ruff_python_ast::{HasNodeIndex, NodeIndex};
+use ruff_python_ast::{HasNodeIndex, NodeIndex, sub_ast_level};
 
 use crate::ast_node_ref::AstNodeRef;
+use crate::frozen::FrozenMap;
+use crate::rank::RankBitBox;
 
 /// Compact key for a node for use in a hash map.
 #[derive(
@@ -18,5 +20,105 @@ impl NodeKey {
 
     pub fn from_node_ref<T>(node_ref: &AstNodeRef<T>) -> Self {
         NodeKey(node_ref.index())
+    }
+
+    pub(crate) fn index(self) -> NodeIndex {
+        self.0
+    }
+}
+
+/// Compact immutable map keyed by AST node index.
+///
+/// Top-level node indices are dense, so storing every key repeats information already encoded by
+/// its position in the AST. A bitmap records which nodes have values, while prefix ranks map a set
+/// bit to its packed value. String annotations use a separate index space and remain in a sorted
+/// fallback map because their indices are intentionally sparse.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct NodeIndexMap<V> {
+    root_presence: RankBitBox,
+    root_values: Box<[V]>,
+    sub_ast: FrozenMap<u32, V>,
+}
+
+impl<V> NodeIndexMap<V> {
+    pub(crate) fn from_entries(entries: impl IntoIterator<Item = (NodeIndex, V)>) -> Self {
+        let mut root = Vec::new();
+        let mut sub_ast = Vec::new();
+
+        for (index, value) in entries {
+            let raw_index = index
+                .as_u32()
+                .expect("semantic index keys should have assigned node indices");
+            if sub_ast_level(raw_index) == 0 {
+                root.push((raw_index, value));
+            } else {
+                sub_ast.push((raw_index, value));
+            }
+        }
+
+        root.sort_unstable_by_key(|(index, _)| *index);
+        debug_assert!(
+            root.windows(2).all(|entries| entries[0].0 != entries[1].0),
+            "node index map keys must be unique",
+        );
+
+        let root_len = root.last().map_or(0, |(index, _)| *index as usize + 1);
+        let mut root_presence = RankBitBox::bits_with_capacity(root_len);
+        for (index, _) in &root {
+            root_presence.set(*index as usize, true);
+        }
+
+        Self {
+            root_presence: RankBitBox::from_bits(root_presence),
+            root_values: root.into_iter().map(|(_, value)| value).collect(),
+            sub_ast: FrozenMap::from_entries(sub_ast),
+        }
+    }
+
+    pub(crate) fn get(&self, index: NodeIndex) -> Option<&V> {
+        let raw_index = index.as_u32()?;
+        if sub_ast_level(raw_index) != 0 {
+            return self.sub_ast.get(&raw_index);
+        }
+
+        let index = raw_index as usize;
+        if !self.root_presence.get_bit(index)? {
+            return None;
+        }
+
+        self.root_values
+            .get(self.root_presence.rank(index) as usize)
+    }
+
+    pub(crate) fn contains_key(&self, index: NodeIndex) -> bool {
+        self.get(index).is_some()
+    }
+}
+
+impl<V> std::ops::Index<NodeIndex> for NodeIndexMap<V> {
+    type Output = V;
+
+    #[track_caller]
+    fn index(&self, index: NodeIndex) -> &Self::Output {
+        self.get(index).expect("key not found")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::NodeIndex;
+
+    use super::NodeIndexMap;
+
+    #[test]
+    fn node_index_map_supports_root_and_sub_ast_indices() {
+        let root = NodeIndex::from(2);
+        let missing_root = NodeIndex::from(3);
+        let sub_ast = NodeIndex::from(1 << 30);
+        let map = NodeIndexMap::from_entries([(root, "root"), (sub_ast, "sub-AST")]);
+
+        assert_eq!(map.get(root), Some(&"root"));
+        assert_eq!(map.get(missing_root), None);
+        assert_eq!(map.get(sub_ast), Some(&"sub-AST"));
     }
 }

--- a/crates/ty_python_core/src/statement.rs
+++ b/crates/ty_python_core/src/statement.rs
@@ -61,6 +61,12 @@ impl<'db> StatementInner<'db> {
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
 pub struct StatementNodeKey(NodeKey);
 
+impl StatementNodeKey {
+    pub(crate) fn index(self) -> ast::NodeIndex {
+        self.0.index()
+    }
+}
+
 impl From<&ast::Stmt> for StatementNodeKey {
     fn from(node: &ast::Stmt) -> Self {
         Self(NodeKey::from_node(node))


### PR DESCRIPTION
## Summary

The semantic index retains several immutable lookup tables keyed by AST node identity. Top-level node indices are dense, but the existing hash maps repeat each key alongside its value and retain hash-table capacity and metadata.

This introduces a compact `NodeIndexMap` for those tables. A `RankBitBox` records which top-level nodes have entries, and rank queries map each present node to a densely packed value. String annotations use a separate, sparse sub-AST index space, so those entries remain in a sorted fallback map.

We use the compact representation for the common single-definition case and standalone expressions and statements. Definitions with multiple entries retain the existing fallback map.
