### PR TITLE
[ty] Narrow semantic node ID lookup tables

### DIFF
--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -6,7 +6,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::ExprRef;
 
 use crate::Db;
-use crate::frozen::FrozenMap;
+use crate::node_key::NarrowNodeIndexMap;
 use crate::scope::FileScopeId;
 use crate::semantic_index;
 
@@ -29,7 +29,7 @@ pub use node_key::ExpressionNodeKey;
 #[derive(Debug, salsa::Update, get_size2::GetSize)]
 pub(crate) struct AstIds {
     /// Maps expressions which "use" a place (that is, [`ast::ExprName`], [`ast::ExprAttribute`] or [`ast::ExprSubscript`]) to a use id.
-    uses_map: FrozenMap<ExpressionNodeKey, ScopedUseId>,
+    uses_map: NarrowNodeIndexMap<ScopedUseId>,
 }
 
 impl AstIds {
@@ -41,17 +41,19 @@ impl AstIds {
             uses_map.extend(builder.uses_map);
         }
 
-        let uses_map = FrozenMap::from_entries(uses_map);
-        debug_assert!(
-            uses_map.keys().is_sorted_by(|left, right| left < right),
-            "AST ID builders must contain disjoint keys"
+        let uses_map = NarrowNodeIndexMap::from_entries(
+            uses_map
+                .into_iter()
+                .map(|(key, use_id)| (key.index(), use_id)),
         );
 
         Self { uses_map }
     }
 
     fn use_id(&self, key: impl Into<ExpressionNodeKey>) -> ScopedUseId {
-        self.uses_map[&key.into()]
+        self.uses_map
+            .get(key.into().index())
+            .expect("key not found")
     }
 }
 
@@ -139,6 +141,12 @@ pub(crate) mod node_key {
         Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, salsa::Update, get_size2::GetSize,
     )]
     pub struct ExpressionNodeKey(NodeKey);
