### PR TITLE
[ty] Use runtime semantics for Hashable class patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1086,6 +1086,50 @@ def runtime_protocol_pattern_is_exhaustive(value: RuntimeProtocolImplementer) ->
             return 1
 ```
 
+## Runtime `Hashable` patterns
+
+Static protocol subtyping does not determine whether a value matches `Hashable()` at runtime. A
+class can disable an inherited `__hash__` method by setting it to `None`, as `dict` does:
+
+```py
+from collections.abc import Hashable
+from typing import TypedDict
+
+class Payload(TypedDict):
+    value: int
+
+def unhashable_pattern_is_not_exhaustive(
+    value: dict[str, int],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case Hashable():
+            return 1
+
+def typed_dict_hashable_pattern_is_not_exhaustive(
+    value: Payload,
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case Hashable():
+            return 1
+
+def hashable_pattern_fallthrough(value: dict[str, int]) -> None:
+    match value:
+        case Hashable():
+            pass
+        case remaining:
+            reveal_type(remaining)  # revealed: dict[str, int]
+
+def nested_hashable_pattern_is_not_exhaustive(
+    value: tuple[dict[str, int]],
+    # error: [invalid-return-type]
+) -> int:
+    match value:
+        case [Hashable()]:
+            return 1
+```
+
 ## Members from the subject type
 
 A keyword pattern reads the attribute from the matched value. The subject type can therefore provide

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -1740,7 +1740,7 @@ fn report_invalid_union_type_elements<'db>(
 /// this will return `True` at runtime, `Truthiness::AlwaysFalse` if we can definitely infer
 /// that this will return `False` at runtime, or `Truthiness::Ambiguous` if we should infer `bool`
 /// instead.
-fn is_instance_truthiness<'db>(
+pub(super) fn is_instance_truthiness<'db>(
     db: &'db dyn Db,
     ty: Type<'db>,
     class: ClassLiteral<'db>,

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -10,6 +10,7 @@ use crate::Db;
 use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
+use crate::types::function::is_instance_truthiness;
 use crate::types::signatures::CallableSignature;
 use crate::types::tuple::TupleType;
 use crate::types::{
@@ -37,6 +38,21 @@ pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
     Type::Callable(CallableType::unknown(db)).top_materialization(db)
 }
 
+/// Return whether every value in `subject_ty` is guaranteed to match `class` at runtime.
+fn subject_matches_class_pattern(
+    db: &dyn Db,
+    subject_ty: Type<'_>,
+    class: ClassLiteral<'_>,
+) -> bool {
+    if class.is_known(db, KnownClass::Hashable) {
+        // Hashability does not follow normal static subtyping: a class can disable an inherited
+        // `__hash__` method by setting it to `None`.
+        is_instance_truthiness(db, subject_ty, class).is_always_true()
+    } else {
+        subject_ty.is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
+    }
+}
+
 /// Return whether every runtime value represented by a `TypedDict` satisfies `class`.
 ///
 /// `TypedDict` is not a nominal subtype of `dict` in the static type system, but every runtime
@@ -46,8 +62,7 @@ fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> boo
     let Some(dict) = KnownClass::Dict.to_class_literal(db).as_class_literal() else {
         return false;
     };
-    Type::instance(db, dict.top_materialization(db))
-        .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
+    subject_matches_class_pattern(db, Type::instance(db, dict.top_materialization(db)), class)
 }
 
 /// Return whether every value in `ty` belongs to a `TypedDict` domain accepted by `predicate`.
@@ -238,10 +253,10 @@ fn class_pattern_is_exhaustive(
     subject_ty: Type<'_>,
     kind: &ClassPatternPredicateKind<'_>,
 ) -> bool {
-    let class_instance_ty = Type::instance(db, class.top_materialization(db));
     let is_typed_dict_match =
         is_typed_dict_pattern_domain(db, subject_ty) && typed_dict_matches_class_pattern(db, class);
-    if !is_typed_dict_match && !subject_ty.is_subtype_of(db, class_instance_ty) {
+    let is_class_match = subject_matches_class_pattern(db, subject_ty, class);
+    if !is_typed_dict_match && !is_class_match {
         return false;
     }
 
@@ -560,6 +575,9 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                     if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
                         return subject_ty;
                     }
+                    if class.is_known(db, KnownClass::Hashable) {
+                        return Type::Never;
+                    }
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_empty()
@@ -764,6 +782,11 @@ fn subject_independent_definite_match_pattern_type<'db>(
     match kind {
         PatternPredicateKind::Class(kind) => {
             match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
+                Type::ClassLiteral(class)
+                    if kind.is_empty() && class.is_known(db, KnownClass::Hashable) =>
+                {
+                    None
+                }
                 Type::ClassLiteral(class) if kind.is_empty() => {
                     let class_instance_ty = Type::instance(db, class.top_materialization(db));
                     let typed_dict_adds_runtime_matches =


### PR DESCRIPTION
## Summary

Class patterns use `isinstance` at runtime, but we previously used static subtyping to decide whether an argumentless class pattern definitely matches its subject. These relations differ for `Hashable`: static protocol subtyping treats `object` as `Hashable` because it defines `__hash__`, while a class can be unhashable at runtime by setting `__hash__` to `None`.

As a result, a pattern such as `case Hashable()` could be treated as exhaustive for a `dict`, and later cases could incorrectly narrow the subject to `Never`.

This routes `Hashable` class patterns through the existing runtime `isinstance` truthiness analysis. When runtime membership cannot be proven, definite-match analysis keeps the fallthrough reachable rather than subtracting the subject. The same rule applies recursively and to the runtime `dict` representation of `TypedDict`.
