### PR TITLE
[ty] Intersection simplifications with gradual generic specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -9,7 +9,7 @@ python-version = "3.14"
 
 ```pyi
 from typing import Any
-from ty_extensions import static_assert, is_equivalent_to, is_subtype_of
+from ty_extensions import Bottom, static_assert, is_equivalent_to, is_subtype_of
 ```
 
 Throughout the document, we use the following classes as canonical examples for covariant,
@@ -192,12 +192,19 @@ Contra[P] & Contra[Any] = Contra[P | Any]    (5b)
 We can encode all of these in ty assertions:
 
 ```pyi
-# TODO: all of these should pass
+# TODO: both should pass
 static_assert(is_equivalent_to(Co[P] | Co[Any], Co[P | Any]))  # error: [static-assert-error]
-static_assert(is_equivalent_to(Co[P] & Co[Any], Co[P & Any]))  # error: [static-assert-error]
+static_assert(is_equivalent_to(Co[Any] | Co[P], Co[P | Any]))  # error: [static-assert-error]
 
+static_assert(is_equivalent_to(Co[P] & Co[Any], Co[P & Any]))
+static_assert(is_equivalent_to(Co[Any] & Co[P], Co[P & Any]))
+
+# TODO: both should pass
 static_assert(is_equivalent_to(Contra[P] | Contra[Any], Contra[P & Any]))  # error: [static-assert-error]
-static_assert(is_equivalent_to(Contra[P] & Contra[Any], Contra[P | Any]))  # error: [static-assert-error]
+static_assert(is_equivalent_to(Contra[Any] | Contra[P], Contra[P & Any]))  # error: [static-assert-error]
+
+static_assert(is_equivalent_to(Contra[P] & Contra[Any], Contra[P | Any]))
+static_assert(is_equivalent_to(Contra[Any] & Contra[P], Contra[P | Any]))
 ```
 
 What about invariance? We can naively write `Invariant[Any]` in its interval representation:
@@ -284,4 +291,44 @@ materializations of the gradual type `Invariant[P] | Invariant[Any]`. So we enco
 static_assert(is_equivalent_to(Invariant[P] & Invariant[Any], Invariant[P]))
 
 static_assert(not is_equivalent_to(Invariant[P] | Invariant[Any], Invariant[P]))
+```
+
+Finally, we consider intersections with the negation of an `Any`-specialized generic class. For any
+of the generic classes `C` above, we can negate the canonical interval representation of `C[Any]`:
+
+```ignore
+~C[Any]
+    = ~(Bottom[C[Any]] | Top[C[Any]] & Any)
+    = ~Bottom[C[Any]] & (~Top[C[Any]] | Any)
+    = ~Top[C[Any]] | ~Bottom[C[Any]] & Any
+```
+
+Every fully-static specialization `C[P]` is a subtype of `Top[C[Any]]`, therefore:
+
+```ignore
+C[P] & ~C[Any]
+    = C[P] & (~Top[C[Any]] | ~Bottom[C[Any]] & Any)
+    = C[P] & ~Bottom[C[Any]] & Any
+```
+
+For covariant and contravariant classes, we can simplify the bottom materializations as in (3a) and
+(3b):
+
+```ignore
+Co[P]        & ~Co[Any]        = Co[P]        & ~Co[Never]              & Any
+Contra[P]    & ~Contra[Any]    = Contra[P]    & ~Contra[object]         & Any
+Invariant[P] & ~Invariant[Any] = Invariant[P] & ~Bottom[Invariant[Any]] & Any
+```
+
+We can verify all three relations in ty:
+
+```pyi
+static_assert(is_equivalent_to(Co[P] & ~Co[Any], Co[P] & ~Bottom[Co[Any]] & Any))
+static_assert(is_equivalent_to(Contra[P] & ~Contra[Any], Contra[P] & ~Bottom[Contra[Any]] & Any))
+static_assert(is_equivalent_to(Invariant[P] & ~Invariant[Any], Invariant[P] & ~Bottom[Invariant[Any]] & Any))
+
+# The simplification is independent of the order in which the intersection elements are added.
+static_assert(is_equivalent_to(~Co[Any] & Co[P], Co[P] & ~Bottom[Co[Any]] & Any))
+static_assert(is_equivalent_to(~Contra[Any] & Contra[P], Contra[P] & ~Bottom[Contra[Any]] & Any))
+static_assert(is_equivalent_to(~Invariant[Any] & Invariant[P], Invariant[P] & ~Bottom[Invariant[Any]] & Any))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -1,13 +1,13 @@
 # Generics and set theoretic types
 
-This test suite explores the interplay between generics and set theoretic gradual types.
-
-## General relationships
-
 ```toml
 [environment]
 python-version = "3.14"
 ```
+
+This test suite explores the interplay between generics and set theoretic gradual types.
+
+## General relationships
 
 ```pyi
 from typing import Any
@@ -337,12 +337,65 @@ static_assert(is_equivalent_to(~Invariant[Any] & Invariant[P], Invariant[P] & ~B
 
 ## Edge cases
 
-The simplification must preserve the identities of type variables and `NewType` instances:
+### Multi-parameter and mixed-variance generics
 
-```toml
-[environment]
-python-version = "3.14"
+The results above naturally extend to multi-parameter generics and mixed variances:
+
+```pyi
+from typing import Any, Generic, TypeVar
+from ty_extensions import Bottom, static_assert, is_equivalent_to, is_subtype_of
+
+class P: ...
+class Q: ...
+class R: ...
+
+T_co = TypeVar("T_co", covariant=True)
+T_contra = TypeVar("T_contra", contravariant=True)
+T_invariant = TypeVar("T_invariant")
+
+class Mixed(Generic[T_co, T_contra, T_invariant]): ...
+
+static_assert(is_equivalent_to(Mixed[P, Q, R] & Mixed[Any, Any, Any], Mixed[P & Any, Q | Any, R]))
 ```