+
+    impl ExpressionNodeKey {
+        pub(crate) fn index(self) -> ast::NodeIndex {
+            self.0.index()
+        }
+    }
 
     impl From<ast::ExprRef<'_>> for ExpressionNodeKey {
         fn from(value: ast::ExprRef<'_>) -> Self {

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -67,7 +67,8 @@ use crate::use_def::{
 use crate::{Db, Statement, StatementNodeKey};
 use crate::{
     DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopHeaderId,
-    NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
+    NarrowingAliasPredicate, PossiblyNarrowedPlaces, ScopesByNode, SemanticIndex,
+    VisibleAncestorsIter,
 };
 
 use super::place::PlaceExprRef;
@@ -2646,7 +2647,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             scope_ids_by_scope: self.scope_ids_by_scope.into(),
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),
-            scopes_by_node: self.scopes_by_node,
+            scopes_by_node: ScopesByNode::from_map(self.scopes_by_node),
             use_def_maps: self
                 .use_def_maps
                 .into_iter()

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -27,6 +27,7 @@ use builder::SemanticIndexBuilder;
 use definition::{Definition, DefinitionNodeKey, Definitions};
 use expression::Expression;
 use narrowing_constraints::ScopedNarrowingConstraint;
+use node_key::NarrowNodeIndexMap;
 pub use place::{PlaceExprRef, PlaceTable};
 pub use reachability_constraints::ReachabilityConstraintsBuilder;
 pub use scope::FileScopeId;
@@ -241,6 +242,71 @@ struct DefinitionsByNode<'db> {
     non_single: FrozenMap<DefinitionNodeKey, Box<[Definition<'db>]>>,
 }
 
+#[derive(Debug, PartialEq, Eq, Update, get_size2::GetSize)]
+struct ScopesByNode {
+    module: Option<FileScopeId>,
+    primary: NarrowNodeIndexMap<FileScopeId>,
+    type_parameters: NarrowNodeIndexMap<FileScopeId>,
+}
+
+impl ScopesByNode {
+    fn from_map(scopes: FxHashMap<NodeWithScopeKey, FileScopeId>) -> Self {
+        let mut module = None;
+        let mut primary = Vec::new();
+        let mut type_parameters = Vec::new();
+
+        #[expect(
+            clippy::iter_over_hash_type,
+            reason = "each scope is independently partitioned by its node-key kind"
+        )]
+        for (key, scope) in scopes {
+            match key {
+                NodeWithScopeKey::Module => module = Some(scope),
+                NodeWithScopeKey::ClassTypeParameters(key)
+                | NodeWithScopeKey::FunctionTypeParameters(key)
+                | NodeWithScopeKey::TypeAliasTypeParameters(key) => {
+                    type_parameters.push((key.index(), scope));
+                }
+                NodeWithScopeKey::Class(key)
+                | NodeWithScopeKey::Function(key)
+                | NodeWithScopeKey::TypeAlias(key)
+                | NodeWithScopeKey::Lambda(key)
+                | NodeWithScopeKey::ListComprehension(key)
+                | NodeWithScopeKey::SetComprehension(key)
+                | NodeWithScopeKey::DictComprehension(key)
+                | NodeWithScopeKey::GeneratorExpression(key) => {
+                    primary.push((key.index(), scope));
+                }
+            }
+        }
+
+        Self {
+            module,
+            primary: NarrowNodeIndexMap::from_entries(primary),
+            type_parameters: NarrowNodeIndexMap::from_entries(type_parameters),
+        }
+    }
+
+    fn get(&self, key: NodeWithScopeKey) -> Option<FileScopeId> {
+        match key {
+            NodeWithScopeKey::Module => self.module,
+            NodeWithScopeKey::ClassTypeParameters(key)
+            | NodeWithScopeKey::FunctionTypeParameters(key)
+            | NodeWithScopeKey::TypeAliasTypeParameters(key) => {
+                self.type_parameters.get(key.index())
+            }
+            NodeWithScopeKey::Class(key)
+            | NodeWithScopeKey::Function(key)
+            | NodeWithScopeKey::TypeAlias(key)
+            | NodeWithScopeKey::Lambda(key)
+            | NodeWithScopeKey::ListComprehension(key)
+            | NodeWithScopeKey::SetComprehension(key)
+            | NodeWithScopeKey::DictComprehension(key)
+            | NodeWithScopeKey::GeneratorExpression(key) => self.primary.get(key.index()),
+        }
+    }
+}
+
 impl<'db> DefinitionsByNode<'db> {
     fn from_map(definitions_by_node: FxHashMap<DefinitionNodeKey, Definitions<'db>>) -> Self {
         let single_count = definitions_by_node
@@ -301,7 +367,7 @@ pub struct SemanticIndex<'db> {
     statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
 
     /// Map from nodes that create a scope to the scope they create.
-    scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
+    scopes_by_node: ScopesByNode,
 
     /// Map from a lambda expression to its containing statement.
     enclosing_lambda_statements: FrozenMap<ExpressionNodeKey, Statement<'db>>,
@@ -680,12 +746,14 @@ impl<'db> SemanticIndex<'db> {
     /// returns the scope in which that definition is defined in.
     #[track_caller]
     pub fn node_scope(&self, node: NodeWithScopeRef) -> FileScopeId {
-        self.scopes_by_node[&node.node_key()]
+        self.scopes_by_node
+            .get(node.node_key())
+            .expect("key not found")
     }
 
     /// Returns the id of the scope that `node` creates, if it exists.
     pub fn try_node_scope(&self, node: NodeWithScopeRef) -> Option<FileScopeId> {
-        self.scopes_by_node.get(&node.node_key()).copied()
+        self.scopes_by_node.get(node.node_key())
     }
 
     /// Returns the id of the scope that the node identified by `key` creates.
@@ -694,7 +762,7 @@ impl<'db> SemanticIndex<'db> {
     /// [`AstNodeRef`](crate::ast_node_ref::AstNodeRef) and want to avoid loading
     /// the parsed module just to look up the scope.
     pub fn node_scope_by_key(&self, key: NodeWithScopeKey) -> FileScopeId {
-        self.scopes_by_node[&key]
+        self.scopes_by_node.get(key).expect("key not found")
     }
 
     /// Checks if there is an import of `__future__.annotations` in the global scope, which affects

--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -1,6 +1,8 @@
+use ruff_index::Idx;
 use ruff_python_ast::{HasNodeIndex, NodeIndex};
 
 use crate::ast_node_ref::AstNodeRef;
+use crate::frozen::FrozenMap;
 
 /// Compact key for a node for use in a hash map.
 #[derive(
@@ -18,5 +20,160 @@ impl NodeKey {
 
     pub fn from_node_ref<T>(node_ref: &AstNodeRef<T>) -> Self {
         NodeKey(node_ref.index())
+    }
+
+    pub(crate) fn index(self) -> NodeIndex {
+        self.0
+    }
+}
+
+/// A node-index map whose values use 16 bits when every stored index fits.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+pub(crate) struct NarrowNodeIndexMap<I>(NarrowNodeIndexStorage<I>);
+
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+enum NarrowNodeIndexStorage<I> {
+    Narrow(Box<[NarrowNodeIndexEntry]>),
+    Wide(FrozenMap<NodeKey, I>),
+}
+
+/// A packed node index and 16-bit index value.
+///
+/// The byte array keeps the entry's alignment at one; `(NodeKey, u16)` has two bytes of tail
+/// padding and occupies eight bytes.
+#[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
+struct NarrowNodeIndexEntry([u8; 6]);
+
+impl NarrowNodeIndexEntry {
+    fn new(node_index: u32, value: u16) -> Self {
+        let node_index = node_index.to_ne_bytes();
+        let value = value.to_ne_bytes();
+        Self([
+            node_index[0],
+            node_index[1],
+            node_index[2],
+            node_index[3],
+            value[0],
+            value[1],
+        ])
+    }
+
+    fn node_index(&self) -> u32 {
+        u32::from_ne_bytes([self.0[0], self.0[1], self.0[2], self.0[3]])
+    }
+
+    fn value(&self) -> u16 {
+        u16::from_ne_bytes([self.0[4], self.0[5]])
+    }
+}
+
+impl<I: Idx> NarrowNodeIndexMap<I> {
+    pub(crate) fn from_entries(entries: impl IntoIterator<Item = (NodeIndex, I)>) -> Self {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        let narrow = entries
+            .iter()
+            .map(|(index, value)| {
+                Some(NarrowNodeIndexEntry::new(
+                    index.as_u32()?,
+                    u16::try_from(value.index()).ok()?,
+                ))
+            })
+            .collect::<Option<Vec<_>>>();
+
+        if let Some(mut narrow) = narrow {
+            narrow.sort_unstable_by_key(NarrowNodeIndexEntry::node_index);
+            debug_assert!(
+                narrow
+                    .windows(2)
+                    .all(|entries| entries[0].node_index() != entries[1].node_index()),
+                "narrow node index map keys must be unique",
+            );
+            Self(NarrowNodeIndexStorage::Narrow(narrow.into_boxed_slice()))
+        } else {
+            Self(NarrowNodeIndexStorage::Wide(FrozenMap::from_entries(
+                entries
+                    .into_iter()
+                    .map(|(index, value)| (NodeKey(index), value))
+                    .collect(),
+            )))
+        }
+    }
+
+    pub(crate) fn get(&self, index: NodeIndex) -> Option<I> {
+        match &self.0 {
+            NarrowNodeIndexStorage::Narrow(entries) => {
+                let index = index.as_u32()?;
+                let entry = entries
+                    .binary_search_by_key(&index, NarrowNodeIndexEntry::node_index)
+                    .ok()
+                    .and_then(|index| entries.get(index))?;
+                Some(I::new(usize::from(entry.value())))
+            }
+            NarrowNodeIndexStorage::Wide(map) => map.get(&NodeKey(index)).copied(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::{size_of, size_of_val};
+
+    use ruff_index::newtype_index;
+    use ruff_python_ast::NodeIndex;
+
+    use super::{NarrowNodeIndexEntry, NarrowNodeIndexMap, NarrowNodeIndexStorage, NodeKey};
+    use crate::frozen::FrozenMap;
+
+    #[newtype_index]
+    #[derive(get_size2::GetSize)]
+    struct TestId;
+
+    #[test]
+    fn narrow_node_index_entry_is_packed() {
+        assert_eq!(size_of::<NarrowNodeIndexEntry>(), 6);
+    }
+
+    #[test]
+    fn narrow_node_index_map_uses_less_retained_memory() {
+        let entries = (0..16)
+            .map(|index| (NodeIndex::from(index), TestId::from_usize(index as usize)))
+            .collect::<Vec<_>>();
+        let narrow = NarrowNodeIndexMap::from_entries(entries.iter().copied());
+        let wide = FrozenMap::from_entries(
+            entries
+                .into_iter()
+                .map(|(index, value)| (NodeKey(index), value))
+                .collect(),
+        );
+
+        let narrow_size = size_of_val(&narrow) + ruff_memory_usage::heap_size(&narrow);
+        let wide_size = size_of_val(&wide) + ruff_memory_usage::heap_size(&wide);
+        assert!(narrow_size < wide_size, "{narrow_size} >= {wide_size}");
+    }
+
+    #[test]
+    fn narrow_node_index_map_looks_up_values_and_falls_back_for_wide_values() {
+        let node = NodeIndex::from(1);
+        let missing = NodeIndex::from(2);
+        let other = NodeIndex::from(3);
+        let narrow = NarrowNodeIndexMap::from_entries([
+            (other, TestId::from_usize(7)),
+            (node, TestId::from_usize(u16::MAX as usize)),
+        ]);
+        let wide =
+            NarrowNodeIndexMap::from_entries([(node, TestId::from_usize(u16::MAX as usize + 1))]);
+
+        assert!(matches!(narrow.0, NarrowNodeIndexStorage::Narrow(_)));
+        assert!(matches!(wide.0, NarrowNodeIndexStorage::Wide(_)));
+        assert_eq!(
+            narrow.get(node),
+            Some(TestId::from_usize(u16::MAX as usize))
+        );
+        assert_eq!(narrow.get(missing), None);
+        assert_eq!(narrow.get(other), Some(TestId::from_usize(7)));
+        assert_eq!(
+            wide.get(node),
+            Some(TestId::from_usize(u16::MAX as usize + 1))
+        );
     }
 }


### PR DESCRIPTION
## Summary

File-local semantic IDs are stored at their full width in several immutable lookup tables, even though almost every file uses fewer than 65,536 IDs.

This adds an independent `NarrowNodeIndexMap`. When every value fits, it stores each mapping as a packed six-byte entry containing a 32-bit node index and a 16-bit semantic ID, avoiding the padding of a `(NodeKey, u16)` tuple. Unusually large files fall back to the existing full-width `FrozenMap` representation. This PR does not depend on #26350.

We use the narrow representation for AST use IDs and scope lookups. Scope lookups keep module, primary-scope, and type-parameter-scope entries separate because a node can anchor both a primary scope and a type-parameter scope.