### PR TITLE
[ty] Remove unnecessary dependencies and features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,40 +917,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,13 +1317,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1567,12 +1531,6 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -3357,7 +3315,6 @@ dependencies = [
  "ruff_text_size",
  "serde",
  "serde_json",
- "serde_with",
  "test-case",
  "thiserror 2.0.18",
  "uuid",
@@ -3647,7 +3604,6 @@ version = "0.15.19"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "getrandom 0.4.2",
  "js-sys",
  "log",
  "ruff_db",
@@ -3665,7 +3621,6 @@ dependencies = [
  "ruff_workspace",
  "serde",
  "serde-wasm-bindgen",
- "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -3938,28 +3893,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f901ee573cab6b3060453d2d5f0bae4e6d628c23c0a962ff9b5f1d7c8d4f1ed"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
-dependencies = [
- "serde_core",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4920,7 +4853,6 @@ version = "0.0.0"
 dependencies = [
  "console_error_panic_hook",
  "console_log",
- "getrandom 0.4.2",
  "js-sys",
  "log",
  "ruff_db",
@@ -4935,7 +4867,6 @@ dependencies = [
  "ty_ide",
  "ty_project",
  "ty_python_core",
- "uuid",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -5086,9 +5017,7 @@ version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.1",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,13 +105,10 @@ get-size2 = { version = "0.10.0", features = [
     "ordermap",
     "thin-vec",
 ] }
-getrandom = { version = "0.4.1" }
 glob = { version = "0.3.1" }
 globset = { version = "0.4.14" }
 globwalk = { version = "0.9.1" }
 hashbrown = { version = "0.17.0", default-features = false, features = [
-    "raw-entry",
-    "equivalent",
     "inline-more",
 ] }
 heck = "0.5.0"
@@ -151,7 +148,7 @@ quick-junit = { version = "0.6.0" }
 quickcheck = { version = "1.0.3", default-features = false }
 quickcheck_macros = { version = "1.0.0" }
 quote = { version = "1.0.23" }
-rand = { version = "0.10.0" }
+rand = { version = "0.10.0", default-features = false, features = ["std_rng"] }
 rayon = { version = "1.10.0" }
 regex = { version = "1.10.2" }
 regex-automata = { version = "0.4.9" }
@@ -172,9 +169,6 @@ serde = { version = "1.0.197", features = ["derive"] }
 serde-wasm-bindgen = { version = "0.6.4" }
 serde_json = { version = "1.0.113" }
 serde_test = { version = "1.0.152" }
-serde_with = { version = "3.6.0", default-features = false, features = [
-    "macros",
-] }
 shellexpand = { version = "3.0.0" }
 similar = { version = "3.0.0", features = ["inline"] }
 smallvec = { version = "1.13.2", features = ["union", "const_generics", "const_new"] }
@@ -212,17 +206,16 @@ unicode-normalization = { version = "0.1.23" }
 unicode-width = { version = "0.2.0" }
 unicode_names2 = { version = "1.2.2" }
 url = { version = "2.5.0" }
-uuid = { version = "1.6.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
+uuid = { version = "1.6.1" }
 walkdir = { version = "2.3.2" }
 wasm-bindgen = { version = "0.2.92" }
 wasm-bindgen-test = { version = "0.3.42" }
 which = { version = "8.0.0" }
 wild = { version = "2" }
-zip = { version = "8.0", default-features = false, features = ["deflate-flate2-zlib-rs"] }
+zip = { version = "8.0", default-features = false }
 
 [workspace.metadata.cargo-shear]
 ignored = [
-    "getrandom",
     "ruff_mdtest",
     "ty_completion_bench",
     "ty_completion_eval",

--- a/crates/ruff/Cargo.toml
+++ b/crates/ruff/Cargo.toml
@@ -89,7 +89,6 @@ indoc = { workspace = true }
 insta = { workspace = true, features = ["filters", "json"] }
 insta-cmd = { workspace = true }
 ruff_python_trivia = { workspace = true }
-tempfile = { workspace = true }
 test-case = { workspace = true }
 
 [lints]

--- a/crates/ruff_notebook/Cargo.toml
+++ b/crates/ruff_notebook/Cargo.toml
@@ -20,7 +20,6 @@ itertools = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_with = { workspace = true, default-features = false, features = ["macros"] }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 

--- a/crates/ruff_notebook/src/schema.rs
+++ b/crates/ruff_notebook/src/schema.rs
@@ -11,8 +11,8 @@
 //!   `"additionalProperties": false`
 //! * `#[serde(flatten)] pub other: BTreeMap<String, Value>` for
 //!   `"additionalProperties": true` as preparation for round-trip support.
-//! * `#[serde(skip_serializing_none)]` was added to all structs where one or
-//!   more fields were optional to avoid serializing `null` values.
+//! * `#[serde(skip_serializing_if = "Option::is_none")]` was added to optional
+//!   fields where `null` values should not be serialized.
 //! * `Cell::execution_count` is a required property only for code cells, but
 //!   we serialize it for all cells. This is because we can't know if a cell is
 //!   a code cell or not without looking at the `cell_type` property, which
@@ -22,7 +22,6 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use serde_with::skip_serializing_none;
 
 fn sort_alphabetically<T: Serialize, S: serde::Serializer>(
     value: &T,
@@ -112,14 +111,15 @@ pub enum Cell {
 }
 
 /// Notebook raw nbconvert cell.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct RawCell {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Value>,
     /// Technically, id isn't required (it's not even present) in schema v4.0 through v4.4, but
     /// it's required in v4.5. Main issue is that pycharm creates notebooks without an id
     /// <https://youtrack.jetbrains.com/issue/PY-59438/Jupyter-notebooks-created-with-PyCharm-are-missing-the-id-field-in-cells-in-the-.ipynb-json>
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Cell-level metadata.
     pub metadata: CellMetadata,
@@ -127,14 +127,15 @@ pub struct RawCell {
 }
 
 /// Notebook markdown cell.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct MarkdownCell {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachments: Option<Value>,
     /// Technically, id isn't required (it's not even present) in schema v4.0 through v4.4, but
     /// it's required in v4.5. Main issue is that pycharm creates notebooks without an id
     /// <https://youtrack.jetbrains.com/issue/PY-59438/Jupyter-notebooks-created-with-PyCharm-are-missing-the-id-field-in-cells-in-the-.ipynb-json>
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
     /// Cell-level metadata.
     pub metadata: CellMetadata,
@@ -160,7 +161,6 @@ pub struct CodeCell {
 }
 
 /// Cell-level metadata.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct CellMetadata {
     /// VS Code specific cell metadata.
@@ -168,6 +168,7 @@ pub struct CellMetadata {
     /// This is [`Some`] only if the cell's preferred language is different from the notebook's
     /// preferred language.
     /// <https://github.com/microsoft/vscode/blob/e6c009a3d4ee60f352212b978934f52c4689fbd9/extensions/ipynb/src/serializers.ts#L117-L122>
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub vscode: Option<CodeCellMetadataVSCode>,
     /// For additional properties that isn't required by Ruff.
     #[serde(flatten)]
@@ -184,19 +185,23 @@ pub struct CodeCellMetadataVSCode {
 }
 
 /// Notebook root-level metadata.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Default)]
 pub struct RawNotebookMetadata {
     /// The author(s) of the notebook document
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub authors: Option<Value>,
     /// Kernel information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kernelspec: Option<Kernelspec>,
     /// Language information.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language_info: Option<LanguageInfo>,
     /// Original notebook format (major number) before converting the notebook between versions.
     /// This should never be written to a file.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub orig_nbformat: Option<i64>,
     /// The title of the notebook document
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     /// For additional properties.
     #[serde(flatten)]
@@ -204,7 +209,6 @@ pub struct RawNotebookMetadata {
 }
 
 /// Kernel information.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Kernelspec {
     /// The language name. This isn't mentioned in the spec but is populated by various tools and
@@ -214,6 +218,7 @@ pub struct Kernelspec {
     /// <https://github.com/microsoft/vscode/blob/1c31e758985efe11bc0453a45ea0bb6887e670a4/extensions/ipynb/src/deserializers.ts#L20-L22>.
     ///
     /// [`language_info`]: RawNotebookMetadata::language_info
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub language: Option<String>,
     /// For additional properties that isn't required by Ruff.
     #[serde(flatten)]
@@ -221,18 +226,21 @@ pub struct Kernelspec {
 }
 
 /// Language information.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct LanguageInfo {
     /// The codemirror mode to use for code in this language.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub codemirror_mode: Option<Value>,
     /// The file extension for files in this language.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub file_extension: Option<String>,
     /// The mimetype corresponding to files in this language.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mimetype: Option<String>,
     /// The programming language which this kernel runs.
     pub name: String,
     /// The pygments lexer to use for code in this language.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pygments_lexer: Option<String>,
     /// For additional properties.
     #[serde(flatten)]

--- a/crates/ruff_python_formatter/Cargo.toml
+++ b/crates/ruff_python_formatter/Cargo.toml
@@ -45,11 +45,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-ruff_formatter = { workspace = true }
-
 datatest-stable = { workspace = true }
 insta = { workspace = true }
-regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }

--- a/crates/ruff_wasm/Cargo.toml
+++ b/crates/ruff_wasm/Cargo.toml
@@ -32,15 +32,10 @@ ruff_workspace = { workspace = true }
 
 console_error_panic_hook = { workspace = true, optional = true }
 console_log = { workspace = true }
-# Not a direct dependency but required to enable the `wasm_js` feature.
-# See https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
-# Not a direct dependency but required to compile for Wasm.
-uuid = { workspace = true, features = ["js"] }
 wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
@@ -51,8 +46,3 @@ default = ["console_error_panic_hook"]
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-shear]
-ignored = [
-    "uuid",
-]

--- a/crates/ty_ide/Cargo.toml
+++ b/crates/ty_ide/Cargo.toml
@@ -27,7 +27,7 @@ ruff_python_trivia = { workspace = true }
 ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ty_module_resolver = { workspace = true }
-ty_project = { workspace = true, features = ["testing"] }
+ty_project = { workspace = true }
 ty_python_semantic = { workspace = true }
 ty_vendored = { workspace = true }
 ty_python_core = { workspace = true, features = ["serde"] }
@@ -48,6 +48,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ruff_python_parser = { workspace = true }
+ty_project = { workspace = true, features = ["testing"] }
 
 camino = { workspace = true }
 insta = { workspace = true, features = ["filters"] }

--- a/crates/ty_module_resolver/Cargo.toml
+++ b/crates/ty_module_resolver/Cargo.toml
@@ -34,7 +34,6 @@ ruff_db = { workspace = true, features = ["testing", "os"] }
 # Keep this path-only so Cargo strips the unpublished ty dev-dependency when packaging.
 ty_vendored = { path = "../ty_vendored" }
 
-anyhow = { workspace = true }
 insta = { workspace = true, features = ["filters"] }
 tempfile = { workspace = true }
 

--- a/crates/ty_project/Cargo.toml
+++ b/crates/ty_project/Cargo.toml
@@ -29,7 +29,7 @@ ty_combine = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_python_semantic = { workspace = true, features = ["serde"] }
 ty_static = { workspace = true }
-ty_python_core = { workspace = true, features = ["schemars"] }
+ty_python_core = { workspace = true }
 ty_vendored = { workspace = true }
 
 anyhow = { workspace = true }

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -16,7 +16,6 @@ ruff_index = { workspace = true, features = ["salsa"] }
 ruff_memory_usage = { workspace = true }
 ruff_python_ast = { workspace = true, features = ["salsa"] }
 ruff_python_parser = { workspace = true }
-ruff_python_trivia = { workspace = true }
 ruff_text_size = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_vendored = { workspace = true }
@@ -41,7 +40,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing", "os"] }
-ruff_python_parser = { workspace = true }
+ruff_python_trivia = { workspace = true }
 
 anyhow = { workspace = true }
 

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -49,7 +49,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 ruff_db = { workspace = true, features = ["testing"] }
-ruff_python_parser = { workspace = true }
 test-case = { workspace = true }
 ty_test = { workspace = true }
 ty_vendored = { workspace = true }

--- a/crates/ty_vendored/Cargo.toml
+++ b/crates/ty_vendored/Cargo.toml
@@ -18,7 +18,7 @@ zip = { workspace = true }
 [build-dependencies]
 path-slash = { workspace = true }
 walkdir = { workspace = true }
-zip = { workspace = true, features = ["zstd", "deflate-flate2-zlib-rs"] }
+zip = { workspace = true }
 
 [dev-dependencies]
 walkdir = { workspace = true }

--- a/crates/ty_vendored/build.rs
+++ b/crates/ty_vendored/build.rs
@@ -30,16 +30,12 @@ fn write_zipped_typeshed_to(writer: File) -> ZipResult<File> {
     // [source](https://github.com/gyscos/zstd-rs/wiki/Compile-for-WASM) which complicates the build
     // by a lot. Deflated compression is slower but it shouldn't matter much for the WASM use case
     // (WASM itself is already slower than a native build for a specific platform).
-    // We can't use `#[cfg(...)]` here because the target-arch in a build script is the
-    // architecture of the system running the build script and not the architecture of the build-target.
-    // That's why we use the `TARGET` environment variable here.
-    let method = if cfg!(feature = "zstd") {
-        CompressionMethod::Zstd
-    } else if cfg!(feature = "deflate") {
-        CompressionMethod::Deflated
-    } else {
-        CompressionMethod::Stored
-    };
+    #[cfg(feature = "zstd")]
+    let method = CompressionMethod::Zstd;
+    #[cfg(all(not(feature = "zstd"), feature = "deflate"))]
+    let method = CompressionMethod::Deflated;
+    #[cfg(not(any(feature = "zstd", feature = "deflate")))]
+    let method = CompressionMethod::Stored;
 
     let options = SimpleFileOptions::default()
         .compression_method(method)

--- a/crates/ty_wasm/Cargo.toml
+++ b/crates/ty_wasm/Cargo.toml
@@ -15,8 +15,6 @@ description = "WebAssembly bindings for ty"
 ignored = [
     # Depended on only to enable `log` feature as of 2025-10-03.
     "tracing",
-
-    "uuid",
 ]
 
 [lib]
@@ -42,16 +40,10 @@ ruff_text_size = { workspace = true }
 
 console_error_panic_hook = { workspace = true, optional = true }
 console_log = { workspace = true }
-# Not a direct dependency but required to enable the `wasm_js` feature.
-# See https://docs.rs/getrandom/latest/getrandom/#webassembly-support
-getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys = { workspace = true }
 log = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
-# Not a direct dependency but required to compile for Wasm.
-uuid = { workspace = true, features = ["js"] }
-
 wasm-bindgen = { workspace = true }
 
 [dev-dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -22,14 +22,12 @@ ruff_linter = { path = "../crates/ruff_linter" }
 ruff_python_ast = { path = "../crates/ruff_python_ast" }
 ruff_python_codegen = { path = "../crates/ruff_python_codegen" }
 ruff_python_parser = { path = "../crates/ruff_python_parser" }
-ruff_source_file = { path = "../crates/ruff_source_file" }
 ruff_python_formatter = { path = "../crates/ruff_python_formatter" }
 ruff_text_size = { path = "../crates/ruff_text_size" }
 
 ty_module_resolver = { path = "../crates/ty_module_resolver" }
 ty_python_semantic = { path = "../crates/ty_python_semantic" }
 ty_vendored = { path = "../crates/ty_vendored" }
-ty_site_packages = { path = "../crates/ty_site_packages" }
 ty_python_core = { path = "../crates/ty_python_core" }
 
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer", default-features = false }


### PR DESCRIPTION
Removes unused fuzz and duplicate development dependencies, replaces the notebook serde helper with native attributes, and narrows feature activation across native and WebAssembly builds.

This avoids compiling unnecessary RNG, schema, testing, and compression support.

