### PR TITLE
[ty] Reduce typevar constraint overhead

### DIFF
--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -86,7 +86,7 @@
 //!
 //! [duboc]: https://gldubc.github.io/#thesis
 
-use std::cell::{Ref, RefCell};
+use std::cell::{Cell, Ref, RefCell};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::marker::PhantomData;
@@ -286,6 +286,7 @@ impl<'db> OwnedConstraintSet<'db> {
         };
         let builder = ConstraintSetBuilder {
             storage: RefCell::new(storage),
+            recent_typevars: Cell::default(),
         };
         let set = ConstraintSet::from_node(&builder, self.node);
         f(&builder, set)
@@ -680,6 +681,9 @@ impl Debug for ConstraintSet<'_, '_> {
 #[derive(Default)]
 pub(crate) struct ConstraintSetBuilder<'db> {
     storage: RefCell<ConstraintSetStorage<'db>>,
+    /// Exact-instance lookups avoid repeatedly resolving and hashing the logical identity. The
+    /// identity-keyed cache in `storage` remains the source of truth for materialized variants.
+    recent_typevars: Cell<[Option<(BoundTypeVarInstance<'db>, TypeVarId)>; 2]>,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, get_size2::GetSize)]
@@ -938,16 +942,40 @@ impl<'db> ConstraintSetBuilder<'db> {
 
     /// Interns a single typevar, giving it a stable order in this builder
     fn intern_typevar(&self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
+        if let Some(id) = self.recent_typevar_id(typevar) {
+            return id;
+        }
+
         let identity = typevar.identity(db);
         let mut storage = self.storage.borrow_mut();
         storage.ensure_overlay_identity_caches();
         if let Some(id) = storage.typevar_cache.get(&identity) {
-            return *id;
+            let id = *id;
+            drop(storage);
+            self.remember_typevar(typevar, id);
+            return id;
         }
         let id = storage.typevars.push(identity);
         let id = storage.adjusted_typevar_id(id);
         storage.typevar_cache.insert(identity, id);
+        drop(storage);
+        self.remember_typevar(typevar, id);
         id
+    }
+
+    fn recent_typevar_id(&self, typevar: BoundTypeVarInstance<'db>) -> Option<TypeVarId> {
+        self.recent_typevars
+            .get()
+            .into_iter()
+            .flatten()
+            .find_map(|(recent, id)| (recent == typevar).then_some(id))
+    }
+
+    fn remember_typevar(&self, typevar: BoundTypeVarInstance<'db>, id: TypeVarId) {
+        let [most_recent, _] = self.recent_typevars.get();
+        if most_recent.is_none_or(|(recent, _)| recent != typevar) {
+            self.recent_typevars.set([Some((typevar, id)), most_recent]);
+        }
     }
 
     /// Interns all of the typevars mentioned in a type in a stable order.
@@ -1032,14 +1060,21 @@ impl<'db> ConstraintSetBuilder<'db> {
     }
 
     fn typevar_id(&self, db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> TypeVarId {
+        if let Some(id) = self.recent_typevar_id(typevar) {
+            return id;
+        }
+
         let identity = typevar.identity(db);
         let mut storage = self.storage.borrow_mut();
         storage.ensure_overlay_identity_caches();
-        storage
+        let id = storage
             .typevar_cache
             .get(&identity)
             .copied()
-            .expect("typevar should be interned before ordering")
+            .expect("typevar should be interned before ordering");
+        drop(storage);
+        self.remember_typevar(typevar, id);
+        id
     }
 
     fn constraint_data(&self, constraint: ConstraintId) -> Constraint<'db> {

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -5049,20 +5049,46 @@ impl SequentMap {
 
     /// Merges the sequents from another sequent map into this one.
     fn merge(&mut self, other: &Self) {
-        self.single_tautologies.extend(&other.single_tautologies);
-        self.pair_impossibilities
-            .extend(&other.pair_impossibilities);
-        for ((ante1, ante2), post) in &other.pair_implications {
-            self.pair_implications
-                .entry(Self::pair_key(*ante1, *ante2))
-                .or_default()
-                .extend(post);
+        if !other.single_tautologies.is_empty() {
+            if self.single_tautologies.is_empty() {
+                self.single_tautologies
+                    .clone_from(&other.single_tautologies);
+            } else {
+                self.single_tautologies.extend(&other.single_tautologies);
+            }
         }
-        for (ante, post) in &other.single_implications {
+
+        if !other.pair_impossibilities.is_empty() {
+            if self.pair_impossibilities.is_empty() {
+                self.pair_impossibilities
+                    .clone_from(&other.pair_impossibilities);
+            } else {
+                self.pair_impossibilities
+                    .extend(&other.pair_impossibilities);
+            }
+        }
+
+        if !other.pair_implications.is_empty() && self.pair_implications.is_empty() {
+            self.pair_implications.clone_from(&other.pair_implications);
+        } else if !other.pair_implications.is_empty() {
+            for ((ante1, ante2), post) in &other.pair_implications {
+                self.pair_implications
+                    .entry(Self::pair_key(*ante1, *ante2))
+                    .or_default()
+                    .extend(post);
+            }
+        }
+
+        if !other.single_implications.is_empty() && self.single_implications.is_empty() {
             self.single_implications
-                .entry(*ante)
-                .or_default()
-                .extend(post);
+                .clone_from(&other.single_implications);
+        } else if !other.single_implications.is_empty() {
+            for (ante, post) in &other.single_implications {
+                self.single_implications
+                    .entry(*ante)
+                    .or_default()
+                    .extend(post);
+            }
         }
     }
 

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1446,15 +1446,15 @@ struct DisplayBoundTypeVarIdentity<'db> {
 
 impl Display for DisplayBoundTypeVarIdentity<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(self.bound_typevar_identity.identity.name(self.db))?;
-        let binding_context = self.bound_typevar_identity.binding_context;
+        f.write_str(self.bound_typevar_identity.identity(self.db).name(self.db))?;
+        let binding_context = self.bound_typevar_identity.binding_context(self.db);
         if let Some(binding_context_name) = binding_context.name(self.db)
             && let Some(definition) = binding_context.definition()
             && !self.settings.active_scopes.contains(&definition)
         {
             write!(f, "@{binding_context_name}")?;
         }
-        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr {
+        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr(self.db) {
             write!(f, ".{paramspec_attr}")?;
         }
         Ok(())

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -795,11 +795,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
         fn new(db: &'db dyn Db, generic_context: GenericContext<'db>) -> Self {
             let base_identities = generic_context
                 .variables(db)
-                .map(|typevar| {
-                    let mut identity = typevar.identity(db);
-                    identity.freshness = TypeVarNonce::NONE;
-                    identity
-                })
+                .map(|typevar| typevar.identity(db).without_freshness(db))
                 .collect();
             Self {
                 base_identities,
@@ -819,8 +815,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
             db: &'db dyn Db,
             bound_typevar: BoundTypeVarInstance<'db>,
         ) {
-            let mut identity = bound_typevar.identity(db);
-            identity.freshness = TypeVarNonce::NONE;
+            let identity = bound_typevar.identity(db).without_freshness(db);
             if self.base_identities.contains(&identity) {
                 self.max_freshness.set(
                     self.max_freshness
@@ -844,21 +839,49 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
 
 /// A type variable that has been bound to a generic context, and which can be specialized to a
 /// concrete type.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(
+    debug,
+    constructor = new_internal,
+    heap_size = ruff_memory_usage::heap_size
+)]
 pub struct BoundTypeVarInstance<'db> {
     pub typevar: TypeVarInstance<'db>,
-    pub(super) binding_context: BindingContext<'db>,
-    /// If [`Some`], this indicates that this type variable is the `args` or `kwargs` component
-    /// of a `ParamSpec` i.e., `P.args` or `P.kwargs`.
-    pub(super) paramspec_attr: Option<ParamSpecAttrKind>,
-    /// The freshness nonce for this bound typevar occurrence; `0` is the source-level occurrence.
-    pub(super) freshness: TypeVarNonce,
+    identity_inner: BoundTypeVarIdentity<'db>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for BoundTypeVarInstance<'_> {}
 
 impl<'db> BoundTypeVarInstance<'db> {
+    pub(crate) fn new(
+        db: &'db dyn Db,
+        typevar: TypeVarInstance<'db>,
+        binding_context: BindingContext<'db>,
+        paramspec_attr: Option<ParamSpecAttrKind>,
+        freshness: TypeVarNonce,
+    ) -> Self {
+        let identity = BoundTypeVarIdentity::new(
+            db,
+            typevar.identity(db),
+            binding_context,
+            paramspec_attr,
+            freshness,
+        );
+        Self::new_internal(db, typevar, identity)
+    }
+
+    pub(super) fn binding_context(self, db: &'db dyn Db) -> BindingContext<'db> {
+        self.identity(db).binding_context(db)
+    }
+
+    pub(super) fn paramspec_attr(self, db: &'db dyn Db) -> Option<ParamSpecAttrKind> {
+        self.identity(db).paramspec_attr(db)
+    }
+
+    pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
+        self.identity(db).freshness(db)
+    }
+
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
         Self::new(
             db,
@@ -876,12 +899,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// occurrence, regardless of e.g. differences in their bounds or constraints due to
     /// materialization.
     pub(crate) fn identity(self, db: &'db dyn Db) -> BoundTypeVarIdentity<'db> {
-        BoundTypeVarIdentity {
-            identity: self.typevar(db).identity(db),
-            binding_context: self.binding_context(db),
-            paramspec_attr: self.paramspec_attr(db),
-            freshness: self.freshness(db),
-        }
+        self.identity_inner(db)
     }
 
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
@@ -967,7 +985,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns whether two bound typevars represent the same occurrence, regardless of e.g.
     /// differences in their bounds or constraints due to materialization.
     pub(crate) fn is_same_typevar_as(self, db: &'db dyn Db, other: Self) -> bool {
-        self.identity(db) == other.identity(db)
+        self == other || self.identity(db) == other.identity(db)
     }
 
     /// Create a new PEP 695 type variable that can be used in signatures
@@ -1412,7 +1430,10 @@ impl std::fmt::Display for ParamSpecAttrKind {
 /// bounds or constraints. Two bound typevars have the same identity if they represent the same
 /// occurrence, even if their bounds have been materialized differently. Two fresh occurrences of
 /// the same source-level typevar have different bound identities.
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
+///
+/// Interning keeps this frequently copied and hashed identity compact while allowing multiple
+/// materialized [`BoundTypeVarInstance`]s to share it.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct BoundTypeVarIdentity<'db> {
     pub(crate) identity: TypeVarIdentity<'db>,
     pub(crate) binding_context: BindingContext<'db>,
@@ -1423,24 +1444,50 @@ pub struct BoundTypeVarIdentity<'db> {
     pub(super) freshness: TypeVarNonce,
 }
 
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for BoundTypeVarIdentity<'_> {}
+
 impl<'db> BoundTypeVarIdentity<'db> {
     fn kind(self, db: &'db dyn Db) -> TypeVarKind {
-        self.identity.kind(db)
+        self.identity(db).kind(db)
     }
 
     pub(crate) fn is_paramspec(self, db: &'db dyn Db) -> bool {
         self.kind(db).is_paramspec()
     }
 
-    pub(crate) fn without_paramspec_attr(mut self, db: &'db dyn Db) -> Self {
+    pub(crate) fn without_paramspec_attr(self, db: &'db dyn Db) -> Self {
         debug_assert!(
             self.is_paramspec(db),
             "Expected a ParamSpec, got {:?}",
             self.kind(db)
         );
 
-        self.paramspec_attr = None;
-        self
+        if self.paramspec_attr(db).is_none() {
+            self
+        } else {
+            Self::new(
+                db,
+                self.identity(db),
+                self.binding_context(db),
+                None,
+                self.freshness(db),
+            )
+        }
+    }
+
+    fn without_freshness(self, db: &'db dyn Db) -> Self {
+        if self.freshness(db) == TypeVarNonce::NONE {
+            self
+        } else {
+            Self::new(
+                db,
+                self.identity(db),
+                self.binding_context(db),
+                self.paramspec_attr(db),
+                TypeVarNonce::NONE,
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

`BoundTypeVarIdentity` is used as a key throughout generic specialization and constraint solving. We previously reconstructed its four-field value whenever we needed the identity of a bound type variable, even when several materialized `BoundTypeVarInstance` values shared the same logical identity.

This interns bound type-variable identities separately and stores the compact identity handle on each bound type-variable instance. Exact-instance comparisons now bypass identity lookup, while materialized variants retain the existing logical-identity fallback.

Constraint solving also keeps a two-entry cache for recently resolved exact type-variable instances and directly clones the first cached sequent collections into an empty destination instead of inserting and rehashing every element. The identity-keyed cache remains the source of truth, and subsequent sequent merges retain the existing deduplication behavior.

Together, these changes improve the non-microbenchmark CodSpeed CPU simulation results:

| Benchmark | Base | Head | Change |
| --- | ---: | ---: | ---: |
| attrs | 643.85 ms | 623.15 ms | +3.3% |
| hydra-zen | 1.48 s | 1.44 s | +2.5% |
| DateType | 258.16 ms | 253.80 ms | +1.7% |
| anyio | 1.34 s | 1.33 s | +0.8% |

The exact final-source `attrs` result is in [this CodSpeed comparison](https://app.codspeed.io/astral-sh/ruff/runs/compare/6a3c71af689bf98c0d9261d7..6a3c840d4073bc24fb466b93), and the peer-project results are in the [full project-shard comparison](https://app.codspeed.io/astral-sh/ruff/runs/compare/6a3c71af689bf98c0d9261d7..6a3c807e4073bc24fb466b61).

The full `ty_python_semantic` test suite, including 467 mdtests and doctests, passes. Workspace Clippy with all targets and features and the repository hooks also pass, with no snapshot changes.
