### PR TITLE
[ty] Don't treat non-empty ranges as single-valued

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/loops/for.md
+++ b/crates/ty_python_semantic/resources/mdtest/loops/for.md
@@ -86,6 +86,27 @@ def non_empty_first(flag: bool) -> None:
         reveal_type(value)  # revealed: range
 ```
 
+Empty ranges all compare equal, but non-empty ranges with the same type refinement may contain
+different values:
+
+```py
+empty_left = range(0)
+empty_right = range(1, 1)
+
+if empty_left == empty_right:
+    reveal_type(empty_left)  # revealed: range
+else:
+    reveal_type(empty_left)  # revealed: Never
+
+non_empty_left = range(1)
+non_empty_right = range(2)
+
+if non_empty_left == non_empty_right:
+    reveal_type(non_empty_left)  # revealed: range
+else:
+    reveal_type(non_empty_left)  # revealed: range
+```
+
 ## With shadowed `range`
 
 ```py

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -2423,6 +2423,9 @@ impl<'db> Type<'db> {
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
         match self {
+            // All empty ranges compare equal, but non-empty ranges can contain different values.
+            Type::KnownInstance(KnownInstanceType::Range { is_non_empty }) => !is_non_empty,
+
             // Each `partial()` call creates a distinct object at runtime.
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
 


### PR DESCRIPTION
## Summary

This fixes an equality-narrowing regression exposed by #25220. `KnownInstanceType::Range` distinguishes statically empty and non-empty ranges, but `Type::is_single_valued` previously treated both refinements as single-valued. As a result, two different non-empty ranges such as `range(1)` and `range(2)` were considered equality-equivalent and the `else` branch below was incorrectly unreachable:

```python
left = range(1)
right = range(2)

if left == right:
    reveal_type(left)  # range
else:
    reveal_type(left)  # range
```

All empty ranges compare equal, so this keeps the empty-range refinement single-valued. Non-empty ranges can contain different values, so this treats that refinement as multiple-valued and preserves both equality branches. Regression coverage checks both behaviors. The focused mdtest, full ty semantic suite, workspace Clippy, and repository hooks pass.

Follow-up to https://github.com/astral-sh/ruff/pull/25220#issuecomment-4795159203.