+
+### Tuples
+
+Tuple types are covariant in every type parameter, so the results derived for `Co[T]` above apply to
+`tuple` at every position:
+
+```pyi
+from typing import Any, Never
+from ty_extensions import static_assert, is_equivalent_to, is_subtype_of
+
+class P: ...
+class Q: ...
+
+static_assert(is_equivalent_to(tuple[P] & tuple[Any], tuple[P & Any]))
+static_assert(is_equivalent_to(tuple[Any] & tuple[P], tuple[P & Any]))
+
+static_assert(is_equivalent_to(tuple[P] & ~tuple[Any], tuple[P] & ~tuple[Never] & Any))
+static_assert(is_equivalent_to(~tuple[Any] & tuple[P], tuple[P] & ~tuple[Never] & Any))
+
+static_assert(is_equivalent_to(tuple[P, Q] & tuple[Any, Q], tuple[P & Any, Q]))
+static_assert(is_equivalent_to(tuple[Any, Q] & tuple[P, Q], tuple[P & Any, Q]))
+
+static_assert(is_equivalent_to(tuple[P, Q] & tuple[P, Any], tuple[P, Q & Any]))
+static_assert(is_equivalent_to(tuple[P, Any] & tuple[P, Q], tuple[P, Q & Any]))
+
+static_assert(is_equivalent_to(tuple[P, Q] & tuple[Any, Any], tuple[P & Any, Q & Any]))
+static_assert(is_equivalent_to(tuple[Any, Any] & tuple[P, Q], tuple[P & Any, Q & Any]))
+```
+
+Intersections with tuples of different length are not affected:
+
+```pyi
+static_assert(is_equivalent_to(tuple[int, str] & ~tuple[Any], tuple[int, str]))
+static_assert(is_equivalent_to(tuple[int, str] & ~tuple[int, str, Any], tuple[int, str]))
+```
+
+### Type var bounds and `NewTypes`
+
+The simplification preserve the identities of type variables and `NewType` instances:
 
 ```pyi
 from typing import Any, NewType
@@ -362,32 +415,4 @@ def preserve_typevar[T: Co[P]](value: T & Co[Any]) -> T:
 
 def preserve_newtype(value: CoId & Co[Any]) -> CoId:
     return value
-```
-
-Tuple specializations carry information about their length and individual element types in addition
-to the aggregate type argument. Tuple shapes therefore need to match for the generalization to
-apply:
-
-```pyi
-static_assert(is_equivalent_to(tuple[int, str] & ~tuple[Any], tuple[int, str]))
-```
-
-For matching fixed-length tuples, intersections are simplified element-wise:
-
-```pyi
-static_assert(is_equivalent_to(tuple[P, Q] & tuple[Any, Q], tuple[P & Any, Q]))
-static_assert(is_equivalent_to(tuple[Any, Q] & tuple[P, Q], tuple[P & Any, Q]))
-
-static_assert(is_equivalent_to(tuple[P, Q] & tuple[P, Any], tuple[P, Q & Any]))
-static_assert(is_equivalent_to(tuple[P, Any] & tuple[P, Q], tuple[P, Q & Any]))
-```
-
-The same element-wise relationship applies when the gradual tuple is negated:
-
-```pyi
-static_assert(is_equivalent_to(tuple[P, Q] & ~tuple[Any, Q], tuple[P, Q] & Any))
-static_assert(is_equivalent_to(~tuple[Any, Q] & tuple[P, Q], tuple[P, Q] & Any))
-
-static_assert(is_equivalent_to(tuple[P, Q] & ~tuple[P, Any], tuple[P, Q] & Any))
-static_assert(is_equivalent_to(~tuple[P, Any] & tuple[P, Q], tuple[P, Q] & Any))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -1,13 +1,15 @@
 # Generics and set theoretic types
 
+This test suite explores the interplay between generics and set theoretic gradual types.
+
 ```toml
 [environment]
 python-version = "3.14"
 ```
 
-This test suite explores the interplay between generics and set theoretic gradual types.
+## Derivations and general results
 
-## General relationships
+This section concentrates on deriving the main results while the next section covers some more edge cases.
 
 ```pyi
 from typing import Any
@@ -295,7 +297,7 @@ static_assert(is_equivalent_to(Invariant[P] & Invariant[Any], Invariant[P]))
 static_assert(not is_equivalent_to(Invariant[P] | Invariant[Any], Invariant[P]))
 ```
 
-Finally, we consider intersections with the negation of an `Any`-specialized generic class. For any
+We can also consider intersections with the negation of an `Any`-specialized generic class. For all
 of the generic classes `C` above, we can negate the canonical interval representation of `C[Any]`:
 
 ```ignore
@@ -343,7 +345,7 @@ The results above naturally extend to multi-parameter generics and mixed varianc
 
 ```pyi
 from typing import Any, Generic, TypeVar
-from ty_extensions import Bottom, static_assert, is_equivalent_to, is_subtype_of
+from ty_extensions import Bottom, static_assert, is_equivalent_to
 
 class P: ...
 class Q: ...
@@ -365,7 +367,7 @@ Tuple types are covariant in every type parameter, so the results derived for `C
 
 ```pyi
 from typing import Any, Never
-from ty_extensions import static_assert, is_equivalent_to, is_subtype_of
+from ty_extensions import static_assert, is_equivalent_to
 
 class P: ...
 class Q: ...
@@ -391,6 +393,22 @@ Intersections with tuples of different length are not affected:
 ```pyi
 static_assert(is_equivalent_to(tuple[int, str] & ~tuple[Any], tuple[int, str]))
 static_assert(is_equivalent_to(tuple[int, str] & ~tuple[int, str, Any], tuple[int, str]))
+```
+
+### `type[...]`
+
+`type[..]` can also be a covariant type constructor, so these results also hold here:
+
+```pyi
+from typing import Any
+from ty_extensions import static_assert, is_equivalent_to
+
+class P: ...
+class Q: ...
+
+# TODO: these should pass
+static_assert(is_equivalent_to(type[P] & type[Any], type[P & Any]))  # error: [static-assert-error]
+static_assert(is_equivalent_to(type[Any] & type[P], type[P & Any]))  # error: [static-assert-error]
 ```
 
 ### Type var bounds and `NewTypes`

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -9,7 +9,8 @@ python-version = "3.14"
 
 ## Derivations and general results
 
-This section concentrates on deriving the main results while the next section covers some more edge cases.
+This section concentrates on deriving the main results while the next section covers some more edge
+cases.
 
 ```pyi
 from typing import Any
