### PR TITLE
[fastapi] Fix false positive for pre-assigned `Depends` variables (`FAST003`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
+++ b/crates/ruff_linter/resources/test/fixtures/fastapi/FAST003.py
@@ -369,3 +369,19 @@ async def read_thing_callable_dep_instance_default(query: str = Depends(Callable
 # Error: `__call__` has `other`, not `thing_id`.
 @app.get("/things/{thing_id}")
 async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
+
+
+# Assigned `Depends` variables — ruff resolves the RHS of the assignment to
+# determine which parameters the dependency covers.
+# https://github.com/astral-sh/ruff/issues/17226
+async def find_item_by_id(item_id: int): ...
+
+AssignedDepends = Depends(find_item_by_id)
+
+# OK: `AssignedDepends` resolves to `Depends(find_item_by_id)`, which accepts `item_id`.
+@app.get("/items/{item_id}")
+async def get_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+
+# Error: `AssignedDepends` covers `item_id`, not `other_id`.
+@app.get("/items/{other_id}")
+async def get_other_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...

--- a/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
+++ b/crates/ruff_linter/src/rules/fastapi/rules/fastapi_unused_path_parameter.rs
@@ -279,15 +279,52 @@ impl<'a> Dependency<'a> {
         };
 
         let mut dependencies = tuple.elts.iter().skip(1).filter_map(|metadata_element| {
-            let arguments = depends_arguments(metadata_element, semantic)?;
-
-            // Arguments to `Depends` can be empty if the dependency is a class
-            // that FastAPI will call to create an instance of the class itself.
-            // https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/#shortcut
-            if arguments.is_empty() {
-                Self::from_dependency_name(tuple.elts.first()?.as_name_expr()?, semantic)
+            if let Some(arguments) = depends_arguments(metadata_element, semantic) {
+                // Arguments to `Depends` can be empty if the dependency is a class
+                // that FastAPI will call to create an instance of the class itself.
+                // https://fastapi.tiangolo.com/tutorial/dependencies/classes-as-dependencies/#shortcut
+                if arguments.is_empty() {
+                    Self::from_dependency_name(tuple.elts.first()?.as_name_expr()?, semantic)
+                } else {
+                    Self::from_depends_call(arguments, semantic)
+                }
+            } else if let Expr::Name(name) = metadata_element {
+                // The metadata element is a bare name, e.g.:
+                //   `AssignedDepends = Depends(find_item)`
+                // Resolve the binding to decide how to handle it.
+                let binding = semantic.only_binding(name).map(|id| semantic.binding(id))?;
+                match &binding.kind {
+                    // A function or class defined in scope, or an import — not a `Depends`.
+                    BindingKind::FunctionDefinition(_)
+                    | BindingKind::ClassDefinition(_)
+                    | BindingKind::Import(_)
+                    | BindingKind::FromImport(_) => None,
+                    // A plain assignment — check if the RHS is a `Depends(...)` call and
+                    // treat it exactly like an inline `Depends` if so.
+                    BindingKind::Assignment => {
+                        let rhs = binding
+                            .statement(semantic)
+                            .and_then(|stmt| stmt.as_assign_stmt())
+                            .map(|assign| assign.value.as_ref())?;
+                        if let Some(arguments) = depends_arguments(rhs, semantic) {
+                            if arguments.is_empty() {
+                                Self::from_dependency_name(
+                                    tuple.elts.first()?.as_name_expr()?,
+                                    semantic,
+                                )
+                            } else {
+                                Self::from_depends_call(arguments, semantic)
+                            }
+                        } else {
+                            // RHS is not a `Depends` call — treat as unknown to avoid false positives.
+                            Some(Self::Unknown)
+                        }
+                    }
+                    // Anything else we can't reason about.
+                    _ => Some(Self::Unknown),
+                }
             } else {
-                Self::from_depends_call(arguments, semantic)
+                None
             }
         });
 

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__deferred_annotations_diff_fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__deferred_annotations_diff_fast-api-unused-path-parameter_FAST003.py.snap
@@ -7,7 +7,7 @@ source: crates/ruff_linter/src/rules/fastapi/mod.rs
 
 --- Summary ---
 Removed: 7
-Added: 0
+Added: 1
 
 --- Removed ---
 FAST003 [*] Parameter `thing_id` appears in route path, but not in `single` signature
@@ -134,5 +134,25 @@ help: Add `thing_id` to function signature
     - async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)]): ...
 362 + async def read_thing_empty_class_dep(query: Annotated[str, Depends(EmptyClass)], thing_id): ...
 363 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+
+
+--- Added ---
+FAST003 [*] Parameter `item_id` appears in route path, but not in `get_item_assigned_depends` signature
+   --> FAST003.py:382:18
+    |
+381 | # OK: `AssignedDepends` resolves to `Depends(find_item_by_id)`, which accepts `item_id`.
+382 | @app.get("/items/{item_id}")
+    |                  ^^^^^^^^^
+383 | async def get_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+    |
+help: Add `item_id` to function signature
+    |
+382 | @app.get("/items/{item_id}")
+    - async def get_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+383 + async def get_item_assigned_depends(item: Annotated[str, AssignedDepends], item_id): ...
+384 |
     |
 note: This is an unsafe fix and may change runtime behavior

--- a/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
+++ b/crates/ruff_linter/src/rules/fastapi/snapshots/ruff_linter__rules__fastapi__tests__fast-api-unused-path-parameter_FAST003.py.snap
@@ -486,5 +486,39 @@ help: Add `thing_id` to function signature
 370 | @app.get("/things/{thing_id}")
     - async def read_thing_init_and_call_instance_default(query: str = Depends(InitAndCallQuery())): ...
 371 + async def read_thing_init_and_call_instance_default(thing_id, query: str = Depends(InitAndCallQuery())): ...
+372 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FAST003 [*] Parameter `item_id` appears in route path, but not in `get_item_assigned_depends` signature
+   --> FAST003.py:382:18
+    |
+381 | # OK: `AssignedDepends` resolves to `Depends(find_item_by_id)`, which accepts `item_id`.
+382 | @app.get("/items/{item_id}")
+    |                  ^^^^^^^^^
+383 | async def get_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+    |
+help: Add `item_id` to function signature
+    |
+382 | @app.get("/items/{item_id}")
+    - async def get_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+383 + async def get_item_assigned_depends(item: Annotated[str, AssignedDepends], item_id): ...
+384 |
+    |
+note: This is an unsafe fix and may change runtime behavior
+
+FAST003 [*] Parameter `other_id` appears in route path, but not in `get_other_item_assigned_depends` signature
+   --> FAST003.py:386:18
+    |
+385 | # Error: `AssignedDepends` covers `item_id`, not `other_id`.
+386 | @app.get("/items/{other_id}")
+    |                  ^^^^^^^^^^
+387 | async def get_other_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+    |
+help: Add `other_id` to function signature
+    |
+386 | @app.get("/items/{other_id}")
+    - async def get_other_item_assigned_depends(item: Annotated[str, AssignedDepends]): ...
+387 + async def get_other_item_assigned_depends(item: Annotated[str, AssignedDepends], other_id): ...
     |
 note: This is an unsafe fix and may change runtime behavior


### PR DESCRIPTION
## Summary

Addresses https://github.com/astral-sh/ruff/issues/17226#issuecomment-3174557580.

When a `Depends(...)` call is pre-assigned to a variable and that variable is used as metadata in an `Annotated` annotation, `FAST003` incorrectly fires:

```python
async def find_item(item_id: int): ...

FindItem = Depends(find_item)

@app.get("/items/{item_id}")
async def get_item(item: Annotated[str, FindItem]): ...
#                                       ^^^^^^^^^
# FAST003: Parameter `item_id` appears in route path, but not in `get_item` signature
```

The rule scans `Annotated` metadata elements for literal `Depends(...)` calls. A pre-assigned `Depends` variable is a bare name — not a call expression — so `depends_arguments` returns `None`, the element is silently skipped by the `filter_map`, and the path parameter appears unused.

The fix treats a bare-name metadata element as `Dependency::Unknown` (unless it clearly resolves to a function, class, or import), which causes the check to abort conservatively rather than emitting a false positive.

## Test Plan

Snapshot tests (`cargo nextest run` and `cargo insta test`).