@@ -397,18 +398,20 @@ static_assert(is_equivalent_to(tuple[int, str] & ~tuple[int, str, Any], tuple[in
 
 ### `type[...]`
 
-`type[..]` can also be a covariant type constructor, so these results also hold here:
+`type[..]` can also be seen as a covariant type constructor, so the results also hold here:
 
 ```pyi
-from typing import Any
+from typing import Any, Never
 from ty_extensions import static_assert, is_equivalent_to
 
 class P: ...
 class Q: ...
 
-# TODO: these should pass
-static_assert(is_equivalent_to(type[P] & type[Any], type[P & Any]))  # error: [static-assert-error]
-static_assert(is_equivalent_to(type[Any] & type[P], type[P & Any]))  # error: [static-assert-error]
+static_assert(is_equivalent_to(type[P] & type[Any], type[P & Any]))
+static_assert(is_equivalent_to(type[Any] & type[P], type[P & Any]))
+
+static_assert(is_equivalent_to(type[P] & ~type[Any], type[P] & ~type[Never] & Any))
+static_assert(is_equivalent_to(~type[Any] & type[P], type[P] & ~type[Never] & Any))
 ```
 
 ### Type var bounds and `NewTypes`

--- a/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/set_theoretic.md
@@ -2,6 +2,8 @@
 
 This test suite explores the interplay between generics and set theoretic gradual types.
 
+## General relationships
+
 ```toml
 [environment]
 python-version = "3.14"
@@ -324,11 +326,68 @@ We can verify all three relations in ty:
 
 ```pyi
 static_assert(is_equivalent_to(Co[P] & ~Co[Any], Co[P] & ~Bottom[Co[Any]] & Any))
-static_assert(is_equivalent_to(Contra[P] & ~Contra[Any], Contra[P] & ~Bottom[Contra[Any]] & Any))
-static_assert(is_equivalent_to(Invariant[P] & ~Invariant[Any], Invariant[P] & ~Bottom[Invariant[Any]] & Any))
-
-# The simplification is independent of the order in which the intersection elements are added.
 static_assert(is_equivalent_to(~Co[Any] & Co[P], Co[P] & ~Bottom[Co[Any]] & Any))
+
+static_assert(is_equivalent_to(Contra[P] & ~Contra[Any], Contra[P] & ~Bottom[Contra[Any]] & Any))
 static_assert(is_equivalent_to(~Contra[Any] & Contra[P], Contra[P] & ~Bottom[Contra[Any]] & Any))
+
+static_assert(is_equivalent_to(Invariant[P] & ~Invariant[Any], Invariant[P] & ~Bottom[Invariant[Any]] & Any))
 static_assert(is_equivalent_to(~Invariant[Any] & Invariant[P], Invariant[P] & ~Bottom[Invariant[Any]] & Any))
+```
+
+## Edge cases
+
+The simplification must preserve the identities of type variables and `NewType` instances:
+
+```toml
+[environment]
+python-version = "3.14"
+```
+
+```pyi
+from typing import Any, NewType
+from ty_extensions import is_equivalent_to, static_assert
+
+class P: ...
+class Q: ...
+
+class Co[T]:
+    def get(self) -> T:
+        raise NotImplementedError
+
+CoId = NewType("CoId", Co[P])
+
+def preserve_typevar[T: Co[P]](value: T & Co[Any]) -> T:
+    return value
+
+def preserve_newtype(value: CoId & Co[Any]) -> CoId:
+    return value
+```
+
+Tuple specializations carry information about their length and individual element types in addition
+to the aggregate type argument. Tuple shapes therefore need to match for the generalization to
+apply:
+
+```pyi
+static_assert(is_equivalent_to(tuple[int, str] & ~tuple[Any], tuple[int, str]))
+```
+
+For matching fixed-length tuples, intersections are simplified element-wise:
+
+```pyi
+static_assert(is_equivalent_to(tuple[P, Q] & tuple[Any, Q], tuple[P & Any, Q]))
+static_assert(is_equivalent_to(tuple[Any, Q] & tuple[P, Q], tuple[P & Any, Q]))
+
+static_assert(is_equivalent_to(tuple[P, Q] & tuple[P, Any], tuple[P, Q & Any]))
+static_assert(is_equivalent_to(tuple[P, Any] & tuple[P, Q], tuple[P, Q & Any]))
+```
+
+The same element-wise relationship applies when the gradual tuple is negated:
+
+```pyi
+static_assert(is_equivalent_to(tuple[P, Q] & ~tuple[Any, Q], tuple[P, Q] & Any))
+static_assert(is_equivalent_to(~tuple[Any, Q] & tuple[P, Q], tuple[P, Q] & Any))
+
+static_assert(is_equivalent_to(tuple[P, Q] & ~tuple[P, Any], tuple[P, Q] & Any))
+static_assert(is_equivalent_to(~tuple[P, Any] & tuple[P, Q], tuple[P, Q] & Any))
 ```

--- a/crates/ty_python_semantic/resources/mdtest/named_tuple.md
+++ b/crates/ty_python_semantic/resources/mdtest/named_tuple.md
@@ -1455,7 +1455,7 @@ def expects_named_tuple(x: typing.NamedTuple):
     reveal_type(x.__iter__)
 
 def _(y: type[typing.NamedTuple]):
-    reveal_type(y)  # revealed: @Todo(unsupported type[X] special form)
+    reveal_type(y)  # revealed: type[tuple[object, ...]] & type[NamedTupleLike]
 
 # error: [invalid-type-form] "Special form `typing.NamedTuple` expected no type parameter"
 def _(z: typing.NamedTuple[int]): ...

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -1723,7 +1723,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     }
 }
 
-fn specialization_variance<'db>(
+pub(super) fn specialization_variance<'db>(
     db: &'db dyn Db,
     bound_typevar: BoundTypeVarInstance<'db>,
 ) -> TypeVarVariance {

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -1244,7 +1244,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::StringLiteral(_) => {
                 infer_type_argument(self, slice)
             }
-            ast::Expr::BinOp(binary) if binary.op == ast::Operator::BitOr => {
+            ast::Expr::BinOp(binary)
+                if matches!(binary.op, ast::Operator::BitOr | ast::Operator::BitAnd) =>
+            {
                 infer_type_argument(self, slice)
             }
             ast::Expr::Tuple(_) => {

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -12,6 +12,7 @@ use crate::types::{TypeVarBoundOrConstraints, visitor};
 use crate::{Db, FxOrderSet};
 
 pub(crate) mod builder;
+mod generic_gradual_intersections;
 
 pub(crate) use builder::{IntersectionBuilder, UnionBuilder};
 

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -268,6 +268,13 @@ fn negated_generalization_bottom<'db>(
     general: Type<'db>,
     specific: Type<'db>,
 ) -> Option<Type<'db>> {
+    if let (Type::SubclassOf(general_subclass), Type::SubclassOf(_)) = (general, specific)
+        && general_subclass.is_dynamic()
+        && !specific.has_dynamic(db)
+    {
+        return Some(general.bottom_materialization(db));
+    }
+
     dynamic_generalization_of(db, general, specific)?;
     (!specific.has_dynamic(db)).then(|| general.bottom_materialization(db))
 }

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -38,11 +38,13 @@
 
 use super::RecursivelyDefined;
 use crate::types::enums::EnumComplement;
+use crate::types::generics::{Specialization, specialization_variance};
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements,
-    StringLiteralType, SubclassOfType, Type, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
+    StaticClassLiteral, StringLiteralType, SubclassOfType, Type, TypeVarBoundOrConstraints,
+    TypeVarVariance, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
@@ -90,21 +92,66 @@ fn split_truthiness_guarded_intersection<'db>(
     Some((core.build(), guard))
 }
 
-/// Return `true` if `general` and `specific` are specializations of the same generic class and
-/// `general` only differs by using dynamic types for invariant type variables. For example,
-/// `list[Any]` is an invariant-dynamic generalization of `list[int]`.
-fn is_invariant_dynamic_generalization_of<'db>(
+struct DynamicGeneralization<'db> {
+    class: StaticClassLiteral<'db>,
+    general: Specialization<'db>,
+    specific: Specialization<'db>,
+    specific_type: Type<'db>,
+    has_variant_replacement: bool,
+}
+
+impl<'db> DynamicGeneralization<'db> {
+    fn intersection(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let generic_context = self.general.generic_context(db);
+        if !self.has_variant_replacement {
+            return Some(self.specific_type);
+        }
+
+        // Tuple specializations carry additional element information, and variance-based merges
+        // require the specific specialization to be fully static.
+        if self.class.known(db) == Some(KnownClass::Tuple) || self.specific_type.has_dynamic(db) {
+            return None;
+        }
+
+        let types: Vec<_> = generic_context
+            .variables(db)
+            .zip(self.general.types(db))
+            .zip(self.specific.types(db))
+            .map(|((typevar, general), specific)| {
+                if general == specific {
+                    return *specific;
+                }
+                match specialization_variance(db, typevar) {
+                    TypeVarVariance::Covariant => {
+                        IntersectionType::from_two_elements(db, *specific, *general)
+                    }
+                    TypeVarVariance::Contravariant => {
+                        UnionType::from_two_elements(db, *specific, *general)
+                    }
+                    TypeVarVariance::Invariant | TypeVarVariance::Bivariant => *specific,
+                }
+            })
+            .collect();
+        let specialization = generic_context.specialize(db, types);
+
+        Some(Type::instance(
+            db,
+            self.class
+                .apply_optional_specialization(db, Some(specialization)),
+        ))
+    }
+}
+
+/// Return the relationship between two specializations of the same generic class if `general`
+/// only differs from `specific` by using dynamic types.
+fn dynamic_generalization_of<'db>(
     db: &'db dyn Db,
     general: Type<'db>,
     specific: Type<'db>,
-) -> bool {
+) -> Option<DynamicGeneralization<'db>> {
     // Fast path to avoid performance regressions.
-    if !general.has_dynamic(db) {
-        return false;
-    }
-
-    if matches!(general, Type::TypeVar(_) | Type::NewTypeInstance(_)) {
-        return false;
+    if !general.has_dynamic(db) || matches!(general, Type::TypeVar(_) | Type::NewTypeInstance(_)) {
+        return None;
     }
 
     let (
@@ -115,7 +162,7 @@ fn is_invariant_dynamic_generalization_of<'db>(
         specific.class_specialization(db),
     )
     else {
-        return false;
+        return None;
     };
 
     // Top and bottom materializations are not gradual types.
@@ -123,10 +170,11 @@ fn is_invariant_dynamic_generalization_of<'db>(
         || general_specialization.materialization_kind(db).is_some()
         || specific_specialization.materialization_kind(db).is_some()
     {
-        return false;
+        return None;
     }
 
     let mut has_dynamic_replacement = false;
+    let mut has_variant_replacement = false;
     for ((typevar, general_type), specific_type) in general_specialization
         .generic_context(db)
         .variables(db)
@@ -136,15 +184,44 @@ fn is_invariant_dynamic_generalization_of<'db>(
         if general_type == specific_type {
             continue;
         }
-        if general_type.is_non_divergent_dynamic()
-            && typevar.variance(db) == TypeVarVariance::Invariant
-        {
+        if general_type.is_non_divergent_dynamic() {
             has_dynamic_replacement = true;
+            has_variant_replacement |= matches!(
+                specialization_variance(db, typevar),
+                TypeVarVariance::Covariant | TypeVarVariance::Contravariant
+            );
             continue;
         }
-        return false;
+        return None;
     }
-    has_dynamic_replacement
+    has_dynamic_replacement.then_some(DynamicGeneralization {
+        class: general_class,
+        general: general_specialization,
+        specific: specific_specialization,
+        specific_type: specific,
+        has_variant_replacement,
+    })
+}
+
+fn dynamic_intersection<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Option<Type<'db>> {
+    dynamic_generalization_of(db, left, right)
+        .or_else(|| dynamic_generalization_of(db, right, left))
+        .and_then(|generalization| generalization.intersection(db))
+}
+
+/// If `general` is a dynamic generalization of the fully-static `specific`, return the bottom
+/// materialization that should replace `general` in `specific & ~general`.
+fn negated_generalization_bottom<'db>(
+    db: &'db dyn Db,
+    general: Type<'db>,
+    specific: Type<'db>,
+) -> Option<Type<'db>> {
+    dynamic_generalization_of(db, general, specific)?;
+    (!specific.has_dynamic(db)).then(|| general.bottom_materialization(db))
 }
 
 /// Try to merge a complementary guarded pair into an unguarded core.
@@ -1630,25 +1707,22 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
 
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
+                let mut dynamic_merge = None;
                 for (index, existing_positive) in self.positive.iter().enumerate() {
-                    // S & T = S if S <: T or T is an invariant-dynamic generalization of S.
-                    if existing_positive.is_redundant_with(db, new_positive)
-                        || is_invariant_dynamic_generalization_of(
-                            db,
-                            new_positive,
-                            *existing_positive,
-                        )
+                    if let Some(merged) = dynamic_intersection(db, new_positive, *existing_positive)
                     {
+                        if merged == *existing_positive {
+                            return;
+                        }
+                        dynamic_merge = Some((index, merged));
+                        break;
+                    }
+                    // S & T = S if S <: T.
+                    if existing_positive.is_redundant_with(db, new_positive) {
                         return;
                     }
                     // same rule, reverse order
-                    if new_positive.is_redundant_with(db, *existing_positive)
-                        || is_invariant_dynamic_generalization_of(
-                            db,
-                            *existing_positive,
-                            new_positive,
-                        )
-                    {
+                    if new_positive.is_redundant_with(db, *existing_positive) {
                         to_remove.push(index);
                     }
                     // A & B = Never    if A and B are disjoint
@@ -1658,12 +1732,27 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         return;
                     }
                 }
+                if let Some((index, merged)) = dynamic_merge {
+                    self.positive.swap_remove_index(index);
+                    self.add_positive(db, merged);
+                    return;
+                }
                 for index in to_remove.into_iter().rev() {
                     self.positive.swap_remove_index(index);
                 }
 
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
+                let mut replacement_negatives = SmallVec::<[Type<'db>; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
+                    // S & ~G = S & ~Bottom[G] & Any if G is a dynamic generalization of the
+                    // fully-static specialization S. This follows because S <: Top[G].
+                    if let Some(bottom) =
+                        negated_generalization_bottom(db, *existing_negative, new_positive)
+                    {
+                        to_remove.push(index);
+                        replacement_negatives.push(bottom);
+                        continue;
+                    }
                     // S & ~T = Never    if S <: T
                     if new_positive.is_subtype_of(db, *existing_negative) {
                         *self = Self::default();
@@ -1677,6 +1766,14 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
                 for index in to_remove.into_iter().rev() {
                     self.negative.swap_remove_index(index);
+                }
+                if !replacement_negatives.is_empty() {
+                    for bottom in replacement_negatives {
+                        self.add_negative(db, bottom);
+                    }
+                    self.add_positive(db, Type::any());
+                    self.add_positive(db, new_positive);
+                    return;
                 }
 
                 self.positive.insert(new_positive);
@@ -1759,6 +1856,14 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             _ => {
+                if let Some(bottom) = self.positive.iter().find_map(|existing_positive| {
+                    negated_generalization_bottom(db, new_negative, *existing_positive)
+                }) {
+                    self.add_negative(db, bottom);
+                    self.add_positive(db, Type::any());
+                    return;
+                }
+
                 let new_negative_enum = new_negative.as_enum_literal();
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -102,17 +102,39 @@ struct DynamicGeneralization<'db> {
 
 impl<'db> DynamicGeneralization<'db> {
     fn intersection(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        let generic_context = self.general.generic_context(db);
         if !self.has_variant_replacement {
             return Some(self.specific_type);
         }
 
-        // Tuple specializations carry additional element information, and variance-based merges
-        // require the specific specialization to be fully static.
-        if self.class.known(db) == Some(KnownClass::Tuple) || self.specific_type.has_dynamic(db) {
+        // Rebuilding the generic specialization would lose type-variable correlation or NewType
+        // identity.
+        if matches!(
+            self.specific_type,
+            Type::TypeVar(_) | Type::NewTypeInstance(_)
+        ) {
             return None;
         }
 
+        // Variance-based merges require the specific specialization to be fully static.
+        if self.specific_type.has_dynamic(db) {
+            return None;
+        }
+
+        if self.class.known(db) == Some(KnownClass::Tuple) {
+            let general = self.general.tuple(db)?.as_fixed_length()?;
+            let specific = self.specific.tuple(db)?.as_fixed_length()?;
+            return Some(Type::heterogeneous_tuple(
+                db,
+                specific
+                    .iter_all_elements()
+                    .zip(general.iter_all_elements())
+                    .map(|(specific, general)| {
+                        IntersectionType::from_two_elements(db, specific, general)
+                    }),
+            ));
+        }
+
+        let generic_context = self.general.generic_context(db);
         let types: Vec<_> = generic_context
             .variables(db)
             .zip(self.general.types(db))
@@ -173,27 +195,53 @@ fn dynamic_generalization_of<'db>(
         return None;
     }
 
-    let mut has_dynamic_replacement = false;
-    let mut has_variant_replacement = false;
-    for ((typevar, general_type), specific_type) in general_specialization
-        .generic_context(db)
-        .variables(db)
-        .zip(general_specialization.types(db))
-        .zip(specific_specialization.types(db))
-    {
-        if general_type == specific_type {
-            continue;
-        }
-        if general_type.is_non_divergent_dynamic() {
-            has_dynamic_replacement = true;
-            has_variant_replacement |= matches!(
-                specialization_variance(db, typevar),
-                TypeVarVariance::Covariant | TypeVarVariance::Contravariant
-            );
-            continue;
-        }
-        return None;
-    }
+    let (has_dynamic_replacement, has_variant_replacement) =
+        if general_class.known(db) == Some(KnownClass::Tuple) {
+            let general_tuple = general_specialization.tuple(db)?.as_fixed_length()?;
+            let specific_tuple = specific_specialization.tuple(db)?.as_fixed_length()?;
+            if general_tuple.len() != specific_tuple.len() {
+                return None;
+            }
+
+            let mut has_dynamic_replacement = false;
+            for (general_type, specific_type) in general_tuple
+                .iter_all_elements()
+                .zip(specific_tuple.iter_all_elements())
+            {
+                if general_type == specific_type {
+                    continue;
+                }
+                if general_type.is_non_divergent_dynamic() {
+                    has_dynamic_replacement = true;
+                    continue;
+                }
+                return None;
+            }
+            (has_dynamic_replacement, has_dynamic_replacement)
+        } else {
+            let mut has_dynamic_replacement = false;
+            let mut has_variant_replacement = false;
+            for ((typevar, general_type), specific_type) in general_specialization
+                .generic_context(db)
+                .variables(db)
+                .zip(general_specialization.types(db))
+                .zip(specific_specialization.types(db))
+            {
+                if general_type == specific_type {
+                    continue;
+                }
+                if general_type.is_non_divergent_dynamic() {
+                    has_dynamic_replacement = true;
+                    has_variant_replacement |= matches!(
+                        specialization_variance(db, typevar),
+                        TypeVarVariance::Covariant | TypeVarVariance::Contravariant
+                    );
+                    continue;
+                }
+                return None;
+            }
+            (has_dynamic_replacement, has_variant_replacement)
+        };
     has_dynamic_replacement.then_some(DynamicGeneralization {
         class: general_class,
         general: general_specialization,

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1336,6 +1336,11 @@ impl<'db> IntersectionBuilder<'db> {
     }
 }
 
+struct Replacement<'db> {
+    index: usize,
+    value: Type<'db>,
+}
+
 #[derive(Debug, Clone, Default)]
 struct InnerIntersectionBuilder<'db> {
     positive: FxOrderSet<Type<'db>>,
@@ -1576,10 +1581,6 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
 
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
-                struct Replacement<'db> {
-                    index: usize,
-                    value: Type<'db>,
-                }
                 let mut replacement = None;
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     if let Some(merged) =

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -37,14 +37,15 @@
 //! (unless exactly the same literal type), we can avoid many unnecessary redundancy checks.
 
 use super::RecursivelyDefined;
+use super::generic_gradual_intersections::{
+    generic_gradual_intersection, negated_generalization_bottom,
+};
 use crate::types::enums::EnumComplement;
-use crate::types::generics::{Specialization, specialization_variance};
 use crate::types::set_theoretic::expand_intersection_typevars_and_newtypes;
 use crate::types::{
     BytesLiteralType, ClassLiteral, EnumLiteralType, IntersectionType, KnownClass,
     KnownInstanceType, LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements,
-    StaticClassLiteral, StringLiteralType, SubclassOfType, Type, TypeVarBoundOrConstraints,
-    TypeVarVariance, UnionType,
+    StringLiteralType, SubclassOfType, Type, TypeVarBoundOrConstraints, UnionType,
 };
 use crate::{Db, FxOrderMap, FxOrderSet};
 use rustc_hash::FxHashSet;
@@ -90,193 +91,6 @@ fn split_truthiness_guarded_intersection<'db>(
         core = core.add_negative(*negative);
     }
     Some((core.build(), guard))
-}
-
-struct DynamicGeneralization<'db> {
-    class: StaticClassLiteral<'db>,
-    general: Specialization<'db>,
-    specific: Specialization<'db>,
-    specific_type: Type<'db>,
-    has_variant_replacement: bool,
-}
-
-impl<'db> DynamicGeneralization<'db> {
-    fn intersection(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        if !self.has_variant_replacement {
-            return Some(self.specific_type);
-        }
-
-        // Rebuilding the generic specialization would lose type-variable correlation or NewType
-        // identity.
-        if matches!(
-            self.specific_type,
-            Type::TypeVar(_) | Type::NewTypeInstance(_)
-        ) {
-            return None;
-        }
-
-        // Variance-based merges require the specific specialization to be fully static.
-        if self.specific_type.has_dynamic(db) {
-            return None;
-        }
-
-        if self.class.known(db) == Some(KnownClass::Tuple) {
-            let general = self.general.tuple(db)?.as_fixed_length()?;
-            let specific = self.specific.tuple(db)?.as_fixed_length()?;
-            return Some(Type::heterogeneous_tuple(
-                db,
-                specific
-                    .iter_all_elements()
-                    .zip(general.iter_all_elements())
-                    .map(|(specific, general)| {
-                        IntersectionType::from_two_elements(db, specific, general)
-                    }),
-            ));
-        }
-
-        let generic_context = self.general.generic_context(db);
-        let types: Vec<_> = generic_context
-            .variables(db)
-            .zip(self.general.types(db))
-            .zip(self.specific.types(db))
-            .map(|((typevar, general), specific)| {
-                if general == specific {
-                    return *specific;
-                }
-                match specialization_variance(db, typevar) {
-                    TypeVarVariance::Covariant => {
-                        IntersectionType::from_two_elements(db, *specific, *general)
-                    }
-                    TypeVarVariance::Contravariant => {
-                        UnionType::from_two_elements(db, *specific, *general)
-                    }
-                    TypeVarVariance::Invariant | TypeVarVariance::Bivariant => *specific,
-                }
-            })
-            .collect();
-        let specialization = generic_context.specialize(db, types);
-
-        Some(Type::instance(
-            db,
-            self.class
-                .apply_optional_specialization(db, Some(specialization)),
-        ))
-    }
-}
-
-/// Return the relationship between two specializations of the same generic class if `general`
-/// only differs from `specific` by using dynamic types.
-fn dynamic_generalization_of<'db>(
-    db: &'db dyn Db,
-    general: Type<'db>,
-    specific: Type<'db>,
-) -> Option<DynamicGeneralization<'db>> {
-    // Fast path to avoid performance regressions.
-    if !general.has_dynamic(db) || matches!(general, Type::TypeVar(_) | Type::NewTypeInstance(_)) {
-        return None;
-    }
-
-    let (
-        Some((general_class, general_specialization)),
-        Some((specific_class, specific_specialization)),
-    ) = (
-        general.class_specialization(db),
-        specific.class_specialization(db),
-    )
-    else {
-        return None;
-    };
-
-    // Top and bottom materializations are not gradual types.
-    if general_class != specific_class
-        || general_specialization.materialization_kind(db).is_some()
-        || specific_specialization.materialization_kind(db).is_some()
-    {
-        return None;
-    }
-
-    let (has_dynamic_replacement, has_variant_replacement) =
-        if general_class.known(db) == Some(KnownClass::Tuple) {
-            let general_tuple = general_specialization.tuple(db)?.as_fixed_length()?;
-            let specific_tuple = specific_specialization.tuple(db)?.as_fixed_length()?;
-            if general_tuple.len() != specific_tuple.len() {
-                return None;
-            }
-
-            let mut has_dynamic_replacement = false;
-            for (general_type, specific_type) in general_tuple
-                .iter_all_elements()
-                .zip(specific_tuple.iter_all_elements())
-            {
-                if general_type == specific_type {
-                    continue;
-                }
-                if general_type.is_non_divergent_dynamic() {
-                    has_dynamic_replacement = true;
-                    continue;
-                }
-                return None;
-            }
-            (has_dynamic_replacement, has_dynamic_replacement)
-        } else {
-            let mut has_dynamic_replacement = false;
-            let mut has_variant_replacement = false;
-            for ((typevar, general_type), specific_type) in general_specialization
-                .generic_context(db)
-                .variables(db)
-                .zip(general_specialization.types(db))
-                .zip(specific_specialization.types(db))
-            {
-                if general_type == specific_type {
-                    continue;
-                }
-                if general_type.is_non_divergent_dynamic() {
-                    has_dynamic_replacement = true;
-                    has_variant_replacement |= matches!(
-                        specialization_variance(db, typevar),
-                        TypeVarVariance::Covariant | TypeVarVariance::Contravariant
-                    );
-                    continue;
-                }
-                return None;
-            }
-            (has_dynamic_replacement, has_variant_replacement)
-        };
-    has_dynamic_replacement.then_some(DynamicGeneralization {
-        class: general_class,
-        general: general_specialization,
-        specific: specific_specialization,
-        specific_type: specific,
-        has_variant_replacement,
-    })
-}
-
-fn dynamic_intersection<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-) -> Option<Type<'db>> {
-    dynamic_generalization_of(db, left, right)
-        .or_else(|| dynamic_generalization_of(db, right, left))
-        .and_then(|generalization| generalization.intersection(db))
-}
-
-/// If `general` is a dynamic generalization of the fully-static `specific`, return the bottom
-/// materialization that should replace `general` in `specific & ~general`.
-fn negated_generalization_bottom<'db>(
-    db: &'db dyn Db,
-    general: Type<'db>,
-    specific: Type<'db>,
-) -> Option<Type<'db>> {
-    if let (Type::SubclassOf(general_subclass), Type::SubclassOf(_)) = (general, specific)
-        && general_subclass.is_dynamic()
-        && !specific.has_dynamic(db)
-    {
-        return Some(general.bottom_materialization(db));
-    }
-
-    dynamic_generalization_of(db, general, specific)?;
-    (!specific.has_dynamic(db)).then(|| general.bottom_materialization(db))
 }
 
 /// Try to merge a complementary guarded pair into an unguarded core.
@@ -1764,7 +1578,8 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 let mut dynamic_merge = None;
                 for (index, existing_positive) in self.positive.iter().enumerate() {
-                    if let Some(merged) = dynamic_intersection(db, new_positive, *existing_positive)
+                    if let Some(merged) =
+                        generic_gradual_intersection(db, new_positive, *existing_positive)
                     {
                         if merged == *existing_positive {
                             return;

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -1576,7 +1576,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 }
 
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
-                let mut dynamic_merge = None;
+                struct Replacement<'db> {
+                    index: usize,
+                    value: Type<'db>,
+                }
+                let mut replacement = None;
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     if let Some(merged) =
                         generic_gradual_intersection(db, new_positive, *existing_positive)
@@ -1584,7 +1588,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         if merged == *existing_positive {
                             return;
                         }
-                        dynamic_merge = Some((index, merged));
+                        replacement = Some(Replacement {
+                            index,
+                            value: merged,
+                        });
                         break;
                     }
                     // S & T = S if S <: T.
@@ -1602,9 +1609,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         return;
                     }
                 }
-                if let Some((index, merged)) = dynamic_merge {
+                if let Some(Replacement { index, value }) = replacement {
                     self.positive.swap_remove_index(index);
-                    self.add_positive(db, merged);
+                    self.add_positive(db, value);
                     return;
                 }
                 for index in to_remove.into_iter().rev() {
@@ -1615,7 +1622,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut replacement_negatives = SmallVec::<[Type<'db>; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // S & ~G = S & ~Bottom[G] & Any if G is a dynamic generalization of the
-                    // fully-static specialization S. This follows because S <: Top[G].
+                    // fully-static specialization S.
                     if let Some(bottom) =
                         negated_generalization_bottom(db, *existing_negative, new_positive)
                     {
@@ -1637,6 +1644,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 for index in to_remove.into_iter().rev() {
                     self.negative.swap_remove_index(index);
                 }
+                // For example, if we add `Co[P]` to an intersection containing `~Co[Any]`,
+                // replace that negative with `~Bottom[Co[Any]]` and add `Any`, producing
+                // `Co[P] & ~Bottom[Co[Any]] & Any`. See `generics/set_theoretic.md` for details.
                 if !replacement_negatives.is_empty() {
                     for bottom in replacement_negatives {
                         self.add_negative(db, bottom);
@@ -1726,6 +1736,9 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 self.add_negative(db, Type::string_literal(db, ""));
             }
             _ => {
+                // For example, if we add `~Co[Any]` to an intersection containing `Co[P]`,
+                // replace that negative with `~Bottom[Co[Any]]` and add `Any`, producing
+                // `Co[P] & ~Bottom[Co[Any]] & Any`. See `generics/set_theoretic.md` for details.
                 if let Some(bottom) = self.positive.iter().find_map(|existing_positive| {
                     negated_generalization_bottom(db, new_negative, *existing_positive)
                 }) {

--- a/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/generic_gradual_intersections.rs
@@ -1,0 +1,219 @@
+use crate::Db;
+use crate::types::generics::{Specialization, specialization_variance};
+use crate::types::tuple::FixedLengthTuple;
+use crate::types::{
+    IntersectionType, KnownClass, StaticClassLiteral, Type, TypeVarVariance, UnionType,
+};
+
+/// Simplify the intersection of two generic specializations when one is a gradual
+/// generalization of the other.
+///
+/// For example, `list[int] & list[Any]` simplifies to `list[int]`, while
+/// `Sequence[int] & Sequence[Any]` simplifies to `Sequence[int & Any]`.
+pub(super) fn generic_gradual_intersection<'db>(
+    db: &'db dyn Db,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> Option<Type<'db>> {
+    dynamic_generalization_of(db, left, right)
+        .or_else(|| dynamic_generalization_of(db, right, left))
+        .map(|generalization| generalization.intersection(db))
+}
+
+/// If `general` is a dynamic generalization of the fully-static `specific`, return the bottom
+/// materialization that should replace `general` in `specific & ~general`.
+///
+/// For example, `Co[P] & ~Co[Any] = Co[P] & ~Bottom[Co[Any]] & Any`; this function returns
+/// `Bottom[Co[Any]]`. Similarly, `type[P] & ~type[Any] = type[P] & ~type[Never] & Any`; this
+/// function returns `type[Never]`.
+pub(super) fn negated_generalization_bottom<'db>(
+    db: &'db dyn Db,
+    general: Type<'db>,
+    specific: Type<'db>,
+) -> Option<Type<'db>> {
+    if let (Type::SubclassOf(general_subclass), Type::SubclassOf(_)) = (general, specific)
+        && general_subclass.is_dynamic()
+        && !specific.has_dynamic(db)
+    {
+        return Some(general.bottom_materialization(db));
+    }
+
+    dynamic_generalization_of(db, general, specific)?;
+    if specific.has_dynamic(db) {
+        None
+    } else {
+        Some(general.bottom_materialization(db))
+    }
+}
+
+/// Describes how intersecting a dynamic generic specialization such as `list[Any]` with a more
+/// specific specialization such as `list[int]` should be simplified.
+enum DynamicGeneralization<'db> {
+    /// All dynamic replacements occur in invariant or bivariant positions, so the intersection
+    /// simplifies to the original specific type.
+    ///
+    /// For example, `list[int] & list[Any] = list[int]`.
+    UseSpecific(Type<'db>),
+    /// At least one dynamic replacement occurs in a covariant or contravariant position, so the
+    /// intersection requires rebuilding the specialization according to each parameter's variance.
+    ///
+    /// For example, `Sequence[int] & Sequence[Any] = Sequence[int & Any]`.
+    RebuildSpecialization {
+        class: StaticClassLiteral<'db>,
+        general: Specialization<'db>,
+        specific: Specialization<'db>,
+    },
+    /// Tuple specializations require rebuilding each element independently.
+    RebuildTuple {
+        general: &'db FixedLengthTuple<Type<'db>>,
+        specific: &'db FixedLengthTuple<Type<'db>>,
+    },
+}
+
+impl<'db> DynamicGeneralization<'db> {
+    /// Simplify the intersection represented by this relationship.
+    ///
+    /// Returns the original specific type when no reconstruction is needed, or rebuilds the
+    /// specialization according to its parameter variances.
+    fn intersection(self, db: &'db dyn Db) -> Type<'db> {
+        match self {
+            Self::UseSpecific(specific) => specific,
+            Self::RebuildTuple { general, specific } => Type::heterogeneous_tuple(
+                db,
+                specific
+                    .iter_all_elements()
+                    .zip(general.iter_all_elements())
+                    .map(|(specific, general)| {
+                        IntersectionType::from_two_elements(db, specific, general)
+                    }),
+            ),
+            Self::RebuildSpecialization {
+                class,
+                general,
+                specific,
+            } => {
+                let generic_context = general.generic_context(db);
+                let types: Vec<_> = generic_context
+                    .variables(db)
+                    .zip(general.types(db))
+                    .zip(specific.types(db))
+                    .map(|((typevar, general), specific)| {
+                        if general == specific {
+                            return *specific;
+                        }
+                        match specialization_variance(db, typevar) {
+                            TypeVarVariance::Covariant => {
+                                IntersectionType::from_two_elements(db, *specific, *general)
+                            }
+                            TypeVarVariance::Contravariant => {
+                                UnionType::from_two_elements(db, *specific, *general)
+                            }
+                            TypeVarVariance::Invariant | TypeVarVariance::Bivariant => *specific,
+                        }
+                    })
+                    .collect();
+                let specialization = generic_context.specialize(db, types);
+
+                Type::instance(
+                    db,
+                    class.apply_optional_specialization(db, Some(specialization)),
+                )
+            }
+        }
+    }
+}
+
+/// Return the relationship between two specializations of the same generic class if `general`
+/// only differs from `specific` by using dynamic types.
+///
+/// For example, `list[Any]` dynamically generalizes `list[int]`, while `list[str]` does not.
+fn dynamic_generalization_of<'db>(
+    db: &'db dyn Db,
+    general: Type<'db>,
+    specific: Type<'db>,
+) -> Option<DynamicGeneralization<'db>> {
+    // Fast path to avoid performance regressions.
+    if !general.has_dynamic(db)
+        || matches!(general, Type::TypeVar(_) | Type::NewTypeInstance(_))
+        || matches!(specific, Type::TypeVar(_) | Type::NewTypeInstance(_))
+    {
+        return None;
+    }
+
+    let (
+        Some((general_class, general_specialization)),
+        Some((specific_class, specific_specialization)),
+    ) = (
+        general.class_specialization(db),
+        specific.class_specialization(db),
+    )
+    else {
+        return None;
+    };
+
+    // Top and bottom materializations are not gradual types.
+    if general_class != specific_class
+        || general_specialization == specific_specialization
+        || general_specialization.materialization_kind(db).is_some()
+        || specific_specialization.materialization_kind(db).is_some()
+    {
+        return None;
+    }
+
+    if general_class.known(db) == Some(KnownClass::Tuple) {
+        let general_tuple = general_specialization.tuple(db)?.as_fixed_length()?;
+        let specific_tuple = specific_specialization.tuple(db)?.as_fixed_length()?;
+        if general_tuple.len() != specific_tuple.len()
+            || general_tuple
+                .iter_all_elements()
+                .zip(specific_tuple.iter_all_elements())
+                .any(|(general, specific)| {
+                    general != specific && !general.is_non_divergent_dynamic()
+                })
+        {
+            return None;
+        }
+        if specific.has_dynamic(db) {
+            return None;
+        }
+
+        return Some(DynamicGeneralization::RebuildTuple {
+            general: general_tuple,
+            specific: specific_tuple,
+        });
+    }
+
+    let generic_context = general_specialization.generic_context(db);
+    if generic_context
+        .variables(db)
+        .zip(general_specialization.types(db))
+        .zip(specific_specialization.types(db))
+        .any(|((_, general), specific)| general != specific && !general.is_non_divergent_dynamic())
+    {
+        return None;
+    }
+
+    if generic_context
+        .variables(db)
+        .zip(general_specialization.types(db))
+        .zip(specific_specialization.types(db))
+        .any(|((typevar, general), specific)| {
+            general != specific
+                && matches!(
+                    specialization_variance(db, typevar),
+                    TypeVarVariance::Covariant | TypeVarVariance::Contravariant
+                )
+        })
+    {
+        if specific.has_dynamic(db) {
+            return None;
+        }
+        Some(DynamicGeneralization::RebuildSpecialization {
+            class: general_class,
+            general: general_specialization,
+            specific: specific_specialization,
+        })
+    } else {
+        Some(DynamicGeneralization::UseSpecific(specific))
+    }
+}

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -6,9 +6,9 @@ use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::variance::VarianceInferable;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassLiteral, ClassType, DynamicType,
-    FindLegacyTypeVarsVisitor, KnownClass, MaterializationKind, MemberLookupPolicy,
-    SpecialFormType, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
-    TypedDictType, UnionType, todo_type,
+    FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, MaterializationKind,
+    MemberLookupPolicy, SpecialFormType, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
+    TypeVarVariance, TypedDictType, UnionType, todo_type,
 };
 use crate::{Db, FxOrderSet};
 use ty_python_core::definition::Definition;
@@ -78,8 +78,9 @@ impl<'db> SubclassOfType<'db> {
 
     /// Given an instance of the class or type variable `T`, returns a [`Type`] instance representing `type[T]`.
     pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-        // Handle unions by distributing `type[]` over each element:
+        // Handle unions and intersections by distributing `type[]` over each element:
         // `type[A | B]` -> `type[A] | type[B]`
+        // `type[A & B]` -> `type[A] & type[B]`
         match ty {
             Type::Union(union) => UnionType::try_from_elements(
                 db,
@@ -88,6 +89,15 @@ impl<'db> SubclassOfType<'db> {
                     .iter()
                     .map(|element| Self::try_from_instance(db, *element)),
             ),
+            Type::Intersection(intersection) if intersection.iter_negative(db).next().is_none() => {
+                Some(IntersectionType::from_elements(
+                    db,
+                    intersection
+                        .iter_positive(db)
+                        .map(|element| Self::try_from_instance(db, element))
+                        .collect::<Option<Vec<_>>>()?,
+                ))
+            }
             Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
             _ => SubclassOfInner::try_from_instance(db, ty)
                 .map(|subclass_of| Self::from(db, subclass_of)),

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -6,7 +6,7 @@ use crate::types::relation::{DisjointnessChecker, TypeRelationChecker};
 use crate::types::variance::VarianceInferable;
 use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassLiteral, ClassType, DynamicType,
-    FindLegacyTypeVarsVisitor, IntersectionType, KnownClass, MaterializationKind,
+    FindLegacyTypeVarsVisitor, IntersectionBuilder, KnownClass, MaterializationKind,
     MemberLookupPolicy, SpecialFormType, Type, TypeContext, TypeMapping, TypeVarBoundOrConstraints,
     TypeVarVariance, TypedDictType, UnionType, todo_type,
 };
@@ -90,13 +90,12 @@ impl<'db> SubclassOfType<'db> {
                     .map(|element| Self::try_from_instance(db, *element)),
             ),
             Type::Intersection(intersection) if intersection.iter_negative(db).next().is_none() => {
-                Some(IntersectionType::from_elements(
-                    db,
-                    intersection
-                        .iter_positive(db)
-                        .map(|element| Self::try_from_instance(db, element))
-                        .collect::<Option<Vec<_>>>()?,
-                ))
+                intersection
+                    .iter_positive(db)
+                    .try_fold(IntersectionBuilder::new(db), |builder, element| {
+                        Some(builder.add_positive(Self::try_from_instance(db, element)?))
+                    })
+                    .map(IntersectionBuilder::build)
             }
             Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
             _ => SubclassOfInner::try_from_instance(db, ty)


### PR DESCRIPTION
## Summary

In `isinstance(..., C)` and `TypeIs[..]` narrowing, we currently intersect with the top materialization `Top[C[Unknown]]` of a generic type `C`. If we want to relax that to an intersection with `C[Unknown]` directly, then we will not just see intersections like `C[P] & C[Unknown]` in the `if` branch, we'll also see intersections like `C[P] & ~C[Unknown]` in the `else` branch. If we don't simplify/transform these intersections further, we are currently unable to infer that the bottom materialization of something like `list[str] & ~list[Unknown]` is `Never`[^1]. So here, we implement the following intersection transformation:

```py
# For C a co-, contra-, or invariant generic class:
C[P] & ~C[Unknown] = C[P] & ~Bottom[C[Unknown]] & Unknown
```

In this form, due to the intersection with a plain `Unknown`, it is now obvious to ty that the gradual type extends all the way down to `Never`.

I realize that the type on the right hand side doesn't look better, but it is much easier to reason about. Also, for some specific `C`'s, the `~Bottom[C[Unknown]]` may simplify to `object`, so it falls out of the intersection. For example, I believe we could further simplify `type[P] & ~type[Unknown] = type[P] & Unknown` in a follow-up.

In addition, we also implement these transformations that we have derived before:

```py
Co[P] & Co[Unknown] = Co[P & Unknown]
Contra[P] & Contra[Unknown] = Contra[P | Unknown]
```

## Ecosystem

A few new diagnostics since we remove a TODO type for intersections of `type[..]`. All new diagnostics are true positives (they all have suppression comments for other type checkers).

## Test Plan

- New and updated Markdown tests.
- Much better ecosystem results on https://github.com/astral-sh/ruff/pull/26361


[^1]: We might actually be able to infer that if we explicitly asked for the bottom materialization of that type. But when accessing attributes/methods on the type, we don't explicitly perform that operation. Instead, we iterate over the intersection elements and combine the attribute types.