### PR TITLE
[ty] Support multiple analysis environments in one database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4673,6 +4673,7 @@ dependencies = [
  "ruff_text_size",
  "ty_ide",
  "ty_project",
+ "ty_python_core",
 ]
 
 [[package]]
@@ -4692,6 +4693,7 @@ dependencies = [
  "ty_ide",
  "ty_module_resolver",
  "ty_project",
+ "ty_python_core",
  "walkdir",
 ]
 

--- a/crates/mdtest/src/assertion.rs
+++ b/crates/mdtest/src/assertion.rs
@@ -519,7 +519,7 @@ mod tests {
     use super::*;
     use crate::tests::TestDb;
     use ruff_db::files::system_path_to_file;
-    use ruff_db::parsed::parsed_module;
+    use ruff_db::parsed::{VersionedFile, parsed_module};
     use ruff_db::source::line_index;
     use ruff_db::system::DbWithWritableSystem as _;
     use ruff_python_trivia::textwrap::dedent;
@@ -529,7 +529,9 @@ mod tests {
         let mut db = TestDb::setup();
         db.write_file("/src/test.py", source).unwrap();
         let file = system_path_to_file(&db, "/src/test.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let versioned_file =
+            VersionedFile::new(&db, file, ruff_python_ast::PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
         InlineFileAssertions::from_file(source, &parsed, &line_index(&db, file))
     }
 

--- a/crates/mdtest/src/matcher.rs
+++ b/crates/mdtest/src/matcher.rs
@@ -11,7 +11,7 @@ use path_slash::PathExt;
 use ruff_db::Db;
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::{VersionedFile, parsed_module};
 use ruff_db::source::{SourceText, line_index, source_text};
 use ruff_source_file::{LineIndex, OneIndexed};
 use smallvec::SmallVec;
@@ -88,16 +88,17 @@ struct LineFailures {
     range: Range<usize>,
 }
 
-pub fn match_file(
-    db: &dyn Db,
-    file: File,
+pub fn match_file<'db>(
+    db: &'db dyn Db,
+    versioned_file: VersionedFile<'db>,
     diagnostics: &[Diagnostic],
     options: RunOptions,
 ) -> Result<Vec<Diagnostic>, FailuresByLine> {
+    let file = versioned_file.file(db);
     // Parse assertions from comments in the file, and get diagnostics from the file; both
     // ordered by line number.
     let source = source_text(db, file);
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, versioned_file).load(db);
     let line_index = line_index(db, file);
     let assertions = InlineFileAssertions::from_file(&source, &parsed, &line_index);
 
@@ -534,6 +535,7 @@ mod tests {
     use super::FailuresByLine;
     use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, Severity, Span};
     use ruff_db::files::{File, system_path_to_file};
+    use ruff_db::parsed::VersionedFile;
     use ruff_db::system::DbWithWritableSystem as _;
     use ruff_python_trivia::textwrap::dedent;
     use ruff_source_file::OneIndexed;
@@ -595,7 +597,9 @@ mod tests {
             .into_iter()
             .map(|diagnostic| diagnostic.into_diagnostic(file))
             .collect();
-        super::match_file(&db, file, &diagnostics, options)
+        let versioned_file =
+            VersionedFile::new(&db, file, ruff_python_ast::PythonVersion::latest_ty());
+        super::match_file(&db, versioned_file, &diagnostics, options)
     }
 
     fn assert_fail(result: Result<Vec<Diagnostic>, FailuresByLine>, messages: &[(usize, &[&str])]) {

--- a/crates/ruff_benchmark/benches/module_resolution.rs
+++ b/crates/ruff_benchmark/benches/module_resolution.rs
@@ -12,7 +12,7 @@ use ty_module_resolver::{ModuleName, resolve_module};
 use ty_project::metadata::options::{EnvironmentOptions, Options};
 use ty_project::metadata::python_version::SupportedPythonVersion;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_project::{Db as _, ProjectDatabase, ProjectMetadata};
 
 const SEEDED_TARGETS: &[&str] = &["target_0", "target_1", "target_2", "target_3", "target_4"];
 // Exercise stub-overlay discovery followed by normal fallback.
@@ -93,8 +93,13 @@ fn ty_module_resolver<const PATHS: usize>(bencher: Bencher) {
     bencher
         .with_inputs(|| setup_case(PATHS))
         .bench_local_refs(|case| {
+            let importing_file = case
+                .db
+                .project()
+                .program(&case.db)
+                .resolver_file(&case.db, case.importing_file);
             for name in &case.resolves {
-                black_box(resolve_module(&case.db, case.importing_file, name));
+                black_box(resolve_module(&case.db, importing_file, name));
             }
         });
 }

--- a/crates/ruff_db/src/parsed.rs
+++ b/crates/ruff_db/src/parsed.rs
@@ -5,7 +5,7 @@ use arc_swap::ArcSwapOption;
 use get_size2::GetSize;
 use ruff_python_ast::{
     AnyRootNodeRef, HasNodeIndex, ModExpression, ModModule, NodeIndex, NodeIndexError,
-    StringLiteral,
+    PythonVersion, StringLiteral,
 };
 use ruff_python_parser::{
     ParseError, ParseErrorType, ParseOptions, Parsed, parse_cells_unchecked,
@@ -31,24 +31,45 @@ use crate::source::source_text;
 /// The LRU capacity of 200 was picked without any empirical evidence that it's optimal,
 /// instead it's a wild guess that it should be unlikely that incremental changes involve
 /// more than 200 modules. Parsed ASTs within the same revision are never evicted by Salsa.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+pub struct VersionedFile<'db> {
+    #[returns(copy)]
+    pub file: File,
+    #[returns(copy)]
+    pub python_version: PythonVersion,
+}
+
+// The Salsa allocation is tracked separately.
+impl get_size2::GetSize for VersionedFile<'_> {}
+
 #[salsa::tracked(returns(ref), no_eq, heap_size=ruff_memory_usage::heap_size, lru=200)]
-pub fn parsed_module(db: &dyn Db, file: File) -> ParsedModule {
-    let _span = tracing::trace_span!("parsed_module", ?file).entered();
+pub fn parsed_module(db: &dyn Db, file: VersionedFile<'_>) -> ParsedModule {
+    let source_file = file.file(db);
+    let python_version = file.python_version(db);
+    let _span = tracing::trace_span!(
+        "parsed_module",
+        ?source_file,
+        %python_version
+    )
+    .entered();
 
-    let parsed = parsed_module_impl(db, file);
+    let parsed = parsed_module_impl(db, source_file, python_version);
 
-    ParsedModule::new(file, parsed)
+    ParsedModule::new(source_file, python_version, parsed)
 }
 
 pub(super) fn disable_lru(db: &mut dyn Db) {
     parsed_module::set_lru_capacity(db, 0);
 }
 
-pub fn parsed_module_impl(db: &dyn Db, file: File) -> Parsed<ModModule> {
-    let source = source_text(db, file);
-    let ty = file.source_type(db);
+fn parsed_module_impl(
+    db: &dyn Db,
+    source_file: File,
+    target_version: PythonVersion,
+) -> Parsed<ModModule> {
+    let source = source_text(db, source_file);
+    let ty = source_file.source_type(db);
 
-    let target_version = db.python_version();
     let options = ParseOptions::from(ty).with_target_version(target_version);
 
     // Notebooks parse each cell as an independent module so a syntax error confined to one cell is
@@ -110,14 +131,16 @@ pub fn parsed_string_annotation(
 #[derive(Clone, get_size2::GetSize)]
 pub struct ParsedModule {
     file: File,
+    python_version: PythonVersion,
     #[get_size(size_fn = arc_swap_size)]
     inner: Arc<ArcSwapOption<indexed::IndexedModule>>,
 }
 
 impl ParsedModule {
-    pub fn new(file: File, parsed: Parsed<ModModule>) -> Self {
+    pub fn new(file: File, python_version: PythonVersion, parsed: Parsed<ModModule>) -> Self {
         Self {
             file,
+            python_version,
             inner: Arc::new(ArcSwapOption::new(Some(indexed::IndexedModule::new(
                 parsed,
             )))),
@@ -132,7 +155,11 @@ impl ParsedModule {
             Some(parsed) => parsed,
             None => {
                 // Re-parse the file.
-                let parsed = indexed::IndexedModule::new(parsed_module_impl(db, self.file));
+                let parsed = indexed::IndexedModule::new(parsed_module_impl(
+                    db,
+                    self.file,
+                    self.python_version,
+                ));
                 tracing::debug!(
                     "File `{}` was reparsed after being collected in the current Salsa revision",
                     self.file.path(db)
@@ -865,12 +892,13 @@ class C[T](Base, metaclass=Meta):
 mod tests {
     use crate::Db;
     use crate::files::{system_path_to_file, vendored_path_to_file};
-    use crate::parsed::parsed_module;
+    use crate::parsed::{VersionedFile, parsed_module};
     use crate::system::{
         DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemVirtualPath,
     };
     use crate::tests::TestDb;
     use crate::vendored::{VendoredFileSystemBuilder, VendoredPath};
+    use ruff_python_ast::PythonVersion;
     use zip::CompressionMethod;
 
     #[test]
@@ -882,7 +910,8 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        let parsed = parsed_module(&db, file).load(&db);
+        let versioned_file = VersionedFile::new(&db, file, PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
 
         assert!(parsed.has_valid_syntax());
 
@@ -898,7 +927,8 @@ mod tests {
 
         let file = system_path_to_file(&db, path).unwrap();
 
-        let parsed = parsed_module(&db, file).load(&db);
+        let versioned_file = VersionedFile::new(&db, file, PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
 
         assert!(parsed.has_valid_syntax());
 
@@ -914,7 +944,9 @@ mod tests {
 
         let virtual_file = db.files().virtual_file(&db, path);
 
-        let parsed = parsed_module(&db, virtual_file.file()).load(&db);
+        let versioned_file =
+            VersionedFile::new(&db, virtual_file.file(), PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
 
         assert!(parsed.has_valid_syntax());
 
@@ -930,7 +962,9 @@ mod tests {
 
         let virtual_file = db.files().virtual_file(&db, path);
 
-        let parsed = parsed_module(&db, virtual_file.file()).load(&db);
+        let versioned_file =
+            VersionedFile::new(&db, virtual_file.file(), PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
 
         assert!(parsed.has_valid_syntax());
 
@@ -961,8 +995,34 @@ else:
 
         let file = vendored_path_to_file(&db, VendoredPath::new("path.pyi")).unwrap();
 
-        let parsed = parsed_module(&db, file).load(&db);
+        let versioned_file = VersionedFile::new(&db, file, PythonVersion::latest_ty());
+        let parsed = parsed_module(&db, versioned_file).load(&db);
 
         assert!(parsed.has_valid_syntax());
+    }
+
+    #[test]
+    fn same_file_at_different_python_versions() -> crate::system::Result<()> {
+        let mut db = TestDb::new();
+        db.write_file("test.py", "type Alias = int")?;
+        let file = system_path_to_file(&db, "test.py").unwrap();
+
+        let py311 = VersionedFile::new(&db, file, PythonVersion::PY311);
+        let py312 = VersionedFile::new(&db, file, PythonVersion::PY312);
+
+        assert!(
+            !parsed_module(&db, py311)
+                .load(&db)
+                .unsupported_syntax_errors()
+                .is_empty()
+        );
+        assert!(
+            parsed_module(&db, py312)
+                .load(&db)
+                .unsupported_syntax_errors()
+                .is_empty()
+        );
+
+        Ok(())
     }
 }

--- a/crates/ruff_graph/src/db.rs
+++ b/crates/ruff_graph/src/db.rs
@@ -8,7 +8,7 @@ use ruff_db::files::Files;
 use ruff_db::system::{System, SystemPathBuf};
 use ruff_db::vendored::{VendoredFileSystem, VendoredFileSystemBuilder};
 use ruff_python_ast::PythonVersion;
-use ty_module_resolver::{FallibleStrategy, SearchPathSettings, SearchPaths};
+use ty_module_resolver::{FallibleStrategy, ResolverProgram, SearchPathSettings};
 use ty_site_packages::{PythonEnvironment, SysPrefixPathOrigin};
 
 static EMPTY_VENDORED: std::sync::LazyLock<VendoredFileSystem> = std::sync::LazyLock::new(|| {
@@ -23,8 +23,7 @@ pub struct ModuleDb {
     storage: salsa::Storage<Self>,
     files: Files,
     system: Arc<dyn System + Send + Sync + RefUnwindSafe>,
-    search_paths: Arc<SearchPaths>,
-    python_version: PythonVersion,
+    resolver_program: Option<ResolverProgram>,
 }
 
 impl ModuleDb {
@@ -52,18 +51,20 @@ impl ModuleDb {
             .to_search_paths(&system, &EMPTY_VENDORED, &FallibleStrategy)
             .context("Invalid search path settings")?;
 
-        let db = Self {
+        let mut db = Self {
             storage: salsa::Storage::new(None),
             files: Files::default(),
             system: Arc::new(system),
-            search_paths: Arc::new(search_paths),
-            python_version,
+            resolver_program: None,
         };
-
-        // Register the static roots for salsa durability
-        db.search_paths.try_register_static_roots(&db);
+        db.resolver_program = Some(ResolverProgram::create(&db, python_version, &search_paths));
 
         Ok(db)
+    }
+
+    pub(crate) fn resolver_program(&self) -> ResolverProgram {
+        self.resolver_program
+            .expect("module database has a resolver program")
     }
 }
 
@@ -82,16 +83,12 @@ impl SourceDb for ModuleDb {
     }
 
     fn python_version(&self) -> PythonVersion {
-        self.python_version
+        self.resolver_program().python_version(self)
     }
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for ModuleDb {
-    fn search_paths(&self) -> &SearchPaths {
-        &self.search_paths
-    }
-}
+impl ty_module_resolver::Db for ModuleDb {}
 
 #[salsa::db]
 impl salsa::Database for ModuleDb {}

--- a/crates/ruff_graph/src/resolver.rs
+++ b/crates/ruff_graph/src/resolver.rs
@@ -1,8 +1,8 @@
-use ruff_db::files::{File, FilePath, system_path_to_file};
+use ruff_db::files::{FilePath, system_path_to_file};
 use ruff_db::system::SystemPath;
 use ty_module_resolver::{
-    ModuleName, resolve_module, resolve_module_confident, resolve_real_module,
-    resolve_real_module_confident,
+    ModuleName, ResolverFile, ResolverProgram, resolve_module, resolve_module_confident,
+    resolve_real_module, resolve_real_module_confident,
 };
 
 use crate::ModuleDb;
@@ -11,15 +11,19 @@ use crate::collector::CollectedImport;
 /// Collect all imports for a given Python file.
 pub(crate) struct Resolver<'a> {
     db: &'a ModuleDb,
-    file: Option<File>,
+    program: ResolverProgram,
+    file: Option<ResolverFile<'a>>,
 }
 
 impl<'a> Resolver<'a> {
     /// Initialize a [`Resolver`] with a given [`ModuleDb`].
     pub(crate) fn new(db: &'a ModuleDb, path: &SystemPath) -> Self {
+        let program = db.resolver_program();
         // If we know the importing file we can potentially resolve more imports
-        let file = system_path_to_file(db, path).ok();
-        Self { db, file }
+        let file = system_path_to_file(db, path)
+            .ok()
+            .map(|file| ResolverFile::new(db, program, file));
+        Self { db, program, file }
     }
 
     /// Resolve the [`CollectedImport`] into a [`FilePath`].
@@ -103,7 +107,7 @@ impl<'a> Resolver<'a> {
         let module = if let Some(file) = self.file {
             resolve_module(self.db, file, module_name)?
         } else {
-            resolve_module_confident(self.db, module_name)?
+            resolve_module_confident(self.db, self.program, module_name)?
         };
         Some(module.file(self.db)?.path(self.db))
     }
@@ -113,7 +117,7 @@ impl<'a> Resolver<'a> {
         let module = if let Some(file) = self.file {
             resolve_real_module(self.db, file, module_name)?
         } else {
-            resolve_real_module_confident(self.db, module_name)?
+            resolve_real_module_confident(self.db, self.program, module_name)?
         };
         Some(module.file(self.db)?.path(self.db))
     }

--- a/crates/ruff_mdtest/src/lib.rs
+++ b/crates/ruff_mdtest/src/lib.rs
@@ -8,6 +8,7 @@ use mdtest::{
 };
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span};
 use ruff_db::files::{File, system_path_to_file};
+use ruff_db::parsed::VersionedFile;
 use ruff_db::source::source_text;
 use ruff_db::system::{DbWithWritableSystem as _, SystemPathBuf};
 use ruff_linter::source_kind::SourceKind;
@@ -140,7 +141,7 @@ fn run_test(
 
             let failure = match matcher::match_file(
                 db,
-                test_file.file,
+                VersionedFile::new(db, test_file.file, ruff_python_ast::PythonVersion::latest()),
                 &diagnostics,
                 mdtest::RunOptions::default(),
             )

--- a/crates/ruff_python_formatter/src/lib.rs
+++ b/crates/ruff_python_formatter/src/lib.rs
@@ -1,6 +1,5 @@
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId, Severity};
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::{VersionedFile, parsed_module};
 use ruff_db::source::source_text;
 use thiserror::Error;
 use tracing::Level;
@@ -177,10 +176,14 @@ where
     Ok(formatted)
 }
 
-pub fn formatted_file(db: &dyn Db, file: File) -> Result<Option<String>, FormatModuleError> {
+pub fn formatted_file(
+    db: &dyn Db,
+    versioned_file: VersionedFile<'_>,
+) -> Result<Option<String>, FormatModuleError> {
+    let file = versioned_file.file(db);
     let options = db.format_options(file);
 
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, versioned_file).load(db);
 
     if let Some(first) = parsed.errors().first() {
         return Err(FormatModuleError::ParseError(first.clone()));

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -8,7 +8,7 @@
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22abstract-method-in-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L958" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L959" target="_blank">View source</a>
 </small>
 
 
@@ -54,7 +54,7 @@ class Derived(Base):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ambiguous-protocol-member%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L335" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L336" target="_blank">View source</a>
 </small>
 
 
@@ -118,7 +118,7 @@ class SubProto(BaseProto, Protocol):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22assert-type-unspellable-subtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1003" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1004" target="_blank">View source</a>
 </small>
 
 
@@ -201,7 +201,7 @@ value = unknown  # ty: ignore[unresolved-reference]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L967" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L968" target="_blank">View source</a>
 </small>
 
 
@@ -256,7 +256,7 @@ Foo.method()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-non-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L189" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L190" target="_blank">View source</a>
 </small>
 
 
@@ -284,7 +284,7 @@ Calling a non-callable object will raise a `TypeError` at runtime.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.7">0.0.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-top-callable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L198" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L199" target="_blank">View source</a>
 </small>
 
 
@@ -319,7 +319,7 @@ def f(x: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-declarations%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L216" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L217" target="_blank">View source</a>
 </small>
 
 
@@ -353,7 +353,7 @@ a = 1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22conflicting-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L225" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L226" target="_blank">View source</a>
 </small>
 
 
@@ -388,7 +388,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-class-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L234" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L235" target="_blank">View source</a>
 </small>
 
 
@@ -424,7 +424,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22cyclic-type-alias-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L243" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L244" target="_blank">View source</a>
 </small>
 
 
@@ -460,7 +460,7 @@ type B = A  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22dataclass-field-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L288" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L289" target="_blank">View source</a>
 </small>
 
 
@@ -497,7 +497,7 @@ class Example:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.16">0.0.1-alpha.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22deprecated%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L261" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L262" target="_blank">View source</a>
 </small>
 
 
@@ -536,7 +536,7 @@ old_func()  # error: [deprecated]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22division-by-zero%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L252" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L253" target="_blank">View source</a>
 </small>
 
 
@@ -569,7 +569,7 @@ false positives it can produce.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L270" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L271" target="_blank">View source</a>
 </small>
 
 
@@ -600,7 +600,7 @@ class B(A, A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22duplicate-kw-only%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L279" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L280" target="_blank">View source</a>
 </small>
 
 
@@ -643,7 +643,7 @@ class A:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22empty-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L435" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L436" target="_blank">View source</a>
 </small>
 
 
@@ -720,7 +720,7 @@ def foo() -> "intt\b": ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.50">0.0.50</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22experimental-syntax%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L180" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L181" target="_blank">View source</a>
 </small>
 
 
@@ -760,7 +760,7 @@ def g(value: ~A) -> None: ...  # error: [experimental-syntax]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-on-non-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L940" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L941" target="_blank">View source</a>
 </small>
 
 
@@ -795,7 +795,7 @@ def my_function() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22final-without-value%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L949" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L950" target="_blank">View source</a>
 </small>
 
 
@@ -911,7 +911,7 @@ def test() -> "Literal[5]":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22inconsistent-mro%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L362" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L363" target="_blank">View source</a>
 </small>
 
 
@@ -947,7 +947,7 @@ class C(A, B): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22index-out-of-bounds%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L371" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L372" target="_blank">View source</a>
 </small>
 
 
@@ -977,7 +977,7 @@ t[3]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.33">0.0.1-alpha.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22ineffective-final%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L931" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L932" target="_blank">View source</a>
 </small>
 
 
@@ -1014,7 +1014,7 @@ class MyClass: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.12">0.0.1-alpha.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22instance-layout-conflict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L316" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L317" target="_blank">View source</a>
 </small>
 
 
@@ -1115,7 +1115,7 @@ an atypical memory layout.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-argument-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L408" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L409" target="_blank">View source</a>
 </small>
 
 
@@ -1147,7 +1147,7 @@ func("foo")  # error: [invalid-argument-type]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-assignment%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L444" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L445" target="_blank">View source</a>
 </small>
 
 
@@ -1178,7 +1178,7 @@ a: int = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-access%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1129" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1130" target="_blank">View source</a>
 </small>
 
 
@@ -1236,7 +1236,7 @@ C.instance_only_var = 56  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.33">0.0.33</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-attribute-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1210" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1211" target="_blank">View source</a>
 </small>
 
 
@@ -1282,7 +1282,7 @@ class Sub(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-await%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L453" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L454" target="_blank">View source</a>
 </small>
 
 
@@ -1324,7 +1324,7 @@ asyncio.run(main())
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L462" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L463" target="_blank">View source</a>
 </small>
 
 
@@ -1351,7 +1351,7 @@ class A(42): ...  # error: [invalid-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-context-manager%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L489" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L490" target="_blank">View source</a>
 </small>
 
 
@@ -1381,7 +1381,7 @@ with 1:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L306" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L307" target="_blank">View source</a>
 </small>
 
 
@@ -1434,7 +1434,7 @@ See: <https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.13">0.0.13</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-dataclass-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L297" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L298" target="_blank">View source</a>
 </small>
 
 
@@ -1470,7 +1470,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-declaration%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L498" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L499" target="_blank">View source</a>
 </small>
 
 
@@ -1502,7 +1502,7 @@ a: str  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-enum-member-annotation%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L516" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L517" target="_blank">View source</a>
 </small>
 
 
@@ -1559,7 +1559,7 @@ class Pet(Enum):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-exception-caught%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L507" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L508" target="_blank">View source</a>
 </small>
 
 
@@ -1623,7 +1623,7 @@ This rule corresponds to Ruff's [`except-with-non-exception-classes` (`B030`)](h
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.28">0.0.1-alpha.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-explicit-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L976" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L977" target="_blank">View source</a>
 </small>
 
 
@@ -1676,7 +1676,7 @@ class D(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.35">0.0.1-alpha.35</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-frozen-dataclass-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1229" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1230" target="_blank">View source</a>
 </small>
 
 
@@ -1727,7 +1727,7 @@ class NonFrozenChild(FrozenBase):  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L534" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L535" target="_blank">View source</a>
 </small>
 
 
@@ -1776,7 +1776,7 @@ class D(Generic[U, T]): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-generic-enum%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L525" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L526" target="_blank">View source</a>
 </small>
 
 
@@ -1872,7 +1872,7 @@ a = 20 / 0  # type: ignore
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.17">0.0.1-alpha.17</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L381" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L382" target="_blank">View source</a>
 </small>
 
 
@@ -1920,7 +1920,7 @@ carol = Person(name="Carol", aeg=25)  # typo!
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-positional-parameter%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1247" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1248" target="_blank">View source</a>
 </small>
 
 
@@ -1982,7 +1982,7 @@ def f(x, y, /):  # Python 3.8+ syntax
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-legacy-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L552" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L553" target="_blank">View source</a>
 </small>
 
 
@@ -2022,7 +2022,7 @@ def f(t: TypeVar("U")): ...  # ty: ignore[invalid-type-form]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-match-pattern%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L669" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L670" target="_blank">View source</a>
 </small>
 
 
@@ -2072,7 +2072,7 @@ match object():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-metaclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L597" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L598" target="_blank">View source</a>
 </small>
 
 
@@ -2107,7 +2107,7 @@ class B(metaclass=42): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-method-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1219" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1220" target="_blank">View source</a>
 </small>
 
 
@@ -2225,7 +2225,7 @@ Correct use of `@override` is enforced by ty's [`invalid-explicit-override`](#in
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.19">0.0.1-alpha.19</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L344" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L345" target="_blank">View source</a>
 </small>
 
 
@@ -2282,7 +2282,7 @@ AttributeError: Cannot overwrite NamedTuple attribute _asdict
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.31">0.0.31</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-named-tuple-override%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L353" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L354" target="_blank">View source</a>
 </small>
 
 
@@ -2330,7 +2330,7 @@ admin[0]  # "Alice"
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.27">0.0.1-alpha.27</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-newtype%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L579" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L580" target="_blank">View source</a>
 </small>
 
 
@@ -2368,7 +2368,7 @@ Baz = NewType("Baz", int | str)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L606" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L607" target="_blank">View source</a>
 </small>
 
 
@@ -2425,7 +2425,7 @@ def foo(x: int) -> int: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-parameter-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L624" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L625" target="_blank">View source</a>
 </small>
 
 
@@ -2454,7 +2454,7 @@ def f(a: int = ""): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-paramspec%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L561" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L562" target="_blank">View source</a>
 </small>
 
 
@@ -2490,7 +2490,7 @@ P2 = ParamSpec()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L325" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L326" target="_blank">View source</a>
 </small>
 
 
@@ -2526,7 +2526,7 @@ TypeError: Protocols can only inherit from other protocols, got <class 'int'>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-raise%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L633" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L634" target="_blank">View source</a>
 </small>
 
 
@@ -2597,7 +2597,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-return-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L417" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L418" target="_blank">View source</a>
 </small>
 
 
@@ -2629,7 +2629,7 @@ def func() -> int:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-super-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L642" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L643" target="_blank">View source</a>
 </small>
 
 
@@ -2740,7 +2740,7 @@ class C: ...
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.10">0.0.10</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-total-ordering%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1238" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1239" target="_blank">View source</a>
 </small>
 
 
@@ -2791,7 +2791,7 @@ class MyClass:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.6">0.0.1-alpha.6</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-alias-type%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L570" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L571" target="_blank">View source</a>
 </small>
 
 
@@ -2832,7 +2832,7 @@ NewAlias = TypeAliasType(get_name(), int)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L823" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L824" target="_blank">View source</a>
 </small>
 
 
@@ -2899,7 +2899,7 @@ Bar[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-checking-constant%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L651" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L652" target="_blank">View source</a>
 </small>
 
 
@@ -2932,7 +2932,7 @@ TYPE_CHECKING = ""  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-form%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L660" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L661" target="_blank">View source</a>
 </small>
 
 
@@ -2968,7 +2968,7 @@ b: Annotated[int]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L687" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L688" target="_blank">View source</a>
 </small>
 
 
@@ -3015,7 +3015,7 @@ is_int(value=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.11">0.0.1-alpha.11</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-guard-definition%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L678" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L679" target="_blank">View source</a>
 </small>
 
 
@@ -3072,7 +3072,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-bound%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L705" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L706" target="_blank">View source</a>
 </small>
 
 
@@ -3116,7 +3116,7 @@ def g[U, T: U](): ...  # error: [invalid-type-variable-bound]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-constraints%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L696" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L697" target="_blank">View source</a>
 </small>
 
 
@@ -3173,7 +3173,7 @@ V = TypeVar("V", list[int], int)  # valid constrained Type
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-type-variable-default%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L714" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L715" target="_blank">View source</a>
 </small>
 
 
@@ -3215,7 +3215,7 @@ U = TypeVar("U", int, str, default=bytes)  # error: [invalid-type-variable-defau
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.28">0.0.28</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-field%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1192" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1193" target="_blank">View source</a>
 </small>
 
 
@@ -3251,7 +3251,7 @@ class Child(Base):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-header%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1201" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1202" target="_blank">View source</a>
 </small>
 
 
@@ -3294,7 +3294,7 @@ def f(options: dict[str, object]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.9">0.0.9</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-typed-dict-statement%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1183" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1184" target="_blank">View source</a>
 </small>
 
 
@@ -3329,7 +3329,7 @@ class Foo(TypedDict):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.25">0.0.25</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22invalid-yield%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L426" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L427" target="_blank">View source</a>
 </small>
 
 
@@ -3364,7 +3364,7 @@ def gen() -> Iterator[int]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.14">0.0.14</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-protocol%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L390" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L391" target="_blank">View source</a>
 </small>
 
 
@@ -3431,7 +3431,7 @@ def h(arg2: type):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.15">0.0.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22isinstance-against-typed-dict%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L399" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L400" target="_blank">View source</a>
 </small>
 
 
@@ -3481,7 +3481,7 @@ def g(arg: object):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22mismatched-type-name%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L588" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L589" target="_blank">View source</a>
 </small>
 
 
@@ -3524,7 +3524,7 @@ Movie = TypedDict("Film", {"title": str})  # error: [mismatched-type-name]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L732" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L733" target="_blank">View source</a>
 </small>
 
 
@@ -3555,7 +3555,7 @@ func()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L985" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L986" target="_blank">View source</a>
 </small>
 
 
@@ -3614,7 +3614,7 @@ class ExplicitChild(Parent):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.45">0.0.45</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-type-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L741" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L742" target="_blank">View source</a>
 </small>
 
 
@@ -3653,7 +3653,7 @@ def handle(m: re.Match[str]) -> str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.20">0.0.1-alpha.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-typed-dict-key%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1174" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1175" target="_blank">View source</a>
 </small>
 
 
@@ -3692,7 +3692,7 @@ alice["age"]  # KeyError
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22no-matching-overload%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L805" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L806" target="_blank">View source</a>
 </small>
 
 
@@ -3730,7 +3730,7 @@ func("string")  # error: [no-matching-overload]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.30">0.0.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22non-callable-init-subclass%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L543" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L544" target="_blank">View source</a>
 </small>
 
 
@@ -3768,7 +3768,7 @@ class Sub(Super): ...  # error: [non-callable-init-subclass]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-iterable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L832" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L833" target="_blank">View source</a>
 </small>
 
 
@@ -3797,7 +3797,7 @@ for i in 34:  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22not-subscriptable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L814" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L815" target="_blank">View source</a>
 </small>
 
 
@@ -3825,7 +3825,7 @@ Subscripting an object that does not support it will raise a `TypeError` at runt
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.29">0.0.1-alpha.29</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L913" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L914" target="_blank">View source</a>
 </small>
 
 
@@ -3862,7 +3862,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22override-of-final-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L922" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L923" target="_blank">View source</a>
 </small>
 
 
@@ -3899,7 +3899,7 @@ class B(A):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22parameter-already-assigned%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L850" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L851" target="_blank">View source</a>
 </small>
 
 
@@ -3930,7 +3930,7 @@ f(1, x=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22positional-only-parameter-as-kwarg%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1057" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1058" target="_blank">View source</a>
 </small>
 
 
@@ -3961,7 +3961,7 @@ f(x=1)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L859" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L860" target="_blank">View source</a>
 </small>
 
 
@@ -4000,7 +4000,7 @@ A.c  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-implicit-call%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L207" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L208" target="_blank">View source</a>
 </small>
 
 
@@ -4039,7 +4039,7 @@ A()[0]  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L877" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L878" target="_blank">View source</a>
 </small>
 
 
@@ -4085,7 +4085,7 @@ from module import a  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.23">0.0.23</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-missing-submodule%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L868" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L869" target="_blank">View source</a>
 </small>
 
 
@@ -4117,7 +4117,7 @@ html.parser  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22possibly-unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L886" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L887" target="_blank">View source</a>
 </small>
 
 
@@ -4189,7 +4189,7 @@ def test() -> "int":
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-cast%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1138" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1139" target="_blank">View source</a>
 </small>
 
 
@@ -4224,7 +4224,7 @@ cast(int, f())  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.18">0.0.18</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22redundant-final-classvar%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1147" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1148" target="_blank">View source</a>
 </small>
 
 
@@ -4262,7 +4262,7 @@ class C:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22shadowed-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1156" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1157" target="_blank">View source</a>
 </small>
 
 
@@ -4306,7 +4306,7 @@ class Outer[T]:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22static-assert-error%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1120" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1121" target="_blank">View source</a>
 </small>
 
 
@@ -4341,7 +4341,7 @@ static_assert(int(2.0 * 3.0) == 6)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.39">0.0.39</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-dataclass-with-order%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L904" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L905" target="_blank">View source</a>
 </small>
 
 
@@ -4392,7 +4392,7 @@ Consider using [`functools.total_ordering`][total_ordering] instead, which does 
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22subclass-of-final-class%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L895" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L896" target="_blank">View source</a>
 </small>
 
 
@@ -4426,7 +4426,7 @@ class B(A): ...  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.30">0.0.1-alpha.30</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22super-call-in-named-tuple-method%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1030" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1031" target="_blank">View source</a>
 </small>
 
 
@@ -4466,7 +4466,7 @@ class F(NamedTuple):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22too-many-positional-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1012" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1013" target="_blank">View source</a>
 </small>
 
 
@@ -4496,7 +4496,7 @@ f("foo")  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22type-assertion-failure%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L994" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L995" target="_blank">View source</a>
 </small>
 
 
@@ -4535,7 +4535,7 @@ def _(x: int):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unavailable-implicit-super-arguments%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1021" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1022" target="_blank">View source</a>
 </small>
 
 
@@ -4593,7 +4593,7 @@ class A:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.20">0.0.20</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unbound-type-variable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L723" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L724" target="_blank">View source</a>
 </small>
 
 
@@ -4637,7 +4637,7 @@ class C(Generic[T]):
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22undefined-reveal%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1039" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1040" target="_blank">View source</a>
 </small>
 
 
@@ -4666,7 +4666,7 @@ reveal_type(1)  # revealed: Literal[1]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unknown-argument%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1048" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1049" target="_blank">View source</a>
 </small>
 
 
@@ -4697,7 +4697,7 @@ f(x=1, y=2)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-attribute%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1066" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1067" target="_blank">View source</a>
 </small>
 
 
@@ -4730,7 +4730,7 @@ A().foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.15">0.0.1-alpha.15</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-global%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1165" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1166" target="_blank">View source</a>
 </small>
 
 
@@ -4805,7 +4805,7 @@ def g():
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-import%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1075" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1076" target="_blank">View source</a>
 </small>
 
 
@@ -4834,7 +4834,7 @@ import foo  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unresolved-reference%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1084" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1085" target="_blank">View source</a>
 </small>
 
 
@@ -4862,7 +4862,7 @@ print(x)  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.7">0.0.1-alpha.7</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L471" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L472" target="_blank">View source</a>
 </small>
 
 
@@ -4909,7 +4909,7 @@ class D(C): ...  # error: [unsupported-base]
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-bool-conversion%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L841" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L842" target="_blank">View source</a>
 </small>
 
 
@@ -4958,7 +4958,7 @@ b1 < b2 < b1  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.12">0.0.12</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-dynamic-base%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L480" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L481" target="_blank">View source</a>
 </small>
 
 
@@ -5005,7 +5005,7 @@ def factory(base: type[Base]) -> type:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unsupported-operator%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1093" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1094" target="_blank">View source</a>
 </small>
 
 
@@ -5038,7 +5038,7 @@ A() + A()  # error
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1102" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1103" target="_blank">View source</a>
 </small>
 
 
@@ -5158,7 +5158,7 @@ to `false`.
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.22">0.0.1-alpha.22</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22useless-overload-body%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L615" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L616" target="_blank">View source</a>
 </small>
 
 
@@ -5237,7 +5237,7 @@ def foo(x: int | str) -> int | str:
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
 Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.1-alpha.1">0.0.1-alpha.1</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22zero-stepsize-in-slice%22" target="_blank">Related issues</a> ·
-<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1111" target="_blank">View source</a>
+<a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1112" target="_blank">View source</a>
 </small>
 
 

--- a/crates/ty/src/lib.rs
+++ b/crates/ty/src/lib.rs
@@ -395,12 +395,17 @@ impl MainLoop {
                             }
                         }
                         MainLoopMode::Fix(mode) => {
+                            let program = db.project().program(db);
                             let result = match mode {
-                                FixMode::AddIgnore => {
-                                    suppress_all_diagnostics(db, result, &self.cancellation_token)
-                                }
+                                FixMode::AddIgnore => suppress_all_diagnostics(
+                                    db,
+                                    program,
+                                    result,
+                                    &self.cancellation_token,
+                                ),
                                 FixMode::ApplyFixes => fix_all_diagnostics(
                                     db,
+                                    program,
                                     result,
                                     Applicability::Safe,
                                     &self.cancellation_token,

--- a/crates/ty/tests/file_watching.rs
+++ b/crates/ty/tests/file_watching.rs
@@ -11,7 +11,7 @@ use ruff_db::system::{
 };
 use ruff_python_ast::PythonVersion;
 use ruff_ranged_value::{RangedValue, ValueSource};
-use ty_module_resolver::{Module, ModuleName, resolve_module_confident};
+use ty_module_resolver::{Module, ModuleName};
 use ty_project::metadata::options::{EnvironmentOptions, Options, SrcOptions};
 use ty_project::metadata::pyproject::{PyProject, Tool};
 use ty_project::metadata::python_version::SupportedPythonVersion;
@@ -20,6 +20,13 @@ use ty_project::watch::{ChangeEvent, ProjectWatcher, directory_watcher};
 use ty_project::{ChangeResult, Db, ProjectDatabase, ProjectMetadata};
 use ty_python_core::platform::PythonPlatform;
 use ty_static::EnvVars;
+
+fn resolve_module_confident<'db>(
+    db: &'db ProjectDatabase,
+    name: &ModuleName,
+) -> Option<Module<'db>> {
+    ty_module_resolver::resolve_module_confident(db, db.project().program(db).resolver(db), name)
+}
 
 struct TestCase {
     db: ProjectDatabase,

--- a/crates/ty_completion_bench/Cargo.toml
+++ b/crates/ty_completion_bench/Cargo.toml
@@ -16,6 +16,7 @@ ruff_text_size = { workspace = true }
 
 ty_ide = { workspace = true }
 ty_project = { workspace = true }
+ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_bench/src/main.rs
+++ b/crates/ty_completion_bench/src/main.rs
@@ -17,7 +17,8 @@ use ty_ide::{Completion, CompletionCapabilities};
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_project::{Db as _, ProjectDatabase, ProjectMetadata};
+use ty_python_core::environment::ProgramFile;
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -142,7 +143,7 @@ fn get_completions<'db>(
         db,
         &settings,
         CompletionCapabilities::default(),
-        file,
+        ProgramFile::new(db, db.project().program(db), file),
         offset,
     ))
 }

--- a/crates/ty_completion_eval/Cargo.toml
+++ b/crates/ty_completion_eval/Cargo.toml
@@ -17,6 +17,7 @@ ruff_text_size = { workspace = true }
 ty_ide = { workspace = true }
 ty_module_resolver = { workspace = true }
 ty_project = { workspace = true }
+ty_python_core = { workspace = true }
 
 anyhow = { workspace = true }
 bstr = { workspace = true }

--- a/crates/ty_completion_eval/src/main.rs
+++ b/crates/ty_completion_eval/src/main.rs
@@ -17,7 +17,8 @@ use ty_module_resolver::ModuleName;
 use ty_project::metadata::Options;
 use ty_project::metadata::options::EnvironmentOptions;
 use ty_project::metadata::value::RelativePathBuf;
-use ty_project::{ProjectDatabase, ProjectMetadata};
+use ty_project::{Db as _, ProjectDatabase, ProjectMetadata};
+use ty_python_core::environment::ProgramFile;
 
 #[derive(Debug, clap::Parser)]
 #[command(
@@ -330,7 +331,7 @@ impl Task {
             &self.db,
             &self.settings,
             CompletionCapabilities::default(),
-            file,
+            ProgramFile::new(&self.db, self.db.project().program(&self.db), file),
             offset,
         );
         Ok(completions)

--- a/crates/ty_ide/src/all_symbols.rs
+++ b/crates/ty_ide/src/all_symbols.rs
@@ -3,6 +3,7 @@ use rayon::prelude::*;
 use ruff_db::files::File;
 use ty_module_resolver::{Module, ModuleName, all_modules, resolve_real_shadowable_module};
 use ty_project::{Db, parallel::ParallelIteratorExt};
+use ty_python_core::environment::ProgramFile;
 
 use crate::{
     SymbolKind,
@@ -15,7 +16,7 @@ use crate::{
 /// by the query.
 pub fn all_symbols<'db>(
     db: &'db dyn Db,
-    importing_from: File,
+    importing_from: ProgramFile<'db>,
     query: &QueryPattern,
 ) -> Vec<AllSymbolInfo<'db>> {
     // If the query is empty, return immediately to avoid expensive file scanning
@@ -26,11 +27,14 @@ pub fn all_symbols<'db>(
     let all_symbols_span = tracing::debug_span!("all_symbols");
     let _span = all_symbols_span.enter();
 
+    let file = importing_from.file(db);
+    let program = importing_from.program(db);
     let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
-    let is_typing_extensions_available = importing_from.is_stub(db)
-        || resolve_real_shadowable_module(db, importing_from, &typing_extensions).is_some();
+    let is_typing_extensions_available = file.is_stub(db)
+        || resolve_real_shadowable_module(db, importing_from.resolver_file(db), &typing_extensions)
+            .is_some();
 
-    let results = all_modules(db)
+    let results = all_modules(db, program.resolver(db))
         .into_par_iter()
         .map_with_db(db, |db, module| {
             let Some(file) = module.file(db) else {
@@ -69,7 +73,8 @@ pub fn all_symbols<'db>(
             if query.is_match_symbol_name(module.name(db)) {
                 symbols.push(AllSymbolInfo::from_module(db, module, file));
             }
-            for (_, symbol) in symbols_for_file_global_only(db, file).search(query) {
+            let program_file = ProgramFile::new(db, program, file);
+            for (_, symbol) in symbols_for_file_global_only(db, program_file).search(query) {
                 // Test functions (starting with `test_`) in third-party
                 // packages are almost never useful to import.
                 if is_non_first_party && symbol.name.starts_with("test_") {
@@ -709,7 +714,11 @@ def zqzqzq():
         info: Function zqzqzq
         ");
 
-        let symbols = all_symbols(&test.db, test.cursor.file, &QueryPattern::fuzzy("zqzqzq"));
+        let symbols = all_symbols(
+            &test.db,
+            test.cursor_program_file(),
+            &QueryPattern::fuzzy("zqzqzq"),
+        );
         let symbol = symbols
             .iter()
             .find_map(|info| info.symbol.as_ref())
@@ -1126,7 +1135,11 @@ def test_helper_xyzxyzxyz():
 
     impl CursorTest {
         fn all_symbols(&self, query: &str) -> String {
-            let symbols = all_symbols(&self.db, self.cursor.file, &QueryPattern::fuzzy(query));
+            let symbols = all_symbols(
+                &self.db,
+                self.cursor_program_file(),
+                &QueryPattern::fuzzy(query),
+            );
 
             if symbols.is_empty() {
                 return "No symbols found".to_string();

--- a/crates/ty_ide/src/call_hierarchy.rs
+++ b/crates/ty_ide/src/call_hierarchy.rs
@@ -14,13 +14,13 @@ pub(crate) mod outgoing_calls;
 use crate::goto::{GotoTarget, find_goto_target};
 use crate::{Db, SymbolKind};
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::CoveringNode;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_python_core::definition::DefinitionKind;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
 /// Resolve the symbol at `offset` to a list of [`CallHierarchyItem`]s.
@@ -32,11 +32,11 @@ use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticMode
 /// cursor on a specific `@overload def` yields just that one.
 pub fn prepare_call_hierarchy(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<Vec<CallHierarchyItem>> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let definitions = goto_target
         .definitions(&model, ImportAliasResolution::ResolveAliases)?
@@ -48,7 +48,7 @@ pub fn prepare_call_hierarchy(
             continue;
         };
 
-        let module_ref = parsed_module(db, def.file(db)).load(db);
+        let module_ref = def.program_file(db).parsed(db).load(db);
 
         if let Some(item) = CallHierarchyItem::from_definition(db, resolved, &module_ref) {
             items.push(item);
@@ -108,7 +108,7 @@ impl CallHierarchyItem {
         Some(CallHierarchyItem {
             name: Name::new(name),
             kind,
-            detail: module_detail(db, def_file),
+            detail: module_detail(db, def.program_file(db)),
             file: def_file,
             full_range: def.full_range(db, module).range(),
             selection_range: def.focus_range(db, module).range(),
@@ -116,8 +116,9 @@ impl CallHierarchyItem {
     }
 }
 
-fn module_detail(db: &dyn Db, file: File) -> Option<String> {
-    ty_module_resolver::file_to_module(db, file).map(|module| module.name(db).to_string())
+fn module_detail(db: &dyn Db, program_file: ProgramFile<'_>) -> Option<String> {
+    ty_module_resolver::file_to_module(db, program_file.resolver_file(db))
+        .map(|module| module.name(db).to_string())
 }
 
 #[cfg(test)]
@@ -196,7 +197,7 @@ mod tests {
 
     impl CursorTest {
         pub(super) fn prepare_calls(&self) -> Option<Vec<CallHierarchyItem>> {
-            prepare_call_hierarchy(&self.db, self.cursor.file, self.cursor.offset)
+            prepare_call_hierarchy(&self.db, self.cursor_program_file(), self.cursor.offset)
         }
 
         fn prepare_call_hierarchy(&self) -> String {

--- a/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/incoming_calls.rs
@@ -4,7 +4,7 @@ use crate::references::{contains_identifier, has_any_external_visible_definition
 use crate::{CallHierarchyItem, Db, SymbolKind};
 use rayon::prelude::*;
 use ruff_db::files::File;
-use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+use ruff_db::parsed::ParsedModuleRef;
 use ruff_python_ast::helpers::is_dunder;
 use ruff_python_ast::name::Name;
 use ruff_python_ast::token::Tokens;
@@ -13,6 +13,7 @@ use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::FxHashMap;
 use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::scope::{NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::types::ide_support::static_member_type_for_attribute;
 use ty_python_semantic::types::{PropertyAccessorRole, Type};
@@ -26,9 +27,15 @@ const MAX_MIN_FILES_PER_PARALLEL_JOB: usize = 16;
 
 /// Find every place in the project that calls the symbol at `offset`, grouped
 /// by enclosing function/method/class/module.
-pub fn incoming_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<IncomingCall> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+pub fn incoming_calls(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+    offset: TextSize,
+) -> Vec<IncomingCall> {
+    let file = program_file.file(db);
+    let program = program_file.program(db);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let Some(goto_target) = find_goto_target(&model, &module, offset) else {
         return Vec::new();
     };
@@ -68,7 +75,7 @@ pub fn incoming_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Incoming
     let needle = (!is_dunder(needle)).then_some(needle);
 
     // Collect raw `(caller_file, call_site_range, enclosing_scope)` triples.
-    let mut raw = call_sites_for_file(db, file, &target_definitions, target_role, needle);
+    let mut raw = call_sites_for_file(db, program_file, &target_definitions, target_role, needle);
 
     if is_externally_visible {
         let files = db.project().files(db);
@@ -96,7 +103,13 @@ pub fn incoming_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Incoming
                     return Vec::new();
                 }
 
-                call_sites_for_file(db, other_file, &target_definitions, target_role, needle)
+                call_sites_for_file(
+                    db,
+                    ProgramFile::new(db, program, other_file),
+                    &target_definitions,
+                    target_role,
+                    needle,
+                )
             })
             .flat_map_iter(|sites| sites)
             .collect::<Vec<_>>();
@@ -159,14 +172,14 @@ struct EnclosingKey {
 /// `target_definitions`.
 fn call_sites_for_file(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_role: Option<PropertyAccessorRole>,
     needle: Option<&str>,
 ) -> Vec<RawCallSite> {
-    let parsed = parsed_module(db, file);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
     let mut sites = Vec::new();
 
     let mut finder = CallSitesFinder {
@@ -386,11 +399,11 @@ impl<'a> CallSitesFinder<'a, '_> {
                 ScopeKind::Module | ScopeKind::Function | ScopeKind::Class | ScopeKind::Lambda
             )
         }) else {
-            return module_item(self.db, file);
+            return module_item(self.db, self.model.program_file());
         };
 
         match enclosing.node() {
-            NodeWithScopeKind::Module => module_item(self.db, file),
+            NodeWithScopeKind::Module => module_item(self.db, self.model.program_file()),
             NodeWithScopeKind::Function(func) => {
                 let func = func.node(self.module);
                 let is_method = ancestors
@@ -409,7 +422,7 @@ impl<'a> CallSitesFinder<'a, '_> {
                     } else {
                         SymbolKind::Function
                     },
-                    detail: module_detail(self.db, file),
+                    detail: module_detail(self.db, self.model.program_file()),
                     file,
                     full_range: func.range(),
                     selection_range: func.name.range(),
@@ -420,7 +433,7 @@ impl<'a> CallSitesFinder<'a, '_> {
                 CallHierarchyItem {
                     name: Name::new(class.name.as_str()),
                     kind: SymbolKind::Class,
-                    detail: module_detail(self.db, file),
+                    detail: module_detail(self.db, self.model.program_file()),
                     file,
                     full_range: class.range(),
                     selection_range: class.name.range(),
@@ -437,13 +450,13 @@ impl<'a> CallSitesFinder<'a, '_> {
                 CallHierarchyItem {
                     name: Name::new_static("(lambda)"),
                     kind: SymbolKind::Function,
-                    detail: module_detail(self.db, file),
+                    detail: module_detail(self.db, self.model.program_file()),
                     file,
                     full_range: lambda.range(),
                     selection_range: TextRange::new(lambda.start(), end),
                 }
             }
-            _ => module_item(self.db, file),
+            _ => module_item(self.db, self.model.program_file()),
         }
     }
 }
@@ -454,8 +467,9 @@ struct RawCallSite {
 }
 
 /// Build an item for the module-level enclosing scope (no enclosing function).
-fn module_item(db: &dyn Db, file: File) -> CallHierarchyItem {
-    let name = ty_module_resolver::file_to_module(db, file)
+fn module_item(db: &dyn Db, program_file: ProgramFile<'_>) -> CallHierarchyItem {
+    let file = program_file.file(db);
+    let name = ty_module_resolver::file_to_module(db, program_file.resolver_file(db))
         .map(|module| Name::new(module.name(db).last_component()))
         .unwrap_or_else(|| Name::new_static("<module>"));
     CallHierarchyItem {
@@ -512,7 +526,11 @@ mod tests {
             else {
                 return "No incoming calls found".to_string();
             };
-            let calls = incoming_calls(&self.db, target.file, target.selection_range.start());
+            let calls = incoming_calls(
+                &self.db,
+                self.program_file(target.file),
+                target.selection_range.start(),
+            );
             if calls.is_empty() {
                 return "No incoming calls found".to_string();
             }
@@ -1160,7 +1178,11 @@ def make() -> C:
         else {
             panic!("expected a call hierarchy target");
         };
-        let incoming = incoming_calls(&test.db, target.file, target.selection_range.start());
+        let incoming = incoming_calls(
+            &test.db,
+            test.program_file(target.file),
+            target.selection_range.start(),
+        );
         // The selection identifies the anonymous callable header.
         let sel = incoming[0].from.selection_range;
         let source = test.cursor.source.as_str();
@@ -1297,14 +1319,18 @@ def make() -> C:
         else {
             panic!("expected a call hierarchy target");
         };
-        let incoming = incoming_calls(&test.db, target.file, target.selection_range.start());
+        let incoming = incoming_calls(
+            &test.db,
+            test.program_file(target.file),
+            target.selection_range.start(),
+        );
         assert_eq!(incoming.len(), 1, "got {incoming:?}");
         let lambda_item = &incoming[0].from;
         assert_eq!(lambda_item.name.as_str(), "(lambda)");
 
         let follow_up_incoming = incoming_calls(
             &test.db,
-            lambda_item.file,
+            test.program_file(lambda_item.file),
             lambda_item.selection_range.start(),
         );
         assert!(
@@ -1314,7 +1340,7 @@ def make() -> C:
 
         let follow_up_outgoing = outgoing_calls(
             &test.db,
-            lambda_item.file,
+            test.program_file(lambda_item.file),
             lambda_item.selection_range.start(),
         );
         assert!(

--- a/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
+++ b/crates/ty_ide/src/call_hierarchy/outgoing_calls.rs
@@ -4,7 +4,6 @@ use crate::call_hierarchy::CalleeLeaf;
 use crate::goto::find_goto_target;
 use crate::{CallHierarchyItem, Db};
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::visitor::source_order::{
     walk_arguments, walk_decorator, walk_expr, walk_parameters, walk_type_params,
@@ -16,6 +15,7 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashMap;
 use ty_python_core::definition::DefinitionKind;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
 /// Find the callees associated with the function, method, or class at `offset`.
@@ -29,9 +29,13 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// are reported when the nested callable is expanded separately. Declaration
 /// expressions attached to a nested callable are still included while
 /// traversing the containing item's body.
-pub fn outgoing_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<OutgoingCall> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+pub fn outgoing_calls(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+    offset: TextSize,
+) -> Vec<OutgoingCall> {
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let Some(goto_target) = find_goto_target(&model, &module, offset) else {
         return Vec::new();
     };
@@ -51,10 +55,10 @@ pub fn outgoing_calls(db: &dyn Db, file: File, offset: TextSize) -> Vec<Outgoing
         let Some(def) = resolved.definition() else {
             continue;
         };
-        let def_file = def.file(db);
-        let parsed = parsed_module(db, def_file).load(db);
+        let program_file = def.program_file(db);
+        let parsed = program_file.parsed(db).load(db);
 
-        let model = SemanticModel::new(db, def_file);
+        let model = SemanticModel::new(db, program_file);
         let mut finder = OutgoingCallsFinder {
             db,
             model: &model,
@@ -151,8 +155,9 @@ impl<'a> OutgoingCallsFinder<'a, '_> {
                 DefinitionKind::Function(_) | DefinitionKind::Class(_) => {}
                 _ => continue,
             }
-            let def_file = def.file(self.db);
-            let module_ref = parsed_module(self.db, def_file).load(self.db);
+            let program_file = def.program_file(self.db);
+            let def_file = program_file.file(self.db);
+            let module_ref = program_file.parsed(self.db).load(self.db);
             let selection_range = def.focus_range(self.db, &module_ref).range();
 
             let key = CalleeKey {
@@ -304,7 +309,11 @@ mod tests {
             else {
                 return "No outgoing calls found".to_string();
             };
-            let calls = outgoing_calls(&self.db, target.file, target.selection_range.start());
+            let calls = outgoing_calls(
+                &self.db,
+                self.program_file(target.file),
+                target.selection_range.start(),
+            );
             if calls.is_empty() {
                 return "No outgoing calls found".to_string();
             }

--- a/crates/ty_ide/src/code_action.rs
+++ b/crates/ty_ide/src/code_action.rs
@@ -1,10 +1,10 @@
 use crate::completion;
 
-use ruff_db::{files::File, parsed::parsed_module};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::find_node::covering_node;
 use ruff_text_size::TextRange;
 use ty_project::Db;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::lint::LintId;
 use ty_python_semantic::suppress_single;
 use ty_python_semantic::types::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE};
@@ -19,7 +19,7 @@ pub struct QuickFix {
 
 pub fn code_actions(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     diagnostic_range: TextRange,
     diagnostic_id: &str,
 ) -> Vec<QuickFix> {
@@ -34,7 +34,7 @@ pub fn code_actions(
     let is_unresolved_reference =
         lint_id == LintId::of(&UNRESOLVED_REFERENCE) || lint_id == LintId::of(&UNDEFINED_REVEAL);
     if is_unresolved_reference
-        && let Some(import_quick_fix) = unresolved_fixes(db, file, diagnostic_range)
+        && let Some(import_quick_fix) = unresolved_fixes(db, program_file, diagnostic_range)
     {
         actions.extend(import_quick_fix);
     }
@@ -42,7 +42,13 @@ pub fn code_actions(
     // Suggest just suppressing the lint (always a valid option, but never ideal)
     actions.push(QuickFix {
         title: format!("Ignore '{}' for this line", lint_id.name()),
-        edits: suppress_single(db, file, lint_id, diagnostic_range).into_edits(),
+        edits: suppress_single(
+            db,
+            program_file.versioned_file(db),
+            lint_id,
+            diagnostic_range,
+        )
+        .into_edits(),
         preferred: false,
     });
 
@@ -51,15 +57,15 @@ pub fn code_actions(
 
 fn unresolved_fixes(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     diagnostic_range: TextRange,
 ) -> Option<impl Iterator<Item = QuickFix>> {
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = program_file.parsed(db).load(db);
     let node = covering_node(parsed.syntax().into(), diagnostic_range).node();
     let symbol = &node.expr_name()?.id;
 
     Some(
-        completion::unresolved_fixes(db, file, &parsed, symbol, node)
+        completion::unresolved_fixes(db, program_file, &parsed, symbol, node)
             .into_iter()
             .map(|import| QuickFix {
                 title: import.label,
@@ -86,7 +92,8 @@ mod tests {
     use ruff_diagnostics::Fix;
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::{TextRange, TextSize};
-    use ty_project::ProjectMetadata;
+    use ty_project::{Db as _, ProjectMetadata};
+    use ty_python_core::environment::ProgramFile;
     use ty_python_semantic::{
         lint::LintMetadata,
         types::{UNDEFINED_REVEAL, UNRESOLVED_REFERENCE},
@@ -826,7 +833,11 @@ mod tests {
                 .context(0)
                 .format(DiagnosticFormat::Full);
 
-            for mut action in code_actions(&self.db, self.file, self.diagnostic_range, &lint.name) {
+            let program_file =
+                ProgramFile::new(&self.db, self.db.project().program(&self.db), self.file);
+            for mut action in
+                code_actions(&self.db, program_file, self.diagnostic_range, &lint.name)
+            {
                 let mut diagnostic = Diagnostic::new(
                     DiagnosticId::Lint(LintName::of("code-action")),
                     ruff_db::diagnostic::Severity::Info,

--- a/crates/ty_ide/src/completion.rs
+++ b/crates/ty_ide/src/completion.rs
@@ -2,8 +2,7 @@ use std::cmp::Ordering;
 use std::collections::{BinaryHeap, binary_heap};
 
 use compact_str::CompactString;
-use ruff_db::files::File;
-use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+use ruff_db::parsed::ParsedModuleRef;
 use ruff_db::source::{SourceText, source_text};
 use ruff_diagnostics::Edit;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
@@ -16,6 +15,8 @@ use ruff_python_literal::escape::{Escape, UnicodeEscape};
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{KnownModule, Module, ModuleName};
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::Program;
 use ty_python_semantic::HasType;
 use ty_python_semantic::types::{SpecialFormType, UnionType};
 use ty_python_semantic::{
@@ -33,24 +34,30 @@ pub fn completion<'db>(
     db: &'db dyn Db,
     settings: &CompletionSettings,
     capabilities: CompletionCapabilities,
-    file: File,
+    program_file: ProgramFile<'db>,
     offset: TextSize,
 ) -> Vec<Completion<'db>> {
-    let parsed = parsed_module(db, file).load(db);
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db).load(db);
     let source = source_text(db, file);
 
-    let Some(context) = Context::new(db, file, &parsed, &source, offset) else {
+    let Some(context) = Context::new(db, program_file, &parsed, &source, offset) else {
         return vec![];
     };
-    let model = SemanticModel::new(db, file);
+    let program = program_file.program(db);
+    let model = SemanticModel::new(db, program_file);
 
     if !matches!(context.kind, ContextKind::Keywords(_)) && context.cursor.is_in_string() {
         let Some(string_expr) = context.cursor.enclosing_string_literal_expr() else {
             return vec![];
         };
 
-        let mut completions =
-            Completions::new(db, CollectionContext::none(), UserQuery::fuzzy(None));
+        let mut completions = Completions::new(
+            db,
+            program,
+            CollectionContext::none(),
+            UserQuery::fuzzy(None),
+        );
 
         add_string_literal_completions(
             &model,
@@ -65,6 +72,7 @@ pub fn completion<'db>(
     let query = UserQuery::fuzzy(context.cursor.typed);
     let mut completions = Completions::new(
         db,
+        program,
         context.collection_context(db, &model, settings, capabilities),
         query,
     );
@@ -76,7 +84,7 @@ pub fn completion<'db>(
             }
         }
         ContextKind::Import(ref import) => {
-            import.add_completions(db, file, &mut completions);
+            import.add_completions(db, program_file, &mut completions);
         }
         ContextKind::NonImport(ref non_import) => match non_import.target {
             CompletionTargetAst::ObjectDot { expr } => {
@@ -90,16 +98,20 @@ pub fn completion<'db>(
                         ModuleDependencyKind::Current
                     };
                     completions.add(
-                        CompletionBuilder::from_semantic_completion(db, semantic_completion)
-                            .module_dependency_kind(module_dependency_kind),
+                        CompletionBuilder::from_semantic_completion(
+                            db,
+                            program,
+                            semantic_completion,
+                        )
+                        .module_dependency_kind(module_dependency_kind),
                     );
                 }
-                add_keyword_completions(db, &mut completions);
+                add_keyword_completions(db, program, &mut completions);
                 add_argument_completions(db, &model, &context.cursor, &mut completions);
                 if settings.auto_import {
                     add_unimported_completions(
                         db,
-                        file,
+                        program_file,
                         &parsed,
                         scoped,
                         |module_name: &ModuleName, symbol: &str| {
@@ -131,6 +143,7 @@ impl CompletionCapabilities {
 /// A collection of completions built up from various sources.
 struct Completions<'db> {
     db: &'db dyn Db,
+    program: Program,
     context: CollectionContext<'db>,
     items: BinaryHeap<CompletionRanker<'db>>,
     /// The query used to match against candidate completions.
@@ -154,9 +167,15 @@ impl<'db> Completions<'db> {
     /// the user has typed as part of the next symbol they are writing.
     /// This collection will treat it as a query when present, and only
     /// add completions that match it.
-    fn new(db: &'db dyn Db, context: CollectionContext<'db>, query: UserQuery) -> Completions<'db> {
+    fn new(
+        db: &'db dyn Db,
+        program: Program,
+        context: CollectionContext<'db>,
+        query: UserQuery,
+    ) -> Completions<'db> {
         Completions {
             db,
+            program,
             context,
             items: BinaryHeap::new(),
             query,
@@ -228,7 +247,9 @@ impl<'db> Completions<'db> {
     /// When added, `true` is returned.
     fn add_semantic(&mut self, completion: SemanticCompletion<'db>) -> bool {
         self.add(CompletionBuilder::from_semantic_completion(
-            self.db, completion,
+            self.db,
+            self.program,
+            completion,
         ))
     }
 
@@ -243,10 +264,11 @@ impl<'db> Completions<'db> {
     /// when the completion context determines that the given suggestion
     /// is never valid.
     fn add_skip_query(&mut self, builder: CompletionBuilder<'db>) -> bool {
-        if self.context.exclude(self.db, &builder) {
+        if self.context.exclude(self.db, self.program, &builder) {
             return false;
         }
-        let completion = CompletionRanker(builder.build(self.db, &self.context, &self.query));
+        let completion =
+            CompletionRanker(builder.build(self.db, self.program, &self.context, &self.query));
         if self.items.len() >= Completions::LIMIT {
             // OK because `self.items` is guaranteed to be non-empty here.
             let worst = self.items.peek_mut().unwrap();
@@ -403,10 +425,13 @@ impl<'db> CompletionBuilder<'db> {
 
     fn from_semantic_completion(
         db: &'db dyn Db,
+        program: Program,
         semantic: SemanticCompletion<'db>,
     ) -> CompletionBuilder<'db> {
-        let definition = semantic.ty.and_then(|ty| Definitions::from_ty(db, ty));
-        let documentation = definition.and_then(|def| def.docstring(db));
+        let definition = semantic
+            .ty
+            .and_then(|ty| Definitions::from_ty(db, program, ty));
+        let documentation = definition.and_then(|def| def.docstring(db, program));
         Completion::builder(semantic.name)
             .ty(semantic.ty)
             .builtin(semantic.builtin)
@@ -444,6 +469,7 @@ impl<'db> CompletionBuilder<'db> {
     fn build(
         mut self,
         db: &'db dyn Db,
+        program: Program,
         ctx: &CollectionContext<'db>,
         query: &UserQuery,
     ) -> Completion<'db> {
@@ -457,7 +483,7 @@ impl<'db> CompletionBuilder<'db> {
             // but aren't marked here. That is, false negatives are
             // possible but false positives are not.
             if let Some(exception_ty) = ctx.exception_ty {
-                self.is_context_specific |= ty.is_assignable_to(db, exception_ty);
+                self.is_context_specific |= ty.is_assignable_to(db, program, exception_ty);
             }
             if ctx.is_in_class_def() {
                 self.is_context_specific |= ty.is_class_literal()
@@ -570,9 +596,9 @@ impl<'db> CompletionBuilder<'db> {
 
     /// Returns true when this completion refers to the
     /// `NotImplemented` builtin.
-    fn is_notimplemented(&self, db: &dyn Db) -> bool {
+    fn is_notimplemented(&self, db: &dyn Db, program: Program) -> bool {
         let Some(ty) = self.ty else { return false };
-        ty.is_notimplemented(db)
+        ty.is_notimplemented(db, program)
     }
 }
 
@@ -710,7 +736,7 @@ impl<'m> Context<'m> {
     /// Create a new context for finding completions.
     fn new(
         db: &'_ dyn Db,
-        file: File,
+        program_file: ProgramFile<'_>,
         parsed: &'m ParsedModuleRef,
         source: &'m SourceText,
         offset: TextSize,
@@ -724,7 +750,7 @@ impl<'m> Context<'m> {
             ContextKind::Keywords(keywords)
         } else if cursor.is_in_definition_place() {
             return None;
-        } else if let Some(import) = ImportStatement::detect(db, file, &cursor) {
+        } else if let Some(import) = ImportStatement::detect(db, program_file, &cursor) {
             ContextKind::Import(import)
         } else {
             let target_token = CompletionTargetTokens::find(&cursor)?;
@@ -746,7 +772,9 @@ impl<'m> Context<'m> {
         match self.kind {
             ContextKind::Keywords(_) | ContextKind::Import(_) => CollectionContext::none(),
             ContextKind::NonImport(_) => {
-                let exception_ty = self.cursor.exception_ty(db);
+                let exception_ty = self
+                    .cursor
+                    .exception_ty(db, model.program_file().program(db));
                 let complete_callable_parentheses = settings.complete_function_parentheses
                     && !self.cursor.suppress_callable_parentheses();
                 let existing_class_bases = self.cursor.enclosing_class_def().map(|class_def| {
@@ -1281,13 +1309,15 @@ impl<'m> ContextCursor<'m> {
     ///
     /// The return value is always `None` if the cursor is not
     /// inside a `raise` or `except` context.
-    fn exception_ty<'db>(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        let base_exception_ty = KnownClass::BaseException.to_subclass_of(db);
-        let base_exception_instance = KnownClass::BaseException.to_instance(db);
-        let raise_ty = UnionType::from_elements(db, [base_exception_ty, base_exception_instance]);
-        let cause_ty = UnionType::from_elements(db, [raise_ty, Type::none(db)]);
+    fn exception_ty<'db>(&self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        let base_exception_ty = KnownClass::BaseException.to_subclass_of(db, program);
+        let base_exception_instance = KnownClass::BaseException.to_instance(db, program);
+        let raise_ty =
+            UnionType::from_elements(db, program, [base_exception_ty, base_exception_instance]);
+        let cause_ty = UnionType::from_elements(db, program, [raise_ty, Type::none(db, program)]);
         let except_ty = UnionType::from_elements(
             db,
+            program,
             [
                 base_exception_ty,
                 Type::homogeneous_tuple(db, base_exception_ty),
@@ -1574,8 +1604,8 @@ impl<'db> CollectionContext<'db> {
     ///
     /// This only returns `true` when it is definitively known that the
     /// completion would never be valid for this context.
-    fn exclude(&self, db: &dyn Db, builder: &CompletionBuilder<'_>) -> bool {
-        if self.is_raising_exception && builder.is_notimplemented(db) {
+    fn exclude(&self, db: &dyn Db, program: Program, builder: &CompletionBuilder<'_>) -> bool {
+        if self.is_raising_exception && builder.is_notimplemented(db, program) {
             return true;
         }
         if builder.kind == Some(CompletionKind::Keyword)
@@ -1898,7 +1928,7 @@ fn add_argument_completions<'db>(
             }
             ast::AnyNodeRef::ExprCall(_) => {
                 if in_arguments {
-                    add_function_arg_completions(db, model.file(), cursor, completions);
+                    add_function_arg_completions(db, model.program_file(), cursor, completions);
                 }
                 return;
             }
@@ -1938,7 +1968,8 @@ fn add_class_arg_completions<'db>(
     };
 
     if !is_set("metaclass") {
-        let ty = KnownClass::Type.to_subclass_of(model.db());
+        let ty =
+            KnownClass::Type.to_subclass_of(model.db(), model.program_file().program(model.db()));
         completions.add(CompletionBuilder::argument("metaclass").ty(ty));
     }
 
@@ -1952,7 +1983,7 @@ fn add_class_arg_completions<'db>(
     //
     // See https://peps.python.org/pep-0728/
     if is_typed_dict && !is_set("total") {
-        let ty = KnownClass::Bool.to_instance(model.db());
+        let ty = KnownClass::Bool.to_instance(model.db(), model.program_file().program(model.db()));
         completions.add(CompletionBuilder::argument("total").ty(ty));
     }
 }
@@ -1964,7 +1995,7 @@ fn add_class_arg_completions<'db>(
 /// set and 2) been defined as positional-only.
 fn add_function_arg_completions<'db>(
     db: &'db dyn Db,
-    file: File,
+    program_file: ProgramFile<'db>,
     cursor: &ContextCursor<'_>,
     completions: &mut Completions<'db>,
 ) {
@@ -1978,7 +2009,7 @@ fn add_function_arg_completions<'db>(
         adding completions for something like `(<CURSOR>)(arg1, arg2)`-style expressions"
     );
 
-    let Some(sig_help) = signature_help(db, file, cursor.offset) else {
+    let Some(sig_help) = signature_help(db, program_file, cursor.offset) else {
         return;
     };
     let mut set_function_args = detect_set_function_args(cursor);
@@ -2045,7 +2076,7 @@ pub(crate) struct ImportEdit {
 /// Get fixes that would resolve an unresolved reference
 pub(crate) fn unresolved_fixes(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     parsed: &ParsedModuleRef,
     symbol: &str,
     node: AnyNodeRef,
@@ -2054,12 +2085,13 @@ pub(crate) fn unresolved_fixes(
     let scoped = ScopedTarget { node };
     let query = UserQuery::exactly(symbol);
     let ctx = CollectionContext::none();
+    let program = program_file.program(db);
 
     // Request imports we could add to put the symbol in scope
-    let mut completions = Completions::new(db, ctx.clone(), query.clone());
+    let mut completions = Completions::new(db, program, ctx.clone(), query.clone());
     add_unimported_completions(
         db,
-        file,
+        program_file,
         parsed,
         scoped,
         |module_name: &ModuleName, symbol: &str| {
@@ -2070,10 +2102,10 @@ pub(crate) fn unresolved_fixes(
     results.extend(completions.into_imports());
 
     // Request qualifications we could apply to the symbol to make it resolve
-    let mut completions = Completions::new(db, ctx, query);
+    let mut completions = Completions::new(db, program, ctx, query);
     add_unimported_completions(
         db,
-        file,
+        program_file,
         parsed,
         scoped,
         |module_name: &ModuleName, symbol: &str| {
@@ -2091,9 +2123,13 @@ pub(crate) fn unresolved_fixes(
 /// This should generally only be used when offering "scoped" completions.
 /// This will include keywords corresponding to Python values (like `None`)
 /// and general language keywords (like `raise`).
-fn add_keyword_completions<'db>(db: &'db dyn Db, completions: &mut Completions<'db>) {
+fn add_keyword_completions<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    completions: &mut Completions<'db>,
+) {
     let keyword_values = [
-        ("None", Type::none(db)),
+        ("None", Type::none(db, program)),
         ("True", Type::bool_literal(true)),
         ("False", Type::bool_literal(false)),
     ];
@@ -2184,7 +2220,7 @@ fn add_string_literal_completions<'db>(
 /// when selected into `File`.
 fn add_unimported_completions<'db>(
     db: &'db dyn Db,
-    file: File,
+    program_file: ProgramFile<'db>,
     parsed: &ParsedModuleRef,
     scoped: ScopedTarget<'_>,
     create_import_request: impl for<'a> Fn(&'a ModuleName, &'a str) -> ImportRequest<'a>,
@@ -2198,12 +2234,14 @@ fn add_unimported_completions<'db>(
         return;
     }
 
+    let file = program_file.file(db);
     let source = source_text(db, file);
     let stylist = Stylist::from_tokens(parsed.tokens(), source.as_str());
-    let importer = Importer::new(db, &stylist, file, source.as_str(), parsed);
+    let importer = Importer::new(db, &stylist, program_file, source.as_str(), parsed);
     let members = importer.members_in_scope_at(scoped.node, scoped.node.start());
+    let resolver_file = program_file.resolver_file(db);
 
-    for symbol in all_symbols(db, file, &completions.query.pattern) {
+    for symbol in all_symbols(db, program_file, &completions.query.pattern) {
         if symbol.file() == file || symbol.module().is_known(db, KnownModule::Builtins) {
             continue;
         }
@@ -2218,7 +2256,7 @@ fn add_unimported_completions<'db>(
             });
 
         // Don't suggest symbols that are already imported.
-        if members.satisfies(db, file, &request) {
+        if members.satisfies(db, resolver_file, &request) {
             continue;
         }
 
@@ -2483,7 +2521,7 @@ impl<'a> ImportStatement<'a> {
     /// `tokens`.
     fn detect(
         db: &'_ dyn Db,
-        file: File,
+        program_file: ProgramFile<'_>,
         cursor: &ContextCursor<'a>,
     ) -> Option<ImportStatement<'a>> {
         use TokenKind as TK;
@@ -2606,6 +2644,7 @@ impl<'a> ImportStatement<'a> {
             ImportFinal,
         }
 
+        let file = program_file.resolver_file(db);
         let mut state = S::Start;
         // The token immediate before (or at) the cursor.
         let last = cursor.tokens_before.last()?;
@@ -2881,10 +2920,10 @@ impl<'a> ImportStatement<'a> {
     fn add_completions<'db>(
         &self,
         db: &'db dyn Db,
-        file: File,
+        program_file: ProgramFile<'db>,
         completions: &mut Completions<'db>,
     ) {
-        let model = SemanticModel::new(db, file);
+        let model = SemanticModel::new(db, program_file);
         match *self {
             ImportStatement::Import(Import { ref kind, .. }) => match *kind {
                 ImportKind::Module => {
@@ -2980,7 +3019,8 @@ fn add_import_completions_impl<'db>(
 ) {
     for semantic in semantic_completions {
         let module_dependency_kind = module_dependency_kind(&semantic);
-        let mut builder = CompletionBuilder::from_semantic_completion(db, semantic);
+        let mut builder =
+            CompletionBuilder::from_semantic_completion(db, completions.program, semantic);
         if let Some(module_dependency_kind) = module_dependency_kind {
             builder = builder.module_dependency_kind(module_dependency_kind);
         }
@@ -3194,6 +3234,7 @@ mod tests {
     use ruff_python_ast::token::{TokenKind, Tokens};
     use ruff_python_parser::{Mode, ParseOptions};
     use ty_module_resolver::ModuleName;
+    use ty_python_core::program::Program;
 
     use crate::CompletionCapabilities;
     use crate::completion::{Completion, completion};
@@ -10727,7 +10768,7 @@ raise <CURSOR>
                 &self.cursor_test.db,
                 &self.settings,
                 self.capabilities,
-                self.cursor_test.cursor.file,
+                self.cursor_test.cursor_program_file(),
                 self.cursor_test.cursor.offset,
             );
             let filtered = original
@@ -10745,6 +10786,7 @@ raise <CURSOR>
                 .collect();
             CompletionTest {
                 db: self.db(),
+                program: self.cursor_test.program(),
                 original,
                 filtered,
                 type_signatures: self.type_signatures,
@@ -10860,6 +10902,7 @@ raise <CURSOR>
 
     struct CompletionTest<'db> {
         db: &'db ty_project::TestDb,
+        program: Program,
         /// The original completions returned before any additional
         /// test-specific filtering. We keep this around in order to
         /// slightly modify the test snapshot generated. This
@@ -10900,7 +10943,7 @@ raise <CURSOR>
                     let mut snapshot = c.insert.as_deref().unwrap_or(c.label.as_str()).to_string();
                     if self.type_signatures {
                         let ty =
-                            c.ty.map(|ty| ty.display(self.db).to_string())
+                            c.ty.map(|ty| ty.display(self.db, self.program).to_string())
                                 .unwrap_or_else(|| "Unavailable".to_string());
                         snapshot = format!("{snapshot} :: {ty}");
                     }

--- a/crates/ty_ide/src/doc_highlights.rs
+++ b/crates/ty_ide/src/doc_highlights.rs
@@ -1,26 +1,31 @@
 use crate::goto::find_goto_target;
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
-use ruff_db::files::File;
 use ruff_text_size::TextSize;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Find all document highlights for a symbol at the given position.
 /// Document highlights are limited to the current file only.
 pub fn document_highlights(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
 
     // Get the definitions for the symbol at the cursor position
     let goto_target = find_goto_target(&model, &module, offset)?;
 
     // Use DocumentHighlights mode which limits search to current file only
-    references(db, file, &goto_target, ReferencesMode::DocumentHighlights)
+    references(
+        db,
+        program_file,
+        &goto_target,
+        ReferencesMode::DocumentHighlights,
+    )
 }
 
 #[cfg(test)]
@@ -35,7 +40,7 @@ mod tests {
     impl CursorTest {
         fn document_highlights(&self) -> String {
             let Some(highlight_results) =
-                document_highlights(&self.db, self.cursor.file, self.cursor.offset)
+                document_highlights(&self.db, self.cursor_program_file(), self.cursor.offset)
             else {
                 return "No highlights found".to_string();
             };

--- a/crates/ty_ide/src/document_symbols.rs
+++ b/crates/ty_ide/src/document_symbols.rs
@@ -1,10 +1,13 @@
 use crate::symbols::{FlatSymbols, symbols_for_file};
-use ruff_db::files::File;
 use ty_project::Db;
+use ty_python_core::environment::ProgramFile;
+
+#[cfg(test)]
+use ruff_db::files::File;
 
 /// Get all document symbols for a file with the given options.
-pub fn document_symbols(db: &dyn Db, file: File) -> &FlatSymbols {
-    symbols_for_file(db, file)
+pub fn document_symbols<'db>(db: &'db dyn Db, program_file: ProgramFile<'db>) -> &'db FlatSymbols {
+    symbols_for_file(db, program_file)
 }
 
 #[cfg(test)]
@@ -288,7 +291,7 @@ class Aliases:
 
     impl CursorTest {
         fn document_symbols(&self) -> String {
-            let symbols = document_symbols(&self.db, self.cursor.file).to_hierarchical();
+            let symbols = document_symbols(&self.db, self.cursor_program_file()).to_hierarchical();
 
             if symbols.is_empty() {
                 return "No symbols found".to_string();

--- a/crates/ty_ide/src/find_references.rs
+++ b/crates/ty_ide/src/find_references.rs
@@ -1,21 +1,21 @@
 use crate::goto::find_goto_target;
 use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
-use ruff_db::files::File;
 use ruff_text_size::TextSize;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Find all references to a symbol at the given position.
 /// Search for references across all files in the project.
 pub fn find_references(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
     include_declaration: bool,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
 
     // Get the definitions for the symbol at the cursor position
     let goto_target = find_goto_target(&model, &module, offset)?;
@@ -26,7 +26,7 @@ pub fn find_references(
         ReferencesMode::ReferencesSkipDeclaration
     };
 
-    references(db, file, &goto_target, mode)
+    references(db, program_file, &goto_target, mode)
 }
 
 #[cfg(test)]
@@ -48,7 +48,7 @@ mod tests {
         fn references_with_include_declaration(&self, include_declaration: bool) -> String {
             let Some(mut reference_results) = find_references(
                 &self.db,
-                self.cursor.file,
+                self.cursor_program_file(),
                 self.cursor.offset,
                 include_declaration,
             ) else {

--- a/crates/ty_ide/src/folding_range.rs
+++ b/crates/ty_ide/src/folding_range.rs
@@ -1,5 +1,3 @@
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::token::{TokenKind, Tokens, parenthesized_range};
 use ruff_python_ast::visitor::source_order::{
@@ -11,6 +9,7 @@ use ruff_python_ast::{
 use ruff_python_trivia::{CommentLinePosition, is_python_whitespace};
 use ruff_source_file::{LineRanges, UniversalNewlines};
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use ty_python_core::environment::ProgramFile;
 
 use crate::Db;
 
@@ -56,10 +55,11 @@ impl From<TextRange> for FoldingRange {
 /// Returns a list of folding ranges for the given file.
 pub fn folding_ranges(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     range_filter: Option<TextRange>,
 ) -> Vec<FoldingRange> {
-    let parsed = parsed_module(db, file).load(db);
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db).load(db);
     let source = source_text(db, file);
 
     let mut visitor = FoldingRangeVisitor {
@@ -762,6 +762,7 @@ mod tests {
     use crate::tests::CursorTest;
     use insta::assert_snapshot;
     use ruff_db::diagnostic::{Annotation, Diagnostic, DiagnosticId, LintName, Severity, Span};
+    use ruff_db::files::File;
 
     #[test]
     fn test_folding_range_class() {
@@ -2691,7 +2692,7 @@ with open("file.txt") as f:
 
     impl CursorTest {
         fn folding_ranges(&self) -> String {
-            let ranges = folding_ranges(&self.db, self.cursor.file, None);
+            let ranges = folding_ranges(&self.db, self.cursor_program_file(), None);
 
             if ranges.is_empty() {
                 return "No folding ranges found".to_string();

--- a/crates/ty_ide/src/goto.rs
+++ b/crates/ty_ide/src/goto.rs
@@ -256,11 +256,19 @@ impl<'db> Definitions<'db> {
         Self(resolved)
     }
 
-    pub(crate) fn from_ty(db: &'db dyn crate::Db, ty: Type<'db>) -> Option<Self> {
-        let ty_def = ty.definition(db)?;
+    pub(crate) fn from_ty(
+        db: &'db dyn crate::Db,
+        program: ty_python_core::program::Program,
+        ty: Type<'db>,
+    ) -> Option<Self> {
+        let ty_def = ty.definition(db, program)?;
         let resolved = match ty_def {
             ty_python_semantic::types::TypeDefinition::Module(module) => {
-                ResolvedDefinition::Module(module.file(db)?)
+                ResolvedDefinition::Module(ty_python_core::environment::ProgramFile::new(
+                    db,
+                    program,
+                    module.file(db)?,
+                ))
             }
             ty_python_semantic::types::TypeDefinition::StaticClass(definition)
             | ty_python_semantic::types::TypeDefinition::DynamicClass(definition)
@@ -339,7 +347,8 @@ impl<'db> Definitions<'db> {
         goto_target: &GotoTarget<'_>,
     ) -> Option<Definitions<'db>> {
         let definitions = self.goto_declaration(model, goto_target)?;
-        let resolved = StubMapper::new(model.db()).map_definitions(definitions.0);
+        let resolved = StubMapper::new(model.db(), model.program_file().program(model.db()))
+            .map_definitions(definitions.0);
         Some(Self::new(resolved))
     }
 
@@ -352,8 +361,7 @@ impl<'db> Definitions<'db> {
             .into_iter()
             .map(|definition| match definition {
                 ResolvedDefinition::Definition(definition) => {
-                    let file = definition.file(db);
-                    let module = ruff_db::parsed::parsed_module(db, file).load(db);
+                    let module = definition.program_file(db).parsed(db).load(db);
 
                     let focus_range = definition.focus_range(db, &module);
                     let full_range = definition.full_range(db, &module);
@@ -365,7 +373,7 @@ impl<'db> Definitions<'db> {
                     }
                 }
                 ResolvedDefinition::Module(file) => {
-                    NavigationTarget::new(file, TextRange::default())
+                    NavigationTarget::new(file.file(db), TextRange::default())
                 }
                 ResolvedDefinition::FileWithRange(file_range) => NavigationTarget::from(file_range),
             })
@@ -377,7 +385,11 @@ impl<'db> Definitions<'db> {
     /// Typically documentation only appears on implementations and not stubs,
     /// so this will check both the goto-declarations and goto-definitions (in that order)
     /// and return the first one found.
-    pub(crate) fn docstring(self, db: &'db dyn crate::Db) -> Option<Docstring> {
+    pub(crate) fn docstring(
+        self,
+        db: &'db dyn crate::Db,
+        program: ty_python_core::program::Program,
+    ) -> Option<Docstring> {
         for definition in &self {
             // If we got a docstring from the original definition, use it
             if let Some(docstring) = definition.docstring(db) {
@@ -388,7 +400,7 @@ impl<'db> Definitions<'db> {
         // If the definition is located within a stub file and no docstring
         // is present, try to map the symbol to an implementation file and extract
         // the docstring from that location.
-        let stub_mapper = StubMapper::new(db);
+        let stub_mapper = StubMapper::new(db, program);
 
         // Try to find the corresponding implementation definition
         for definition in stub_mapper.map_definitions(self.0) {
@@ -438,9 +450,10 @@ pub(crate) fn docstring_for_call_definition<'db>(
     db: &'db dyn crate::Db,
     definition: Definition<'db>,
 ) -> Option<Docstring> {
+    let program = definition.program_file(db).program(db);
     let resolved = ResolvedDefinition::Definition(definition);
     Definitions::new(vec![resolved.clone()])
-        .docstring(db)
+        .docstring(db, program)
         .or_else(|| resolved.implementation_docstring(db).map(Docstring::new))
 }
 
@@ -1394,7 +1407,13 @@ fn definitions_for_module<'db>(
 ) -> Option<Vec<ResolvedDefinition<'db>>> {
     let module = model.resolve_module(module, level)?;
     let file = module.file(model.db())?;
-    Some(vec![ResolvedDefinition::Module(file)])
+    Some(vec![ResolvedDefinition::Module(
+        ty_python_core::environment::ProgramFile::new(
+            model.db(),
+            model.program_file().program(model.db()),
+            file,
+        ),
+    )])
 }
 
 /// Helper function to extract module component information from a dotted module name

--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -1,8 +1,8 @@
 use crate::goto::find_goto_target;
 use crate::{Db, NavigationTargets, RangedValue};
-use ruff_db::files::{File, FileRange};
-use ruff_db::parsed::parsed_module;
+use ruff_db::files::FileRange;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
 /// Navigate to the declaration of a symbol.
@@ -12,11 +12,12 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// is needed because Python doesn't require formal declarations of variables like most languages do.
 pub fn goto_declaration(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+    let file = program_file.file(db);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &module, offset)?;
 
     let declaration_targets = goto_target
@@ -2921,7 +2922,7 @@ def ab(a: int, *, c: int): ...
     impl CursorTest {
         fn goto_declaration(&self) -> String {
             let Some(targets) = salsa::attach(&self.db, || {
-                goto_declaration(&self.db, self.cursor.file, self.cursor.offset)
+                goto_declaration(&self.db, self.cursor_program_file(), self.cursor.offset)
             }) else {
                 return "No goto target found".to_string();
             };

--- a/crates/ty_ide/src/goto_definition.rs
+++ b/crates/ty_ide/src/goto_definition.rs
@@ -1,8 +1,8 @@
 use crate::goto::find_goto_target;
 use crate::{Db, NavigationTargets, RangedValue};
-use ruff_db::files::{File, FileRange};
-use ruff_db::parsed::parsed_module;
+use ruff_db::files::FileRange;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 
 /// Navigate to the definition of a symbol.
@@ -13,11 +13,12 @@ use ty_python_semantic::{ImportAliasResolution, SemanticModel};
 /// source file implementations using the `StubMapper`.
 pub fn goto_definition(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+    let file = program_file.file(db);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let definition_targets = goto_target
         .definitions(&model, ImportAliasResolution::ResolveAliases)?
@@ -2549,7 +2550,7 @@ class GenericFoo[T](Base):
     impl CursorTest {
         fn goto_definition(&self) -> String {
             let Some(targets) = salsa::attach(&self.db, || {
-                goto_definition(&self.db, self.cursor.file, self.cursor.offset)
+                goto_definition(&self.db, self.cursor_program_file(), self.cursor.offset)
             }) else {
                 return "No goto target found".to_string();
             };

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -16,13 +16,14 @@ pub fn goto_type_definition(
     let goto_target = find_goto_target(&model, &module, offset)?;
 
     let ty = goto_target.inferred_type(&model)?;
+    let program = program_file.program(db);
 
     tracing::debug!(
         "Inferred type of covering node is {}",
-        ty.display(db, program_file.program(db))
+        ty.display(db, program)
     );
 
-    let navigation_targets = ty.navigation_targets(db, program_file.program(db));
+    let navigation_targets = ty.navigation_targets(db, program);
 
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),

--- a/crates/ty_ide/src/goto_type_definition.rs
+++ b/crates/ty_ide/src/goto_type_definition.rs
@@ -1,24 +1,28 @@
 use crate::goto::find_goto_target;
 use crate::{Db, HasNavigationTargets, NavigationTargets, RangedValue};
-use ruff_db::files::{File, FileRange};
-use ruff_db::parsed::parsed_module;
+use ruff_db::files::FileRange;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 pub fn goto_type_definition(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<RangedValue<NavigationTargets>> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+    let file = program_file.file(db);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &module, offset)?;
 
     let ty = goto_target.inferred_type(&model)?;
 
-    tracing::debug!("Inferred type of covering node is {}", ty.display(db));
+    tracing::debug!(
+        "Inferred type of covering node is {}",
+        ty.display(db, program_file.program(db))
+    );
 
-    let navigation_targets = ty.navigation_targets(db);
+    let navigation_targets = ty.navigation_targets(db, program_file.program(db));
 
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),
@@ -2173,7 +2177,7 @@ def function():
     impl CursorTest {
         fn goto_type_definition(&self) -> String {
             let Some(targets) = salsa::attach(&self.db, || {
-                goto_type_definition(&self.db, self.cursor.file, self.cursor.offset)
+                goto_type_definition(&self.db, self.cursor_program_file(), self.cursor.offset)
             }) else {
                 return "No goto target found".to_string();
             };

--- a/crates/ty_ide/src/hints.rs
+++ b/crates/ty_ide/src/hints.rs
@@ -1,6 +1,6 @@
-use ruff_db::files::File;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::types::ide_support::{
     UnreachableKind, unreachable_ranges, unused_bindings,
 };
@@ -40,14 +40,15 @@ impl HintKind {
     }
 }
 
-pub fn hints(db: &dyn Db, file: File) -> Vec<Hint> {
+pub fn hints(db: &dyn Db, program_file: ProgramFile<'_>) -> Vec<Hint> {
+    let file = program_file.file(db);
     if !db.should_check_file(file) {
         return Vec::new();
     }
 
-    let unreachable = unreachable_ranges(db, file);
+    let unreachable = unreachable_ranges(db, program_file);
 
-    let mut hints = unused_bindings(db, file)
+    let mut hints = unused_bindings(db, program_file)
         .iter()
         // Avoid a narrower unused-binding hint inside code that is already reported as unreachable.
         .filter(|binding| {

--- a/crates/ty_ide/src/hover.rs
+++ b/crates/ty_ide/src/hover.rs
@@ -1,20 +1,27 @@
 use crate::docstring::{Docstring, DocstringFragment};
 use crate::goto::{Definitions, GotoTarget, docstring_for_call_definition, find_goto_target};
 use crate::{Db, MarkupKind, RangedValue};
-use ruff_db::files::{File, FileRange};
-use ruff_db::parsed::parsed_module;
+use ruff_db::files::FileRange;
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextSize};
 use std::fmt;
 use std::fmt::Formatter;
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::Program;
 use ty_python_semantic::types::ide_support::{resolved_call_signature, typed_dict_key_hover};
 use ty_python_semantic::types::{KnownInstanceType, Type, TypeAliasType, TypeVarVariance};
 
 use ty_python_semantic::{DisplaySettings, SemanticModel, TypeQualifiers};
 
-pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Hover<'_>>> {
-    let parsed = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+pub fn hover<'db>(
+    db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
+    offset: TextSize,
+) -> Option<RangedValue<Hover<'db>>> {
+    let file = program_file.file(db);
+    let program = program_file.program(db);
+    let parsed = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &parsed, offset)?;
 
     if let GotoTarget::Expression(expr) = goto_target {
@@ -50,7 +57,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
                         &model,
                         ty_python_semantic::ImportAliasResolution::ResolveAliases,
                     )
-                    .and_then(|definitions| definitions.docstring(db))
+                    .and_then(|definitions| definitions.docstring(db, program))
             })
             .map(HoverContent::Docstring)
     } else {
@@ -59,7 +66,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
                 &model,
                 ty_python_semantic::ImportAliasResolution::ResolveAliases,
             )
-            .and_then(|definitions| definitions.docstring(db))
+            .and_then(|definitions| definitions.docstring(db, program))
             .map(HoverContent::Docstring)
     };
 
@@ -78,7 +85,10 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
             contents.push(HoverContent::Docstring(Docstring::new(docstring)));
         }
     } else if let Some(ty) = goto_target.inferred_type(&model) {
-        tracing::debug!("Inferred type of covering node is {}", ty.display(db));
+        tracing::debug!(
+            "Inferred type of covering node is {}",
+            ty.display(db, program)
+        );
         let qualifiers = goto_target.type_qualifiers(&model);
         let inferred_type_hover_content = match ty {
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
@@ -90,7 +100,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
                     },
                     |typevar| HoverContent::Type {
                         ty: Type::TypeVar(typevar),
-                        variance: Some(typevar.variance(db)),
+                        variance: Some(typevar.variance(db, program)),
                         qualifiers,
                     },
                 )
@@ -99,17 +109,18 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
             | Type::TypeAlias(alias) => {
                 let value_ty = alias.value_type(db);
 
-                alias_docstring = Definitions::from_ty(db, ty)
-                    .and_then(|def| def.docstring(db))
+                alias_docstring = Definitions::from_ty(db, program, ty)
+                    .and_then(|def| def.docstring(db, program))
                     .or_else(|| {
-                        Definitions::from_ty(db, value_ty).and_then(|def| def.docstring(db))
+                        Definitions::from_ty(db, program, value_ty)
+                            .and_then(|def| def.docstring(db, program))
                     });
 
                 HoverContent::TypeAlias { alias, qualifiers }
             }
             Type::TypeVar(typevar) => HoverContent::Type {
                 ty,
-                variance: Some(typevar.variance(db)),
+                variance: Some(typevar.variance(db, program)),
                 qualifiers,
             },
             _ => HoverContent::Type {
@@ -134,7 +145,7 @@ pub fn hover(db: &dyn Db, file: File, offset: TextSize) -> Option<RangedValue<Ho
 
     Some(RangedValue {
         range: FileRange::new(file, goto_target.range()),
-        value: Hover { contents },
+        value: Hover { program, contents },
     })
 }
 
@@ -214,6 +225,7 @@ fn documentation_for_parameter(docstring: &Docstring, name: &str) -> Option<Docs
 }
 
 pub struct Hover<'db> {
+    program: Program,
     contents: Vec<HoverContent<'db>>,
 }
 
@@ -264,7 +276,9 @@ impl fmt::Display for DisplayHover<'_, '_> {
                 self.kind.horizontal_line().fmt(f)?;
             }
 
-            content.display(self.db, self.kind).fmt(f)?;
+            content
+                .display(self.db, self.hover.program, self.kind)
+                .fmt(f)?;
             first = false;
         }
 
@@ -300,9 +314,15 @@ pub enum HoverContent<'db> {
 }
 
 impl<'db> HoverContent<'db> {
-    fn display(&self, db: &'db dyn Db, kind: MarkupKind) -> DisplayHoverContent<'_, 'db> {
+    fn display(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        kind: MarkupKind,
+    ) -> DisplayHoverContent<'_, 'db> {
         DisplayHoverContent {
             db,
+            program,
             content: self,
             kind,
         }
@@ -311,6 +331,7 @@ impl<'db> HoverContent<'db> {
 
 pub(crate) struct DisplayHoverContent<'a, 'db> {
     db: &'db dyn Db,
+    program: Program,
     content: &'a HoverContent<'db>,
     kind: MarkupKind,
 }
@@ -320,7 +341,11 @@ impl<'db> DisplayHoverContent<'_, 'db> {
         // Special types like `<special-form of whatever 'blahblah' with 'florps'>`
         // render poorly with python syntax-highlighting but well as xml
         let ty_string = ty
-            .display_with(self.db, DisplaySettings::default().multiline())
+            .display_with(
+                self.db,
+                self.program,
+                DisplaySettings::default().multiline(),
+            )
             .to_string();
         let syntax = if ty_string.starts_with('<') {
             "xml"
@@ -7013,7 +7038,8 @@ type U<CURSOR> = MyType
         fn hover(&self) -> String {
             use std::fmt::Write;
 
-            let Some(hover) = hover(&self.db, self.cursor.file, self.cursor.offset) else {
+            let Some(hover) = hover(&self.db, self.cursor_program_file(), self.cursor.offset)
+            else {
                 return "Hover provided no content".to_string();
             };
 

--- a/crates/ty_ide/src/importer.rs
+++ b/crates/ty_ide/src/importer.rs
@@ -29,15 +29,18 @@ use ruff_python_ast::visitor::source_order::{SourceOrderVisitor, TraversalSignal
 use ruff_python_codegen::Stylist;
 use ruff_python_importer::Insertion;
 use ruff_text_size::{Ranged, TextRange, TextSize};
-use ty_module_resolver::ModuleName;
+use ty_module_resolver::{ModuleName, ResolverFile};
 use ty_project::Db;
 use ty_python_core::definition::DefinitionKind;
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::{MemberDefinition, SemanticModel};
 
 pub(crate) struct Importer<'a> {
     /// The ty Salsa database.
     db: &'a dyn Db,
+    program_file: ProgramFile<'a>,
+    resolver_file: ResolverFile<'a>,
     /// The file corresponding to the module that
     /// we want to insert an import statement into.
     file: File,
@@ -54,6 +57,10 @@ pub(crate) struct Importer<'a> {
 }
 
 impl<'a> Importer<'a> {
+    pub(crate) fn program_file(&self) -> ProgramFile<'a> {
+        self.program_file
+    }
+
     /// Create a new importer.
     ///
     /// The [`Stylist`] dictates the code formatting options of any code
@@ -73,14 +80,18 @@ impl<'a> Importer<'a> {
     pub(crate) fn new(
         db: &'a dyn Db,
         stylist: &'a Stylist<'a>,
-        file: File,
+        program_file: ProgramFile<'a>,
         source: &'a str,
         parsed: &'a ParsedModuleRef,
     ) -> Self {
         let imports = TopLevelImports::find(parsed.syntax());
 
+        let file = program_file.file(db);
+        let resolver_file = program_file.resolver_file(db);
         Self {
             db,
+            program_file,
+            resolver_file,
             file,
             parsed,
             tokens: parsed.tokens(),
@@ -111,7 +122,7 @@ impl<'a> Importer<'a> {
         node: ast::AnyNodeRef<'_>,
         at: TextSize,
     ) -> MembersInScope<'a> {
-        MembersInScope::new(self.db, self.file, self.parsed, node, at)
+        MembersInScope::new(self.db, self.program_file, self.parsed, node, at)
     }
 
     /// Imports a symbol into this importer's module.
@@ -145,7 +156,7 @@ impl<'a> Importer<'a> {
         request: ImportRequest<'_>,
         members: &MembersInScope,
     ) -> ImportAction {
-        let request = request.avoid_conflicts(self.db, self.file, members);
+        let request = request.avoid_conflicts(self.db, self.resolver_file, members);
         let mut symbol_text: Box<str> = request.member.unwrap_or(request.module).into();
         let Some(response) = self.find(&request, members.at) else {
             let insertion = if let Some(future) = self.find_last_future_import(members.at) {
@@ -247,7 +258,7 @@ impl<'a> Importer<'a> {
                 return choice;
             }
 
-            if let Some(response) = import.satisfies(self.db, self.file, request) {
+            if let Some(response) = import.satisfies(self.db, self.resolver_file, request) {
                 let partial = matches!(response.kind, ImportResponseKind::Partial { .. });
 
                 // The LSP doesn't support edits across cell boundaries.
@@ -330,12 +341,12 @@ pub struct MembersInScope<'ast> {
 impl<'ast> MembersInScope<'ast> {
     fn new(
         db: &'ast dyn Db,
-        file: File,
+        program_file: ProgramFile<'ast>,
         parsed: &'ast ParsedModuleRef,
         node: ast::AnyNodeRef<'_>,
         at: TextSize,
     ) -> MembersInScope<'ast> {
-        let model = SemanticModel::new(db, file);
+        let model = SemanticModel::new(db, program_file);
         let map = model
             .members_in_scope_at(node)
             .into_iter()
@@ -375,7 +386,7 @@ impl<'ast> MembersInScope<'ast> {
     pub(crate) fn satisfies(
         &self,
         db: &dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let symbol_text = request.member.unwrap_or(request.module);
@@ -411,7 +422,7 @@ impl<'ast> MemberInScope<'ast> {
     fn satisfies_anywhere(
         &self,
         db: &dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> bool {
         let MemberImportKind::Imported(ref ast_import) = self.kind else {
@@ -483,7 +494,7 @@ impl<'ast> AstImport<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponse<'importer, 'ast>> {
         self.kind
@@ -514,7 +525,7 @@ impl<'ast> AstImportKind<'ast> {
     fn satisfies<'importer>(
         &'importer self,
         db: &'_ dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
         request: &ImportRequest<'_>,
     ) -> Option<ImportResponseKind<'ast>> {
         match *self {
@@ -638,7 +649,12 @@ impl<'a> ImportRequest<'a> {
     /// Attempts to change the import request style so that the chances
     /// of an import conflict are minimized (although not always reduced
     /// to zero).
-    fn avoid_conflicts(self, db: &dyn Db, importing_file: File, members: &MembersInScope) -> Self {
+    fn avoid_conflicts(
+        self,
+        db: &dyn Db,
+        importing_file: ResolverFile<'_>,
+        members: &MembersInScope,
+    ) -> Self {
         let Some(member) = self.member else {
             return Self {
                 style: ImportStyle::Import,
@@ -910,7 +926,6 @@ mod tests {
     use crate::tests::{CursorTest, CursorTestBuilder, cursor_test};
     use ruff_db::diagnostic::{Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig};
     use ruff_db::files::{File, FileRootKind, system_path_to_file};
-    use ruff_db::parsed::parsed_module;
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_db::{Db, system};
@@ -975,7 +990,7 @@ mod tests {
             Importer::new(
                 &self.db,
                 &self.cursor.stylist,
-                self.cursor.file,
+                self.cursor_program_file(),
                 self.cursor.source.as_str(),
                 &self.cursor.parsed,
             )

--- a/crates/ty_ide/src/inlay_hints.rs
+++ b/crates/ty_ide/src/inlay_hints.rs
@@ -4,14 +4,14 @@ use rustc_hash::FxHashMap;
 
 use crate::importer::{ImportAction, ImportRequest, Importer, MembersInScope};
 use crate::{Db, HasNavigationTargets, NavigationTarget};
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::visitor::source_order::{self, SourceOrderVisitor, TraversalSignal};
 use ruff_python_ast::{AnyNodeRef, ArgOrKeyword, Expr, ExprUnaryOp, Stmt, UnaryOp};
 use ruff_python_codegen::Stylist;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 use ty_module_resolver::file_to_module;
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::Program;
 use ty_python_semantic::types::ide_support::inlay_hint_call_argument_details;
 use ty_python_semantic::types::{Type, TypeDetail};
 use ty_python_semantic::{HasType, SemanticModel};
@@ -34,14 +34,16 @@ impl InlayHint {
     ) -> Option<Self> {
         let InlayHintImportContext {
             db,
-            file,
+            program_file,
             importer,
             dynamic_imports,
         } = context;
+        let program = program_file.program(db);
+        let file = program_file.file(db);
 
         let position = expr.range().end();
         // Render the type to a string, and get subspans for all the types that make it up
-        let details = ty.display(db).to_string_parts();
+        let details = ty.display(db, program).to_string_parts();
 
         // Filter out repetitive hints like `x: T = T()`
         if call_matches_name(rhs, &details.label) {
@@ -78,7 +80,7 @@ impl InlayHint {
 
                     // Possibly import the current type and return the qualified name
                     let mut qualified_name = |dynamic_importer: &mut DynamicImporter| {
-                        let type_definition = ty.definition(db)?;
+                        let type_definition = ty.definition(db, program)?;
                         let definition = type_definition.definition()?;
 
                         // Only module-level names can be imported with `from <module> import <name>`.
@@ -100,9 +102,10 @@ impl InlayHint {
                             .as_deref()
                             .unwrap_or(&details.label[start..end]);
 
-                        let module = file_to_module(db, definition.file(db))?;
+                        let module =
+                            file_to_module(db, program.resolver_file(db, definition.file(db)))?;
 
-                        if should_skip_import(db, module, *ty) {
+                        if should_skip_import(db, program, module, *ty) {
                             return None;
                         }
 
@@ -129,7 +132,7 @@ impl InlayHint {
                                 qualified_name.len().cast_signed() - (end - start).cast_signed();
                         }
 
-                        let target = ty.navigation_targets(db).into_iter().next();
+                        let target = ty.navigation_targets(db, program).into_iter().next();
 
                         // Always use original text for the label part
                         label_parts.push(
@@ -287,17 +290,18 @@ pub struct InlayHintTextEdit {
 
 pub fn inlay_hints(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     range: TextRange,
     settings: &InlayHintSettings,
 ) -> Vec<InlayHint> {
-    let ast = parsed_module(db, file).load(db);
+    let file = program_file.file(db);
+    let ast = program_file.parsed(db).load(db);
 
     let source = source_text(db, file);
     let stylist = Stylist::from_tokens(ast.tokens(), source.as_str());
-    let importer = Importer::new(db, &stylist, file, source.as_str(), &ast);
+    let importer = Importer::new(db, &stylist, program_file, source.as_str(), &ast);
 
-    let mut visitor = InlayHintVisitor::new(db, file, importer, range, settings);
+    let mut visitor = InlayHintVisitor::new(db, program_file, importer, range, settings);
 
     visitor.visit_body(ast.suite());
 
@@ -343,7 +347,7 @@ impl Default for InlayHintSettings {
 
 struct InlayHintImportContext<'a, 'db> {
     db: &'db dyn Db,
-    file: File,
+    program_file: ProgramFile<'db>,
     importer: &'a Importer<'db>,
     dynamic_imports: &'a mut FxHashMap<DynamicallyImportedMember, ImportAction>,
 }
@@ -365,14 +369,14 @@ struct InlayHintVisitor<'a, 'db> {
 impl<'a, 'db> InlayHintVisitor<'a, 'db> {
     fn new(
         db: &'db dyn Db,
-        file: File,
+        program_file: ProgramFile<'db>,
         importer: Importer<'db>,
         range: TextRange,
         settings: &'a InlayHintSettings,
     ) -> Self {
         Self {
             db,
-            model: SemanticModel::new(db, file),
+            model: SemanticModel::new(db, program_file),
             dynamic_imports: FxHashMap::default(),
             importer,
             hints: Vec::new(),
@@ -394,7 +398,7 @@ impl<'a, 'db> InlayHintVisitor<'a, 'db> {
 
         let context = InlayHintImportContext {
             db: self.db,
-            file: self.model.file(),
+            program_file: self.model.program_file(),
             importer: &self.importer,
             dynamic_imports: &mut self.dynamic_imports,
         };
@@ -635,8 +639,13 @@ fn type_hint_is_excessive_for_expr(expr: &Expr) -> bool {
     }
 }
 
-fn should_skip_import(db: &dyn Db, module: ty_module_resolver::Module, ty: Type) -> bool {
-    module.is_known(db, ty_module_resolver::KnownModule::Builtins) || ty.is_none(db)
+fn should_skip_import(
+    db: &dyn Db,
+    program: Program,
+    module: ty_module_resolver::Module,
+    ty: Type,
+) -> bool {
+    module.is_known(db, ty_module_resolver::KnownModule::Builtins) || ty.is_none(db, program)
 }
 
 fn annotations_are_valid_syntax(stmt_assign: &ruff_python_ast::StmtAssign) -> bool {
@@ -720,7 +729,8 @@ impl<'a, 'db> DynamicImporter<'a, 'db> {
         let mut is_possibly_qualified_name = label_text.contains('.');
 
         if let Some(member) = members.find_member(symbol_name) {
-            if member.ty.definition(db) == ty.definition(db) {
+            let program = self.importer.program_file().program(db);
+            if member.ty.definition(db, program) == ty.definition(db, program) {
                 return None;
             }
 
@@ -803,7 +813,7 @@ mod tests {
     use ruff_text_size::{TextLen, TextSize};
 
     use ruff_db::system::{DbWithWritableSystem, SystemPathBuf};
-    use ty_project::ProjectMetadata;
+    use ty_project::{Db as _, ProjectMetadata};
 
     pub(super) fn inlay_hint_test(source: &str) -> InlayHintTest {
         const START: &str = "<START>";
@@ -874,7 +884,9 @@ mod tests {
 
         /// Returns the inlay hints for the given test case with custom settings.
         fn inlay_hints_with_settings(&mut self, settings: &InlayHintSettings) -> String {
-            let hints = inlay_hints(&self.db, self.file, self.range, settings);
+            let program_file =
+                ProgramFile::new(&self.db, self.db.project().program(&self.db), self.file);
+            let hints = inlay_hints(&self.db, program_file, self.range, settings);
 
             let mut inlay_hint_buf = source_text(&self.db, self.file).as_str().to_string();
             let mut text_edit_buf = inlay_hint_buf.clone();

--- a/crates/ty_ide/src/lib.rs
+++ b/crates/ty_ide/src/lib.rs
@@ -72,6 +72,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use std::ops::{Deref, DerefMut};
 use ty_project::Db;
+use ty_python_core::program::Program;
 use ty_python_semantic::types::{Type, TypeDefinition};
 
 /// Information associated with a text range.
@@ -276,23 +277,23 @@ impl FromIterator<NavigationTarget> for NavigationTargets {
 }
 
 pub trait HasNavigationTargets {
-    fn navigation_targets(&self, db: &dyn Db) -> NavigationTargets;
+    fn navigation_targets(&self, db: &dyn Db, program: Program) -> NavigationTargets;
 }
 
 impl HasNavigationTargets for Type<'_> {
-    fn navigation_targets(&self, db: &dyn Db) -> NavigationTargets {
+    fn navigation_targets(&self, db: &dyn Db, program: Program) -> NavigationTargets {
         match self {
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .flat_map(|target| target.navigation_targets(db))
+                .flat_map(|target| target.navigation_targets(db, program))
                 .collect(),
 
             Type::Intersection(intersection) => {
-                if let Some(alternatives) = intersection.finite_alternatives(db) {
+                if let Some(alternatives) = intersection.finite_alternatives(db, program) {
                     return alternatives
                         .iter()
-                        .flat_map(|alternative| alternative.navigation_targets(db))
+                        .flat_map(|alternative| alternative.navigation_targets(db, program))
                         .collect();
                 }
 
@@ -309,26 +310,26 @@ impl HasNavigationTargets for Type<'_> {
                         // because the type is the intersection of all those types.
                         NavigationTargets::empty()
                     }
-                    None => first.navigation_targets(db),
+                    None => first.navigation_targets(db, program),
                 }
             }
 
             Type::EnumComplement(complement) => complement
                 .remaining_literal_types(db)
                 .iter()
-                .flat_map(|alternative| alternative.navigation_targets(db))
+                .flat_map(|alternative| alternative.navigation_targets(db, program))
                 .collect(),
 
             ty => ty
-                .definition(db)
-                .map(|definition| definition.navigation_targets(db))
+                .definition(db, program)
+                .map(|definition| definition.navigation_targets(db, program))
                 .unwrap_or_else(NavigationTargets::empty),
         }
     }
 }
 
 impl HasNavigationTargets for TypeDefinition<'_> {
-    fn navigation_targets(&self, db: &dyn Db) -> NavigationTargets {
+    fn navigation_targets(&self, db: &dyn Db, _program: Program) -> NavigationTargets {
         let Some(full_range) = self.full_range(db) else {
             return NavigationTargets::empty();
         };
@@ -402,7 +403,7 @@ mod tests {
         Annotation, Diagnostic, DiagnosticFormat, DisplayDiagnosticConfig, UnifiedFile,
     };
     use ruff_db::files::{File, FileRootKind, system_path_to_file};
-    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+    use ruff_db::parsed::ParsedModuleRef;
     use ruff_db::source::{SourceText, source_text};
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_python_ast::PythonVersion;
@@ -410,7 +411,8 @@ mod tests {
     use ruff_python_trivia::textwrap::dedent;
     use ruff_text_size::TextSize;
     use ty_module_resolver::SearchPathSettings;
-    use ty_project::ProjectMetadata;
+    use ty_project::{Db as _, ProjectMetadata};
+    use ty_python_core::environment::ProgramFile;
     use ty_python_core::platform::PythonPlatform;
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_python_semantic::PythonVersionWithSource;
@@ -432,6 +434,18 @@ mod tests {
     impl CursorTest {
         pub(super) fn builder() -> CursorTestBuilder {
             CursorTestBuilder::default()
+        }
+
+        pub(super) fn program(&self) -> Program {
+            self.db.project().program(&self.db)
+        }
+
+        pub(super) fn program_file(&self, file: File) -> ProgramFile<'_> {
+            ProgramFile::new(&self.db, self.program(), file)
+        }
+
+        pub(super) fn cursor_program_file(&self) -> ProgramFile<'_> {
+            self.program_file(self.cursor.file)
         }
 
         pub(super) fn write_file(
@@ -553,7 +567,9 @@ mod tests {
                         "found more than one source that contains `<CURSOR>`"
                     );
                     let source = source_text(&db, file);
-                    let parsed = parsed_module(&db, file).load(&db);
+                    let parsed = ProgramFile::new(&db, db.project().program(&db), file)
+                        .parsed(&db)
+                        .load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {
@@ -666,14 +682,11 @@ mod tests {
             .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
             .expect("valid search paths");
 
-            Program::from_settings(
-                &db,
-                ProgramSettings {
-                    python_version: PythonVersionWithSource::default(),
-                    python_platform: PythonPlatform::default(),
-                    search_paths,
-                },
-            );
+            db.update_program_settings(ProgramSettings {
+                python_version: PythonVersionWithSource::default(),
+                python_platform: PythonPlatform::default(),
+                search_paths,
+            });
 
             db.files()
                 .try_add_root(&db, &project_root, FileRootKind::Project);
@@ -700,7 +713,9 @@ mod tests {
                         "found more than one source that contains `<CURSOR>`"
                     );
                     let source = source_text(&db, file);
-                    let parsed = parsed_module(&db, file).load(&db);
+                    let parsed = ProgramFile::new(&db, db.project().program(&db), file)
+                        .parsed(&db)
+                        .load(&db);
                     let stylist =
                         Stylist::from_tokens(parsed.tokens(), source.as_str()).into_owned();
                     cursor = Some(Cursor {

--- a/crates/ty_ide/src/references.rs
+++ b/crates/ty_ide/src/references.rs
@@ -13,7 +13,6 @@
 use crate::goto::{Definitions, GotoTarget};
 use crate::{Db, ReferenceKind, ReferenceTarget};
 use rayon::prelude::*;
-use ruff_db::files::File;
 use ruff_python_ast::find_node::{CoveringNode, covering_node};
 use ruff_python_ast::token::Tokens;
 use ruff_python_ast::{
@@ -23,6 +22,7 @@ use ruff_python_ast::{
 use ruff_text_size::Ranged;
 use ty_project::parallel::{ParallelIteratorExt, minimum_parallel_job_len};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKind, ScopeKind};
 use ty_python_semantic::{ImportAliasResolution, ResolvedDefinition, SemanticModel};
 
@@ -84,11 +84,13 @@ impl ReferencesMode {
 /// Search for references across all files in the project.
 pub(crate) fn references(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     goto_target: &GotoTarget,
     mode: ReferencesMode,
 ) -> Option<Vec<ReferenceTarget>> {
-    let model = SemanticModel::new(db, file);
+    let file = program_file.file(db);
+    let program = program_file.program(db);
+    let model = SemanticModel::new(db, program_file);
     let target_definitions = goto_target.definitions(&model, mode.to_import_alias_resolution())?;
     let is_externally_visible_symbol =
         has_any_external_visible_definitions(db, &target_definitions);
@@ -98,7 +100,8 @@ pub(crate) fn references(
     let target_text = goto_target.to_string()?;
 
     // Find all of the references to the symbol within this file
-    let mut references = references_for_file(db, file, &target_definitions, &target_text, mode);
+    let mut references =
+        references_for_file(db, program_file, &target_definitions, &target_text, mode);
 
     // Check if we should search across files based on the mode
     let search_across_files = matches!(
@@ -131,11 +134,17 @@ pub(crate) fn references(
                 }
 
                 if is_externally_visible_symbol {
-                    references_for_file(db, other_file, &target_definitions, &target_text, mode)
+                    references_for_file(
+                        db,
+                        ProgramFile::new(db, program, other_file),
+                        &target_definitions,
+                        &target_text,
+                        mode,
+                    )
                 } else {
                     references_for_keyword_arguments_in_file(
                         db,
-                        other_file,
+                        ProgramFile::new(db, program, other_file),
                         &target_definitions,
                         &target_text,
                         mode,
@@ -157,7 +166,7 @@ pub(crate) fn references(
 
 fn references_for_keyword_arguments_in_file(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
@@ -169,9 +178,9 @@ fn references_for_keyword_arguments_in_file(
         "keyword-label cross-file scan should not run in DocumentHighlights mode"
     );
 
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
     let mut references = Vec::new();
 
     let mut finder = KeywordArgumentReferencesFinder(LocalReferencesFinder {
@@ -248,14 +257,14 @@ fn is_slots_assignment(node: AnyNodeRef<'_>, value: AnyNodeRef<'_>) -> bool {
 /// The behavior depends on the provided mode.
 fn references_for_file(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     target_definitions: &Definitions<'_>,
     target_text: &str,
     mode: ReferencesMode,
 ) -> Vec<ReferenceTarget> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
     let mut references = Vec::new();
 
     let mut finder = LocalReferencesFinder {
@@ -308,10 +317,12 @@ fn parameter_owner_is_externally_visible_for_target(
     db: &dyn Db,
     definition: &ResolvedDefinition,
 ) -> bool {
-    let target = definition.focus_range(db);
-    let file = target.file();
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let Some(definition) = definition.definition() else {
+        return false;
+    };
+    let parsed = definition.program_file(db).parsed(db);
     let module = parsed.load(db);
+    let target = definition.focus_range(db, &module);
 
     let covering = covering_node(module.syntax().into(), target.range());
     let Ok(parameter_covering) =
@@ -721,8 +732,10 @@ impl<'a> LocalReferencesFinder<'a> {
         let db = self.model.db();
         let file = self.model.file();
         let class_range = class.range();
-        let module = ruff_db::parsed::parsed_module(db, file).load(db);
-        let index = ty_python_core::semantic_index(db, file);
+        let module =
+            ruff_db::parsed::parsed_module(db, self.model.program_file().versioned_file(db))
+                .load(db);
+        let index = ty_python_core::semantic_index(db, self.model.program_file());
 
         // The nearest class scope lexically enclosing `scope`, if any. `ancestor_scopes` skips
         // class scopes for name resolution, so we walk the lexical parents directly to stop at the
@@ -777,8 +790,9 @@ impl<'a> LocalReferencesFinder<'a> {
             return false;
         };
 
-        let file = local_definition.file(db);
-        let module = ruff_db::parsed::parsed_module(db, file).load(db);
+        let program_file = local_definition.program_file(db);
+        let file = program_file.file(db);
+        let module = program_file.parsed(db).load(db);
         let kind = local_definition.kind(db);
         let category = kind.category(file.is_stub(db), &module);
 
@@ -822,7 +836,7 @@ mod tests {
     use crate::tests::{CursorTest, cursor_test};
 
     fn cursor_target_is_externally_visible(test: &CursorTest) -> bool {
-        let model = SemanticModel::new(&test.db, test.cursor.file);
+        let model = SemanticModel::new(&test.db, test.cursor_program_file());
         let goto_target =
             find_goto_target(&model, &test.cursor.parsed, test.cursor.offset).unwrap();
         let definitions = goto_target

--- a/crates/ty_ide/src/rename.rs
+++ b/crates/ty_ide/src/rename.rs
@@ -3,13 +3,19 @@ use crate::references::{ReferencesMode, references};
 use crate::{Db, ReferenceTarget};
 use ruff_db::files::File;
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::SemanticModel;
 
 /// Returns the range of the symbol if it can be renamed, None if not.
-pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text_size::TextRange> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+pub fn can_rename(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+    offset: TextSize,
+) -> Option<ruff_text_size::TextRange> {
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
 
     // Get the definitions for the symbol at the offset
     let goto_target = find_goto_target(&model, &module, offset)?;
@@ -50,13 +56,14 @@ pub fn can_rename(db: &dyn Db, file: File, offset: TextSize) -> Option<ruff_text
 /// Returns all locations that need to be updated with the new name.
 pub fn rename(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
     new_name: &str,
 ) -> Option<Vec<ReferenceTarget>> {
-    let parsed = ruff_db::parsed::parsed_module(db, file);
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
 
     // Get the definitions for the symbol at the offset
     let goto_target = find_goto_target(&model, &module, offset)?;
@@ -80,7 +87,7 @@ pub fn rename(
     };
 
     // Find all references that need to be renamed
-    references(db, file, &goto_target, rename_mode)
+    references(db, program_file, &goto_target, rename_mode)
 }
 
 /// Helper function to check if a file is included in the project.
@@ -100,7 +107,7 @@ mod tests {
     impl CursorTest {
         fn prepare_rename(&self) -> String {
             let Some(range) = salsa::attach(&self.db, || {
-                can_rename(&self.db, self.cursor.file, self.cursor.offset)
+                can_rename(&self.db, self.cursor_program_file(), self.cursor.offset)
             }) else {
                 return "Cannot rename".to_string();
             };
@@ -110,9 +117,14 @@ mod tests {
 
         fn rename(&self, new_name: &str) -> String {
             let rename_results = salsa::attach(&self.db, || {
-                can_rename(&self.db, self.cursor.file, self.cursor.offset)?;
+                can_rename(&self.db, self.cursor_program_file(), self.cursor.offset)?;
 
-                rename(&self.db, self.cursor.file, self.cursor.offset, new_name)
+                rename(
+                    &self.db,
+                    self.cursor_program_file(),
+                    self.cursor.offset,
+                    new_name,
+                )
             });
 
             let Some(rename_results) = rename_results else {

--- a/crates/ty_ide/src/selection_range.rs
+++ b/crates/ty_ide/src/selection_range.rs
@@ -1,14 +1,17 @@
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::covering_node;
 use ruff_text_size::{Ranged, TextRange, TextSize};
+use ty_python_core::environment::ProgramFile;
 
 use crate::Db;
 
 /// Returns a list of nested selection ranges, where each range contains the next one.
 /// The first range in the list is the largest range containing the cursor position.
-pub fn selection_range(db: &dyn Db, file: File, offset: TextSize) -> Vec<TextRange> {
-    let parsed = parsed_module(db, file).load(db);
+pub fn selection_range(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+    offset: TextSize,
+) -> Vec<TextRange> {
+    let parsed = program_file.parsed(db).load(db);
     let range = TextRange::empty(offset);
 
     let covering = covering_node(parsed.syntax().into(), range);
@@ -469,7 +472,7 @@ b"123a𝐁<CURSOR>c"
 
     impl CursorTest {
         fn selection_range(&self) -> String {
-            let ranges = selection_range(&self.db, self.cursor.file, self.cursor.offset);
+            let ranges = selection_range(&self.db, self.cursor_program_file(), self.cursor.offset);
 
             if ranges.is_empty() {
                 return "No selection range found".to_string();

--- a/crates/ty_ide/src/semantic_tokens.rs
+++ b/crates/ty_ide/src/semantic_tokens.rs
@@ -28,8 +28,6 @@
 
 use crate::Db;
 use bitflags::bitflags;
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::visitor::source_order::{
     SourceOrderVisitor, TraversalSignal, walk_arguments, walk_expr,
     walk_interpolated_string_element, walk_stmt,
@@ -41,6 +39,7 @@ use ruff_python_ast::{
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use std::ops::Deref;
 use ty_python_core::definition::{Definition, DefinitionKind, ParameterDefinitionNodeKind};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::{
     HasType, ImportAliasResolution, ResolvedDefinition, SemanticModel, definitions_for_attribute,
     definitions_for_imported_symbol,
@@ -183,9 +182,13 @@ impl Deref for SemanticTokens {
 
 /// Generates semantic tokens for a Python file within the specified range.
 /// Pass None to get tokens for the entire file.
-pub fn semantic_tokens(db: &dyn Db, file: File, range: Option<TextRange>) -> SemanticTokens {
-    let parsed = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+pub fn semantic_tokens(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+    range: Option<TextRange>,
+) -> SemanticTokens {
+    let parsed = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
 
     let mut visitor = SemanticTokenVisitor::new(&model, range);
     visitor.expecting_docstring = true;
@@ -299,7 +302,7 @@ impl<'db> SemanticTokenVisitor<'db> {
     ) -> Option<(SemanticTokenType, SemanticTokenModifier)> {
         let mut modifiers = SemanticTokenModifier::empty();
         let db = self.model.db();
-        let model = SemanticModel::new(db, definition.file(db));
+        let model = SemanticModel::new(db, definition.program_file(db));
 
         if model.is_type_alias_definition(definition) {
             return Some((SemanticTokenType::Class, modifiers));
@@ -319,7 +322,7 @@ impl<'db> SemanticTokenVisitor<'db> {
                 Some((SemanticTokenType::TypeParameter, modifiers))
             }
             DefinitionKind::Parameter(ParameterDefinitionNodeKind::Parameter(parameter)) => {
-                let parsed = parsed_module(db, definition.file(db));
+                let parsed = definition.program_file(db).parsed(db);
                 let ty = parameter.node(&parsed.load(db)).inferred_type(&model);
 
                 if let Some(ty) = ty {
@@ -361,7 +364,7 @@ impl<'db> SemanticTokenVisitor<'db> {
                     modifiers |= SemanticTokenModifier::READONLY;
                 }
 
-                let parsed = parsed_module(db, definition.file(db));
+                let parsed = definition.program_file(db).parsed(db);
                 let parsed = parsed.load(db);
                 let value = match definition.kind(db) {
                     DefinitionKind::Assignment(assignment) => Some(assignment.value(&parsed)),
@@ -1283,11 +1286,12 @@ mod tests {
     use super::*;
 
     use insta::assert_snapshot;
+    use ruff_db::files::File;
     use ruff_db::{
         files::system_path_to_file,
         system::{DbWithWritableSystem, SystemPath, SystemPathBuf},
     };
-    use ty_project::ProjectMetadata;
+    use ty_project::{Db as _, ProjectMetadata};
 
     #[test]
     fn semantic_tokens_basic() {
@@ -4708,12 +4712,16 @@ from pathlib import Missing as Alias
 
         /// Get semantic tokens for the entire file
         fn highlight_file(&self) -> SemanticTokens {
-            semantic_tokens(&self.db, self.file, None)
+            let program_file =
+                ProgramFile::new(&self.db, self.db.project().program(&self.db), self.file);
+            semantic_tokens(&self.db, program_file, None)
         }
 
         /// Get semantic tokens for a specific range in the file
         fn highlight_range(&self, range: TextRange) -> SemanticTokens {
-            semantic_tokens(&self.db, self.file, Some(range))
+            let program_file =
+                ProgramFile::new(&self.db, self.db.project().program(&self.db), self.file);
+            semantic_tokens(&self.db, program_file, Some(range))
         }
 
         /// Helper function to convert semantic tokens to a snapshot-friendly text format

--- a/crates/ty_ide/src/signature_help.rs
+++ b/crates/ty_ide/src/signature_help.rs
@@ -9,12 +9,11 @@
 use crate::Db;
 use crate::docstring::Docstring;
 use crate::goto::docstring_for_call_definition;
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::find_node::covering_node;
 use ruff_python_ast::token::TokenKind;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextSize};
+use ty_python_core::environment::ProgramFile;
 use ty_python_semantic::SemanticModel;
 use ty_python_semantic::types::Type;
 use ty_python_semantic::types::ide_support::{
@@ -73,13 +72,17 @@ pub struct SignatureHelpInfo<'db> {
 }
 
 /// Signature help information for function calls at the given position
-pub fn signature_help(db: &dyn Db, file: File, offset: TextSize) -> Option<SignatureHelpInfo<'_>> {
-    let parsed = parsed_module(db, file).load(db);
+pub fn signature_help<'db>(
+    db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
+    offset: TextSize,
+) -> Option<SignatureHelpInfo<'db>> {
+    let parsed = program_file.parsed(db).load(db);
 
     // Get the call expression at the given position.
     let (call_expr, current_arg_index) = get_call_expr(&parsed, offset)?;
 
-    let model = SemanticModel::new(db, file);
+    let model = SemanticModel::new(db, program_file);
 
     // Get signature details from the semantic analyzer.
     let signature_details: Vec<CallSignatureDetails<'_>> =
@@ -975,7 +978,7 @@ def ab(a: int, *, c: int):
         // the parameter type should be `str` (not `_KT`).
         let key_param = &signature.parameters[0];
         assert_eq!(key_param.name, "key");
-        let type_display = format!("{}", key_param.ty.display(&test.db));
+        let type_display = format!("{}", key_param.ty.display(&test.db, test.program()));
         assert_eq!(type_display, "str");
     }
 
@@ -996,7 +999,7 @@ def ab(a: int, *, c: int):
         // list.append's parameter is typed as `_T`, which should resolve
         // to `int` for a `list[int]`.
         let object_param = &signature.parameters[0];
-        let type_display = format!("{}", object_param.ty.display(&test.db));
+        let type_display = format!("{}", object_param.ty.display(&test.db, test.program()));
         assert_eq!(type_display, "int");
     }
 
@@ -1023,12 +1026,12 @@ def ab(a: int, *, c: int):
         // `T` should be resolved to `str` from the first argument.
         let a_param = &signature.parameters[0];
         assert_eq!(a_param.name, "a");
-        let a_type = format!("{}", a_param.ty.display(&test.db));
+        let a_type = format!("{}", a_param.ty.display(&test.db, test.program()));
         assert_eq!(a_type, "str");
 
         let b_param = &signature.parameters[1];
         assert_eq!(b_param.name, "b");
-        let b_type = format!("{}", b_param.ty.display(&test.db));
+        let b_type = format!("{}", b_param.ty.display(&test.db, test.program()));
         assert_eq!(b_type, "str");
     }
 
@@ -1441,7 +1444,11 @@ def ab(a: int, *, c: int):
 
     impl CursorTest {
         fn signature_help(&self) -> Option<SignatureHelpInfo<'_>> {
-            crate::signature_help::signature_help(&self.db, self.cursor.file, self.cursor.offset)
+            crate::signature_help::signature_help(
+                &self.db,
+                self.cursor_program_file(),
+                self.cursor.offset,
+            )
         }
 
         fn signature_help_render(&self) -> String {

--- a/crates/ty_ide/src/stub_mapping.rs
+++ b/crates/ty_ide/src/stub_mapping.rs
@@ -1,5 +1,6 @@
 use itertools::Either;
 use ruff_db::system::SystemPathBuf;
+use ty_python_core::program::Program;
 use ty_python_semantic::{ResolvedDefinition, map_stub_definition};
 
 use crate::cached_vendored_root;
@@ -12,14 +13,16 @@ use crate::cached_vendored_root;
 /// docstrings for functions that resolve to stubs.
 pub(crate) struct StubMapper<'db> {
     db: &'db dyn ty_python_semantic::Db,
+    program: Program,
     cached_vendored_root: Option<SystemPathBuf>,
 }
 
 impl<'db> StubMapper<'db> {
-    pub(crate) fn new(db: &'db dyn ty_python_semantic::Db) -> Self {
+    pub(crate) fn new(db: &'db dyn ty_python_semantic::Db, program: Program) -> Self {
         let cached_vendored_root = cached_vendored_root(db);
         Self {
             db,
+            program,
             cached_vendored_root,
         }
     }
@@ -32,9 +35,12 @@ impl<'db> StubMapper<'db> {
         &self,
         def: ResolvedDefinition<'db>,
     ) -> impl Iterator<Item = ResolvedDefinition<'db>> {
-        if let Some(definitions) =
-            map_stub_definition(self.db, &def, self.cached_vendored_root.as_deref())
-        {
+        if let Some(definitions) = map_stub_definition(
+            self.db,
+            self.program,
+            &def,
+            self.cached_vendored_root.as_deref(),
+        ) {
             return Either::Left(definitions.into_iter());
         }
         Either::Right(std::iter::once(def))

--- a/crates/ty_ide/src/symbols.rs
+++ b/crates/ty_ide/src/symbols.rs
@@ -7,7 +7,6 @@ use std::ops::Range;
 use regex::Regex;
 
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::name::{Name, UnqualifiedName};
@@ -16,6 +15,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use ty_module_resolver::{ModuleName, resolve_module};
 use ty_project::Db;
+use ty_python_core::environment::ProgramFile;
 
 use crate::completion::CompletionKind;
 
@@ -388,11 +388,11 @@ impl SymbolKind {
 /// The flattened list includes parent/child information and can be
 /// converted into a hierarchical collection of symbols.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn symbols_for_file(db: &dyn Db, file: File) -> FlatSymbols {
-    let parsed = parsed_module(db, file);
+pub(crate) fn symbols_for_file(db: &dyn Db, program_file: ProgramFile<'_>) -> FlatSymbols {
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::tree(db, file);
+    let mut visitor = SymbolVisitor::tree(db, program_file);
     visitor.visit_body(&module.syntax().body);
     visitor.into_flat_symbols()
 }
@@ -407,11 +407,15 @@ pub(crate) fn symbols_for_file(db: &dyn Db, file: File) -> FlatSymbols {
     cycle_initial=|_, _, _| FlatSymbols::default(),
     heap_size=ruff_memory_usage::heap_size,
 )]
-pub(crate) fn symbols_for_file_global_only(db: &dyn Db, file: File) -> FlatSymbols {
-    let parsed = parsed_module(db, file);
+pub(crate) fn symbols_for_file_global_only(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+) -> FlatSymbols {
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db);
     let module = parsed.load(db);
 
-    let mut visitor = SymbolVisitor::globals(db, file);
+    let mut visitor = SymbolVisitor::globals(db, program_file);
     visitor.visit_body(&module.syntax().body);
 
     if file
@@ -450,11 +454,12 @@ impl ImportedFrom {
 
     fn import_from(
         db: &dyn Db,
-        importing_file: File,
+        importing_file: ProgramFile<'_>,
         ast: &ast::StmtImportFrom,
         kind: ImportKind,
     ) -> Option<ImportedFrom> {
-        let module_name = ModuleName::from_import_statement(db, importing_file, ast).ok()?;
+        let module_name =
+            ModuleName::from_import_statement(db, importing_file.resolver_file(db), ast).ok()?;
         Some(ImportedFrom { module_name, kind })
     }
 
@@ -591,7 +596,7 @@ impl<'db> Imports<'db> {
     fn get_module_symbols(
         &self,
         db: &'db dyn Db,
-        importing_file: File,
+        importing_file: ProgramFile<'db>,
         name: &ModuleName,
     ) -> Option<&'db FlatSymbols> {
         let module_name = match self.module_names.get(name.as_str())? {
@@ -599,8 +604,11 @@ impl<'db> Imports<'db> {
                 name.to_module_name(db, importing_file)?
             }
         };
-        let module = resolve_module(db, importing_file, &module_name)?;
-        Some(symbols_for_file_global_only(db, module.file(db)?))
+        let module = resolve_module(db, importing_file.resolver_file(db), &module_name)?;
+        Some(symbols_for_file_global_only(
+            db,
+            ProgramFile::new(db, importing_file.program(db), module.file(db)?),
+        ))
     }
 }
 
@@ -649,12 +657,17 @@ enum ImportModuleName<'db> {
 impl<'db> ImportModuleName<'db> {
     /// Converts the lazy representation of a module name into an
     /// actual `ModuleName` that can be used for module resolution.
-    fn to_module_name(self, db: &'db dyn Db, importing_file: File) -> Option<ModuleName> {
+    fn to_module_name(
+        self,
+        db: &'db dyn Db,
+        importing_file: ProgramFile<'db>,
+    ) -> Option<ModuleName> {
         match self {
             ImportModuleName::Import(name) => ModuleName::new(name),
             ImportModuleName::ImportFrom { parent, child } => {
                 let mut module_name =
-                    ModuleName::from_import_statement(db, importing_file, parent).ok()?;
+                    ModuleName::from_import_statement(db, importing_file.resolver_file(db), parent)
+                        .ok()?;
                 let child_module_name = ModuleName::new(child)?;
                 module_name.extend(&child_module_name);
                 Some(module_name)
@@ -685,6 +698,7 @@ impl Ranged for AstImport<'_> {
 #[expect(clippy::struct_excessive_bools)]
 struct SymbolVisitor<'db> {
     db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
     file: File,
     symbols: IndexVec<SymbolId, SymbolTree>,
     symbol_stack: Vec<SymbolId>,
@@ -719,10 +733,11 @@ struct SymbolVisitor<'db> {
 }
 
 impl<'db> SymbolVisitor<'db> {
-    fn tree(db: &'db dyn Db, file: File) -> Self {
+    fn tree(db: &'db dyn Db, program_file: ProgramFile<'db>) -> Self {
         Self {
             db,
-            file,
+            program_file,
+            file: program_file.file(db),
             symbols: IndexVec::new(),
             symbol_stack: vec![],
             in_function: false,
@@ -735,10 +750,10 @@ impl<'db> SymbolVisitor<'db> {
         }
     }
 
-    fn globals(db: &'db dyn Db, file: File) -> Self {
+    fn globals(db: &'db dyn Db, program_file: ProgramFile<'db>) -> Self {
         Self {
             exports_only: true,
-            ..Self::tree(db, file)
+            ..Self::tree(db, program_file)
         }
     }
 
@@ -883,7 +898,7 @@ impl<'db> SymbolVisitor<'db> {
         let Some(imported_from) = (match import {
             AstImport::Import(_) => ImportedFrom::import(alias, import_kind),
             AstImport::ImportFrom(ast) => {
-                ImportedFrom::import_from(self.db, self.file, ast, import_kind)
+                ImportedFrom::import_from(self.db, self.program_file, ast, import_kind)
             }
         }) else {
             tracing::debug!(
@@ -977,10 +992,11 @@ impl<'db> SymbolVisitor<'db> {
                 else {
                     return false;
                 };
-                let Some(symbols) =
-                    self.imports
-                        .get_module_symbols(self.db, self.file, &possible_module_name)
-                else {
+                let Some(symbols) = self.imports.get_module_symbols(
+                    self.db,
+                    self.program_file,
+                    &possible_module_name,
+                ) else {
                     return false;
                 };
                 let Some(ref all) = symbols.all_names else {
@@ -1064,7 +1080,7 @@ impl<'db> SymbolVisitor<'db> {
                 }
                 let Some(imported_from) = ImportedFrom::import_from(
                     self.db,
-                    self.file,
+                    self.program_file,
                     import_from,
                     ImportKind::Wildcard,
                 ) else {
@@ -1109,10 +1125,18 @@ impl<'db> SymbolVisitor<'db> {
         &self,
         import_from: &ast::StmtImportFrom,
     ) -> Option<&'db FlatSymbols> {
+        let resolver_file = self.program_file.resolver_file(self.db);
         let module_name =
-            ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
-        let module = resolve_module(self.db, self.file, &module_name)?;
-        Some(symbols_for_file_global_only(self.db, module.file(self.db)?))
+            ModuleName::from_import_statement(self.db, resolver_file, import_from).ok()?;
+        let module = resolve_module(self.db, resolver_file, &module_name)?;
+        Some(symbols_for_file_global_only(
+            self.db,
+            ProgramFile::new(
+                self.db,
+                self.program_file.program(self.db),
+                module.file(self.db)?,
+            ),
+        ))
     }
 
     /// Add valid names from `__all__` to the set of existing `__all__`
@@ -1493,7 +1517,8 @@ mod tests {
     use ruff_db::system::{DbWithWritableSystem, SystemPath, SystemPathBuf};
     use ruff_python_ast::PythonVersion;
     use ruff_python_trivia::textwrap::dedent;
-    use ty_project::{ProjectMetadata, TestDb};
+    use ty_project::{Db as _, ProjectMetadata, TestDb};
+    use ty_python_core::environment::ProgramFile;
 
     use super::symbols_for_file_global_only;
 
@@ -2937,7 +2962,10 @@ class C: ...
         /// The path given must have been written to this test's salsa DB.
         fn exported_symbols_for(&self, path: impl AsRef<SystemPath>) -> &super::FlatSymbols {
             let file = system_path_to_file(&self.db, path.as_ref()).unwrap();
-            symbols_for_file_global_only(&self.db, file)
+            symbols_for_file_global_only(
+                &self.db,
+                ProgramFile::new(&self.db, self.db.project().program(&self.db), file),
+            )
         }
 
         /// Returns the exports from the module at the given path.

--- a/crates/ty_ide/src/type_hierarchy.rs
+++ b/crates/ty_ide/src/type_hierarchy.rs
@@ -1,9 +1,10 @@
 use crate::Db;
 use crate::goto::find_goto_target;
 use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{TextRange, TextSize};
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::Program;
 use ty_python_semantic::SemanticModel;
 use ty_python_semantic::TypeHierarchyClass;
 use ty_python_semantic::types::Type;
@@ -28,45 +29,48 @@ pub struct TypeHierarchyItem {
 /// Returns `None` if the position is not on a class definition or class reference.
 pub fn prepare_type_hierarchy(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Option<TypeHierarchyItem> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+    let program = program_file.program(db);
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
     let goto_target = find_goto_target(&model, &module, offset)?;
     let ty = goto_target.inferred_type(&model)?;
 
-    let hierarchy_class = ty_python_semantic::type_hierarchy_prepare(db, ty)?;
-    Some(type_hierarchy_class_to_item(db, hierarchy_class))
+    let hierarchy_class = ty_python_semantic::type_hierarchy_prepare(db, program, ty)?;
+    Some(type_hierarchy_class_to_item(db, program, hierarchy_class))
 }
 
 /// Get the supertypes (base classes) of a type hierarchy item.
 pub fn type_hierarchy_supertypes(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Vec<TypeHierarchyItem> {
-    let Some(ty) = resolve_type_at(db, file, offset) else {
+    let program = program_file.program(db);
+    let Some(ty) = resolve_type_at(db, program_file, offset) else {
         return vec![];
     };
-    ty_python_semantic::type_hierarchy_supertypes(db, ty)
+    ty_python_semantic::type_hierarchy_supertypes(db, program, ty)
         .into_iter()
-        .map(|c| type_hierarchy_class_to_item(db, c))
+        .map(|class| type_hierarchy_class_to_item(db, program, class))
         .collect()
 }
 
 /// Get the subtypes (derived classes) of a type hierarchy item.
 pub fn type_hierarchy_subtypes(
     db: &dyn Db,
-    file: File,
+    program_file: ProgramFile<'_>,
     offset: TextSize,
 ) -> Vec<TypeHierarchyItem> {
-    let Some(ty) = resolve_type_at(db, file, offset) else {
+    let program = program_file.program(db);
+    let Some(ty) = resolve_type_at(db, program_file, offset) else {
         return vec![];
     };
-    ty_python_semantic::type_hierarchy_subtypes(db, ty)
+    ty_python_semantic::type_hierarchy_subtypes(db, program, ty)
         .into_iter()
-        .map(|c| type_hierarchy_class_to_item(db, c))
+        .map(|class| type_hierarchy_class_to_item(db, program, class))
         .collect()
 }
 
@@ -74,16 +78,24 @@ pub fn type_hierarchy_subtypes(
 ///
 /// If a symbol could not be found at the given offset or its type could
 /// not be inferred, `None` is returned.
-fn resolve_type_at(db: &dyn Db, file: File, offset: TextSize) -> Option<Type<'_>> {
-    let module = parsed_module(db, file).load(db);
-    let model = SemanticModel::new(db, file);
+fn resolve_type_at<'db>(
+    db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
+    offset: TextSize,
+) -> Option<Type<'db>> {
+    let module = program_file.parsed(db).load(db);
+    let model = SemanticModel::new(db, program_file);
 
     let goto_target = find_goto_target(&model, &module, offset)?;
     goto_target.inferred_type(&model)
 }
 
-fn type_hierarchy_class_to_item(db: &dyn Db, class: TypeHierarchyClass) -> TypeHierarchyItem {
-    let detail = ty_module_resolver::file_to_module(db, class.file)
+fn type_hierarchy_class_to_item(
+    db: &dyn Db,
+    program: Program,
+    class: TypeHierarchyClass,
+) -> TypeHierarchyItem {
+    let detail = ty_module_resolver::file_to_module(db, program.resolver_file(db, class.file))
         .map(|module| module.name(db).to_string());
 
     TypeHierarchyItem {
@@ -709,21 +721,29 @@ Public = _Internal
 
     impl CursorTest {
         fn prepare(&self) -> Option<TypeHierarchyItem> {
-            prepare_type_hierarchy(&self.db, self.cursor.file, self.cursor.offset)
+            prepare_type_hierarchy(&self.db, self.cursor_program_file(), self.cursor.offset)
         }
 
         fn supertypes(&self) -> Vec<TypeHierarchyItem> {
             let Some(item) = self.prepare() else {
                 return vec![];
             };
-            type_hierarchy_supertypes(&self.db, item.file, item.selection_range.start())
+            type_hierarchy_supertypes(
+                &self.db,
+                self.program_file(item.file),
+                item.selection_range.start(),
+            )
         }
 
         fn subtypes(&self) -> Vec<TypeHierarchyItem> {
             let Some(item) = self.prepare() else {
                 return vec![];
             };
-            type_hierarchy_subtypes(&self.db, item.file, item.selection_range.start())
+            type_hierarchy_subtypes(
+                &self.db,
+                self.program_file(item.file),
+                item.selection_range.start(),
+            )
         }
     }
 }

--- a/crates/ty_ide/src/workspace_symbols.rs
+++ b/crates/ty_ide/src/workspace_symbols.rs
@@ -2,10 +2,12 @@ use crate::symbols::{QueryPattern, SymbolInfo, symbols_for_file};
 use rayon::prelude::*;
 use ruff_db::files::File;
 use ty_project::{Db, parallel::ParallelIteratorExt};
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::Program;
 
 /// Get all workspace symbols matching the query string.
 /// Returns symbols from all files in the workspace, filtered by the query.
-pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
+pub fn workspace_symbols(db: &dyn Db, program: Program, query: &str) -> Vec<WorkspaceSymbolInfo> {
     // If the query is empty, return immediately to avoid expensive file scanning
     if query.is_empty() {
         return Vec::new();
@@ -30,7 +32,7 @@ pub fn workspace_symbols(db: &dyn Db, query: &str) -> Vec<WorkspaceSymbolInfo> {
             );
             let _entered = symbols_for_file_span.entered();
 
-            symbols_for_file(db, file)
+            symbols_for_file(db, ProgramFile::new(db, program, file))
                 .search(&query)
                 .map(|(_, symbol)| WorkspaceSymbolInfo {
                     symbol: symbol.to_owned(),
@@ -198,7 +200,7 @@ foo = 1
 
     impl CursorTest {
         fn workspace_symbols(&self, query: &str) -> String {
-            let symbols = workspace_symbols(&self.db, query);
+            let symbols = workspace_symbols(&self.db, self.program(), query);
 
             if symbols.is_empty() {
                 return "No symbols found".to_string();

--- a/crates/ty_module_resolver/src/db.rs
+++ b/crates/ty_module_resolver/src/db.rs
@@ -1,12 +1,7 @@
 use ruff_db::Db as SourceDb;
 
-use crate::resolve::SearchPaths;
-
 #[salsa::db]
-pub trait Db: SourceDb {
-    /// Returns the search paths for module resolution.
-    fn search_paths(&self) -> &SearchPaths;
-}
+pub trait Db: SourceDb {}
 
 #[cfg(test)]
 pub(crate) mod tests {
@@ -19,7 +14,7 @@ pub(crate) mod tests {
     use ruff_python_ast::PythonVersion;
 
     use super::Db;
-    use crate::resolve::SearchPaths;
+    use crate::{ResolverProgram, resolve::SearchPaths};
 
     type Events = Arc<Mutex<Vec<salsa::Event>>>;
 
@@ -32,13 +27,14 @@ pub(crate) mod tests {
         vendored: VendoredFileSystem,
         search_paths: Arc<SearchPaths>,
         python_version: PythonVersion,
+        resolver_program: Option<ResolverProgram>,
         events: Events,
     }
 
     impl TestDb {
         pub(crate) fn new() -> Self {
             let events = Events::default();
-            Self {
+            let mut db = Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     let events = events.clone();
                     move |event| {
@@ -52,8 +48,15 @@ pub(crate) mod tests {
                 files: Files::default(),
                 search_paths: Arc::new(SearchPaths::empty(ty_vendored::file_system())),
                 python_version: PythonVersion::default(),
+                resolver_program: None,
                 events,
-            }
+            };
+            db.resolver_program = Some(ResolverProgram::create(
+                &db,
+                db.python_version,
+                &db.search_paths,
+            ));
+            db
         }
 
         pub(crate) fn with_search_paths(mut self, search_paths: SearchPaths) -> Self {
@@ -62,13 +65,32 @@ pub(crate) mod tests {
         }
 
         pub(crate) fn with_python_version(mut self, python_version: PythonVersion) -> Self {
+            let search_paths = self.search_paths().clone();
+            self.resolver_program = Some(self.resolver_program().with_settings(
+                &self,
+                python_version,
+                search_paths,
+            ));
             self.python_version = python_version;
             self
         }
 
         pub(crate) fn set_search_paths(&mut self, search_paths: SearchPaths) {
-            search_paths.try_register_static_roots(self);
+            let python_version = self.python_version;
+            self.resolver_program = Some(self.resolver_program().with_settings(
+                self,
+                python_version,
+                search_paths.clone(),
+            ));
             self.search_paths = Arc::new(search_paths);
+        }
+
+        pub(crate) fn search_paths(&self) -> &SearchPaths {
+            &self.search_paths
+        }
+
+        pub(crate) fn resolver_program(&self) -> ResolverProgram {
+            self.resolver_program.expect("resolver program initialized")
         }
 
         /// Takes the salsa events.
@@ -113,11 +135,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl Db for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            &self.search_paths
-        }
-    }
+    impl Db for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}

--- a/crates/ty_module_resolver/src/lib.rs
+++ b/crates/ty_module_resolver/src/lib.rs
@@ -7,6 +7,7 @@ pub use module::KnownModule;
 pub use module::Module;
 pub use module_name::{ModuleName, ModuleNameResolutionError};
 pub use path::{SearchPath, SearchPathError};
+pub use program::{ResolverFile, ResolverProgram};
 pub use resolve::{
     SearchPaths, file_to_module, resolve_module, resolve_module_confident, resolve_real_module,
     resolve_real_module_confident, resolve_real_shadowable_module,
@@ -27,6 +28,7 @@ mod module;
 mod module_glob;
 mod module_name;
 mod path;
+mod program;
 mod resolve;
 mod settings;
 mod strategy;
@@ -36,11 +38,14 @@ mod typeshed;
 mod testing;
 
 /// Returns an iterator over all search paths pointing to a system path
-pub fn system_module_search_paths(db: &dyn Db) -> SystemModuleSearchPathsIter<'_> {
+pub fn system_module_search_paths(
+    db: &dyn Db,
+    program: ResolverProgram,
+) -> SystemModuleSearchPathsIter<'_> {
     SystemModuleSearchPathsIter {
         // Always run in `Typing` mode because we want to include as much as possible
         // and we don't care about the "real" stdlib
-        inner: search_paths(db, ModuleResolveMode::Typing),
+        inner: search_paths(db, program, ModuleResolveMode::Typing),
     }
 }
 

--- a/crates/ty_module_resolver/src/list.rs
+++ b/crates/ty_module_resolver/src/list.rs
@@ -7,11 +7,12 @@ use crate::db::Db;
 use crate::module::{Module, ModuleKind};
 use crate::module_name::ModuleName;
 use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
+use crate::program::ResolverProgram;
 use crate::resolve::{ModuleResolveMode, ResolverContext, resolve_file_module, search_paths};
 
 /// List all available modules, including all sub-modules, sorted in lexicographic order.
-pub fn all_modules(db: &dyn Db) -> Vec<Module<'_>> {
-    let mut modules = list_modules(db).to_vec();
+pub fn all_modules(db: &dyn Db, program: ResolverProgram) -> Vec<Module<'_>> {
+    let mut modules = list_modules(db, program).to_vec();
     let mut stack = modules.clone();
     while let Some(module) = stack.pop() {
         for &submodule in module.all_submodules(db) {
@@ -23,13 +24,17 @@ pub fn all_modules(db: &dyn Db) -> Vec<Module<'_>> {
     modules
 }
 
-/// List all available top-level modules.
+/// List all available top-level modules in one resolver program.
 #[salsa::tracked(returns(deref))]
-pub fn list_modules(db: &dyn Db) -> Box<[Module<'_>]> {
+pub fn list_modules(db: &dyn Db, program: ResolverProgram) -> Box<[Module<'_>]> {
     let mut modules: BTreeMap<&ModuleName, ListedModule<'_>> = BTreeMap::new();
-    for search_path in search_paths(db, ModuleResolveMode::Typing) {
-        for &new in list_modules_in(db, SearchPathIngredient::new(db, search_path.clone())) {
-            match modules.entry(new.module(db).name(db)) {
+    for search_path in search_paths(db, program, ModuleResolveMode::Typing) {
+        for &new in list_modules_in(
+            db,
+            SearchPathIngredient::new(db, program, search_path.clone()),
+        ) {
+            let new_module = new.module(db);
+            match modules.entry(new_module.name(db)) {
                 Entry::Vacant(entry) => {
                     entry.insert(new);
                 }
@@ -46,7 +51,7 @@ pub fn list_modules(db: &dyn Db) -> Box<[Module<'_>]> {
                     //    per the typing spec's import resolution ordering.
                     let existing = entry.get();
                     let existing_is_namespace = existing.module(db).search_path(db).is_none();
-                    let new_is_non_namespace = new.module(db).search_path(db).is_some();
+                    let new_is_non_namespace = new_module.search_path(db).is_some();
                     if (existing_is_namespace && new_is_non_namespace)
                         || (!existing.is_stub_package(db) && new.is_stub_package(db))
                     {
@@ -64,6 +69,8 @@ pub fn list_modules(db: &dyn Db) -> Box<[Module<'_>]> {
 
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 struct SearchPathIngredient<'db> {
+    #[returns(copy)]
+    program: ResolverProgram,
     #[returns(ref)]
     path: SearchPath,
 }
@@ -74,9 +81,10 @@ fn list_modules_in<'db>(
     db: &'db dyn Db,
     search_path: SearchPathIngredient<'db>,
 ) -> Vec<ListedModule<'db>> {
-    tracing::debug!("Listing modules in search path '{}'", search_path.path(db));
-    let mut lister = Lister::new(db, search_path.path(db));
-    match search_path.path(db).as_path() {
+    let path = search_path.path(db);
+    tracing::debug!("Listing modules in search path '{path}'");
+    let mut lister = Lister::new(db, search_path.program(db), path);
+    match path.as_path() {
         SystemOrVendoredPathRef::System(system_search_path) => {
             let Ok(listing) = directory_listing(db, system_search_path) else {
                 return vec![];
@@ -115,6 +123,7 @@ impl get_size2::GetSize for ListedModule<'_> {}
 /// in the same directory).
 struct Lister<'db> {
     db: &'db dyn Db,
+    program: ResolverProgram,
     search_path: &'db SearchPath,
     modules: BTreeMap<&'db ModuleName, ListedModule<'db>>,
 }
@@ -122,9 +131,10 @@ struct Lister<'db> {
 impl<'db> Lister<'db> {
     /// Create new state that can accumulate modules from a list
     /// of file paths.
-    fn new(db: &'db dyn Db, search_path: &'db SearchPath) -> Lister<'db> {
+    fn new(db: &'db dyn Db, program: ResolverProgram, search_path: &'db SearchPath) -> Lister<'db> {
         Lister {
             db,
+            program,
             search_path,
             modules: BTreeMap::new(),
         }
@@ -177,6 +187,7 @@ impl<'db> Lister<'db> {
                         &module_path,
                         Module::file_module(
                             self.db,
+                            self.program,
                             module_name,
                             ModuleKind::Package,
                             self.search_path.clone(),
@@ -221,7 +232,7 @@ impl<'db> Lister<'db> {
                 if !self.search_path.is_standard_library() {
                     self.add_module(
                         &module_path,
-                        Module::namespace_package(self.db, module_name),
+                        Module::namespace_package(self.db, self.program, module_name),
                     );
                 }
                 return;
@@ -249,6 +260,7 @@ impl<'db> Lister<'db> {
             &module_path,
             Module::file_module(
                 self.db,
+                self.program,
                 module_name,
                 ModuleKind::Module,
                 self.search_path.clone(),
@@ -326,7 +338,7 @@ impl<'db> Lister<'db> {
     /// Returns the Python version we want to perform module resolution
     /// with.
     fn python_version(&self) -> PythonVersion {
-        self.db.python_version()
+        self.program.python_version(self.db)
     }
 
     /// Constructs a resolver context for use with some APIs that require it.
@@ -334,6 +346,7 @@ impl<'db> Lister<'db> {
         ResolverContext {
             db: self.db,
             python_version: self.python_version(),
+            typeshed_versions: self.program.search_paths(self.db).typeshed_versions(),
             // We don't currently support listing modules
             // in a "no stubs allowed" mode.
             mode: ModuleResolveMode::Typing,
@@ -403,6 +416,7 @@ mod tests {
 
     use crate::db::{Db, tests::TestDb};
     use crate::module::Module;
+    use crate::program::ResolverProgram;
     use crate::resolve::{
         ModuleResolveMode, ModuleResolveModeIngredient, dynamic_resolution_paths,
     };
@@ -410,7 +424,15 @@ mod tests {
     use crate::strategy::FallibleStrategy;
     use crate::testing::{FileSpec, MockedTypeshed, TestCase, TestCaseBuilder};
 
-    use super::list_modules;
+    use super::list_modules as list_modules_query;
+
+    fn resolver_program(db: &TestDb) -> ResolverProgram {
+        db.resolver_program()
+    }
+
+    fn list_modules(db: &TestDb) -> Box<[Module<'_>]> {
+        list_modules_query(db, resolver_program(db)).into()
+    }
 
     struct ModuleDebugSnapshot<'db> {
         db: &'db dyn Db,
@@ -460,18 +482,18 @@ mod tests {
         }
     }
 
-    fn sorted_list(db: &dyn Db) -> Vec<Module<'_>> {
+    fn sorted_list(db: &TestDb) -> Vec<Module<'_>> {
         let mut modules = list_modules(db).to_vec();
         modules.sort_by(|m1, m2| m1.name(db).cmp(m2.name(db)));
         modules
     }
 
-    fn list_snapshot(db: &dyn Db) -> Vec<ModuleDebugSnapshot<'_>> {
+    fn list_snapshot(db: &TestDb) -> Vec<ModuleDebugSnapshot<'_>> {
         list_snapshot_filter(db, |_| true)
     }
 
     fn list_snapshot_filter<'db>(
-        db: &'db dyn Db,
+        db: &'db TestDb,
         predicate: impl Fn(&Module<'db>) -> bool,
     ) -> Vec<ModuleDebugSnapshot<'db>> {
         sorted_list(db)
@@ -1439,7 +1461,7 @@ not_a_directory
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(&db, resolver_program(&db), ModuleResolveMode::Typing),
             &events,
         );
     }

--- a/crates/ty_module_resolver/src/module.rs
+++ b/crates/ty_module_resolver/src/module.rs
@@ -10,6 +10,7 @@ use salsa::plumbing::AsId;
 use crate::Db;
 use crate::module_name::ModuleName;
 use crate::path::{SearchPath, SystemOrVendoredPathRef};
+use crate::program::ResolverProgram;
 
 /// Representation of a Python module.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, salsa::Supertype, salsa::SalsaValue)]
@@ -25,6 +26,7 @@ impl get_size2::GetSize for Module<'_> {}
 impl<'db> Module<'db> {
     pub(crate) fn file_module(
         db: &'db dyn Db,
+        program: ResolverProgram,
         name: ModuleName,
         kind: ModuleKind,
         search_path: SearchPath,
@@ -32,11 +34,30 @@ impl<'db> Module<'db> {
     ) -> Self {
         let known = KnownModule::try_from_search_path_and_name(&search_path, &name);
 
-        Self::File(FileModule::new(db, name, kind, search_path, file, known))
+        Self::File(FileModule::new(
+            db,
+            program,
+            name,
+            kind,
+            search_path,
+            file,
+            known,
+        ))
     }
 
-    pub(crate) fn namespace_package(db: &'db dyn Db, name: ModuleName) -> Self {
-        Self::Namespace(NamespacePackage::new(db, name))
+    pub(crate) fn namespace_package(
+        db: &'db dyn Db,
+        program: ResolverProgram,
+        name: ModuleName,
+    ) -> Self {
+        Self::Namespace(NamespacePackage::new(db, program, name))
+    }
+
+    pub fn program(self, db: &'db dyn Database) -> ResolverProgram {
+        match self {
+            Module::File(module) => module.program(db),
+            Module::Namespace(package) => package.program(db),
+        }
     }
 
     /// The absolute name of the module (e.g. `foo.bar`)
@@ -171,14 +192,18 @@ fn all_submodule_names_for_package<'db>(
 
     Some(match path.parent()? {
         SystemOrVendoredPathRef::System(parent_directory) => {
-            directory_listing(db, parent_directory)
+            let listing = directory_listing(db, parent_directory)
                 .inspect_err(|error| {
                     tracing::debug!(
                         "Failed to read {parent_directory:?} when looking for \
                          its possible submodules: {error}"
                     );
                 })
-                .ok()?
+                .ok()?;
+            let program = module.program(db);
+            let module_name = module.name(db);
+            let search_path = module.search_path(db);
+            listing
                 .iter()
                 .filter(|(name, ty)| {
                     let path = SystemPath::new(name);
@@ -193,7 +218,7 @@ fn all_submodule_names_for_package<'db>(
                     let relative = SystemPath::new(entry_name);
                     let stem = relative.file_stem()?;
                     let path = parent_directory.join(relative);
-                    let mut name = module.name(db).clone();
+                    let mut name = module_name.clone();
                     name.extend(&ModuleName::new(stem)?);
 
                     let (kind, file) = if file_type.is_directory() {
@@ -204,56 +229,64 @@ fn all_submodule_names_for_package<'db>(
                     };
                     Some(Module::file_module(
                         db,
+                        program,
                         name,
                         kind,
-                        module.search_path(db).clone(),
+                        search_path.clone(),
                         file,
                     ))
                 })
                 .collect()
         }
-        SystemOrVendoredPathRef::Vendored(parent_directory) => db
-            .vendored()
-            .read_directory(parent_directory)
-            .filter(|entry| {
-                let ty = entry.file_type();
-                let path = entry.path();
-                is_submodule(
-                    ty.is_directory(),
-                    ty.is_file(),
-                    path.file_name(),
-                    path.extension(),
-                )
-            })
-            .filter_map(|entry| {
-                let stem = entry.path().file_stem()?;
-                let mut name = module.name(db).clone();
-                name.extend(&ModuleName::new(stem)?);
-
-                let (kind, file) = if entry.file_type().is_directory() {
-                    (
-                        ModuleKind::Package,
-                        find_package_init_vendored(db, entry.path())?,
+        SystemOrVendoredPathRef::Vendored(parent_directory) => {
+            let program = module.program(db);
+            let module_name = module.name(db);
+            let search_path = module.search_path(db);
+            db.vendored()
+                .read_directory(parent_directory)
+                .filter(|entry| {
+                    let ty = entry.file_type();
+                    let path = entry.path();
+                    is_submodule(
+                        ty.is_directory(),
+                        ty.is_file(),
+                        path.file_name(),
+                        path.extension(),
                     )
-                } else {
-                    let file = vendored_path_to_file(db, entry.path()).ok()?;
-                    (ModuleKind::Module, file)
-                };
-                Some(Module::file_module(
-                    db,
-                    name,
-                    kind,
-                    module.search_path(db).clone(),
-                    file,
-                ))
-            })
-            .collect(),
+                })
+                .filter_map(|entry| {
+                    let stem = entry.path().file_stem()?;
+                    let mut name = module_name.clone();
+                    name.extend(&ModuleName::new(stem)?);
+
+                    let (kind, file) = if entry.file_type().is_directory() {
+                        (
+                            ModuleKind::Package,
+                            find_package_init_vendored(db, entry.path())?,
+                        )
+                    } else {
+                        let file = vendored_path_to_file(db, entry.path()).ok()?;
+                        (ModuleKind::Module, file)
+                    };
+                    Some(Module::file_module(
+                        db,
+                        program,
+                        name,
+                        kind,
+                        search_path.clone(),
+                        file,
+                    ))
+                })
+                .collect()
+        }
     })
 }
 
 /// A module that resolves to a file (`lib.py` or `package/__init__.py`)
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct FileModule<'db> {
+    #[returns(copy)]
+    pub(super) program: ResolverProgram,
     #[returns(ref)]
     pub(super) name: ModuleName,
     #[returns(copy)]
@@ -272,6 +305,8 @@ pub struct FileModule<'db> {
 /// multiple possible paths and they have no corresponding code file.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct NamespacePackage<'db> {
+    #[returns(copy)]
+    pub(super) program: ResolverProgram,
     #[returns(ref)]
     pub(super) name: ModuleName,
 }

--- a/crates/ty_module_resolver/src/module_name.rs
+++ b/crates/ty_module_resolver/src/module_name.rs
@@ -4,11 +4,11 @@ use std::ops::Deref;
 
 use compact_str::{CompactString, ToCompactString};
 
-use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::db::Db;
+use crate::program::ResolverFile;
 use crate::resolve::file_to_module;
 
 /// A module name, e.g. `foo.bar`.
@@ -305,13 +305,12 @@ impl ModuleName {
     /// Extracts a module name from the AST of a `from <module> import ...`
     /// statement.
     ///
-    /// `importing_file` must be the [`File`] that contains the import
-    /// statement.
+    /// `importing_file` must contain the import statement.
     ///
     /// This handles relative import statements.
     pub fn from_import_statement<'db>(
         db: &'db dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'db>,
         node: &'db ast::StmtImportFrom,
     ) -> Result<Self, ModuleNameResolutionError> {
         let ast::StmtImportFrom {
@@ -328,7 +327,7 @@ impl ModuleName {
     /// Computes the absolute module name from the LHS components of `from LHS import RHS`
     pub fn from_identifier_parts(
         db: &dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
         module: Option<&str>,
         level: u32,
     ) -> Result<Self, ModuleNameResolutionError> {
@@ -346,7 +345,7 @@ impl ModuleName {
     /// i.e. this resolves `.`
     pub fn package_for_file(
         db: &dyn Db,
-        importing_file: File,
+        importing_file: ResolverFile<'_>,
     ) -> Result<Self, ModuleNameResolutionError> {
         Self::from_identifier_parts(db, importing_file, None, 1)
     }
@@ -480,7 +479,7 @@ impl std::fmt::Display for ModuleName {
 ///   - `from ..foo.bar import baz` => `tail == "foo.bar"`
 fn relative_module_name(
     db: &dyn Db,
-    importing_file: File,
+    importing_file: ResolverFile<'_>,
     tail: Option<&str>,
     level: NonZeroU32,
 ) -> Result<ModuleName, ModuleNameResolutionError> {

--- a/crates/ty_module_resolver/src/path.rs
+++ b/crates/ty_module_resolver/src/path.rs
@@ -13,7 +13,7 @@ use ruff_db::vendored::{VendoredPath, VendoredPathBuf};
 use crate::Db;
 use crate::module_name::ModuleName;
 use crate::resolve::{PyTyped, ResolverContext};
-use crate::typeshed::{TypeshedVersionsQueryResult, typeshed_versions};
+use crate::typeshed::TypeshedVersionsQueryResult;
 
 /// A path that points to a Python module.
 ///
@@ -429,12 +429,13 @@ fn query_stdlib_version(
         return TypeshedVersionsQueryResult::DoesNotExist;
     };
     let ResolverContext {
-        db,
+        db: _,
         python_version,
+        typeshed_versions,
         mode: _,
     } = context;
 
-    typeshed_versions(*db).query_module(&module_name, *python_version)
+    typeshed_versions.query_module(&module_name, *python_version)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -1146,6 +1147,15 @@ mod tests {
         typeshed_test_case(typeshed, PythonVersion::PY39)
     }
 
+    fn resolver_context(db: &TestDb, python_version: PythonVersion) -> ResolverContext<'_> {
+        ResolverContext::new(
+            db,
+            python_version,
+            db.search_paths().typeshed_versions(),
+            ModuleResolveMode::Typing,
+        )
+    }
+
     #[test]
     fn mocked_typeshed_existing_regular_stdlib_pkg_py38() {
         const VERSIONS: &str = "\
@@ -1159,7 +1169,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let asyncio_regular_package = stdlib_path.join("asyncio");
         assert!(asyncio_regular_package.is_directory(&resolver));
@@ -1189,7 +1199,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let xml_namespace_package = stdlib_path.join("xml");
         assert!(xml_namespace_package.is_directory(&resolver));
@@ -1211,7 +1221,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let functools_module = stdlib_path.join("functools.pyi");
         assert!(functools_module.to_file(&resolver).is_some());
@@ -1227,7 +1237,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let collections_regular_package = stdlib_path.join("collections");
         assert_eq!(collections_regular_package.to_file(&resolver), None);
@@ -1243,7 +1253,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let importlib_namespace_package = stdlib_path.join("importlib");
         assert_eq!(importlib_namespace_package.to_file(&resolver), None);
@@ -1264,7 +1274,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py38_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY38, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY38);
 
         let non_existent = stdlib_path.join("doesnt_even_exist");
         assert_eq!(non_existent.to_file(&resolver), None);
@@ -1292,7 +1302,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY39);
 
         // Since we've set the target version to Py39,
         // `collections` should now exist as a directory, according to VERSIONS...
@@ -1323,7 +1333,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY39);
 
         // The `importlib` directory now also exists
         let importlib_namespace_package = stdlib_path.join("importlib");
@@ -1347,7 +1357,7 @@ mod tests {
         };
 
         let (db, stdlib_path) = py39_typeshed_test_case(TYPESHED);
-        let resolver = ResolverContext::new(&db, PythonVersion::PY39, ModuleResolveMode::Typing);
+        let resolver = resolver_context(&db, PythonVersion::PY39);
 
         // The `xml` package no longer exists on py39:
         let xml_namespace_package = stdlib_path.join("xml");

--- a/crates/ty_module_resolver/src/program.rs
+++ b/crates/ty_module_resolver/src/program.rs
@@ -1,0 +1,58 @@
+use ruff_db::files::File;
+use ruff_python_ast::PythonVersion;
+use salsa::Durability;
+
+use crate::{Db, SearchPaths};
+
+/// The portion of a Python program used during parsing and module resolution.
+#[salsa::input(heap_size = ruff_memory_usage::heap_size)]
+#[derive(Debug)]
+pub struct ResolverProgram {
+    #[returns(copy)]
+    pub python_version: PythonVersion,
+
+    #[returns(ref)]
+    pub search_paths: SearchPaths,
+}
+
+impl get_size2::GetSize for ResolverProgram {}
+
+impl ResolverProgram {
+    pub fn create(db: &dyn Db, python_version: PythonVersion, search_paths: &SearchPaths) -> Self {
+        Self::from_settings(db, python_version, search_paths.clone())
+    }
+
+    fn from_settings(
+        db: &dyn Db,
+        python_version: PythonVersion,
+        search_paths: SearchPaths,
+    ) -> Self {
+        search_paths.try_register_static_roots(db);
+        Self::builder(python_version, search_paths)
+            .durability(Durability::NEVER_CHANGE)
+            .new(db)
+    }
+
+    #[must_use]
+    pub fn with_settings(
+        self,
+        db: &dyn Db,
+        python_version: PythonVersion,
+        search_paths: SearchPaths,
+    ) -> Self {
+        if self.python_version(db) == python_version && self.search_paths(db) == &search_paths {
+            self
+        } else {
+            Self::from_settings(db, python_version, search_paths)
+        }
+    }
+}
+
+/// A physical file interpreted in one module-resolution environment.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+pub struct ResolverFile<'db> {
+    #[returns(copy)]
+    pub program: ResolverProgram,
+    #[returns(copy)]
+    pub file: File,
+}

--- a/crates/ty_module_resolver/src/resolve.rs
+++ b/crates/ty_module_resolver/src/resolve.rs
@@ -50,6 +50,7 @@ use crate::db::Db;
 use crate::module::{Module, ModuleKind};
 use crate::module_name::ModuleName;
 use crate::path::{ModulePath, SearchPath, SystemOrVendoredPathRef};
+use crate::program::{ResolverFile, ResolverProgram};
 use crate::strategy::MisconfigurationStrategy;
 use crate::typeshed::{TypeshedVersions, vendored_typeshed_versions};
 use crate::{SearchPathSettings, SearchPathSettingsError};
@@ -57,13 +58,18 @@ use crate::{SearchPathSettings, SearchPathSettingsError};
 /// Resolves a module name to a module.
 pub fn resolve_module<'db>(
     db: &'db dyn Db,
-    importing_file: File,
+    importing_file: ResolverFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name = ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Typing);
+    let interned_name = ModuleNameIngredient::new(
+        db,
+        importing_file.program(db),
+        module_name,
+        ModuleResolveMode::Typing,
+    );
 
     resolve_module_query(db, interned_name)
-        .or_else(|| desperately_resolve_module(db, importing_file, interned_name))
+        .or_else(|| desperately_resolve_module(db, importing_file.file(db), interned_name))
 }
 
 /// Resolves a module name to a module, without desperate resolution available.
@@ -72,9 +78,11 @@ pub fn resolve_module<'db>(
 /// we don't have a well-defined importing file.
 pub fn resolve_module_confident<'db>(
     db: &'db dyn Db,
+    program: ResolverProgram,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name = ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Typing);
+    let interned_name =
+        ModuleNameIngredient::new(db, program, module_name, ModuleResolveMode::Typing);
 
     resolve_module_query(db, interned_name)
 }
@@ -82,13 +90,18 @@ pub fn resolve_module_confident<'db>(
 /// Resolves a module name to a module (stubs not allowed).
 pub fn resolve_real_module<'db>(
     db: &'db dyn Db,
-    importing_file: File,
+    importing_file: ResolverFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name = ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Runtime);
+    let interned_name = ModuleNameIngredient::new(
+        db,
+        importing_file.program(db),
+        module_name,
+        ModuleResolveMode::Runtime,
+    );
 
     resolve_module_query(db, interned_name)
-        .or_else(|| desperately_resolve_module(db, importing_file, interned_name))
+        .or_else(|| desperately_resolve_module(db, importing_file.file(db), interned_name))
 }
 
 /// Resolves a module name to a module, without desperate resolution available (stubs not allowed).
@@ -97,9 +110,11 @@ pub fn resolve_real_module<'db>(
 /// we don't have a well-defined importing file.
 pub fn resolve_real_module_confident<'db>(
     db: &'db dyn Db,
+    program: ResolverProgram,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
-    let interned_name = ModuleNameIngredient::new(db, module_name, ModuleResolveMode::Runtime);
+    let interned_name =
+        ModuleNameIngredient::new(db, program, module_name, ModuleResolveMode::Runtime);
 
     resolve_module_query(db, interned_name)
 }
@@ -117,17 +132,18 @@ pub fn resolve_real_module_confident<'db>(
 /// are involved in an import cycle with `builtins`.
 pub fn resolve_real_shadowable_module<'db>(
     db: &'db dyn Db,
-    importing_file: File,
+    importing_file: ResolverFile<'db>,
     module_name: &ModuleName,
 ) -> Option<Module<'db>> {
     let interned_name = ModuleNameIngredient::new(
         db,
+        importing_file.program(db),
         module_name,
         ModuleResolveMode::RuntimeSomeShadowingAllowed,
     );
 
     resolve_module_query(db, interned_name)
-        .or_else(|| desperately_resolve_module(db, importing_file, interned_name))
+        .or_else(|| desperately_resolve_module(db, importing_file.file(db), interned_name))
 }
 
 /// Selects typing or runtime module-resolution semantics.
@@ -158,6 +174,8 @@ pub enum ModuleResolveMode {
 #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
 #[derive(Debug)]
 pub(crate) struct ModuleResolveModeIngredient<'db> {
+    #[returns(copy)]
+    program: ResolverProgram,
     #[returns(copy)]
     mode: ModuleResolveMode,
 }
@@ -212,9 +230,10 @@ fn resolve_module_query<'db>(
 ) -> Option<Module<'db>> {
     let name = module_name.name(db);
     let mode = module_name.mode(db);
+    let program = module_name.program(db);
     let _span = tracing::trace_span!("resolve_module", %name).entered();
 
-    let Some(resolved) = resolve_name(db, name, mode) else {
+    let Some(resolved) = resolve_name(db, program, name, mode) else {
         tracing::debug!("Module `{name}` not found in search paths");
         return None;
     };
@@ -222,7 +241,7 @@ fn resolve_module_query<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name.clone()))
+        .map(|candidate| candidate.into_module(db, program, name.clone()))
 }
 
 /// Like `resolve_module_query` but for cases where it failed to resolve the module
@@ -243,6 +262,8 @@ fn desperately_resolve_module<'db>(
     importing_file: File,
     module_name: ModuleNameIngredient<'db>,
 ) -> Option<Module<'db>> {
+    let program = module_name.program(db);
+    let importing_file = ResolverFile::new(db, program, importing_file);
     let name = module_name.name(db);
     let mode = module_name.mode(db);
     let _span = tracing::trace_span!("desperately_resolve_module", %name).entered();
@@ -262,14 +283,18 @@ fn desperately_resolve_module<'db>(
     resolved
         .into_iter()
         .next()
-        .map(|candidate| candidate.into_module(db, name.clone()))
+        .map(|candidate| candidate.into_module(db, program, name.clone()))
 }
 
 /// Resolves the module for the given path.
 ///
 /// Returns `None` if the path is not a module locatable via any of the known search paths.
 #[allow(unused)]
-pub(crate) fn path_to_module<'db>(db: &'db dyn Db, path: &FilePath) -> Option<Module<'db>> {
+pub(crate) fn path_to_module<'db>(
+    db: &'db dyn Db,
+    program: ResolverProgram,
+    path: &FilePath,
+) -> Option<Module<'db>> {
     // It's not entirely clear on first sight why this method calls `file_to_module` instead of
     // it being the other way round, considering that the first thing that `file_to_module` does
     // is to retrieve the file's path.
@@ -279,7 +304,7 @@ pub(crate) fn path_to_module<'db>(db: &'db dyn Db, path: &FilePath) -> Option<Mo
     // `VfsFile` is. So what we do here is to retrieve the `path`'s `VfsFile` so that we can make
     // use of Salsa's caching and invalidation.
     let file = path.to_file(db)?;
-    file_to_module(db, file)
+    file_to_module(db, ResolverFile::new(db, program, file))
 }
 
 /// Resolves the module for the file with the given id.
@@ -291,23 +316,37 @@ pub(crate) fn path_to_module<'db>(db: &'db dyn Db, path: &FilePath) -> Option<Mo
 /// This intuition is particularly useful for understanding why it's correct that we pass
 /// the file itself as `importing_file` to various subroutines.
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-pub fn file_to_module(db: &dyn Db, file: File) -> Option<Module<'_>> {
+pub fn file_to_module<'db>(
+    db: &'db dyn Db,
+    resolver_file: ResolverFile<'db>,
+) -> Option<Module<'db>> {
+    let file = resolver_file.file(db);
+    let program = resolver_file.program(db);
     let _span = tracing::trace_span!("file_to_module", ?file).entered();
 
     let path = SystemOrVendoredPathRef::try_from_file(db, file)?;
 
-    file_to_module_impl(db, file, path, search_paths(db, ModuleResolveMode::Typing)).or_else(|| {
+    file_to_module_impl(
+        db,
+        resolver_file,
+        file,
+        path,
+        search_paths(db, program, ModuleResolveMode::Typing),
+    )
+    .or_else(|| {
         file_to_module_impl(
             db,
+            resolver_file,
             file,
             path,
-            relative_desperate_search_paths(db, file).iter(),
+            relative_desperate_search_paths(db, resolver_file).iter(),
         )
     })
 }
 
 fn file_to_module_impl<'db, 'a>(
     db: &'db dyn Db,
+    resolver_file: ResolverFile<'db>,
     file: File,
     path: SystemOrVendoredPathRef<'a>,
     mut search_paths: impl Iterator<Item = &'a SearchPath>,
@@ -324,7 +363,7 @@ fn file_to_module_impl<'db, 'a>(
     // If it doesn't, then that means that multiple modules have the same name in different
     // root paths, but that the module corresponding to `path` is in a lower priority search path,
     // in which case we ignore it.
-    let module = resolve_module(db, file, &module_name)?;
+    let module = resolve_module(db, resolver_file, &module_name)?;
     let module_file = module.file(db)?;
 
     if file.path(db) == module_file.path(db) {
@@ -335,7 +374,7 @@ fn file_to_module_impl<'db, 'a>(
         // If a .py and .pyi are both defined, the .pyi will be the one returned by `resolve_module().file`,
         // which would make us erroneously believe the `.py` is *not* also this module (breaking things
         // like relative imports). So here we try `resolve_real_module().file` to cover both cases.
-        let module = resolve_real_module(db, file, &module_name)?;
+        let module = resolve_real_module(db, resolver_file, &module_name)?;
         let module_file = module.file(db)?;
         if file.path(db) == module_file.path(db) {
             return Some(module);
@@ -351,8 +390,12 @@ fn file_to_module_impl<'db, 'a>(
     None
 }
 
-pub fn search_paths(db: &dyn Db, resolve_mode: ModuleResolveMode) -> SearchPathIterator<'_> {
-    db.search_paths().iter(db, resolve_mode)
+pub fn search_paths(
+    db: &dyn Db,
+    program: ResolverProgram,
+    resolve_mode: ModuleResolveMode,
+) -> SearchPathIterator<'_> {
+    program.search_paths(db).iter(db, program, resolve_mode)
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -441,8 +484,8 @@ impl StubPackageIndex {
 /// Returns an index of search paths that may contain a top-level stub package, preserving their
 /// resolution order relative to stdlib.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-fn stub_package_index(db: &dyn Db) -> StubPackageIndex {
-    StubPackageIndex::from_search_paths(db, search_paths(db, ModuleResolveMode::Typing))
+fn stub_package_index(db: &dyn Db, program: ResolverProgram) -> StubPackageIndex {
+    StubPackageIndex::from_search_paths(db, search_paths(db, program, ModuleResolveMode::Typing))
 }
 
 fn search_path_may_contain_stub_package(db: &dyn Db, search_path: &SearchPath) -> bool {
@@ -464,21 +507,27 @@ fn search_path_may_contain_stub_package(db: &dyn Db, search_path: &SearchPath) -
 ///
 /// We exclude `__init__.py(i)` dirs to avoid truncating packages.
 #[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
-fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<Box<[SearchPath]>> {
+fn absolute_desperate_search_paths(
+    db: &dyn Db,
+    importing_file: ResolverFile<'_>,
+) -> Option<Box<[SearchPath]>> {
     let system = db.system();
-    let importing_path = importing_file.path(db).as_system_path()?;
+    let file = importing_file.file(db);
+    let importing_path = file.path(db).as_system_path()?;
 
     // Only allow this if the importing_file is under the first-party search path
     let (base_path, rel_path) =
-        search_paths(db, ModuleResolveMode::Typing).find_map(|search_path| {
-            if !search_path.is_first_party() {
-                return None;
-            }
-            Some((
-                search_path.as_system_path()?,
-                search_path.relativize_system_path_only(importing_path)?,
-            ))
-        })?;
+        search_paths(db, importing_file.program(db), ModuleResolveMode::Typing).find_map(
+            |search_path| {
+                if !search_path.is_first_party() {
+                    return None;
+                }
+                Some((
+                    search_path.as_system_path()?,
+                    search_path.relativize_system_path_only(importing_path)?,
+                ))
+            },
+        )?;
 
     // Only allow searching up to the first-party path's root
     let mut search_paths = Vec::new();
@@ -528,21 +577,26 @@ fn absolute_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<
 /// chaotic things. In particular, all files under a given pyproject.toml will currently
 /// agree on this being their desperate search-path, which is really nice.
 #[salsa::tracked(returns(clone), heap_size=ruff_memory_usage::heap_size)]
-fn relative_desperate_search_paths(db: &dyn Db, importing_file: File) -> Option<SearchPath> {
+fn relative_desperate_search_paths(
+    db: &dyn Db,
+    importing_file: ResolverFile<'_>,
+) -> Option<SearchPath> {
     let system = db.system();
-    let importing_path = importing_file.path(db).as_system_path()?;
+    let importing_path = importing_file.file(db).path(db).as_system_path()?;
 
     // Only allow this if the importing_file is under the first-party search path
     let (base_path, rel_path) =
-        search_paths(db, ModuleResolveMode::Typing).find_map(|search_path| {
-            if !search_path.is_first_party() {
-                return None;
-            }
-            Some((
-                search_path.as_system_path()?,
-                search_path.relativize_system_path_only(importing_path)?,
-            ))
-        })?;
+        search_paths(db, importing_file.program(db), ModuleResolveMode::Typing).find_map(
+            |search_path| {
+                if !search_path.is_first_party() {
+                    return None;
+                }
+                Some((
+                    search_path.as_system_path()?,
+                    search_path.relativize_system_path_only(importing_path)?,
+                ))
+            },
+        )?;
 
     // Only allow searching up to the first-party path's root
     for rel_dir in rel_path.ancestors() {
@@ -791,6 +845,7 @@ impl SearchPaths {
     pub(super) fn iter<'a>(
         &'a self,
         db: &'a dyn Db,
+        program: ResolverProgram,
         mode: ModuleResolveMode,
     ) -> SearchPathIterator<'a> {
         let stdlib_path = self.stdlib(mode);
@@ -799,7 +854,7 @@ impl SearchPaths {
             static_paths: self.static_paths.iter(),
             stdlib_path,
             dynamic_paths: None,
-            mode: ModuleResolveModeIngredient::new(db, mode),
+            mode: ModuleResolveModeIngredient::new(db, program, mode),
         }
     }
 
@@ -815,11 +870,13 @@ impl SearchPaths {
     pub fn display<'a>(
         &'a self,
         db: &'a dyn Db,
+        program: ResolverProgram,
         mode: ModuleResolveMode,
     ) -> DisplaySearchPaths<'a> {
         DisplaySearchPaths {
             search_paths: self,
             db,
+            program,
             mode,
         }
     }
@@ -838,12 +895,16 @@ impl SearchPaths {
 pub struct DisplaySearchPaths<'a> {
     search_paths: &'a SearchPaths,
     db: &'a dyn Db,
+    program: ResolverProgram,
     mode: ModuleResolveMode,
 }
 
 impl fmt::Display for DisplaySearchPaths<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut paths = self.search_paths.iter(self.db, self.mode).peekable();
+        let mut paths = self
+            .search_paths
+            .iter(self.db, self.program, self.mode)
+            .peekable();
 
         if paths.peek().is_none() {
             return f.write_str("[]");
@@ -878,7 +939,7 @@ pub(crate) fn dynamic_resolution_paths<'db>(
         site_packages,
         typeshed_versions: _,
         real_stdlib_path,
-    } = db.search_paths();
+    } = mode.program(db).search_paths(db);
 
     let mut dynamic_paths = Vec::new();
 
@@ -1052,6 +1113,8 @@ impl FusedIterator for SearchPathIterator<'_> {}
 /// This is needed because Salsa requires that all query arguments are salsa ingredients.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 struct ModuleNameIngredient<'db> {
+    #[returns(copy)]
+    pub(super) program: ResolverProgram,
     #[returns(ref)]
     pub(super) name: ModuleName,
     #[returns(copy)]
@@ -1060,13 +1123,18 @@ struct ModuleNameIngredient<'db> {
 
 /// Given a module name and a list of search paths in which to lookup modules,
 /// attempt to resolve the module name
-fn resolve_name(db: &dyn Db, name: &ModuleName, mode: ModuleResolveMode) -> Option<ResolvedNames> {
-    let resolver = NameResolver::new(db, name, mode);
+fn resolve_name(
+    db: &dyn Db,
+    program: ResolverProgram,
+    name: &ModuleName,
+    mode: ModuleResolveMode,
+) -> Option<ResolvedNames> {
+    let resolver = NameResolver::new(db, program, name, mode);
 
     match mode {
-        ModuleResolveMode::Typing => resolver.resolve_typing(stub_package_index(db)),
+        ModuleResolveMode::Typing => resolver.resolve_typing(stub_package_index(db, program)),
         ModuleResolveMode::Runtime | ModuleResolveMode::RuntimeSomeShadowingAllowed => {
-            resolver.resolve_runtime(search_paths(db, mode))
+            resolver.resolve_runtime(search_paths(db, program, mode))
         }
     }
 }
@@ -1077,12 +1145,12 @@ fn resolve_name(db: &dyn Db, name: &ModuleName, mode: ModuleResolveMode) -> Opti
 /// to this import.
 fn desperately_resolve_name(
     db: &dyn Db,
-    importing_file: File,
+    importing_file: ResolverFile<'_>,
     name: &ModuleName,
     mode: ModuleResolveMode,
 ) -> Option<ResolvedNames> {
     let search_paths = absolute_desperate_search_paths(db, importing_file).unwrap_or_default();
-    let resolver = NameResolver::new(db, name, mode);
+    let resolver = NameResolver::new(db, importing_file.program(db), name, mode);
 
     match mode {
         ModuleResolveMode::Typing => resolver.resolve_desperate_typing(search_paths),
@@ -1166,11 +1234,11 @@ impl ModuleResolutionCandidate {
     }
 
     // This is the module we were actually interested in resolving, complete the resolution
-    fn into_module(self, db: &'_ dyn Db, name: ModuleName) -> Module<'_> {
+    fn into_module(self, db: &dyn Db, program: ResolverProgram, name: ModuleName) -> Module<'_> {
         match self.module {
             ResolvedModule::NamespacePackage => {
                 tracing::trace!("Resolve namespace package `{name}`");
-                Module::namespace_package(db, name)
+                Module::namespace_package(db, program, name)
             }
             ResolvedModule::LegacyNamespacePackage(file) => {
                 // legacy namespace packages behave like regular packages
@@ -1181,6 +1249,7 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
+                    program,
                     name,
                     ModuleKind::Package,
                     self.path.into_search_path(),
@@ -1194,6 +1263,7 @@ impl ModuleResolutionCandidate {
                 );
                 Module::file_module(
                     db,
+                    program,
                     name,
                     ModuleKind::Package,
                     self.path.into_search_path(),
@@ -1204,6 +1274,7 @@ impl ModuleResolutionCandidate {
                 tracing::trace!("Resolved module `{name}` to `{path}`", path = file.path(db));
                 Module::file_module(
                     db,
+                    program,
                     name,
                     ModuleKind::Module,
                     self.path.into_search_path(),
@@ -1241,16 +1312,28 @@ impl ModuleResolutionCandidate {
 }
 
 struct NameResolver<'db, 'name> {
+    program: ResolverProgram,
     context: ResolverContext<'db>,
     name: &'name ModuleName,
     is_non_shadowable: bool,
 }
 
 impl<'db, 'name> NameResolver<'db, 'name> {
-    fn new(db: &'db dyn Db, name: &'name ModuleName, mode: ModuleResolveMode) -> Self {
-        let python_version = db.python_version();
+    fn new(
+        db: &'db dyn Db,
+        program: ResolverProgram,
+        name: &'name ModuleName,
+        mode: ModuleResolveMode,
+    ) -> Self {
+        let python_version = program.python_version(db);
         Self {
-            context: ResolverContext::new(db, python_version, mode),
+            program,
+            context: ResolverContext::new(
+                db,
+                python_version,
+                program.search_paths(db).typeshed_versions(),
+                mode,
+            ),
             name,
             is_non_shadowable: mode.is_non_shadowable(python_version.minor, name.as_str()),
         }
@@ -1262,11 +1345,11 @@ impl<'db, 'name> NameResolver<'db, 'name> {
     /// a fallback when no stub provides the requested module. A stub overlay may use runtime
     /// packages as parents, but its final module must come from a stub file.
     fn resolve_typing(&self, stub_packages: &StubPackageIndex) -> Option<ResolvedNames> {
-        let search_paths = self.context.db.search_paths();
+        let search_paths = self.program.search_paths(self.context.db);
 
         if self.name.components().nth(1).is_none() {
             let candidates = self.discover_roots(
-                search_paths.iter(self.context.db, ModuleResolveMode::Typing),
+                search_paths.iter(self.context.db, self.program, ModuleResolveMode::Typing),
                 stub_packages.all(),
             );
             return self.resolve_remaining(candidates, ComponentFileFilter::ByMode);
@@ -1278,7 +1361,7 @@ impl<'db, 'name> NameResolver<'db, 'name> {
         let (overlay_stub_packages, remaining_stub_packages) = stub_packages.split_overlay();
         let mut candidates = self.discover_roots(
             search_paths
-                .iter(self.context.db, ModuleResolveMode::Typing)
+                .iter(self.context.db, self.program, ModuleResolveMode::Typing)
                 .take_while(|search_path| search_path.is_extra()),
             overlay_stub_packages,
         );
@@ -1290,7 +1373,7 @@ impl<'db, 'name> NameResolver<'db, 'name> {
 
         let remaining_candidates = self.discover_roots(
             search_paths
-                .iter(self.context.db, ModuleResolveMode::Typing)
+                .iter(self.context.db, self.program, ModuleResolveMode::Typing)
                 .skip_while(|search_path| search_path.is_extra()),
             remaining_stub_packages,
         );
@@ -1695,7 +1778,9 @@ fn is_legacy_namespace_package(
     //
     // The downside is if you write slightly different syntax we will fail to detect the idiom,
     // but hey, this is better than nothing!
-    let parsed = ruff_db::parsed::parsed_module(context.db, init);
+    let versioned_file =
+        ruff_db::parsed::VersionedFile::new(context.db, init, context.python_version);
+    let parsed = ruff_db::parsed::parsed_module(context.db, versioned_file);
     let mut visitor = LegacyNamespacePackageVisitor::default();
     visitor.visit_body(parsed.load(context.db).suite());
 
@@ -1731,6 +1816,7 @@ impl PyTyped {
 pub(super) struct ResolverContext<'db> {
     pub(super) db: &'db dyn Db,
     pub(super) python_version: PythonVersion,
+    pub(super) typeshed_versions: &'db TypeshedVersions,
     pub(super) mode: ModuleResolveMode,
 }
 
@@ -1738,11 +1824,13 @@ impl<'db> ResolverContext<'db> {
     pub(super) fn new(
         db: &'db dyn Db,
         python_version: PythonVersion,
+        typeshed_versions: &'db TypeshedVersions,
         mode: ModuleResolveMode,
     ) -> Self {
         Self {
             db,
             python_version,
+            typeshed_versions,
             mode,
         }
     }
@@ -1969,6 +2057,48 @@ mod tests {
 
     use super::*;
 
+    fn resolver_program(db: &TestDb) -> ResolverProgram {
+        db.resolver_program()
+    }
+
+    fn resolver_file(db: &TestDb, file: File) -> ResolverFile<'_> {
+        ResolverFile::new(db, resolver_program(db), file)
+    }
+
+    fn resolve_module_confident<'db>(
+        db: &'db TestDb,
+        module_name: &ModuleName,
+    ) -> Option<Module<'db>> {
+        super::resolve_module_confident(db, resolver_program(db), module_name)
+    }
+
+    fn resolve_real_module_confident<'db>(
+        db: &'db TestDb,
+        module_name: &ModuleName,
+    ) -> Option<Module<'db>> {
+        super::resolve_real_module_confident(db, resolver_program(db), module_name)
+    }
+
+    fn resolve_module<'db>(
+        db: &'db TestDb,
+        importing_file: File,
+        module_name: &ModuleName,
+    ) -> Option<Module<'db>> {
+        super::resolve_module(db, resolver_file(db, importing_file), module_name)
+    }
+
+    fn file_to_module(db: &TestDb, file: File) -> Option<Module<'_>> {
+        super::file_to_module(db, resolver_file(db, file))
+    }
+
+    fn path_to_module<'db>(db: &'db TestDb, path: &FilePath) -> Option<Module<'db>> {
+        super::path_to_module(db, resolver_program(db), path)
+    }
+
+    fn search_paths(db: &TestDb, mode: ModuleResolveMode) -> SearchPathIterator<'_> {
+        super::search_paths(db, resolver_program(db), mode)
+    }
+
     #[test]
     fn first_party_module() {
         let TestCase { db, src, .. } = TestCaseBuilder::new()
@@ -1992,6 +2122,36 @@ mod tests {
         assert_eq!(
             Some(foo_module),
             path_to_module(&db, &FilePath::from(expected_foo_path))
+        );
+    }
+
+    #[test]
+    fn same_name_resolves_independently_in_two_programs() {
+        let TestCase { mut db, src, .. } = TestCaseBuilder::new()
+            .with_src_files(&[("foo.py", "source = 'first'")])
+            .build();
+        let alternate = src.parent().unwrap().join("alternate");
+        db.write_file(alternate.join("foo.py"), "source = 'second'")
+            .unwrap();
+
+        let first_paths = SearchPathSettings::new(vec![src.clone()])
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+            .unwrap();
+        let second_paths = SearchPathSettings::new(vec![alternate.clone()])
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+            .unwrap();
+        let first_program = ResolverProgram::create(&db, PythonVersion::PY313, &first_paths);
+        let second_program = ResolverProgram::create(&db, PythonVersion::PY313, &second_paths);
+        let name = ModuleName::new_static("foo").unwrap();
+
+        let first = super::resolve_module_confident(&db, first_program, &name).unwrap();
+        let second = super::resolve_module_confident(&db, second_program, &name).unwrap();
+
+        assert_ne!(first, second);
+        assert_eq!(first.file(&db).unwrap().path(&db), &src.join("foo.py"));
+        assert_eq!(
+            second.file(&db).unwrap().path(&db),
+            &alternate.join("foo.py")
         );
     }
 
@@ -2771,7 +2931,12 @@ mod tests {
         assert_function_query_was_not_run(
             &db,
             resolve_module_query,
-            ModuleNameIngredient::new(&db, functools_module_name, ModuleResolveMode::Typing),
+            ModuleNameIngredient::new(
+                &db,
+                resolver_program(&db),
+                functools_module_name,
+                ModuleResolveMode::Typing,
+            ),
             &events,
         );
         assert_eq!(&functools_search_path, &stdlib);
@@ -3029,7 +3194,7 @@ not_a_directory
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(&db, resolver_program(&db), ModuleResolveMode::Typing),
             &events,
         );
     }
@@ -3048,7 +3213,7 @@ not_a_directory
 
         dynamic_resolution_paths(
             &db,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(&db, resolver_program(&db), ModuleResolveMode::Typing),
         );
         db.clear_salsa_events();
 
@@ -3056,14 +3221,14 @@ not_a_directory
             .unwrap();
         dynamic_resolution_paths(
             &db,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(&db, resolver_program(&db), ModuleResolveMode::Typing),
         );
 
         let events = db.take_salsa_events();
         assert_function_query_was_not_run(
             &db,
             dynamic_resolution_paths,
-            ModuleResolveModeIngredient::new(&db, ModuleResolveMode::Typing),
+            ModuleResolveModeIngredient::new(&db, resolver_program(&db), ModuleResolveMode::Typing),
             &events,
         );
     }

--- a/crates/ty_module_resolver/src/typeshed.rs
+++ b/crates/ty_module_resolver/src/typeshed.rs
@@ -8,7 +8,6 @@ use ruff_db::vendored::VendoredFileSystem;
 use ruff_python_ast::{PythonVersion, PythonVersionDeserializationError};
 use rustc_hash::FxHashMap;
 
-use crate::db::Db;
 use crate::module_name::ModuleName;
 
 pub fn vendored_typeshed_versions(vendored: &VendoredFileSystem) -> TypeshedVersions {
@@ -18,10 +17,6 @@ pub fn vendored_typeshed_versions(vendored: &VendoredFileSystem) -> TypeshedVers
             .expect("The vendored typeshed stubs should contain a VERSIONS file"),
     )
     .expect("The VERSIONS file in the vendored typeshed stubs should be well-formed")
-}
-
-pub(crate) fn typeshed_versions(db: &dyn Db) -> &TypeshedVersions {
-    db.search_paths().typeshed_versions()
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/crates/ty_project/src/db.rs
+++ b/crates/ty_project/src/db.rs
@@ -14,10 +14,8 @@ use ruff_db::files::{File, Files};
 use ruff_db::system::System;
 use ruff_db::vendored::VendoredFileSystem;
 use salsa::{Database, Event, Setter};
-use ty_module_resolver::SearchPaths;
-use ty_python_core::program::{
-    FallibleStrategy, MisconfigurationStrategy, Program, UseDefaultStrategy,
-};
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{AnalysisSettings, Db as SemanticDb};
 
@@ -77,15 +75,12 @@ impl ProjectDatabase {
 
     /// Permanently freezes the most heavily read inputs that are immutable during a one-shot check.
     ///
-    /// This is intentionally not exhaustive. It includes every [`Program`] input, the most heavily
-    /// read immutable [`Project`] inputs, and every field on files created after this call. Existing
-    /// files retain their durability. This must not be used by incremental consumers or checks that
-    /// apply fixes.
+    /// This is intentionally not exhaustive. It includes the most heavily read immutable
+    /// [`Project`] inputs and every field on files created after this call. Existing files retain
+    /// their durability. This must not be used by incremental consumers or checks that apply fixes.
     pub fn freeze(&mut self) {
-        let program = Program::try_get(self).expect("the program should be initialized");
         let project = self.project();
 
-        program.freeze(self);
         project.freeze(self);
         self.files.freeze();
     }
@@ -126,7 +121,6 @@ impl ProjectDatabase {
 
         let merged_options = project_metadata.to_merged_options();
 
-        // Initialize the `Program` singleton
         let (program_settings, program_settings_diagnostics) = strategy
             .to_anyhow(merged_options.to_program_settings(db.system(), db.vendored(), strategy))?;
 
@@ -134,8 +128,6 @@ impl ProjectDatabase {
         // will take precedence over the `Project` root, resulting in
         // all project files having HIGH durability.
         project_metadata.try_add_project_root(&db);
-
-        Program::from_settings(&db, program_settings);
 
         let (settings, settings_diagnostics) = strategy
             .map_err(merged_options.to_settings(&db, strategy), |error| {
@@ -146,6 +138,7 @@ impl ProjectDatabase {
             &db,
             project_metadata,
             settings,
+            &program_settings,
             settings_diagnostics,
             program_settings_diagnostics,
         ));
@@ -175,7 +168,10 @@ impl ProjectDatabase {
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub fn check_file(&self, file: File) -> Vec<Diagnostic> {
-        crate::check_file(self, file)
+        crate::check_file(
+            self,
+            ProgramFile::new(self, self.project().program(self), file),
+        )
     }
 
     /// Set the check mode for the project.
@@ -229,7 +225,10 @@ impl ProjectDatabase {
                 0
             });
 
-            cmp::Reverse(ingredient.size_of_fields() + heap_size)
+            (
+                cmp::Reverse(ingredient.size_of_fields() + heap_size),
+                cmp::Reverse(ingredient.debug_name()),
+            )
         });
 
         memos.sort_by_key(|(query, memo)| {
@@ -238,7 +237,10 @@ impl ProjectDatabase {
                 0
             });
 
-            cmp::Reverse(memo.size_of_fields() + heap_size)
+            (
+                cmp::Reverse(memo.size_of_fields() + heap_size),
+                cmp::Reverse(*query),
+            )
         });
 
         let mut total_fields = 0;
@@ -522,16 +524,12 @@ impl SalsaMemoryDump {
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for ProjectDatabase {
-    fn search_paths(&self) -> &SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for ProjectDatabase {}
 
 #[salsa::db]
 impl SemanticDb for ProjectDatabase {
-    fn check_file(&self, file: File) -> Vec<Diagnostic> {
-        ProjectDatabase::check_file(self, file)
+    fn check_file(&self, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+        crate::check_file(self, program_file)
     }
 
     fn rule_selection(&self, file: File) -> &RuleSelection {
@@ -585,7 +583,7 @@ impl SourceDb for ProjectDatabase {
     }
 
     fn python_version(&self) -> ruff_python_ast::PythonVersion {
-        Program::get(self).python_version(self)
+        self.project().program(self).python_version(self)
     }
 }
 
@@ -625,13 +623,13 @@ pub(crate) mod testing {
 
     use ruff_db::Db as SourceDb;
     use ruff_db::diagnostic::Diagnostic;
-    use ruff_db::files::{File, FileRootKind, Files};
+    use ruff_db::files::{FileRootKind, Files};
     use ruff_db::system::{DbWithTestSystem, System, TestSystem};
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_python_ast::PythonVersion;
     use ty_module_resolver::SearchPathSettings;
     use ty_python_core::platform::PythonPlatform;
-    use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
+    use ty_python_core::program::{FallibleStrategy, ProgramSettings};
     use ty_python_semantic::lint::{LintRegistry, RuleSelection};
     use ty_python_semantic::{AnalysisSettings, PythonVersionWithSource};
 
@@ -673,8 +671,18 @@ pub(crate) mod testing {
                 .to_merged_options()
                 .to_settings(&db, &FallibleStrategy)
                 .unwrap();
-            let project =
-                Project::from_metadata(&db, project, settings, settings_diagnostics, Vec::new());
+            let project = Project::from_metadata(
+                &db,
+                project,
+                settings,
+                &ProgramSettings {
+                    python_version: PythonVersionWithSource::default(),
+                    python_platform: PythonPlatform::default(),
+                    search_paths: ty_module_resolver::SearchPaths::empty(db.vendored()),
+                },
+                settings_diagnostics,
+                Vec::new(),
+            );
             db.project = Some(project);
             db
         }
@@ -695,7 +703,7 @@ pub(crate) mod testing {
 
             self.files().try_add_root(self, root, FileRootKind::Project);
 
-            Program::from_settings(
+            self.project().update_program_settings(
                 self,
                 ProgramSettings {
                     python_version: PythonVersionWithSource {
@@ -706,8 +714,13 @@ pub(crate) mod testing {
                     search_paths,
                 },
             );
-
             Ok(())
+        }
+
+        #[allow(dead_code, reason = "used by downstream test-support consumers")]
+        pub fn update_program_settings(&mut self, settings: ProgramSettings) {
+            let project = self.project();
+            project.update_program_settings(self, settings);
         }
     }
 
@@ -745,16 +758,12 @@ pub(crate) mod testing {
         }
 
         fn python_version(&self) -> ruff_python_ast::PythonVersion {
-            Program::get(self).python_version(self)
+            self.project().program(self).python_version(self)
         }
     }
 
     #[salsa::db]
-    impl ty_module_resolver::Db for TestDb {
-        fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ty_module_resolver::Db for TestDb {}
 
     #[salsa::db]
     impl ty_python_core::Db for TestDb {
@@ -766,8 +775,11 @@ pub(crate) mod testing {
     #[salsa::db]
     impl ty_python_semantic::Db for TestDb {
         #[inline]
-        fn check_file(&self, file: File) -> Vec<Diagnostic> {
-            crate::check_file(self, file)
+        fn check_file(
+            &self,
+            program_file: ty_python_core::environment::ProgramFile<'_>,
+        ) -> Vec<Diagnostic> {
+            crate::check_file(self, program_file)
         }
 
         fn rule_selection(&self, _file: ruff_db::files::File) -> &RuleSelection {
@@ -808,10 +820,15 @@ pub(crate) mod testing {
 
 #[cfg(test)]
 mod tests {
+    use crate::db::Db as _;
     use ruff_db::Db as _;
     use ruff_db::files::FileRootKind;
     use ruff_db::system::{SystemPathBuf, TestSystem};
+    use ruff_python_ast::PythonVersion;
     use ty_module_resolver::list_modules;
+    use ty_python_core::environment::InferenceSettings;
+    use ty_python_core::program::{Program, ProgramSettings};
+    use ty_python_semantic::{PythonVersionSource, PythonVersionWithSource};
 
     use crate::{ProjectDatabase, ProjectMetadata};
 
@@ -828,6 +845,104 @@ mod tests {
         db.freeze();
 
         assert_eq!(db.check().len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn program_retains_its_python_version_source() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let project = SystemPathBuf::from("/project");
+        system.memory_file_system().create_directory_all(&project)?;
+
+        let metadata = ProjectMetadata::discover(&project, &system)?;
+        let db = ProjectDatabase::fallible(metadata, system)?;
+        let project_program = db.project().program(&db);
+        let alternate_program = Program::from_settings(
+            &db,
+            &ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: PythonVersion::PY310,
+                    source: PythonVersionSource::Cli,
+                },
+                python_platform: project_program.python_platform(&db).clone(),
+                search_paths: project_program.search_paths(&db).clone(),
+            },
+            &InferenceSettings::default(),
+        );
+
+        assert_eq!(
+            alternate_program.python_version_source(&db),
+            &PythonVersionSource::Cli
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn updating_program_settings_updates_the_project_program() -> anyhow::Result<()> {
+        let system = TestSystem::default();
+        let project_root = SystemPathBuf::from("/project");
+        system
+            .memory_file_system()
+            .create_directory_all(&project_root)?;
+
+        let metadata = ProjectMetadata::discover(&project_root, &system)?;
+        let mut db = ProjectDatabase::fallible(metadata, system)?;
+        let project = db.project();
+        let original = project.program(&db);
+        let original_python_version = original.python_version(&db);
+        let original_python_version_source = original.python_version_source(&db).clone();
+        let (python_version, python_platform, search_paths) = {
+            let original = project.program(&db);
+            let python_version = if original.python_version(&db) == PythonVersion::PY310 {
+                PythonVersion::PY311
+            } else {
+                PythonVersion::PY310
+            };
+            (
+                python_version,
+                original.python_platform(&db).clone(),
+                original.search_paths(&db).clone(),
+            )
+        };
+
+        let mut settings = ProgramSettings {
+            python_version: PythonVersionWithSource {
+                version: python_version,
+                source: PythonVersionSource::Cli,
+            },
+            python_platform,
+            search_paths,
+        };
+        project.update_program_settings(&mut db, settings.clone());
+
+        let updated = project.program(&db);
+        assert_ne!(updated, original);
+        assert_eq!(original.python_version(&db), original_python_version);
+        assert_eq!(
+            original.python_version_source(&db),
+            &original_python_version_source
+        );
+        assert_eq!(updated.python_version(&db), python_version);
+        assert_eq!(
+            updated.python_version_source(&db),
+            &PythonVersionSource::Cli
+        );
+
+        settings.python_version.source = PythonVersionSource::Editor;
+        project.update_program_settings(&mut db, settings);
+
+        let provenance_updated = project.program(&db);
+        assert_ne!(provenance_updated, updated);
+        assert_eq!(
+            updated.python_version_source(&db),
+            &PythonVersionSource::Cli
+        );
+        assert_eq!(
+            provenance_updated.python_version_source(&db),
+            &PythonVersionSource::Editor
+        );
 
         Ok(())
     }
@@ -857,13 +972,6 @@ mod tests {
         let metadata = ProjectMetadata::discover(&project, &system)?;
         let db = ProjectDatabase::fallible(metadata, system)?;
 
-        let modules = list_modules(&db);
-        assert!(
-            modules
-                .iter()
-                .any(|module| module.name(&db).as_str() == "bar")
-        );
-
         let project_src_root = db
             .files()
             .root(&db, &project_src)
@@ -889,6 +997,14 @@ mod tests {
         assert_eq!(
             venv_root.kind_at_time_of_creation(&db),
             FileRootKind::SearchPath
+        );
+
+        let program = db.project().program(&db).resolver(&db);
+        let modules = list_modules(&db, program);
+        assert!(
+            modules
+                .iter()
+                .any(|module| module.name(&db).as_str() == "bar")
         );
 
         Ok(())

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -9,7 +9,7 @@ use ruff_db::Db as _;
 use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{SystemPath, SystemPathBuf};
 use rustc_hash::FxHashSet;
-use ty_python_core::program::{FallibleStrategy, Program};
+use ty_python_core::program::FallibleStrategy;
 
 /// Represents the result of applying changes to the project database.
 pub struct ChangeResult {
@@ -35,8 +35,8 @@ impl ProjectDatabase {
         let project = self.project();
         let project_root = project.root(self).to_path_buf();
         let configuration_paths = ConfigurationPaths::from_metadata(project.metadata(self));
-        let program = Program::get(self);
-        let custom_stdlib_versions_path = program
+        let custom_stdlib_versions_path = project
+            .program(self)
             .custom_stdlib_search_path(self)
             .map(|path| path.join("VERSIONS"));
 
@@ -245,21 +245,17 @@ impl ProjectDatabase {
                     metadata.try_add_project_root(self);
                     let merged_options = metadata.to_merged_options();
 
-                    let program_settings_diagnostics = match merged_options.to_program_settings(
-                        self.system(),
-                        self.vendored(),
-                        &FallibleStrategy,
-                    ) {
+                    let (program_settings, program_settings_diagnostics) = match merged_options
+                        .to_program_settings(self.system(), self.vendored(), &FallibleStrategy)
+                    {
                         Ok((program_settings, diagnostics)) => {
-                            let program = Program::get(self);
-                            program.update_from_settings(self, program_settings);
-                            diagnostics
+                            (Some(program_settings), diagnostics)
                         }
                         Err(error) => {
                             tracing::error!(
                                 "Failed to convert metadata to program settings, continuing without applying them: {error}"
                             );
-                            Vec::new()
+                            (None, Vec::new())
                         }
                     };
 
@@ -280,6 +276,7 @@ impl ProjectDatabase {
                         self,
                         metadata,
                         settings,
+                        program_settings,
                         settings_diagnostics,
                         program_settings_diagnostics,
                     ) {
@@ -328,7 +325,7 @@ impl ProjectDatabase {
                             Ok((_, diagnostics)) => diagnostics,
                             Err(error) => vec![error.into_diagnostic()],
                         };
-                    program.update_from_settings(self, program_settings);
+                    project.update_program_settings(self, program_settings);
                     project.update_settings_diagnostics(
                         self,
                         settings_diagnostics,

--- a/crates/ty_project/src/lib.rs
+++ b/crates/ty_project/src/lib.rs
@@ -27,6 +27,8 @@ use std::collections::{BTreeSet, hash_set};
 use std::iter::FusedIterator;
 use std::panic::{AssertUnwindSafe, UnwindSafe};
 use std::sync::Arc;
+use ty_python_core::environment::{InferenceSettings, ProgramFile};
+use ty_python_core::program::{Program, ProgramSettings};
 use ty_python_semantic::lint::RuleSelection;
 
 mod db;
@@ -76,6 +78,10 @@ pub struct Project {
     /// salsa allocated table for `Project`.
     #[returns(deref)]
     pub settings: Box<Settings>,
+
+    /// The default Python environment used to analyze this project.
+    #[returns(copy)]
+    pub program: Program,
 
     /// The paths that should be included when checking this project.
     ///
@@ -180,6 +186,7 @@ impl Project {
         db: &dyn Db,
         metadata: ProjectMetadata,
         settings: Settings,
+        program_settings: &ProgramSettings,
         settings_diagnostics: Vec<OptionDiagnostic>,
         program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
     ) -> Self {
@@ -188,8 +195,10 @@ impl Project {
             settings_diagnostics,
             program_settings_diagnostics,
         );
+        let program =
+            Program::from_settings(db, program_settings, &Self::inference_settings(&settings));
 
-        Project::builder(Box::new(metadata), Box::new(settings), diagnostics)
+        Project::builder(Box::new(metadata), Box::new(settings), program, diagnostics)
             .durability(Durability::MEDIUM)
             .open_fileset_durability(Durability::LOW)
             .file_set_durability(Durability::LOW)
@@ -203,6 +212,7 @@ impl Project {
         let durability = Durability::NEVER_CHANGE;
         let metadata = Box::new(self.metadata(db).clone());
         let settings = Box::new(self.settings(db).clone());
+        let program = self.program(db);
         let included_paths = self.included_paths_list(db).to_vec();
         let open_files = self.open_fileset(db).clone();
         let check_mode = self.check_mode(db);
@@ -215,6 +225,7 @@ impl Project {
         self.set_settings(db)
             .with_durability(durability)
             .to(settings);
+        self.set_program(db).with_durability(durability).to(program);
         self.set_included_paths_list(db)
             .with_durability(durability)
             .to(included_paths);
@@ -280,6 +291,7 @@ impl Project {
         db: &mut dyn Db,
         metadata: ProjectMetadata,
         settings: Option<Settings>,
+        program_settings: Option<ProgramSettings>,
         settings_diagnostics: Vec<OptionDiagnostic>,
         program_settings_diagnostics: Vec<ProgramSettingsDiagnostic>,
     ) -> ProjectReloadResult {
@@ -290,6 +302,21 @@ impl Project {
             settings_diagnostics,
             program_settings_diagnostics,
         );
+
+        let program = self.program(db);
+        let next_inference_settings = settings
+            .as_ref()
+            .map(Self::inference_settings)
+            .unwrap_or_else(|| program.settings(db).clone());
+        let next_program = program_settings
+            .map_or(program, |settings| {
+                program.with_program_settings(db, settings)
+            })
+            .with_inference_settings(db, next_inference_settings);
+        let program_changed = next_program != program;
+        if program_changed {
+            self.set_program(db).to(next_program);
+        }
 
         let root_changed = metadata.root() != self.root(db);
         let (settings_changed, files_changed) = if let Some(settings) = settings
@@ -318,7 +345,7 @@ impl Project {
             self.set_metadata(db).to(Box::new(metadata));
         }
 
-        if metadata_changed || settings_changed {
+        if metadata_changed || settings_changed || program_changed {
             ProjectReloadResult::Changed { files_changed }
         } else {
             ProjectReloadResult::Unchanged
@@ -346,6 +373,24 @@ impl Project {
         }
     }
 
+    pub(crate) fn update_program_settings(
+        self,
+        db: &mut dyn Db,
+        program_settings: ProgramSettings,
+    ) {
+        let program = self.program(db);
+        let next_program = program.with_program_settings(db, program_settings);
+        if next_program != program {
+            self.set_program(db).to(next_program);
+        }
+    }
+
+    fn inference_settings(settings: &Settings) -> InferenceSettings {
+        InferenceSettings {
+            replace_imports_with_any: settings.analysis().replace_imports_with_any.clone(),
+        }
+    }
+
     fn settings_diagnostics_with_program_diagnostics(
         db: &dyn Db,
         mut settings_diagnostics: Vec<OptionDiagnostic>,
@@ -361,6 +406,7 @@ impl Project {
 
     /// Checks the project and its dependencies according to the project's check mode.
     pub(crate) fn check(self, db: &ProjectDatabase, reporter: &mut dyn ProgressReporter) {
+        let program = self.program(db);
         let project_span = tracing::debug_span!("Project::check");
         let _span = project_span.enter();
 
@@ -397,7 +443,8 @@ impl Project {
                     tracing::debug_span!(parent: &project_span, "check_file", ?file);
                 let _entered = check_file_span.entered();
 
-                match check_file_impl(db, file) {
+                let program_file = ProgramFile::new(db, program, file);
+                match check_file_impl(db, program_file) {
                     Ok(diagnostics) => {
                         reporter.report_checked_file(db, file, diagnostics);
 
@@ -406,7 +453,7 @@ impl Project {
                         if !open_files.contains(&file) {
                             // The module has already been parsed by `check_file_impl`.
                             // We only retrieve it here so that we can call `clear` on it.
-                            let parsed = parsed_module(db, file);
+                            let parsed = parsed_module(db, program_file.versioned_file(db));
 
                             // Drop the AST now that we are done checking this file. It is not currently open,
                             // so it is unlikely to be accessed again soon. If any queries need to access the AST
@@ -648,12 +695,13 @@ impl Project {
     }
 }
 
-pub(crate) fn check_file(db: &dyn Db, file: File) -> Vec<Diagnostic> {
+pub(crate) fn check_file(db: &dyn Db, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+    let file = program_file.file(db);
     if !db.should_check_file(file) {
         return Vec::new();
     }
 
-    check_file_impl(db, file)
+    check_file_impl(db, program_file)
         .map(<[Diagnostic]>::to_vec)
         .unwrap_or_else(|diagnostic| vec![diagnostic.clone()])
 }
@@ -735,10 +783,16 @@ pub enum ProjectReloadResult {
 }
 
 #[salsa::tracked(returns(as_deref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn check_file_impl(db: &dyn Db, file: File) -> Result<Box<[Diagnostic]>, Diagnostic> {
+pub(crate) fn check_file_impl<'db>(
+    db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
+) -> Result<Box<[Diagnostic]>, Diagnostic> {
+    let file = program_file.file(db);
     {
         let db = AssertUnwindSafe(db);
-        match catch(&**db, file, || ty_python_semantic::check_file(*db, file)) {
+        match catch(&**db, file, || {
+            ty_python_semantic::check_file(*db, program_file)
+        }) {
             Ok(result) => result,
             Err(diagnostic) => Ok(Box::new([diagnostic])),
         }
@@ -885,6 +939,7 @@ mod tests {
     use ruff_db::source::source_text;
     use ruff_db::system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf};
     use ruff_db::testing::assert_function_query_was_not_run;
+    use ty_python_core::environment::ProgramFile;
     use ty_python_semantic::types::check_types;
 
     #[test]
@@ -902,8 +957,9 @@ mod tests {
         file.sync(&mut db);
 
         assert_eq!(source_text(&db, file).as_str(), "");
+        let program_file = ProgramFile::new(&db, db.project().program(&db), file);
         assert_eq!(
-            check_file_impl(&db, file)
+            check_file_impl(&db, program_file)
                 .as_ref()
                 .unwrap_err()
                 .primary_message()
@@ -912,15 +968,17 @@ mod tests {
         );
 
         let events = db.take_salsa_events();
-        assert_function_query_was_not_run(&db, check_types, file, &events);
+        let program_file = ProgramFile::new(&db, db.project().program(&db), file);
+        assert_function_query_was_not_run(&db, check_types, program_file, &events);
 
         // The user now creates a new file with an empty text. The source text
         // content returned by `source_text` remains unchanged, but the diagnostics should get updated.
         db.write_file(path, "").unwrap();
 
         assert_eq!(source_text(&db, file).as_str(), "");
+        let program_file = ProgramFile::new(&db, db.project().program(&db), file);
         assert_eq!(
-            check_file_impl(&db, file)
+            check_file_impl(&db, program_file)
                 .as_ref()
                 .unwrap()
                 .iter()

--- a/crates/ty_project/src/watch/project_watcher.rs
+++ b/crates/ty_project/src/watch/project_watcher.rs
@@ -40,7 +40,8 @@ impl ProjectWatcher {
     }
 
     pub fn update(&mut self, db: &ProjectDatabase) {
-        let search_paths: Vec<_> = system_module_search_paths(db).collect();
+        let program = db.project().program(db).resolver(db);
+        let search_paths: Vec<_> = system_module_search_paths(db, program).collect();
         let project_path = db.project().root(db);
 
         let new_cache_key = Self::compute_cache_key(project_path, &search_paths);

--- a/crates/ty_python_core/src/ast_ids.rs
+++ b/crates/ty_python_core/src/ast_ids.rs
@@ -1,11 +1,11 @@
 use rustc_hash::FxHashMap;
 
-use ruff_db::files::File;
 use ruff_index::{IndexVec, newtype_index};
 use ruff_python_ast as ast;
 use ruff_python_ast::ExprRef;
 
 use crate::Db;
+use crate::environment::ProgramFile;
 use crate::frozen::FrozenMap;
 use crate::scope::FileScopeId;
 use crate::semantic_index;
@@ -55,7 +55,7 @@ impl AstIds {
     }
 }
 
-fn ast_ids(db: &dyn Db, file: File) -> &AstIds {
+fn ast_ids<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> &'db AstIds {
     semantic_index(db, file).ast_ids()
 }
 
@@ -66,46 +66,46 @@ pub struct ScopedUseId;
 
 pub trait HasScopedUseId {
     /// Returns the ID that uniquely identifies the use in its scope.
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId;
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId;
 }
 
 impl HasScopedUseId for ast::Identifier {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprName {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprAttribute {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::ExprSubscript {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let expression_ref = ExprRef::from(self);
         expression_ref.scoped_use_id(db, file)
     }
 }
 
 impl HasScopedUseId for ast::Keyword {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(self)
     }
 }
 
 impl HasScopedUseId for ast::ExprRef<'_> {
-    fn scoped_use_id(&self, db: &dyn Db, file: File) -> ScopedUseId {
+    fn scoped_use_id(&self, db: &dyn Db, file: ProgramFile<'_>) -> ScopedUseId {
         let ast_ids = ast_ids(db, file);
         ast_ids.use_id(*self)
     }

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -19,7 +19,7 @@ use ruff_python_parser::semantic_errors::{
 };
 use ruff_text_size::{Ranged, TextRange};
 use smallvec::SmallVec;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::ModuleName;
 
 use crate::HasTrackedScope;
 use crate::ast_ids::node_key::ExpressionNodeKey;
@@ -35,6 +35,7 @@ use crate::definition::{
     MatchPatternDefinitionNodeRef, NestedBindingsDefinitionKind, ParameterDefinitionNodeRef,
     StarImportDefinitionNodeRef, WithItemDefinitionNodeRef,
 };
+use crate::environment::ProgramFile;
 use crate::expression::{Expression, ExpressionKind};
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::member::MemberExprBuilder;
@@ -48,7 +49,6 @@ use crate::predicate::{
     PatternPredicateKind, Predicate, PredicateNode, PredicateOrLiteral, ScopedPredicateId,
     SequencePatternPredicateKind, StarImportPlaceholderPredicate, SubjectElementPatternPredicate,
 };
-use crate::program::Program;
 use crate::re_exports::exported_names;
 use crate::reachability_constraints::{
     ReachabilityConstraintsBuilder, ScopedReachabilityConstraintId,
@@ -230,6 +230,7 @@ impl ConditionFlowSnapshot {
 pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     // Builder state
     db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
     file: File,
     source_type: PySourceType,
     module: &'ast ParsedModuleRef,
@@ -301,9 +302,16 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
 }
 
 impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
-    pub(super) fn new(db: &'db dyn Db, file: File, module_ref: &'ast ParsedModuleRef) -> Self {
+    pub(super) fn new(
+        db: &'db dyn Db,
+        program_file: ProgramFile<'db>,
+        module_ref: &'ast ParsedModuleRef,
+    ) -> Self {
+        let file = program_file.file(db);
+        let python_version = program_file.program(db).python_version(db);
         let mut builder = Self {
             db,
+            program_file,
             file,
             source_type: file.source_type(db),
             module: module_ref,
@@ -341,7 +349,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
             enclosing_snapshots: FxHashMap::default(),
 
-            python_version: Program::get(db).python_version(db),
+            python_version,
             source_text: OnceCell::new(),
             semantic_checker: SemanticSyntaxChecker::default(),
             in_try: false,
@@ -512,7 +520,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             .push(Box::new(UseDefMapBuilder::new(is_class_scope)));
         let ast_id_scope = self.ast_ids.push(AstIdsBuilder::default());
 
-        let scope_id = ScopeId::new(self.db, self.file, file_scope_id);
+        let scope_id = ScopeId::new(self.db, self.program_file, file_scope_id);
 
         self.scope_ids_by_scope.push(scope_id);
         let previous = self.scopes_by_node.insert(node.node_key(), file_scope_id);
@@ -2161,7 +2169,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
         PatternPredicate::new(
             self.db,
-            self.file,
+            self.program_file,
             self.current_scope(),
             subject,
             kind,
@@ -2303,7 +2311,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         } else {
             Statement::Other(StatementInner::new(
                 self.db,
-                self.file,
+                self.program_file,
                 self.current_scope(),
                 AstNodeRef::new(self.module, statement_node),
             ))
@@ -2606,7 +2614,7 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                     };
                 let unpack = Unpack::new(
                     self.db,
-                    self.file,
+                    self.program_file,
                     value_file_scope,
                     self.current_scope(),
                     // Note `target` belongs to the `self.module` tree
@@ -2921,14 +2929,18 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                 // that `x` can be freely overwritten, and that we don't assume that an import
                 // in one function is visible in another function.
                 let mut is_self_import = false;
-                if self.file.is_package(self.db)
+                let package_program_file = self
+                    .file
+                    .is_package(self.db)
+                    .then(|| self.program_file.resolver_file(self.db));
+                if let Some(resolver_file) = package_program_file
                     && let Ok(module_name) = ModuleName::from_identifier_parts(
                         self.db,
-                        self.file,
+                        resolver_file,
                         node.module.as_deref(),
                         node.level,
                     )
-                    && let Ok(thispackage) = ModuleName::package_for_file(self.db, self.file)
+                    && let Ok(thispackage) = ModuleName::package_for_file(self.db, resolver_file)
                 {
                     // Record whether this is equivalent to `from . import ...`
                     is_self_import = module_name == thispackage;
@@ -3001,13 +3013,20 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                             continue;
                         }
 
+                        let program = self.program_file.program(self.db);
+                        let resolver_file = package_program_file
+                            .unwrap_or_else(|| program.resolver_file(self.db, self.file));
                         let Ok(module_name) =
-                            ModuleName::from_import_statement(self.db, self.file, node)
+                            ModuleName::from_import_statement(self.db, resolver_file, node)
                         else {
                             continue;
                         };
 
-                        let Some(module) = resolve_module(self.db, self.file, &module_name) else {
+                        let Some(module) = ty_module_resolver::resolve_module(
+                            self.db,
+                            resolver_file,
+                            &module_name,
+                        ) else {
                             continue;
                         };
 
@@ -3029,14 +3048,16 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         // ```
                         //
                         // For more details, see the doc-comment on `StarImportPlaceholderPredicate`.
-                        for export in exported_names(self.db, referenced_module) {
+                        let referenced_program_file =
+                            ProgramFile::new(self.db, program, referenced_module);
+                        for export in exported_names(self.db, referenced_program_file) {
                             let symbol_id = self.add_symbol(export.clone());
                             let node_ref = StarImportDefinitionNodeRef { node, symbol_id };
                             let star_import = StarImportPlaceholderPredicate::new(
                                 self.db,
-                                self.file,
+                                self.program_file,
                                 symbol_id,
-                                referenced_module,
+                                referenced_program_file,
                             );
 
                             let star_import_predicate = self.add_predicate(star_import.into());

--- a/crates/ty_python_core/src/db.rs
+++ b/crates/ty_python_core/src/db.rs
@@ -21,9 +21,7 @@ pub(crate) mod tests {
     };
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_python_ast::PythonVersion;
-    use ty_module_resolver::{
-        Db as ModuleResolverDb, FallibleStrategy, SearchPathSettings, SearchPaths,
-    };
+    use ty_module_resolver::{Db as ModuleResolverDb, FallibleStrategy, SearchPathSettings};
     use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
     use crate::platform::PythonPlatform;
@@ -40,11 +38,13 @@ pub(crate) mod tests {
         files: Files,
         system: TestSystem,
         vendored: VendoredFileSystem,
+        program: Option<Program>,
     }
 
     impl TestDb {
         pub(crate) fn new() -> Self {
             let events = Events::default();
+            let vendored = ty_vendored::file_system().clone();
             Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     move |event| {
@@ -54,9 +54,14 @@ pub(crate) mod tests {
                     }
                 }))),
                 system: TestSystem::default(),
-                vendored: ty_vendored::file_system().clone(),
+                program: None,
+                vendored,
                 files: Files::default(),
             }
+        }
+
+        pub(crate) fn program(&self) -> Program {
+            self.program.expect("test database has a program")
         }
     }
 
@@ -85,7 +90,7 @@ pub(crate) mod tests {
         }
 
         fn python_version(&self) -> PythonVersion {
-            Program::get(self).python_version(self)
+            self.program().python_version(self)
         }
     }
 
@@ -97,11 +102,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl ModuleResolverDb for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ModuleResolverDb for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}
@@ -142,19 +143,21 @@ pub(crate) mod tests {
             db.write_files(self.files)
                 .context("Failed to write test files")?;
 
-            Program::from_settings(
-                &db,
-                ProgramSettings {
-                    python_version: PythonVersionWithSource {
-                        version: self.python_version,
-                        source: PythonVersionSource::default(),
-                    },
-                    python_platform: self.python_platform,
-                    search_paths: SearchPathSettings::new(vec![src_root])
-                        .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
-                        .context("Invalid search path settings")?,
+            let settings = ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: self.python_version,
+                    source: PythonVersionSource::default(),
                 },
-            );
+                python_platform: self.python_platform,
+                search_paths: SearchPathSettings::new(vec![src_root])
+                    .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+                    .context("Invalid search path settings")?,
+            };
+            db.program = Some(Program::from_settings(
+                &db,
+                &settings,
+                &crate::environment::InferenceSettings::default(),
+            ));
 
             Ok(db)
         }

--- a/crates/ty_python_core/src/definition.rs
+++ b/crates/ty_python_core/src/definition.rs
@@ -12,6 +12,7 @@ use smallvec::SmallVec;
 use crate::Db;
 use crate::LoopHeaderId;
 use crate::ast_node_ref::AstNodeRef;
+use crate::environment::ProgramFile;
 use crate::member::ScopedMemberId;
 use crate::node_key::NodeKey;
 use crate::place::ScopedPlaceId;
@@ -82,6 +83,10 @@ impl<'db> Definition<'db> {
         self.scope_id(db).file(db)
     }
 
+    pub fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.scope_id(db).program_file(db)
+    }
+
     pub fn file_scope(self, db: &'db dyn Db) -> FileScopeId {
         self.scope_id(db).file_scope_id(db)
     }
@@ -104,8 +109,7 @@ impl<'db> Definition<'db> {
 
     /// Returns the name of the item being defined, if applicable.
     pub fn name(self, db: &'db dyn Db) -> Option<String> {
-        let file = self.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, self.program_file(db).versioned_file(db)).load(db);
         let kind = self.kind(db);
         match kind {
             DefinitionKind::Function(def) => {
@@ -141,8 +145,7 @@ impl<'db> Definition<'db> {
     /// This method returns a docstring for function, class, and attribute definitions.
     /// The docstring is extracted from the first statement in the body if it's a string literal.
     pub fn docstring(self, db: &'db dyn Db) -> Option<String> {
-        let file = self.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, self.program_file(db).versioned_file(db)).load(db);
         let kind = self.kind(db);
 
         match kind {

--- a/crates/ty_python_core/src/environment.rs
+++ b/crates/ty_python_core/src/environment.rs
@@ -20,20 +20,23 @@ impl Default for InferenceSettings {
 }
 
 /// A physical file interpreted as part of one program.
-#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, constructor = new_internal, heap_size = ruff_memory_usage::heap_size)]
 pub struct ProgramFile<'db> {
     #[returns(copy)]
     pub program: Program,
     #[returns(copy)]
     pub file: File,
+    #[returns(copy)]
+    pub versioned_file: VersionedFile<'db>,
 }
 
 // The Salsa allocation is tracked separately.
 impl get_size2::GetSize for ProgramFile<'_> {}
 
 impl<'db> ProgramFile<'db> {
-    pub fn versioned_file(self, db: &'db dyn Db) -> VersionedFile<'db> {
-        VersionedFile::new(db, self.file(db), self.program(db).python_version(db))
+    pub fn new(db: &'db dyn Db, program: Program, file: File) -> Self {
+        let versioned_file = VersionedFile::new(db, file, program.python_version(db));
+        Self::new_internal(db, program, file, versioned_file)
     }
 
     pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {

--- a/crates/ty_python_core/src/environment.rs
+++ b/crates/ty_python_core/src/environment.rs
@@ -1,0 +1,46 @@
+use ruff_db::files::File;
+use ruff_db::parsed::{ParsedModule, VersionedFile, parsed_module};
+use ty_module_resolver::{ModuleGlobSet, ResolverFile};
+
+use crate::Db;
+use crate::program::Program;
+
+/// Settings that can change inferred types and must therefore participate in inference keys.
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
+pub struct InferenceSettings {
+    pub replace_imports_with_any: ModuleGlobSet,
+}
+
+impl Default for InferenceSettings {
+    fn default() -> Self {
+        Self {
+            replace_imports_with_any: ModuleGlobSet::empty(),
+        }
+    }
+}
+
+/// A physical file interpreted as part of one program.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+pub struct ProgramFile<'db> {
+    #[returns(copy)]
+    pub program: Program,
+    #[returns(copy)]
+    pub file: File,
+}
+
+// The Salsa allocation is tracked separately.
+impl get_size2::GetSize for ProgramFile<'_> {}
+
+impl<'db> ProgramFile<'db> {
+    pub fn versioned_file(self, db: &'db dyn Db) -> VersionedFile<'db> {
+        VersionedFile::new(db, self.file(db), self.program(db).python_version(db))
+    }
+
+    pub fn resolver_file(self, db: &'db dyn Db) -> ResolverFile<'db> {
+        self.program(db).resolver_file(db, self.file(db))
+    }
+
+    pub fn parsed(self, db: &'db dyn Db) -> &'db ParsedModule {
+        parsed_module(db, self.versioned_file(db))
+    }
+}

--- a/crates/ty_python_core/src/expression.rs
+++ b/crates/ty_python_core/src/expression.rs
@@ -1,5 +1,6 @@
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
+use crate::environment::ProgramFile;
 use crate::scope::ScopeId;
 use ruff_db::files::File;
 use ruff_python_ast as ast;
@@ -72,5 +73,9 @@ impl<'db> Expression<'db> {
 
     pub fn file(self, db: &'db dyn Db) -> File {
         self.scope_id(db).file(db)
+    }
+
+    pub fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.scope_id(db).program_file(db)
     }
 }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -6,7 +6,6 @@ use ruff_python_ast as ast;
 use std::iter::{FusedIterator, once};
 use std::sync::Arc;
 
-use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{FrozenIndexVec, IndexSlice};
 use ruff_python_ast::NodeIndex;
@@ -24,6 +23,7 @@ use ast_ids::AstIds;
 pub use ast_ids::ExpressionNodeKey;
 use builder::SemanticIndexBuilder;
 use definition::{Definition, DefinitionNodeKey, Definitions};
+use environment::ProgramFile;
 use expression::Expression;
 use narrowing_constraints::ScopedNarrowingConstraint;
 pub use place::{PlaceExprRef, PlaceTable};
@@ -43,6 +43,7 @@ pub mod ast_node_ref;
 mod builder;
 mod db;
 pub mod definition;
+pub mod environment;
 pub mod expression;
 pub mod frozen;
 pub(crate) mod member;
@@ -66,12 +67,14 @@ pub mod program;
 ///
 /// Prefer using [`symbol_table`] when working with symbols from a single scope.
 #[salsa::tracked(returns(ref), no_eq, heap_size=ruff_memory_usage::heap_size)]
-pub fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex<'_> {
+pub fn semantic_index<'db>(db: &'db dyn Db, program_file: ProgramFile<'db>) -> SemanticIndex<'db> {
+    let versioned_file = program_file.versioned_file(db);
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("semantic_index", ?file).entered();
 
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, versioned_file).load(db);
 
-    SemanticIndexBuilder::new(db, file, &module).build()
+    SemanticIndexBuilder::new(db, program_file, &module).build()
 }
 
 /// Returns the place table for a specific `scope`.
@@ -81,9 +84,10 @@ pub fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex<'_> {
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable> {
-    let file = scope.file(db);
+    let program_file = scope.program_file(db);
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("place_table", scope=?scope.as_id(), ?file).entered();
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, program_file);
     Arc::clone(&index.place_tables[scope.file_scope_id(db)])
 }
 
@@ -94,9 +98,10 @@ pub fn place_table<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<PlaceTable>
 /// is unchanged.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 pub fn use_def_map<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Arc<UseDefMap<'db>> {
-    let file = scope.file(db);
+    let program_file = scope.program_file(db);
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("use_def_map", scope=?scope.as_id(), ?file).entered();
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, program_file);
     Arc::clone(&index.use_def_maps[scope.file_scope_id(db)])
 }
 
@@ -171,8 +176,7 @@ pub fn attribute_scopes<'db>(
     db: &'db dyn Db,
     class_body_scope: ScopeId<'db>,
 ) -> impl Iterator<Item = FileScopeId> + 'db {
-    let file = class_body_scope.file(db);
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, class_body_scope.program_file(db));
     let class_scope_id = class_body_scope.file_scope_id(db);
     ChildrenIter::new(&index.scopes, class_scope_id)
         .filter_map(move |(child_scope_id, scope)| {
@@ -221,7 +225,7 @@ pub fn attribute_scopes<'db>(
 
 /// Returns the module global scope of `file`.
 #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
-pub fn global_scope(db: &dyn Db, file: File) -> ScopeId<'_> {
+pub fn global_scope<'db>(db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db> {
     let _span = tracing::trace_span!("global_scope", ?file).entered();
 
     FileScopeId::global().to_scope_id(db, file)
@@ -1069,7 +1073,10 @@ impl HasTrackedScope for ast::Identifier {}
 
 #[cfg(test)]
 mod tests {
-    use ruff_db::{files::system_path_to_file, parsed::ParsedModuleRef};
+    use ruff_db::{
+        files::{File, system_path_to_file},
+        parsed::ParsedModuleRef,
+    };
     use ruff_python_ast as ast;
     use ruff_text_size::{Ranged, TextRange};
 
@@ -1082,6 +1089,18 @@ mod tests {
             DefinitionKind, LambdaParameterDefinitionNodeKind, ParameterDefinitionNodeKind,
         },
     };
+
+    fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
+        ProgramFile::new(db, db.program(), file)
+    }
+
+    fn global_scope(db: &TestDb, file: File) -> ScopeId<'_> {
+        super::global_scope(db, program_file(db, file))
+    }
+
+    fn semantic_index(db: &TestDb, file: File) -> &SemanticIndex<'_> {
+        super::semantic_index(db, program_file(db, file))
+    }
 
     impl UseDefMap<'_> {
         fn first_public_binding(&self, symbol: ScopedSymbolId) -> Option<Definition<'_>> {
@@ -1266,7 +1285,7 @@ y = 2
 
         assert_eq!(names(global_table), vec!["C", "y"]);
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
 
         let [(class_scope_id, class_scope)] = index
@@ -1277,7 +1296,9 @@ y = 2
         };
         assert_eq!(class_scope.kind(), ScopeKind::Class);
         assert_eq!(
-            class_scope_id.to_scope_id(&db, file).name(&db, &module),
+            class_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "C"
         );
 
@@ -1300,7 +1321,7 @@ def func():
 y = 2
 ",
         );
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1314,7 +1335,9 @@ y = 2
         };
         assert_eq!(function_scope.kind(), ScopeKind::Function);
         assert_eq!(
-            function_scope_id.to_scope_id(&db, file).name(&db, &module),
+            function_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "func"
         );
 
@@ -1448,7 +1471,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1464,7 +1487,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             comprehension_scope_id
-                .to_scope_id(&db, file)
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<listcomp>"
         );
@@ -1509,7 +1532,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 
         let use_def = index.use_def_map(comprehension_scope_id);
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let syntax = module.syntax();
         let element = syntax.body[0]
             .as_expr_stmt()
@@ -1520,7 +1543,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
             .elt
             .as_name_expr()
             .unwrap();
-        let element_use_id = element.scoped_use_id(&db, file);
+        let element_use_id = element.scoped_use_id(&db, program_file(&db, file));
 
         let binding = use_def.first_binding_at_use(element_use_id).unwrap();
         let DefinitionKind::Comprehension(comprehension) = binding.kind(&db) else {
@@ -1544,7 +1567,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
 ",
         );
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1560,7 +1583,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             comprehension_scope_id
-                .to_scope_id(&db, file)
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<listcomp>"
         );
@@ -1579,7 +1602,7 @@ def f(a: str, /, b: str, c: int = 1, *args, d: int = 2, **kwargs):
         assert_eq!(inner_comprehension_scope.kind(), ScopeKind::Comprehension);
         assert_eq!(
             inner_comprehension_scope_id
-                .to_scope_id(&db, file)
+                .to_scope_id(&db, program_file(&db, file))
                 .name(&db, &module),
             "<setcomp>"
         );
@@ -1645,7 +1668,7 @@ def func():
     y = 2
 ",
         );
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1663,12 +1686,16 @@ def func():
         assert_eq!(func_scope_1.kind(), ScopeKind::Function);
 
         assert_eq!(
-            func_scope1_id.to_scope_id(&db, file).name(&db, &module),
+            func_scope1_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "func"
         );
         assert_eq!(func_scope_2.kind(), ScopeKind::Function);
         assert_eq!(
-            func_scope2_id.to_scope_id(&db, file).name(&db, &module),
+            func_scope2_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "func"
         );
 
@@ -1693,7 +1720,7 @@ def func[T]():
 ",
         );
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1708,7 +1735,9 @@ def func[T]():
 
         assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
         assert_eq!(
-            ann_scope_id.to_scope_id(&db, file).name(&db, &module),
+            ann_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "func"
         );
         let ann_table = index.place_table(ann_scope_id);
@@ -1721,7 +1750,9 @@ def func[T]():
         };
         assert_eq!(func_scope.kind(), ScopeKind::Function);
         assert_eq!(
-            func_scope_id.to_scope_id(&db, file).name(&db, &module),
+            func_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "func"
         );
         let func_table = index.place_table(func_scope_id);
@@ -1737,7 +1768,7 @@ class C[T]:
 ",
         );
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
         let global_table = index.place_table(FileScopeId::global());
 
@@ -1751,7 +1782,12 @@ class C[T]:
         };
 
         assert_eq!(ann_scope.kind(), ScopeKind::TypeParams);
-        assert_eq!(ann_scope_id.to_scope_id(&db, file).name(&db, &module), "C");
+        assert_eq!(
+            ann_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
+            "C"
+        );
         let ann_table = index.place_table(ann_scope_id);
         assert_eq!(names(ann_table), vec!["T"]);
         assert!(
@@ -1769,7 +1805,9 @@ class C[T]:
 
         assert_eq!(class_scope.kind(), ScopeKind::Class);
         assert_eq!(
-            class_scope_id.to_scope_id(&db, file).name(&db, &module),
+            class_scope_id
+                .to_scope_id(&db, program_file(&db, file))
+                .name(&db, &module),
             "C"
         );
         assert_eq!(names(index.place_table(class_scope_id)), vec!["x"]);
@@ -1778,7 +1816,7 @@ class C[T]:
     #[test]
     fn reachability_trivial() {
         let TestCase { db, file } = test_case("x = 1; x");
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let scope = global_scope(&db, file);
         let ast = module.syntax();
         let ast::Stmt::Expr(ast::StmtExpr {
@@ -1790,7 +1828,7 @@ class C[T]:
         let ast::Expr::Name(x_use_expr_name) = x_use_expr.as_ref() else {
             panic!("expected a Name");
         };
-        let x_use_id = x_use_expr_name.scoped_use_id(&db, file);
+        let x_use_id = x_use_expr_name.scoped_use_id(&db, program_file(&db, file));
         let use_def = use_def_map(&db, scope);
         let binding = use_def.first_binding_at_use(x_use_id).unwrap();
         let DefinitionKind::Assignment(assignment) = binding.kind(&db) else {
@@ -1811,7 +1849,7 @@ class C[T]:
         let TestCase { db, file } = test_case("x = 1;\ndef test():\n  y = 4");
 
         let index = semantic_index(&db, file);
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let ast = module.syntax();
 
         let x_stmt = ast.body[0].as_assign_stmt().unwrap();
@@ -1832,12 +1870,12 @@ class C[T]:
         fn scope_names<'a, 'db>(
             scopes: impl Iterator<Item = (FileScopeId, &'db Scope)>,
             db: &'db dyn Db,
-            file: File,
+            program_file: ProgramFile<'db>,
             module: &'a ParsedModuleRef,
         ) -> Vec<&'a str> {
             scopes
                 .into_iter()
-                .map(|(scope_id, _)| scope_id.to_scope_id(db, file).name(db, module))
+                .map(|(scope_id, _)| scope_id.to_scope_id(db, program_file).name(db, module))
                 .collect()
         }
 
@@ -1854,22 +1892,26 @@ def x():
     pass",
         );
 
-        let module = parsed_module(&db, file).load(&db);
+        let module = program_file(&db, file).parsed(&db).load(&db);
         let index = semantic_index(&db, file);
+        let program_file = program_file(&db, file);
 
         let descendants = index.descendent_scopes(FileScopeId::global());
         assert_eq!(
-            scope_names(descendants, &db, file, &module),
+            scope_names(descendants, &db, program_file, &module),
             vec!["Test", "foo", "bar", "baz", "x"]
         );
 
         let children = index.child_scopes(FileScopeId::global());
-        assert_eq!(scope_names(children, &db, file, &module), vec!["Test", "x"]);
+        assert_eq!(
+            scope_names(children, &db, program_file, &module),
+            vec!["Test", "x"]
+        );
 
         let test_class = index.child_scopes(FileScopeId::global()).next().unwrap().0;
         let test_child_scopes = index.child_scopes(test_class);
         assert_eq!(
-            scope_names(test_child_scopes, &db, file, &module),
+            scope_names(test_child_scopes, &db, program_file, &module),
             vec!["foo", "baz"]
         );
 
@@ -1881,7 +1923,7 @@ def x():
         let ancestors = index.ancestor_scopes(bar_scope);
 
         assert_eq!(
-            scope_names(ancestors, &db, file, &module),
+            scope_names(ancestors, &db, program_file, &module),
             vec!["bar", "foo", "Test", "<module>"]
         );
     }

--- a/crates/ty_python_core/src/predicate.rs
+++ b/crates/ty_python_core/src/predicate.rs
@@ -13,6 +13,7 @@ use ruff_python_ast::{Singleton, name::Name};
 
 use crate::ast_ids::ExpressionNodeKey;
 use crate::db::Db;
+use crate::environment::ProgramFile;
 use crate::expression::Expression;
 use crate::global_scope;
 use crate::scope::{FileScopeId, ScopeId};
@@ -231,7 +232,7 @@ pub enum PatternPredicateKind<'db> {
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct PatternPredicate<'db> {
     #[returns(copy)]
-    pub file: File,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub file_scope: FileScopeId,
@@ -254,8 +255,12 @@ pub struct PatternPredicate<'db> {
 impl get_size2::GetSize for PatternPredicate<'_> {}
 
 impl<'db> PatternPredicate<'db> {
+    pub fn file(self, db: &'db dyn Db) -> File {
+        self.program_file(db).file(db)
+    }
+
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.file(db))
+        self.file_scope(db).to_scope_id(db, self.program_file(db))
     }
 }
 
@@ -302,7 +307,7 @@ impl<'db> PatternPredicate<'db> {
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct StarImportPlaceholderPredicate<'db> {
     #[returns(copy)]
-    pub importing_file: File,
+    pub importing_file: ProgramFile<'db>,
 
     /// Each symbol imported by a `*` import has a separate predicate associated with it:
     /// this field identifies which symbol that is.
@@ -317,7 +322,7 @@ pub struct StarImportPlaceholderPredicate<'db> {
     pub symbol_id: ScopedSymbolId,
 
     #[returns(copy)]
-    pub referenced_file: File,
+    pub referenced_file: ProgramFile<'db>,
 }
 
 // The Salsa heap is tracked separately.

--- a/crates/ty_python_core/src/program.rs
+++ b/crates/ty_python_core/src/program.rs
@@ -1,109 +1,185 @@
+use crate::environment::InferenceSettings;
 use crate::{Db, platform::PythonPlatform};
 
-use ruff_db::system::SystemPath;
+use ruff_db::{files::File, system::SystemPath};
 use ruff_python_ast::PythonVersion;
 use salsa::Durability;
-use salsa::Setter;
-use ty_module_resolver::SearchPaths;
-use ty_site_packages::PythonVersionWithSource;
+use ty_module_resolver::{ResolverFile, ResolverProgram, SearchPaths};
+use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
 // Re-export the misconfiguration strategy types from ty_module_resolver.
 pub use ty_module_resolver::{FallibleStrategy, MisconfigurationStrategy, UseDefaultStrategy};
 
-#[salsa::input(singleton, heap_size=ruff_memory_usage::heap_size)]
+/// The semantic Python environment used to analyze source files.
+#[salsa::input(heap_size = ruff_memory_usage::heap_size)]
+#[derive(Debug)]
 pub struct Program {
+    #[returns(copy)]
+    resolver_program: ResolverProgram,
+
     #[returns(ref)]
-    pub python_version_with_source: PythonVersionWithSource,
+    pub python_version_source: PythonVersionSource,
 
     #[returns(ref)]
     pub python_platform: PythonPlatform,
 
     #[returns(ref)]
-    pub search_paths: SearchPaths,
+    pub settings: InferenceSettings,
 }
 
+impl get_size2::GetSize for Program {}
+
 impl Program {
-    pub fn init_or_update(db: &mut dyn Db, settings: ProgramSettings) -> Self {
-        match Self::try_get(db) {
-            Some(program) => {
-                program.update_from_settings(db, settings);
-                program
-            }
-            None => Self::from_settings(db, settings),
-        }
+    pub fn create(db: &dyn Db, settings: &ProgramSettings) -> Self {
+        Self::from_settings(db, settings, &InferenceSettings::default())
     }
 
-    pub fn from_settings(db: &dyn Db, settings: ProgramSettings) -> Self {
-        let ProgramSettings {
-            python_version,
-            python_platform,
-            search_paths,
-        } = settings;
+    pub fn from_settings(
+        db: &dyn Db,
+        settings: &ProgramSettings,
+        inference_settings: &InferenceSettings,
+    ) -> Self {
+        let resolver_program =
+            ResolverProgram::create(db, settings.python_version.version, &settings.search_paths);
+        Self::builder(
+            resolver_program,
+            settings.python_version.source.clone(),
+            settings.python_platform.clone(),
+            inference_settings.clone(),
+        )
+        .durability(Durability::NEVER_CHANGE)
+        .new(db)
+    }
 
-        search_paths.try_register_static_roots(db);
-
-        Program::builder(python_version, python_platform, search_paths)
-            .durability(Durability::HIGH)
+    #[must_use]
+    pub fn with_inference_settings(self, db: &dyn Db, settings: InferenceSettings) -> Self {
+        if self.settings(db) == &settings {
+            self
+        } else {
+            Self::builder(
+                self.resolver(db),
+                self.python_version_source(db).clone(),
+                self.python_platform(db).clone(),
+                settings,
+            )
+            .durability(Durability::NEVER_CHANGE)
             .new(db)
+        }
     }
 
-    pub fn python_version(self, db: &dyn Db) -> PythonVersion {
-        self.python_version_with_source(db).version
-    }
-
-    pub fn update_from_settings(self, db: &mut dyn Db, settings: ProgramSettings) {
+    #[must_use]
+    pub fn with_program_settings(self, db: &dyn Db, settings: ProgramSettings) -> Self {
         let ProgramSettings {
             python_version,
             python_platform,
             search_paths,
         } = settings;
 
-        if self.search_paths(db) != &search_paths {
-            tracing::debug!("Updating search paths");
-            search_paths.try_register_static_roots(db);
-            self.set_search_paths(db).to(search_paths);
+        let current_resolver = self.resolver(db);
+        let resolver = current_resolver.with_settings(db, python_version.version, search_paths);
+
+        if resolver == current_resolver
+            && self.python_version_source(db) == &python_version.source
+            && self.python_platform(db) == &python_platform
+        {
+            self
+        } else {
+            Self::builder(
+                resolver,
+                python_version.source,
+                python_platform,
+                self.settings(db).clone(),
+            )
+            .durability(Durability::NEVER_CHANGE)
+            .new(db)
         }
-
-        if &python_platform != self.python_platform(db) {
-            tracing::debug!("Updating python platform: `{python_platform:?}`");
-            self.set_python_platform(db).to(python_platform);
-        }
-
-        if &python_version != self.python_version_with_source(db) {
-            tracing::debug!(
-                "Updating python version: Python {version}",
-                version = python_version.version
-            );
-            self.set_python_version_with_source(db).to(python_version);
-        }
-    }
-
-    /// Permanently freezes all program inputs.
-    pub fn freeze(self, db: &mut dyn Db) {
-        let durability = Durability::NEVER_CHANGE;
-        let python_version = self.python_version_with_source(db).clone();
-        let python_platform = self.python_platform(db).clone();
-        let search_paths = self.search_paths(db).clone();
-
-        self.set_python_version_with_source(db)
-            .with_durability(durability)
-            .to(python_version);
-        self.set_python_platform(db)
-            .with_durability(durability)
-            .to(python_platform);
-        self.set_search_paths(db)
-            .with_durability(durability)
-            .to(search_paths);
     }
 
     pub fn custom_stdlib_search_path(self, db: &dyn Db) -> Option<&SystemPath> {
         self.search_paths(db).custom_stdlib()
     }
+
+    pub fn python_version(self, db: &dyn Db) -> PythonVersion {
+        self.resolver(db).python_version(db)
+    }
+
+    pub fn search_paths(self, db: &dyn Db) -> &SearchPaths {
+        self.resolver(db).search_paths(db)
+    }
+
+    /// Returns the module-resolution projection of this program.
+    pub fn resolver(self, db: &dyn Db) -> ResolverProgram {
+        self.resolver_program(db)
+    }
+
+    pub fn resolver_file(self, db: &dyn Db, file: File) -> ResolverFile<'_> {
+        ResolverFile::new(db, self.resolver(db), file)
+    }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, get_size2::GetSize)]
 pub struct ProgramSettings {
     pub python_version: PythonVersionWithSource,
     pub python_platform: PythonPlatform,
     pub search_paths: SearchPaths,
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_python_ast::PythonVersion;
+    use ty_module_resolver::SearchPaths;
+    use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
+
+    use super::{Program, ProgramSettings};
+    use crate::db::tests::TestDbBuilder;
+
+    fn settings(db: &dyn crate::Db, version: PythonVersion) -> ProgramSettings {
+        ProgramSettings {
+            python_version: PythonVersionWithSource {
+                version,
+                source: PythonVersionSource::default(),
+            },
+            python_platform: crate::platform::PythonPlatform::default(),
+            search_paths: SearchPaths::empty(db.vendored()),
+        }
+    }
+
+    #[test]
+    fn programs_are_independent_inputs() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new().build()?;
+        let first_settings = settings(&db, PythonVersion::default());
+        let first = Program::create(&db, &first_settings);
+
+        let mut different_provenance = first_settings;
+        different_provenance.python_version.source = PythonVersionSource::Cli;
+        let second = Program::create(&db, &different_provenance);
+
+        assert_ne!(first, second);
+        assert_eq!(second.python_version_source(&db), &PythonVersionSource::Cli);
+        Ok(())
+    }
+
+    #[test]
+    fn changing_settings_creates_an_independent_program() -> anyhow::Result<()> {
+        let db = TestDbBuilder::new().build()?;
+        let original_settings = settings(&db, PythonVersion::default());
+        let original = Program::create(&db, &original_settings);
+        assert_eq!(
+            original.with_program_settings(&db, original_settings.clone()),
+            original
+        );
+
+        let mut changed_settings = original_settings;
+        changed_settings.python_version = PythonVersionWithSource {
+            version: PythonVersion::PY311,
+            source: PythonVersionSource::Cli,
+        };
+        let changed = original.with_program_settings(&db, changed_settings);
+
+        assert_ne!(changed, original);
+        assert_ne!(changed.resolver(&db), original.resolver(&db));
+        assert_eq!(original.python_version(&db), PythonVersion::default());
+        assert_eq!(changed.python_version(&db), PythonVersion::PY311);
+        Ok(())
+    }
 }

--- a/crates/ty_python_core/src/re_exports.rs
+++ b/crates/ty_python_core/src/re_exports.rs
@@ -20,7 +20,7 @@
 //! to handle cycles. We do this using fixpoint iteration; adding fixpoint iteration to the
 //! whole [`super::semantic_index()`] query would probably be prohibitively expensive.
 
-use ruff_db::{files::File, parsed::parsed_module};
+use ruff_db::parsed::parsed_module;
 use ruff_python_ast::{
     self as ast,
     name::Name,
@@ -29,16 +29,16 @@ use ruff_python_ast::{
 use rustc_hash::FxHashMap;
 use ty_module_resolver::{ModuleName, resolve_module};
 
-use crate::Db;
+use crate::{Db, environment::ProgramFile};
 
 #[salsa::tracked(
     returns(deref),
     cycle_initial=|_, _, _| Box::default(),
     heap_size=ruff_memory_usage::heap_size)
 ]
-pub(super) fn exported_names(db: &dyn Db, file: File) -> Box<[Name]> {
-    let module = parsed_module(db, file).load(db);
-    let mut finder = ExportFinder::new(db, file);
+pub(super) fn exported_names(db: &dyn Db, program_file: ProgramFile<'_>) -> Box<[Name]> {
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
+    let mut finder = ExportFinder::new(db, program_file);
     finder.visit_body(module.suite());
 
     let mut exports = finder.resolve_exports();
@@ -51,17 +51,18 @@ pub(super) fn exported_names(db: &dyn Db, file: File) -> Box<[Name]> {
 
 struct ExportFinder<'db> {
     db: &'db dyn Db,
-    file: File,
+    program_file: ProgramFile<'db>,
     visiting_stub_file: bool,
     exports: FxHashMap<&'db Name, PossibleExportKind>,
     dunder_all: DunderAll,
 }
 
 impl<'db> ExportFinder<'db> {
-    fn new(db: &'db dyn Db, file: File) -> Self {
+    fn new(db: &'db dyn Db, program_file: ProgramFile<'db>) -> Self {
+        let file = program_file.file(db);
         Self {
             db,
-            file,
+            program_file,
             visiting_stub_file: file.is_stub(db),
             exports: FxHashMap::default(),
             dunder_all: DunderAll::NotPresent,
@@ -248,21 +249,19 @@ impl<'db> Visitor<'db> for ExportFinder<'db> {
                     if &name.name.id == "*" {
                         if !found_star {
                             found_star = true;
-                            for export in
-                                ModuleName::from_import_statement(self.db, self.file, node)
-                                    .ok()
-                                    .and_then(|module_name| {
-                                        resolve_module(self.db, self.file, &module_name)
-                                    })
-                                    .iter()
-                                    .flat_map(|module| {
-                                        module
-                                            .file(self.db)
-                                            .map(|file| exported_names(self.db, file))
-                                            .unwrap_or_default()
-                                    })
+                            let program = self.program_file.program(self.db);
+                            let resolver_file =
+                                program.resolver_file(self.db, self.program_file.file(self.db));
+                            if let Ok(module_name) =
+                                ModuleName::from_import_statement(self.db, resolver_file, node)
+                                && let Some(module) =
+                                    resolve_module(self.db, resolver_file, &module_name)
+                                && let Some(file) = module.file(self.db)
                             {
-                                self.possibly_add_export(export, PossibleExportKind::Normal);
+                                let program_file = ProgramFile::new(self.db, program, file);
+                                for export in exported_names(self.db, program_file) {
+                                    self.possibly_add_export(export, PossibleExportKind::Normal);
+                                }
                             }
                         }
                     } else {

--- a/crates/ty_python_core/src/scope.rs
+++ b/crates/ty_python_core/src/scope.rs
@@ -4,16 +4,17 @@ use ruff_db::{files::File, parsed::ParsedModuleRef};
 use ruff_index::newtype_index;
 use ruff_python_ast::{self as ast, NodeIndex};
 
+use crate::program::Program;
 use crate::{
-    Db, SemanticIndex, ast_node_ref::AstNodeRef, definition::Definition, node_key::NodeKey,
-    semantic_index,
+    Db, SemanticIndex, ast_node_ref::AstNodeRef, definition::Definition, environment::ProgramFile,
+    node_key::NodeKey, semantic_index,
 };
 
 /// A cross-module identifier of a scope that can be used as a salsa query parameter.
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct ScopeId<'db> {
     #[returns(copy)]
-    pub file: File,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub file_scope_id: FileScopeId,
@@ -23,11 +24,19 @@ pub struct ScopeId<'db> {
 impl get_size2::GetSize for ScopeId<'_> {}
 
 impl<'db> ScopeId<'db> {
+    pub fn program(self, db: &'db dyn Db) -> Program {
+        self.program_file(db).program(db)
+    }
+
+    pub fn file(self, db: &'db dyn Db) -> File {
+        self.program_file(db).file(db)
+    }
+
     pub fn is_annotation(self, db: &'db dyn Db) -> bool {
         self.node(db).scope_kind().is_annotation()
     }
 
-    pub fn node(self, db: &dyn Db) -> &NodeWithScopeKind {
+    pub fn node(self, db: &'db dyn Db) -> &'db NodeWithScopeKind {
         self.scope(db).node()
     }
 
@@ -43,13 +52,13 @@ impl<'db> ScopeId<'db> {
         )
     }
 
-    pub fn scope(self, db: &dyn Db) -> &Scope {
-        semantic_index(db, self.file(db)).scope(self.file_scope_id(db))
+    pub fn scope(self, db: &'db dyn Db) -> &'db Scope {
+        semantic_index(db, self.program_file(db)).scope(self.file_scope_id(db))
     }
 
     /// Returns the class definition for the enclosing class if this scope is a method body.
     pub fn class_definition_of_method(self, db: &'db dyn Db) -> Option<Definition<'db>> {
-        semantic_index(db, self.file(db)).class_definition_of_method(self.file_scope_id(db))
+        semantic_index(db, self.program_file(db)).class_definition_of_method(self.file_scope_id(db))
     }
 
     pub fn is_method_scope(self, db: &'db dyn Db) -> bool {
@@ -97,7 +106,7 @@ impl FileScopeId {
         self == FileScopeId::global()
     }
 
-    pub fn to_scope_id(self, db: &dyn Db, file: File) -> ScopeId<'_> {
+    pub fn to_scope_id<'db>(self, db: &'db dyn Db, file: ProgramFile<'db>) -> ScopeId<'db> {
         let index = semantic_index(db, file);
         index.scope_ids_by_scope[self]
     }

--- a/crates/ty_python_core/src/statement.rs
+++ b/crates/ty_python_core/src/statement.rs
@@ -1,10 +1,10 @@
 use crate::ast_node_ref::AstNodeRef;
 use crate::db::Db;
 use crate::definition::Definition;
+use crate::environment::ProgramFile;
 use crate::expression::Expression;
 use crate::node_key::NodeKey;
 use crate::scope::{FileScopeId, ScopeId};
-use ruff_db::files::File;
 use ruff_python_ast as ast;
 use salsa;
 
@@ -38,7 +38,7 @@ pub enum Statement<'db> {
 pub struct StatementInner<'db> {
     /// The file in which the statement occurs.
     #[returns(copy)]
-    pub file: File,
+    pub program_file: ProgramFile<'db>,
 
     /// The scope in which the statement occurs.
     #[returns(copy)]
@@ -55,8 +55,12 @@ pub struct StatementInner<'db> {
 impl get_size2::GetSize for StatementInner<'_> {}
 
 impl<'db> StatementInner<'db> {
+    pub fn file(self, db: &'db dyn Db) -> ruff_db::files::File {
+        self.program_file(db).file(db)
+    }
+
     pub fn scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.file_scope(db).to_scope_id(db, self.file(db))
+        self.file_scope(db).to_scope_id(db, self.program_file(db))
     }
 }
 

--- a/crates/ty_python_core/src/unpack.rs
+++ b/crates/ty_python_core/src/unpack.rs
@@ -1,4 +1,3 @@
-use ruff_db::files::File;
 use ruff_db::parsed::ParsedModuleRef;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 use ruff_text_size::{Ranged, TextRange};
@@ -6,6 +5,7 @@ use ruff_text_size::{Ranged, TextRange};
 use crate::Db;
 use crate::EvaluationMode;
 use crate::ast_node_ref::AstNodeRef;
+use crate::environment::ProgramFile;
 use crate::expression::Expression;
 use crate::scope::{FileScopeId, ScopeId};
 
@@ -30,7 +30,7 @@ use crate::scope::{FileScopeId, ScopeId};
 #[salsa::tracked(debug, heap_size=ruff_memory_usage::heap_size)]
 pub struct Unpack<'db> {
     #[returns(copy)]
-    pub file: File,
+    pub program_file: ProgramFile<'db>,
 
     #[returns(copy)]
     pub(crate) value_file_scope: FileScopeId,
@@ -55,13 +55,18 @@ pub struct Unpack<'db> {
 impl get_size2::GetSize for Unpack<'_> {}
 
 impl<'db> Unpack<'db> {
+    pub fn file(self, db: &'db dyn Db) -> ruff_db::files::File {
+        self.program_file(db).file(db)
+    }
+
     pub fn target<'ast>(self, db: &'db dyn Db, parsed: &'ast ParsedModuleRef) -> &'ast ast::Expr {
         self._target(db).node(parsed)
     }
 
     /// Returns the scope where the unpack target expression belongs to.
     pub fn target_scope(self, db: &'db dyn Db) -> ScopeId<'db> {
-        self.target_file_scope(db).to_scope_id(db, self.file(db))
+        self.target_file_scope(db)
+            .to_scope_id(db, self.program_file(db))
     }
 
     /// Returns the range of the unpack target expression.

--- a/crates/ty_python_semantic/src/db.rs
+++ b/crates/ty_python_semantic/src/db.rs
@@ -3,11 +3,12 @@ use crate::lint::{LintRegistry, RuleSelection};
 use ruff_db::diagnostic::Diagnostic;
 use ruff_db::files::File;
 use ty_python_core::Db as PythonCoreDb;
+use ty_python_core::environment::ProgramFile;
 
 /// Database giving access to semantic information about a Python program.
 #[salsa::db]
 pub trait Db: PythonCoreDb {
-    fn check_file(&self, file: File) -> Vec<Diagnostic>;
+    fn check_file(&self, program_file: ProgramFile<'_>) -> Vec<Diagnostic>;
 
     /// Resolves the rule selection for a given file.
     fn rule_selection(&self, file: File) -> &RuleSelection;
@@ -39,7 +40,7 @@ pub(crate) mod tests {
     };
     use ruff_db::vendored::VendoredFileSystem;
     use ruff_python_ast::PythonVersion;
-    use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings, SearchPaths};
+    use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings};
     use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
     use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
@@ -55,11 +56,13 @@ pub(crate) mod tests {
         events: Events,
         rule_selection: Arc<RuleSelection>,
         analysis_settings: Arc<AnalysisSettings>,
+        program: Option<Program>,
     }
 
     impl TestDb {
         pub(crate) fn new() -> Self {
             let events = Events::default();
+            let vendored = ty_vendored::file_system().clone();
             Self {
                 storage: salsa::Storage::new(Some(Box::new({
                     let events = events.clone();
@@ -70,12 +73,30 @@ pub(crate) mod tests {
                     }
                 }))),
                 system: TestSystem::default(),
-                vendored: ty_vendored::file_system().clone(),
+                program: None,
+                vendored,
                 events,
                 files: Files::default(),
                 rule_selection: Arc::new(RuleSelection::from_registry(default_lint_registry())),
                 analysis_settings: AnalysisSettings::default().into(),
             }
+        }
+
+        pub(crate) fn program(&self) -> Program {
+            self.program.expect("test database has a program")
+        }
+
+        pub(crate) fn set_python_version(&mut self, version: PythonVersion) {
+            let program = self.program();
+            let settings = ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version,
+                    source: program.python_version_source(self).clone(),
+                },
+                python_platform: program.python_platform(self).clone(),
+                search_paths: program.search_paths(self).clone(),
+            };
+            self.program = Some(program.with_program_settings(self, settings));
         }
 
         /// Takes the salsa events.
@@ -119,7 +140,7 @@ pub(crate) mod tests {
         }
 
         fn python_version(&self) -> PythonVersion {
-            Program::get(self).python_version(self)
+            self.program().python_version(self)
         }
     }
 
@@ -132,12 +153,13 @@ pub(crate) mod tests {
 
     #[salsa::db]
     impl Db for TestDb {
-        fn check_file(&self, file: File) -> Vec<Diagnostic> {
+        fn check_file(&self, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+            let file = program_file.file(self);
             if !self.should_check_file(file) {
                 return Vec::new();
             }
 
-            check_file_unwrap(self, file)
+            check_file_unwrap(self, program_file)
         }
 
         fn rule_selection(&self, _file: File) -> &RuleSelection {
@@ -162,11 +184,7 @@ pub(crate) mod tests {
     }
 
     #[salsa::db]
-    impl ModuleResolverDb for TestDb {
-        fn search_paths(&self) -> &SearchPaths {
-            Program::get(self).search_paths(self)
-        }
-    }
+    impl ModuleResolverDb for TestDb {}
 
     #[salsa::db]
     impl salsa::Database for TestDb {}
@@ -217,19 +235,17 @@ pub(crate) mod tests {
             db.write_files(self.files)
                 .context("Failed to write test files")?;
 
-            Program::from_settings(
-                &db,
-                ProgramSettings {
-                    python_version: PythonVersionWithSource {
-                        version: self.python_version,
-                        source: PythonVersionSource::default(),
-                    },
-                    python_platform: self.python_platform,
-                    search_paths: SearchPathSettings::new(vec![src_root])
-                        .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
-                        .context("Invalid search path settings")?,
+            let settings = ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: self.python_version,
+                    source: PythonVersionSource::default(),
                 },
-            );
+                python_platform: self.python_platform,
+                search_paths: SearchPathSettings::new(vec![src_root])
+                    .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+                    .context("Invalid search path settings")?,
+            };
+            db.program = Some(Program::create(&db, &settings));
 
             Ok(db)
         }

--- a/crates/ty_python_semantic/src/diagnostic/mod.rs
+++ b/crates/ty_python_semantic/src/diagnostic/mod.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Db, Program, PythonVersionSource, PythonVersionWithSource, lint::lint_documentation_url,
-    types::TypeCheckDiagnostics,
+    Db, Program, PythonVersionSource, lint::lint_documentation_url, types::TypeCheckDiagnostics,
 };
 use levenshtein::{HideUnderscoredSuggestions, find_best_suggestion};
 use ruff_db::{
@@ -45,11 +44,12 @@ pub fn inferred_python_version_source_annotation(
 /// configuration files, or defaults.
 pub fn add_inferred_python_version_hint_to_diagnostic(
     db: &dyn Db,
+    program: Program,
     diagnostic: &mut Diagnostic,
     action: &str,
 ) {
-    let program = Program::get(db);
-    let PythonVersionWithSource { version, source } = program.python_version_with_source(db);
+    let version = program.python_version(db);
+    let source = program.python_version_source(db).clone();
 
     match source {
         crate::PythonVersionSource::Cli => {
@@ -58,7 +58,7 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
             ));
         }
         source @ crate::PythonVersionSource::ConfigFile(_) => {
-            if let Some(annotation) = inferred_python_version_source_annotation(db, source) {
+            if let Some(annotation) = inferred_python_version_source_annotation(db, &source) {
                 let mut sub_diagnostic = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!("Python {version} was assumed when {action}"),
@@ -72,7 +72,7 @@ pub fn add_inferred_python_version_hint_to_diagnostic(
             }
         }
         source @ crate::PythonVersionSource::PyvenvCfgFile(_) => {
-            if let Some(annotation) = inferred_python_version_source_annotation(db, source) {
+            if let Some(annotation) = inferred_python_version_source_annotation(db, &source) {
                 let mut sub_diagnostic = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!(

--- a/crates/ty_python_semantic/src/dunder_all.rs
+++ b/crates/ty_python_semantic/src/dunder_all.rs
@@ -6,19 +6,23 @@ use ruff_python_ast::{self as ast};
 use rustc_hash::FxHashSet;
 use ty_module_resolver::{ModuleName, resolve_module};
 
-use crate::Db;
 use crate::types::{Type, TypeContext, infer_expression_types};
+use crate::{Db, ProgramFile};
 use ty_python_core::{SemanticIndex, Truthiness, semantic_index};
 
 /// Returns a set of names in the `__all__` variable for `file`, [`None`] if it is not defined or
 /// if it contains invalid elements.
 #[salsa::tracked(returns(as_ref), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name>> {
+pub(crate) fn dunder_all_names(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+) -> Option<FxHashSet<Name>> {
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("dunder_all_names", file=?file.path(db)).entered();
 
-    let module = parsed_module(db, file).load(db);
-    let index = semantic_index(db, file);
-    let mut collector = DunderAllNamesCollector::new(db, file, index);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
+    let index = semantic_index(db, program_file);
+    let mut collector = DunderAllNamesCollector::new(db, program_file, index);
     collector.visit_body(module.suite());
     collector.into_names()
 }
@@ -27,6 +31,7 @@ pub(crate) fn dunder_all_names(db: &dyn Db, file: File) -> Option<FxHashSet<Name
 struct DunderAllNamesCollector<'db> {
     db: &'db dyn Db,
     file: File,
+    program_file: ProgramFile<'db>,
 
     /// The semantic index for the module.
     index: &'db SemanticIndex<'db>,
@@ -43,10 +48,16 @@ struct DunderAllNamesCollector<'db> {
 }
 
 impl<'db> DunderAllNamesCollector<'db> {
-    fn new(db: &'db dyn Db, file: File, index: &'db SemanticIndex<'db>) -> Self {
+    fn new(
+        db: &'db dyn Db,
+        program_file: ProgramFile<'db>,
+        index: &'db SemanticIndex<'db>,
+    ) -> Self {
+        let file = program_file.file(db);
         Self {
             db,
             file,
+            program_file,
             index,
             origin: None,
             invalid: false,
@@ -90,7 +101,12 @@ impl<'db> DunderAllNamesCollector<'db> {
                 let Some(module_dunder_all_names) = module_literal
                     .module(self.db)
                     .file(self.db)
-                    .and_then(|file| dunder_all_names(self.db, file))
+                    .and_then(|file| {
+                        dunder_all_names(
+                            self.db,
+                            ProgramFile::new(self.db, self.program_file.program(self.db), file),
+                        )
+                    })
                 else {
                     // The module either does not have a `__all__` variable or it is invalid.
                     return false;
@@ -156,10 +172,18 @@ impl<'db> DunderAllNamesCollector<'db> {
         &self,
         import_from: &ast::StmtImportFrom,
     ) -> Option<&'db FxHashSet<Name>> {
+        let resolver_file = self.program_file.resolver_file(self.db);
         let module_name =
-            ModuleName::from_import_statement(self.db, self.file, import_from).ok()?;
-        let module = resolve_module(self.db, self.file, &module_name)?;
-        dunder_all_names(self.db, module.file(self.db)?)
+            ModuleName::from_import_statement(self.db, resolver_file, import_from).ok()?;
+        let module = resolve_module(self.db, resolver_file, &module_name)?;
+        dunder_all_names(
+            self.db,
+            ProgramFile::new(
+                self.db,
+                self.program_file.program(self.db),
+                module.file(self.db)?,
+            ),
+        )
     }
 
     /// Infer the type of a standalone expression.
@@ -176,7 +200,9 @@ impl<'db> DunderAllNamesCollector<'db> {
     ///
     /// Returns [`None`] if the expression type doesn't implement `__bool__` correctly.
     fn evaluate_test_expr(&self, expr: &ast::Expr) -> Option<Truthiness> {
-        self.standalone_expression_type(expr).try_bool(self.db).ok()
+        self.standalone_expression_type(expr)
+            .try_bool(self.db, self.program_file.program(self.db))
+            .ok()
     }
 
     /// Add valid names to the set.

--- a/crates/ty_python_semantic/src/fixes.rs
+++ b/crates/ty_python_semantic/src/fixes.rs
@@ -1,7 +1,7 @@
 use crate::{SuppressFix, is_unused_ignore_comment_lint, suppress_all};
 use ruff_db::cancellation::{Canceled, CancellationToken};
 use ruff_db::diagnostic::{DisplayDiagnosticConfig, DisplayDiagnostics};
-use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+use ruff_db::parsed::{ParsedModuleRef, VersionedFile};
 use ruff_db::source::SourceText;
 use ruff_db::system::{SystemPath, SystemPathBuf, WritableSystem};
 use ruff_db::{
@@ -17,7 +17,8 @@ use std::collections::BTreeMap;
 use std::sync::Mutex;
 use thiserror::Error;
 
-use crate::Db;
+use crate::{Db, ProgramFile};
+use ty_python_core::program::Program;
 
 pub struct FixAllResults {
     /// The non-lint diagnostics that can't be fixed or the diagnostics of files
@@ -37,15 +38,17 @@ pub struct FixAllResults {
 /// If the `db`'s system isn't [writable](WritableSystem).
 pub fn suppress_all_diagnostics(
     db: &mut dyn Db,
+    program: Program,
     diagnostics: Vec<Diagnostic>,
     cancellation_token: &CancellationToken,
 ) -> Result<FixAllResults, Canceled> {
     fix_all(
         db,
+        program,
         diagnostics,
         FixMode::Suppress,
         cancellation_token,
-        Db::check_file,
+        |db, file| Db::check_file(db, ProgramFile::new(db, program, file)),
     )
 }
 
@@ -57,16 +60,18 @@ pub fn suppress_all_diagnostics(
 /// If the `db`'s system isn't [writable](WritableSystem).
 pub fn fix_all_diagnostics(
     db: &mut dyn Db,
+    program: Program,
     diagnostics: Vec<Diagnostic>,
     applicability: Applicability,
     cancellation_token: &CancellationToken,
 ) -> Result<FixAllResults, Canceled> {
     fix_all(
         db,
+        program,
         diagnostics,
         FixMode::ApplyFixes(applicability),
         cancellation_token,
-        Db::check_file,
+        |db, file| Db::check_file(db, ProgramFile::new(db, program, file)),
     )
 }
 
@@ -77,6 +82,7 @@ const MAX_ITERATIONS: usize = 10;
 /// `check_file` is a separate parameter so that tests can easily mock out a file's diagnostics.
 fn fix_all<F>(
     db: &mut dyn Db,
+    program: Program,
     mut diagnostics: Vec<Diagnostic>,
     fix_mode: FixMode,
     cancellation_token: &CancellationToken,
@@ -128,13 +134,14 @@ where
             continue;
         };
 
-        let parsed = parsed_module(db, file);
+        let program_file = ProgramFile::new(db, program, file);
+        let parsed = program_file.parsed(db);
         if parsed.load(db).has_syntax_errors() {
             tracing::warn!("Skipping file `{path}` with syntax errors");
             continue;
         }
 
-        let fixes = fix_mode.fixes(db, file, diagnostics);
+        let fixes = fix_mode.fixes(db, program_file.versioned_file(db), diagnostics);
 
         if fixes.is_empty() {
             tracing::debug!("Skipping file `{path}` without applicable fixes.");
@@ -176,6 +183,7 @@ where
         // This is done outside the above loop so that it can run in parallel.
         let check_results = recheck_files(
             &*db,
+            program,
             unstaged_fixes,
             fix_mode,
             cancellation_token,
@@ -379,7 +387,12 @@ impl FixMode {
         }
     }
 
-    fn fixes(self, db: &dyn Db, file: File, file_diagnostics: &[Diagnostic]) -> Vec<ApplicableFix> {
+    fn fixes(
+        self,
+        db: &dyn Db,
+        versioned_file: VersionedFile<'_>,
+        file_diagnostics: &[Diagnostic],
+    ) -> Vec<ApplicableFix> {
         match self {
             FixMode::Suppress => {
                 let suppressable_diagnostics: Vec<_> = file_diagnostics
@@ -400,7 +413,7 @@ impl FixMode {
                     })
                     .collect();
 
-                suppress_all(db, file, &suppressable_diagnostics)
+                suppress_all(db, versioned_file, &suppressable_diagnostics)
                     .into_iter()
                     .map(
                         |SuppressFix {
@@ -743,6 +756,7 @@ enum CheckResult<'a> {
 
 fn recheck_files<'a, F>(
     db: &dyn Db,
+    program: Program,
     changes: Vec<(QueuedFile<'a>, usize)>,
     fix_mode: FixMode,
     cancellation_token: &CancellationToken,
@@ -768,8 +782,8 @@ where
 
                     let db = &*db;
 
-                    let parsed = parsed_module(db, file.file);
-                    let parsed = parsed.load(db);
+                    let program_file = ProgramFile::new(db, program, file.file);
+                    let parsed = program_file.parsed(db).load(db);
 
                     let result = if parsed.has_syntax_errors() {
                         let diagnostic =
@@ -778,7 +792,8 @@ where
                         CheckResult::SyntaxError { diagnostic, file }
                     } else {
                         let diagnostics = check_file(db, file.file);
-                        let fixes = fix_mode.fixes(db, file.file, &diagnostics);
+                        let fixes =
+                            fix_mode.fixes(db, program_file.versioned_file(db), &diagnostics);
 
                         file.applied_fixes += applied_fixes;
                         file.diagnostics = Some(diagnostics);
@@ -807,7 +822,6 @@ mod tests {
         Severity, Span,
     };
     use ruff_db::files::{File, system_path_to_file};
-    use ruff_db::parsed::parsed_module;
     use ruff_db::source::source_text;
     use ruff_db::system::SystemPath;
     use ruff_diagnostics::{Applicability, Edit, Fix};
@@ -815,9 +829,9 @@ mod tests {
     use rustc_hash::FxHashMap;
 
     use super::suppress_all_diagnostics;
-    use crate::Db;
     use crate::db::tests::TestDbBuilder;
     use crate::fixes::{FixMode, fix_all};
+    use crate::{Db, ProgramFile};
 
     #[test]
     fn simple_suppression() {
@@ -1148,9 +1162,11 @@ class B(A):
 
         let initial_diagnostics = check_file(&db, file);
 
+        let program = db.program();
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
+            program,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1225,9 +1241,11 @@ class B(A):
 
         let initial_diagnostics = check_file(&db, file);
 
+        let program = db.program();
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
+            program,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1299,8 +1317,10 @@ class B(A):
             create_diagnostics(file)
         };
 
+        let program = db.program();
         let result = fix_all(
             &mut db,
+            program,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1400,9 +1420,11 @@ class B(A):
 
         let initial_diagnostics = check_file(&db, file);
 
+        let program = db.program();
         let cancellation_token_source = CancellationTokenSource::new();
         let fixes = fix_all(
             &mut db,
+            program,
             initial_diagnostics,
             FixMode::ApplyFixes(Applicability::Safe),
             &cancellation_token_source.token(),
@@ -1434,15 +1456,19 @@ class B(A):
 
         let file = system_path_to_file(&db, "test.py").unwrap();
 
-        let parsed_before = parsed_module(&db, file);
-        let had_syntax_errors = parsed_before.load(&db).has_syntax_errors();
-
-        let diagnostics = db.check_file(file);
+        let program = db.program();
+        let program_file = ProgramFile::new(&db, program, file);
+        let had_syntax_errors = program_file.parsed(&db).load(&db).has_syntax_errors();
+        let diagnostics = db.check_file(program_file);
         let total_diagnostics = diagnostics.len();
         let cancellation_token_source = CancellationTokenSource::new();
-        let fixes =
-            suppress_all_diagnostics(&mut db, diagnostics, &cancellation_token_source.token())
-                .expect("operation never gets cancelled");
+        let fixes = suppress_all_diagnostics(
+            &mut db,
+            program,
+            diagnostics,
+            &cancellation_token_source.token(),
+        )
+        .expect("operation never gets cancelled");
 
         assert_eq!(fixes.count, total_diagnostics - fixes.diagnostics.len());
 
@@ -1450,10 +1476,9 @@ class B(A):
 
         let fixed = source_text(&db, file);
 
-        let parsed = parsed_module(&db, file);
-        let parsed = parsed.load(&db);
-
-        let diagnostics_after_applying_fixes = db.check_file(file);
+        let program_file = ProgramFile::new(&db, program, file);
+        let parsed = program_file.parsed(&db).load(&db);
+        let diagnostics_after_applying_fixes = db.check_file(program_file);
 
         let mut output = String::new();
 

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -7,7 +7,6 @@ use crate::suppression::{
     BLANKET_IGNORE_COMMENT, IGNORE_COMMENT_UNKNOWN_RULE, INVALID_IGNORE_COMMENT,
     UNUSED_TYPE_IGNORE_COMMENT,
 };
-use crate::types::check_types;
 pub use db::Db;
 pub use diagnostic::{
     add_inferred_python_version_hint_to_diagnostic, inferred_python_version_source_annotation,
@@ -29,12 +28,12 @@ pub use suppression::{
 };
 use ty_module_resolver::ModuleGlobSet;
 use ty_python_core::definition::docstring_from_body;
+pub use ty_python_core::environment::{InferenceSettings, ProgramFile};
 use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::Program;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{
     BindingWithConstraintsIterator, DeclarationsIterator, FileScopeId, attribute_scopes,
-    semantic_index,
 };
 pub use ty_site_packages::{
     PythonEnvironment, PythonVersionFileSource, PythonVersionSource, PythonVersionWithSource,
@@ -130,8 +129,7 @@ pub(crate) fn attribute_assignments<'db, 's>(
     class_body_scope: ScopeId<'db>,
     name: &'s str,
 ) -> impl Iterator<Item = (BindingWithConstraintsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
-    let file = class_body_scope.file(db);
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, class_body_scope.program_file(db));
 
     attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
         let place_table = index.place_table(function_scope_id);
@@ -151,8 +149,7 @@ pub(crate) fn attribute_declarations<'db, 's>(
     class_body_scope: ScopeId<'db>,
     name: &'s str,
 ) -> impl Iterator<Item = (DeclarationsIterator<'db, 'db>, FileScopeId)> + use<'s, 'db> {
-    let file = class_body_scope.file(db);
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, class_body_scope.program_file(db));
 
     attribute_scopes(db, class_body_scope).filter_map(|function_scope_id| {
         let place_table = index.place_table(function_scope_id);
@@ -166,19 +163,23 @@ pub(crate) fn attribute_declarations<'db, 's>(
 }
 
 /// Get the module-level docstring for the given file.
-pub(crate) fn module_docstring(db: &dyn Db, file: File) -> Option<String> {
-    let module = parsed_module(db, file).load(db);
+pub(crate) fn module_docstring(db: &dyn Db, file: ProgramFile<'_>) -> Option<String> {
+    let module = file.parsed(db).load(db);
     docstring_from_body(module.suite())
         .map(|docstring_expr| docstring_expr.value.to_str().to_owned())
 }
 
-pub fn check_file_unwrap(db: &dyn Db, file: File) -> Vec<Diagnostic> {
-    check_file(db, file)
+pub fn check_file_unwrap(db: &dyn Db, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+    check_file(db, program_file)
         .map(<[ruff_db::diagnostic::Diagnostic]>::into_vec)
         .unwrap_or_else(|error| vec![error])
 }
 
-pub fn check_file(db: &dyn Db, file: File) -> Result<Box<[Diagnostic]>, Diagnostic> {
+pub fn check_file(
+    db: &dyn Db,
+    program_file: ProgramFile<'_>,
+) -> Result<Box<[Diagnostic]>, Diagnostic> {
+    let file = program_file.file(db);
     let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
     // Abort checking if there are IO errors.
@@ -192,7 +193,7 @@ pub fn check_file(db: &dyn Db, file: File) -> Result<Box<[Diagnostic]>, Diagnost
         .to_diagnostic());
     }
 
-    let parsed = parsed_module(db, file);
+    let parsed = parsed_module(db, program_file.versioned_file(db));
 
     let parsed_ref = parsed.load(db);
     diagnostics.extend(
@@ -204,11 +205,16 @@ pub fn check_file(db: &dyn Db, file: File) -> Result<Box<[Diagnostic]>, Diagnost
 
     diagnostics.extend(parsed_ref.unsupported_syntax_errors().iter().map(|error| {
         let mut error = Diagnostic::invalid_syntax(file, error, error);
-        add_inferred_python_version_hint_to_diagnostic(db, &mut error, "parsing syntax");
+        add_inferred_python_version_hint_to_diagnostic(
+            db,
+            program_file.program(db),
+            &mut error,
+            "parsing syntax",
+        );
         error
     }));
 
-    diagnostics.extend(check_types(db, file));
+    diagnostics.extend(types::check_types(db, program_file));
 
     diagnostics.sort_unstable_by(|a, b| a.rendering_sort_key(db).cmp(&b.rendering_sort_key(db)));
 

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1390,16 +1390,16 @@ fn symbol_impl<'db>(
     considered_definitions: ConsideredDefinitions,
 ) -> PlaceAndQualifiers<'db> {
     let _span = tracing::trace_span!("symbol", ?name).entered();
-    let program_file = scope.program_file(db);
-    let program = program_file.program(db);
 
     let is_known_module = |known_module| {
+        let program_file = scope.program_file(db);
         ty_module_resolver::file_to_module(db, program_file.resolver_file(db))
             .is_some_and(|module| module.is_known(db, known_module))
     };
 
     // Check the symbol name first to avoid a module-resolution query for every symbol lookup.
     if matches!(name, "version_info" | "platform") && is_known_module(KnownModule::Sys) {
+        let program = scope.program(db);
         match name {
             "version_info" => {
                 return Place::bound(Type::sys_version_info(program.python_version(db))).into();
@@ -1417,6 +1417,7 @@ fn symbol_impl<'db>(
     }
 
     if name == "name" && is_known_module(KnownModule::Os) {
+        let program = scope.program(db);
         match program.python_platform(db) {
             crate::PythonPlatform::Identifier(platform) => {
                 // In CPython, `os.name` is `"nt"` on Windows and `"posix"` otherwise.
@@ -1727,7 +1728,8 @@ fn place_from_bindings_impl<'db>(
             // We need to "look through" loop header definitions to do boundness analysis. The
             // actual type is computed by `infer_loop_header_definition` via `binding_type` below,
             // like all other bindings, so that it can participate in fixpoint iteration.
-            if binding.kind(db).is_loop_header() {
+            let binding_kind = binding.kind(db);
+            if binding_kind.is_loop_header() {
                 let loop_header = loop_header_reachability(db, binding);
                 deleted_reachability = deleted_reachability.or(loop_header.deleted_reachability);
                 // If all the bindings in the loop are in statically false branches, it might be
@@ -1737,7 +1739,7 @@ fn place_from_bindings_impl<'db>(
                 if loop_header.reachable_bindings.is_empty() {
                     return None;
                 }
-            } else if matches!(binding.kind(db), DefinitionKind::NestedBindings(_)) {
+            } else if matches!(binding_kind, DefinitionKind::NestedBindings(_)) {
                 // Nested bindings definitions similar to loop header definitions, synthetic
                 // bindings with special shadowing behavior. They can also coexist with `UNBOUND`.
             } else {

--- a/crates/ty_python_semantic/src/place.rs
+++ b/crates/ty_python_semantic/src/place.rs
@@ -1,10 +1,7 @@
 use itertools::Either;
-use ruff_db::files::File;
 use ruff_index::IndexSlice;
 use ruff_python_ast::PythonVersion;
-use ty_module_resolver::{
-    KnownModule, Module, ModuleName, file_to_module, resolve_module_confident,
-};
+use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module_confident};
 
 use crate::dunder_all::dunder_all_names;
 use crate::reachability::{
@@ -17,6 +14,7 @@ use crate::types::{
 };
 use crate::{Db, FxIndexSet, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind, DefinitionState};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::narrowing_constraints::ScopedNarrowingConstraint;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::predicate::{Predicate, ScopedPredicateId};
@@ -88,16 +86,21 @@ pub(crate) enum PublicTypePolicy {
 
 impl PublicTypePolicy {
     /// Apply the public-type policy to the raw type.
-    pub(crate) fn apply_if_needed<'db>(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+    pub(crate) fn apply_if_needed<'db>(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+    ) -> Type<'db> {
         match self {
             Self::Raw => ty,
-            Self::Promote => ty.promote(db).promote_singletons(db),
+            Self::Promote => ty.promote(db, program).promote_singletons(db, program),
         }
     }
 }
 
 /// The source definition provenance for a place.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) enum Provenance<'db> {
     /// No source definition is known.
     #[default]
@@ -136,7 +139,7 @@ impl<'db> Provenance<'db> {
 }
 
 /// A defined place with its raw type, origin, definedness, public-type policy, and provenance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct DefinedPlace<'db> {
     pub(crate) ty: Type<'db>,
     pub(crate) origin: TypeOrigin,
@@ -215,7 +218,7 @@ impl<'db> DefinedPlace<'db> {
 /// bound_or_declared:   Place::Defined(DefinedPlace { ty: Literal[1], origin: TypeOrigin::Inferred, definedness: Definedness::PossiblyUndefined, .. }),
 /// non_existent:        Place::Undefined,
 /// ```
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) enum Place<'db> {
     Defined(DefinedPlace<'db>),
     #[default]
@@ -332,15 +335,21 @@ impl<'db> Place<'db> {
     /// Try to call `__get__(None, owner)` on the type of this place (not on the meta type).
     /// If it succeeds, return the `__get__` return type. Otherwise, returns the original place.
     /// This is used to resolve (potential) descriptor attributes.
-    pub(crate) fn try_call_dunder_get(self, db: &'db dyn Db, owner: Type<'db>) -> Place<'db> {
+    pub(crate) fn try_call_dunder_get(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        owner: Type<'db>,
+    ) -> Place<'db> {
         match self {
             Place::Defined(
                 place @ DefinedPlace {
                     ty: Type::Union(union),
                     ..
                 },
-            ) => union.map_with_boundness(db, |elem| {
-                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
+            ) => union.map_with_boundness(db, program, |elem| {
+                Place::Defined(DefinedPlace { ty: *elem, ..place })
+                    .try_call_dunder_get(db, program, owner)
             }),
 
             Place::Defined(
@@ -348,13 +357,14 @@ impl<'db> Place<'db> {
                     ty: Type::Intersection(intersection),
                     ..
                 },
-            ) => intersection.map_with_boundness(db, |elem| {
-                Place::Defined(DefinedPlace { ty: *elem, ..place }).try_call_dunder_get(db, owner)
+            ) => intersection.map_with_boundness(db, program, |elem| {
+                Place::Defined(DefinedPlace { ty: *elem, ..place })
+                    .try_call_dunder_get(db, program, owner)
             }),
 
             Place::Defined(defined) => {
                 if let Some((dunder_get_return_ty, _)) =
-                    defined.ty.try_call_dunder_get(db, None, owner)
+                    defined.ty.try_call_dunder_get(db, program, None, owner)
                 {
                     Place::Defined(DefinedPlace {
                         ty: dunder_get_return_ty,
@@ -414,14 +424,15 @@ impl<'db> LookupError<'db> {
     pub(crate) fn or_fall_back_to(
         self,
         db: &'db dyn Db,
+        program: Program,
         fallback: PlaceAndQualifiers<'db>,
     ) -> LookupResult<'db> {
-        let fallback = fallback.into_lookup_result(db);
+        let fallback = fallback.into_lookup_result(db, program);
         match (&self, &fallback) {
             (LookupError::Undefined(_), _) => fallback,
             (LookupError::PossiblyUndefined { .. }, Err(LookupError::Undefined(_))) => Err(self),
             (LookupError::PossiblyUndefined(ty), Ok(ty2)) => Ok(TypeAndQualifiers::new(
-                UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
+                UnionType::from_two_elements(db, program, ty.inner_type(), ty2.inner_type()),
                 ty.origin().merge(ty2.origin()),
                 ty.qualifiers().union(ty2.qualifiers()),
             )
@@ -429,7 +440,12 @@ impl<'db> LookupError<'db> {
             (LookupError::PossiblyUndefined(ty), Err(LookupError::PossiblyUndefined(ty2))) => {
                 Err(LookupError::PossiblyUndefined(
                     TypeAndQualifiers::new(
-                        UnionType::from_two_elements(db, ty.inner_type(), ty2.inner_type()),
+                        UnionType::from_two_elements(
+                            db,
+                            program,
+                            ty.inner_type(),
+                            ty2.inner_type(),
+                        ),
                         ty.origin().merge(ty2.origin()),
                         ty.qualifiers().union(ty2.qualifiers()),
                     )
@@ -475,7 +491,7 @@ pub(crate) fn symbol<'db>(
 /// Use [`imported_symbol`] to perform the lookup as seen from outside the file (e.g. via imports).
 pub(crate) fn explicit_global_symbol<'db>(
     db: &'db dyn Db,
-    file: File,
+    file: ty_python_core::environment::ProgramFile<'db>,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     symbol_impl(
@@ -497,25 +513,52 @@ pub(crate) fn explicit_global_symbol<'db>(
 #[allow(unused)]
 pub(crate) fn global_symbol<'db>(
     db: &'db dyn Db,
-    file: File,
+    file: ty_python_core::environment::ProgramFile<'db>,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
-    explicit_global_symbol(db, file, name)
-        .or_fall_back_to(db, || module_type_implicit_global_symbol(db, file, name))
+    explicit_global_symbol(db, file, name).or_fall_back_to(db, file.program(db), || {
+        module_type_implicit_global_symbol(db, file, name)
+    })
+}
+
+/// The module in which to look up an imported symbol.
+#[derive(Clone, Copy)]
+pub(crate) enum ImportedSymbolContext<'db> {
+    Namespace(Program),
+    File(ProgramFile<'db>),
+}
+
+impl<'db> ImportedSymbolContext<'db> {
+    fn program(self, db: &'db dyn Db) -> Program {
+        match self {
+            Self::Namespace(program) => program,
+            Self::File(file) => file.program(db),
+        }
+    }
+
+    fn file(self) -> Option<ProgramFile<'db>> {
+        match self {
+            Self::Namespace(_) => None,
+            Self::File(file) => Some(file),
+        }
+    }
 }
 
 /// Infers the public type of an imported symbol.
 ///
 /// If `requires_explicit_reexport` is [`None`], it will be inferred from the file's source type.
-/// For stub files, explicit re-export will be required, while for non-stub files, it will not.
+/// Stub files require explicit re-exports, while non-stub files do not.
 ///
-/// `None` should be passed for the `file` parameter if looking up a symbol on a namespace package.
+/// Use [`ImportedSymbolContext::Namespace`] when looking up a symbol on a namespace package.
 pub(crate) fn imported_symbol<'db>(
     db: &'db dyn Db,
-    file: Option<File>,
+    context: ImportedSymbolContext<'db>,
     name: &str,
     requires_explicit_reexport: Option<RequiresExplicitReExport>,
 ) -> PlaceAndQualifiers<'db> {
+    let program = context.program(db);
+    let file = context.file();
+
     // If it's not found in the global scope, check if it's present as an instance on
     // `types.ModuleType` or `builtins.object`.
     //
@@ -532,8 +575,9 @@ pub(crate) fn imported_symbol<'db>(
     // dynamic imports; we shouldn't use it for `ModuleLiteral` types where we know exactly which
     // module we're dealing with.
     file.map(|file| {
+        let source_file = file.file(db);
         let requires_explicit_reexport = requires_explicit_reexport.unwrap_or_else(|| {
-            if file.is_stub(db) {
+            if source_file.is_stub(db) {
                 RequiresExplicitReExport::Yes
             } else {
                 RequiresExplicitReExport::No
@@ -542,14 +586,14 @@ pub(crate) fn imported_symbol<'db>(
 
         symbol_impl(
             db,
-            global_scope(db, file),
+            ty_python_core::global_scope(db, file),
             name,
             requires_explicit_reexport,
             ConsideredDefinitions::EndOfScope,
         )
     })
     .unwrap_or_default()
-    .or_fall_back_to(db, || {
+    .or_fall_back_to(db, program, || {
         match name {
             "__file__" => {
                 // We special-case `__file__` here because we know that for a successfully imported
@@ -564,16 +608,21 @@ pub(crate) fn imported_symbol<'db>(
                 // do not attempt to detect this; we just infer `str` still. This matches the
                 // behaviour of other major type checkers.
                 if file.is_some() {
-                    Place::bound(KnownClass::Str.to_instance(db)).into()
+                    Place::bound(KnownClass::Str.to_instance(db, program)).into()
                 } else {
-                    Place::bound(Type::none(db)).into()
+                    Place::bound(Type::none(db, program)).into()
                 }
             }
             "__getattr__" => Place::Undefined.into(),
             "__builtins__" => Place::bound(Type::any()).into(),
             _ => KnownClass::ModuleType
-                .to_instance(db)
-                .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NO_GETATTR_LOOKUP),
+                .to_instance(db, program)
+                .member_lookup_with_policy(
+                    db,
+                    program,
+                    name.into(),
+                    MemberLookupPolicy::NO_GETATTR_LOOKUP,
+                ),
         }
     })
 }
@@ -585,31 +634,44 @@ pub(crate) fn imported_symbol<'db>(
 /// Note that this function is only intended for use in the context of the builtins *namespace*
 /// and should not be used when a symbol is being explicitly imported from the `builtins` module
 /// (e.g. `from builtins import int`).
-pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQualifiers<'db> {
+pub(crate) fn builtins_symbol<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    symbol: &str,
+) -> PlaceAndQualifiers<'db> {
     let resolver = |module: Module<'_>| {
         let file = module.file(db)?;
+        let program_file = ty_python_core::environment::ProgramFile::new(db, program, file);
         let found_symbol = symbol_impl(
             db,
-            global_scope(db, file),
+            ty_python_core::global_scope(db, program_file),
             symbol,
             RequiresExplicitReExport::Yes,
             ConsideredDefinitions::EndOfScope,
         )
-        .or_fall_back_to(db, || {
+        .or_fall_back_to(db, program, || {
             // We're looking up in the builtins namespace and not the module, so we should
             // do the normal lookup in `types.ModuleType` and not the special one as in
             // `imported_symbol`.
-            module_type_implicit_global_symbol(db, file, symbol)
+            module_type_implicit_global_symbol(db, program_file, symbol)
         });
         // If this symbol is not present in project-level builtins, search in the default ones.
         found_symbol
             .ignore_possibly_undefined()
             .map(|_| found_symbol)
     };
-    resolve_module_confident(db, &ModuleName::new_static("__builtins__").unwrap())
-        .and_then(&resolver)
-        .or_else(|| resolve_module_confident(db, &KnownModule::Builtins.name()).and_then(resolver))
-        .unwrap_or_default()
+    let resolver_program = program.resolver(db);
+    resolve_module_confident(
+        db,
+        resolver_program,
+        &ModuleName::new_static("__builtins__").unwrap(),
+    )
+    .and_then(&resolver)
+    .or_else(|| {
+        resolve_module_confident(db, resolver_program, &KnownModule::Builtins.name())
+            .and_then(resolver)
+    })
+    .unwrap_or_default()
 }
 
 /// Lookup the type of `symbol` in a given known module.
@@ -617,13 +679,19 @@ pub(crate) fn builtins_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQua
 /// Returns `Place::Undefined` if the given known module cannot be resolved for some reason.
 pub(crate) fn known_module_symbol<'db>(
     db: &'db dyn Db,
+    program: Program,
     known_module: KnownModule,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    resolve_module_confident(db, &known_module.name())
+    resolve_module_confident(db, program.resolver(db), &known_module.name())
         .and_then(|module| {
             let file = module.file(db)?;
-            Some(imported_symbol(db, Some(file), symbol, None))
+            Some(imported_symbol(
+                db,
+                ImportedSymbolContext::File(ProgramFile::new(db, program, file)),
+                symbol,
+                None,
+            ))
         })
         .unwrap_or_default()
 }
@@ -633,8 +701,12 @@ pub(crate) fn known_module_symbol<'db>(
 /// Returns `Place::Undefined` if the `typing` module isn't available for some reason.
 #[inline]
 #[cfg(test)]
-pub(crate) fn typing_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQualifiers<'db> {
-    known_module_symbol(db, KnownModule::Typing, symbol)
+pub(crate) fn typing_symbol<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    symbol: &str,
+) -> PlaceAndQualifiers<'db> {
+    known_module_symbol(db, program, KnownModule::Typing, symbol)
 }
 
 /// Lookup the type of `symbol` in the `typing_extensions` module namespace.
@@ -643,24 +715,32 @@ pub(crate) fn typing_symbol<'db>(db: &'db dyn Db, symbol: &str) -> PlaceAndQuali
 #[inline]
 pub(crate) fn typing_extensions_symbol<'db>(
     db: &'db dyn Db,
+    program: Program,
     symbol: &str,
 ) -> PlaceAndQualifiers<'db> {
-    known_module_symbol(db, KnownModule::TypingExtensions, symbol)
+    known_module_symbol(db, program, KnownModule::TypingExtensions, symbol)
 }
 
 /// Get the `builtins` module scope.
 ///
 /// Can return `None` if a custom typeshed is used that is missing `builtins.pyi`.
-pub(crate) fn builtins_module_scope(db: &dyn Db) -> Option<ScopeId<'_>> {
-    core_module_scope(db, KnownModule::Builtins)
+pub(crate) fn builtins_module_scope(db: &dyn Db, program: Program) -> Option<ScopeId<'_>> {
+    core_module_scope(db, program, KnownModule::Builtins)
 }
 
 /// Get the scope of a core stdlib module.
 ///
 /// Can return `None` if a custom typeshed is used that is missing the core module in question.
-fn core_module_scope(db: &dyn Db, core_module: KnownModule) -> Option<ScopeId<'_>> {
-    let module = resolve_module_confident(db, &core_module.name())?;
-    Some(global_scope(db, module.file(db)?))
+fn core_module_scope(
+    db: &dyn Db,
+    program: Program,
+    core_module: KnownModule,
+) -> Option<ScopeId<'_>> {
+    let module = resolve_module_confident(db, program.resolver(db), &core_module.name())?;
+    Some(ty_python_core::global_scope(
+        db,
+        ty_python_core::environment::ProgramFile::new(db, program, module.file(db)?),
+    ))
 }
 
 /// Infer the combined type from an iterator of bindings, and return it
@@ -669,10 +749,12 @@ fn core_module_scope(db: &dyn Db, core_module: KnownModule) -> Option<ScopeId<'_
 /// The type will be a union if there are multiple bindings with different types.
 pub(super) fn place_from_bindings<'db>(
     db: &'db dyn Db,
+    program: Program,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(
         db,
+        program,
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         None,
@@ -681,11 +763,13 @@ pub(super) fn place_from_bindings<'db>(
 
 pub(super) fn place_from_bindings_with_reachability_cache<'db>(
     db: &'db dyn Db,
+    program: Program,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     reachability_cache: &ReachabilityEvaluationCache<'db>,
 ) -> PlaceWithDefinition<'db> {
     place_from_bindings_impl(
         db,
+        program,
         bindings_with_constraints,
         RequiresExplicitReExport::No,
         Some(reachability_cache),
@@ -702,18 +786,27 @@ pub(super) fn place_from_bindings_with_reachability_cache<'db>(
 /// [`TypeQualifiers`] that have been specified on the declaration(s).
 pub(crate) fn place_from_declarations<'db>(
     db: &'db dyn Db,
+    program: Program,
     declarations: DeclarationsIterator<'_, 'db>,
 ) -> PlaceFromDeclarationsResult<'db> {
-    place_from_declarations_impl(db, declarations, RequiresExplicitReExport::No, None)
+    place_from_declarations_impl(
+        db,
+        program,
+        declarations,
+        RequiresExplicitReExport::No,
+        None,
+    )
 }
 
 pub(crate) fn place_from_declarations_with_reachability_cache<'db>(
     db: &'db dyn Db,
+    program: Program,
     declarations: DeclarationsIterator<'_, 'db>,
     reachability_cache: &ReachabilityEvaluationCache<'db>,
 ) -> PlaceFromDeclarationsResult<'db> {
     place_from_declarations_impl(
         db,
+        program,
         declarations,
         RequiresExplicitReExport::No,
         Some(reachability_cache),
@@ -776,7 +869,7 @@ impl<'db> PlaceFromDeclarationsResult<'db> {
 /// that this comes with a [`CLASS_VAR`] type qualifier.
 ///
 /// [`CLASS_VAR`]: crate::types::TypeQualifiers::CLASS_VAR
-#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Default, Copy, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct PlaceAndQualifiers<'db> {
     pub(crate) place: Place<'db>,
     pub(crate) qualifiers: TypeQualifiers,
@@ -852,13 +945,19 @@ impl<'db> PlaceAndQualifiers<'db> {
     ///
     /// For places whose public type differs from their raw stored type, this applies the
     /// public-type policy lazily during lookup.
-    pub(crate) fn into_lookup_result(self, db: &'db dyn Db) -> LookupResult<'db> {
+    pub(crate) fn into_lookup_result(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> LookupResult<'db> {
         match self {
             PlaceAndQualifiers {
                 place: Place::Defined(place),
                 qualifiers,
             } => {
-                let ty = place.public_type_policy.apply_if_needed(db, place.ty);
+                let ty = place
+                    .public_type_policy
+                    .apply_if_needed(db, program, place.ty);
                 let type_and_qualifiers = TypeAndQualifiers::new(ty, place.origin, qualifiers)
                     .with_provenance(place.provenance);
                 match place.definedness {
@@ -884,9 +983,11 @@ impl<'db> PlaceAndQualifiers<'db> {
     pub(crate) fn unwrap_with_diagnostic(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         diagnostic_fn: impl FnOnce(LookupError<'db>) -> TypeAndQualifiers<'db>,
     ) -> TypeAndQualifiers<'db> {
-        self.into_lookup_result(db).unwrap_or_else(diagnostic_fn)
+        self.into_lookup_result(db, program)
+            .unwrap_or_else(diagnostic_fn)
     }
 
     /// Fallback (partially or fully) to another place if `self` is partially or fully unbound.
@@ -903,16 +1004,18 @@ impl<'db> PlaceAndQualifiers<'db> {
     pub(crate) fn or_fall_back_to(
         self,
         db: &'db dyn Db,
+        program: Program,
         fallback_fn: impl FnOnce() -> PlaceAndQualifiers<'db>,
     ) -> Self {
-        self.into_lookup_result(db)
-            .or_else(|lookup_error| lookup_error.or_fall_back_to(db, fallback_fn()))
+        self.into_lookup_result(db, program)
+            .or_else(|lookup_error| lookup_error.or_fall_back_to(db, program, fallback_fn()))
             .into()
     }
 
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,
+        program: Program,
         previous_place: Self,
         cycle: &salsa::Cycle,
     ) -> Self {
@@ -927,7 +1030,7 @@ impl<'db> PlaceAndQualifiers<'db> {
             // iteration into the current result; after the first couple iterations, the same
             // applies to boundness and qualifiers.
             (Place::Defined(prev), Place::Defined(current)) => Place::Defined(DefinedPlace {
-                ty: current.ty.cycle_normalized(db, prev.ty, cycle),
+                ty: current.ty.cycle_normalized(db, program, prev.ty, cycle),
                 definedness: if cycle.iteration() <= 1
                     || matches!(
                         (prev.definedness, current.definedness),
@@ -948,7 +1051,7 @@ impl<'db> PlaceAndQualifiers<'db> {
             // However, the handling described above may reduce the exactness of reachability analysis,
             // so it may be better to remove it. In that case, this branch is necessary.
             (Place::Undefined, Place::Defined(current)) => Place::Defined(DefinedPlace {
-                ty: current.ty.recursive_type_normalized(db, cycle),
+                ty: current.ty.recursive_type_normalized(db, program, cycle),
                 definedness: if cycle.iteration() <= 1 {
                     current.definedness
                 } else {
@@ -963,7 +1066,7 @@ impl<'db> PlaceAndQualifiers<'db> {
                     Place::Undefined
                 } else {
                     Place::Defined(DefinedPlace {
-                        ty: prev.ty.recursive_type_normalized(db, cycle),
+                        ty: prev.ty.recursive_type_normalized(db, program, cycle),
                         definedness: Definedness::PossiblyUndefined,
                         ..prev
                     })
@@ -984,8 +1087,8 @@ impl<'db> From<Place<'db>> for PlaceAndQualifiers<'db> {
 #[salsa::tracked(
     returns(copy),
     cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
-    cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, place: PlaceAndQualifiers<'db>, _, _, _, _| {
-        place.cycle_normalized(db, *previous, cycle)
+    cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, place: PlaceAndQualifiers<'db>, scope: ScopeId<'db>, _, _, _| {
+        place.cycle_normalized(db, scope.program(db), *previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -996,6 +1099,7 @@ pub(crate) fn place_by_id<'db>(
     requires_explicit_reexport: RequiresExplicitReExport,
     considered_definitions: ConsideredDefinitions,
 ) -> PlaceAndQualifiers<'db> {
+    let program = scope.program(db);
     let use_def = use_def_map(db, scope);
 
     // If the place is declared, the public type is based on declarations; otherwise, it's based
@@ -1006,8 +1110,9 @@ pub(crate) fn place_by_id<'db>(
         ConsideredDefinitions::AllReachable => use_def.reachable_declarations(place_id),
     };
 
-    let declared = place_from_declarations_impl(db, declarations, requires_explicit_reexport, None)
-        .ignore_conflicting_declarations();
+    let declared =
+        place_from_declarations_impl(db, program, declarations, requires_explicit_reexport, None)
+            .ignore_conflicting_declarations();
 
     let all_considered_bindings = || match considered_definitions {
         ConsideredDefinitions::EndOfScope => use_def.end_of_scope_bindings(place_id),
@@ -1018,7 +1123,7 @@ pub(crate) fn place_by_id<'db>(
     // inferred type, without unioning with `Unknown`, because it cannot be modified.
     if let Some(qualifiers) = declared.is_bare_final() {
         let bindings = all_considered_bindings();
-        return place_from_bindings_impl(db, bindings, requires_explicit_reexport, None)
+        return place_from_bindings_impl(db, program, bindings, requires_explicit_reexport, None)
             .place
             .with_qualifiers(qualifiers);
     }
@@ -1038,7 +1143,9 @@ pub(crate) fn place_by_id<'db>(
             qualifiers,
         } if qualifiers.contains(TypeQualifiers::CLASS_VAR) => {
             let bindings = all_considered_bindings();
-            match place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place {
+            match place_from_bindings_impl(db, program, bindings, requires_explicit_reexport, None)
+                .place
+            {
                 Place::Defined(DefinedPlace {
                     ty: inferred,
                     origin,
@@ -1046,7 +1153,7 @@ pub(crate) fn place_by_id<'db>(
                     provenance: inferred_provenance,
                     ..
                 }) => Place::Defined(DefinedPlace {
-                    ty: UnionType::from_two_elements(db, Type::unknown(), inferred),
+                    ty: UnionType::from_two_elements(db, program, Type::unknown(), inferred),
                     origin,
                     definedness: boundness,
                     public_type_policy: PublicTypePolicy::Raw,
@@ -1086,7 +1193,8 @@ pub(crate) fn place_by_id<'db>(
         } => {
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
-            let inferred = place_from_bindings_impl(db, bindings, requires_explicit_reexport, None);
+            let inferred =
+                place_from_bindings_impl(db, program, bindings, requires_explicit_reexport, None);
 
             let place = match inferred.place {
                 // Place is possibly undeclared and definitely unbound
@@ -1110,7 +1218,7 @@ pub(crate) fn place_by_id<'db>(
                     provenance: inferred_provenance,
                     ..
                 }) => Place::Defined(DefinedPlace {
-                    ty: UnionType::from_two_elements(db, inferred_ty, declared_ty),
+                    ty: UnionType::from_two_elements(db, program, inferred_ty, declared_ty),
                     origin,
                     definedness: if boundness_analysis == BoundnessAnalysis::AssumeBound {
                         Definedness::AlwaysDefined
@@ -1132,7 +1240,8 @@ pub(crate) fn place_by_id<'db>(
             let bindings = all_considered_bindings();
             let boundness_analysis = bindings.boundness_analysis();
             let mut inferred =
-                place_from_bindings_impl(db, bindings, requires_explicit_reexport, None).place;
+                place_from_bindings_impl(db, program, bindings, requires_explicit_reexport, None)
+                    .place;
 
             if boundness_analysis == BoundnessAnalysis::AssumeBound {
                 if let Place::Defined(defined) = inferred {
@@ -1281,18 +1390,21 @@ fn symbol_impl<'db>(
     considered_definitions: ConsideredDefinitions,
 ) -> PlaceAndQualifiers<'db> {
     let _span = tracing::trace_span!("symbol", ?name).entered();
+    let program_file = scope.program_file(db);
+    let program = program_file.program(db);
 
     let is_known_module = |known_module| {
-        file_to_module(db, scope.file(db)).is_some_and(|module| module.is_known(db, known_module))
+        ty_module_resolver::file_to_module(db, program_file.resolver_file(db))
+            .is_some_and(|module| module.is_known(db, known_module))
     };
 
     // Check the symbol name first to avoid a module-resolution query for every symbol lookup.
     if matches!(name, "version_info" | "platform") && is_known_module(KnownModule::Sys) {
         match name {
             "version_info" => {
-                return Place::bound(Type::sys_version_info()).into();
+                return Place::bound(Type::sys_version_info(program.python_version(db))).into();
             }
-            "platform" => match Program::get(db).python_platform(db) {
+            "platform" => match program.python_platform(db) {
                 crate::PythonPlatform::Identifier(platform) => {
                     return Place::bound(Type::string_literal(db, platform.as_str())).into();
                 }
@@ -1305,7 +1417,7 @@ fn symbol_impl<'db>(
     }
 
     if name == "name" && is_known_module(KnownModule::Os) {
-        match Program::get(db).python_platform(db) {
+        match program.python_platform(db) {
             crate::PythonPlatform::Identifier(platform) => {
                 // In CPython, `os.name` is `"nt"` on Windows and `"posix"` otherwise.
                 let os_name = if platform == "win32" { "nt" } else { "posix" };
@@ -1333,7 +1445,6 @@ fn symbol_impl<'db>(
 
 /// Pre-computed reachability analysis for loop-back bindings in a loop header.
 #[salsa::tracked(
-    returns(clone),
     cycle_initial=|db, _, definition| loop_header_reachability_impl(db, definition, true),
     cycle_fn=loop_header_reachability_cycle_recover,
     heap_size = ruff_memory_usage::heap_size,
@@ -1426,7 +1537,7 @@ fn loop_header_reachability_impl<'db>(
 }
 
 /// Result of [`loop_header_reachability`]: pre-computed reachability info for loop-back bindings.
-#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct LoopHeaderReachability<'db> {
     pub(crate) deleted_reachability: Truthiness,
     /// Reachable loop-back bindings that are not `del`s.
@@ -1456,7 +1567,7 @@ impl<'db> LoopHeaderReachability<'db> {
 }
 
 /// A single reachable loop-back binding with its narrowing constraint.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct ReachableLoopBinding<'db> {
     pub(crate) definition: Definition<'db>,
     pub(crate) narrowing_constraint: ScopedNarrowingConstraint,
@@ -1469,6 +1580,7 @@ pub(crate) struct ReachableLoopBinding<'db> {
 /// access any AST nodes from the file containing the declarations.
 fn place_from_bindings_impl<'db>(
     db: &'db dyn Db,
+    program: Program,
     bindings_with_constraints: BindingWithConstraintsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
     reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
@@ -1636,7 +1748,7 @@ fn place_from_bindings_impl<'db>(
             provenance = provenance.or(Provenance::SingleDefinition(binding));
             let binding_ty = binding_type(db, binding);
             Some((
-                narrowing_constraint.narrow(db, binding_ty, binding.place(db)),
+                narrowing_constraint.narrow(db, program, binding_ty, binding.place(db)),
                 static_reachability,
             ))
         },
@@ -1644,7 +1756,7 @@ fn place_from_bindings_impl<'db>(
 
     let place = if let Some((first, first_reachability)) = types.next() {
         let ty = if let Some((second, second_reachability)) = types.next() {
-            let mut builder = PublicTypeBuilder::new(db);
+            let mut builder = PublicTypeBuilder::new(db, program);
             builder.add(first, first_reachability);
             builder.add(second, second_reachability);
 
@@ -1717,11 +1829,11 @@ struct PublicTypeBuilder<'db> {
 }
 
 impl<'db> PublicTypeBuilder<'db> {
-    fn new(db: &'db dyn Db) -> Self {
+    fn new(db: &'db dyn Db, program: Program) -> Self {
         PublicTypeBuilder {
             db,
             queue: None,
-            builder: UnionBuilder::new(db),
+            builder: UnionBuilder::new(db, program),
         }
     }
 
@@ -1799,9 +1911,9 @@ struct DeclaredTypeBuilder<'db> {
 }
 
 impl<'db> DeclaredTypeBuilder<'db> {
-    fn new(db: &'db dyn Db) -> Self {
+    fn new(db: &'db dyn Db, program: Program) -> Self {
         DeclaredTypeBuilder {
-            inner: PublicTypeBuilder::new(db),
+            inner: PublicTypeBuilder::new(db, program),
             qualifiers: TypeQualifiers::empty(),
             first_type: None,
             conflicting_types: FxOrderSet::default(),
@@ -1813,7 +1925,11 @@ impl<'db> DeclaredTypeBuilder<'db> {
 
         if self.inner.add(element_ty, reachability) {
             if let Some(first_ty) = self.first_type {
-                if !first_ty.is_equivalent_to(self.inner.db, element_ty) {
+                if !first_ty.is_equivalent_to(
+                    self.inner.db,
+                    self.inner.builder.program(),
+                    element_ty,
+                ) {
                     self.conflicting_types.insert(element_ty);
                 }
             } else {
@@ -1850,6 +1966,7 @@ impl<'db> DeclaredTypeBuilder<'db> {
 /// access any AST nodes from the file containing the declarations.
 fn place_from_declarations_impl<'db>(
     db: &'db dyn Db,
+    program: Program,
     declarations_iterator: DeclarationsIterator<'_, 'db>,
     requires_explicit_reexport: RequiresExplicitReExport,
     reachability_cache: Option<&ReachabilityEvaluationCache<'db>>,
@@ -1921,7 +2038,7 @@ fn place_from_declarations_impl<'db>(
 
     if let Some((first, first_reachability)) = types.next() {
         let (declared, conflicting) = if let Some((second, second_reachability)) = types.next() {
-            let mut builder = DeclaredTypeBuilder::new(db);
+            let mut builder = DeclaredTypeBuilder::new(db, program);
             builder.add(first, first_reachability);
             builder.add(second, second_reachability);
             for (element, reachability) in types {
@@ -1977,7 +2094,7 @@ fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
     // At this point, the definition should either be an `import` or `from ... import` statement.
     // This is because the default value of `is_reexported` is `true` for any other kind of
     // definition.
-    let Some(all_names) = dunder_all_names(db, definition.file(db)) else {
+    let Some(all_names) = dunder_all_names(db, definition.program_file(db)) else {
         return false;
     };
     let table = place_table(db, definition.scope(db));
@@ -1987,7 +2104,6 @@ fn is_reexported(db: &dyn Db, definition: Definition<'_>) -> bool {
 }
 
 pub(crate) mod implicit_globals {
-    use ruff_db::files::File;
     use ruff_python_ast as ast;
     use ruff_python_ast::name::Name;
 
@@ -2006,15 +2122,17 @@ pub(crate) mod implicit_globals {
 
     pub(crate) fn module_type_implicit_global_declaration<'db>(
         db: &'db dyn Db,
+        program: Program,
         name: &str,
     ) -> PlaceAndQualifiers<'db> {
-        if !module_type_symbols(db)
+        if !module_type_symbols(db, program)
             .iter()
             .any(|module_type_member| module_type_member == name)
         {
             return Place::Undefined.into();
         }
-        let Type::ClassLiteral(module_type_class) = KnownClass::ModuleType.to_class_literal(db)
+        let Type::ClassLiteral(module_type_class) =
+            KnownClass::ModuleType.to_class_literal(db, program)
         else {
             return Place::Undefined.into();
         };
@@ -2028,6 +2146,7 @@ pub(crate) mod implicit_globals {
         };
         place_from_declarations(
             db,
+            program,
             use_def_map(db, module_type_scope).end_of_scope_symbol_declarations(symbol_id),
         )
         .ignore_conflicting_declarations()
@@ -2049,53 +2168,48 @@ pub(crate) mod implicit_globals {
     /// global scope if they're being imported **from a different file**.
     pub(crate) fn module_type_implicit_global_symbol<'db>(
         db: &'db dyn Db,
-        file: File,
+        file: ty_python_core::environment::ProgramFile<'db>,
         name: &str,
     ) -> PlaceAndQualifiers<'db> {
+        let program = file.program(db);
         match name {
             // We special-case `__file__` here because we know that for an internal implicit global
             // lookup in a Python module, it is always a string, even though typeshed says `str |
             // None`.
-            "__file__" => Place::bound(KnownClass::Str.to_instance(db)).into(),
+            "__file__" => Place::bound(KnownClass::Str.to_instance(db, program)).into(),
 
-            // We special-case `__doc__` because a module with a literal docstring has `__doc__`
-            // set to that string at runtime. We only narrow when a docstring is present: `__doc__`
-            // may be set dynamically, so we fall back to the typeshed's `str | None`.
             "__doc__" if module_docstring(db, file).is_some() => {
-                // Docstrings are stripped in `-OO` optimized mode, but here we assume that the
-                // existence of an actual docstring AND the usage of `__doc__` is reason enough to
-                // believe that it will exist at runtime.
-                Place::bound(KnownClass::Str.to_instance(db)).into()
+                Place::bound(KnownClass::Str.to_instance(db, program)).into()
             }
 
             "__builtins__" => Place::bound(Type::any()).into(),
 
-            "__debug__" => Place::bound(KnownClass::Bool.to_instance(db)).into(),
+            "__debug__" => Place::bound(KnownClass::Bool.to_instance(db, program)).into(),
 
             // Created lazily by the warnings machinery; may be absent.
             // Model as possibly-unbound to avoid false negatives.
-            "__warningregistry__" => {
-                Place::Defined(
-                    DefinedPlace::new(KnownClass::Dict.to_specialized_instance(
-                        db,
-                        &[Type::any(), KnownClass::Int.to_instance(db)],
-                    ))
-                    .with_definedness(Definedness::PossiblyUndefined),
-                )
-                .into()
-            }
+            "__warningregistry__" => Place::Defined(
+                DefinedPlace::new(KnownClass::Dict.to_specialized_instance(
+                    db,
+                    program,
+                    &[Type::any(), KnownClass::Int.to_instance(db, program)],
+                ))
+                .with_definedness(Definedness::PossiblyUndefined),
+            )
+            .into(),
 
             // Marked as possibly-unbound as it is only present in the module namespace
             // if at least one global symbol is annotated in the module.
-            "__annotate__" if Program::get(db).python_version(db) >= PythonVersion::PY314 => {
+            "__annotate__" if program.python_version(db) >= PythonVersion::PY314 => {
                 let signature = Signature::new(
                     Parameters::standard([Parameter::positional_only(Some(Name::new_static(
                         "format",
                     )))
-                    .with_annotated_type(KnownClass::Int.to_instance(db))]),
+                    .with_annotated_type(KnownClass::Int.to_instance(db, program))]),
                     KnownClass::Dict.to_specialized_instance(
                         db,
-                        &[KnownClass::Str.to_instance(db), Type::any()],
+                        program,
+                        &[KnownClass::Str.to_instance(db, program), Type::any()],
                     ),
                 );
                 Place::Defined(
@@ -2110,14 +2224,15 @@ pub(crate) mod implicit_globals {
             // type, since it has the same end result. The reason to only call `.member()` on `ModuleType`
             // when absolutely necessary is that this function is used in a very hot path (name resolution
             // in `infer.rs`). We use less idiomatic (and much more verbose) code here as a micro-optimisation.
-            _ if module_type_symbols(db)
+            _ if module_type_symbols(db, program)
                 .iter()
                 .any(|module_type_member| &**module_type_member == name) =>
             {
                 KnownClass::ModuleType
-                    .to_instance(db)
+                    .to_instance(db, program)
                     .member_lookup_with_policy(
                         db,
+                        program,
                         name.into(),
                         MemberLookupPolicy::NO_GETATTR_LOOKUP,
                     )
@@ -2146,12 +2261,15 @@ pub(crate) mod implicit_globals {
     /// so the cost of hashing the names is likely to be more expensive than it's worth.
     #[salsa::tracked(
         returns(deref),
-        cycle_initial=|_, _| smallvec::SmallVec::default(),
+        cycle_initial=|_, _, _| smallvec::SmallVec::default(),
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn module_type_symbols(db: &dyn Db) -> smallvec::SmallVec<[ast::name::Name; 8]> {
+    fn module_type_symbols(
+        db: &dyn Db,
+        program: Program,
+    ) -> smallvec::SmallVec<[ast::name::Name; 8]> {
         let Some(module_type) = KnownClass::ModuleType
-            .to_class_literal(db)
+            .to_class_literal(db, program)
             .as_class_literal()
         else {
             // The most likely way we get here is if a user specified a `--custom-typeshed-dir`
@@ -2183,17 +2301,18 @@ pub(crate) mod implicit_globals {
     /// This is used for completions in the global scope of a module. It returns
     /// the correct types for special-cased symbols like `__file__` (which is `str`
     /// for the current module, not `str | None`).
-    pub(crate) fn all_implicit_module_globals(
-        db: &dyn Db,
-        file: File,
-    ) -> impl Iterator<Item = (Name, Type<'_>)> + '_ {
+    pub(crate) fn all_implicit_module_globals<'db>(
+        db: &'db dyn Db,
+        file: ty_python_core::environment::ProgramFile<'db>,
+    ) -> impl Iterator<Item = (Name, Type<'db>)> + 'db {
+        let program = file.program(db);
         // Special-cased implicit globals that are not in `module_type_symbols`
         let special_cased = ["__builtins__", "__debug__", "__warningregistry__"]
             .into_iter()
             .map(Name::new_static);
 
         // All symbols from ModuleType (already includes `__file__`, `__name__`, etc.)
-        let module_type_syms = module_type_symbols(db).iter().cloned();
+        let module_type_syms = module_type_symbols(db, program).iter().cloned();
 
         // Combine and map to (name, type) pairs
         special_cased
@@ -2213,7 +2332,7 @@ pub(crate) mod implicit_globals {
         #[test]
         fn module_type_symbols_includes_declared_types_but_not_referenced_types() {
             let db = setup_db();
-            let symbol_names = module_type_symbols(&db);
+            let symbol_names = module_type_symbols(&db, db.program());
 
             let dunder_name_symbol_name = ast::name::Name::new_static("__name__");
             assert!(symbol_names.contains(&dunder_name_symbol_name));
@@ -2234,21 +2353,23 @@ pub(crate) mod implicit_globals {
 /// See <https://docs.python.org/3/reference/datamodel.html#creating-the-class-object>
 pub(crate) fn class_body_implicit_symbol<'db>(
     db: &'db dyn Db,
+    program: Program,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
     match name {
-        "__qualname__" => Place::bound(KnownClass::Str.to_instance(db)).into(),
-        "__module__" => Place::bound(KnownClass::Str.to_instance(db)).into(),
+        "__qualname__" => Place::bound(KnownClass::Str.to_instance(db, program)).into(),
+        "__module__" => Place::bound(KnownClass::Str.to_instance(db, program)).into(),
         // __doc__ is `str` if there's a docstring, `None` if there isn't
         "__doc__" => Place::bound(UnionType::from_two_elements(
             db,
-            KnownClass::Str.to_instance(db),
-            Type::none(db),
+            program,
+            KnownClass::Str.to_instance(db, program),
+            Type::none(db, program),
         ))
         .into(),
         // __firstlineno__ was added in Python 3.13
-        "__firstlineno__" if Program::get(db).python_version(db) >= PythonVersion::PY313 => {
-            Place::bound(KnownClass::Int.to_instance(db)).into()
+        "__firstlineno__" if program.python_version(db) >= PythonVersion::PY313 => {
+            Place::bound(KnownClass::Int.to_instance(db, program)).into()
         }
         _ => Place::Undefined.into(),
     }
@@ -2279,7 +2400,7 @@ impl RequiresExplicitReExport {
 ///     if flag():
 ///         x = 3
 /// ```
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue)]
 pub(crate) enum ConsideredDefinitions {
     /// Consider only the definitions that are "live" at the end of the scope, i.e. those
     /// that have not been shadowed or deleted.
@@ -2299,6 +2420,7 @@ mod tests {
         use TypeOrigin::Inferred;
 
         let db = setup_db();
+        let program = db.program();
         let ty1 = Type::int_literal(1);
         let ty2 = Type::int_literal(2);
 
@@ -2347,22 +2469,25 @@ mod tests {
         };
 
         // Start from an unbound symbol
-        assert_eq!(unbound().or_fall_back_to(&db, unbound), unbound());
+        assert_eq!(unbound().or_fall_back_to(&db, program, unbound), unbound());
         assert_eq!(
-            unbound().or_fall_back_to(&db, possibly_unbound_ty1),
+            unbound().or_fall_back_to(&db, program, possibly_unbound_ty1),
             possibly_unbound_ty1()
         );
-        assert_eq!(unbound().or_fall_back_to(&db, bound_ty1), bound_ty1());
+        assert_eq!(
+            unbound().or_fall_back_to(&db, program, bound_ty1),
+            bound_ty1()
+        );
 
         // Start from a possibly unbound symbol
         assert_eq!(
-            possibly_unbound_ty1().or_fall_back_to(&db, unbound),
+            possibly_unbound_ty1().or_fall_back_to(&db, program, unbound),
             possibly_unbound_ty1()
         );
         assert_eq!(
-            possibly_unbound_ty1().or_fall_back_to(&db, possibly_unbound_ty2),
+            possibly_unbound_ty1().or_fall_back_to(&db, program, possibly_unbound_ty2),
             Place::Defined(DefinedPlace {
-                ty: UnionType::from_elements(&db, [ty1, ty2]),
+                ty: UnionType::from_elements(&db, program, [ty1, ty2]),
                 origin: Inferred,
                 definedness: PossiblyUndefined,
                 public_type_policy: PublicTypePolicy::Raw,
@@ -2371,9 +2496,9 @@ mod tests {
             .into()
         );
         assert_eq!(
-            possibly_unbound_ty1().or_fall_back_to(&db, bound_ty2),
+            possibly_unbound_ty1().or_fall_back_to(&db, program, bound_ty2),
             Place::Defined(DefinedPlace {
-                ty: UnionType::from_elements(&db, [ty1, ty2]),
+                ty: UnionType::from_elements(&db, program, [ty1, ty2]),
                 origin: Inferred,
                 definedness: AlwaysDefined,
                 public_type_policy: PublicTypePolicy::Raw,
@@ -2383,16 +2508,22 @@ mod tests {
         );
 
         // Start from a definitely bound symbol
-        assert_eq!(bound_ty1().or_fall_back_to(&db, unbound), bound_ty1());
         assert_eq!(
-            bound_ty1().or_fall_back_to(&db, possibly_unbound_ty2),
+            bound_ty1().or_fall_back_to(&db, program, unbound),
             bound_ty1()
         );
-        assert_eq!(bound_ty1().or_fall_back_to(&db, bound_ty2), bound_ty1());
+        assert_eq!(
+            bound_ty1().or_fall_back_to(&db, program, possibly_unbound_ty2),
+            bound_ty1()
+        );
+        assert_eq!(
+            bound_ty1().or_fall_back_to(&db, program, bound_ty2),
+            bound_ty1()
+        );
     }
 
     #[track_caller]
-    fn assert_bound_string_symbol<'db>(db: &'db dyn Db, symbol: Place<'db>) {
+    fn assert_bound_string_symbol<'db>(db: &'db dyn Db, program: Program, symbol: Place<'db>) {
         assert!(matches!(
             symbol,
             Place::Defined(DefinedPlace {
@@ -2401,33 +2532,49 @@ mod tests {
                 ..
             })
         ));
-        assert_eq!(symbol.expect_type(), KnownClass::Str.to_instance(db));
+        assert_eq!(
+            symbol.expect_type(),
+            KnownClass::Str.to_instance(db, program)
+        );
     }
 
     #[test]
     fn implicit_builtin_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, builtins_symbol(&db, "__name__").place);
+        let program = db.program();
+        assert_bound_string_symbol(
+            &db,
+            program,
+            builtins_symbol(&db, program, "__name__").place,
+        );
     }
 
     #[test]
     fn implicit_typing_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, typing_symbol(&db, "__name__").place);
+        let program = db.program();
+        assert_bound_string_symbol(&db, program, typing_symbol(&db, program, "__name__").place);
     }
 
     #[test]
     fn implicit_typing_extensions_globals() {
         let db = setup_db();
-        assert_bound_string_symbol(&db, typing_extensions_symbol(&db, "__name__").place);
+        let program = db.program();
+        assert_bound_string_symbol(
+            &db,
+            program,
+            typing_extensions_symbol(&db, program, "__name__").place,
+        );
     }
 
     #[test]
     fn implicit_sys_globals() {
         let db = setup_db();
+        let program = db.program();
         assert_bound_string_symbol(
             &db,
-            known_module_symbol(&db, KnownModule::Sys, "__name__").place,
+            program,
+            known_module_symbol(&db, program, KnownModule::Sys, "__name__").place,
         );
     }
 }

--- a/crates/ty_python_semantic/src/pull_types.rs
+++ b/crates/ty_python_semantic/src/pull_types.rs
@@ -3,16 +3,15 @@
 //! This is used in the "corpus" and (indirectly) the "mdtest" integration tests for this crate.
 //! (Mdtest uses the `pull_types` function via the `ty_test` crate.)
 
-use crate::{Db, HasType, SemanticModel};
-use ruff_db::{files::File, parsed::parsed_module};
+use crate::{Db, HasType, ProgramFile, SemanticModel};
 use ruff_python_ast::{
     self as ast, visitor::source_order, visitor::source_order::SourceOrderVisitor,
 };
 
-pub fn pull_types(db: &dyn Db, file: File) {
-    let mut visitor = PullTypesVisitor::new(db, file);
+pub fn pull_types(db: &dyn Db, program_file: ProgramFile<'_>) {
+    let mut visitor = PullTypesVisitor::new(db, program_file);
 
-    let ast = parsed_module(db, file).load(db);
+    let ast = program_file.parsed(db).load(db);
 
     visitor.visit_body(ast.suite());
 }
@@ -22,7 +21,7 @@ struct PullTypesVisitor<'db> {
 }
 
 impl<'db> PullTypesVisitor<'db> {
-    fn new(db: &'db dyn Db, file: File) -> Self {
+    fn new(db: &'db dyn Db, file: ProgramFile<'db>) -> Self {
         Self {
             model: SemanticModel::new(db, file),
         }

--- a/crates/ty_python_semantic/src/reachability.rs
+++ b/crates/ty_python_semantic/src/reachability.rs
@@ -196,9 +196,12 @@
 use std::cell::RefCell;
 
 use crate::{
-    Db,
+    Db, Program,
     dunder_all::dunder_all_names,
-    place::{DefinedPlace, Definedness, Place, RequiresExplicitReExport, imported_symbol},
+    place::{
+        DefinedPlace, Definedness, ImportedSymbolContext, Place, RequiresExplicitReExport,
+        imported_symbol,
+    },
     types::{
         ActiveRecursionDetector, CallableTypes, EnumClassLiteral, KnownInstanceType,
         NarrowingConstraint, SpecialFormType, Type, TypeContext, UnionType, callable_pattern_type,
@@ -238,8 +241,14 @@ use ty_python_core::{
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, id, _, _| Type::divergent(id),
-    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
-        result.cycle_normalized(db, *previous, cycle)
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, predicate: PatternPredicate<'db>, _| {
+        let program = predicate.program_file(db).program(db);
+        result.cycle_normalized(
+            db,
+            program,
+            *previous,
+            cycle,
+        )
     },
     heap_size = ruff_memory_usage::heap_size
 )]
@@ -268,8 +277,14 @@ pub(crate) fn type_narrowed_by_previous_patterns<'db>(
 #[salsa::tracked(
     returns(copy),
     cycle_initial = |_, id, _, _| Type::divergent(id),
-    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
-        result.cycle_normalized(db, *previous, cycle)
+    cycle_fn = |db, cycle, previous: &Type<'db>, result: Type<'db>, predicate: PatternPredicate<'db>, _| {
+        let program = predicate.program_file(db).program(db);
+        result.cycle_normalized(
+            db,
+            program,
+            *previous,
+            cycle,
+        )
     },
     heap_size = ruff_memory_usage::heap_size
 )]
@@ -278,7 +293,8 @@ fn type_narrowed_by_pattern<'db>(
     predicate: PatternPredicate<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    pattern_binding_fallthrough_type(db, predicate.kind(db), subject_ty)
+    let program = predicate.program_file(db).program(db);
+    pattern_binding_fallthrough_type(db, program, predicate.kind(db), subject_ty)
 }
 
 /// Return the enum class and canonical member names represented by an enum-literal subject type.
@@ -325,7 +341,9 @@ fn enum_literal_subject_names<'db>(
                 add_enum_literal(db, &mut enum_class, &mut names, *element)?;
             }
         }
-        Type::TypeAlias(alias) => return enum_literal_subject_names(db, alias.value_type(db)),
+        Type::TypeAlias(alias) => {
+            return enum_literal_subject_names(db, alias.value_type(db));
+        }
         _ => return None,
     }
 
@@ -339,10 +357,11 @@ fn enum_literal_subject_names<'db>(
 /// canonical member names before returning.
 fn enum_member_pattern_name<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     enum_class: EnumClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
 ) -> Option<Name> {
-    let value_ty = definite_match_pattern_type(db, kind);
+    let value_ty = definite_match_pattern_type(db, program, kind);
     let enum_literal = value_ty.as_enum_literal()?;
     if enum_literal.enum_class_literal(db) != enum_class {
         return None;
@@ -368,6 +387,7 @@ struct EnumMemberPatternCoverage {
 /// produces only a lower bound: it definitely matches `Color.GREEN`, but can match other members.
 fn enum_member_pattern_coverage<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     enum_class: EnumClassLiteral<'db>,
     kind: &PatternPredicateKind<'db>,
 ) -> EnumMemberPatternCoverage {
@@ -378,7 +398,7 @@ fn enum_member_pattern_coverage<'db>(
     match kind {
         PatternPredicateKind::Or(alts) => {
             for alt in alts {
-                let alt_coverage = enum_member_pattern_coverage(db, enum_class, alt);
+                let alt_coverage = enum_member_pattern_coverage(db, program, enum_class, alt);
                 coverage
                     .definitely_matched
                     .extend(alt_coverage.definitely_matched);
@@ -386,10 +406,10 @@ fn enum_member_pattern_coverage<'db>(
             }
         }
         PatternPredicateKind::As(Some(inner), _) => {
-            return enum_member_pattern_coverage(db, enum_class, inner);
+            return enum_member_pattern_coverage(db, program, enum_class, inner);
         }
         _ => {
-            if let Some(name) = enum_member_pattern_name(db, enum_class, kind) {
+            if let Some(name) = enum_member_pattern_name(db, program, enum_class, kind) {
                 coverage.definitely_matched.insert(name);
             } else {
                 coverage.is_exact = false;
@@ -410,7 +430,9 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     subject_ty: Type<'db>,
 ) -> Option<Truthiness> {
     let (enum_class, mut remaining_names) = enum_literal_subject_names(db, subject_ty)?;
-    let current_coverage = enum_member_pattern_coverage(db, enum_class, predicate.kind(db));
+    let program = enum_class.class_literal(db).program(db);
+    let current_coverage =
+        enum_member_pattern_coverage(db, program, enum_class, predicate.kind(db));
     let current_names = &current_coverage.definitely_matched;
     if current_names.is_empty() {
         return None;
@@ -425,7 +447,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
         }
 
         let previous_coverage =
-            enum_member_pattern_coverage(db, enum_class, previous_predicate.kind(db));
+            enum_member_pattern_coverage(db, program, enum_class, previous_predicate.kind(db));
         #[expect(
             clippy::iter_over_hash_type,
             reason = "set removal is independent of iteration order"
@@ -468,6 +490,7 @@ fn analyze_enum_literal_union_pattern_predicate<'db>(
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'db>) -> Truthiness {
+    let program = predicate.subject(db).program_file(db).program(db);
     let subject_ty =
         infer_same_file_expression_type(db, predicate.subject(db), TypeContext::default());
 
@@ -477,8 +500,8 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
         return truthiness;
     }
 
-    let coverage_subject_ty = expand_type(db, subject_ty)
-        .map(|types| UnionType::from_elements(db, types))
+    let coverage_subject_ty = expand_type(db, program, subject_ty)
+        .map(|types| UnionType::from_elements(db, program, types))
         .unwrap_or(subject_ty);
     let narrowed_subject_ty =
         type_narrowed_by_previous_patterns(db, predicate, coverage_subject_ty);
@@ -497,8 +520,13 @@ fn analyze_pattern_predicate<'db>(db: &'db dyn Db, predicate: PatternPredicate<'
         return Truthiness::AlwaysTrue;
     }
 
-    let truthiness =
-        analyze_single_pattern_predicate_kind(db, predicate.kind(db), narrowed_subject_ty, None);
+    let truthiness = analyze_single_pattern_predicate_kind(
+        db,
+        program,
+        predicate.kind(db),
+        narrowed_subject_ty,
+        None,
+    );
 
     if truthiness == Truthiness::AlwaysTrue && predicate.guard(db).is_some() {
         // Fall back to ambiguous, the guard might change the result.
@@ -655,6 +683,7 @@ impl<'db> ReachabilityConstraintsExtension<'db> for ReachabilityConstraints {
 
 pub(crate) fn narrow_type_by_constraint<'db>(
     db: &'db dyn Db,
+    program: Program,
     constraints: &NarrowingConstraints,
     predicates: &IndexSlice<ScopedPredicateId, Predicate<'db>>,
     id: ScopedNarrowingConstraint,
@@ -671,6 +700,7 @@ pub(crate) fn narrow_type_by_constraint<'db>(
     let projected_root = projector.project(id);
     let mut context = ProjectedNarrowingContext {
         db,
+        program,
         base_ty,
         graph: &projector.graph,
         joins: projector.graph.joins(projected_root),
@@ -681,13 +711,14 @@ pub(crate) fn narrow_type_by_constraint<'db>(
 
 fn apply_accumulated_narrowing<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     base_ty: Type<'db>,
     accumulated: Option<NarrowingConstraint<'db>>,
 ) -> Type<'db> {
     match accumulated {
         Some(constraint) => NarrowingConstraint::intersection(base_ty)
             .merge_constraint_and(constraint)
-            .evaluate_constraint_type(db),
+            .evaluate_constraint_type(db, program),
         None => base_ty,
     }
 }
@@ -1026,6 +1057,7 @@ impl<'a, 'db> NarrowingProjector<'a, 'db> {
 /// Evaluates narrowed types over a projected narrowing graph.
 struct ProjectedNarrowingContext<'a, 'db> {
     db: &'db dyn Db,
+    program: Program,
     base_ty: Type<'db>,
     graph: &'a ProjectedNarrowingGraph<'db>,
     /// Marks join boundaries in the projected DAG.
@@ -1060,7 +1092,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
             // Preserve replacement narrowing order at a join: evaluate the shared suffix once,
             // then apply the incoming prefix constraint to its narrowed type.
             let suffix_ty = self.narrow_join(id);
-            return apply_accumulated_narrowing(self.db, suffix_ty, accumulated);
+            return apply_accumulated_narrowing(self.db, self.program, suffix_ty, accumulated);
         }
 
         self.narrow_uncached(id, accumulated)
@@ -1077,7 +1109,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
         }
 
         if id == ProjectedNarrowingNodeId::ALWAYS_TRUE {
-            apply_accumulated_narrowing(self.db, self.base_ty, accumulated)
+            apply_accumulated_narrowing(self.db, self.program, self.base_ty, accumulated)
         } else {
             let node = self.graph.node(id);
             let (pos_constraint, neg_constraint) =
@@ -1103,8 +1135,8 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
                 let false_ty = self.narrow(node.if_false, false_accumulated);
 
                 let true_or_uncertain =
-                    UnionType::from_two_elements(self.db, true_ty, uncertain_ty);
-                UnionType::from_two_elements(self.db, true_or_uncertain, false_ty)
+                    UnionType::from_two_elements(self.db, self.program, true_ty, uncertain_ty);
+                UnionType::from_two_elements(self.db, self.program, true_or_uncertain, false_ty)
             }
         }
     }
@@ -1112,6 +1144,7 @@ impl<'db> ProjectedNarrowingContext<'_, 'db> {
 
 fn analyze_single_pattern_predicate_kind<'db>(
     db: &'db dyn Db,
+    program: Program,
     predicate_kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
     precomputed_definite_match_ty: Option<Type<'db>>,
@@ -1120,18 +1153,18 @@ fn analyze_single_pattern_predicate_kind<'db>(
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
 
-            if subject_ty.is_single_valued(db) {
-                equality_truthiness(db, subject_ty, value_ty)
+            if subject_ty.is_single_valued(db, program) {
+                equality_truthiness(db, program, subject_ty, value_ty)
             } else {
                 Truthiness::Ambiguous
             }
         }
         PatternPredicateKind::Singleton(singleton) => {
-            let singleton_ty = singleton_pattern_type(db, *singleton);
+            let singleton_ty = singleton_pattern_type(db, program, *singleton);
 
-            if subject_ty.is_equivalent_to(db, singleton_ty) {
+            if subject_ty.is_equivalent_to(db, program, singleton_ty) {
                 Truthiness::AlwaysTrue
-            } else if subject_ty.is_disjoint_from(db, singleton_ty) {
+            } else if subject_ty.is_disjoint_from(db, program, singleton_ty) {
                 Truthiness::AlwaysFalse
             } else {
                 Truthiness::Ambiguous
@@ -1146,22 +1179,28 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 .map(|p| {
                     let narrowed_subject_ty = remaining_subject_ty;
 
-                    let definitely_matched =
-                        definite_match_pattern_type_for_subject(db, p, narrowed_subject_ty);
+                    let definitely_matched = definite_match_pattern_type_for_subject(
+                        db,
+                        program,
+                        p,
+                        narrowed_subject_ty,
+                    );
 
-                    let truthiness = if narrowed_subject_ty.is_subtype_of(db, definitely_matched) {
-                        Truthiness::AlwaysTrue
-                    } else {
-                        analyze_single_pattern_predicate_kind(
-                            db,
-                            p,
-                            narrowed_subject_ty,
-                            Some(definitely_matched),
-                        )
-                    };
+                    let truthiness =
+                        if narrowed_subject_ty.is_subtype_of(db, program, definitely_matched) {
+                            Truthiness::AlwaysTrue
+                        } else {
+                            analyze_single_pattern_predicate_kind(
+                                db,
+                                program,
+                                p,
+                                narrowed_subject_ty,
+                                Some(definitely_matched),
+                            )
+                        };
 
                     remaining_subject_ty =
-                        pattern_binding_fallthrough_type(db, p, narrowed_subject_ty);
+                        pattern_binding_fallthrough_type(db, program, p, narrowed_subject_ty);
                     truthiness
                 })
                 // this is just a "max", but with a slight optimization:
@@ -1184,47 +1223,47 @@ fn analyze_single_pattern_predicate_kind<'db>(
                 match infer_same_file_expression_type(db, kind.class, TypeContext::default()) {
                     Type::ClassLiteral(class) => Type::instance(db, class.top_materialization(db)),
                     Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-                        callable_pattern_type(db)
+                        callable_pattern_type(db, program)
                     }
                     _ => return Truthiness::Ambiguous,
                 };
             let definitely_matched = precomputed_definite_match_ty.unwrap_or_else(|| {
-                definite_match_pattern_type_for_subject(db, predicate_kind, subject_ty)
+                definite_match_pattern_type_for_subject(db, program, predicate_kind, subject_ty)
             });
 
-            if subject_ty.is_equivalent_to(db, definitely_matched)
-                || subject_ty.is_subtype_of(db, definitely_matched)
+            if subject_ty.is_equivalent_to(db, program, definitely_matched)
+                || subject_ty.is_subtype_of(db, program, definitely_matched)
             {
                 Truthiness::AlwaysTrue
-            } else if subject_ty.is_disjoint_from(db, class_ty) {
+            } else if subject_ty.is_disjoint_from(db, program, class_ty) {
                 Truthiness::AlwaysFalse
             } else {
                 Truthiness::Ambiguous
             }
         }
         PatternPredicateKind::Mapping(kind) => {
-            let mapping_ty = mapping_pattern_type(db);
-            if subject_ty.is_subtype_of(db, mapping_ty) {
+            let mapping_ty = mapping_pattern_type(db, program);
+            if subject_ty.is_subtype_of(db, program, mapping_ty) {
                 if kind.is_irrefutable() {
                     Truthiness::AlwaysTrue
                 } else {
                     Truthiness::Ambiguous
                 }
-            } else if subject_ty.is_disjoint_from(db, mapping_ty) {
+            } else if subject_ty.is_disjoint_from(db, program, mapping_ty) {
                 Truthiness::AlwaysFalse
             } else {
                 Truthiness::Ambiguous
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            let sequence_ty = sequence_pattern_type_builder(db).build();
-            if subject_ty.is_subtype_of(db, sequence_ty) {
+            let sequence_ty = sequence_pattern_type_builder(db, program).build();
+            if subject_ty.is_subtype_of(db, program, sequence_ty) {
                 if kind.is_irrefutable() {
                     Truthiness::AlwaysTrue
                 } else {
                     Truthiness::Ambiguous
                 }
-            } else if subject_ty.is_disjoint_from(db, sequence_ty) {
+            } else if subject_ty.is_disjoint_from(db, program, sequence_ty) {
                 Truthiness::AlwaysFalse
             } else {
                 Truthiness::Ambiguous
@@ -1235,6 +1274,7 @@ fn analyze_single_pattern_predicate_kind<'db>(
             .map(|p| {
                 analyze_single_pattern_predicate_kind(
                     db,
+                    program,
                     p,
                     subject_ty,
                     precomputed_definite_match_ty,
@@ -1263,6 +1303,7 @@ fn analyze_non_terminal_call<'db>(
     call_expr: Expression<'db>,
     is_await: bool,
 ) -> Truthiness {
+    let program = callable.program_file(db).program(db);
     // We first infer just the type of the callable. In the most likely case that the function is
     // not marked with `NoReturn`, or that it always returns `NoReturn`, doing so allows us to avoid
     // the more expensive work of inferring the entire call expression (which could involve
@@ -1281,7 +1322,7 @@ fn analyze_non_terminal_call<'db>(
     }
 
     let overloads_iterator = if let Some(callable) = ty
-        .try_upcast_to_callable(db)
+        .try_upcast_to_callable(db, program)
         .and_then(CallableTypes::exactly_one)
     {
         callable.signatures(db).overloads.iter()
@@ -1294,10 +1335,12 @@ fn analyze_non_terminal_call<'db>(
     let mut any_overload_is_generic = false;
 
     for overload in overloads_iterator {
-        let returns_never = overload.return_ty.is_equivalent_to(db, Type::Never);
+        let returns_never = overload
+            .return_ty
+            .is_equivalent_to(db, program, Type::Never);
         no_overloads_return_never &= !returns_never;
         all_overloads_return_never &= returns_never;
-        any_overload_is_generic |= overload.return_ty.has_typevar(db);
+        any_overload_is_generic |= overload.return_ty.has_typevar(db, program);
     }
 
     if no_overloads_return_never && !any_overload_is_generic && !is_await {
@@ -1306,7 +1349,7 @@ fn analyze_non_terminal_call<'db>(
         Truthiness::AlwaysFalse
     } else {
         let call_expr_ty = infer_same_file_expression_type(db, call_expr, TypeContext::default());
-        if call_expr_ty.is_equivalent_to(db, Type::Never) {
+        if call_expr_ty.is_equivalent_to(db, program, Type::Never) {
             Truthiness::AlwaysFalse
         } else {
             Truthiness::AlwaysTrue
@@ -1329,7 +1372,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
     match predicate.node {
         PredicateNode::Expression(test_expr) => {
             infer_same_file_expression_type(db, test_expr, TypeContext::default())
-                .bool(db)
+                .bool(db, test_expr.program_file(db).program(db))
                 .negate_if(!predicate.is_positive)
         }
         PredicateNode::IsNonTerminalCall(CallableAndCallExpr {
@@ -1358,7 +1401,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
                         tracing::trace!(
                             "Symbol `{}` (via star import) not found in `__all__` of `{}`",
                             symbol.name(),
-                            referenced_file.path(db)
+                            referenced_file.file(db).path(db)
                         );
                         return Truthiness::AlwaysFalse;
                     }
@@ -1368,7 +1411,7 @@ fn analyze_single(db: &dyn Db, predicate: &Predicate) -> Truthiness {
 
             match imported_symbol(
                 db,
-                Some(referenced_file),
+                ImportedSymbolContext::File(referenced_file),
                 symbol.name(),
                 requires_explicit_reexport,
             )
@@ -1623,9 +1666,10 @@ mod tests {
                             y = x
                     "#,
                 )?;
+                let program = db.program();
 
                 let file = system_path_to_file(&db, "/src/test.py").unwrap();
-                let index = semantic_index(&db, file);
+                let index = semantic_index(&db, crate::ProgramFile::new(&db, program, file));
                 let function_scope = index.child_scopes(FileScopeId::global()).next().unwrap().0;
                 let use_def = index.use_def_map(function_scope);
                 let predicate = use_def

--- a/crates/ty_python_semantic/src/semantic_model.rs
+++ b/crates/ty_python_semantic/src/semantic_model.rs
@@ -1,4 +1,3 @@
-use compact_str::CompactString;
 use ruff_db::files::{File, FilePath};
 use ruff_db::parsed::{parsed_module, parsed_string_annotation};
 use ruff_db::source::{line_index, source_text};
@@ -10,7 +9,7 @@ use ruff_source_file::LineIndex;
 use ruff_text_size::Ranged;
 use rustc_hash::FxHashMap;
 use ty_module_resolver::{
-    KnownModule, Module, ModuleName, list_modules, resolve_module, resolve_real_shadowable_module,
+    KnownModule, Module, ModuleName, list_modules, resolve_real_shadowable_module,
 };
 
 use crate::Db;
@@ -22,6 +21,7 @@ use crate::types::{
     inferred_declaration,
 };
 use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::place_table;
 use ty_python_core::scope::{FileScopeId, Scope};
 use ty_python_core::semantic_index;
@@ -40,6 +40,7 @@ use ty_python_core::symbol::Symbol;
 /// methods will automatically handle using the string literal's AST node when necessary.
 pub struct SemanticModel<'db> {
     db: &'db dyn Db,
+    program_file: ProgramFile<'db>,
     file: File,
     /// If `Some` then this `SemanticModel` is for analyzing the sub-AST of a string annotation.
     /// This expression will be used as a witness to the scope/location we're analyzing.
@@ -47,10 +48,11 @@ pub struct SemanticModel<'db> {
 }
 
 impl<'db> SemanticModel<'db> {
-    pub fn new(db: &'db dyn Db, file: File) -> Self {
+    pub fn new(db: &'db dyn Db, program_file: ProgramFile<'db>) -> Self {
         Self {
             db,
-            file,
+            program_file,
+            file: program_file.file(db),
             in_string_annotation_expr: None,
         }
     }
@@ -61,6 +63,14 @@ impl<'db> SemanticModel<'db> {
 
     pub fn file(&self) -> File {
         self.file
+    }
+
+    pub fn program_file(&self) -> ProgramFile<'db> {
+        self.program_file
+    }
+
+    pub(crate) fn program(&self) -> crate::Program {
+        self.program_file.program(self.db)
     }
 
     pub fn file_path(&self) -> &FilePath {
@@ -81,7 +91,7 @@ impl<'db> SemanticModel<'db> {
         node: ast::AnyNodeRef<'_>,
     ) -> FxHashMap<Name, MemberDefinition<'db>> {
         let mut members = FxHashMap::default();
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         let Some(file_scope) = self.scope(node) else {
             return members;
         };
@@ -93,7 +103,7 @@ impl<'db> SemanticModel<'db> {
             .rev()
         {
             for memberdef in
-                all_reachable_members(self.db, file_scope.to_scope_id(self.db, self.file))
+                all_reachable_members(self.db, file_scope.to_scope_id(self.db, self.program_file))
             {
                 members.insert(
                     memberdef.member.name,
@@ -110,42 +120,55 @@ impl<'db> SemanticModel<'db> {
     /// Resolve the given import made in this file to a Type
     pub fn resolve_module_type(&self, module: Option<&str>, level: u32) -> Option<Type<'db>> {
         let module = self.resolve_module(module, level)?;
-        Some(Type::module_literal(self.db, self.file, module))
+        Some(Type::module_literal(self.db, self.program_file, module))
     }
 
     /// Resolve the given import made in this file to a Module
     pub fn resolve_module(&self, module: Option<&str>, level: u32) -> Option<Module<'db>> {
+        let resolver_file = self.program_file.resolver_file(self.db);
         let module_name =
-            ModuleName::from_identifier_parts(self.db, self.file, module, level).ok()?;
-        resolve_module(self.db, self.file, &module_name)
+            ModuleName::from_identifier_parts(self.db, resolver_file, module, level).ok()?;
+        ty_module_resolver::resolve_module(self.db, resolver_file, &module_name)
     }
 
     /// Returns completions for symbols available in a `import <CURSOR>` context.
     pub fn import_completions(&self) -> Vec<Completion<'db>> {
         let typing_extensions = ModuleName::new_static("typing_extensions").unwrap();
         let is_typing_extensions_available = self.file.is_stub(self.db)
-            || resolve_real_shadowable_module(self.db, self.file, &typing_extensions).is_some();
-        list_modules(self.db)
-            .iter()
-            .copied()
-            .filter(|module| {
-                is_typing_extensions_available || module.name(self.db) != &typing_extensions
-            })
-            .map(|module| {
-                let builtin = module.is_known(self.db, KnownModule::Builtins);
-                let ty = Type::module_literal(self.db, self.file, module);
-                Completion {
-                    name: CompactString::new(module.name(self.db).as_str()),
-                    ty: Some(ty),
-                    builtin,
-                }
-            })
-            .collect()
+            || resolve_real_shadowable_module(
+                self.db,
+                self.program_file.resolver_file(self.db),
+                &typing_extensions,
+            )
+            .is_some();
+        list_modules(
+            self.db,
+            self.program_file.program(self.db).resolver(self.db),
+        )
+        .iter()
+        .copied()
+        .filter(|module| {
+            is_typing_extensions_available || module.name(self.db) != &typing_extensions
+        })
+        .map(|module| {
+            let builtin = module.is_known(self.db, KnownModule::Builtins);
+            let ty = Type::module_literal(self.db, self.program_file, module);
+            Completion {
+                name: Name::new(module.name(self.db).as_str()),
+                ty: Some(ty),
+                builtin,
+            }
+        })
+        .collect()
     }
 
     /// Returns completions for symbols available in a `from module import <CURSOR>` context.
     pub fn from_import_completions(&self, import: &ast::StmtImportFrom) -> Vec<Completion<'db>> {
-        let module_name = match ModuleName::from_import_statement(self.db, self.file, import) {
+        let module_name = match ModuleName::from_import_statement(
+            self.db,
+            self.program_file.resolver_file(self.db),
+            import,
+        ) {
             Ok(module_name) => module_name,
             Err(err) => {
                 tracing::debug!(
@@ -164,7 +187,11 @@ impl<'db> SemanticModel<'db> {
         &self,
         module_name: &ModuleName,
     ) -> Vec<Completion<'db>> {
-        let Some(module) = resolve_module(self.db, self.file, module_name) else {
+        let Some(module) = ty_module_resolver::resolve_module(
+            self.db,
+            self.program_file.resolver_file(self.db),
+            module_name,
+        ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
@@ -174,11 +201,15 @@ impl<'db> SemanticModel<'db> {
     /// Returns completions for symbols available in the given module as if
     /// it were imported by this model's `File`.
     fn module_completions(&self, module_name: &ModuleName) -> Vec<Completion<'db>> {
-        let Some(module) = resolve_module(self.db, self.file, module_name) else {
+        let Some(module) = ty_module_resolver::resolve_module(
+            self.db,
+            self.program_file.resolver_file(self.db),
+            module_name,
+        ) else {
             tracing::debug!("Could not resolve module from `{module_name:?}`");
             return vec![];
         };
-        let ty = Type::module_literal(self.db, self.file, module);
+        let ty = Type::module_literal(self.db, self.program_file, module);
         let builtin = module.is_known(self.db, KnownModule::Builtins);
 
         let mut completions = vec![];
@@ -186,9 +217,9 @@ impl<'db> SemanticModel<'db> {
             clippy::iter_over_hash_type,
             reason = "completion order is determined later by relevance ranking"
         )]
-        for Member { name, ty } in all_members(self.db, ty) {
+        for Member { name, ty } in all_members(self.db, self.program(), ty) {
             completions.push(Completion {
-                name: name.into(),
+                name,
                 ty: Some(ty),
                 builtin,
             });
@@ -203,10 +234,10 @@ impl<'db> SemanticModel<'db> {
 
         let mut completions = vec![];
         for submodule in module.all_submodules(self.db) {
-            let ty = Type::module_literal(self.db, self.file, *submodule);
+            let ty = Type::module_literal(self.db, self.program_file, *submodule);
             let base = submodule.name(self.db).last_component();
             completions.push(Completion {
-                name: CompactString::new(base),
+                name: Name::new(base),
                 ty: Some(ty),
                 builtin,
             });
@@ -220,10 +251,10 @@ impl<'db> SemanticModel<'db> {
             return Vec::new();
         };
 
-        all_members(self.db, ty)
+        all_members(self.db, self.program(), ty)
             .into_iter()
             .map(|member| Completion {
-                name: member.name.into(),
+                name: member.name,
                 ty: Some(member.ty),
                 builtin: false,
             })
@@ -236,20 +267,19 @@ impl<'db> SemanticModel<'db> {
     /// If a scope could not be determined, then completions for the global
     /// scope of this model's `File` are returned.
     pub fn scoped_completions(&self, node: ast::AnyNodeRef<'_>) -> Vec<Completion<'db>> {
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         let Some(file_scope) = self.scope(node) else {
             return vec![];
         };
         let mut completions = vec![];
         for (file_scope, _) in index.ancestor_scopes(file_scope) {
             completions.extend(
-                all_reachable_members(self.db, file_scope.to_scope_id(self.db, self.file)).map(
-                    |memberdef| Completion {
-                        name: memberdef.member.name.into(),
+                all_reachable_members(self.db, file_scope.to_scope_id(self.db, self.program_file))
+                    .map(|memberdef| Completion {
+                        name: memberdef.member.name,
                         ty: Some(memberdef.member.ty),
                         builtin: false,
-                    },
-                ),
+                    }),
             );
         }
 
@@ -257,13 +287,13 @@ impl<'db> SemanticModel<'db> {
         // correct types. These are added before builtins so that the deduplication
         // keeps the correct types (e.g., `__file__` is `str` for the current module,
         // not `str | None`).
-        completions.extend(
-            all_implicit_module_globals(self.db, self.file).map(|(name, ty)| Completion {
-                name: name.into(),
+        completions.extend(all_implicit_module_globals(self.db, self.program_file).map(
+            |(name, ty)| Completion {
+                name,
                 ty: Some(ty),
                 builtin: true,
-            }),
-        );
+            },
+        ));
 
         // Builtins are available in all scopes.
         let builtins = ModuleName::new_static("builtins").expect("valid module name");
@@ -279,7 +309,7 @@ impl<'db> SemanticModel<'db> {
     /// Returns `true` if the given class definition's name was previously
     /// bound in the same scope (i.e., the class definition is a re-assignment).
     pub fn is_class_name_reassigned(&self, class_def: &ast::StmtClassDef) -> bool {
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         let definition = index.expect_single_definition(class_def);
         let scope = definition.scope(self.db);
         let table = place_table(self.db, scope);
@@ -289,7 +319,7 @@ impl<'db> SemanticModel<'db> {
 
     /// Returns the scope in which `node` is defined (handles string annotations).
     pub fn scope(&self, node: ast::AnyNodeRef<'_>) -> Option<FileScopeId> {
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         match self.node_in_ast(node) {
             ast::AnyNodeRef::Identifier(identifier) => index.try_expression_scope_id(identifier),
 
@@ -343,7 +373,7 @@ impl<'db> SemanticModel<'db> {
         &self,
         node: ast::AnyNodeRef<'_>,
     ) -> impl Iterator<Item = (FileScopeId, &Scope)> + '_ {
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         self.scope(node)
             .into_iter()
             .flat_map(move |scope| index.ancestor_scopes(scope))
@@ -361,8 +391,9 @@ impl<'db> SemanticModel<'db> {
         &self,
         covering_node: &CoveringNode<'_>,
     ) -> Option<Definition<'db>> {
-        let index = semantic_index(self.db, self.file);
-        let parsed = parsed_module(self.db, self.file).load(self.db);
+        let index = semantic_index(self.db, self.program_file);
+        let parsed =
+            parsed_module(self.db, self.program_file.versioned_file(self.db)).load(self.db);
         let target_range = covering_node.node().range();
 
         for node in covering_node.ancestors() {
@@ -432,11 +463,11 @@ impl<'db> SemanticModel<'db> {
     ) -> Option<(Parsed<ModExpression>, Self)> {
         // Ask the inference engine whether this is actually a string annotation
         let expr = ExprRef::StringLiteral(string_expr);
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         // When looking up scopes, use the expr in the top-level AST
         // (we might be trying to enter a sub-sub-AST, so this isn't silly)
         let file_scope = index.expression_scope_id(&self.expr_ref_in_ast(expr));
-        let scope = file_scope.to_scope_id(self.db, self.file);
+        let scope = file_scope.to_scope_id(self.db, self.program_file);
         // When querying whether the expr is a string annotation, we do however use the actual expr
         // (the inference engine should record this information even for sub-nodes)
         if !infer_complete_scope_types(self.db, scope).is_string_annotation(expr) {
@@ -453,6 +484,7 @@ impl<'db> SemanticModel<'db> {
         let ast = parsed_string_annotation(source.as_str(), string_literal).ok()?;
         let model = Self {
             db: self.db,
+            program_file: self.program_file,
             file: self.file,
             // Use expr_in_ast here because we might be entering a sub-sub-AST
             in_string_annotation_expr: Some(Box::new(
@@ -476,8 +508,9 @@ impl<'db> SemanticModel<'db> {
         match definition.kind(self.db) {
             DefinitionKind::TypeAlias(_) => true,
             DefinitionKind::AnnotatedAssignment(assignment) => {
-                let parsed = parsed_module(self.db, definition.file(self.db));
-                let model = Self::new(self.db, definition.file(self.db));
+                let program_file = definition.program_file(self.db);
+                let parsed = program_file.parsed(self.db);
+                let model = Self::new(self.db, program_file);
                 model.is_type_alias_annotation(assignment.annotation(&parsed.load(self.db)))
             }
             _ => false,
@@ -494,8 +527,9 @@ impl<'db> SemanticModel<'db> {
                 else {
                     return TypeQualifiers::empty();
                 };
-                let definition_file = definition.file(self.db);
-                let module = parsed_module(self.db, definition_file).load(self.db);
+                let program_file = definition.program_file(self.db);
+                let definition_file = program_file.file(self.db);
+                let module = program_file.parsed(self.db).load(self.db);
                 if !definition
                     .kind(self.db)
                     .category(definition_file.is_stub(self.db), &module)
@@ -515,6 +549,7 @@ impl<'db> SemanticModel<'db> {
                 value_ty
                     .member_lookup_with_policy(
                         self.db,
+                        self.program_file.program(self.db),
                         attr.attr.id.clone(),
                         crate::types::MemberLookupPolicy::default(),
                     )
@@ -589,9 +624,9 @@ impl<'db> SemanticModel<'db> {
         string_expr: &ast::ExprStringLiteral,
     ) -> Option<Type<'db>> {
         let expr = ast::ExprRef::from(string_expr);
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         let file_scope = index.try_expression_scope_id(&self.expr_ref_in_ast(expr))?;
-        let scope = file_scope.to_scope_id(self.db, self.file);
+        let scope = file_scope.to_scope_id(self.db, self.program_file);
 
         infer_complete_scope_types(self.db, scope).try_expected_type(expr)
     }
@@ -641,7 +676,7 @@ impl NameKind {
 #[derive(Clone, Debug)]
 pub struct Completion<'db> {
     /// The label shown to the user for this suggestion.
-    pub name: CompactString,
+    pub name: Name,
     /// The type of this completion, if available.
     ///
     /// Generally speaking, this is always available
@@ -690,13 +725,13 @@ pub trait HasOptionalDefinition {
 
 impl HasType for ast::ExprRef<'_> {
     fn inferred_type<'db>(&self, model: &SemanticModel<'db>) -> Option<Type<'db>> {
-        let index = semantic_index(model.db, model.file);
+        let index = semantic_index(model.db, model.program_file);
         // TODO(#1637): semantic tokens is making this crash even with
         // `try_expr_ref_in_ast` guarding this, for now just use `try_expression_scope_id`.
         // The problematic input is `x: "float` (with a dangling quote). I imagine the issue
         // is we're too eagerly setting `is_string_annotation` in inference.
         let file_scope = index.try_expression_scope_id(&model.expr_ref_in_ast(*self))?;
-        let scope = file_scope.to_scope_id(model.db, model.file);
+        let scope = file_scope.to_scope_id(model.db, model.program_file);
 
         infer_complete_scope_types(model.db, scope).try_expression_type(*self)
     }
@@ -793,7 +828,7 @@ macro_rules! impl_binding_has_ty_def {
         impl HasDefinition for $ty {
             #[inline]
             fn definition<'db>(&self, model: &SemanticModel<'db>) -> Definition<'db> {
-                let index = semantic_index(model.db, model.file);
+                let index = semantic_index(model.db, model.program_file);
                 index.expect_single_definition(self)
             }
         }
@@ -822,7 +857,7 @@ impl HasType for ast::Alias {
         if &self.name == "*" {
             return Some(Type::Never);
         }
-        let index = semantic_index(model.db, model.file);
+        let index = semantic_index(model.db, model.program_file);
         Some(binding_type(model.db, index.expect_single_definition(self)))
     }
 }
@@ -831,7 +866,7 @@ impl HasOptionalDefinition for ast::ExceptHandlerExceptHandler {
     fn optional_definition<'db>(&self, model: &SemanticModel<'db>) -> Option<Definition<'db>> {
         self.name.as_ref()?;
 
-        let index = semantic_index(model.db, model.file);
+        let index = semantic_index(model.db, model.program_file);
         Some(index.expect_single_definition(self))
     }
 }
@@ -846,9 +881,8 @@ impl HasType for ast::ExceptHandlerExceptHandler {
 #[cfg(test)]
 mod tests {
     use crate::db::tests::TestDbBuilder;
-    use crate::{HasType, SemanticModel};
+    use crate::{HasType, ProgramFile, SemanticModel};
     use ruff_db::files::system_path_to_file;
-    use ruff_db::parsed::parsed_module;
 
     #[test]
     fn function_type() -> anyhow::Result<()> {
@@ -858,10 +892,11 @@ mod tests {
 
         let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
 
-        let ast = parsed_module(&db, foo).load(&db);
+        let program_file = ProgramFile::new(&db, db.program(), foo);
+        let ast = program_file.parsed(&db).load(&db);
 
         let function = ast.suite()[0].as_function_def_stmt().unwrap();
-        let model = SemanticModel::new(&db, foo);
+        let model = SemanticModel::new(&db, program_file);
         let ty = function.inferred_type(&model).unwrap();
 
         assert!(ty.is_function_literal());
@@ -877,10 +912,11 @@ mod tests {
 
         let foo = system_path_to_file(&db, "/src/foo.py").unwrap();
 
-        let ast = parsed_module(&db, foo).load(&db);
+        let program_file = ProgramFile::new(&db, db.program(), foo);
+        let ast = program_file.parsed(&db).load(&db);
 
         let class = ast.suite()[0].as_class_def_stmt().unwrap();
-        let model = SemanticModel::new(&db, foo);
+        let model = SemanticModel::new(&db, program_file);
         let ty = class.inferred_type(&model).unwrap();
 
         assert!(ty.is_class_literal());
@@ -897,11 +933,12 @@ mod tests {
 
         let bar = system_path_to_file(&db, "/src/bar.py").unwrap();
 
-        let ast = parsed_module(&db, bar).load(&db);
+        let program_file = ProgramFile::new(&db, db.program(), bar);
+        let ast = program_file.parsed(&db).load(&db);
 
         let import = ast.suite()[0].as_import_from_stmt().unwrap();
         let alias = &import.names[0];
-        let model = SemanticModel::new(&db, bar);
+        let model = SemanticModel::new(&db, program_file);
         let ty = alias.inferred_type(&model).unwrap();
 
         assert!(ty.is_class_literal());

--- a/crates/ty_python_semantic/src/suppression.rs
+++ b/crates/ty_python_semantic/src/suppression.rs
@@ -8,7 +8,7 @@ use std::fmt;
 use ruff_db::diagnostic::{
     Annotation, Diagnostic, DiagnosticId, IntoDiagnosticMessage, LintName, Severity, Span,
 };
-use ruff_db::{files::File, parsed::parsed_module, source::source_text};
+use ruff_db::{files::File, parsed::VersionedFile, parsed::parsed_module, source::source_text};
 use ruff_python_ast::token::TokenKind;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 
@@ -72,8 +72,12 @@ pub fn is_unused_ignore_comment_lint(name: LintName) -> bool {
 }
 
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
-pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
-    let parsed = parsed_module(db, file).load(db);
+pub(crate) fn suppressions<'db>(
+    db: &'db dyn Db,
+    versioned_file: VersionedFile<'db>,
+) -> Suppressions {
+    let file = versioned_file.file(db);
+    let parsed = parsed_module(db, versioned_file).load(db);
     let source = source_text(db, file);
 
     let respect_type_ignore = db.analysis_settings(file).respect_type_ignore_comments;
@@ -129,10 +133,10 @@ pub(crate) fn suppressions(db: &dyn Db, file: File) -> Suppressions {
 
 pub(crate) fn check_suppressions(
     db: &dyn Db,
-    file: File,
+    versioned_file: VersionedFile<'_>,
     diagnostics: TypeCheckDiagnostics,
 ) -> Vec<Diagnostic> {
-    let mut context = CheckSuppressionsContext::new(db, file, diagnostics);
+    let mut context = CheckSuppressionsContext::new(db, versioned_file, diagnostics);
 
     check_unknown_rule(&mut context);
     check_invalid_suppression(&mut context);
@@ -206,8 +210,13 @@ struct CheckSuppressionsContext<'a> {
 }
 
 impl<'a> CheckSuppressionsContext<'a> {
-    fn new(db: &'a dyn Db, file: File, diagnostics: TypeCheckDiagnostics) -> Self {
-        let suppressions = suppressions(db, file);
+    fn new(
+        db: &'a dyn Db,
+        versioned_file: VersionedFile<'a>,
+        diagnostics: TypeCheckDiagnostics,
+    ) -> Self {
+        let file = versioned_file.file(db);
+        let suppressions = suppressions(db, versioned_file);
         Self {
             db,
             file,

--- a/crates/ty_python_semantic/src/suppression/add_ignore.rs
+++ b/crates/ty_python_semantic/src/suppression/add_ignore.rs
@@ -3,8 +3,7 @@ use std::fmt::Formatter;
 
 use ruff_db::diagnostic::LintName;
 use ruff_db::display::FormatterJoinExtension;
-use ruff_db::files::File;
-use ruff_db::parsed::parsed_module;
+use ruff_db::parsed::{VersionedFile, parsed_module};
 use ruff_db::source::source_text;
 use ruff_diagnostics::{Edit, Fix};
 use ruff_python_ast::token::TokenKind;
@@ -22,18 +21,19 @@ use crate::suppression::{SuppressionKind, SuppressionTarget, Suppressions, suppr
 /// suppression with possibly multiple codes instead of adding multiple suppression comments.
 pub fn suppress_all(
     db: &dyn Db,
-    file: File,
+    versioned_file: VersionedFile<'_>,
     ids_with_range: &[(LintName, TextRange)],
 ) -> Vec<SuppressFix> {
-    let suppressions = suppressions(db, file);
+    let file = versioned_file.file(db);
+    let suppressions = suppressions(db, versioned_file);
     let source = source_text(db, file);
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, versioned_file).load(db);
     let tokens = parsed.tokens();
 
     // Compute the full suppression ranges for each diagnostic.
     let mut ids_full_range: Vec<_> = ids_with_range
         .iter()
-        .map(|&(id, range)| (id, suppression_range(db, file, range)))
+        .map(|&(id, range)| (id, suppression_range(db, versioned_file, range)))
         .collect();
 
     // Sort the suppression ranges by their start position and length (end position).
@@ -160,10 +160,16 @@ pub struct SuppressFix {
 }
 
 /// Creates a fix to suppress a single lint.
-pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) -> Fix {
-    let suppression_range = suppression_range(db, file, range);
+pub fn suppress_single(
+    db: &dyn Db,
+    versioned_file: VersionedFile<'_>,
+    id: LintId,
+    range: TextRange,
+) -> Fix {
+    let suppression_range = suppression_range(db, versioned_file, range);
 
-    let suppressions = suppressions(db, file);
+    let file = versioned_file.file(db);
+    let suppressions = suppressions(db, versioned_file);
     let source = source_text(db, file);
     let codes = &[id.name()];
 
@@ -194,10 +200,14 @@ pub fn suppress_single(db: &dyn Db, file: File, id: LintId, range: TextRange) ->
 /// * If `range` is within a single-line interpolated expression, then the start and end are extended to the start and end of the enclosing interpolated string.
 /// * If there's a line continuation, then the suppression range is extended to include the following line too.
 /// * If there's a multiline string, then the suppression range is extended to cover the starting and ending line of the multiline string.
-fn suppression_range(db: &dyn Db, file: File, range: TextRange) -> TextRange {
+fn suppression_range(
+    db: &dyn Db,
+    versioned_file: VersionedFile<'_>,
+    range: TextRange,
+) -> TextRange {
     // Always insert a new suppression at the end of the range to avoid having to deal with multiline strings
     // etc. Also make sure to not pass a sub-token range to `Tokens::after`.
-    let parsed = parsed_module(db, file).load(db);
+    let parsed = parsed_module(db, versioned_file).load(db);
     let line_start = line_start(parsed.tokens(), range.start());
 
     let after_token_range = match parsed.tokens().at_offset(range.end()) {

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -20,7 +20,7 @@ use ruff_python_ast as ast;
 use ruff_python_ast::name::Name;
 use ruff_text_size::Ranged;
 use smallvec::smallvec_inline;
-use ty_module_resolver::{KnownModule, Module, ModuleName, resolve_module};
+use ty_module_resolver::{KnownModule, Module, ModuleName};
 
 pub(crate) use self::callable::UpcastPolicy;
 pub use self::cyclic::CycleDetector;
@@ -55,8 +55,8 @@ pub(crate) use self::subclass_of::{SubclassOfInner, SubclassOfType};
 pub(crate) use self::type_expansion::expand_type;
 pub use crate::diagnostic::add_inferred_python_version_hint_to_diagnostic;
 use crate::place::{
-    DefinedPlace, Definedness, Place, PlaceAndQualifiers, Provenance, TypeOrigin,
-    builtins_module_scope, imported_symbol, known_module_symbol, place_from_bindings,
+    DefinedPlace, Definedness, ImportedSymbolContext, Place, PlaceAndQualifiers, Provenance,
+    TypeOrigin, builtins_module_scope, imported_symbol, known_module_symbol, place_from_bindings,
 };
 use crate::suppression::check_suppressions;
 use crate::types::bound_super::BoundSuperType;
@@ -173,13 +173,17 @@ mod definition;
 mod property_tests;
 mod subscript;
 
-pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
+pub fn check_types(
+    db: &dyn Db,
+    program_file: ty_python_core::environment::ProgramFile<'_>,
+) -> Vec<Diagnostic> {
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("check_types", ?file).entered();
     tracing::debug!("Checking file '{path}'", path = file.path(db));
 
     let start = Instant::now();
 
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
     let mut diagnostics = TypeCheckDiagnostics::default();
 
     for scope_id in index.scope_ids() {
@@ -203,7 +207,7 @@ pub fn check_types(db: &dyn Db, file: File) -> Vec<Diagnostic> {
             .map(|error| Diagnostic::invalid_syntax(file, error, error)),
     );
 
-    let diagnostics = check_suppressions(db, file, diagnostics);
+    let diagnostics = check_suppressions(db, program_file.versioned_file(db), diagnostics);
 
     let elapsed = start.elapsed();
     if elapsed >= Duration::from_millis(100) {
@@ -242,10 +246,10 @@ fn definition_expression_type<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> Type<'db> {
-    let file = definition.file(db);
-    let index = semantic_index(db, file);
+    let program_file = definition.program_file(db);
+    let index = ty_python_core::semantic_index(db, program_file);
     let file_scope = index.expression_scope_id(expression);
-    let scope = file_scope.to_scope_id(db, file);
+    let scope = file_scope.to_scope_id(db, program_file);
     if scope == definition.scope(db) {
         // expression is in the definition scope
         let inference = infer_definition_types(db, definition);
@@ -269,10 +273,10 @@ fn definition_expression_annotation<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> TypeAndQualifiers<'db> {
-    let file = definition.file(db);
-    let index = semantic_index(db, file);
+    let program_file = definition.program_file(db);
+    let index = ty_python_core::semantic_index(db, program_file);
     let file_scope = index.expression_scope_id(expression);
-    let scope = file_scope.to_scope_id(db, file);
+    let scope = file_scope.to_scope_id(db, program_file);
     if scope == definition.scope(db) {
         let inference = infer_deferred_types(db, definition);
         TypeAndQualifiers::new(
@@ -342,11 +346,12 @@ impl<'db> ApplyTypeMappingVisitor<'db> {
     pub(crate) fn is_equivalent_to_materialization(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         left: Type<'db>,
         right: Type<'db>,
     ) -> bool {
         self.materialization_equivalence().visit((left, right), || {
-            left.is_equivalent_to_with_materialization_visitor(db, right, self)
+            left.is_equivalent_to_with_materialization_visitor(db, program, right, self)
         })
     }
 
@@ -398,7 +403,7 @@ pub(crate) struct VisitSpecialization;
 /// Similarly, there is `Bottom[list[Any]]`.
 /// This type is harder to make sense of in a set-theoretic framework, but
 /// it is a subtype of all materializations of `list[Any]`.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub enum MaterializationKind {
     Top,
     Bottom,
@@ -419,7 +424,7 @@ impl MaterializationKind {
 /// define a `__get__` method, while data descriptors additionally define a `__set__`
 /// method or a `__delete__` method. This enum is used to categorize attributes into two
 /// groups: (1) data descriptors and (2) normal attributes or non-data descriptors.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) enum AttributeKind {
     DataDescriptor,
     NormalOrNonDataDescriptor,
@@ -630,17 +635,18 @@ pub struct PropertyInstanceType<'db> {
 
 fn walk_property_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: Program,
     property: PropertyInstanceType<'db>,
     visitor: &V,
 ) {
     if let Some(getter) = property.getter(db) {
-        visitor.visit_type(db, getter);
+        visitor.visit_type(db, program, getter);
     }
     if let Some(setter) = property.setter(db) {
-        visitor.visit_type(db, setter);
+        visitor.visit_type(db, program, setter);
     }
     if let Some(deleter) = property.deleter(db) {
-        visitor.visit_type(db, deleter);
+        visitor.visit_type(db, program, deleter);
     }
 }
 
@@ -676,8 +682,8 @@ impl<'db> PropertyInstanceType<'db> {
         Self::new_internal(db, getter, setter, deleter, self.instance_class(db))
     }
 
-    fn instance_fallback(self, db: &'db dyn Db) -> Type<'db> {
-        self.instance_class(db).to_instance(db)
+    fn instance_fallback(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        self.instance_class(db).to_instance(db, program)
     }
 
     /// Returns the [`PropertyAccessorRole`] that `def` plays in this property, or `None` when
@@ -714,48 +720,50 @@ impl<'db> PropertyInstanceType<'db> {
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         let getter = self
             .getter(db)
-            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor));
         let setter = self
             .setter(db)
-            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor));
         let deleter = self
             .deleter(db)
-            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+            .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor));
         self.with_accessors(db, getter, setter, deleter)
     }
 
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let getter = match self.getter(db) {
-            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, program, div, true)?),
             Some(ty) => Some(
-                ty.recursive_type_normalized_impl(db, div, true)
+                ty.recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
             ),
             None => None,
         };
         let setter = match self.setter(db) {
-            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, program, div, true)?),
             Some(ty) => Some(
-                ty.recursive_type_normalized_impl(db, div, true)
+                ty.recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
             ),
             None => None,
         };
         let deleter = match self.deleter(db) {
-            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+            Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, program, div, true)?),
             Some(ty) => Some(
-                ty.recursive_type_normalized_impl(db, div, true)
+                ty.recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
             ),
             None => None,
@@ -766,18 +774,19 @@ impl<'db> PropertyInstanceType<'db> {
     fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         if let Some(ty) = self.getter(db) {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
         if let Some(ty) = self.setter(db) {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
         if let Some(ty) = self.deleter(db) {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 }
@@ -863,12 +872,12 @@ pub struct DataclassParams<'db> {
 impl get_size2::GetSize for DataclassParams<'_> {}
 
 impl<'db> DataclassParams<'db> {
-    fn default_params(db: &'db dyn Db) -> Self {
-        Self::from_flags(db, DataclassFlags::default())
+    fn default_params(db: &'db dyn Db, program: Program) -> Self {
+        Self::from_flags(db, program, DataclassFlags::default())
     }
 
-    fn from_flags(db: &'db dyn Db, flags: DataclassFlags) -> Self {
-        let dataclasses_field = known_module_symbol(db, KnownModule::Dataclasses, "field")
+    fn from_flags(db: &'db dyn Db, program: Program, flags: DataclassFlags) -> Self {
+        let dataclasses_field = known_module_symbol(db, program, KnownModule::Dataclasses, "field")
             .place
             .ignore_possibly_undefined()
             .unwrap_or_else(Type::unknown);
@@ -887,6 +896,7 @@ impl<'db> DataclassParams<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -894,7 +904,7 @@ impl<'db> DataclassParams<'db> {
             .field_specifiers(db)
             .iter()
             .map(|ty| {
-                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                let ty = ty.recursive_type_normalized_impl(db, program, div, true);
                 if nested { ty } else { Some(ty.unwrap_or(div)) }
             })
             .collect::<Option<Box<_>>>()?;
@@ -905,7 +915,7 @@ impl<'db> DataclassParams<'db> {
 
 /// Representation of a type: a set of possible values at runtime.
 ///
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub enum Type<'db> {
     /// The dynamic type: a statically unknown set of values
     Dynamic(DynamicType<'db>),
@@ -1015,6 +1025,7 @@ pub enum Type<'db> {
 /// Helper for `recursive_type_normalized_impl` for `TypeGuardLike` types.
 fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
     db: &'db dyn Db,
+    program: Program,
     guard: T,
     div: Type<'db>,
     nested: bool,
@@ -1022,11 +1033,11 @@ fn recursive_type_normalize_type_guard_like<'db, T: TypeGuardLike<'db>>(
     let ty = if nested {
         guard
             .type_argument(db)
-            .recursive_type_normalized_impl(db, div, true)?
+            .recursive_type_normalized_impl(db, program, div, true)?
     } else {
         guard
             .type_argument(db)
-            .recursive_type_normalized_impl(db, div, true)
+            .recursive_type_normalized_impl(db, program, div, true)
             .unwrap_or(div)
     };
     Some(guard.with_type(db, ty))
@@ -1130,14 +1141,14 @@ impl<'db> Type<'db> {
     }
 
     /// Returns `true` if this type contains a `Self` type variable.
-    pub(crate) fn contains_self(self, db: &'db dyn Db) -> bool {
+    pub(crate) fn contains_self(self, db: &'db dyn Db, program: Program) -> bool {
         if let Type::NominalInstance(instance) = self
             && !instance.is_definition_generic(db)
         {
             return false;
         }
 
-        any_over_type(db, self, false, |ty| {
+        any_over_type(db, program, self, false, |ty| {
             ty.as_typevar().is_some_and(|tv| tv.typevar(db).is_self(db))
         })
     }
@@ -1146,11 +1157,11 @@ impl<'db> Type<'db> {
     ///
     /// `FunctionLiteral`, `BoundMethod`, and function-like `Callable` types return `false`
     /// because their `Self` binding is deferred to call time via the signature binding path.
-    fn supports_self_binding(&self, db: &'db dyn Db) -> bool {
+    fn supports_self_binding(&self, db: &'db dyn Db, program: Program) -> bool {
         match self {
             Type::FunctionLiteral(_) | Type::BoundMethod(_) | Type::KnownBoundMethod(_) => false,
             Type::Callable(callable) if callable.is_function_like(db) => false,
-            _ => self.contains_self(db),
+            _ => self.contains_self(db, program),
         }
     }
 
@@ -1161,14 +1172,20 @@ impl<'db> Type<'db> {
     ///
     /// Types that defer `Self` binding to call time (functions, bound methods, function-like
     /// callables) are skipped; see `supports_self_binding`.
-    pub(crate) fn bind_self_typevars(self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
-        if !self.supports_self_binding(db) {
+    pub(crate) fn bind_self_typevars(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> Self {
+        if !self.supports_self_binding(db, program) {
             return self;
         }
 
         self.apply_type_mapping(
             db,
-            &TypeMapping::BindSelf(SelfBinding::new(db, self_type, None)),
+            program,
+            &TypeMapping::BindSelf(SelfBinding::new(db, program, self_type, None)),
             TypeContext::default(),
         )
     }
@@ -1181,6 +1198,7 @@ impl<'db> Type<'db> {
     pub(crate) fn cycle_normalized(
         self,
         db: &'db dyn Db,
+        program: Program,
         previous: Self,
         cycle: &salsa::Cycle,
     ) -> Self {
@@ -1199,15 +1217,15 @@ impl<'db> Type<'db> {
         // still ensures convergence in cases that are prone to oscillation.
         if cycle.iteration() <= crate::TAINTED_CYCLES {
             let self_degraded_by_overload =
-                any_over_type(db, self, false, |ty| {
+                any_over_type(db, program, self, false, |ty| {
                     matches!(ty, Type::Dynamic(DynamicType::AmbiguousOverload))
-                }) && !any_over_type(db, self, false, |ty| ty.is_divergent())
-                    && any_over_type(db, previous, false, |ty| ty.is_divergent());
+                }) && !any_over_type(db, program, self, false, |ty| ty.is_divergent())
+                    && any_over_type(db, program, previous, false, |ty| ty.is_divergent());
             // Generally, the precision of type inference improves with each iteration.
             // However, overload is an exception; as iterations progress, overload matching may become ambiguous, and a reversal of precision can occur.
             // This kind of precision degradation can be determined by whether the type contains `DynamicType::AmbiguousOverload`.
             if self_degraded_by_overload {
-                UnionType::from_elements_cycle_recovery(db, [previous, self])
+                UnionType::from_elements_cycle_recovery(db, program, [previous, self])
             } else {
                 self
             }
@@ -1221,22 +1239,23 @@ impl<'db> Type<'db> {
             // where the order of union types is different between the previous and current cycle.
             // We should use the previous union type as the base and only add new element types in
             // this cycle, if any.
-            UnionType::from_elements_cycle_recovery(db, [previous, self])
+            UnionType::from_elements_cycle_recovery(db, program, [previous, self])
         }
-        .recursive_type_normalized(db, cycle)
+        .recursive_type_normalized(db, program, cycle)
     }
 
-    pub fn is_none(&self, db: &'db dyn Db) -> bool {
-        self.is_instance_of(db, KnownClass::NoneType)
+    pub fn is_none(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.is_instance_of(db, program, KnownClass::NoneType)
     }
 
-    fn is_bool(&self, db: &'db dyn Db) -> bool {
-        self.is_instance_of(db, KnownClass::Bool)
+    fn is_bool(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.is_instance_of(db, program, KnownClass::Bool)
     }
 
-    fn is_enum(&self, db: &'db dyn Db) -> bool {
-        self.as_nominal_instance()
-            .is_some_and(|instance| enum_metadata(db, instance.class_literal(db)).is_some())
+    fn is_enum(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.as_nominal_instance().is_some_and(|instance| {
+            enum_metadata(db, instance.class_literal(db, program)).is_some()
+        })
     }
 
     fn is_typealias_special_form(&self) -> bool {
@@ -1244,7 +1263,7 @@ impl<'db> Type<'db> {
     }
 
     /// Return true if this type overrides __eq__ or __ne__ methods
-    fn overrides_equality(&self, db: &'db dyn Db) -> bool {
+    fn overrides_equality(&self, db: &'db dyn Db, program: crate::Program) -> bool {
         let check_dunder = |dunder_name, allowed_return_value| {
             // Note that we do explicitly exclude dunder methods on `object`, `int` and `str` here.
             // The reason for this is that we know that these dunder methods behave in a predictable way.
@@ -1252,6 +1271,7 @@ impl<'db> Type<'db> {
             // by always returning `False`, for example.
             let call_result = self.try_call_dunder_with_policy(
                 db,
+                program,
                 dunder_name,
                 &mut CallArguments::positional([Type::unknown()]),
                 TypeContext::default(),
@@ -1261,7 +1281,7 @@ impl<'db> Type<'db> {
             let call_result = call_result.as_ref();
             call_result.is_ok_and(|bindings| {
                 bindings
-                    .return_type(db)
+                    .return_type(db, program)
                     .as_literal_value()
                     .and_then(literal::LiteralValueType::as_bool)
                     == Some(allowed_return_value)
@@ -1271,8 +1291,8 @@ impl<'db> Type<'db> {
         !(check_dunder("__eq__", true) && check_dunder("__ne__", false))
     }
 
-    pub fn is_notimplemented(&self, db: &'db dyn Db) -> bool {
-        self.is_instance_of(db, KnownClass::NotImplementedType)
+    pub fn is_notimplemented(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.is_instance_of(db, program, KnownClass::NotImplementedType)
     }
 
     pub(crate) fn is_todo(&self) -> bool {
@@ -1394,9 +1414,10 @@ impl<'db> Type<'db> {
     pub(crate) fn known_specialization(
         &self,
         db: &'db dyn Db,
+        program: Program,
         known_class: KnownClass,
     ) -> Option<Specialization<'db>> {
-        let class_literal = known_class.try_to_class_literal(db)?;
+        let class_literal = known_class.try_to_class_literal(db, program)?;
         self.specialization_of(db, class_literal)
     }
 
@@ -1404,9 +1425,10 @@ impl<'db> Type<'db> {
     pub(crate) fn specialization_of(
         self,
         db: &'db dyn Db,
-        expected_class: StaticClassLiteral<'_>,
+        expected_class: StaticClassLiteral<'db>,
     ) -> Option<Specialization<'db>> {
-        self.nominal_class(db)?
+        let program = expected_class.program(db);
+        self.nominal_class(db, program)?
             .static_class_literal(db)
             .filter(|(class_literal, _)| *class_literal == expected_class)
             .and_then(|(_, specialization)| specialization)
@@ -1416,29 +1438,42 @@ impl<'db> Type<'db> {
     pub(crate) fn class_specialization(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
     ) -> Option<(StaticClassLiteral<'db>, Specialization<'db>)> {
-        self.nominal_class(db)?
+        self.nominal_class(db, program)?
             .static_class_literal(db)
             .and_then(|(class_literal, specialization)| Some((class_literal, specialization?)))
     }
 
     /// If this type is a class instance, returns its class.
-    pub(crate) fn nominal_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
+    pub(crate) fn nominal_class(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<ClassType<'db>> {
         match self {
-            Type::NominalInstance(instance) => Some(instance.class(db)),
-            Type::ProtocolInstance(instance) => instance.to_nominal_instance().map(|i| i.class(db)),
-            Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).nominal_class(db),
+            Type::NominalInstance(instance) => Some(instance.class(db, program)),
+            Type::ProtocolInstance(instance) => {
+                instance.to_nominal_instance().map(|i| i.class(db, program))
+            }
+            Type::TypeAlias(alias) => alias.value_type(db).nominal_class(db, program),
+            Type::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).nominal_class(db, program)
+            }
             Type::TypeVar(typevar) => {
                 let TypeVarBoundOrConstraints::UpperBound(bound) =
                     typevar.typevar(db).bound_or_constraints(db)?
                 else {
                     return None;
                 };
-                bound.nominal_class(db)
+                bound.nominal_class(db, program)
             }
-            Type::LiteralValue(literal) => literal.fallback_instance(db).nominal_class(db),
-            Type::PropertyInstance(property) => property.instance_fallback(db).nominal_class(db),
+            Type::LiteralValue(literal) => literal
+                .fallback_instance(db, program)
+                .nominal_class(db, program),
+            Type::PropertyInstance(property) => property
+                .instance_fallback(db, program)
+                .nominal_class(db, program),
             _ => None,
         }
     }
@@ -1448,41 +1483,44 @@ impl<'db> Type<'db> {
     ///
     /// This is the case for any type which may contain types in non-covariant position within it,
     /// e.g., nominal instances of a generic class, or callables.
-    pub(crate) fn may_prefer_declared_type(self, db: &'db dyn Db) -> bool {
-        self.class_specialization(db).is_some() || self.expand_eagerly(db).is_callable_type()
+    pub(crate) fn may_prefer_declared_type(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.class_specialization(db, program).is_some()
+            || self.expand_eagerly(db, program).is_callable_type()
     }
 
     /// Returns the top materialization (or upper bound materialization) of this type, which is the
     /// most general form of the type that is fully static.
     #[must_use]
-    pub(crate) fn top_materialization(&self, db: &'db dyn Db) -> Type<'db> {
-        (*self).cached_materialization(db, MaterializationKind::Top)
+    pub(crate) fn top_materialization(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        (*self).cached_materialization(db, program, MaterializationKind::Top)
     }
 
     /// Returns the bottom materialization (or lower bound materialization) of this type, which is
     /// the most specific form of the type that is fully static.
     #[must_use]
-    pub(crate) fn bottom_materialization(&self, db: &'db dyn Db) -> Type<'db> {
-        (*self).cached_materialization(db, MaterializationKind::Bottom)
+    pub(crate) fn bottom_materialization(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        (*self).cached_materialization(db, program, MaterializationKind::Bottom)
     }
 
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, materialization_kind| {
+        cycle_initial=|_, id, _, _, materialization_kind| {
             Type::Divergent(DivergentType::new(id).materialized(materialization_kind))
         },
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, _| {
-            value.cycle_normalized(db, *previous, cycle)
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, program, _| {
+            value.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
     fn cached_materialization(
         self,
         db: &'db dyn Db,
+        program: Program,
         materialization_kind: MaterializationKind,
     ) -> Type<'db> {
         self.materialize(
             db,
+            program,
             materialization_kind,
             &ApplyTypeMappingVisitor::default(),
         )
@@ -1492,9 +1530,13 @@ impl<'db> Type<'db> {
     ///
     /// I.e., for the type `tuple[int, str]`, this will return the tuple spec `[int, str]`.
     /// For a subclass of `tuple[int, str]`, it will return the same tuple spec.
-    fn tuple_instance_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
+    fn tuple_instance_spec(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Cow<'db, TupleSpec<'db>>> {
         self.as_nominal_instance()
-            .and_then(|instance| instance.tuple_spec(db))
+            .and_then(|instance| instance.tuple_spec(db, program))
     }
 
     /// If this type is an *exact* tuple type (*not* a subclass of `tuple`), returns the
@@ -1532,19 +1574,21 @@ impl<'db> Type<'db> {
     pub(crate) fn materialize(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
         self.apply_type_mapping_impl(
             db,
+            program,
             &TypeMapping::Materialize(materialization_kind),
             TypeContext::default(),
             visitor,
         )
     }
 
-    pub(crate) fn has_dynamic(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, false, |ty| ty.is_dynamic())
+    pub(crate) fn has_dynamic(self, db: &'db dyn Db, program: Program) -> bool {
+        any_over_type(db, program, self, false, |ty| ty.is_dynamic())
     }
 
     pub(crate) const fn as_special_form(self) -> Option<SpecialFormType> {
@@ -1677,13 +1721,17 @@ impl<'db> Type<'db> {
 
     pub(crate) fn module_literal(
         db: &'db dyn Db,
-        importing_file: File,
+        importing_file: ty_python_core::environment::ProgramFile<'db>,
         submodule: Module<'db>,
     ) -> Self {
         Self::ModuleLiteral(ModuleLiteralType::new(
             db,
             submodule,
-            submodule.kind(db).is_package().then_some(importing_file),
+            importing_file.program(db),
+            submodule
+                .kind(db)
+                .is_package()
+                .then_some(importing_file.file(db)),
         ))
     }
 
@@ -1780,12 +1828,16 @@ impl<'db> Type<'db> {
     }
 
     /// Detects types which are valid to appear inside a `Literal[…]` type annotation.
-    pub(crate) fn is_literal_or_union_of_literals(&self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_literal_or_union_of_literals(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> bool {
         match self {
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .all(|ty| ty.is_literal_or_union_of_literals(db)),
+                .all(|ty| ty.is_literal_or_union_of_literals(db, program)),
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::String(_)
                 | LiteralValueTypeKind::Bytes(_)
@@ -1794,7 +1846,9 @@ impl<'db> Type<'db> {
                 | LiteralValueTypeKind::Enum(_) => true,
                 LiteralValueTypeKind::LiteralString => false,
             },
-            Type::NominalInstance(_) => self.is_none(db) || self.is_bool(db) || self.is_enum(db),
+            Type::NominalInstance(_) => {
+                self.is_none(db, program) || self.is_bool(db, program) || self.is_enum(db, program)
+            }
             _ => false,
         }
     }
@@ -1853,11 +1907,11 @@ impl<'db> Type<'db> {
     }
 
     #[must_use]
-    pub(crate) fn negate(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn negate(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         // Avoid invoking the `IntersectionBuilder` for negations that are trivial.
         //
         // We verify that this always produces the same result as
-        // `IntersectionBuilder::new(db).add_negative(*self).build()` via the
+        // `IntersectionBuilder::new(db, program).add_negative(*self).build()` via the
         // property test `all_negated_types_identical_to_intersection_with_single_negated_element`
         match self {
             Type::Never => Type::object(),
@@ -1903,14 +1957,16 @@ impl<'db> Type<'db> {
             )),
 
             Type::Union(_) | Type::Intersection(_) | Type::EnumComplement(_) => {
-                IntersectionBuilder::new(db).add_negative(*self).build()
+                IntersectionBuilder::new(db, program)
+                    .add_negative(*self)
+                    .build()
             }
         }
     }
 
     #[must_use]
-    pub(crate) fn negate_if(&self, db: &'db dyn Db, yes: bool) -> Type<'db> {
-        if yes { self.negate(db) } else { *self }
+    pub(crate) fn negate_if(&self, db: &'db dyn Db, program: Program, yes: bool) -> Type<'db> {
+        if yes { self.negate(db, program) } else { *self }
     }
 
     /// Return `true` if it is possible to spell an equivalent type to this one
@@ -2051,28 +2107,33 @@ impl<'db> Type<'db> {
     pub(crate) fn filter_disjoint_elements(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> Type<'db> {
         let constraints = ConstraintSetBuilder::new();
         self.filter_union(db, |elem| {
             !elem
-                .when_disjoint_from(db, target, &constraints, inferable)
-                .is_always_satisfied(db)
+                .when_disjoint_from(db, program, target, &constraints, inferable)
+                .is_always_satisfied(db, program)
         })
     }
 
     /// Returns the fallback instance type that a literal is an instance of, or `None` if the type
     /// is not a literal.
-    pub(crate) fn literal_fallback_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn literal_fallback_instance(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<Type<'db>> {
         // There are other literal types that could conceivable be included here: class literals
         // falling back to `type[X]`, for instance. For now, there is not much rigorous thought put
         // into what's included vs not; this is just an empirical choice that makes our ecosystem
         // report look better until we have proper bidirectional type inference.
         match self {
-            Type::ModuleLiteral(_) => Some(KnownClass::ModuleType.to_instance(db)),
-            Type::FunctionLiteral(_) => Some(KnownClass::FunctionType.to_instance(db)),
-            Type::LiteralValue(literal) => Some(literal.fallback_instance(db)),
+            Type::ModuleLiteral(_) => Some(KnownClass::ModuleType.to_instance(db, program)),
+            Type::FunctionLiteral(_) => Some(KnownClass::FunctionType.to_instance(db, program)),
+            Type::LiteralValue(literal) => Some(literal.fallback_instance(db, program)),
             _ => None,
         }
     }
@@ -2082,17 +2143,18 @@ impl<'db> Type<'db> {
     /// Note that this function tries to promote literals to a more user-friendly form than their
     /// fallback instance type. For example, `def _() -> int` is promoted to `Callable[[], int]`,
     /// as opposed to `FunctionType`.
-    pub(crate) fn promote(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn promote(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular),
             TypeContext::default(),
         )
     }
 
     /// Promote a top-level singleton type (like `None`, `EllipsisType`) to `T | Unknown`.
-    pub(crate) fn promote_singletons(self, db: &'db dyn Db) -> Type<'db> {
-        self.promote_singletons_impl(db)
+    pub(crate) fn promote_singletons(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        self.promote_singletons_impl(db, program)
     }
 
     /// Promote class literals to the class objects represented by `type[...]`.
@@ -2100,9 +2162,10 @@ impl<'db> Type<'db> {
     /// This is intentionally separate from regular promotion. Applying it during collection
     /// inference would lose useful precision for local and module-level collections of class
     /// objects.
-    pub(crate) fn promote_class_literals(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn promote_class_literals(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly),
             TypeContext::default(),
         )
@@ -2112,28 +2175,35 @@ impl<'db> Type<'db> {
     /// `T | Unknown` within nominal type parameters, without recursing into unions.
     /// Used for collection literal inference so that `[None]` is inferred as
     /// `list[None | Unknown]` rather than `list[None]`.
-    pub(crate) fn promote_singletons_recursively(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn promote_singletons_recursively(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Type<'db> {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly),
             TypeContext::default(),
         )
     }
 
     /// Like [`Type::promote`], but does not recurse into nested types.
-    fn promote_impl(self, db: &'db dyn Db) -> Type<'db> {
+    fn promote_impl(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
-            Type::LiteralValue(literal) if literal.is_promotable() => literal.fallback_instance(db),
+            Type::LiteralValue(literal) if literal.is_promotable() => {
+                literal.fallback_instance(db, program)
+            }
             Type::FunctionLiteral(literal) => Type::Callable(literal.into_callable_type(db)),
             _ => self,
         }
     }
 
     /// Like [`Type::promote_singletons_recursively`], but does not recurse into nested types.
-    fn promote_singletons_impl(self, db: &'db dyn Db) -> Type<'db> {
+    fn promote_singletons_impl(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             Type::NominalInstance(instance) if instance.is_singleton(db) => {
-                UnionType::from_two_elements(db, self, Type::unknown())
+                UnionType::from_two_elements(db, program, self, Type::unknown())
             }
             _ => self,
         }
@@ -2154,9 +2224,14 @@ impl<'db> Type<'db> {
     /// If this continues, the query will not converge, so this method is called in the cycle recovery function.
     /// Then `tuple[tuple[Divergent, Literal[1]], Literal[1]]` is replaced with `tuple[Divergent, Literal[1]]` and the query converges.
     #[must_use]
-    pub(crate) fn recursive_type_normalized(self, db: &'db dyn Db, cycle: &salsa::Cycle) -> Self {
+    pub(crate) fn recursive_type_normalized(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         cycle.head_ids().fold(self, |ty, id| {
-            ty.recursive_type_normalized_impl(db, Type::divergent(id), false)
+            ty.recursive_type_normalized_impl(db, program, Type::divergent(id), false)
                 .unwrap_or(Type::divergent(id))
         })
     }
@@ -2180,6 +2255,7 @@ impl<'db> Type<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -2187,39 +2263,39 @@ impl<'db> Type<'db> {
             return None;
         }
         match self {
-            Type::Union(union) => union.recursive_type_normalized_impl(db, div, nested),
+            Type::Union(union) => union.recursive_type_normalized_impl(db, program, div, nested),
             Type::Intersection(intersection) => intersection
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::Intersection),
             Type::EnumComplement(complement) => complement
                 .to_intersection(db)
-                .recursive_type_normalized_impl(db, div, nested),
+                .recursive_type_normalized_impl(db, program, div, nested),
             Type::Callable(callable) => callable
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::Callable),
             Type::ProtocolInstance(protocol) => protocol
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::ProtocolInstance),
             Type::NominalInstance(instance) => instance
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::NominalInstance),
             Type::FunctionLiteral(function) => function
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::FunctionLiteral),
             Type::PropertyInstance(property) => property
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::PropertyInstance),
             Type::KnownBoundMethod(method_kind) => method_kind
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::KnownBoundMethod),
             Type::BoundMethod(method) => method
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(Type::BoundMethod),
             Type::BoundSuper(bound_super) => bound_super
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::BoundSuper),
             Type::GenericAlias(generic) => generic
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl_with_program(db, program, div, nested)
                 .map(Type::GenericAlias),
             Type::ClassLiteral(class) => class
                 .recursive_type_normalized_impl(db, div, nested)
@@ -2229,17 +2305,17 @@ impl<'db> Type<'db> {
                 .map(Type::SubclassOf),
             Type::TypeVar(_) => Some(self),
             Type::KnownInstance(known_instance) => known_instance
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::KnownInstance),
             Type::TypeIs(type_is) => {
-                recursive_type_normalize_type_guard_like(db, type_is, div, nested)
+                recursive_type_normalize_type_guard_like(db, program, type_is, div, nested)
             }
             Type::TypeGuard(type_guard) => {
-                recursive_type_normalize_type_guard_like(db, type_guard, div, nested)
+                recursive_type_normalize_type_guard_like(db, program, type_guard, div, nested)
             }
             Type::TypeForm(typeform) => typeform
                 .type_argument(db)
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(|ty| TypeFormType::from_type_expression(db, ty)),
             Type::Divergent(_) => Some(self),
             Type::Dynamic(dynamic) => Some(Type::Dynamic(dynamic.recursive_type_normalized())),
@@ -2249,7 +2325,7 @@ impl<'db> Type<'db> {
             }
             Type::TypeAlias(_) => Some(self),
             Type::NewTypeInstance(newtype) => newtype
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Type::NewTypeInstance),
             Type::AlwaysFalsy
             | Type::AlwaysTruthy
@@ -2267,12 +2343,13 @@ impl<'db> Type<'db> {
     ///
     /// The provided closure will be called on any nested types, along with their variance with
     /// respect to the outermost type.
-    pub(crate) fn visit_specialization<F>(self, db: &'db dyn Db, mut f: F)
+    pub(crate) fn visit_specialization<F>(self, db: &'db dyn Db, program: crate::Program, mut f: F)
     where
         F: FnMut(Type<'db>, TypeVarVariance),
     {
         self.visit_specialization_impl(
             db,
+            program,
             TypeVarVariance::Covariant,
             &mut f,
             &SpecializationVisitor::default(),
@@ -2282,26 +2359,27 @@ impl<'db> Type<'db> {
     fn visit_specialization_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         polarity: TypeVarVariance,
         f: &mut dyn FnMut(Type<'db>, TypeVarVariance),
         visitor: &SpecializationVisitor<'db>,
     ) {
-        let Some((_, specialization)) = self.class_specialization(db) else {
+        let Some((_, specialization)) = self.class_specialization(db, program) else {
             match self {
                 Type::Union(union) => {
                     for element in union.elements(db) {
-                        element.visit_specialization_impl(db, polarity, f, visitor);
+                        element.visit_specialization_impl(db, program, polarity, f, visitor);
                     }
                 }
                 Type::Intersection(intersection) => {
                     for element in intersection.positive(db) {
-                        element.visit_specialization_impl(db, polarity, f, visitor);
+                        element.visit_specialization_impl(db, program, polarity, f, visitor);
                     }
                 }
                 Type::TypeAlias(alias) => visitor.visit(self, || {
                     alias
                         .value_type(db)
-                        .visit_specialization_impl(db, polarity, f, visitor);
+                        .visit_specialization_impl(db, program, polarity, f, visitor);
                 }),
                 Type::Callable(callable) => {
                     for signature in callable.signatures(db) {
@@ -2313,14 +2391,14 @@ impl<'db> Type<'db> {
                             visitor.visit(parameter.annotated_type(), || {
                                 parameter
                                     .annotated_type()
-                                    .visit_specialization_impl(db, variance, f, visitor);
+                                    .visit_specialization_impl(db, program, variance, f, visitor);
                             });
                         }
 
                         visitor.visit(signature.return_ty, || {
                             signature
                                 .return_ty
-                                .visit_specialization_impl(db, polarity, f, visitor);
+                                .visit_specialization_impl(db, program, polarity, f, visitor);
                         });
                     }
                 }
@@ -2334,12 +2412,12 @@ impl<'db> Type<'db> {
             specialization.generic_context(db).variables(db),
             specialization.types(db),
         ) {
-            let variance = typevar.variance_with_polarity(db, polarity);
+            let variance = typevar.variance_with_polarity(db, program, polarity);
 
             f(*ty, variance);
 
             visitor.visit(*ty, || {
-                ty.visit_specialization_impl(db, variance, f, visitor);
+                ty.visit_specialization_impl(db, program, variance, f, visitor);
             });
         }
     }
@@ -2348,7 +2426,7 @@ impl<'db> Type<'db> {
     ///
     /// Note: This function aims to have no false positives, but might return `false`
     /// for more complicated types that are actually singletons.
-    pub(crate) fn is_singleton(self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_singleton(self, db: &'db dyn Db, program: crate::Program) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => false,
 
@@ -2398,7 +2476,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_singleton(db)),
+                        .all(|constraint| constraint.is_singleton(db, program)),
                 }
             }
 
@@ -2453,7 +2531,7 @@ impl<'db> Type<'db> {
                 false
             }
             Type::Intersection(intersection) => intersection
-                .enum_complement(db)
+                .enum_complement(db, program)
                 .is_some_and(|complement| complement.is_singleton(db)),
             Type::EnumComplement(complement) => complement.is_singleton(db),
             Type::AlwaysTruthy | Type::AlwaysFalsy => false,
@@ -2461,21 +2539,21 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypeForm(_) => false,
             Type::TypedDict(_) => false,
-            Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_singleton(db),
+            Type::TypeAlias(alias) => alias.value_type(db).is_singleton(db, program),
+            Type::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).is_singleton(db, program)
+            }
         }
     }
 
     /// Return true if this type is non-empty and all inhabitants of this type compare equal.
-    pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_single_valued(self, db: &'db dyn Db, program: crate::Program) -> bool {
         match self {
             // All empty ranges compare equal, but non-empty ranges can contain different values.
             Type::KnownInstance(KnownInstanceType::Range { is_non_empty }) => !is_non_empty,
 
             // Each `partial()` call creates a distinct object at runtime.
-            Type::KnownInstance(
-                KnownInstanceType::FunctoolsPartial(_) | KnownInstanceType::FunctoolsPartialCall(_),
-            ) => false,
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_)) => false,
 
             Type::FunctionLiteral(..)
             | Type::WrapperDescriptor(_)
@@ -2487,7 +2565,7 @@ impl<'db> Type<'db> {
             | Type::KnownInstance(..) => true,
 
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Enum(..) => !self.overrides_equality(db),
+                LiteralValueTypeKind::Enum(..) => !self.overrides_equality(db, program),
 
                 LiteralValueTypeKind::Int(..)
                 | LiteralValueTypeKind::String(..)
@@ -2515,7 +2593,7 @@ impl<'db> Type<'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
                         .elements(db)
                         .iter()
-                        .all(|constraint| constraint.is_single_valued(db)),
+                        .all(|constraint| constraint.is_single_valued(db, program)),
                 }
             }
 
@@ -2524,8 +2602,10 @@ impl<'db> Type<'db> {
                 false
             }
 
-            Type::NominalInstance(instance) => instance.is_single_valued(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).is_single_valued(db),
+            Type::NominalInstance(instance) => instance.is_single_valued(db, program),
+            Type::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).is_single_valued(db, program)
+            }
 
             Type::BoundSuper(_) => {
                 // At runtime two super instances never compare equal, even if their arguments are identical.
@@ -2541,7 +2621,7 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => type_guard.is_bound(db),
             Type::TypeForm(_) => false,
 
-            Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db),
+            Type::TypeAlias(alias) => alias.value_type(db).is_single_valued(db, program),
 
             Type::Dynamic(_)
             | Type::Divergent(_)
@@ -2556,7 +2636,7 @@ impl<'db> Type<'db> {
             | Type::TypedDict(_) => false,
 
             Type::Intersection(intersection) => intersection
-                .enum_complement(db)
+                .enum_complement(db, program)
                 .is_some_and(|complement| complement.is_single_valued(db)),
             Type::EnumComplement(complement) => complement.is_single_valued(db),
         }
@@ -2569,35 +2649,47 @@ impl<'db> Type<'db> {
     ///
     /// [descriptor guide]: https://docs.python.org/3/howto/descriptor.html#invocation-from-an-instance
     /// [`_PyType_Lookup`]: https://github.com/python/cpython/blob/e285232c76606e3be7bf216efb1be1e742423e4b/Objects/typeobject.c#L5223
-    fn find_name_in_mro(&self, db: &'db dyn Db, name: &str) -> Option<PlaceAndQualifiers<'db>> {
-        self.find_name_in_mro_with_policy(db, name, MemberLookupPolicy::default())
+    fn find_name_in_mro(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        name: &str,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        self.find_name_in_mro_with_policy(db, program, name, MemberLookupPolicy::default())
     }
 
     fn find_name_in_mro_with_policy(
         &self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
         if let Some(fallback) = (*self).materialized_divergent_fallback() {
-            return fallback.find_name_in_mro_with_policy(db, name, policy);
+            return fallback.find_name_in_mro_with_policy(db, program, name, policy);
         }
 
         match self {
-            Type::Union(union) => Some(union.map_with_boundness_and_qualifiers(db, |elem| {
-                elem.find_name_in_mro_with_policy(db, name, policy)
-                    // If some elements are classes, and some are not, we simply fall back to `Unbound` for the non-class
-                    // elements instead of short-circuiting the whole result to `None`. We would need a more detailed
-                    // return type otherwise, and since `find_name_in_mro` is usually called via `class_member`, this is
-                    // not a problem.
-                    .unwrap_or_default()
-            })),
+            Type::Union(union) => {
+                Some(
+                    union.map_with_boundness_and_qualifiers(db, program, |elem| {
+                        elem.find_name_in_mro_with_policy(db, program, name, policy)
+                            // If some elements are classes, and some are not, we simply fall back to `Unbound` for the non-class
+                            // elements instead of short-circuiting the whole result to `None`. We would need a more detailed
+                            // return type otherwise, and since `find_name_in_mro` is usually called via `class_member`, this is
+                            // not a problem.
+                            .unwrap_or_default()
+                    }),
+                )
+            }
             Type::Intersection(inter) => {
-                Some(inter.map_with_boundness_and_qualifiers(db, |elem| {
-                    elem.find_name_in_mro_with_policy(db, name, policy)
-                        // Fall back to Unbound, similar to the union case (see above).
-                        .unwrap_or_default()
-                }))
+                Some(
+                    inter.map_with_boundness_and_qualifiers(db, program, |elem| {
+                        elem.find_name_in_mro_with_policy(db, program, name, policy)
+                            // Fall back to Unbound, similar to the union case (see above).
+                            .unwrap_or_default()
+                    }),
+                )
             }
 
             Type::Dynamic(_) if policy.require_concrete() => Some(Place::Undefined.into()),
@@ -2652,14 +2744,14 @@ impl<'db> Type<'db> {
             }
 
             Type::SubclassOf(subclass_of_ty) => {
-                subclass_of_ty.find_name_in_mro_with_policy(db, name, policy)
+                subclass_of_ty.find_name_in_mro_with_policy(db, program, name, policy)
             }
 
             // Note: `super(pivot, owner).__class__` is `builtins.super`, not the owner's class.
             // `BoundSuper` should look up the name in the MRO of `builtins.super`.
             Type::BoundSuper(_) => KnownClass::Super
-                .to_class_literal(db)
-                .find_name_in_mro_with_policy(db, name, policy),
+                .to_class_literal(db, program)
+                .find_name_in_mro_with_policy(db, program, name, policy),
 
             // We eagerly normalize type[object], i.e. Type::SubclassOf(object) to `type`,
             // i.e. Type::NominalInstance(type). So looking up a name in the MRO of
@@ -2670,14 +2762,14 @@ impl<'db> Type<'db> {
                     Some(Place::Undefined.into())
                 } else {
                     KnownClass::Object
-                        .to_class_literal(db)
-                        .find_name_in_mro_with_policy(db, name, policy)
+                        .to_class_literal(db, program)
+                        .find_name_in_mro_with_policy(db, program, name, policy)
                 }
             }
 
             Type::TypeAlias(alias) => alias
                 .value_type(db)
-                .find_name_in_mro_with_policy(db, name, policy),
+                .find_name_in_mro_with_policy(db, program, name, policy),
 
             Type::FunctionLiteral(_)
             | Type::Callable(_)
@@ -2705,21 +2797,26 @@ impl<'db> Type<'db> {
         }
     }
 
-    fn lookup_dunder_new(self, db: &'db dyn Db) -> Option<PlaceAndQualifiers<'db>> {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, ()| None, heap_size=ruff_memory_usage::heap_size)]
+    fn lookup_dunder_new(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<PlaceAndQualifiers<'db>> {
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, ()| None, heap_size=ruff_memory_usage::heap_size)]
         fn lookup_dunder_new_inner<'db>(
             db: &'db dyn Db,
             ty: Type<'db>,
+            program: Program,
             _: (),
         ) -> Option<PlaceAndQualifiers<'db>> {
             let mut flags = MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK;
-            if !ty.is_subtype_of(db, KnownClass::Type.to_instance(db)) {
+            if !ty.is_subtype_of(db, program, KnownClass::Type.to_instance(db, program)) {
                 flags |= MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK;
             }
-            ty.find_name_in_mro_with_policy(db, "__new__", flags)
+            ty.find_name_in_mro_with_policy(db, program, "__new__", flags)
         }
 
-        lookup_dunder_new_inner(db, self, ())
+        lookup_dunder_new_inner(db, self, program, ())
     }
 
     /// Look up an attribute in the MRO of the meta-type of `self`. This returns class-level attributes
@@ -2727,41 +2824,49 @@ impl<'db> Type<'db> {
     ///
     /// Basically corresponds to `self.to_meta_type().find_name_in_mro(name)`, except for the handling
     /// of union and intersection types.
-    fn class_member(self, db: &'db dyn Db, name: Name) -> PlaceAndQualifiers<'db> {
-        self.class_member_with_policy(db, name, MemberLookupPolicy::default())
+    fn class_member(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        name: Name,
+    ) -> PlaceAndQualifiers<'db> {
+        self.class_member_with_policy(db, program, name, MemberLookupPolicy::default())
     }
 
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, _, _| Place::bound(Type::divergent(id)).into(),
-        cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _| {
-            member.cycle_normalized(db, *previous, cycle)
+        cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
+        cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, program, _, _| {
+            member.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
     fn class_member_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        tracing::trace!("class_member: {}.{}", self.display(db), name);
+        tracing::trace!("class_member: {}.{}", self.display(db, program), name);
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.class_member_with_policy(db, name, policy);
+            return fallback.class_member_with_policy(db, program, name, policy);
         }
 
         match self {
-            Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
-                elem.class_member_with_policy(db, name.clone(), policy)
+            Type::Union(union) => union.map_with_boundness_and_qualifiers(db, program, |elem| {
+                elem.class_member_with_policy(db, program, name.clone(), policy)
             }),
-            Type::Intersection(inter) => inter.map_with_boundness_and_qualifiers(db, |elem| {
-                elem.class_member_with_policy(db, name.clone(), policy)
-            }),
+            Type::Intersection(inter) => {
+                inter.map_with_boundness_and_qualifiers(db, program, |elem| {
+                    elem.class_member_with_policy(db, program, name.clone(), policy)
+                })
+            }
             // TODO: Once `to_meta_type` for the synthesized protocol is fully implemented, this handling should be removed.
             Type::ProtocolInstance(ProtocolInstanceType {
                 inner: Protocol::Synthesized(_),
                 ..
-            }) => self.instance_member(db, &name),
+            }) => self.instance_member(db, program, &name),
 
             Type::LiteralValue(literal) if name == "__len__" => {
                 if let Some(length) = match literal.kind() {
@@ -2780,8 +2885,8 @@ impl<'db> Type<'db> {
                     ))
                     .into()
                 } else {
-                    self.to_meta_type(db)
-                        .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                    self.to_meta_type(db, program)
+                        .find_name_in_mro_with_policy(db, program, name.as_str(), policy)
                         .expect(
                             "`Type::find_name_in_mro()` should return `Some()` when called on a meta-type",
                         )
@@ -2794,34 +2899,37 @@ impl<'db> Type<'db> {
             // their correct types instead of collapsing to `Any`/`Unknown`.
             Type::SubclassOf(subclass_of) if subclass_of.is_dynamic() => {
                 let type_result = KnownClass::Type
-                    .to_class_literal(db)
-                    .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                    .to_class_literal(db, program)
+                    .find_name_in_mro_with_policy(db, program, name.as_str(), policy)
                     .expect("`find_name_in_mro` should return `Some` for a class literal");
                 if !type_result.place.is_undefined() {
                     type_result
                 } else {
-                    self.to_meta_type(db)
-                        .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                    self.to_meta_type(db, program)
+                        .find_name_in_mro_with_policy(db, program, name.as_str(), policy)
                         .expect(
                             "`Type::find_name_in_mro()` should return `Some()` when called on a meta-type",
                         )
                 }
             }
 
-            Type::NominalInstance(instance) => self.to_meta_type(db).class_namespace_member(
-                db,
-                instance.class(db),
-                name.as_str(),
-                policy,
-            ),
+            Type::NominalInstance(instance) => {
+                self.to_meta_type(db, program).class_namespace_member(
+                    db,
+                    program,
+                    instance.class(db, program),
+                    name.as_str(),
+                    policy,
+                )
+            }
 
             Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => self
-                .to_meta_type(db)
-                .class_object_member(db, name.as_str(), policy),
+                .to_meta_type(db, program)
+                .class_object_member(db, program, name.as_str(), policy),
 
             _ => self
-                .to_meta_type(db)
-                .find_name_in_mro_with_policy(db, name.as_str(), policy)
+                .to_meta_type(db, program)
+                .find_name_in_mro_with_policy(db, program, name.as_str(), policy)
                 .expect(
                     "`Type::find_name_in_mro()` should return `Some()` when called on a meta-type",
                 ),
@@ -2829,23 +2937,25 @@ impl<'db> Type<'db> {
     }
 
     /// Look up the class member that participates in descriptor access through an instance.
-    ///
-    /// The meta-type of a type variable preserves method binding to that type variable, but it does
-    /// not carry attributes stored in a nominal upper-bound class's namespace by its metaclass.
-    /// Add those attributes using the same lookup as a concrete nominal instance.
     fn instance_lookup_class_member_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         if let Type::TypeVar(_) = self
-            && let Some(class) = self.nominal_class(db)
+            && let Some(class) = self.nominal_class(db, program)
         {
-            self.to_meta_type(db)
-                .class_namespace_member(db, class, name.as_str(), policy)
+            self.to_meta_type(db, program).class_namespace_member(
+                db,
+                program,
+                class,
+                name.as_str(),
+                policy,
+            )
         } else {
-            self.class_member_with_policy(db, name, policy)
+            self.class_member_with_policy(db, program, name, policy)
         }
     }
 
@@ -2857,15 +2967,16 @@ impl<'db> Type<'db> {
     fn class_object_member(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        let class_attr = self.find_name_in_mro_with_policy(db, name, policy).expect(
+        let class_attr = self.find_name_in_mro_with_policy(db, program, name, policy).expect(
             "Calling `class_object_member` on class literals and subclass-of types should always find an MRO",
         );
 
         let own_class = match self {
-            Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db),
+            Type::SubclassOf(subclass_of) => subclass_of.subclass_of().into_class(db, program),
             _ => self.to_class_type(db),
         };
         let own_class_attr = own_class.map(|class| class.own_class_member(db, None, name).inner);
@@ -2890,17 +3001,18 @@ impl<'db> Type<'db> {
             return class_attr;
         }
 
-        let Some(metaclass_instance) = self.to_meta_type(db).to_instance(db) else {
+        let Some(metaclass_instance) = self.to_meta_type(db, program).to_instance(db, program)
+        else {
             return class_attr;
         };
-        let metaclass_attr = metaclass_instance.instance_member(db, name);
+        let metaclass_attr = metaclass_instance.instance_member(db, program, name);
 
         if own_declaration_definedness.is_some() {
             // A conditionally-declared attribute is a contract only on paths where that
             // declaration is present; the metaclass value is the fallback on other paths.
-            class_attr.or_fall_back_to(db, || metaclass_attr)
+            class_attr.or_fall_back_to(db, program, || metaclass_attr)
         } else {
-            metaclass_attr.or_fall_back_to(db, || class_attr)
+            metaclass_attr.or_fall_back_to(db, program, || class_attr)
         }
     }
 
@@ -2918,40 +3030,21 @@ impl<'db> Type<'db> {
     }
 
     /// Look up metaclass instance members in a constructed class's namespace.
-    ///
-    /// A class object is an instance of its metaclass, and its instance storage is also the class
-    /// namespace consulted when looking up attributes through instances of that class.
-    ///
-    /// ```python
-    /// class Meta(type):
-    ///     generated: int
-    ///
-    /// class C(metaclass=Meta): ...
-    ///
-    /// reveal_type(C().generated)  # int
-    /// ```
-    ///
-    /// An own class binding or `ClassVar` contract shadows a normal generated attribute. During
-    /// instance lookup, the result participates in the existing descriptor and instance-fallback
-    /// logic.
-    ///
-    /// Metaclass instance members participate, including inherited declarations and attributes
-    /// inferred from instance methods. Class-body-only bindings remain attributes of the
-    /// metaclass itself and are excluded.
     fn class_namespace_member(
         self,
         db: &'db dyn Db,
+        program: Program,
         class: ClassType<'db>,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
         let class_attr = self
-            .find_name_in_mro_with_policy(db, name, policy)
+            .find_name_in_mro_with_policy(db, program, name, policy)
             .expect("The meta-type of an instance-like type should always have an MRO");
         let Some(metaclass) = class
             .metaclass(db)
-            .to_instance(db)
-            .and_then(|metaclass| metaclass.nominal_class(db))
+            .to_instance(db, program)
+            .and_then(|metaclass| metaclass.nominal_class(db, program))
         else {
             return class_attr;
         };
@@ -2969,8 +3062,6 @@ impl<'db> Type<'db> {
             policy,
             class.iter_mro(db).take(1),
         );
-        // A non-ClassVar declaration-only member describes instance storage but does not add a
-        // value to the class namespace.
         let own_class_member = if !own_class_member.is_class_var()
             && class.static_class_literal(db).is_some_and(|(class, _)| {
                 let scope = class.body_scope(db);
@@ -2979,6 +3070,7 @@ impl<'db> Type<'db> {
                     .is_some_and(|symbol| {
                         place_from_bindings(
                             db,
+                            program,
                             use_def_map(db, scope).end_of_scope_symbol_bindings(symbol),
                         )
                         .place
@@ -3002,11 +3094,9 @@ impl<'db> Type<'db> {
             metaclass_member
         };
         let class_member = own_class_member
-            .or_fall_back_to(db, || metaclass_member)
-            .or_fall_back_to(db, || inherited_class_member);
+            .or_fall_back_to(db, program, || metaclass_member)
+            .or_fall_back_to(db, program, || inherited_class_member);
         let class_member = if metaclass_member_is_implicit {
-            // Preserve the existing convention that an inferred instance member is assumed to be
-            // available even when no lower-precedence fallback exists.
             Self::with_definedness(class_member, Definedness::AlwaysDefined)
         } else {
             class_member
@@ -3023,14 +3113,10 @@ impl<'db> Type<'db> {
             return class_member;
         };
         let dynamic_instance_fallback = Place::bound(dynamic_instance_type).into();
-
-        // A dynamic base can provide arbitrary instance storage that shadows non-data class
-        // attributes. Preserve only the data-descriptor alternatives before falling back to the
-        // actual dynamic type.
         let Some(class_member_ty) = class_member.ignore_possibly_undefined() else {
             return dynamic_instance_fallback;
         };
-        if !class_member_ty.may_be_data_descriptor(db) {
+        if !class_member_ty.may_be_data_descriptor(db, program) {
             return dynamic_instance_fallback;
         }
         let PlaceAndQualifiers {
@@ -3048,12 +3134,12 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .all(|ty| ty.may_be_data_descriptor(db))
+                    .all(|ty| ty.may_be_data_descriptor(db, program))
             });
         Place::Defined(DefinedPlace {
             ty: declaration
                 .ty
-                .filter_union(db, |ty| ty.may_be_data_descriptor(db)),
+                .filter_union(db, |ty| ty.may_be_data_descriptor(db, program)),
             definedness: if all_arms_are_possible_data_descriptors {
                 declaration.definedness
             } else {
@@ -3062,7 +3148,7 @@ impl<'db> Type<'db> {
             ..declaration
         })
         .with_qualifiers(qualifiers)
-        .or_fall_back_to(db, || dynamic_instance_fallback)
+        .or_fall_back_to(db, program, || dynamic_instance_fallback)
     }
 
     /// This function roughly corresponds to looking up an attribute in the `__dict__` of an object.
@@ -3081,18 +3167,23 @@ impl<'db> Type<'db> {
     ///     def __init__(self):
     ///         self.b: str = "a"
     /// ```
-    fn instance_member(&self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+    fn instance_member(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        name: &str,
+    ) -> PlaceAndQualifiers<'db> {
         match self {
-            Type::Union(union) => {
-                union.map_with_boundness_and_qualifiers(db, |elem| elem.instance_member(db, name))
-            }
+            Type::Union(union) => union.map_with_boundness_and_qualifiers(db, program, |elem| {
+                elem.instance_member(db, program, name)
+            }),
 
             Type::Intersection(intersection) => {
-                if let Some(complement) = intersection.enum_complement(db) {
+                if let Some(complement) = intersection.enum_complement(db, program) {
                     enums::instance_member_for_enum_complement(db, complement, name)
                 } else {
-                    intersection.map_with_boundness_and_qualifiers(db, |elem| {
-                        elem.instance_member(db, name)
+                    intersection.map_with_boundness_and_qualifiers(db, program, |elem| {
+                        elem.instance_member(db, program, name)
                     })
                 }
             }
@@ -3103,71 +3194,78 @@ impl<'db> Type<'db> {
 
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Place::bound(self).into(),
 
-            Type::NominalInstance(instance) => instance.class(db).instance_member(db, name),
-            Type::NewTypeInstance(newtype) => {
-                newtype.concrete_base_type(db).instance_member(db, name)
+            Type::NominalInstance(instance) => {
+                instance.class(db, program).instance_member(db, name)
             }
+            Type::NewTypeInstance(newtype) => newtype
+                .concrete_base_type(db)
+                .instance_member(db, program, name),
 
-            Type::ProtocolInstance(protocol) => protocol.instance_member(db, name),
+            Type::ProtocolInstance(protocol) => protocol.instance_member(db, program, name),
 
             Type::FunctionLiteral(_) => KnownClass::FunctionType
-                .to_instance(db)
-                .instance_member(db, name),
+                .to_instance(db, program)
+                .instance_member(db, program, name),
 
             Type::BoundMethod(_) => KnownClass::MethodType
-                .to_instance(db)
-                .instance_member(db, name),
-            Type::KnownBoundMethod(method) => {
-                method.class().to_instance(db).instance_member(db, name)
-            }
+                .to_instance(db, program)
+                .instance_member(db, program, name),
+            Type::KnownBoundMethod(method) => method
+                .class()
+                .to_instance(db, program)
+                .instance_member(db, program, name),
             Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
-                .to_instance(db)
-                .instance_member(db, name),
+                .to_instance(db, program)
+                .instance_member(db, program, name),
             Type::DataclassDecorator(_) => KnownClass::FunctionType
-                .to_instance(db)
-                .instance_member(db, name),
+                .to_instance(db, program)
+                .instance_member(db, program, name),
             Type::Callable(_) | Type::DataclassTransformer(_) => {
-                Type::object().instance_member(db, name)
+                Type::object().instance_member(db, program, name)
             }
 
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
-                    None => Type::object().instance_member(db, name),
+                    None => Type::object().instance_member(db, program, name),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        bound.instance_member(db, name)
+                        bound.instance_member(db, program, name)
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                        .map_with_boundness_and_qualifiers(db, |constraint| {
-                            constraint.instance_member(db, name)
+                        .map_with_boundness_and_qualifiers(db, program, |constraint| {
+                            constraint.instance_member(db, program, name)
                         }),
                 }
             }
 
-            Type::TypeIs(_) | Type::TypeGuard(_) => {
-                KnownClass::Bool.to_instance(db).instance_member(db, name)
-            }
+            Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool
+                .to_instance(db, program)
+                .instance_member(db, program, name),
 
-            Type::LiteralValue(literal) => literal.fallback_instance(db).instance_member(db, name),
+            Type::LiteralValue(literal) => literal
+                .fallback_instance(db, program)
+                .instance_member(db, program, name),
 
             Type::AlwaysTruthy | Type::AlwaysFalsy | Type::TypeForm(_) => {
-                Type::object().instance_member(db, name)
+                Type::object().instance_member(db, program, name)
             }
             Type::ModuleLiteral(_) => KnownClass::ModuleType
-                .to_instance(db)
-                .instance_member(db, name),
+                .to_instance(db, program)
+                .instance_member(db, program, name),
 
             Type::SpecialForm(_) | Type::KnownInstance(_) => Place::Undefined.into(),
 
-            Type::PropertyInstance(property) => {
-                property.instance_fallback(db).instance_member(db, name)
-            }
+            Type::PropertyInstance(property) => property
+                .instance_fallback(db, program)
+                .instance_member(db, program, name),
 
             // Note: `super(pivot, owner).__dict__` refers to the `__dict__` of the `builtins.super` instance,
             // not that of the owner.
             // This means we should only look up instance members defined on the `builtins.super()` instance itself.
             // If you want to look up a member in the MRO of the `super`'s owner,
             // refer to [`Type::member`] instead.
-            Type::BoundSuper(_) => KnownClass::Super.to_instance(db).instance_member(db, name),
+            Type::BoundSuper(_) => KnownClass::Super
+                .to_instance(db, program)
+                .instance_member(db, program, name),
 
             // TODO: we currently don't model the fact that class literals and subclass-of types have
             // a `__dict__` that is filled with class level attributes. Modeling this is currently not
@@ -3179,7 +3277,7 @@ impl<'db> Type<'db> {
 
             Type::TypedDict(_) => Place::Undefined.into(),
 
-            Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, name),
+            Type::TypeAlias(alias) => alias.value_type(db).instance_member(db, program, name),
         }
     }
 
@@ -3187,17 +3285,19 @@ impl<'db> Type<'db> {
     /// method corresponds to `inspect.getattr_static(<object of type 'self'>, name)`.
     ///
     /// See also: [`Type::member`]
-    fn static_member(&self, db: &'db dyn Db, name: &str) -> Place<'db> {
+    fn static_member(&self, db: &'db dyn Db, program: crate::Program, name: &str) -> Place<'db> {
         if let Type::ModuleLiteral(module) = self {
             module.static_member(db, name).place
-        } else if let place @ Place::Defined(_) = self.class_member(db, name.into()).place {
+        } else if let place @ Place::Defined(_) = self.class_member(db, program, name.into()).place
+        {
             place
-        } else if let Some(place @ Place::Defined(_)) =
-            self.find_name_in_mro(db, name).map(|inner| inner.place)
+        } else if let Some(place @ Place::Defined(_)) = self
+            .find_name_in_mro(db, program, name)
+            .map(|inner| inner.place)
         {
             place
         } else {
-            self.instance_member(db, name).place
+            self.instance_member(db, program, name).place
         }
     }
 
@@ -3224,18 +3324,20 @@ impl<'db> Type<'db> {
     pub(crate) fn try_call_dunder_get(
         self,
         db: &'db dyn Db,
+        program: Program,
         instance: Option<Type<'db>>,
         owner: Type<'db>,
     ) -> Option<(Type<'db>, AttributeKind)> {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn try_call_dunder_get_inner<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             instance: Option<Type<'db>>,
             owner: Type<'db>,
         ) -> Option<(Type<'db>, AttributeKind)> {
             if let Some(fallback) = ty.materialized_divergent_fallback() {
-                return fallback.try_call_dunder_get(db, instance, owner);
+                return fallback.try_call_dunder_get(db, program, instance, owner);
             }
 
             if let Some(dynamic) = ty.dynamic_descriptor_type() {
@@ -3264,11 +3366,11 @@ impl<'db> Type<'db> {
                     } else {
                         let self_type = instance.unwrap_or_else(|| {
                             // For classmethod-like callables, bind to the owner class.
-                            owner.to_instance(db).unwrap_or(owner)
+                            owner.to_instance(db, program).unwrap_or(owner)
                         });
 
                         Some((
-                            Type::Callable(callable.bind_self(db, Some(self_type))),
+                            Type::Callable(callable.bind_self(db, program, Some(self_type))),
                             AttributeKind::NormalOrNonDataDescriptor,
                         ))
                     };
@@ -3282,6 +3384,7 @@ impl<'db> Type<'db> {
             }) = ty
                 .class_member_with_policy(
                     db,
+                    program,
                     "__get__".into(),
                     MemberLookupPolicy::REQUIRE_CONCRETE,
                 )
@@ -3296,8 +3399,6 @@ impl<'db> Type<'db> {
                 return None;
             }
 
-            // Descriptor special-method lookup checks the descriptor's type, so instance storage
-            // cannot shadow `__get__`. Dynamic MRO entries still participate in the lookup.
             let Place::Defined(DefinedPlace {
                 ty: descr_get,
                 definedness: descr_get_boundness,
@@ -3305,6 +3406,7 @@ impl<'db> Type<'db> {
             }) = ty
                 .class_member_with_policy(
                     db,
+                    program,
                     "__get__".into(),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
@@ -3313,21 +3415,30 @@ impl<'db> Type<'db> {
                 return None;
             };
 
-            let instance_ty = instance.unwrap_or_else(|| Type::none(db));
+            let instance_ty = instance.unwrap_or_else(|| Type::none(db, program));
             let return_ty = descr_get
-                .try_call(db, &CallArguments::positional([ty, instance_ty, owner]))
+                .try_call(
+                    db,
+                    program,
+                    &CallArguments::positional([ty, instance_ty, owner]),
+                )
                 .map(|bindings| {
                     if descr_get_boundness == Definedness::AlwaysDefined {
-                        bindings.return_type(db)
+                        bindings.return_type(db, program)
                     } else {
-                        UnionType::from_two_elements(db, bindings.return_type(db), ty)
+                        UnionType::from_two_elements(
+                            db,
+                            program,
+                            bindings.return_type(db, program),
+                            ty,
+                        )
                     }
                 })
                 // TODO: an error when calling `__get__` will lead to a `TypeError` or similar at runtime;
                 // we should emit a diagnostic here instead of silently ignoring the error.
-                .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db));
+                .unwrap_or_else(|CallError(_, bindings)| bindings.return_type(db, program));
 
-            let descriptor_kind = if ty.is_data_descriptor(db) {
+            let descriptor_kind = if ty.is_data_descriptor(db, program) {
                 AttributeKind::DataDescriptor
             } else {
                 AttributeKind::NormalOrNonDataDescriptor
@@ -3338,9 +3449,11 @@ impl<'db> Type<'db> {
 
         tracing::trace!(
             "try_call_dunder_get: {}, {}, {}",
-            self.display(db),
-            instance.unwrap_or_else(|| Type::none(db)).display(db),
-            owner.display(db)
+            self.display(db, program),
+            instance
+                .unwrap_or_else(|| Type::none(db, program))
+                .display(db, program),
+            owner.display(db, program)
         );
 
         // Function descriptors have fixed binding behavior, so avoid retaining a tracked query
@@ -3359,7 +3472,7 @@ impl<'db> Type<'db> {
             return Some((descriptor_result, AttributeKind::NormalOrNonDataDescriptor));
         }
 
-        try_call_dunder_get_inner(db, self, instance, owner)
+        try_call_dunder_get_inner(db, program, self, instance, owner)
     }
 
     /// Look up `__get__` on the meta-type of `attribute`, and call it with `attribute`, `instance`,
@@ -3367,6 +3480,7 @@ impl<'db> Type<'db> {
     /// and intersections explicitly.
     fn try_call_dunder_get_on_attribute(
         db: &'db dyn Db,
+        program: Program,
         attribute: PlaceAndQualifiers<'db>,
         instance: Option<Type<'db>>,
         owner: Type<'db>,
@@ -3386,6 +3500,7 @@ impl<'db> Type<'db> {
         {
             return Self::try_call_dunder_get_on_attribute(
                 db,
+                program,
                 Place::Defined(DefinedPlace {
                     ty: fallback,
                     origin,
@@ -3424,10 +3539,10 @@ impl<'db> Type<'db> {
                 qualifiers,
             } => (
                 union
-                    .map_with_boundness(db, |elem| {
+                    .map_with_boundness(db, program, |elem| {
                         Place::Defined(DefinedPlace {
                             ty: elem
-                                .try_call_dunder_get(db, instance, owner)
+                                .try_call_dunder_get(db, program, instance, owner)
                                 .map_or(*elem, |(ty, _)| ty),
                             origin,
                             definedness: boundness,
@@ -3439,7 +3554,7 @@ impl<'db> Type<'db> {
                     .with_qualifiers(qualifiers),
                 // TODO: avoid the duplication here:
                 if union.elements(db).iter().all(|elem| {
-                    elem.try_call_dunder_get(db, instance, owner)
+                    elem.try_call_dunder_get(db, program, instance, owner)
                         .is_some_and(|(_, kind)| kind.is_data())
                 }) {
                     AttributeKind::DataDescriptor
@@ -3463,10 +3578,10 @@ impl<'db> Type<'db> {
                     attribute
                 } else {
                     intersection
-                        .map_with_boundness(db, |elem| {
+                        .map_with_boundness(db, program, |elem| {
                             Place::Defined(DefinedPlace {
                                 ty: elem
-                                    .try_call_dunder_get(db, instance, owner)
+                                    .try_call_dunder_get(db, program, instance, owner)
                                     .map_or(*elem, |(ty, _)| ty),
                                 origin,
                                 definedness,
@@ -3493,7 +3608,7 @@ impl<'db> Type<'db> {
                 qualifiers: _,
             } => {
                 if let Some((return_ty, attribute_kind)) =
-                    attribute_ty.try_call_dunder_get(db, instance, owner)
+                    attribute_ty.try_call_dunder_get(db, program, instance, owner)
                 {
                     (
                         Place::Defined(DefinedPlace {
@@ -3518,8 +3633,8 @@ impl<'db> Type<'db> {
     /// Returns whether this type is a data descriptor, i.e. defines `__set__` or `__delete__`.
     /// If this type is a union, requires all elements of union to be data descriptors.
     /// A directly dynamic type is treated as a data descriptor because it could inhabit one.
-    pub(crate) fn is_data_descriptor(self, d: &'db dyn Db) -> bool {
-        self.is_data_descriptor_impl(d, false)
+    pub(crate) fn is_data_descriptor(self, db: &'db dyn Db, program: Program) -> bool {
+        self.is_data_descriptor_impl(db, program, false)
     }
 
     /// Returns whether this type should be considered a possible data descriptor.
@@ -3527,49 +3642,51 @@ impl<'db> Type<'db> {
     /// This is used to determine whether an attribute assignment is valid for narrowing.
     /// For practical convenience, dynamic union elements are not considered possible data
     /// descriptors here, because doing so would disable narrowing too frequently.
-    pub(crate) fn may_be_data_descriptor(self, d: &'db dyn Db) -> bool {
-        self.is_data_descriptor_impl(d, true)
+    pub(crate) fn may_be_data_descriptor(self, db: &'db dyn Db, program: Program) -> bool {
+        self.is_data_descriptor_impl(db, program, true)
     }
 
     /// Returns whether this type is known not to be a data descriptor.
-    ///
-    /// Descriptor uncertainty only propagates through outer unions, intersections, and aliases;
-    /// type arguments do not affect the runtime descriptor class.
-    pub(crate) fn is_definitely_non_data_descriptor(self, db: &'db dyn Db) -> bool {
-        self.is_definitely_non_data_descriptor_impl(db, ())
+    pub(crate) fn is_definitely_non_data_descriptor(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> bool {
+        self.is_definitely_non_data_descriptor_impl(db, program, ())
     }
 
-    // Recursive aliases use `true`, the identity for the all-of classifications above.
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|_, _, _, ()| true,
-        heap_size=ruff_memory_usage::heap_size
-    )]
-    fn is_definitely_non_data_descriptor_impl(self, db: &'db dyn Db, (): ()) -> bool {
+    #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, ()| true, heap_size=ruff_memory_usage::heap_size)]
+    fn is_definitely_non_data_descriptor_impl(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        (): (),
+    ) -> bool {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::TypeVar(_) => false,
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, ())),
+                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, program, ())),
             Type::Intersection(intersection) => intersection
                 .iter_positive(db)
-                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, ())),
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .is_definitely_non_data_descriptor_impl(db, ()),
-            _ => !self.may_be_data_descriptor(db),
+                .all(|ty| ty.is_definitely_non_data_descriptor_impl(db, program, ())),
+            Type::TypeAlias(alias) => {
+                alias
+                    .value_type(db)
+                    .is_definitely_non_data_descriptor_impl(db, program, ())
+            }
+            _ => !self.may_be_data_descriptor(db, program),
         }
     }
 
-    // Definite data descriptors use an all-of union fold; possible data descriptors use any-of.
-    // Seed recursive aliases with the corresponding identity value.
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|_, _, _, any_of_union: bool| !any_of_union,
-        heap_size=ruff_memory_usage::heap_size
-    )]
-    fn is_data_descriptor_impl(self, db: &'db dyn Db, any_of_union: bool) -> bool {
+    #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, any_of_union: bool| !any_of_union, heap_size=ruff_memory_usage::heap_size)]
+    fn is_data_descriptor_impl(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        any_of_union: bool,
+    ) -> bool {
         match self {
             Type::Dynamic(_) => !any_of_union,
             Type::SubclassOf(_) if self.dynamic_descriptor_type().is_some() => true,
@@ -3577,21 +3694,24 @@ impl<'db> Type<'db> {
             Type::Union(union) if any_of_union => union
                 .elements(db)
                 .iter()
-                .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
+                .any(|ty| ty.is_data_descriptor_impl(db, program, any_of_union)),
             Type::Union(union) => union
                 .elements(db)
                 .iter()
-                .all(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
+                .all(|ty| ty.is_data_descriptor_impl(db, program, any_of_union)),
             Type::Intersection(intersection) => intersection
                 .iter_positive(db)
-                .any(|ty| ty.is_data_descriptor_impl(db, any_of_union)),
-            Type::TypeAlias(alias) => alias
-                .value_type(db)
-                .is_data_descriptor_impl(db, any_of_union),
+                .any(|ty| ty.is_data_descriptor_impl(db, program, any_of_union)),
+            Type::TypeAlias(alias) => {
+                alias
+                    .value_type(db)
+                    .is_data_descriptor_impl(db, program, any_of_union)
+            }
             _ => {
                 !self
                     .class_member_with_policy(
                         db,
+                        program,
                         "__set__".into(),
                         MemberLookupPolicy::REQUIRE_CONCRETE,
                     )
@@ -3600,6 +3720,7 @@ impl<'db> Type<'db> {
                     || !self
                         .class_member_with_policy(
                             db,
+                            program,
                             "__delete__".into(),
                             MemberLookupPolicy::REQUIRE_CONCRETE,
                         )
@@ -3623,9 +3744,11 @@ impl<'db> Type<'db> {
     ///
     /// In addition to that, we also handle various cases of possibly-unbound symbols and fall
     /// back to lower-precedence stages of the descriptor protocol by building union types.
+    #[expect(clippy::too_many_arguments)]
     fn invoke_descriptor_protocol(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         receiver: Type<'db>,
         name: &str,
         fallback: PlaceAndQualifiers<'db>,
@@ -3640,9 +3763,10 @@ impl<'db> Type<'db> {
             meta_attr_kind,
         ) = Self::try_call_dunder_get_on_attribute(
             db,
-            self.instance_lookup_class_member_with_policy(db, name.into(), member_policy),
+            program,
+            self.instance_lookup_class_member_with_policy(db, program, name.into(), member_policy),
             Some(receiver),
-            self.to_meta_type(db),
+            self.to_meta_type(db, program),
         );
 
         let PlaceAndQualifiers {
@@ -3688,7 +3812,7 @@ impl<'db> Type<'db> {
                     provenance: fallback_provenance,
                 }),
             ) => Place::Defined(DefinedPlace {
-                ty: UnionType::from_two_elements(db, meta_attr_ty, fallback_ty),
+                ty: UnionType::from_two_elements(db, program, meta_attr_ty, fallback_ty),
                 origin: meta_origin.merge(fallback_origin),
                 definedness: fallback_boundness,
                 public_type_policy: fallback_public_type_policy,
@@ -3735,7 +3859,7 @@ impl<'db> Type<'db> {
                     provenance: fallback_provenance,
                 }),
             ) => Place::Defined(DefinedPlace {
-                ty: UnionType::from_two_elements(db, meta_attr_ty, fallback_ty),
+                ty: UnionType::from_two_elements(db, program, meta_attr_ty, fallback_ty),
                 origin: meta_origin.merge(fallback_origin),
                 definedness: meta_attr_boundness.max(fallback_boundness),
                 public_type_policy: fallback_public_type_policy,
@@ -3756,8 +3880,13 @@ impl<'db> Type<'db> {
     /// TODO: We should return a `Result` here to handle errors that can appear during attribute
     /// lookup, like a failed `__get__` call on a descriptor.
     #[must_use]
-    pub(crate) fn member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
-        self.member_lookup_with_policy(db, name.into(), MemberLookupPolicy::default())
+    pub(crate) fn member(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        name: &str,
+    ) -> PlaceAndQualifiers<'db> {
+        self.member_lookup_with_policy(db, program, name.into(), MemberLookupPolicy::default())
     }
 
     /// Similar to [`Type::member`], but allows the caller to specify what policy should be used
@@ -3765,10 +3894,11 @@ impl<'db> Type<'db> {
     pub(crate) fn member_lookup_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: Name,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
-        self.member_lookup_with_policy_and_receiver(db, name, policy, None)
+        self.member_lookup_with_policy_and_receiver(db, program, name, policy, None)
     }
 
     /// Perform member lookup while optionally binding descriptors and `Self` to a more precise
@@ -3779,27 +3909,30 @@ impl<'db> Type<'db> {
     fn member_lookup_with_policy_and_receiver(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: Name,
         policy: MemberLookupPolicy,
         receiver: Option<Type<'db>>,
     ) -> PlaceAndQualifiers<'db> {
         #[salsa::tracked(
             returns(copy),
-            cycle_initial=|_, id, _, _, _, _| Place::bound(Type::divergent(id)).into(),
-            cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _, _| {
-                member.cycle_normalized(db, *previous, cycle)
+            cycle_initial=|_, id, _, _, _, _, _| Place::bound(Type::divergent(id)).into(),
+            cycle_fn=|db, cycle, previous: &PlaceAndQualifiers<'db>, member: PlaceAndQualifiers<'db>, _, _, _, _, _| {
+                member.cycle_normalized(db, program, *previous, cycle)
             },
             heap_size=ruff_memory_usage::heap_size
         )]
         fn member_lookup_with_policy_inner<'db>(
             db: &'db dyn Db,
             this: Type<'db>,
+            program: Program,
             name: Name,
             policy: MemberLookupPolicy,
             receiver: Option<Type<'db>>,
         ) -> PlaceAndQualifiers<'db> {
             fn promote_inferred_attribute_class_literals<'db>(
                 db: &'db dyn Db,
+                program: Program,
                 result: PlaceAndQualifiers<'db>,
             ) -> PlaceAndQualifiers<'db> {
                 let should_promote = matches!(
@@ -3811,7 +3944,7 @@ impl<'db> Type<'db> {
                 ) && !result.qualifiers.contains(TypeQualifiers::FINAL);
 
                 if should_promote {
-                    result.map_type(|ty| ty.promote_class_literals(db))
+                    result.map_type(|ty| ty.promote_class_literals(db, program))
                 } else {
                     result
                 }
@@ -3819,6 +3952,7 @@ impl<'db> Type<'db> {
 
             fn instance_like_member_lookup<'db>(
                 db: &'db dyn Db,
+                program: Program,
                 this: Type<'db>,
                 name: &Name,
                 policy: MemberLookupPolicy,
@@ -3833,7 +3967,7 @@ impl<'db> Type<'db> {
                         .as_enum()
                         .map(|enum_literal| enum_literal.enum_class_literal(db)),
                     _ => this
-                        .nominal_class(db)
+                        .nominal_class(db, program)
                         .map(|class| class.class_literal(db))
                         .and_then(|class| class.into_enum_class(db)),
                 } && let Some(resolved_name) = enum_class.resolve_member(db, name)
@@ -3846,10 +3980,11 @@ impl<'db> Type<'db> {
                     .into();
                 }
 
-                let fallback = this.instance_member(db, name_str);
+                let fallback = this.instance_member(db, program, name_str);
 
                 let result = this.invoke_descriptor_protocol(
                     db,
+                    program,
                     receiver,
                     name_str,
                     fallback,
@@ -3863,38 +3998,47 @@ impl<'db> Type<'db> {
                     return Place::Undefined.into();
                 }
 
-                let result = this.fallback_to_getattr(db, name, result, policy);
+                let result = this.fallback_to_getattr(db, program, name, result, policy);
                 // An inferred attribute accessed through an instance can resolve to an override
                 // on a subclass, so an exact class object is not a safe public type here.
-                let result = result.map_type(|ty| ty.bind_self_typevars(db, receiver));
-                promote_inferred_attribute_class_literals(db, result)
+                let result = result.map_type(|ty| ty.bind_self_typevars(db, program, receiver));
+                promote_inferred_attribute_class_literals(db, program, result)
             }
 
-            tracing::trace!("member_lookup_with_policy: {}.{}", this.display(db), name);
+            tracing::trace!(
+                "member_lookup_with_policy: {}.{}",
+                this.display(db, program),
+                name
+            );
             if let Some(fallback) = this.materialized_divergent_fallback() {
-                return fallback.member_lookup_with_policy_and_receiver(db, name, policy, receiver);
+                return fallback
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver);
             }
 
             let name_str = name.as_str();
 
             match this {
-                Type::Union(union) => union.map_with_boundness_and_qualifiers(db, |elem| {
-                    elem.member_lookup_with_policy_and_receiver(
-                        db,
-                        name_str.into(),
-                        policy,
-                        receiver,
-                    )
-                }),
+                Type::Union(union) => {
+                    union.map_with_boundness_and_qualifiers(db, program, |elem| {
+                        elem.member_lookup_with_policy_and_receiver(
+                            db,
+                            program,
+                            name_str.into(),
+                            policy,
+                            receiver,
+                        )
+                    })
+                }
 
                 Type::Intersection(intersection) => {
-                    if let Some(complement) = intersection.enum_complement(db) {
+                    if let Some(complement) = intersection.enum_complement(db, program) {
                         enums::member_lookup_for_enum_complement(db, complement, name_str, policy)
                     } else {
                         let receiver = Some(receiver.unwrap_or(this));
-                        intersection.map_with_boundness_and_qualifiers(db, |elem| {
+                        intersection.map_with_boundness_and_qualifiers(db, program, |elem| {
                             elem.member_lookup_with_policy_and_receiver(
                                 db,
+                                program,
                                 name_str.into(),
                                 policy,
                                 receiver,
@@ -4034,33 +4178,34 @@ impl<'db> Type<'db> {
                     }
                     _ => {
                         KnownClass::MethodType
-                            .to_instance(db)
+                            .to_instance(db, program)
                             .member_lookup_with_policy_and_receiver(
                                 db,
+                                program,
                                 name.clone(),
                                 policy,
                                 receiver,
                             )
-                            .or_fall_back_to(db, || {
+                            .or_fall_back_to(db, program, || {
                                 // If an attribute is not available on the bound method object,
                                 // it will be looked up on the underlying function object. This
                                 // changes the lookup object, so do not forward the bound-method
                                 // receiver.
                                 Type::FunctionLiteral(bound_method.function(db))
-                                    .member_lookup_with_policy(db, name, policy)
+                                    .member_lookup_with_policy(db, program, name, policy)
                             })
                     }
                 },
                 Type::KnownBoundMethod(method) => method
                     .class()
-                    .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .to_instance(db, program)
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver),
                 Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType
-                    .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .to_instance(db, program)
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver),
                 Type::DataclassDecorator(_) => KnownClass::FunctionType
-                    .to_instance(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .to_instance(db, program)
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver),
 
                 Type::Callable(_) | Type::DataclassTransformer(_) if name_str == "__call__" => {
                     Place::bound(this).into()
@@ -4068,18 +4213,20 @@ impl<'db> Type<'db> {
 
                 Type::Callable(callable) if callable.is_function_like(db) => {
                     KnownClass::FunctionType
-                        .to_instance(db)
-                        .member_lookup_with_policy_and_receiver(db, name, policy, receiver)
+                        .to_instance(db, program)
+                        .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver)
                 }
 
                 Type::Callable(_) | Type::DataclassTransformer(_) => Type::object()
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver),
 
                 Type::NominalInstance(instance)
                     if matches!(name.as_str(), "major" | "minor")
                         && instance.is_sys_version_info() =>
                 {
-                    let python_version = Program::get(db).python_version(db);
+                    let python_version = instance
+                        .sys_version_info_version()
+                        .expect("checked above that this is sys.version_info");
                     let segment = if name == "major" {
                         python_version.major
                     } else {
@@ -4089,13 +4236,13 @@ impl<'db> Type<'db> {
                 }
 
                 Type::PropertyInstance(property) if name == "fget" => {
-                    Place::bound(property.getter(db).unwrap_or(Type::none(db))).into()
+                    Place::bound(property.getter(db).unwrap_or(Type::none(db, program))).into()
                 }
                 Type::PropertyInstance(property) if name == "fset" => {
-                    Place::bound(property.setter(db).unwrap_or(Type::none(db))).into()
+                    Place::bound(property.setter(db).unwrap_or(Type::none(db, program))).into()
                 }
                 Type::PropertyInstance(property) if name == "fdel" => {
-                    Place::bound(property.deleter(db).unwrap_or(Type::none(db))).into()
+                    Place::bound(property.deleter(db).unwrap_or(Type::none(db, program))).into()
                 }
 
                 Type::LiteralValue(literal)
@@ -4140,24 +4287,25 @@ impl<'db> Type<'db> {
                 Type::NewTypeInstance(new_type_instance) if this.as_union_like(db).is_some() => {
                     new_type_instance
                         .concrete_base_type(db)
-                        .member_lookup_with_policy(db, name, policy)
+                        .member_lookup_with_policy(db, program, name, policy)
                 }
 
                 Type::TypeAlias(alias) => alias
                     .value_type(db)
-                    .member_lookup_with_policy_and_receiver(db, name, policy, receiver),
+                    .member_lookup_with_policy_and_receiver(db, program, name, policy, receiver),
 
                 _ if policy.no_instance_fallback() => {
                     let receiver = receiver.unwrap_or(this);
                     this.invoke_descriptor_protocol(
                         db,
+                        program,
                         receiver,
                         name_str,
                         Place::Undefined.into(),
                         InstanceFallbackShadowsNonDataDescriptor::No,
                         policy,
                     )
-                    .map_type(|ty| ty.bind_self_typevars(db, receiver))
+                    .map_type(|ty| ty.bind_self_typevars(db, program, receiver))
                 }
 
                 Type::LiteralValue(literal)
@@ -4173,7 +4321,7 @@ impl<'db> Type<'db> {
                     let enum_literal = literal.as_enum().unwrap();
                     let enum_class = enum_literal.enum_class_literal(db);
                     let is_enum_subclass = Type::ClassLiteral(enum_class.class_literal(db))
-                        .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
+                        .is_subtype_of(db, program, KnownClass::Enum.to_subclass_of(db, program));
 
                     (match name_str {
                         "name" if is_enum_subclass => {
@@ -4191,15 +4339,19 @@ impl<'db> Type<'db> {
                 }
 
                 Type::TypeVar(typevar) if name_str == "args" && typevar.is_paramspec(db) => {
-                    Place::declared(Type::TypeVar(
-                        typevar.with_paramspec_attr(db, ParamSpecAttrKind::Args),
-                    ))
+                    Place::declared(Type::TypeVar(typevar.with_paramspec_attr(
+                        db,
+                        program,
+                        ParamSpecAttrKind::Args,
+                    )))
                     .into()
                 }
                 Type::TypeVar(typevar) if name_str == "kwargs" && typevar.is_paramspec(db) => {
-                    Place::declared(Type::TypeVar(
-                        typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs),
-                    ))
+                    Place::declared(Type::TypeVar(typevar.with_paramspec_attr(
+                        db,
+                        program,
+                        ParamSpecAttrKind::Kwargs,
+                    )))
                     .into()
                 }
                 Type::TypeVar(typevar) => {
@@ -4207,41 +4359,47 @@ impl<'db> Type<'db> {
                     if let Some(bound) = typevar
                         .typevar(db)
                         .bound_or_constraints(db)
-                        .map(|bound| bound.as_type(db))
-                        && bound.to_instance(db).is_some()
+                        .map(|bound| bound.as_type(db, program))
+                        && bound.to_instance(db, program).is_some()
                     {
                         // A TypeVar can be bounded by a class-object type such as `type[A]`, which
                         // requires the full lookup path rather than instance-member lookup.
                         return bound.member_lookup_with_policy_and_receiver(
                             db,
+                            program,
                             name,
                             policy,
                             Some(receiver),
                         );
                     }
 
-                    instance_like_member_lookup(db, this, &name, policy, receiver)
+                    instance_like_member_lookup(db, program, this, &name, policy, receiver)
                 }
 
                 Type::NominalInstance(instance)
                     if matches!(name_str, "name" | "_name_" | "value" | "_value_")
-                        && enum_metadata(db, instance.class_literal(db)).is_some()
+                        && enum_metadata(db, instance.class_literal(db, program)).is_some()
                         && !enums::class_defines_property(
                             db,
-                            instance.class_literal(db),
+                            instance.class_literal(db, program),
                             name_str,
                         ) =>
                 {
-                    let class_literal = instance.class_literal(db);
-                    let is_enum_subclass = Type::ClassLiteral(class_literal)
-                        .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
+                    let class_literal = instance.class_literal(db, program);
+                    let is_enum_subclass = Type::ClassLiteral(class_literal).is_subtype_of(
+                        db,
+                        program,
+                        KnownClass::Enum.to_subclass_of(db, program),
+                    );
 
                     enum_metadata(db, class_literal)
                         .and_then(|metadata| match name_str {
-                            "name" if is_enum_subclass => metadata.instance_name_type(db),
-                            "_name_" => metadata.instance_name_type(db),
-                            "value" if is_enum_subclass => metadata.instance_value_type(db),
-                            "_value_" => metadata.instance_value_type(db),
+                            "name" if is_enum_subclass => metadata.instance_name_type(db, program),
+                            "_name_" => metadata.instance_name_type(db, program),
+                            "value" if is_enum_subclass => {
+                                metadata.instance_value_type(db, program)
+                            }
+                            "_value_" => metadata.instance_value_type(db, program),
                             _ => None,
                         })
                         .map_or_else(Place::default, Place::bound)
@@ -4251,24 +4409,21 @@ impl<'db> Type<'db> {
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial))
                     if name_str == "__call__" =>
                 {
-                    Place::bound(Type::KnownInstance(
-                        KnownInstanceType::FunctoolsPartialCall(partial),
-                    ))
-                    .into()
-                }
-
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(_))
-                    if name_str == "__call__" =>
-                {
-                    Place::bound(this).into()
+                    Place::bound(Type::Callable(partial.partial(db))).into()
                 }
 
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
                     let wrapped = partial.wrapped(db).inner(db);
                     let nominal_lookup = partial
                         .partial(db)
-                        .into_functools_partial_instance(db)
-                        .member_lookup_with_policy_and_receiver(db, name.clone(), policy, receiver);
+                        .into_functools_partial_instance(db, program)
+                        .member_lookup_with_policy_and_receiver(
+                            db,
+                            program,
+                            name.clone(),
+                            policy,
+                            receiver,
+                        );
                     if name_str == "func" {
                         match nominal_lookup.place {
                             Place::Defined(DefinedPlace {
@@ -4307,7 +4462,7 @@ impl<'db> Type<'db> {
                 | Type::TypeForm(..)
                 | Type::TypedDict(_) => {
                     let receiver = receiver.unwrap_or(this);
-                    instance_like_member_lookup(db, this, &name, policy, receiver)
+                    instance_like_member_lookup(db, program, this, &name, policy, receiver)
                 }
 
                 Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
@@ -4318,7 +4473,7 @@ impl<'db> Type<'db> {
                         Type::ClassLiteral(literal) => literal.into_enum_class(db),
                         Type::SubclassOf(subclass_of) => subclass_of
                             .subclass_of()
-                            .into_class(db)
+                            .into_class(db, program)
                             .and_then(|class| class.class_literal(db).into_enum_class(db)),
                         _ => None,
                     };
@@ -4333,16 +4488,17 @@ impl<'db> Type<'db> {
                         .into();
                     }
 
-                    let class_attr_plain = this.class_object_member(db, name_str, policy);
+                    let class_attr_plain = this.class_object_member(db, program, name_str, policy);
 
-                    let self_instance = receiver.to_instance(db).expect(
+                    let self_instance = receiver.to_instance(db, program).expect(
                         "The receiver for a class-object lookup should always be instantiable",
                     );
-                    let class_attr_plain =
-                        class_attr_plain.map_type(|ty| ty.bind_self_typevars(db, self_instance));
+                    let class_attr_plain = class_attr_plain
+                        .map_type(|ty| ty.bind_self_typevars(db, program, self_instance));
 
                     let class_attr_fallback = Type::try_call_dunder_get_on_attribute(
                         db,
+                        program,
                         class_attr_plain,
                         None,
                         receiver,
@@ -4351,6 +4507,7 @@ impl<'db> Type<'db> {
 
                     let result = this.invoke_descriptor_protocol(
                         db,
+                        program,
                         receiver,
                         name_str,
                         class_attr_fallback,
@@ -4364,13 +4521,13 @@ impl<'db> Type<'db> {
                     // attribute access falls back to `__getattr__`/`__getattribute__` on the
                     // class. `try_call_dunder` adds `NO_INSTANCE_FALLBACK`, which causes the
                     // lookup to hit the catch-all that only checks the meta-type (the metaclass).
-                    let result = this.fallback_to_getattr(db, &name, result, policy);
+                    let result = this.fallback_to_getattr(db, program, &name, result, policy);
                     // Unlike a specific class literal, `type[C]` can represent any subclass of
                     // `C`, unless a `TypeVar` upper bound normalizes to a final class.
                     let result = if let Type::SubclassOf(subclass_of) = this
-                        && subclass_of.exact_typevar_upper_bound(db).is_none()
+                        && subclass_of.exact_typevar_upper_bound(db, program).is_none()
                     {
-                        promote_inferred_attribute_class_literals(db, result)
+                        promote_inferred_attribute_class_literals(db, program, result)
                     } else {
                         result
                     };
@@ -4386,7 +4543,12 @@ impl<'db> Type<'db> {
                             if ty.is_dynamic() {
                                 ty
                             } else {
-                                IntersectionType::from_two_elements(db, ty, Type::Dynamic(dynamic))
+                                IntersectionType::from_two_elements(
+                                    db,
+                                    program,
+                                    ty,
+                                    Type::Dynamic(dynamic),
+                                )
                             }
                         })
                     } else {
@@ -4400,10 +4562,11 @@ impl<'db> Type<'db> {
                 // 1. Search for the attribute in the MRO, starting just after the pivot class.
                 // 2. If the attribute is a descriptor, invoke its `__get__` method.
                 Type::BoundSuper(bound_super) => {
-                    let owner_attr = bound_super.find_name_in_mro_after_pivot(db, name_str, policy);
+                    let owner_attr =
+                        bound_super.find_name_in_mro_after_pivot(db, program, name_str, policy);
 
                     bound_super
-                        .try_call_dunder_get_on_attribute(db, owner_attr)
+                        .try_call_dunder_get_on_attribute(db, program, owner_attr)
                         .unwrap_or(owner_attr)
                 }
             }
@@ -4411,7 +4574,7 @@ impl<'db> Type<'db> {
 
         if self.materialized_divergent_fallback().is_none() {
             if name == "__class__" {
-                return Place::bound(self.dunder_class(db)).into();
+                return Place::bound(self.dunder_class(db, program)).into();
             }
 
             if matches!(self, Type::Dynamic(_) | Type::Divergent(_) | Type::Never) {
@@ -4419,7 +4582,7 @@ impl<'db> Type<'db> {
             }
         }
 
-        member_lookup_with_policy_inner(db, self, name, policy, receiver)
+        member_lookup_with_policy_inner(db, self, program, name, policy, receiver)
     }
 
     /// Return the type of `len()` on a type if it is known more precisely than `int`,
@@ -4427,8 +4590,12 @@ impl<'db> Type<'db> {
     ///
     /// In the second case, the return type of `len()` in `typeshed` (`int`)
     /// is used as a fallback.
-    fn len(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        fn non_negative_int_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    fn len(&self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        fn non_negative_int_literal<'db>(
+            db: &'db dyn Db,
+            program: crate::Program,
+            ty: Type<'db>,
+        ) -> Option<Type<'db>> {
             match ty {
                 // TODO: Emit diagnostic for non-integers and negative integers
                 Type::LiteralValue(literal) => match literal.kind() {
@@ -4436,28 +4603,31 @@ impl<'db> Type<'db> {
                     LiteralValueTypeKind::Bool(value) => Some(Type::int_literal(i64::from(value))),
                     _ => None,
                 },
-                Type::Union(union) => {
-                    union.try_map(db, |element| non_negative_int_literal(db, *element))
-                }
+                Type::Union(union) => union.try_map(db, program, |element| {
+                    non_negative_int_literal(db, program, *element)
+                }),
                 _ => None,
             }
         }
 
         let return_ty = match self.try_call_dunder(
             db,
+            program,
             "__len__",
             CallArguments::none(),
             TypeContext::default(),
         ) {
-            Ok(bindings) => bindings.return_type(db),
-            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => bindings.return_type(db),
+            Ok(bindings) => bindings.return_type(db, program),
+            Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
+                bindings.return_type(db, program)
+            }
 
             // TODO: emit a diagnostic
             Err(CallDunderError::MethodNotAvailable) => return None,
-            Err(CallDunderError::CallError(_, bindings, _)) => bindings.return_type(db),
+            Err(CallDunderError::CallError(_, bindings, _)) => bindings.return_type(db, program),
         };
 
-        non_negative_int_literal(db, return_ty)
+        non_negative_int_literal(db, program, return_ty)
     }
 
     /// If this type is a `ParamSpec` type variable, returns it. Otherwise, returns `None`.
@@ -4471,7 +4641,12 @@ impl<'db> Type<'db> {
     // Returns the value type of a `__getitem__` dunder call on this object.
     //
     // Returns `None` if `__getitem__` is undefined or results in a call error.
-    fn getitem_dunder_call(self, db: &'db dyn Db, key: Option<&str>) -> Option<Type<'db>> {
+    fn getitem_dunder_call(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        key: Option<&str>,
+    ) -> Option<Type<'db>> {
         let key = key
             .map(|key| Type::string_literal(db, key))
             .unwrap_or(Type::unknown());
@@ -4479,6 +4654,7 @@ impl<'db> Type<'db> {
         match self
             .member_lookup_with_policy(
                 db,
+                program,
                 Name::new_static("__getitem__"),
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
             )
@@ -4489,9 +4665,9 @@ impl<'db> Type<'db> {
                 definedness: Definedness::AlwaysDefined,
                 ..
             }) => getitem_method
-                .try_call(db, &CallArguments::positional([key]))
+                .try_call(db, program, &CallArguments::positional([key]))
                 .ok()
-                .map(|bindings| bindings.return_type(db)),
+                .map(|bindings| bindings.return_type(db, program)),
 
             _ => None,
         }
@@ -4499,10 +4675,15 @@ impl<'db> Type<'db> {
 
     /// Returns the key and value types of this object if it was unpacked using `**`,
     /// or `None` if the object does not support unpacking.
-    fn unpack_keys_and_items(self, db: &'db dyn Db) -> Option<(Type<'db>, Type<'db>)> {
+    fn unpack_keys_and_items(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<(Type<'db>, Type<'db>)> {
         let key_ty = match self
             .member_lookup_with_policy(
                 db,
+                program,
                 Name::new_static("keys"),
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
             )
@@ -4513,15 +4694,15 @@ impl<'db> Type<'db> {
                 definedness: Definedness::AlwaysDefined,
                 ..
             }) => keys_method
-                .try_call(db, &CallArguments::none())
+                .try_call(db, program, &CallArguments::none())
                 .ok()
                 .and_then(|bindings| {
                     Some(
                         bindings
-                            .return_type(db)
-                            .try_iterate(db)
+                            .return_type(db, program)
+                            .try_iterate(db, program)
                             .ok()?
-                            .homogeneous_element_type(db),
+                            .homogeneous_element_type(db, program),
                     )
                 })?,
 
@@ -4529,7 +4710,7 @@ impl<'db> Type<'db> {
         };
 
         let value_ty = self
-            .getitem_dunder_call(db, None)
+            .getitem_dunder_call(db, program, None)
             .unwrap_or(Type::unknown());
 
         Some((key_ty, value_ty))
@@ -4545,9 +4726,9 @@ impl<'db> Type<'db> {
     /// elements might be inconsistent, such that there's no argument list that's valid for all
     /// elements. It's usually best to only worry about "callability" relative to a particular
     /// argument list, via [`try_call`][Self::try_call] and [`CallErrorKind::NotCallable`].
-    fn bindings(self, db: &'db dyn Db) -> Bindings<'db> {
+    fn bindings(self, db: &'db dyn Db, program: Program) -> Bindings<'db> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.bindings(db);
+            return fallback.bindings(db, program);
         }
 
         match self {
@@ -4559,11 +4740,16 @@ impl<'db> Type<'db> {
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => CallableBinding::not_callable(self).into(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.bindings(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.bindings(db, program)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Bindings::from_union(
                             self,
-                            constraints.elements(db).iter().map(|ty| ty.bindings(db)),
+                            constraints
+                                .elements(db)
+                                .iter()
+                                .map(|ty| ty.bindings(db, program)),
                         )
                     }
                 }
@@ -4572,9 +4758,6 @@ impl<'db> Type<'db> {
             Type::BoundMethod(bound_method) => {
                 let signature = bound_method.function(db).signature(db);
                 let self_instance = bound_method.self_instance(db);
-                // Class-based protocol member lookup has already specialized the method for this
-                // receiver. Bake an implicit positional receiver into the signature instead of
-                // checking it structurally again during call inference.
                 if self_instance
                     .as_protocol_instance()
                     .is_some_and(|protocol| protocol.to_nominal_instance().is_some())
@@ -4586,7 +4769,7 @@ impl<'db> Type<'db> {
                     let mut binding =
                         CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
                             .with_bound_type(bound_method.typing_self_type(db));
-                    binding.bake_bound_type_into_overloads(db);
+                    binding.bake_bound_type_into_overloads(db, program);
                     binding.into()
                 } else {
                     CallableBinding::from_overloads(self, signature.overloads.iter().cloned())
@@ -4596,11 +4779,12 @@ impl<'db> Type<'db> {
             }
 
             Type::KnownBoundMethod(method) => {
-                CallableBinding::from_overloads(self, method.signatures(db)).into()
+                CallableBinding::from_overloads(self, method.signatures(db, program)).into()
             }
 
             Type::WrapperDescriptor(wrapper_descriptor) => {
-                CallableBinding::from_overloads(self, wrapper_descriptor.signatures(db)).into()
+                CallableBinding::from_overloads(self, wrapper_descriptor.signatures(db, program))
+                    .into()
             }
 
             // TODO: We should probably also check the original return type of the function
@@ -4622,6 +4806,7 @@ impl<'db> Type<'db> {
                 Some(KnownFunction::AssertType) => {
                     let val_ty = BoundTypeVarInstance::synthetic(
                         db,
+                        program,
                         Name::new_static("T"),
                         TypeVarVariance::Invariant,
                     );
@@ -4629,7 +4814,11 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new_generic(
-                            Some(GenericContext::from_typevar_instances(db, [val_ty])),
+                            Some(GenericContext::from_typevar_instances(
+                                db,
+                                program,
+                                [val_ty],
+                            )),
                             Parameters::standard([
                                 Parameter::positional_only(Some(Name::new_static("value")))
                                     .with_annotated_type(Type::TypeVar(val_ty)),
@@ -4675,9 +4864,10 @@ impl<'db> Type<'db> {
                 .into(),
 
                 Some(KnownFunction::Dataclass) => {
+                    let python_version = function_type.program(db).python_version(db);
                     let bool_parameter = |name: &'static str, default: bool| {
                         Parameter::keyword_only(Name::new_static(name))
-                            .with_annotated_type(KnownClass::Bool.to_instance(db))
+                            .with_annotated_type(KnownClass::Bool.to_instance(db, program))
                             .with_default_type(Type::bool_literal(default))
                     };
 
@@ -4690,7 +4880,7 @@ impl<'db> Type<'db> {
                         bool_parameter("frozen", false),
                     ];
 
-                    if Program::get(db).python_version(db) >= ast::PythonVersion::PY310 {
+                    if python_version >= ast::PythonVersion::PY310 {
                         decorator_factory_parameters.extend([
                             bool_parameter("match_args", true),
                             bool_parameter("kw_only", false),
@@ -4698,7 +4888,7 @@ impl<'db> Type<'db> {
                         ]);
                     }
 
-                    if Program::get(db).python_version(db) >= ast::PythonVersion::PY311 {
+                    if python_version >= ast::PythonVersion::PY311 {
                         decorator_factory_parameters.push(bool_parameter("weakref_slot", false));
                     }
 
@@ -4718,13 +4908,13 @@ impl<'db> Type<'db> {
                         [
                             // def dataclass(cls: None, /, *, ...) -> Callable[[type[_T]], type[_T]]: ...
                             Signature::new(
-                                Parameters::standard(parameters_with_cls(Type::none(db))),
+                                Parameters::standard(parameters_with_cls(Type::none(db, program))),
                                 Type::unknown(),
                             ),
                             // def dataclass(cls: type[_T], /, *, ...) -> type[_T]: ...
                             Signature::new(
                                 Parameters::standard(parameters_with_cls(
-                                    KnownClass::Type.to_instance(db),
+                                    KnownClass::Type.to_instance(db, program),
                                 )),
                                 Type::unknown(),
                             ),
@@ -4772,9 +4962,11 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => {
                     let constructor_instance_type = Type::TypeVar(tvar);
                     let bindings = match tvar.typevar(db).bound_or_constraints(db) {
-                        None => KnownClass::Type.to_instance(db).bindings(db),
+                        None => KnownClass::Type
+                            .to_instance(db, program)
+                            .bindings(db, program),
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                            bound.to_meta_type(db).bindings(db)
+                            bound.to_meta_type(db, program).bindings(db, program)
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                             Bindings::from_union(
@@ -4782,7 +4974,7 @@ impl<'db> Type<'db> {
                                 constraints
                                     .elements(db)
                                     .iter()
-                                    .map(|ty| ty.to_meta_type(db).bindings(db)),
+                                    .map(|ty| ty.to_meta_type(db, program).bindings(db, program)),
                             )
                         }
                     };
@@ -4821,6 +5013,7 @@ impl<'db> Type<'db> {
                 match self
                     .member_lookup_with_policy(
                         db,
+                        program,
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
@@ -4831,7 +5024,7 @@ impl<'db> Type<'db> {
                         definedness: boundness,
                         ..
                     }) => {
-                        let mut bindings = dunder_callable.bindings(db);
+                        let mut bindings = dunder_callable.bindings(db, program);
                         bindings.replace_callable_type(dunder_callable, self);
                         if boundness == Definedness::PossiblyUndefined {
                             bindings.set_dunder_call_is_possibly_unbound();
@@ -4854,31 +5047,35 @@ impl<'db> Type<'db> {
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings(db, program)),
             ),
 
             Type::Intersection(intersection) => Bindings::from_intersection(
                 self,
                 intersection
                     .positive_elements_or_object(db)
-                    .map(|element| element.bindings(db)),
+                    .map(|element| element.bindings(db, program)),
             ),
 
-            Type::EnumComplement(complement) => complement.to_intersection(db).bindings(db),
+            Type::EnumComplement(complement) => {
+                complement.to_intersection(db).bindings(db, program)
+            }
 
             Type::DataclassDecorator(_) => {
                 let typevar = BoundTypeVarInstance::synthetic(
                     db,
+                    program,
                     Name::new_static("T"),
                     TypeVarVariance::Invariant,
                 );
-                let typevar_meta = SubclassOfType::from(db, typevar);
-                let context = GenericContext::from_typevar_instances(db, [typevar]);
+                let typevar_meta = SubclassOfType::from(db, program, typevar);
+                let context = GenericContext::from_typevar_instances(db, program, [typevar]);
                 let parameters = [Parameter::positional_only(Some(Name::new_static("cls")))
                     .with_annotated_type(typevar_meta)];
                 // Intersect with `Any` for the return type to reflect the fact that the `dataclass()`
                 // decorator adds methods to the class
-                let returns = IntersectionType::from_two_elements(db, typevar_meta, Type::any());
+                let returns =
+                    IntersectionType::from_two_elements(db, program, typevar_meta, Type::any());
                 let signature = Signature::new_generic(
                     Some(context),
                     Parameters::standard(parameters),
@@ -4892,7 +5089,7 @@ impl<'db> Type<'db> {
 
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => {
-                    enum_literal.enum_class_instance(db).bindings(db)
+                    enum_literal.enum_class_instance(db).bindings(db, program)
                 }
                 _ => CallableBinding::not_callable(self).into(),
             },
@@ -4901,22 +5098,21 @@ impl<'db> Type<'db> {
                 self,
                 Signature::new(
                     Parameters::standard([Parameter::positional_only(None)
-                        .with_annotated_type(newtype.base(db).instance_type(db))]),
+                        .with_annotated_type(newtype.base(db).instance_type(db, program))]),
                     Type::NewTypeInstance(newtype),
                 ),
             )
             .into(),
 
-            Type::KnownInstance(
-                KnownInstanceType::FunctoolsPartial(partial)
-                | KnownInstanceType::FunctoolsPartialCall(partial),
-            ) => Type::Callable(partial.partial(db)).bindings(db),
-
-            Type::KnownInstance(known_instance) => {
-                known_instance.instance_fallback(db).bindings(db)
+            Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)) => {
+                Type::Callable(partial.partial(db)).bindings(db, program)
             }
 
-            Type::TypeAlias(alias) => alias.value_type(db).bindings(db),
+            Type::KnownInstance(known_instance) => known_instance
+                .instance_fallback(db, program)
+                .bindings(db, program),
+
+            Type::TypeAlias(alias) => alias.value_type(db).bindings(db, program),
 
             Type::PropertyInstance(_)
             | Type::AlwaysFalsy
@@ -4935,6 +5131,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         class: ClassLiteral<'db>,
     ) -> Option<Bindings<'db>> {
+        let program = class.program(db);
         // TODO: Some of these cases date back to when we didn't even support overloads yet; see if
         // any can be removed: https://github.com/astral-sh/ty/issues/2715
         match class.known(db)? {
@@ -4952,7 +5149,7 @@ impl<'db> Type<'db> {
                             ))
                             .with_annotated_type(Type::any())
                             .with_default_type(Type::bool_literal(false))]),
-                            KnownClass::Bool.to_instance(db),
+                            KnownClass::Bool.to_instance(db, program),
                         ),
                     )
                     .into(),
@@ -4992,16 +5189,19 @@ impl<'db> Type<'db> {
                                     Parameter::positional_only(Some(Name::new_static("obj")))
                                         .with_annotated_type(Type::any()),
                                 ]),
-                                KnownClass::Super.to_instance(db),
+                                KnownClass::Super.to_instance(db, program),
                             ),
                             Signature::new(
                                 Parameters::standard([Parameter::positional_only(Some(
                                     Name::new_static("t"),
                                 ))
                                 .with_annotated_type(Type::any())]),
-                                KnownClass::Super.to_instance(db),
+                                KnownClass::Super.to_instance(db, program),
                             ),
-                            Signature::new(Parameters::empty(), KnownClass::Super.to_instance(db)),
+                            Signature::new(
+                                Parameters::empty(),
+                                KnownClass::Super.to_instance(db, program),
+                            ),
                         ],
                     )
                     .into(),
@@ -5020,7 +5220,7 @@ impl<'db> Type<'db> {
                 //         stacklevel: int = 1
                 //     ) -> Self: ...
                 // ```
-                let warning_class_type = KnownClass::Warning.to_subclass_of(db);
+                let warning_class_type = KnownClass::Warning.to_subclass_of(db, program);
 
                 Some(
                     Binding::single(
@@ -5032,15 +5232,16 @@ impl<'db> Type<'db> {
                                 Parameter::keyword_only(Name::new_static("category"))
                                     .with_annotated_type(UnionType::from_two_elements(
                                         db,
+                                        program,
                                         warning_class_type,
-                                        Type::none(db),
+                                        Type::none(db, program),
                                     ))
                                     .with_default_type(warning_class_type),
                                 Parameter::keyword_only(Name::new_static("stacklevel"))
-                                    .with_annotated_type(KnownClass::Int.to_instance(db))
+                                    .with_annotated_type(KnownClass::Int.to_instance(db, program))
                                     .with_default_type(Type::int_literal(1)),
                             ]),
-                            KnownClass::Deprecated.to_instance(db),
+                            KnownClass::Deprecated.to_instance(db, program),
                         ),
                     )
                     .into(),
@@ -5063,7 +5264,7 @@ impl<'db> Type<'db> {
                         Signature::new(
                             Parameters::standard([
                                 Parameter::positional_or_keyword(Name::new_static("name"))
-                                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
                                 Parameter::positional_or_keyword(Name::new_static("value"))
                                     .with_annotated_type(object_type_form(db)),
                                 Parameter::keyword_only(Name::new_static("type_params"))
@@ -5071,10 +5272,11 @@ impl<'db> Type<'db> {
                                         db,
                                         UnionType::from_elements(
                                             db,
+                                            program,
                                             [
-                                                KnownClass::TypeVar.to_instance(db),
-                                                KnownClass::ParamSpec.to_instance(db),
-                                                KnownClass::TypeVarTuple.to_instance(db),
+                                                KnownClass::TypeVar.to_instance(db, program),
+                                                KnownClass::ParamSpec.to_instance(db, program),
+                                                KnownClass::TypeVarTuple.to_instance(db, program),
                                             ],
                                         ),
                                     ))
@@ -5099,7 +5301,7 @@ impl<'db> Type<'db> {
                         Parameter::positional_only(None).with_annotated_type(Type::any()),
                         Parameter::positional_only(None).with_annotated_type(Type::any()),
                     ]),
-                    Type::none(db),
+                    Type::none(db, program),
                 );
                 let deleter_signature = Signature::new(
                     Parameters::standard([
@@ -5116,31 +5318,35 @@ impl<'db> Type<'db> {
                                 Parameter::positional_or_keyword(Name::new_static("fget"))
                                     .with_annotated_type(UnionType::from_two_elements(
                                         db,
+                                        program,
                                         Type::single_callable(db, getter_signature),
-                                        Type::none(db),
+                                        Type::none(db, program),
                                     ))
-                                    .with_default_type(Type::none(db)),
+                                    .with_default_type(Type::none(db, program)),
                                 Parameter::positional_or_keyword(Name::new_static("fset"))
                                     .with_annotated_type(UnionType::from_two_elements(
                                         db,
+                                        program,
                                         Type::single_callable(db, setter_signature),
-                                        Type::none(db),
+                                        Type::none(db, program),
                                     ))
-                                    .with_default_type(Type::none(db)),
+                                    .with_default_type(Type::none(db, program)),
                                 Parameter::positional_or_keyword(Name::new_static("fdel"))
                                     .with_annotated_type(UnionType::from_two_elements(
                                         db,
+                                        program,
                                         Type::single_callable(db, deleter_signature),
-                                        Type::none(db),
+                                        Type::none(db, program),
                                     ))
-                                    .with_default_type(Type::none(db)),
+                                    .with_default_type(Type::none(db, program)),
                                 Parameter::positional_or_keyword(Name::new_static("doc"))
                                     .with_annotated_type(UnionType::from_two_elements(
                                         db,
-                                        KnownClass::Str.to_instance(db),
-                                        Type::none(db),
+                                        program,
+                                        KnownClass::Str.to_instance(db, program),
+                                        Type::none(db, program),
                                     ))
-                                    .with_default_type(Type::none(db)),
+                                    .with_default_type(Type::none(db, program)),
                             ]),
                             Type::unknown(),
                         ),
@@ -5156,6 +5362,7 @@ impl<'db> Type<'db> {
                 // ```
                 let return_ty = BoundTypeVarInstance::synthetic(
                     db,
+                    program,
                     Name::new_static("_T"),
                     TypeVarVariance::Covariant,
                 );
@@ -5164,9 +5371,14 @@ impl<'db> Type<'db> {
                     Binding::single(
                         self,
                         Signature::new_generic(
-                            Some(GenericContext::from_typevar_instances(db, [return_ty])),
+                            Some(GenericContext::from_typevar_instances(
+                                db,
+                                program,
+                                [return_ty],
+                            )),
                             Parameters::concatenate(
                                 db,
+                                program,
                                 vec![
                                     Parameter::positional_only(Some(Name::new_static("func")))
                                         .with_annotated_type(Type::single_callable(
@@ -5179,8 +5391,11 @@ impl<'db> Type<'db> {
                                 ],
                                 ConcatenateTail::Gradual,
                             ),
-                            KnownClass::FunctoolsPartial
-                                .to_specialized_instance(db, &[Type::TypeVar(return_ty)]),
+                            KnownClass::FunctoolsPartial.to_specialized_instance(
+                                db,
+                                program,
+                                &[Type::TypeVar(return_ty)],
+                            ),
                         ),
                     )
                     .into(),
@@ -5190,6 +5405,7 @@ impl<'db> Type<'db> {
             KnownClass::Tuple => {
                 let element_ty = BoundTypeVarInstance::synthetic(
                     db,
+                    program,
                     Name::new_static("T"),
                     TypeVarVariance::Covariant,
                 );
@@ -5207,13 +5423,20 @@ impl<'db> Type<'db> {
                         [
                             Signature::new(Parameters::empty(), Type::empty_tuple(db)),
                             Signature::new_generic(
-                                Some(GenericContext::from_typevar_instances(db, [element_ty])),
+                                Some(GenericContext::from_typevar_instances(
+                                    db,
+                                    program,
+                                    [element_ty],
+                                )),
                                 Parameters::standard([Parameter::positional_only(Some(
                                     Name::new_static("iterable"),
                                 ))
                                 .with_annotated_type(
-                                    KnownClass::Iterable
-                                        .to_specialized_instance(db, &[Type::TypeVar(element_ty)]),
+                                    KnownClass::Iterable.to_specialized_instance(
+                                        db,
+                                        program,
+                                        &[Type::TypeVar(element_ty)],
+                                    ),
                                 )]),
                                 Type::homogeneous_tuple(db, Type::TypeVar(element_ty)),
                             ),
@@ -5232,6 +5455,7 @@ impl<'db> Type<'db> {
     fn constructor_bindings(self, db: &'db dyn Db, class: ClassType<'db>) -> Bindings<'db> {
         fn resolve_dunder_new_callable<'db>(
             db: &'db dyn Db,
+            program: Program,
             owner: Type<'db>,
             place: Place<'db>,
         ) -> Option<(Type<'db>, Definedness)> {
@@ -5248,7 +5472,7 @@ impl<'db> Type<'db> {
             ) {
                 return None;
             }
-            match place.try_call_dunder_get(db, owner) {
+            match place.try_call_dunder_get(db, program, owner) {
                 Place::Defined(DefinedPlace {
                     ty: callable,
                     definedness,
@@ -5259,6 +5483,7 @@ impl<'db> Type<'db> {
         }
         fn bind_constructor_new<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             bindings: Bindings<'db>,
             self_type: Type<'db>,
         ) -> Bindings<'db> {
@@ -5268,18 +5493,19 @@ impl<'db> Type<'db> {
                 // first, then bind `cls` for constructor-call semantics (the call site omits `cls`).
                 // Note: This intentionally preserves `type.__call__` behavior for `@classmethod __new__`,
                 // which receives an extra implicit `cls` and errors at call sites.
-                binding.bake_bound_type_into_overloads(db);
+                binding.bake_bound_type_into_overloads(db, program);
                 binding.bound_type = Some(self_type);
                 binding
             })
         }
 
+        let program = class.program(db);
         let class_literal = class.class_literal(db);
         let class_generic_context = class_literal.generic_context(db);
 
         // Keep bespoke constructor behavior for cases that don't map cleanly to `__new__`/`__init__`.
         let fallback_bindings = || {
-            let return_type = self.to_instance(db).unwrap_or(Type::unknown());
+            let return_type = self.to_instance(db, program).unwrap_or(Type::unknown());
             Binding::single(
                 self,
                 Signature::new_generic(
@@ -5325,7 +5551,7 @@ impl<'db> Type<'db> {
         // functional syntax for creating enum classes. TODO we should ideally check e.g.
         // `MyEnum(1)` to make sure `1` is a valid value for `MyEnum`.
         if KnownClass::Enum
-            .to_class_literal(db)
+            .to_class_literal(db, program)
             .to_class_type(db)
             .is_some_and(|enum_class| class.is_subclass_of(db, enum_class))
         {
@@ -5352,33 +5578,39 @@ impl<'db> Type<'db> {
         // until call-time overload resolution.
         let metaclass_dunder_call = self_type.member_lookup_with_policy(
             db,
+            program,
             "__call__".into(),
             MemberLookupPolicy::NO_INSTANCE_FALLBACK
                 | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
         );
 
-        let Some(constructor_instance_ty) = self_type.to_instance(db) else {
+        let Some(constructor_instance_ty) = self_type.to_instance(db, program) else {
             return fallback_bindings();
         };
 
-        let new_method = self_type.lookup_dunder_new(db);
+        let new_method = self_type.lookup_dunder_new(db, program);
 
         let init_method_no_object = constructor_instance_ty.member_lookup_with_policy(
             db,
+            program,
             "__init__".into(),
             MemberLookupPolicy::NO_INSTANCE_FALLBACK | MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
 
         let (new_bindings, has_any_new) = match new_method.as_ref().map(|method| method.place) {
-            Some(place) => match resolve_dunder_new_callable(db, self_type, place) {
+            Some(place) => match resolve_dunder_new_callable(db, program, self_type, place) {
                 Some((new_callable, definedness)) => {
-                    let mut bindings =
-                        bind_constructor_new(db, new_callable.bindings(db), self_type)
-                            .into_constructor_bindings(
-                                constructor_instance_ty,
-                                ConstructorCallableKind::New,
-                            )
-                            .with_constructed_instance_type(db, constructor_instance_ty);
+                    let mut bindings = bind_constructor_new(
+                        db,
+                        program,
+                        new_callable.bindings(db, program),
+                        self_type,
+                    )
+                    .into_constructor_bindings(
+                        constructor_instance_ty,
+                        ConstructorCallableKind::New,
+                    )
+                    .with_constructed_instance_type(db, constructor_instance_ty);
                     if definedness == Definedness::PossiblyUndefined {
                         bindings.set_implicit_dunder_new_is_possibly_unbound();
                     }
@@ -5400,7 +5632,7 @@ impl<'db> Type<'db> {
                 _,
             ) => {
                 let mut bindings = init_method
-                    .bindings(db)
+                    .bindings(db, program)
                     .into_constructor_bindings(
                         constructor_instance_ty,
                         ConstructorCallableKind::Init,
@@ -5414,6 +5646,7 @@ impl<'db> Type<'db> {
             (Place::Undefined, false) => {
                 let init_method_with_object = constructor_instance_ty.member_lookup_with_policy(
                     db,
+                    program,
                     "__init__".into(),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 );
@@ -5424,7 +5657,7 @@ impl<'db> Type<'db> {
                         ..
                     }) => {
                         let mut bindings = init_method
-                            .bindings(db)
+                            .bindings(db, program)
                             .into_constructor_bindings(
                                 constructor_instance_ty,
                                 ConstructorCallableKind::Init,
@@ -5478,7 +5711,7 @@ impl<'db> Type<'db> {
         }) = metaclass_dunder_call.place
         {
             let mut metaclass_bindings = metaclass_call_method
-                .bindings(db)
+                .bindings(db, program)
                 .into_constructor_bindings(
                     constructor_instance_ty,
                     ConstructorCallableKind::MetaclassCall,
@@ -5508,13 +5741,15 @@ impl<'db> Type<'db> {
     fn try_call(
         self,
         db: &'db dyn Db,
+        program: Program,
         argument_types: &CallArguments<'_, 'db>,
     ) -> Result<Bindings<'db>, CallError<'db>> {
         let constraints = ConstraintSetBuilder::new();
-        self.bindings(db)
-            .match_parameters(db, argument_types)
+        self.bindings(db, program)
+            .match_parameters(db, program, argument_types)
             .check_types(
                 db,
+                program,
                 &constraints,
                 argument_types,
                 TypeContext::default(),
@@ -5529,12 +5764,14 @@ impl<'db> Type<'db> {
     fn try_call_dunder(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         mut argument_types: CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         self.try_call_dunder_with_policy(
             db,
+            program,
             name,
             &mut argument_types,
             tcx,
@@ -5552,24 +5789,39 @@ impl<'db> Type<'db> {
     fn try_call_dunder_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         argument_types: &mut CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         if let Type::Intersection(intersection) = self {
-            return intersection.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
+            return intersection.try_call_dunder_with_policy(
+                db,
+                program,
+                name,
+                argument_types,
+                tcx,
+                policy,
+            );
         }
 
         if let Type::Union(union) = self {
-            return union.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
+            return union.try_call_dunder_with_policy(
+                db,
+                program,
+                name,
+                argument_types,
+                tcx,
+                policy,
+            );
         }
 
         // Implicit calls to dunder methods never access instance members, so we pass
         // `NO_INSTANCE_FALLBACK` here in addition to other policies:
         let policy = policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK;
         match self
-            .member_lookup_with_policy(db, name.into(), policy)
+            .member_lookup_with_policy(db, program, name.into(), policy)
             .place
         {
             Place::Defined(DefinedPlace {
@@ -5580,9 +5832,9 @@ impl<'db> Type<'db> {
             }) => {
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
-                    .bindings(db)
-                    .match_parameters(db, argument_types)
-                    .check_types(db, &constraints, argument_types, tcx, &[]);
+                    .bindings(db, program)
+                    .match_parameters(db, program, argument_types)
+                    .check_types(db, program, &constraints, argument_types, tcx, &[]);
 
                 let bindings = match bindings {
                     Ok(bindings) => bindings,
@@ -5613,11 +5865,12 @@ impl<'db> Type<'db> {
     fn try_call_dunder_on_class(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         argument_types: &CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        match self.member(db, name).place {
+        match self.member(db, program, name).place {
             Place::Defined(DefinedPlace {
                 ty: dunder_callable,
                 definedness: boundness,
@@ -5626,9 +5879,9 @@ impl<'db> Type<'db> {
             }) => {
                 let constraints = ConstraintSetBuilder::new();
                 let bindings = dunder_callable
-                    .bindings(db)
-                    .match_parameters(db, argument_types)
-                    .check_types(db, &constraints, argument_types, tcx, &[]);
+                    .bindings(db, program)
+                    .match_parameters(db, program, argument_types)
+                    .check_types(db, program, &constraints, argument_types, tcx, &[]);
 
                 let bindings = match bindings {
                     Ok(bindings) => bindings,
@@ -5656,6 +5909,7 @@ impl<'db> Type<'db> {
     fn fallback_to_getattr(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         name: &Name,
         result: PlaceAndQualifiers<'db>,
         policy: MemberLookupPolicy,
@@ -5667,11 +5921,12 @@ impl<'db> Type<'db> {
 
             self.try_call_dunder(
                 db,
+                program,
                 "__getattr__",
                 CallArguments::positional([Type::string_literal(db, name)]),
                 TypeContext::default(),
             )
-            .map(|outcome| Place::bound(outcome.return_type(db)))
+            .map(|outcome| Place::bound(outcome.return_type(db, program)))
             // TODO: Handle call errors here.
             .unwrap_or_default()
             .into()
@@ -5686,12 +5941,13 @@ impl<'db> Type<'db> {
             // already model via the normal attribute-lookup path.
             self.try_call_dunder_with_policy(
                 db,
+                program,
                 "__getattribute__",
                 &mut CallArguments::positional([Type::string_literal(db, name)]),
                 TypeContext::default(),
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
             )
-            .map(|outcome| Place::bound(outcome.return_type(db)))
+            .map(|outcome| Place::bound(outcome.return_type(db, program)))
             // TODO: Handle call errors here.
             .unwrap_or_default()
             .into()
@@ -5714,12 +5970,12 @@ impl<'db> Type<'db> {
                     }),
                 qualifiers: _,
             } => member
-                .or_fall_back_to(db, custom_getattribute_result)
-                .or_fall_back_to(db, custom_getattr_result),
+                .or_fall_back_to(db, program, custom_getattribute_result)
+                .or_fall_back_to(db, program, custom_getattr_result),
             PlaceAndQualifiers {
                 place: Place::Undefined,
                 qualifiers: _,
-            } => custom_getattribute_result().or_fall_back_to(db, custom_getattr_result),
+            } => custom_getattribute_result().or_fall_back_to(db, program, custom_getattr_result),
         }
     }
 
@@ -5738,13 +5994,15 @@ impl<'db> Type<'db> {
     ///
     /// This only flattens typevars directly in unions and intersections; it does not descend
     /// into generic types or other nested structures.
-    fn flatten_typevars(self, db: &'db dyn Db) -> Type<'db> {
+    fn flatten_typevars(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
-                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.flatten_typevars(db),
-                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    constraints.as_type(db).flatten_typevars(db)
+                Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                    bound.flatten_typevars(db, program)
                 }
+                Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
+                    .as_type(db, program)
+                    .flatten_typevars(db, program),
                 // Unbounded typevar is effectively `object`.
                 None => Type::object(),
             },
@@ -5752,17 +6010,21 @@ impl<'db> Type<'db> {
                 // Flatten each element and rebuild through the union builder.
                 UnionType::from_elements(
                     db,
-                    union.elements(db).iter().map(|e| e.flatten_typevars(db)),
+                    program,
+                    union
+                        .elements(db)
+                        .iter()
+                        .map(|e| e.flatten_typevars(db, program)),
                 )
             }
             Type::Intersection(intersection) => {
                 // Flatten each positive element and rebuild through the intersection builder.
-                let mut builder = IntersectionBuilder::new(db);
+                let mut builder = IntersectionBuilder::new(db, program);
                 for pos in intersection.positive(db) {
-                    builder = builder.add_positive(pos.flatten_typevars(db));
+                    builder = builder.add_positive(pos.flatten_typevars(db, program));
                 }
                 for neg in intersection.negative(db) {
-                    builder = builder.add_negative(neg.flatten_typevars(db));
+                    builder = builder.add_negative(neg.flatten_typevars(db, program));
                 }
                 builder.build()
             }
@@ -5772,19 +6034,22 @@ impl<'db> Type<'db> {
     }
 
     /// Resolve the type of an `await …` expression where `self` is the type of the awaitable.
-    fn try_await(self, db: &'db dyn Db) -> Result<Type<'db>, AwaitError<'db>> {
+    fn try_await(self, db: &'db dyn Db, program: Program) -> Result<Type<'db>, AwaitError<'db>> {
         let await_result = self.try_call_dunder(
             db,
+            program,
             "__await__",
             CallArguments::none(),
             TypeContext::default(),
         );
         match await_result {
             Ok(bindings) => {
-                let return_type = bindings.return_type(db);
-                Ok(return_type.generator_return_type(db).ok_or_else(|| {
-                    AwaitError::InvalidReturnType(return_type, Box::new(bindings))
-                })?)
+                let return_type = bindings.return_type(db, program);
+                Ok(return_type
+                    .generator_return_type(db, program)
+                    .ok_or_else(|| {
+                        AwaitError::InvalidReturnType(return_type, Box::new(bindings))
+                    })?)
             }
             Err(call_error) => Err(AwaitError::Call(call_error)),
         }
@@ -5794,7 +6059,7 @@ impl<'db> Type<'db> {
     ///
     /// This corresponds to the `ReturnT` parameter of the generic `typing.Generator[YieldT, SendT, ReturnT]`
     /// protocol.
-    fn generator_types(self, db: &'db dyn Db) -> Option<GeneratorTypes<'db>> {
+    fn generator_types(self, db: &'db dyn Db, program: Program) -> Option<GeneratorTypes<'db>> {
         // TODO: Ideally, we would first try to upcast `self` to an instance of `Generator` and *then*
         // match on the protocol instance to get the `ReturnType` type parameter. For now, implement
         // an ad-hoc solution that works for protocols and instances of classes that explicitly inherit
@@ -5829,8 +6094,8 @@ impl<'db> Type<'db> {
             {
                 Some(GeneratorTypes {
                     yield_ty: Some(*yield_ty),
-                    send_ty: Some(Type::none(db)),
-                    return_ty: Some(Type::none(db)),
+                    send_ty: Some(Type::none(db, program)),
+                    return_ty: Some(Type::none(db, program)),
                 })
             } else {
                 None
@@ -5838,9 +6103,10 @@ impl<'db> Type<'db> {
         };
 
         match self {
-            Type::NominalInstance(instance) => {
-                instance.class(db).iter_mro(db).find_map(from_class_base)
-            }
+            Type::NominalInstance(instance) => instance
+                .class(db, program)
+                .iter_mro(db)
+                .find_map(from_class_base),
             Type::ProtocolInstance(instance) => {
                 if let Protocol::FromClass(class) = instance.inner {
                     class.iter_mro(db).find_map(from_class_base)
@@ -5849,12 +6115,12 @@ impl<'db> Type<'db> {
                 }
             }
             Type::Union(union) => {
-                let mut yield_builder = Some(UnionBuilder::new(db));
-                let mut send_builder = Some(UnionBuilder::new(db));
-                let mut return_builder = Some(UnionBuilder::new(db));
+                let mut yield_builder = Some(UnionBuilder::new(db, program));
+                let mut send_builder = Some(UnionBuilder::new(db, program));
+                let mut return_builder = Some(UnionBuilder::new(db, program));
 
                 for ty in union.elements(db) {
-                    let gt = ty.generator_types(db)?;
+                    let gt = ty.generator_types(db, program)?;
                     match gt.yield_ty {
                         Some(ty) => yield_builder = yield_builder.map(|b| b.add(ty)),
                         None => yield_builder = None,
@@ -5879,13 +6145,13 @@ impl<'db> Type<'db> {
                 // Using `positive()` rather than `positive_elements_or_object()` is safe
                 // here because `object` is not a generator, so falling back to it would
                 // still return `None`.
-                let mut yield_builder = Some(IntersectionBuilder::new(db));
-                let mut send_builder = Some(IntersectionBuilder::new(db));
-                let mut return_builder = Some(IntersectionBuilder::new(db));
+                let mut yield_builder = Some(IntersectionBuilder::new(db, program));
+                let mut send_builder = Some(IntersectionBuilder::new(db, program));
+                let mut return_builder = Some(IntersectionBuilder::new(db, program));
                 let mut any_success = false;
 
                 for ty in intersection.positive(db) {
-                    let Some(gt) = ty.generator_types(db) else {
+                    let Some(gt) = ty.generator_types(db, program) else {
                         continue;
                     };
                     any_success = true;
@@ -5928,18 +6194,18 @@ impl<'db> Type<'db> {
         }
     }
 
-    fn generator_return_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.generator_types(db)
+    fn generator_return_type(self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        self.generator_types(db, program)
             .and_then(|generator_types| generator_types.return_ty)
     }
 
-    fn generator_send_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.generator_types(db)
+    fn generator_send_type(self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        self.generator_types(db, program)
             .and_then(|generator_types| generator_types.send_ty)
     }
 
     #[must_use]
-    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn to_instance(self, db: &'db dyn Db, program: crate::Program) -> Option<Type<'db>> {
         match self {
             Type::Dynamic(_) | Type::Divergent(_) | Type::Never => Some(self),
             Type::ClassLiteral(class) => Some(Type::instance(db, class.default_specialization(db))),
@@ -5948,20 +6214,22 @@ impl<'db> Type<'db> {
             Type::KnownInstance(KnownInstanceType::NewType(newtype)) => {
                 Some(Type::NewTypeInstance(newtype))
             }
-            Type::Union(union) => union.to_instance(db),
+            Type::Union(union) => union.to_instance(db, program),
             // If there is no bound or constraints on a typevar `T`, `T: object` implicitly, which
             // has no instance type. Otherwise, synthesize a typevar with bound or constraints
             // mapped through `to_instance`.
-            Type::TypeVar(bound_typevar) => Some(Type::TypeVar(bound_typevar.to_instance(db)?)),
-            Type::TypeAlias(alias) => alias.value_type(db).to_instance(db),
+            Type::TypeVar(bound_typevar) => {
+                Some(Type::TypeVar(bound_typevar.to_instance(db, program)?))
+            }
+            Type::TypeAlias(alias) => alias.value_type(db).to_instance(db, program),
             Type::Intersection(_) => Some(todo_type!("Type::Intersection.to_instance")),
             // An instance of class `C` may itself have instances if `C` is a subclass of `type`.
             Type::NominalInstance(instance)
                 if KnownClass::Type
-                    .to_class_literal(db)
+                    .to_class_literal(db, program)
                     .to_class_type(db)
                     .is_some_and(|type_class| {
-                        instance.class(db).is_subclass_of(db, type_class)
+                        instance.class(db, program).is_subclass_of(db, type_class)
                     }) =>
             {
                 Some(Type::object())
@@ -6004,6 +6272,7 @@ impl<'db> Type<'db> {
     pub(crate) fn in_type_expression(
         &self,
         db: &'db dyn Db,
+        program: Program,
         scope_id: ScopeId<'db>,
         typevar_binding_context: Option<Definition<'db>>,
         inference_flags: InferenceFlags,
@@ -6013,8 +6282,8 @@ impl<'db> Type<'db> {
             // https://typing.python.org/en/latest/spec/special-types.html#special-cases-for-float-and-complex
             Type::ClassLiteral(class) => {
                 let ty = match class.known(db) {
-                    Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
-                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
+                    Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db, program),
+                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db, program),
                     _ => Type::instance(db, class.default_specialization(db)),
                 };
                 Ok(ty)
@@ -6063,7 +6332,7 @@ impl<'db> Type<'db> {
                             fallback_type: Type::unknown(),
                         });
                     }
-                    let index = semantic_index(db, scope_id.file(db));
+                    let index = semantic_index(db, scope_id.program_file(db));
                     Ok(bind_typevar(
                         db,
                         index,
@@ -6122,7 +6391,7 @@ impl<'db> Type<'db> {
                     // (`int` -> instance of `int` -> subclass of `int`) can be lossy, but it is
                     // okay for all valid arguments to `type[…]`.
 
-                    Ok(instance.inner(db).to_meta_type(db))
+                    Ok(instance.inner(db).to_meta_type(db, program))
                 }
                 KnownInstanceType::Callable(callable) => Ok(Type::Callable(*callable)),
                 KnownInstanceType::LiteralStringAlias(ty) => Ok(ty.inner(db)),
@@ -6140,7 +6409,13 @@ impl<'db> Type<'db> {
             },
 
             Type::SpecialForm(special_form) => special_form
-                .in_type_expression(db, scope_id, typevar_binding_context, inference_flags)
+                .in_type_expression(
+                    db,
+                    program,
+                    scope_id,
+                    typevar_binding_context,
+                    inference_flags,
+                )
                 .map_err(|err| {
                     let fallback_type = if matches!(
                         err,
@@ -6161,11 +6436,12 @@ impl<'db> Type<'db> {
                 }),
 
             Type::Union(union) => {
-                let mut builder = UnionBuilder::new(db);
+                let mut builder = UnionBuilder::new(db, program);
                 let mut invalid_expressions = smallvec::SmallVec::default();
                 for element in union.elements(db) {
                     match element.in_type_expression(
                         db,
+                        program,
                         scope_id,
                         typevar_binding_context,
                         inference_flags,
@@ -6193,7 +6469,7 @@ impl<'db> Type<'db> {
             Type::Dynamic(_) | Type::Divergent(_) => Ok(*self),
 
             Type::NominalInstance(instance) => match instance.known_class(db) {
-                Some(KnownClass::NoneType) => Ok(Type::none(db)),
+                Some(KnownClass::NoneType) => Ok(Type::none(db, program)),
                 Some(KnownClass::TypeVar) => Ok(todo_type!(
                     "Support for `typing.TypeVar` instances in type expressions"
                 )),
@@ -6210,6 +6486,7 @@ impl<'db> Type<'db> {
 
             Type::TypeAlias(alias) => alias.value_type(db).in_type_expression(
                 db,
+                program,
                 scope_id,
                 typevar_binding_context,
                 inference_flags,
@@ -6225,8 +6502,8 @@ impl<'db> Type<'db> {
     }
 
     /// The type `NoneType` / `None`
-    pub fn none(db: &'db dyn Db) -> Type<'db> {
-        KnownClass::NoneType.to_instance(db)
+    pub fn none(db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        KnownClass::NoneType.to_instance(db, program)
     }
 
     /// Given a type that is assumed to represent an instance of a class,
@@ -6235,71 +6512,82 @@ impl<'db> Type<'db> {
     /// Note: the return type of `type(obj)` is subtly different from this.
     /// See `Self::dunder_class` for more details.
     #[must_use]
-    pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn to_meta_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self {
             Type::Never => Type::Never,
-            Type::NominalInstance(instance) => instance.to_meta_type(db),
-            Type::KnownInstance(known_instance) => known_instance.to_meta_type(db),
-            Type::SpecialForm(special_form) => special_form.to_meta_type(db),
-            Type::PropertyInstance(property) => property.instance_class(db).to_class_literal(db),
-            Type::Union(union) => union.map(db, |ty| ty.to_meta_type(db)),
-            Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db),
-            Type::TypeForm(_) => Type::object().to_meta_type(db),
+            Type::NominalInstance(instance) => instance.to_meta_type(db, program),
+            Type::KnownInstance(known_instance) => known_instance.to_meta_type(db, program),
+            Type::SpecialForm(special_form) => special_form.to_meta_type(db, program),
+            Type::PropertyInstance(property) => {
+                property.instance_class(db).to_class_literal(db, program)
+            }
+            Type::Union(union) => union.map(db, program, |ty| ty.to_meta_type(db, program)),
+            Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_class_literal(db, program),
+            Type::TypeForm(_) => Type::object().to_meta_type(db, program),
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db),
-                LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db),
-                LiteralValueTypeKind::Int(_) => KnownClass::Int.to_class_literal(db),
+                LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_class_literal(db, program),
+                LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_class_literal(db, program),
+                LiteralValueTypeKind::Int(_) => KnownClass::Int.to_class_literal(db, program),
                 LiteralValueTypeKind::Enum(enum_literal) => {
                     Type::ClassLiteral(enum_literal.enum_class(db))
                 }
                 LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
-                    KnownClass::Str.to_class_literal(db)
+                    KnownClass::Str.to_class_literal(db, program)
                 }
             },
-            Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db),
-            Type::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db),
-            Type::KnownBoundMethod(method) => method.class().to_class_literal(db),
-            Type::WrapperDescriptor(_) => KnownClass::WrapperDescriptorType.to_class_literal(db),
-            Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db),
-            Type::Callable(callable) if callable.is_function_like(db) => {
-                KnownClass::FunctionType.to_class_literal(db)
+            Type::FunctionLiteral(_) => KnownClass::FunctionType.to_class_literal(db, program),
+            Type::BoundMethod(_) => KnownClass::MethodType.to_class_literal(db, program),
+            Type::KnownBoundMethod(method) => method.class().to_class_literal(db, program),
+            Type::WrapperDescriptor(_) => {
+                KnownClass::WrapperDescriptorType.to_class_literal(db, program)
             }
-            Type::Callable(_) | Type::DataclassTransformer(_) => KnownClass::Type.to_instance(db),
-            Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db),
+            Type::DataclassDecorator(_) => KnownClass::FunctionType.to_class_literal(db, program),
+            Type::Callable(callable) if callable.is_function_like(db) => {
+                KnownClass::FunctionType.to_class_literal(db, program)
+            }
+            Type::Callable(_) | Type::DataclassTransformer(_) => {
+                KnownClass::Type.to_instance(db, program)
+            }
+            Type::ModuleLiteral(_) => KnownClass::ModuleType.to_class_literal(db, program),
             Type::TypeVar(bound_typevar) => {
-                SubclassOfType::from(db, SubclassOfInner::TypeVar(bound_typevar))
+                SubclassOfType::from(db, program, SubclassOfInner::TypeVar(bound_typevar))
             }
             Type::ClassLiteral(class) => class.metaclass(db),
             Type::GenericAlias(alias) => ClassType::from(alias).metaclass(db),
-            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db),
-            Type::Dynamic(dynamic) => SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic)),
+            Type::SubclassOf(subclass_of_ty) => subclass_of_ty.to_meta_type(db, program),
+            Type::Dynamic(dynamic) => {
+                SubclassOfType::from(db, program, SubclassOfInner::Dynamic(dynamic))
+            }
             Type::Divergent(_) => self,
             // TODO intersections
             Type::Intersection(intersection) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db) {
-                    alternatives.to_meta_type(db)
+                if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
+                    alternatives.to_meta_type(db, program)
                 } else {
-                    SubclassOfType::try_from_type(db, todo_type!("Intersection meta-type"))
+                    SubclassOfType::try_from_type(db, program, todo_type!("Intersection meta-type"))
                         .expect("Type::Todo should be a valid `SubclassOfInner`")
                 }
             }
-            Type::EnumComplement(complement) => {
-                complement.remaining_literal_union(db).to_meta_type(db)
-            }
-            Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db),
-            Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db),
-            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db),
+            Type::EnumComplement(complement) => complement
+                .remaining_literal_union(db)
+                .to_meta_type(db, program),
+            Type::AlwaysTruthy | Type::AlwaysFalsy => KnownClass::Type.to_instance(db, program),
+            Type::BoundSuper(_) => KnownClass::Super.to_class_literal(db, program),
+            Type::ProtocolInstance(protocol) => protocol.to_meta_type(db, program),
             // `TypedDict` instances are instances of `dict` at runtime, but its important that we
             // understand a more specific meta type in order to correctly handle `__getitem__`.
             Type::TypedDict(typed_dict) => match typed_dict {
-                TypedDictType::Class(class) => SubclassOfType::from(db, class),
+                TypedDictType::Class(class) => SubclassOfType::from(db, program, class),
                 TypedDictType::Synthesized(_) => SubclassOfType::from(
                     db,
+                    program,
                     todo_type!("TypedDict synthesized meta-type").expect_dynamic(),
                 ),
             },
-            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db),
-            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).to_meta_type(db),
+            Type::TypeAlias(alias) => alias.value_type(db).to_meta_type(db, program),
+            Type::NewTypeInstance(newtype) => {
+                newtype.concrete_base_type(db).to_meta_type(db, program)
+            }
         }
     }
 
@@ -6309,16 +6597,20 @@ impl<'db> Type<'db> {
     /// this returns `type[dict[str, object]]` instead, because inhabitants of a `TypedDict` are
     /// instances of `dict` at runtime.
     #[must_use]
-    pub(crate) fn dunder_class(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn dunder_class(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         if self.is_typed_dict() {
             return KnownClass::Dict
-                .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), Type::object()])
+                .to_specialized_class_type(
+                    db,
+                    program,
+                    &[KnownClass::Str.to_instance(db, program), Type::object()],
+                )
                 .map(Type::from)
                 // Guard against user-customized typesheds with a broken `dict` class
                 .unwrap_or_else(Type::unknown);
         }
 
-        self.to_meta_type(db)
+        self.to_meta_type(db, program)
     }
 
     #[must_use]
@@ -6395,8 +6687,9 @@ impl<'db> Type<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_initial=|_, id, _, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, _| {
-            value.cycle_normalized(db, *previous, cycle)
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, specialization: Specialization<'db>| {
+            let program = specialization.generic_context(db).program(db);
+            value.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
@@ -6405,6 +6698,7 @@ impl<'db> Type<'db> {
         db: &'db dyn Db,
         specialization: Specialization<'db>,
     ) -> Type<'db> {
+        let program = specialization.generic_context(db).program(db);
         let type_mapping = match specialization.materialization_kind(db) {
             None => TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
                 specialization,
@@ -6415,21 +6709,29 @@ impl<'db> Type<'db> {
             },
         };
 
-        self.apply_type_mapping(db, &type_mapping, TypeContext::default())
+        self.apply_type_mapping(db, program, &type_mapping, TypeContext::default())
     }
 
     fn apply_type_mapping<'a>(
         self,
         db: &'db dyn Db,
+        program: Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
     ) -> Type<'db> {
-        self.apply_type_mapping_impl(db, type_mapping, tcx, &ApplyTypeMappingVisitor::default())
+        self.apply_type_mapping_impl(
+            db,
+            program,
+            type_mapping,
+            tcx,
+            &ApplyTypeMappingVisitor::default(),
+        )
     }
 
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -6458,12 +6760,12 @@ impl<'db> Type<'db> {
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::ClassLiteralsOnly)
             )
         {
-            return SubclassOfType::from(db, class.default_specialization(db));
+            return SubclassOfType::from(db, program, class.default_specialization(db));
         }
 
         match self {
-            Type::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, type_mapping, visitor),
-            Type::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            Type::TypeVar(bound_typevar) => bound_typevar.apply_type_mapping_impl(db, program, type_mapping, visitor),
+            Type::KnownInstance(known_instance) => known_instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
 
             Type::FunctionLiteral(function) => visitor.visit(db, self, type_mapping, || {
                 match type_mapping {
@@ -6476,7 +6778,7 @@ impl<'db> Type<'db> {
                             tcx,
                             visitor,
                         ))
-                        .promote_impl(db)
+                        .promote_impl(db, program)
                     }
                     _ => Type::FunctionLiteral(function.apply_type_mapping_impl(
                         db,
@@ -6490,32 +6792,38 @@ impl<'db> Type<'db> {
             Type::BoundMethod(method) => Type::BoundMethod(BoundMethodType::new(
                 db,
                 method.function(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                method.self_instance(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                method.self_instance(db).apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             )),
 
             Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular)) => {
                 match instance.known_class(db) {
-                    Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db),
-                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db),
-                    _ => instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    Some(KnownClass::Complex) => KnownUnion::Complex.to_type(db, program),
+                    Some(KnownClass::Float) => KnownUnion::Float.to_type(db, program),
+                    _ => instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 }
             }
 
             Type::NominalInstance(instance) if matches!(type_mapping, TypeMapping::Promote(PromotionMode::On, PromotionKind::SingletonsOnly)) => {
                 if instance.is_singleton(db) {
-                    self.promote_singletons_impl(db)
+                    self.promote_singletons_impl(db, program)
                 } else {
-                    instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
                 }
             }
 
             Type::NominalInstance(instance) => {
-                instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
             },
 
             Type::NewTypeInstance(newtype) => visitor.visit(db, self, type_mapping, || {
                 Type::NewTypeInstance(newtype.map_base_class_type(db, |class_type| {
-                    class_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    class_type.apply_type_mapping_impl_with_program(
+                        db,
+                        program,
+                        type_mapping,
+                        tcx,
+                        visitor,
+                    )
                 }))
             }),
 
@@ -6527,7 +6835,7 @@ impl<'db> Type<'db> {
                 // > read-only property members, and method members, on protocols act covariantly;
                 // > write-only property members act contravariantly; and read/write attribute
                 // > members on protocols act invariantly
-                Type::ProtocolInstance(instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::ProtocolInstance(instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderGet(function)) => {
@@ -6544,47 +6852,53 @@ impl<'db> Type<'db> {
 
             Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(
-                    property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    property.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
 
             Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderSet(
-                    property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    property.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
             Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(property)) => {
                 Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderDelete(
-                    property.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    property.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
 
             Type::Callable(callable) => visitor.visit(db, self, type_mapping, || {
-                Type::Callable(callable.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::Callable(callable.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }),
 
             Type::GenericAlias(generic) => {
-                Type::GenericAlias(generic.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::GenericAlias(generic.apply_type_mapping_impl_with_program(
+                    db,
+                    program,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ))
             }
 
             Type::TypedDict(typed_dict) => {
-                Type::TypedDict(typed_dict.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::TypedDict(typed_dict.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
 
-            Type::SubclassOf(subclass_of) => subclass_of.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            Type::SubclassOf(subclass_of) => subclass_of.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
 
             Type::PropertyInstance(property) => {
-                Type::PropertyInstance(property.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::PropertyInstance(property.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
 
-            Type::Union(union) => union.map_leave_aliases(db, |element| {
-                element.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+            Type::Union(union) => union.map_leave_aliases(db, program, |element| {
+                element.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
             }),
             Type::Intersection(intersection) => {
-                let mut builder = IntersectionBuilder::new(db);
+                let mut builder = IntersectionBuilder::new(db, program);
                 for positive in intersection.positive(db) {
                     builder =
-                        builder.add_positive(positive.apply_type_mapping_impl(db, type_mapping, tcx, visitor));
+                        builder.add_positive(positive.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor));
                 }
                 // Regular promotion should remove negative contributions from intersections,
                 // so we don't preserve them here when regular promotion is enabled.
@@ -6594,7 +6908,7 @@ impl<'db> Type<'db> {
                 ) {
                     for negative in intersection.negative(db) {
                         builder = builder.add_negative(
-                            negative.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+                            negative.apply_type_mapping_impl(db, program, &type_mapping.flip(), tcx, visitor),
                         );
                     }
                 }
@@ -6603,14 +6917,14 @@ impl<'db> Type<'db> {
 
             Type::EnumComplement(complement) => complement
                 .to_intersection(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
 
             Type::TypeIs(type_is) => visitor.visit(db, self, type_mapping, || {
                 type_is.with_type(
                     db,
                     type_is
                         .type_argument(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 )
             }),
 
@@ -6619,7 +6933,7 @@ impl<'db> Type<'db> {
                     db,
                     type_guard
                         .return_type(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 )
             }),
 
@@ -6628,7 +6942,7 @@ impl<'db> Type<'db> {
                     db,
                     typeform
                         .type_argument(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 )
             }),
 
@@ -6638,7 +6952,7 @@ impl<'db> Type<'db> {
                     // detection rather than the visitor's cycle detection, because the visitor tracks
                     // Type values and `RecursiveList` is different from `RecursiveList[T]`.
                     TypeMapping::EagerExpansion => {
-                        alias.raw_value_type(db).expand_eagerly(db)
+                        alias.raw_value_type(db).expand_eagerly(db, program)
                     },
                     // When specializing a generic type alias, instead of specializing the expanded type, the type alias itself is specialized.
                     // Without this special handling, recursive type aliases would result in cycles, returning an unspecialized fallback type.
@@ -6679,8 +6993,8 @@ impl<'db> Type<'db> {
                         // this same TypeAlias again (e.g., in `type RecursiveT = int | tuple[RecursiveT, ...]`), the visitor
                         // will detect the cycle and return the fallback value.
                         let mapped = visitor.visit(db, self, type_mapping, || {
-                            let value_type = alias.raw_value_type(db).apply_type_mapping_impl(db, type_mapping, tcx, visitor);
-                            alias.apply_function_specialization(db, value_type).apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                            let value_type = alias.raw_value_type(db).apply_type_mapping_impl(db, program, type_mapping, tcx, visitor);
+                            alias.apply_function_specialization(db, value_type).apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
                         });
 
                         // If the type mapping does not result in any change to this type alias, keep the
@@ -6710,7 +7024,7 @@ impl<'db> Type<'db> {
                     PromotionMode::On,
                     PromotionKind::ClassLiteralsOnly | PromotionKind::SingletonsOnly,
                 ) => self,
-                TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => self.promote_impl(db),
+                TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => self.promote_impl(db, program),
             }
 
             Type::Dynamic(_) => match type_mapping {
@@ -6771,11 +7085,13 @@ impl<'db> Type<'db> {
     pub(crate) fn find_legacy_typevars(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.find_legacy_typevars_impl(
             db,
+            program,
             binding_context,
             typevars,
             &FindLegacyTypeVarsVisitor::default(),
@@ -6785,6 +7101,7 @@ impl<'db> Type<'db> {
     pub(crate) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -6830,6 +7147,7 @@ impl<'db> Type<'db> {
             Type::BoundMethod(method) => visitor.visit(self, || {
                 method.self_instance(db).find_legacy_typevars_impl(
                     db,
+                    program,
                     binding_context,
                     typevars,
                     visitor,
@@ -6854,33 +7172,51 @@ impl<'db> Type<'db> {
                 | KnownBoundMethodType::PropertyDunderSet(property)
                 | KnownBoundMethodType::PropertyDunderDelete(property),
             ) => visitor.visit(self, || {
-                property.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                property.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }),
 
             Type::Callable(callable) => {
-                callable.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                callable.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
 
             Type::PropertyInstance(property) => visitor.visit(self, || {
-                property.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                property.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }),
 
             Type::Union(union) => {
                 for element in union.elements(db) {
-                    element.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    element.find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
             }
             Type::Intersection(intersection) => {
                 for positive in intersection.positive(db) {
-                    positive.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    positive.find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
                 for negative in intersection.negative(db) {
-                    negative.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    negative.find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
             }
             Type::EnumComplement(complement) => {
                 for rest in complement.rest(db) {
-                    rest.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    rest.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
                 }
             }
 
@@ -6889,11 +7225,11 @@ impl<'db> Type<'db> {
             }
 
             Type::NominalInstance(instance) => {
-                instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                instance.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
 
             Type::ProtocolInstance(instance) => {
-                instance.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                instance.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
 
             Type::NewTypeInstance(_) => {
@@ -6903,12 +7239,19 @@ impl<'db> Type<'db> {
             }
 
             Type::SubclassOf(subclass_of) => {
-                subclass_of.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                subclass_of.find_legacy_typevars_impl(
+                    db,
+                    program,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
             }
 
             Type::TypeIs(type_is) => {
                 type_is.type_argument(db).find_legacy_typevars_impl(
                     db,
+                    program,
                     binding_context,
                     typevars,
                     visitor,
@@ -6918,6 +7261,7 @@ impl<'db> Type<'db> {
             Type::TypeGuard(type_guard) => {
                 type_guard.return_type(db).find_legacy_typevars_impl(
                     db,
+                    program,
                     binding_context,
                     typevars,
                     visitor,
@@ -6927,6 +7271,7 @@ impl<'db> Type<'db> {
             Type::TypeForm(typeform) => {
                 typeform.type_argument(db).find_legacy_typevars_impl(
                     db,
+                    program,
                     binding_context,
                     typevars,
                     visitor,
@@ -6937,6 +7282,7 @@ impl<'db> Type<'db> {
                 visitor.visit(self, || {
                     alias.value_type(db).find_legacy_typevars_impl(
                         db,
+                        program,
                         binding_context,
                         typevars,
                         visitor,
@@ -6949,6 +7295,7 @@ impl<'db> Type<'db> {
                     if let Ok(union_type) = instance.union_type(db) {
                         union_type.find_legacy_typevars_impl(
                             db,
+                            program,
                             binding_context,
                             typevars,
                             visitor,
@@ -6956,15 +7303,31 @@ impl<'db> Type<'db> {
                     }
                 }
                 KnownInstanceType::Annotated(ty) => {
-                    ty.inner(db)
-                        .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    ty.inner(db).find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
                 KnownInstanceType::Callable(callable_type) => {
-                    callable_type.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    callable_type.find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
                 KnownInstanceType::TypeGenericAlias(ty) => {
-                    ty.inner(db)
-                        .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                    ty.inner(db).find_legacy_typevars_impl(
+                        db,
+                        program,
+                        binding_context,
+                        typevars,
+                        visitor,
+                    );
                 }
                 KnownInstanceType::SubscriptedProtocol(_)
                 | KnownInstanceType::SubscriptedGeneric(_)
@@ -7026,25 +7389,28 @@ impl<'db> Type<'db> {
     pub(crate) fn bind_and_find_all_legacy_typevars(
         self,
         db: &'db dyn Db,
+        program: Program,
         binding_context: Option<Definition<'db>>,
         variables: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
     ) {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::BindLegacyTypevars(
                 binding_context
                     .map(BindingContext::Definition)
-                    .unwrap_or(BindingContext::Synthetic),
+                    .unwrap_or(BindingContext::Synthetic(program)),
             ),
             TypeContext::default(),
         )
-        .find_legacy_typevars(db, None, variables);
+        .find_legacy_typevars(db, program, None, variables);
     }
 
     /// Replace default types in parameters of callables with `Unknown`.
-    pub(crate) fn replace_parameter_defaults(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn replace_parameter_defaults(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::ReplaceParameterDefaults,
             TypeContext::default(),
         )
@@ -7052,21 +7418,26 @@ impl<'db> Type<'db> {
 
     /// Returns the eagerly expanded type.
     /// In the case of recursive type aliases, this will diverge, so that part will be replaced with `Divergent`.
-    fn expand_eagerly(self, db: &'db dyn Db) -> Type<'db> {
-        self.expand_eagerly_(db, ())
+    fn expand_eagerly(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        self.expand_eagerly_(db, program, ())
     }
 
     #[allow(clippy::used_underscore_binding)]
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, ()| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, ()| {
-            value.cycle_normalized(db, *previous, cycle)
+        cycle_initial=|_, id, _, _, ()| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _, program, ()| {
+            value.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn expand_eagerly_(self, db: &'db dyn Db, _unit: ()) -> Type<'db> {
-        self.apply_type_mapping(db, &TypeMapping::EagerExpansion, TypeContext::default())
+    fn expand_eagerly_(self, db: &'db dyn Db, program: Program, _unit: ()) -> Type<'db> {
+        self.apply_type_mapping(
+            db,
+            program,
+            &TypeMapping::EagerExpansion,
+            TypeContext::default(),
+        )
     }
 
     /// Return the string representation of this type when converted to string as it would be
@@ -7075,10 +7446,12 @@ impl<'db> Type<'db> {
     /// When not available, this should fall back to the value of `[Type::repr]`.
     /// Note: this method is used in the builtins `format`, `print`, `str.format` and `f-strings`.
     #[must_use]
-    pub(crate) fn str(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn str(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             Type::LiteralValue(literal) => match literal.kind() {
-                LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => self.repr(db),
+                LiteralValueTypeKind::Int(_) | LiteralValueTypeKind::Bool(_) => {
+                    self.repr(db, program)
+                }
                 LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => *self,
                 LiteralValueTypeKind::Enum(enum_literal) => Type::string_literal(
                     db,
@@ -7088,32 +7461,34 @@ impl<'db> Type<'db> {
                         name = enum_literal.name(db)
                     ),
                 ),
-                LiteralValueTypeKind::Bytes(_) => KnownClass::Str.to_instance(db),
+                LiteralValueTypeKind::Bytes(_) => KnownClass::Str.to_instance(db, program),
             },
             Type::SpecialForm(special_form) => {
                 Type::string_literal(db, special_form.to_compact_string())
             }
             Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, known_instance.repr(db).to_compact_string())
+                Type::string_literal(db, known_instance.repr(db, program).to_compact_string())
             }
-            ty if ty.is_subtype_of(db, Type::literal_string()) => Type::literal_string(),
+            ty if ty.is_subtype_of(db, program, Type::literal_string()) => Type::literal_string(),
             Type::Intersection(intersection) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db) {
-                    alternatives.str(db)
+                if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
+                    alternatives.str(db, program)
                 } else {
-                    KnownClass::Str.to_instance(db)
+                    KnownClass::Str.to_instance(db, program)
                 }
             }
-            Type::EnumComplement(complement) => complement.remaining_literal_union(db).str(db),
+            Type::EnumComplement(complement) => {
+                complement.remaining_literal_union(db).str(db, program)
+            }
             // TODO: handle more complex types
-            _ => KnownClass::Str.to_instance(db),
+            _ => KnownClass::Str.to_instance(db, program),
         }
     }
 
     /// Return the string representation of this type as it would be provided by the  `__repr__`
     /// method at runtime.
     #[must_use]
-    pub(crate) fn repr(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn repr(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self {
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Int(number) => {
@@ -7126,14 +7501,14 @@ impl<'db> Type<'db> {
                     compact_str::format_compact!("'{}'", literal.value(db).escape_default()),
                 ),
                 LiteralValueTypeKind::LiteralString => Type::literal_string(),
-                _ => KnownClass::Str.to_instance(db),
+                _ => KnownClass::Str.to_instance(db, program),
             },
             Type::SpecialForm(special_form) => Type::string_literal(db, &*special_form.to_string()),
             Type::KnownInstance(known_instance) => {
-                Type::string_literal(db, known_instance.repr(db).to_compact_string())
+                Type::string_literal(db, known_instance.repr(db, program).to_compact_string())
             }
             // TODO: handle more complex types
-            _ => KnownClass::Str.to_instance(db),
+            _ => KnownClass::Str.to_instance(db, program),
         }
     }
 
@@ -7146,7 +7521,7 @@ impl<'db> Type<'db> {
     /// should be handled, especially when some variants don't have definitions, is
     /// specific to the call site. Exact singleton finite intersections delegate to
     /// their only alternative, since there is no ambiguity to preserve there.
-    pub fn definition(&self, db: &'db dyn Db) -> Option<TypeDefinition<'db>> {
+    pub fn definition(&self, db: &'db dyn Db, program: Program) -> Option<TypeDefinition<'db>> {
         match self {
             Self::BoundMethod(method) => {
                 Some(TypeDefinition::Function(method.function(db).definition(db)))
@@ -7157,7 +7532,7 @@ impl<'db> Type<'db> {
             Self::ModuleLiteral(module) => Some(TypeDefinition::Module(module.module(db))),
             Self::ClassLiteral(class_literal) => class_literal.type_definition(db),
             Self::GenericAlias(alias) => Some(TypeDefinition::StaticClass(alias.definition(db))),
-            Self::NominalInstance(instance) => instance.class(db).type_definition(db),
+            Self::NominalInstance(instance) => instance.class(db, program).type_definition(db),
             Self::KnownInstance(instance) => match instance {
                 KnownInstanceType::TypeVar(var) => {
                     Some(TypeDefinition::TypeVar(var.definition(db)?))
@@ -7179,30 +7554,34 @@ impl<'db> Type<'db> {
                 )),
             },
 
-            Self::TypeAlias(alias) => alias.value_type(db).definition(db),
+            Self::TypeAlias(alias) => alias.value_type(db).definition(db, program),
             Self::NewTypeInstance(newtype) => Some(TypeDefinition::NewType(newtype.definition(db))),
 
             Self::PropertyInstance(property) => property
                 .getter(db)
-                .and_then(|getter| getter.definition(db))
-                .or_else(|| property.setter(db).and_then(|setter| setter.definition(db)))
+                .and_then(|getter| getter.definition(db, program))
+                .or_else(|| {
+                    property
+                        .setter(db)
+                        .and_then(|setter| setter.definition(db, program))
+                })
                 .or_else(|| {
                     property
                         .deleter(db)
-                        .and_then(|deleter| deleter.definition(db))
+                        .and_then(|deleter| deleter.definition(db, program))
                 }),
 
             Self::LiteralValue(literal) => literal
                 .as_enum()
                 .and_then(|enum_lit| enum_lit.definition(db))
                 .map(TypeDefinition::EnumMember)
-                .or_else(|| self.to_meta_type(db).definition(db)),
+                .or_else(|| self.to_meta_type(db, program).definition(db, program)),
 
             Self::KnownBoundMethod(_)
             | Self::WrapperDescriptor(_)
             | Self::DataclassDecorator(_)
             | Self::DataclassTransformer(_)
-            | Self::BoundSuper(_) => self.to_meta_type(db).definition(db),
+            | Self::BoundSuper(_) => self.to_meta_type(db, program).definition(db, program),
 
             Self::TypeVar(bound_typevar) => Some(TypeDefinition::TypeVar(
                 bound_typevar.typevar(db).definition(db)?,
@@ -7217,39 +7596,45 @@ impl<'db> Type<'db> {
 
             Self::Union(_) => None,
             Self::Intersection(intersection) => {
-                let alternatives = intersection.finite_alternatives(db)?;
+                let alternatives = intersection.finite_alternatives(db, program)?;
                 let [alternative] = alternatives.as_slice() else {
                     return None;
                 };
-                alternative.definition(db)
+                alternative.definition(db, program)
             }
             Self::EnumComplement(complement) => {
                 let alternatives = complement.remaining_literal_types(db);
                 let [alternative] = alternatives.as_slice() else {
                     return None;
                 };
-                alternative.definition(db)
+                alternative.definition(db, program)
             }
 
-            Self::SpecialForm(special_form) => special_form.definition(db),
-            Self::Never => Type::SpecialForm(SpecialFormType::Never).definition(db),
+            Self::SpecialForm(special_form) => special_form.definition(db, program),
+            Self::Never => Type::SpecialForm(SpecialFormType::Never).definition(db, program),
             Self::Dynamic(DynamicType::Any) => {
-                Type::SpecialForm(SpecialFormType::Any).definition(db)
+                Type::SpecialForm(SpecialFormType::Any).definition(db, program)
             }
             Self::Dynamic(
                 DynamicType::Unknown
                 | DynamicType::UnknownGeneric(_)
                 | DynamicType::AmbiguousOverload,
-            ) => Type::SpecialForm(SpecialFormType::Unknown).definition(db),
-            Self::Divergent(_) => Type::SpecialForm(SpecialFormType::Divergent).definition(db),
+            ) => Type::SpecialForm(SpecialFormType::Unknown).definition(db, program),
+            Self::Divergent(_) => {
+                Type::SpecialForm(SpecialFormType::Divergent).definition(db, program)
+            }
             Self::Dynamic(
                 DynamicType::Todo(_)
                 | DynamicType::TodoUnpack
                 | DynamicType::TodoStarredExpression
                 | DynamicType::TodoTypeVarTuple,
-            ) => Type::SpecialForm(SpecialFormType::Todo).definition(db),
-            Self::AlwaysTruthy => Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db),
-            Self::AlwaysFalsy => Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db),
+            ) => Type::SpecialForm(SpecialFormType::Todo).definition(db, program),
+            Self::AlwaysTruthy => {
+                Type::SpecialForm(SpecialFormType::AlwaysTruthy).definition(db, program)
+            }
+            Self::AlwaysFalsy => {
+                Type::SpecialForm(SpecialFormType::AlwaysFalsy).definition(db, program)
+            }
 
             // These types have no definition
             Self::Dynamic(
@@ -7326,11 +7711,15 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub(crate) fn generic_origin(self, db: &'db dyn Db) -> Option<StaticClassLiteral<'db>> {
+    pub(crate) fn generic_origin(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<StaticClassLiteral<'db>> {
         match self {
             Type::GenericAlias(generic) => Some(generic.origin(db)),
             Type::NominalInstance(instance) => {
-                if let ClassType::Generic(generic) = instance.class(db) {
+                if let ClassType::Generic(generic) = instance.class(db, program) {
                     Some(generic.origin(db))
                 } else {
                     None
@@ -7343,18 +7732,22 @@ impl<'db> Type<'db> {
     /// Default-specialize all legacy typevars in this type.
     ///
     /// This is used when an implicit type alias is referenced without explicitly specializing it.
-    pub(crate) fn default_specialize(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn default_specialize(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         let mut variables = FxOrderSet::default();
-        self.find_legacy_typevars(db, None, &mut variables);
-        let generic_context = GenericContext::from_typevar_instances(db, variables);
+        self.find_legacy_typevars(db, program, None, &mut variables);
+        let generic_context = GenericContext::from_typevar_instances(db, program, variables);
         self.apply_specialization(db, generic_context.default_specialization(db, None))
     }
 
-    pub(crate) fn from_truthiness(db: &'db dyn Db, truthiness: Truthiness) -> Self {
+    pub(crate) fn from_truthiness(
+        db: &'db dyn Db,
+        program: Program,
+        truthiness: Truthiness,
+    ) -> Self {
         match truthiness {
             Truthiness::AlwaysTrue => Type::bool_literal(true),
             Truthiness::AlwaysFalse => Type::bool_literal(false),
-            Truthiness::Ambiguous => KnownClass::Bool.to_instance(db),
+            Truthiness::Ambiguous => KnownClass::Bool.to_instance(db, program),
         }
     }
 
@@ -7363,14 +7756,17 @@ impl<'db> Type<'db> {
     pub(crate) fn negation_is_subtype_of_cached(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         negated_cache: &mut Option<Type<'db>>,
     ) -> bool {
         match self {
-            Type::Intersection(intersection) => intersection.negation_is_subtype_of(db, target),
+            Type::Intersection(intersection) => {
+                intersection.negation_is_subtype_of(db, program, target)
+            }
             _ => {
-                let negated = negated_cache.get_or_insert_with(|| self.negate(db));
-                negated.is_subtype_of(db, target)
+                let negated = negated_cache.get_or_insert_with(|| self.negate(db, program));
+                negated.is_subtype_of(db, program, target)
             }
         }
     }
@@ -7382,14 +7778,20 @@ impl<'db> IntersectionType<'db> {
     /// Applying De Morgan's law to an intersection produces a union. Checking each branch
     /// directly avoids constructing and simplifying that temporary union, which can be costly
     /// for the large intersections produced by repeated narrowing.
-    pub(crate) fn negation_is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
-        self.positive(db)
+    pub(crate) fn negation_is_subtype_of(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        target: Type<'db>,
+    ) -> bool {
+        self.positive(db).iter().all(|positive| {
+            positive
+                .negate(db, program)
+                .is_subtype_of(db, program, target)
+        }) && self
+            .negative(db)
             .iter()
-            .all(|positive| positive.negate(db).is_subtype_of(db, target))
-            && self
-                .negative(db)
-                .iter()
-                .all(|negative| negative.is_subtype_of(db, target))
+            .all(|negative| negative.is_subtype_of(db, program, target))
     }
 
     // Calls the dunder on each element separately and combines the results.
@@ -7401,13 +7803,21 @@ impl<'db> IntersectionType<'db> {
     fn try_call_dunder_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         argument_types: &mut CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
-        if let Some(alternatives) = self.finite_alternative_union(db) {
-            return alternatives.try_call_dunder_with_policy(db, name, argument_types, tcx, policy);
+        if let Some(alternatives) = self.finite_alternative_union(db, program) {
+            return alternatives.try_call_dunder_with_policy(
+                db,
+                program,
+                name,
+                argument_types,
+                tcx,
+                policy,
+            );
         }
 
         // Using `positive()` rather than `positive_elements_or_object()` is safe
@@ -7420,7 +7830,14 @@ impl<'db> IntersectionType<'db> {
         let mut error_provenance = Provenance::Unknown;
 
         for element in positive {
-            match element.try_call_dunder_with_policy(db, name, argument_types, tcx, policy) {
+            match element.try_call_dunder_with_policy(
+                db,
+                program,
+                name,
+                argument_types,
+                tcx,
+                policy,
+            ) {
                 Ok(bindings) => successful_bindings.push(bindings),
                 Err(err) => {
                     error_provenance = error_provenance.or(err.provenance());
@@ -7454,13 +7871,14 @@ impl<'db> UnionType<'db> {
     fn try_call_dunder_with_policy(
         self,
         db: &'db dyn Db,
+        program: Program,
         name: &str,
         argument_types: &mut CallArguments<'_, 'db>,
         tcx: TypeContext<'db>,
         policy: MemberLookupPolicy,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         let elements = self.elements(db);
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         let mut unbound_on: Vec<Type<'db>> = Vec::new();
         let mut any_defined = false;
         let mut possibly_undefined = false;
@@ -7470,6 +7888,7 @@ impl<'db> UnionType<'db> {
             match element
                 .member_lookup_with_policy(
                     db,
+                    program,
                     name.into(),
                     policy | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
@@ -7509,9 +7928,9 @@ impl<'db> UnionType<'db> {
         let dunder_callable = builder.build();
         let constraints = ConstraintSetBuilder::new();
         let bindings = match dunder_callable
-            .bindings(db)
-            .match_parameters(db, argument_types)
-            .check_types(db, &constraints, argument_types, tcx, &[])
+            .bindings(db, program)
+            .match_parameters(db, program, argument_types)
+            .check_types(db, program, &constraints, argument_types, tcx, &[])
         {
             Ok(bindings) => bindings,
             Err(CallError(kind, bindings)) => {
@@ -7537,44 +7956,51 @@ impl<'db> From<&Type<'db>> for Type<'db> {
 }
 
 impl<'db> VarianceInferable<'db> for Type<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         tracing::trace!(
             "Checking variance of '{tvar}' in `{ty:?}`",
             tvar = typevar.identity.name(db),
-            ty = self.display(db),
+            ty = self.display(db, program),
         );
 
         let v = match self {
-            Type::ClassLiteral(class_literal) => class_literal.variance_of(db, typevar),
+            Type::ClassLiteral(class_literal) => class_literal.variance_of(db, program, typevar),
 
             Type::FunctionLiteral(function_type) => {
                 // TODO: do we need to replace self?
-                function_type.variance_of(db, typevar)
+                *function_type.variance_of(db, typevar)
             }
 
             Type::BoundMethod(method_type) => {
                 // TODO: do we need to replace self?
-                method_type.function(db).variance_of(db, typevar)
+                *method_type.function(db).variance_of(db, typevar)
             }
 
             Type::NominalInstance(nominal_instance_type) => {
-                nominal_instance_type.variance_of(db, typevar)
+                nominal_instance_type.variance_of(db, program, typevar)
             }
-            Type::GenericAlias(generic_alias) => generic_alias.variance_of(db, typevar),
-            Type::Callable(callable_type) => callable_type.signatures(db).variance_of(db, typevar),
+            Type::GenericAlias(generic_alias) => generic_alias.variance_of(db, program, typevar),
+            Type::Callable(callable_type) => callable_type
+                .signatures(db)
+                .variance_of(db, program, typevar),
             // A type variable is always covariant in itself.
             Type::TypeVar(other_typevar) if other_typevar.identity(db) == typevar => {
                 // type variables are covariant in themselves
                 TypeVarVariance::Covariant
             }
             Type::ProtocolInstance(protocol_instance_type) => {
-                protocol_instance_type.variance_of(db, typevar)
+                protocol_instance_type.variance_of(db, program, typevar)
             }
             // unions are covariant in their disjuncts
             Type::Union(union_type) => union_type
                 .elements(db)
                 .iter()
-                .map(|ty| ty.variance_of(db, typevar))
+                .map(|ty| ty.variance_of(db, program, typevar))
                 .collect(),
 
             // Products are covariant in their conjuncts. For negative
@@ -7586,28 +8012,30 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
             Type::Intersection(intersection_type) => intersection_type
                 .positive(db)
                 .iter()
-                .map(|ty| ty.variance_of(db, typevar))
+                .map(|ty| ty.variance_of(db, program, typevar))
                 .chain(intersection_type.negative(db).iter().map(|ty| {
                     ty.with_polarity(TypeVarVariance::Contravariant)
-                        .variance_of(db, typevar)
+                        .variance_of(db, program, typevar)
                 }))
                 .collect(),
-            Type::EnumComplement(complement) => {
-                complement.to_intersection(db).variance_of(db, typevar)
-            }
+            Type::EnumComplement(complement) => complement
+                .to_intersection(db)
+                .variance_of(db, program, typevar),
             Type::PropertyInstance(property_instance_type) => property_instance_type
                 .getter(db)
                 .iter()
                 .chain(&property_instance_type.setter(db))
                 .chain(&property_instance_type.deleter(db))
-                .map(|ty| ty.variance_of(db, typevar))
+                .map(|ty| ty.variance_of(db, program, typevar))
                 .collect(),
-            Type::SubclassOf(subclass_of_type) => subclass_of_type.variance_of(db, typevar),
-            Type::TypeIs(type_is_type) => type_is_type.variance_of(db, typevar),
-            Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, typevar),
-            Type::TypeForm(typeform_type) => typeform_type.variance_of(db, typevar),
-            Type::KnownInstance(known_instance) => known_instance.variance_of(db, typevar),
-            Type::TypeAlias(alias) => alias.variance_of(db, typevar),
+            Type::SubclassOf(subclass_of_type) => {
+                subclass_of_type.variance_of(db, program, typevar)
+            }
+            Type::TypeIs(type_is_type) => type_is_type.variance_of(db, program, typevar),
+            Type::TypeGuard(type_guard_type) => type_guard_type.variance_of(db, program, typevar),
+            Type::TypeForm(typeform_type) => typeform_type.variance_of(db, program, typevar),
+            Type::KnownInstance(known_instance) => known_instance.variance_of(db, program, typevar),
+            Type::TypeAlias(alias) => alias.variance_of(db, program, typevar),
             Type::Dynamic(_)
             | Type::Divergent(_)
             | Type::Never
@@ -7629,7 +8057,7 @@ impl<'db> VarianceInferable<'db> for Type<'db> {
         tracing::trace!(
             "Result of variance of '{tvar}' in `{ty:?}` is `{v:?}`",
             tvar = typevar.identity.name(db),
-            ty = self.display(db),
+            ty = self.display(db, program),
         );
         v
     }
@@ -7664,12 +8092,13 @@ pub enum PromotionKind {
 /// Returns the [`ClassLiteral`] that "owns" a `Self` typevar (i.e., the class from its upper bound).
 fn self_typevar_owner_class_literal<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<ClassLiteral<'db>> {
     bound_typevar
         .typevar(db)
         .upper_bound(db)
-        .and_then(|ty| ty.nominal_class(db))
+        .and_then(|ty| ty.nominal_class(db, program))
         .map(|class| class.class_literal(db))
 }
 
@@ -7709,15 +8138,16 @@ impl<'db> SelfBinding<'db> {
 impl<'db> SelfBinding<'db> {
     pub(crate) fn new(
         db: &'db dyn Db,
+        program: crate::Program,
         self_type: Type<'db>,
         binding_context: Option<BindingContext<'db>>,
     ) -> Self {
         let class_literal = match self_type {
             Type::TypeVar(typevar) if typevar.typevar(db).is_self(db) => {
-                self_typevar_owner_class_literal(db, typevar)
+                self_typevar_owner_class_literal(db, program, typevar)
             }
             _ => self_type
-                .nominal_class(db)
+                .nominal_class(db, program)
                 .map(|class| class.class_literal(db)),
         };
 
@@ -7729,7 +8159,12 @@ impl<'db> SelfBinding<'db> {
     }
 
     /// Returns whether `bound_typevar` should be replaced by this binding's concrete self type.
-    fn should_bind(&self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) -> bool {
+    fn should_bind(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> bool {
         if !bound_typevar.typevar(db).is_self(db) {
             return false;
         }
@@ -7744,7 +8179,7 @@ impl<'db> SelfBinding<'db> {
         // If we can't determine either class, conservatively don't bind.
         self.class_literal.is_some_and(|class_literal| {
             let class_mro = class_mro_literals(db, class_literal);
-            self_typevar_owner_class_literal(db, bound_typevar)
+            self_typevar_owner_class_literal(db, program, bound_typevar)
                 .is_none_or(|owner_class| class_mro.contains(&owner_class))
         })
     }
@@ -7800,14 +8235,16 @@ impl<'db> TypeMapping<'_, 'db> {
     pub(crate) fn update_signature_generic_context(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         context: GenericContext<'db>,
     ) -> GenericContext<'db> {
         match self {
             TypeMapping::FreshenBoundTypeVars { .. } => GenericContext::from_typevar_instances(
                 db,
+                program,
                 context.variables(db).map(|bound_typevar| {
                     Type::TypeVar(bound_typevar)
-                        .apply_type_mapping(db, self, TypeContext::default())
+                        .apply_type_mapping(db, program, self, TypeContext::default())
                         .as_typevar()
                         .unwrap_or(bound_typevar)
                 }),
@@ -7818,6 +8255,7 @@ impl<'db> TypeMapping<'_, 'db> {
                 // (i.e., mapped to a non-TypeVar type)
                 GenericContext::from_typevar_instances(
                     db,
+                    program,
                     context.variables(db).filter(|bound_typevar| {
                         // Keep the type variable if it's not in the specialization
                         // or if it's mapped to itself (still a TypeVar)
@@ -7847,6 +8285,7 @@ impl<'db> TypeMapping<'_, 'db> {
             }
             TypeMapping::ReplaceSelf { new_upper_bound } => GenericContext::from_typevar_instances(
                 db,
+                program,
                 context.variables(db).map(|typevar| {
                     if typevar.typevar(db).is_self(db) {
                         BoundTypeVarInstance::synthetic_self(
@@ -7893,7 +8332,7 @@ impl<'db> TypeMapping<'_, 'db> {
 /// (e.g. `Divergent` is assignable to `@Todo`, but `@Todo | Divergent` must not be reduced to `@Todo`).
 /// Otherwise, type inference cannot converge properly.
 /// For detailed properties of this type, see the unit test at the end of the file.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue)]
 pub struct DivergentType {
     /// The query ID that caused the cycle.
     id: salsa::Id,
@@ -7929,7 +8368,7 @@ impl DivergentType {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 pub enum DynamicType<'db> {
     /// An explicitly annotated `typing.Any`
     Any,
@@ -8006,7 +8445,7 @@ impl std::fmt::Display for DynamicType<'_> {
 
 bitflags! {
     /// Type qualifiers that appear in an annotation expression.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Hash)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Default, salsa::SalsaValue, Hash)]
     pub struct TypeQualifiers: u8 {
         /// `typing.ClassVar`
         const CLASS_VAR = 1 << 0;
@@ -8072,7 +8511,7 @@ impl TypeQualifiers {
 ///
 /// Example: `Annotated[ClassVar[tuple[int]], "metadata"]` would have type `tuple[int]` and the
 /// qualifier `ClassVar`.
-#[derive(Clone, Debug, Copy, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, Copy, Eq, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct TypeAndQualifiers<'db> {
     inner: Type<'db>,
     origin: TypeOrigin,
@@ -8165,8 +8604,9 @@ impl<'db> InvalidTypeExpressionError<'db> {
             let Some(builder) = context.report_lint(&INVALID_TYPE_FORM, node) else {
                 continue;
             };
-            let diagnostic = builder.into_diagnostic(error.reason(context.db(), flags));
-            error.add_subdiagnostics(context.db(), diagnostic, node);
+            let diagnostic =
+                builder.into_diagnostic(error.reason(context.db(), context.program(), flags));
+            error.add_subdiagnostics(context.db(), context.program(), diagnostic, node);
         }
         fallback_type
     }
@@ -8219,15 +8659,22 @@ enum InvalidTypeExpression<'db> {
 }
 
 impl<'db> InvalidTypeExpression<'db> {
-    const fn reason(self, db: &'db dyn Db, flags: InferenceFlags) -> impl std::fmt::Display + 'db {
+    const fn reason(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        flags: InferenceFlags,
+    ) -> impl std::fmt::Display + 'db {
         struct Display<'db> {
             error: InvalidTypeExpression<'db>,
             db: &'db dyn Db,
+            program: Program,
             flags: InferenceFlags,
         }
 
         impl std::fmt::Display for Display<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let program = self.program;
                 let location = self.flags.type_expression_context();
 
                 match self.error {
@@ -8330,7 +8777,7 @@ impl<'db> InvalidTypeExpression<'db> {
                     InvalidTypeExpression::InvalidType(ty, _) => write!(
                         f,
                         "Variable of type `{ty}` is not allowed in a {location}",
-                        ty = ty.display(self.db)
+                        ty = ty.display(self.db, program)
                     ),
                     InvalidTypeExpression::InvalidBareParamSpec(paramspec) => write!(
                         f,
@@ -8348,6 +8795,7 @@ impl<'db> InvalidTypeExpression<'db> {
         Display {
             error: self,
             db,
+            program,
             flags,
         }
     }
@@ -8355,6 +8803,7 @@ impl<'db> InvalidTypeExpression<'db> {
     fn add_subdiagnostics(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         mut diagnostic: LintDiagnosticGuard,
         node: &impl Ranged,
     ) {
@@ -8369,14 +8818,14 @@ impl<'db> InvalidTypeExpression<'db> {
             let module = module.module(db);
             let module_name_final_part = module.name(db).last_component();
             let Some(module_member_with_same_name) = ty
-                .member(db, module_name_final_part)
+                .member(db, program, module_name_final_part)
                 .place
                 .ignore_possibly_undefined()
             else {
                 return;
             };
             if module_member_with_same_name
-                .in_type_expression(db, scope, None, InferenceFlags::empty())
+                .in_type_expression(db, program, scope, None, InferenceFlags::empty())
                 .is_err()
             {
                 return;
@@ -8404,8 +8853,8 @@ impl<'db> InvalidTypeExpression<'db> {
             && function_body_scope
                 .scope(db)
                 .parent()
-                .map(|parent| parent.to_scope_id(db, function_body_scope.file(db)))
-                == builtins_module_scope(db)
+                .map(|parent| parent.to_scope_id(db, function_body_scope.program_file(db)))
+                == builtins_module_scope(db, function_body_scope.program(db))
         {
             diagnostic.set_primary_message("Did you mean `collections.abc.Callable`?");
         } else if matches!(self, InvalidTypeExpression::InvalidBareParamSpec(_)) {
@@ -8445,9 +8894,10 @@ impl<'db> AwaitError<'db> {
         };
 
         let db = context.db();
+        let program = context.program();
 
         let mut diag = builder.into_diagnostic(
-            format_args!("`{type}` is not awaitable", type = context_expression_type.display(db)),
+            format_args!("`{type}` is not awaitable", type = context_expression_type.display(db, program)),
         );
         match self {
             Self::Call(CallDunderError::CallError(CallErrorKind::BindingError, bindings, _)) => {
@@ -8471,7 +8921,8 @@ impl<'db> AwaitError<'db> {
                 };
                 diag.info(format_args!("`__await__` is{possibly} not callable"));
                 if let Some(definition) = attribute_provenance.definition() {
-                    let module = parsed_module(db, definition.file(db)).load(db);
+                    let module =
+                        parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
                     diag.annotate(
                         Annotation::secondary(definition.focus_range(db, &module).into())
                             .message("attribute defined here"),
@@ -8487,7 +8938,7 @@ impl<'db> AwaitError<'db> {
                     for ty in unbound_on {
                         diag.info(format_args!(
                             "`{}` does not implement `__await__`",
-                            ty.display(db)
+                            ty.display(db, program)
                         ));
                     }
                 }
@@ -8500,7 +8951,7 @@ impl<'db> AwaitError<'db> {
             }
             Self::Call(CallDunderError::MethodNotAvailable) => {
                 diag.info("`__await__` is missing");
-                if let Some(type_definition) = context_expression_type.definition(db)
+                if let Some(type_definition) = context_expression_type.definition(db, program)
                     && let Some(definition_range) = type_definition.focus_range(db)
                 {
                     diag.annotate(
@@ -8511,7 +8962,7 @@ impl<'db> AwaitError<'db> {
             Self::InvalidReturnType(return_type, bindings) => {
                 diag.info(format_args!(
                     "`__await__` returns `{return_type}`, which is not a valid iterator",
-                    return_type = return_type.display(db)
+                    return_type = return_type.display(db, program)
                 ));
                 if let Some(definition_spans) = bindings.callable_type().function_spans(db) {
                     diag.annotate(
@@ -8529,6 +8980,9 @@ pub struct ModuleLiteralType<'db> {
     /// The imported module.
     #[returns(copy)]
     pub module: Module<'db>,
+
+    #[returns(copy)]
+    pub program: Program,
 
     /// The file in which this module was imported.
     ///
@@ -8554,6 +9008,23 @@ impl<'db> ModuleLiteralType<'db> {
             self.module(db).kind(db).is_package()
         );
         self._importing_file(db)
+    }
+
+    fn importing_program_file(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<ty_python_core::environment::ProgramFile<'db>> {
+        self.importing_file(db)
+            .map(|file| ty_python_core::environment::ProgramFile::new(db, self.program(db), file))
+    }
+
+    fn module_program_file(
+        self,
+        db: &'db dyn Db,
+    ) -> Option<ty_python_core::environment::ProgramFile<'db>> {
+        self.module(db)
+            .file(db)
+            .map(|file| ty_python_core::environment::ProgramFile::new(db, self.program(db), file))
     }
 
     /// Get the submodule attributes we believe to be defined on this module.
@@ -8608,37 +9079,48 @@ impl<'db> ModuleLiteralType<'db> {
     /// We instead prefer handling most other import effects as definitions in the scope of
     /// the current file (i.e. `ty_python_core::definition::ImportFromDefinitionNodeRef`).
     fn available_submodule_attributes(&self, db: &'db dyn Db) -> impl Iterator<Item = Name> {
-        self.importing_file(db)
+        self.importing_program_file(db)
             .into_iter()
-            .flat_map(|file| semantic_index(db, file).imported_modules())
+            .flat_map(|file| ty_python_core::semantic_index(db, file).imported_modules())
             .filter_map(|submodule_name| submodule_name.relative_to(self.module(db).name(db)))
             .filter_map(|relative_submodule| relative_submodule.components().next().map(Name::from))
     }
 
     fn resolve_submodule(self, db: &'db dyn Db, name: &str) -> Option<Type<'db>> {
-        let importing_file = self.importing_file(db)?;
+        let importing_file = self.importing_program_file(db)?;
         let relative_submodule_name = ModuleName::new(name)?;
         let mut absolute_submodule_name = self.module(db).name(db).clone();
         absolute_submodule_name.extend(&relative_submodule_name);
-        let submodule = resolve_module(db, importing_file, &absolute_submodule_name)?;
+        let submodule = ty_module_resolver::resolve_module(
+            db,
+            importing_file.resolver_file(db),
+            &absolute_submodule_name,
+        )?;
         Some(Type::module_literal(db, importing_file, submodule))
     }
 
     fn try_module_getattr(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        let program = self.program(db);
         // For module literals, we want to try calling the module's own `__getattr__` function
         // if it exists. First, we need to look up the `__getattr__` function in the module's scope.
-        if let Some(file) = self.module(db).file(db) {
-            let getattr_symbol = imported_symbol(db, Some(file), "__getattr__", None);
+        if let Some(program_file) = self.module_program_file(db) {
+            let getattr_symbol = imported_symbol(
+                db,
+                ImportedSymbolContext::File(program_file),
+                "__getattr__",
+                None,
+            );
             // If we found a __getattr__ function, try to call it with the name argument
             if let Place::Defined(place) = getattr_symbol.place
                 && let Ok(outcome) = place.ty.try_call(
                     db,
+                    program,
                     &CallArguments::positional([Type::string_literal(db, name)]),
                 )
             {
                 return PlaceAndQualifiers {
                     place: Place::Defined(DefinedPlace {
-                        ty: outcome.return_type(db),
+                        ty: outcome.return_type(db, program),
                         provenance: Provenance::Unknown,
                         ..place
                     }),
@@ -8651,13 +9133,14 @@ impl<'db> ModuleLiteralType<'db> {
     }
 
     fn static_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        let program = self.program(db);
         // `__dict__` is a very special member that is never overridden by module globals;
         // we should always look it up directly as an attribute on `types.ModuleType`,
         // never in the global scope of the module.
         if name == "__dict__" {
             return KnownClass::ModuleType
-                .to_instance(db)
-                .member(db, "__dict__");
+                .to_instance(db, program)
+                .member(db, program, "__dict__");
         }
 
         // If the file that originally imported the module has also imported a submodule
@@ -8675,7 +9158,11 @@ impl<'db> ModuleLiteralType<'db> {
             return Place::bound(submodule).into();
         }
 
-        let place_and_qualifiers = imported_symbol(db, self.module(db).file(db), name, None);
+        let context = self.module_program_file(db).map_or(
+            ImportedSymbolContext::Namespace(program),
+            ImportedSymbolContext::File,
+        );
+        let place_and_qualifiers = imported_symbol(db, context, name, None);
 
         // If the normal lookup failed, try to call the module's `__getattr__` function
         if place_and_qualifiers.place.is_undefined() {
@@ -8707,14 +9194,14 @@ impl<'db> ModuleLiteralType<'db> {
 }
 
 /// Either the explicit `metaclass=` keyword of the class, or the inferred metaclass of one of its base classes.
-#[derive(Debug, Clone, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) struct MetaclassCandidate<'db> {
     metaclass: ClassType<'db>,
     explicit_metaclass_of: StaticClassLiteral<'db>,
 }
 
 /// Information about a `@dataclass_transform`-decorated metaclass.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) struct MetaclassTransformInfo<'db> {
     pub(super) params: DataclassTransformerParams<'db>,
 
@@ -8735,10 +9222,11 @@ pub struct TypeIsType<'db> {
 
 fn walk_typeis_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: Program,
     typeis_type: TypeIsType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, typeis_type.type_argument(db));
+    visitor.visit_type(db, program, typeis_type.type_argument(db));
 }
 
 // The Salsa heap is tracked separately.
@@ -8767,13 +9255,13 @@ impl<'db> TypeIsType<'db> {
         Type::TypeIs(Self::new(db, ty, None))
     }
 
-    pub(crate) fn return_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn return_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         // N.B. Using the top materialization here is a pragmatic decision that
         // makes us produce more intuitive results given how `TypeIs` is used in
         // the real world (in particular, in typeshed). However, there's some
         // debate about whether this is really fully correct. See
         // <https://github.com/astral-sh/ruff/pull/20591> for more discussion.
-        self.type_argument(db).top_materialization(db)
+        self.type_argument(db).top_materialization(db, program)
     }
 
     #[must_use]
@@ -8799,10 +9287,15 @@ impl<'db> TypeIsType<'db> {
 impl<'db> VarianceInferable<'db> for TypeIsType<'db> {
     // See the [typing spec] on why `TypeIs` is invariant in its type.
     // [typing spec]: https://typing.python.org/en/latest/spec/narrowing.html#typeis
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         self.type_argument(db)
             .with_polarity(TypeVarVariance::Invariant)
-            .variance_of(db, typevar)
+            .variance_of(db, program, typevar)
     }
 }
 
@@ -8818,10 +9311,11 @@ pub struct TypeGuardType<'db> {
 
 fn walk_typeguard_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: Program,
     typeguard_type: TypeGuardType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, typeguard_type.return_type(db));
+    visitor.visit_type(db, program, typeguard_type.return_type(db));
 }
 
 // The Salsa heap is tracked separately.
@@ -8871,8 +9365,13 @@ impl<'db> TypeGuardType<'db> {
 impl<'db> VarianceInferable<'db> for TypeGuardType<'db> {
     // `TypeGuard` is covariant in its type parameter. See the `TypeGuard`
     // section of mdtest/generics/pep695/variance.md for details.
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
-        self.return_type(db).variance_of(db, typevar)
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.return_type(db).variance_of(db, program, typevar)
     }
 }
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -7221,7 +7221,7 @@ impl<'db> Type<'db> {
             }
 
             Type::GenericAlias(alias) => {
-                alias.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                alias.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
 
             Type::NominalInstance(instance) => {

--- a/crates/ty_python_semantic/src/types/attribute_write.rs
+++ b/crates/ty_python_semantic/src/types/attribute_write.rs
@@ -14,8 +14,8 @@ use super::callable::CallableTypeKind;
 use super::{
     IntersectionType, KnownClass, KnownInstanceType, MemberLookupPolicy, Type, TypeQualifiers,
 };
-use crate::Db;
 use crate::place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, builtins_symbol};
+use crate::{Db, Program};
 
 /// The operation required to write an attribute.
 ///
@@ -145,40 +145,15 @@ pub(super) enum FallbackAttributeWriteRequirement<'db> {
 }
 
 /// The members that can govern an attribute write.
-///
-/// For a class-object receiver, the type member is found on the metaclass while the receiver member
-/// is found on the class's own MRO:
-///
-/// ```python
-/// class Descriptor:
-///     def __set__(self, instance: object, value: object) -> None: ...
-///
-/// class Meta(type):
-///     data = Descriptor()  # Type member: Meta.data
-///     plain = object()  # Type member: Meta.plain
-///
-/// class C(metaclass=Meta):
-///     data: int  # Receiver member: C.data
-///     plain: int  # Receiver member: C.plain
-///
-/// C.data = 1
-/// C.plain = 1
-/// ```
 pub(super) enum AssignmentAttributeMembers<'db> {
-    /// The type member governs the write, as `Meta.data` does above because it is a data descriptor.
-    /// If the type member may be missing, the corresponding receiver member (`C.data`) is retained
-    /// as `receiver_fallback`.
     TypeMember {
         member: PlaceAndQualifiers<'db>,
         receiver_fallback: Option<PlaceAndQualifiers<'db>>,
     },
-    /// The receiver member governs the write, as `C.plain` does above because `Meta.plain` is
-    /// definitely not a data descriptor.
     ReceiverMember(PlaceAndQualifiers<'db>),
 }
 
 impl<'db> AssignmentAttributeMembers<'db> {
-    /// Return the member whose descriptor protocol applies to the receiver, if any.
     pub(super) fn type_member(self) -> Option<PlaceAndQualifiers<'db>> {
         match self {
             Self::TypeMember { member, .. } => Some(member),
@@ -186,7 +161,6 @@ impl<'db> AssignmentAttributeMembers<'db> {
         }
     }
 
-    /// Iterate over every member that can govern the write at runtime.
     pub(super) fn effective_members(self) -> impl Iterator<Item = PlaceAndQualifiers<'db>> {
         let members = match self {
             Self::TypeMember {
@@ -206,6 +180,7 @@ impl<'db> AssignmentAttributeMembers<'db> {
 /// paths. It does not compare the assigned value with the resulting types.
 pub(super) fn attribute_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
 ) -> AttributeWriteRequirement<'db> {
@@ -223,11 +198,16 @@ pub(super) fn attribute_write_requirement<'db>(
             }
         }
 
-        Type::EnumComplement(complement) => {
-            attribute_write_requirement(db, complement.remaining_literal_union(db), attribute)
-        }
+        Type::EnumComplement(complement) => attribute_write_requirement(
+            db,
+            program,
+            complement.remaining_literal_union(db),
+            attribute,
+        ),
 
-        Type::TypeAlias(alias) => attribute_write_requirement(db, alias.value_type(db), attribute),
+        Type::TypeAlias(alias) => {
+            attribute_write_requirement(db, program, alias.value_type(db), attribute)
+        }
 
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Super) => {
             AttributeWriteRequirement::CannotAssign
@@ -240,9 +220,9 @@ pub(super) fn attribute_write_requirement<'db>(
 
         Type::ProtocolInstance(protocol) => protocol
             .interface(db)
-            .instance_write_requirement(db, object_ty, attribute)
+            .instance_write_requirement(db, program, object_ty, attribute)
             .map_or_else(
-                || instance_attribute_write_requirement(db, object_ty, attribute),
+                || instance_attribute_write_requirement(db, program, object_ty, attribute),
                 |(write_ty, qualifiers)| AttributeWriteRequirement::ProtocolMember {
                     write_ty,
                     qualifiers,
@@ -269,11 +249,11 @@ pub(super) fn attribute_write_requirement<'db>(
         | Type::TypeForm(_)
         | Type::TypedDict(_)
         | Type::NewTypeInstance(_) => {
-            instance_attribute_write_requirement(db, object_ty, attribute)
+            instance_attribute_write_requirement(db, program, object_ty, attribute)
         }
 
         Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-            class_attribute_write_requirement(db, object_ty, attribute)
+            class_attribute_write_requirement(db, program, object_ty, attribute)
         }
 
         Type::ModuleLiteral(module) => {
@@ -282,7 +262,7 @@ pub(super) fn attribute_write_requirement<'db>(
                 .known(db)
                 .is_some_and(KnownModule::is_builtins)
             {
-                builtins_symbol(db, attribute)
+                builtins_symbol(db, module.program(db), attribute)
             } else {
                 module.static_member(db, attribute)
             };
@@ -296,12 +276,13 @@ pub(super) fn attribute_write_requirement<'db>(
 
 fn instance_attribute_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
 ) -> AttributeWriteRequirement<'db> {
     AttributeWriteRequirement::Instance {
         object_ty,
-        member: instance_attribute_write_member_requirement(db, object_ty, attribute),
+        member: instance_attribute_write_member_requirement(db, program, object_ty, attribute),
     }
 }
 
@@ -312,10 +293,11 @@ fn instance_attribute_write_requirement<'db>(
 /// `__setattr__`.
 fn instance_attribute_write_member_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
 ) -> InstanceAttributeWriteMember<'db> {
-    let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
+    let Some(members) = assignment_attribute_members(db, program, object_ty, attribute) else {
         return InstanceAttributeWriteMember::SetAttr;
     };
     let (type_member, receiver_fallback) = match members {
@@ -325,7 +307,7 @@ fn instance_attribute_write_member_requirement<'db>(
         } => (member, receiver_fallback),
         AssignmentAttributeMembers::ReceiverMember(member) => {
             return InstanceAttributeWriteMember::Instance(instance_fallback_write_requirement(
-                db, object_ty, attribute, member,
+                db, program, object_ty, attribute, member,
             ));
         }
     };
@@ -338,13 +320,14 @@ fn instance_attribute_write_member_requirement<'db>(
         } => InstanceAttributeWriteMember::Explicit {
             member: explicit_attribute_write_requirement(
                 db,
+                program,
                 object_ty,
                 attribute,
-                ty.bind_self_typevars(db, object_ty),
+                ty.bind_self_typevars(db, program, object_ty),
                 qualifiers,
             ),
             fallback: receiver_fallback.map(|fallback| {
-                instance_fallback_write_requirement(db, object_ty, attribute, fallback)
+                instance_fallback_write_requirement(db, program, object_ty, attribute, fallback)
             }),
         },
         PlaceAndQualifiers {
@@ -357,7 +340,7 @@ fn instance_attribute_write_member_requirement<'db>(
                     ..
                 },
             ) => InstanceAttributeWriteMember::Instance(instance_fallback_write_requirement(
-                db, object_ty, attribute, fallback,
+                db, program, object_ty, attribute, fallback,
             )),
             _ => InstanceAttributeWriteMember::SetAttr,
         },
@@ -370,13 +353,14 @@ fn instance_attribute_write_member_requirement<'db>(
 /// declarations can be bound consistently with normal class-object member lookup.
 fn class_attribute_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
 ) -> AttributeWriteRequirement<'db> {
-    let Some(members) = assignment_attribute_members(db, object_ty, attribute) else {
+    let Some(members) = assignment_attribute_members(db, program, object_ty, attribute) else {
         return AttributeWriteRequirement::Unconstrained;
     };
-    let Some(class_attr_self_ty) = object_ty.to_instance(db) else {
+    let Some(class_attr_self_ty) = object_ty.to_instance(db, program) else {
         return AttributeWriteRequirement::Unconstrained;
     };
     let (type_member, receiver_fallback) = match members {
@@ -388,7 +372,13 @@ fn class_attribute_write_requirement<'db>(
             return AttributeWriteRequirement::Class {
                 object_ty,
                 member: ClassAttributeWriteMember::ClassAttribute(
-                    class_fallback_write_requirement(db, object_ty, class_attr_self_ty, member),
+                    class_fallback_write_requirement(
+                        db,
+                        program,
+                        object_ty,
+                        class_attr_self_ty,
+                        member,
+                    ),
                 ),
             };
         }
@@ -399,9 +389,17 @@ fn class_attribute_write_requirement<'db>(
             place: Place::Defined(DefinedPlace { ty, .. }),
             qualifiers,
         } => ClassAttributeWriteMember::Explicit {
-            member: explicit_attribute_write_requirement(db, object_ty, attribute, ty, qualifiers),
+            member: explicit_attribute_write_requirement(
+                db, program, object_ty, attribute, ty, qualifiers,
+            ),
             fallback: receiver_fallback.map(|fallback| {
-                class_fallback_write_requirement(db, object_ty, class_attr_self_ty, fallback)
+                class_fallback_write_requirement(
+                    db,
+                    program,
+                    object_ty,
+                    class_attr_self_ty,
+                    fallback,
+                )
             }),
         },
         PlaceAndQualifiers {
@@ -415,13 +413,14 @@ fn class_attribute_write_requirement<'db>(
                 },
             ) => ClassAttributeWriteMember::ClassAttribute(class_fallback_write_requirement(
                 db,
+                program,
                 object_ty,
                 class_attr_self_ty,
                 fallback,
             )),
             _ => ClassAttributeWriteMember::Unresolved {
                 has_instance_attribute: !class_attr_self_ty
-                    .instance_member(db, attribute)
+                    .instance_member(db, program, attribute)
                     .place
                     .is_undefined(),
             },
@@ -438,13 +437,19 @@ fn class_attribute_write_requirement<'db>(
 /// ordinary attribute to be treated as a data descriptor.
 fn explicit_attribute_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
     attr_ty: Type<'db>,
     qualifiers: TypeQualifiers,
 ) -> ExplicitAttributeWriteRequirement<'db> {
     if let Place::Defined(DefinedPlace { ty: setter_ty, .. }) = attr_ty
-        .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .class_member_with_policy(
+            db,
+            program,
+            "__set__".into(),
+            MemberLookupPolicy::REQUIRE_CONCRETE,
+        )
         .place
     {
         ExplicitAttributeWriteRequirement::Descriptor {
@@ -454,7 +459,7 @@ fn explicit_attribute_write_requirement<'db>(
         }
     } else {
         ExplicitAttributeWriteRequirement::AssignableTo {
-            ty: effective_write_type(db, object_ty, attribute, attr_ty),
+            ty: effective_write_type(db, program, object_ty, attribute, attr_ty),
             qualifiers,
         }
     }
@@ -466,6 +471,7 @@ fn explicit_attribute_write_requirement<'db>(
 /// assignment diagnostic layer.
 fn instance_fallback_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
     fallback: PlaceAndQualifiers<'db>,
@@ -479,9 +485,9 @@ fn instance_fallback_write_requirement<'db>(
     else {
         return FallbackAttributeWriteRequirement::PossiblyMissing;
     };
-    let ty = ty.bind_self_typevars(db, object_ty);
+    let ty = ty.bind_self_typevars(db, program, object_ty);
     FallbackAttributeWriteRequirement::AssignableTo {
-        ty: effective_write_type(db, object_ty, attribute, ty),
+        ty: effective_write_type(db, program, object_ty, attribute, ty),
         qualifiers,
         possibly_missing: definedness == Definedness::PossiblyUndefined,
     }
@@ -490,6 +496,7 @@ fn instance_fallback_write_requirement<'db>(
 /// Convert a class-attribute fallback into a write type, binding `Self` to the class instance.
 fn class_fallback_write_requirement<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     class_attr_self_ty: Type<'db>,
     fallback: PlaceAndQualifiers<'db>,
@@ -503,7 +510,7 @@ fn class_fallback_write_requirement<'db>(
     else {
         return FallbackAttributeWriteRequirement::PossiblyMissing;
     };
-    let ty = ty.bind_self_typevars(db, class_attr_self_ty);
+    let ty = ty.bind_self_typevars(db, program, class_attr_self_ty);
     let ty = if matches!(object_ty, Type::ClassLiteral(_))
         && let Type::FunctionLiteral(function) = ty
         && function.callable_type_kind(db) == CallableTypeKind::FunctionLike
@@ -526,13 +533,14 @@ fn class_fallback_write_requirement<'db>(
 /// `(str) -> int` converter is read as `int` but accepts `str` assignments.
 fn effective_write_type<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
     attr_ty: Type<'db>,
 ) -> Type<'db> {
     if let Type::NominalInstance(instance) = object_ty
         && let Some(converter_ty) = instance
-            .class(db)
+            .class(db, program)
             .converter_input_type_for_field(db, attribute)
     {
         converter_ty
@@ -559,15 +567,20 @@ fn effective_write_type<'db>(
 /// ```
 pub(super) fn property_setter_returns_never<'db>(
     db: &'db dyn Db,
+    program: Program,
     property_ty: Type<'db>,
     object_ty: Type<'db>,
     value_ty: Type<'db>,
 ) -> bool {
     property_ty.as_property_instance().is_some_and(|property| {
         property.setter(db).is_some_and(|setter| {
-            match setter.try_call(db, &CallArguments::positional([object_ty, value_ty])) {
-                Ok(result) => result.return_type(db).is_never(),
-                Err(error) => error.return_type(db).is_never(),
+            match setter.try_call(
+                db,
+                program,
+                &CallArguments::positional([object_ty, value_ty]),
+            ) {
+                Ok(result) => result.return_type(db, program).is_never(),
+                Err(error) => error.return_type(db, program).is_never(),
             }
         })
     })
@@ -576,6 +589,7 @@ pub(super) fn property_setter_returns_never<'db>(
 /// Return the class member that takes precedence over a definitely non-data metaclass member.
 fn class_member_preceding_non_data_metaclass_member<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
     type_member: PlaceAndQualifiers<'db>,
@@ -586,45 +600,39 @@ fn class_member_preceding_non_data_metaclass_member<'db>(
     ) || !type_member
         .place
         .ignore_possibly_undefined()?
-        .is_definitely_non_data_descriptor(db)
+        .is_definitely_non_data_descriptor(db, program)
     {
         return None;
     }
 
     object_ty
-        .find_name_in_mro_with_policy(db, attribute, MemberLookupPolicy::default())
+        .find_name_in_mro_with_policy(db, program, attribute, MemberLookupPolicy::default())
         .filter(|class_attr| !class_attr.place.is_undefined())
 }
 
 /// Return the members considered by attribute assignment in lookup-precedence order.
-///
-/// The type member comes from class-member lookup. A member found directly on the receiver is
-/// queried when the type member is absent or possibly undefined. For class objects, a class-MRO
-/// member instead takes precedence over a definitely non-data metaclass member. Composite and
-/// dynamic receiver types return `None`; their callers either decompose them before this point or
-/// handle them without member lookup.
-///
-/// This helper deliberately does not bind `Self` or interpret descriptors so that assignment,
-/// protocol compatibility, and `Final` validation share exactly the same lookup precedence.
 pub(super) fn assignment_attribute_members<'db>(
     db: &'db dyn Db,
+    program: Program,
     object_ty: Type<'db>,
     attribute: &str,
 ) -> Option<AssignmentAttributeMembers<'db>> {
-    // Precise `functools.partial` instances synthesize a refined `__call__` member instead of
-    // using the broad signature from typeshed.
     let type_member = if attribute == "__call__"
         && matches!(
             object_ty,
             Type::KnownInstance(KnownInstanceType::FunctoolsPartial(_))
         ) {
-        object_ty.member(db, attribute)
+        object_ty.member(db, program, attribute)
     } else {
-        object_ty.class_member(db, attribute.into())
+        object_ty.class_member(db, program, attribute.into())
     };
-    if let Some(receiver_member) =
-        class_member_preceding_non_data_metaclass_member(db, object_ty, attribute, type_member)
-    {
+    if let Some(receiver_member) = class_member_preceding_non_data_metaclass_member(
+        db,
+        program,
+        object_ty,
+        attribute,
+        type_member,
+    ) {
         return Some(AssignmentAttributeMembers::ReceiverMember(receiver_member));
     }
     let needs_receiver_fallback = matches!(
@@ -657,9 +665,9 @@ pub(super) fn assignment_attribute_members<'db>(
             | Type::TypeGuard(_)
             | Type::TypeForm(_)
             | Type::TypedDict(_)
-            | Type::NewTypeInstance(_) => object_ty.instance_member(db, attribute),
+            | Type::NewTypeInstance(_) => object_ty.instance_member(db, program, attribute),
             Type::ClassLiteral(..) | Type::GenericAlias(..) | Type::SubclassOf(..) => {
-                object_ty.class_object_member(db, attribute, MemberLookupPolicy::default())
+                object_ty.class_object_member(db, program, attribute, MemberLookupPolicy::default())
             }
             Type::Union(..)
             | Type::Intersection(..)

--- a/crates/ty_python_semantic/src/types/bool.rs
+++ b/crates/ty_python_semantic/src/types/bool.rs
@@ -2,7 +2,7 @@ use ruff_db::diagnostic::{Annotation, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::{
-    Db,
+    Db, Program,
     types::{
         CallArguments, CallDunderError, ClassType, CycleDetector, KnownClass, KnownInstanceType,
         LiteralValueTypeKind, SubclassOfInner, Type, TypeContext, TypeVarBoundOrConstraints,
@@ -18,9 +18,14 @@ impl<'db> Type<'db> {
     /// This method should only be used outside type checking or when evaluating if a type
     /// is truthy or falsy in a context where Python doesn't make an implicit `bool` call.
     /// Use [`try_bool`](Self::try_bool) for type checking or implicit `bool` calls.
-    pub(crate) fn bool(&self, db: &'db dyn Db) -> Truthiness {
-        self.try_bool_impl(db, true, &TryBoolVisitor::new(Ok(Truthiness::Ambiguous)))
-            .unwrap_or_else(|err| err.fallback_truthiness())
+    pub(crate) fn bool(&self, db: &'db dyn Db, program: Program) -> Truthiness {
+        self.try_bool_impl(
+            db,
+            program,
+            true,
+            &TryBoolVisitor::new(Ok(Truthiness::Ambiguous)),
+        )
+        .unwrap_or_else(|err| err.fallback_truthiness())
     }
 
     /// Resolves the boolean value of a type.
@@ -29,8 +34,17 @@ impl<'db> Type<'db> {
     /// when `bool(x)` is called on an object `x`.
     ///
     /// Returns an error if the type doesn't implement `__bool__` correctly.
-    pub(crate) fn try_bool(&self, db: &'db dyn Db) -> Result<Truthiness, BoolError<'db>> {
-        self.try_bool_impl(db, false, &TryBoolVisitor::new(Ok(Truthiness::Ambiguous)))
+    pub(crate) fn try_bool(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Result<Truthiness, BoolError<'db>> {
+        self.try_bool_impl(
+            db,
+            program,
+            false,
+            &TryBoolVisitor::new(Ok(Truthiness::Ambiguous)),
+        )
     }
 
     /// Resolves the boolean value of a type.
@@ -48,6 +62,7 @@ impl<'db> Type<'db> {
     fn try_bool_impl(
         &self,
         db: &'db dyn Db,
+        program: Program,
         allow_short_circuit: bool,
         visitor: &TryBoolVisitor<'db>,
     ) -> Result<Truthiness, BoolError<'db>> {
@@ -63,13 +78,18 @@ impl<'db> Type<'db> {
         let try_dunders = || {
             match self.try_call_dunder(
                 db,
+                program,
                 "__bool__",
                 CallArguments::none(),
                 TypeContext::default(),
             ) {
                 Ok(outcome) => {
-                    let return_type = outcome.return_type(db);
-                    if !return_type.is_assignable_to(db, KnownClass::Bool.to_instance(db)) {
+                    let return_type = outcome.return_type(db, program);
+                    if !return_type.is_assignable_to(
+                        db,
+                        program,
+                        KnownClass::Bool.to_instance(db, program),
+                    ) {
                         // The type has a `__bool__` method, but it doesn't return a
                         // boolean.
                         return Err(BoolError::IncorrectReturnType {
@@ -83,12 +103,16 @@ impl<'db> Type<'db> {
                 Err(CallDunderError::PossiblyUnbound {
                     bindings: outcome, ..
                 }) => {
-                    let return_type = outcome.return_type(db);
-                    if !return_type.is_assignable_to(db, KnownClass::Bool.to_instance(db)) {
+                    let return_type = outcome.return_type(db, program);
+                    if !return_type.is_assignable_to(
+                        db,
+                        program,
+                        KnownClass::Bool.to_instance(db, program),
+                    ) {
                         // The type has a `__bool__` method, but it doesn't return a
                         // boolean.
                         return Err(BoolError::IncorrectReturnType {
-                            return_type: outcome.return_type(db),
+                            return_type: outcome.return_type(db, program),
                             not_boolable_type: *self,
                         });
                     }
@@ -107,20 +131,22 @@ impl<'db> Type<'db> {
                     // that is inconsistent with the tuple's length. Otherwise, the special
                     // handling for tuples here isn't sound.
                     if let Some(instance) = self.as_nominal_instance() {
-                        if let Some(tuple_spec) = instance.tuple_spec(db) {
+                        if let Some(tuple_spec) = instance.tuple_spec(db, program) {
                             Ok(tuple_spec.truthiness())
-                        } else if instance.class(db).is_final(db) {
+                        } else if instance.class(db, program).is_final(db) {
                             match self.try_call_dunder(
                                 db,
+                                program,
                                 "__len__",
                                 CallArguments::none(),
                                 TypeContext::default(),
                             ) {
                                 Ok(outcome) => {
-                                    let return_type = outcome.return_type(db);
+                                    let return_type = outcome.return_type(db, program);
                                     if return_type.is_assignable_to(
                                         db,
-                                        KnownClass::SupportsIndex.to_instance(db),
+                                        program,
+                                        KnownClass::SupportsIndex.to_instance(db, program),
                                     ) {
                                         Ok(type_to_truthiness(return_type))
                                     } else {
@@ -147,7 +173,7 @@ impl<'db> Type<'db> {
 
                 Err(CallDunderError::CallError(CallErrorKind::BindingError, bindings, _)) => {
                     Err(BoolError::IncorrectArguments {
-                        truthiness: type_to_truthiness(bindings.return_type(db)),
+                        truthiness: type_to_truthiness(bindings.return_type(db, program)),
                         not_boolable_type: *self,
                     })
                 }
@@ -173,7 +199,7 @@ impl<'db> Type<'db> {
 
             for element in union.elements(db) {
                 let element_truthiness =
-                    match element.try_bool_impl(db, allow_short_circuit, visitor) {
+                    match element.try_bool_impl(db, program, allow_short_circuit, visitor) {
                         Ok(truthiness) => truthiness,
                         Err(err) => {
                             has_errors = true;
@@ -230,8 +256,8 @@ impl<'db> Type<'db> {
 
             Type::KnownInstance(KnownInstanceType::ConstraintSet(tracked_set)) => {
                 let constraints = ConstraintSetBuilder::new();
-                let tracked_set = constraints.load(db, tracked_set.constraints(db));
-                Truthiness::from(tracked_set.is_always_satisfied(db))
+                let tracked_set = constraints.load(db, program, tracked_set.constraints(db));
+                Truthiness::from(tracked_set.is_always_satisfied(db, program))
             }
 
             Type::KnownInstance(KnownInstanceType::Range { is_non_empty }) => {
@@ -253,23 +279,30 @@ impl<'db> Type<'db> {
 
             Type::AlwaysFalsy => Truthiness::AlwaysFalse,
 
-            Type::ClassLiteral(class) => {
-                class
-                    .metaclass_instance_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)?
-            }
+            Type::ClassLiteral(class) => class.metaclass_instance_type(db).try_bool_impl(
+                db,
+                program,
+                allow_short_circuit,
+                visitor,
+            )?,
             Type::GenericAlias(alias) => ClassType::from(*alias)
                 .metaclass_instance_type(db)
-                .try_bool_impl(db, allow_short_circuit, visitor)?,
+                .try_bool_impl(db, program, allow_short_circuit, visitor)?,
 
             Type::SubclassOf(subclass_of_ty) => {
-                match subclass_of_ty.subclass_of().with_transposed_type_var(db) {
+                match subclass_of_ty
+                    .subclass_of()
+                    .with_transposed_type_var(db, program)
+                {
                     SubclassOfInner::Dynamic(_) => Truthiness::Ambiguous,
-                    SubclassOfInner::Class(class) => {
-                        Type::from(class).try_bool_impl(db, allow_short_circuit, visitor)?
-                    }
+                    SubclassOfInner::Class(class) => Type::from(class).try_bool_impl(
+                        db,
+                        program,
+                        allow_short_circuit,
+                        visitor,
+                    )?,
                     SubclassOfInner::TypeVar(bound_typevar) => Type::TypeVar(bound_typevar)
-                        .try_bool_impl(db, allow_short_circuit, visitor)?,
+                        .try_bool_impl(db, program, allow_short_circuit, visitor)?,
                 }
             }
 
@@ -277,11 +310,11 @@ impl<'db> Type<'db> {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     None => Truthiness::Ambiguous,
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        bound.try_bool_impl(db, allow_short_circuit, visitor)?
+                        bound.try_bool_impl(db, program, allow_short_circuit, visitor)?
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => constraints
-                        .as_type(db)
-                        .try_bool_impl(db, allow_short_circuit, visitor)?,
+                        .as_type(db, program)
+                        .try_bool_impl(db, program, allow_short_circuit, visitor)?,
                 }
             }
 
@@ -296,8 +329,8 @@ impl<'db> Type<'db> {
             Type::Union(union) => try_union(*union)?,
 
             Type::Intersection(intersection) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db) {
-                    alternatives.try_bool_impl(db, allow_short_circuit, visitor)?
+                if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
+                    alternatives.try_bool_impl(db, program, allow_short_circuit, visitor)?
                 } else {
                     // TODO
                     Truthiness::Ambiguous
@@ -306,13 +339,13 @@ impl<'db> Type<'db> {
 
             Type::EnumComplement(complement) => complement
                 .remaining_literal_union(db)
-                .try_bool_impl(db, allow_short_circuit, visitor)?,
+                .try_bool_impl(db, program, allow_short_circuit, visitor)?,
 
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::LiteralString => Truthiness::Ambiguous,
                 LiteralValueTypeKind::Enum(enum_type) => enum_type
                     .enum_class_instance(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)?,
+                    .try_bool_impl(db, program, allow_short_circuit, visitor)?,
 
                 LiteralValueTypeKind::Int(num) => Truthiness::from(num.as_i64() != 0),
                 LiteralValueTypeKind::Bool(bool) => Truthiness::from(bool),
@@ -323,13 +356,14 @@ impl<'db> Type<'db> {
             Type::TypeAlias(alias) => visitor.visit(*self, || {
                 alias
                     .value_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)
+                    .try_bool_impl(db, program, allow_short_circuit, visitor)
             })?,
-            Type::NewTypeInstance(newtype) => {
-                newtype
-                    .concrete_base_type(db)
-                    .try_bool_impl(db, allow_short_circuit, visitor)?
-            }
+            Type::NewTypeInstance(newtype) => newtype.concrete_base_type(db).try_bool_impl(
+                db,
+                program,
+                allow_short_circuit,
+                visitor,
+            )?,
         };
 
         Ok(truthiness)
@@ -413,15 +447,15 @@ impl<'db> BoolError<'db> {
             } => {
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Boolean conversion is not supported for type `{}`",
-                    not_boolable_type.display(context.db())
+                    not_boolable_type.display(context.db(), context.program())
                 ));
                 let mut sub = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     "`__bool__` methods must only have a `self` parameter",
                 );
                 if let Some((func_span, parameter_span)) = not_boolable_type
-                    .member(context.db(), "__bool__")
-                    .into_lookup_result(context.db())
+                    .member(context.db(), context.program(), "__bool__")
+                    .into_lookup_result(context.db(), context.program())
                     .ok()
                     .and_then(|quals| quals.inner_type().parameter_span(context.db(), None))
                 {
@@ -438,18 +472,18 @@ impl<'db> BoolError<'db> {
             } => {
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Boolean conversion is not supported for type `{not_boolable}`",
-                    not_boolable = not_boolable_type.display(context.db()),
+                    not_boolable = not_boolable_type.display(context.db(), context.program()),
                 ));
                 let mut sub = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!(
                         "`{return_type}` is not assignable to `bool`",
-                        return_type = return_type.display(context.db()),
+                        return_type = return_type.display(context.db(), context.program()),
                     ),
                 );
                 if let Some((func_span, return_type_span)) = not_boolable_type
-                    .member(context.db(), "__bool__")
-                    .into_lookup_result(context.db())
+                    .member(context.db(), context.program(), "__bool__")
+                    .into_lookup_result(context.db(), context.program())
                     .ok()
                     .and_then(|quals| quals.inner_type().function_spans(context.db()))
                     .and_then(|spans| Some((spans.name, spans.return_type?)))
@@ -464,13 +498,13 @@ impl<'db> BoolError<'db> {
             Self::NotCallable { not_boolable_type } => {
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Boolean conversion is not supported for type `{}`",
-                    not_boolable_type.display(context.db())
+                    not_boolable_type.display(context.db(), context.program())
                 ));
                 let sub = SubDiagnostic::new(
                     SubDiagnosticSeverity::Info,
                     format_args!(
                         "`__bool__` on `{}` must be callable",
-                        not_boolable_type.display(context.db())
+                        not_boolable_type.display(context.db(), context.program())
                     ),
                 );
                 // TODO: It would be nice to create an annotation here for
@@ -482,14 +516,16 @@ impl<'db> BoolError<'db> {
                 let first_error = union
                     .elements(context.db())
                     .iter()
-                    .find_map(|element| element.try_bool(context.db()).err())
+                    .find_map(|element| element.try_bool(context.db(), context.program()).err())
                     .unwrap();
 
                 builder.into_diagnostic(format_args!(
                     "Boolean conversion is not supported for union `{}` \
                      because `{}` doesn't implement `__bool__` correctly",
-                    Type::Union(*union).display(context.db()),
-                    first_error.not_boolable_type().display(context.db()),
+                    Type::Union(*union).display(context.db(), context.program()),
+                    first_error
+                        .not_boolable_type()
+                        .display(context.db(), context.program()),
                 ));
             }
 
@@ -497,7 +533,7 @@ impl<'db> BoolError<'db> {
                 builder.into_diagnostic(format_args!(
                     "Boolean conversion is not supported for type `{}`; \
                      it incorrectly implements `__bool__`",
-                    not_boolable_type.display(context.db())
+                    not_boolable_type.display(context.db(), context.program())
                 ));
             }
         }

--- a/crates/ty_python_semantic/src/types/bound_super.rs
+++ b/crates/ty_python_semantic/src/types/bound_super.rs
@@ -5,7 +5,7 @@ use ruff_db::diagnostic::Diagnostic;
 use ruff_python_ast::{AnyNodeRef, name::Name};
 
 use crate::{
-    Db, DisplaySettings,
+    Db, DisplaySettings, Program,
     place::{Place, PlaceAndQualifiers},
     types::{
         BoundTypeVarInstance, ClassBase, ClassType, DivergentType, DynamicType,
@@ -42,18 +42,19 @@ impl<'db> TypeVarOwnerContext<'db> {
     /// The bound or constraints of this typevar, as a type (i.e. constraints are unioned), wrapped
     /// in `SubclassOf` if this is a `SubclassOf` context. `object` if no bound/constraints.
     /// Used for error messages.
-    fn bound_or_constraints_type(self, db: &'db dyn Db) -> Type<'db> {
+    fn bound_or_constraints_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self {
             TypeVarOwnerContext::Bare(typevar) => typevar
                 .typevar(db)
                 .require_bound_or_constraints(db)
-                .as_type(db),
+                .as_type(db, program),
             TypeVarOwnerContext::SubclassOf(typevar) => SubclassOfType::try_from_instance(
                 db,
+                program,
                 typevar
                     .typevar(db)
                     .require_bound_or_constraints(db)
-                    .as_type(db),
+                    .as_type(db, program),
             )
             .unwrap_or_else(SubclassOfType::subclass_of_unknown),
         }
@@ -102,16 +103,21 @@ impl<'db> BoundSuperError<'db> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "`{owner}` is a type variable with an abstract/structural type as \
                             its bounds or constraints, in `super({pivot_class}, {owner})` call",
-                            pivot_class = pivot_class.display(context.db()),
-                            owner = owner_type.display(context.db()),
+                            pivot_class = pivot_class.display(context.db(), context.program()),
+                            owner = owner_type.display(context.db(), context.program()),
                         ));
-                        Self::describe_typevar(context.db(), &mut diagnostic, *typevar_context);
+                        Self::describe_typevar(
+                            context.db(),
+                            context.program(),
+                            &mut diagnostic,
+                            *typevar_context,
+                        );
                     } else {
                         builder.into_diagnostic(format_args!(
                             "`{owner}` is an abstract/structural type in \
                             `super({pivot_class}, {owner})` call",
-                            pivot_class = pivot_class.display(context.db()),
-                            owner = owner_type.display(context.db()),
+                            pivot_class = pivot_class.display(context.db(), context.program()),
+                            owner = owner_type.display(context.db(), context.program()),
                         ));
                     }
                 }
@@ -130,11 +136,11 @@ impl<'db> BoundSuperError<'db> {
                                 builder.into_diagnostic("Argument is not a valid class");
                             diagnostic.set_primary_message(format_args!(
                                 "Argument has type `{}`",
-                                pivot_class.display(context.db())
+                                pivot_class.display(context.db(), context.program())
                             ));
                             diagnostic.set_concise_message(format_args!(
                                 "`{}` is not a valid class",
-                                pivot_class.display(context.db()),
+                                pivot_class.display(context.db(), context.program()),
                             ));
                         }
                     }
@@ -149,16 +155,21 @@ impl<'db> BoundSuperError<'db> {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "`{owner}` is not an instance or subclass of \
                         `{pivot_class}` in `super({pivot_class}, {owner})` call",
-                        pivot_class = pivot_class.display(context.db()),
-                        owner = owner.display(context.db()),
+                        pivot_class = pivot_class.display(context.db(), context.program()),
+                        owner = owner.display(context.db(), context.program()),
                     ));
                     if let Some(typevar_context) = typevar_context {
-                        Self::describe_typevar(context.db(), &mut diagnostic, *typevar_context);
+                        Self::describe_typevar(
+                            context.db(),
+                            context.program(),
+                            &mut diagnostic,
+                            *typevar_context,
+                        );
                         diagnostic.info(format_args!(
                             "`{bounds_or_constraints}` is not an instance or subclass of `{pivot_class}`",
                             bounds_or_constraints =
-                                typevar_context.bound_or_constraints_type(context.db()).display(context.db()),
-                            pivot_class = pivot_class.display(context.db()),
+                                typevar_context.bound_or_constraints_type(context.db(), context.program()).display(context.db(), context.program()),
+                            pivot_class = pivot_class.display(context.db(), context.program()),
                         ));
                         let typevar = typevar_context.typevar(context.db());
                         if typevar_context.has_implicit_upper_bound(context.db()) {
@@ -186,6 +197,7 @@ impl<'db> BoundSuperError<'db> {
     /// and return the type variable's upper bound or the union of its constraints.
     fn describe_typevar(
         db: &'db dyn Db,
+        program: crate::Program,
         diagnostic: &mut Diagnostic,
         type_var_context: TypeVarOwnerContext<'db>,
     ) -> Type<'db> {
@@ -202,7 +214,7 @@ impl<'db> BoundSuperError<'db> {
                 diagnostic.info(format_args!(
                     "Type variable `{}` has upper bound `{}`",
                     type_var.name(db),
-                    bound.display(db)
+                    bound.display(db, program)
                 ));
                 bound
             }
@@ -213,10 +225,10 @@ impl<'db> BoundSuperError<'db> {
                     constraints
                         .elements(db)
                         .iter()
-                        .map(|c| c.display(db))
+                        .map(|c| c.display(db, program))
                         .join(", ")
                 ));
-                constraints.as_type(db)
+                constraints.as_type(db, program)
             }
         }
     }
@@ -262,13 +274,14 @@ impl<'db> ResolvedSuperOwner<'db> {
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(Self {
             owner_type: self
                 .owner_type
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
             lookup_anchor: self
                 .lookup_anchor
                 .recursive_type_normalized_impl(db, div, nested)?,
@@ -277,11 +290,13 @@ impl<'db> ResolvedSuperOwner<'db> {
     }
 
     fn descriptor_binding(&self, db: &'db dyn Db) -> (Option<Type<'db>>, Type<'db>) {
+        let program = self.lookup_anchor.program(db);
         match self.receiver {
             DescriptorReceiverKind::Class => (None, self.owner_type),
-            DescriptorReceiverKind::Instance => {
-                (Some(self.owner_type), self.owner_type.to_meta_type(db))
-            }
+            DescriptorReceiverKind::Instance => (
+                Some(self.owner_type),
+                self.owner_type.to_meta_type(db, program),
+            ),
         }
     }
 }
@@ -297,6 +312,7 @@ impl<'db> SuperOwnerKind<'db> {
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -306,18 +322,22 @@ impl<'db> SuperOwnerKind<'db> {
             }
             SuperOwnerKind::Divergent(_) => Some(*self),
             SuperOwnerKind::Resolved(resolved_owner) => Some(SuperOwnerKind::Resolved(
-                resolved_owner.recursive_type_normalized_impl(db, div, nested)?,
+                resolved_owner.recursive_type_normalized_impl(db, program, div, nested)?,
             )),
         }
     }
 
-    fn iter_mro(&self, db: &'db dyn Db) -> impl Iterator<Item = ClassBase<'db>> + Clone {
+    fn iter_mro(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         match self {
             SuperOwnerKind::Dynamic(dynamic) => {
-                Either::Left(ClassBase::Dynamic(*dynamic).mro(db, None))
+                Either::Left(ClassBase::Dynamic(*dynamic).mro(db, program, None))
             }
             SuperOwnerKind::Divergent(divergent) => {
-                Either::Left(ClassBase::Divergent(*divergent).mro(db, None))
+                Either::Left(ClassBase::Divergent(*divergent).mro(db, program, None))
             }
             SuperOwnerKind::Resolved(resolved_owner) => {
                 Either::Right(resolved_owner.lookup_anchor.iter_mro(db))
@@ -356,16 +376,19 @@ impl get_size2::GetSize for BoundSuperType<'_> {}
 
 pub(super) fn walk_bound_super_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     bound_super: BoundSuperType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, Type::from(bound_super.pivot_class(db)));
+    visitor.visit_type(db, program, Type::from(bound_super.pivot_class(db)));
     match bound_super.owner(db) {
-        SuperOwnerKind::Dynamic(dynamic) => visitor.visit_type(db, Type::Dynamic(dynamic)),
-        SuperOwnerKind::Divergent(divergent) => visitor.visit_type(db, Type::Divergent(divergent)),
+        SuperOwnerKind::Dynamic(dynamic) => visitor.visit_type(db, program, Type::Dynamic(dynamic)),
+        SuperOwnerKind::Divergent(divergent) => {
+            visitor.visit_type(db, program, Type::Divergent(divergent));
+        }
         SuperOwnerKind::Resolved(resolved_owner) => {
-            visitor.visit_type(db, resolved_owner.owner_type);
-            visitor.visit_type(db, Type::from(resolved_owner.lookup_anchor));
+            visitor.visit_type(db, program, resolved_owner.owner_type);
+            visitor.visit_type(db, program, Type::from(resolved_owner.lookup_anchor));
         }
     }
 }
@@ -486,11 +509,13 @@ impl<'db> BoundSuperType<'db> {
     /// However, the checking is skipped when any of the arguments is a dynamic type.
     pub(super) fn build(
         db: &'db dyn Db,
+        program: Program,
         pivot_class_type: Type<'db>,
         owner_type: Type<'db>,
     ) -> Result<Type<'db>, BoundSuperError<'db>> {
-        let delegate_to =
-            |type_to_delegate_to| BoundSuperType::build(db, pivot_class_type, type_to_delegate_to);
+        let delegate_to = |type_to_delegate_to| {
+            BoundSuperType::build(db, program, pivot_class_type, type_to_delegate_to)
+        };
 
         // Delegate but rewrite errors to preserve TypeVar context.
         let delegate_with_error_mapped =
@@ -532,7 +557,7 @@ impl<'db> BoundSuperType<'db> {
             Type::ClassLiteral(class) => ClassBase::Class(ClassType::NonGeneric(class)),
             Type::SubclassOf(subclass_of) => match subclass_of.subclass_of() {
                 SubclassOfInner::Dynamic(dynamic) => ClassBase::Dynamic(dynamic),
-                _ => match subclass_of.subclass_of().into_class(db) {
+                _ => match subclass_of.subclass_of().into_class(db, program) {
                     Some(class) => ClassBase::Class(class),
                     None => {
                         return Err(BoundSuperError::InvalidPivotClassType {
@@ -558,10 +583,10 @@ impl<'db> BoundSuperType<'db> {
         let build_constrained_union = |constraints: TypeVarConstraints<'db>,
                                        typevar: TypeVarOwnerContext<'db>|
          -> Result<Type<'db>, BoundSuperError<'db>> {
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
             for constraint in constraints.elements(db) {
                 let class = match constraint {
-                    Type::NominalInstance(instance) => Some(instance.class(db)),
+                    Type::NominalInstance(instance) => Some(instance.class(db, program)),
                     _ => constraint.to_class_type(db),
                 };
                 match class {
@@ -632,10 +657,12 @@ impl<'db> BoundSuperType<'db> {
                     match typevar.bound_or_constraints(db) {
                         Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                             let class = match bound {
-                                Type::NominalInstance(instance) => Some(instance.class(db)),
+                                Type::NominalInstance(instance) => {
+                                    Some(instance.class(db, program))
+                                }
                                 Type::ProtocolInstance(protocol) => protocol
                                     .to_nominal_instance()
-                                    .map(|instance| instance.class(db)),
+                                    .map(|instance| instance.class(db, program)),
                                 _ => None,
                             };
                             if let Some(class) = class {
@@ -649,8 +676,9 @@ impl<'db> BoundSuperType<'db> {
                                     Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
                                 )?)
                             } else {
-                                let subclass_of = SubclassOfType::try_from_instance(db, bound)
-                                    .unwrap_or_else(SubclassOfType::subclass_of_unknown);
+                                let subclass_of =
+                                    SubclassOfType::try_from_instance(db, program, bound)
+                                        .unwrap_or_else(SubclassOfType::subclass_of_unknown);
                                 return delegate_with_error_mapped(
                                     subclass_of,
                                     Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
@@ -671,7 +699,7 @@ impl<'db> BoundSuperType<'db> {
                                 pivot_class_type,
                                 owner_type,
                                 owner_type,
-                                ClassType::object(db),
+                                ClassType::object(db, program),
                                 Some(TypeVarOwnerContext::SubclassOf(bound_typevar)),
                             )?)
                         }
@@ -684,7 +712,7 @@ impl<'db> BoundSuperType<'db> {
                     pivot_class,
                     pivot_class_type,
                     owner_type,
-                    instance.class(db),
+                    instance.class(db, program),
                     None,
                 )?)
             }
@@ -696,7 +724,7 @@ impl<'db> BoundSuperType<'db> {
                         pivot_class,
                         pivot_class_type,
                         owner_type,
-                        nominal_instance.class(db),
+                        nominal_instance.class(db, program),
                         None,
                     )?)
                 } else {
@@ -712,13 +740,13 @@ impl<'db> BoundSuperType<'db> {
                 return Ok(union
                     .elements(db)
                     .iter()
-                    .try_fold(UnionBuilder::new(db), |builder, element| {
+                    .try_fold(UnionBuilder::new(db, program), |builder, element| {
                         delegate_to(*element).map(|ty| builder.add(ty))
                     })?
                     .build());
             }
             Type::Intersection(intersection) => {
-                let mut builder = IntersectionBuilder::new(db);
+                let mut builder = IntersectionBuilder::new(db, program);
                 let mut one_good_element_found = false;
                 for positive in intersection.positive(db) {
                     if let Ok(good_element) = delegate_to(*positive) {
@@ -751,10 +779,10 @@ impl<'db> BoundSuperType<'db> {
                 match typevar.bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let class = match bound {
-                            Type::NominalInstance(instance) => Some(instance.class(db)),
+                            Type::NominalInstance(instance) => Some(instance.class(db, program)),
                             Type::ProtocolInstance(protocol) => protocol
                                 .to_nominal_instance()
-                                .map(|instance| instance.class(db)),
+                                .map(|instance| instance.class(db, program)),
                             _ => None,
                         };
                         if let Some(class) = class {
@@ -786,59 +814,68 @@ impl<'db> BoundSuperType<'db> {
                             pivot_class,
                             pivot_class_type,
                             owner_type,
-                            ClassType::object(db),
+                            ClassType::object(db, program),
                             Some(TypeVarOwnerContext::Bare(bound_typevar)),
                         )?)
                     }
                 }
             }
             Type::TypeIs(_) | Type::TypeGuard(_) => {
-                return delegate_to(KnownClass::Bool.to_instance(db));
+                return delegate_to(KnownClass::Bool.to_instance(db, program));
             }
-            Type::LiteralValue(literal) => return delegate_to(literal.fallback_instance(db)),
+            Type::LiteralValue(literal) => {
+                return delegate_to(literal.fallback_instance(db, program));
+            }
             Type::SpecialForm(special_form) => {
-                return delegate_to(special_form.instance_fallback(db));
+                return delegate_to(special_form.instance_fallback(db, program));
             }
             Type::KnownInstance(instance) => {
-                return delegate_to(instance.instance_fallback(db));
+                return delegate_to(instance.instance_fallback(db, program));
             }
             Type::FunctionLiteral(_) | Type::DataclassDecorator(_) => {
-                return delegate_to(KnownClass::FunctionType.to_instance(db));
+                return delegate_to(KnownClass::FunctionType.to_instance(db, program));
             }
             Type::WrapperDescriptor(_) => {
-                return delegate_to(KnownClass::WrapperDescriptorType.to_instance(db));
+                return delegate_to(KnownClass::WrapperDescriptorType.to_instance(db, program));
             }
             Type::KnownBoundMethod(method) => {
-                return delegate_to(method.class().to_instance(db));
+                return delegate_to(method.class().to_instance(db, program));
             }
-            Type::BoundMethod(_) => return delegate_to(KnownClass::MethodType.to_instance(db)),
+            Type::BoundMethod(_) => {
+                return delegate_to(KnownClass::MethodType.to_instance(db, program));
+            }
             Type::ModuleLiteral(_) => {
-                return delegate_to(KnownClass::ModuleType.to_instance(db));
+                return delegate_to(KnownClass::ModuleType.to_instance(db, program));
             }
-            Type::GenericAlias(_) => return delegate_to(KnownClass::GenericAlias.to_instance(db)),
+            Type::GenericAlias(_) => {
+                return delegate_to(KnownClass::GenericAlias.to_instance(db, program));
+            }
             Type::PropertyInstance(property) => {
-                return delegate_to(property.instance_fallback(db));
+                return delegate_to(property.instance_fallback(db, program));
             }
-            Type::BoundSuper(_) => return delegate_to(KnownClass::Super.to_instance(db)),
+            Type::BoundSuper(_) => {
+                return delegate_to(KnownClass::Super.to_instance(db, program));
+            }
             Type::TypedDict(td) => {
                 // In general it isn't sound to upcast a `TypedDict` to a `dict`,
                 // but here it seems like it's probably sound?
-                let mut key_builder = UnionBuilder::new(db);
-                let mut value_builder = UnionBuilder::new(db);
+                let mut key_builder = UnionBuilder::new(db, program);
+                let mut value_builder = UnionBuilder::new(db, program);
                 for (name, field) in td.items(db) {
                     key_builder = key_builder.add(Type::string_literal(db, name));
                     value_builder = value_builder.add(field.declared_ty);
                 }
-                return delegate_to(
-                    KnownClass::Dict
-                        .to_specialized_instance(db, &[key_builder.build(), value_builder.build()]),
-                );
+                return delegate_to(KnownClass::Dict.to_specialized_instance(
+                    db,
+                    program,
+                    &[key_builder.build(), value_builder.build()],
+                ));
             }
             Type::NewTypeInstance(newtype) => {
                 return delegate_to(newtype.concrete_base_type(db));
             }
             Type::Callable(callable) if callable.is_function_like(db) => {
-                return delegate_to(KnownClass::FunctionType.to_instance(db));
+                return delegate_to(KnownClass::FunctionType.to_instance(db, program));
             }
             Type::AlwaysFalsy
             | Type::AlwaysTruthy
@@ -863,10 +900,11 @@ impl<'db> BoundSuperType<'db> {
     fn skip_until_after_pivot(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         mro_iter: impl Iterator<Item = ClassBase<'db>> + Clone,
     ) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         let Some(pivot_class) = self.pivot_class(db).into_class() else {
-            return Either::Left(ClassBase::Dynamic(DynamicType::Unknown).mro(db, None));
+            return Either::Left(ClassBase::Dynamic(DynamicType::Unknown).mro(db, program, None));
         };
 
         let mut pivot_found = false;
@@ -892,10 +930,11 @@ impl<'db> BoundSuperType<'db> {
     pub(super) fn try_call_dunder_get_on_attribute(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         attribute: PlaceAndQualifiers<'db>,
     ) -> Option<PlaceAndQualifiers<'db>> {
         let (instance, owner) = self.owner(db).descriptor_binding(db)?;
-        Some(Type::try_call_dunder_get_on_attribute(db, attribute, instance, owner).0)
+        Some(Type::try_call_dunder_get_on_attribute(db, program, attribute, instance, owner).0)
     }
 
     /// Similar to `Type::find_name_in_mro_with_policy`, but performs lookup starting *after* the
@@ -903,6 +942,7 @@ impl<'db> BoundSuperType<'db> {
     pub(super) fn find_name_in_mro_after_pivot(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
@@ -910,18 +950,19 @@ impl<'db> BoundSuperType<'db> {
         let class = match &owner {
             SuperOwnerKind::Dynamic(dynamic) => {
                 return Type::Dynamic(*dynamic)
-                    .find_name_in_mro_with_policy(db, name, policy)
+                    .find_name_in_mro_with_policy(db, program, name, policy)
                     .expect("Calling `find_name_in_mro` on dynamic type should return `Some`");
             }
             SuperOwnerKind::Divergent(_) => {
                 return Type::unknown()
-                    .find_name_in_mro_with_policy(db, name, policy)
+                    .find_name_in_mro_with_policy(db, program, name, policy)
                     .expect("Calling `find_name_in_mro` on Unknown should return `Some`");
             }
             SuperOwnerKind::Resolved(resolved_owner) => resolved_owner.lookup_anchor,
         };
 
-        let mut mro_after_pivot = self.skip_until_after_pivot(db, owner.iter_mro(db));
+        let mut mro_after_pivot =
+            self.skip_until_after_pivot(db, program, owner.iter_mro(db, program));
         let class_literal = class.class_literal(db);
         let result = class_literal.class_member_from_mro(db, name, policy, mro_after_pivot.clone());
 
@@ -948,6 +989,7 @@ impl<'db> BoundSuperType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -956,7 +998,7 @@ impl<'db> BoundSuperType<'db> {
             self.pivot_class(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
             self.owner(db)
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
         ))
     }
 }
@@ -978,6 +1020,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         left: BoundSuperType<'db>,
         right: BoundSuperType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let mut class_equivalence = match (left.pivot_class(db), right.pivot_class(db)) {
             (ClassBase::Class(left), ClassBase::Class(right)) => {
                 self.check_type_pair(db, Type::from(left), Type::from(right))
@@ -1006,20 +1049,20 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             }
             (ClassBase::TypedDict(_), _) => self.never(),
         };
-        if class_equivalence.is_never_satisfied(db) {
+        if class_equivalence.is_never_satisfied(db, program) {
             return self.never();
         }
         let owner_equivalence = match (left.owner(db), right.owner(db)) {
             (SuperOwnerKind::Resolved(left), SuperOwnerKind::Resolved(right)) => self
                 .check_type_pair(db, left.owner_type, right.owner_type)
-                .and(db, self.constraints, || {
+                .and(db, program, self.constraints, || {
                     self.check_type_pair(
                         db,
                         Type::from(left.lookup_anchor),
                         Type::from(right.lookup_anchor),
                     )
                 })
-                .and(db, self.constraints, || {
+                .and(db, program, self.constraints, || {
                     ConstraintSet::from_bool(self.constraints, left.receiver == right.receiver)
                 }),
             (SuperOwnerKind::Resolved(_), _) => self.never(),

--- a/crates/ty_python_semantic/src/types/call.rs
+++ b/crates/ty_python_semantic/src/types/call.rs
@@ -1,9 +1,9 @@
 use super::context::InferContext;
 use super::{ClassType, Signature, Type, TypeContext, UnionType};
-use crate::Db;
 use crate::place::Provenance;
 use crate::types::call::bind::BindingError;
 use crate::types::{MemberLookupPolicy, PropertyInstanceType};
+use crate::{Db, Program};
 use ruff_python_ast as ast;
 
 mod arguments;
@@ -27,11 +27,11 @@ enum ReflectedMethodPriority {
 ///
 /// This is intentionally conservative: a false negative only widens a binary operation's result,
 /// while a false positive could discard a valid normal-method result.
-fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+fn has_exact_runtime_class<'db>(db: &'db dyn Db, program: Program, ty: Type<'db>) -> bool {
     match ty {
         Type::ClassLiteral(_) | Type::LiteralValue(_) => true,
-        Type::NominalInstance(instance) => instance.class(db).is_final(db),
-        Type::TypeAlias(alias) => has_exact_runtime_class(db, alias.value_type(db)),
+        Type::NominalInstance(instance) => instance.class(db, program).is_final(db),
+        Type::TypeAlias(alias) => has_exact_runtime_class(db, program, alias.value_type(db)),
         _ => false,
     }
 }
@@ -40,10 +40,14 @@ fn has_exact_runtime_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
 ///
 /// Instances dispatch through their nominal class, while class objects dispatch through their
 /// metaclass.
-fn operator_dispatch_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassType<'db>> {
+fn operator_dispatch_class<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    ty: Type<'db>,
+) -> Option<ClassType<'db>> {
     match ty {
         Type::ClassLiteral(class) => class.metaclass(db).to_class_type(db),
-        _ => ty.nominal_class(db),
+        _ => ty.nominal_class(db, program),
     }
 }
 
@@ -63,6 +67,7 @@ fn operator_dispatch_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassT
 /// ```
 fn reflected_method_priority<'db>(
     db: &'db dyn Db,
+    program: Program,
     left_ty: Type<'db>,
     right_ty: Type<'db>,
 ) -> ReflectedMethodPriority {
@@ -71,17 +76,17 @@ fn reflected_method_priority<'db>(
     }
 
     if let (Some(left_class), Some(right_class)) = (
-        operator_dispatch_class(db, left_ty),
-        operator_dispatch_class(db, right_ty),
+        operator_dispatch_class(db, program, left_ty),
+        operator_dispatch_class(db, program, right_ty),
     ) && left_class.class_literal(db) != right_class.class_literal(db)
         && right_class.is_subtype_of_class_literal(db, left_class.class_literal(db))
     {
-        if has_exact_runtime_class(db, left_ty) {
+        if has_exact_runtime_class(db, program, left_ty) {
             ReflectedMethodPriority::Definitely
         } else {
             ReflectedMethodPriority::Possibly
         }
-    } else if right_ty.is_subtype_of(db, left_ty) {
+    } else if right_ty.is_subtype_of(db, program, left_ty) {
         ReflectedMethodPriority::Possibly
     } else {
         ReflectedMethodPriority::Never
@@ -93,36 +98,47 @@ impl<'db> Type<'db> {
     /// expressions don't re-run overload selection at every call site.
     pub(crate) fn try_call_bin_op_return_type(
         db: &'db dyn Db,
+        program: Program,
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
     ) -> Option<Type<'db>> {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _, _| None, heap_size=ruff_memory_usage::heap_size)]
         fn try_call_bin_op_return_type_impl<'db>(
             db: &'db dyn Db,
+            program: Program,
             left_ty: Type<'db>,
             op: ast::Operator,
             right_ty: Type<'db>,
         ) -> Option<Type<'db>> {
-            Type::try_call_bin_op(db, left_ty, op, right_ty)
+            Type::try_call_bin_op(db, program, left_ty, op, right_ty)
                 .ok()
-                .map(|bindings| bindings.return_type(db))
+                .map(|bindings| bindings.return_type(db, program))
         }
 
-        try_call_bin_op_return_type_impl(db, left_ty, op, right_ty)
+        try_call_bin_op_return_type_impl(db, program, left_ty, op, right_ty)
     }
 
     pub(crate) fn try_call_bin_op(
         db: &'db dyn Db,
+        program: Program,
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
     ) -> Result<Bindings<'db>, CallBinOpError> {
-        Self::try_call_bin_op_with_policy(db, left_ty, op, right_ty, MemberLookupPolicy::default())
+        Self::try_call_bin_op_with_policy(
+            db,
+            program,
+            left_ty,
+            op,
+            right_ty,
+            MemberLookupPolicy::default(),
+        )
     }
 
     pub(crate) fn try_call_bin_op_with_policy(
         db: &'db dyn Db,
+        program: Program,
         left_ty: Type<'db>,
         op: ast::Operator,
         right_ty: Type<'db>,
@@ -141,21 +157,23 @@ impl<'db> Type<'db> {
 
         // Runtime classes determine reflected priority, but static operand types may only
         // establish that priority conditionally.
-        let reflected_priority = reflected_method_priority(db, left_ty, right_ty);
+        let reflected_priority = reflected_method_priority(db, program, left_ty, right_ty);
 
-        let left_class = left_ty.to_meta_type(db);
-        let right_class = right_ty.to_meta_type(db);
+        let left_class = left_ty.to_meta_type(db, program);
+        let right_class = right_ty.to_meta_type(db, program);
         if reflected_priority != ReflectedMethodPriority::Never {
             let reflected_dunder = op.reflected_dunder();
-            let rhs_reflected = right_class.member(db, reflected_dunder).place;
+            let rhs_reflected = right_class.member(db, program, reflected_dunder).place;
             // TODO: if `rhs_reflected` is possibly unbound, we should union the two possible
             // Bindings together
             if !rhs_reflected.is_undefined()
-                && !rhs_reflected
-                    .is_equal_ignoring_provenance(left_class.member(db, reflected_dunder).place)
+                && !rhs_reflected.is_equal_ignoring_provenance(
+                    left_class.member(db, program, reflected_dunder).place,
+                )
             {
                 let call_on_right_instance = right_ty.try_call_dunder_with_policy(
                     db,
+                    program,
                     reflected_dunder,
                     &mut CallArguments::positional([left_ty]),
                     TypeContext::default(),
@@ -166,6 +184,7 @@ impl<'db> Type<'db> {
                     return Ok(call_on_right_instance.or_else(|_| {
                         left_ty.try_call_dunder_with_policy(
                             db,
+                            program,
                             op.dunder(),
                             &mut CallArguments::positional([right_ty]),
                             TypeContext::default(),
@@ -176,6 +195,7 @@ impl<'db> Type<'db> {
 
                 let call_on_left_instance = left_ty.try_call_dunder_with_policy(
                     db,
+                    program,
                     op.dunder(),
                     &mut CallArguments::positional([right_ty]),
                     TypeContext::default(),
@@ -186,6 +206,7 @@ impl<'db> Type<'db> {
                     (Ok(right_bindings), Ok(left_bindings)) => {
                         let callable_type = UnionType::from_two_elements(
                             db,
+                            program,
                             right_bindings.callable_type(),
                             left_bindings.callable_type(),
                         );
@@ -202,6 +223,7 @@ impl<'db> Type<'db> {
 
         let call_on_left_instance = left_ty.try_call_dunder_with_policy(
             db,
+            program,
             op.dunder(),
             &mut CallArguments::positional([right_ty]),
             TypeContext::default(),
@@ -214,6 +236,7 @@ impl<'db> Type<'db> {
             } else {
                 Ok(right_ty.try_call_dunder_with_policy(
                     db,
+                    program,
                     op.reflected_dunder(),
                     &mut CallArguments::positional([left_ty]),
                     TypeContext::default(),
@@ -232,8 +255,8 @@ impl<'db> Type<'db> {
 pub(crate) struct CallError<'db>(pub(crate) CallErrorKind, pub(crate) Box<Bindings<'db>>);
 
 impl<'db> CallError<'db> {
-    pub(crate) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.1.return_type(db)
+    pub(crate) fn return_type(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        self.1.return_type(db, program)
     }
 
     /// Returns `Some(property)` if the call error was caused by an attempt to set a property
@@ -330,16 +353,24 @@ impl<'db> CallDunderError<'db> {
         }
     }
 
-    pub(super) fn return_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(super) fn return_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         match self {
             Self::MethodNotAvailable | Self::CallError(CallErrorKind::NotCallable, _, _) => None,
-            Self::CallError(_, bindings, _) => Some(bindings.return_type(db)),
-            Self::PossiblyUnbound { bindings, .. } => Some(bindings.return_type(db)),
+            Self::CallError(_, bindings, _) => Some(bindings.return_type(db, program)),
+            Self::PossiblyUnbound { bindings, .. } => Some(bindings.return_type(db, program)),
         }
     }
 
-    pub(super) fn fallback_return_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.return_type(db).unwrap_or(Type::unknown())
+    pub(super) fn fallback_return_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        self.return_type(db, program).unwrap_or(Type::unknown())
     }
 }
 

--- a/crates/ty_python_semantic/src/types/call/arguments.rs
+++ b/crates/ty_python_semantic/src/types/call/arguments.rs
@@ -270,6 +270,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     pub(crate) fn functools_partial_bound_arguments(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
     ) -> Option<(Self, bool)> {
         let bound_call_arguments = self.start_from(1);
         let mut can_synthesize_signature = true;
@@ -281,7 +282,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                     if !matches!(
                         argument_ty
                             .as_nominal_instance()
-                            .and_then(|nominal| nominal.tuple_spec(db)),
+                            .and_then(|nominal| nominal.tuple_spec(db, program)),
                         Some(spec) if spec.as_fixed_length().is_some()
                     ) {
                         return None;
@@ -291,7 +292,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                     // Known `TypedDict` items can still be checked against their target
                     // parameters, even though possible hidden items prevent us from synthesizing
                     // a precise partial signature.
-                    extract_unpacked_typed_dict_keys_from_value_type(db, argument_ty)?;
+                    extract_unpacked_typed_dict_keys_from_value_type(db, program, argument_ty)?;
                     can_synthesize_signature = false;
                 }
                 Argument::Positional | Argument::Synthetic | Argument::Keyword(_) => {}
@@ -307,7 +308,11 @@ impl<'a, 'db> CallArguments<'a, 'db> {
     /// contains the same arguments, but with one or more of the argument types expanded.
     ///
     /// [argument type expansion]: https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion
-    pub(super) fn expand(&self, db: &'db dyn Db) -> impl Iterator<Item = Expansion<'a, 'db>> + '_ {
+    pub(super) fn expand(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> impl Iterator<Item = Expansion<'a, 'db>> + '_ {
         /// Represents the state of the expansion process.
         enum State<'a, 'db> {
             LimitReached(usize),
@@ -363,7 +368,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                     // this only shows up in very convoluted instances of generic call inference across multiple
                     // overloads, and is unlikely to happen in practice.
                     if let Some(arg_type) = arg_type.get_default()
-                        && let Some(expanded_types) = expand_type(db, arg_type)
+                        && let Some(expanded_types) = expand_type(db, program, arg_type)
                     {
                         break expanded_types;
                     }
@@ -408,10 +413,11 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         })
     }
 
-    pub(super) fn display(&self, db: &'db dyn Db) -> impl Display {
+    pub(super) fn display(&self, db: &'db dyn Db, program: crate::Program) -> impl Display {
         struct DisplayCallArgumentTypes<'a, 'db> {
             types: &'a CallArgumentTypes<'db>,
             db: &'db dyn Db,
+            program: crate::Program,
         }
 
         impl std::fmt::Display for DisplayCallArgumentTypes<'_, '_> {
@@ -419,8 +425,10 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                 f.debug_map()
                     .entries(self.types.iter().map(|(tcx, ty)| {
                         (
-                            tcx.annotation.as_ref().map(|ty| ty.display(self.db)),
-                            ty.display(self.db),
+                            tcx.annotation
+                                .as_ref()
+                                .map(|ty| ty.display(self.db, self.program)),
+                            ty.display(self.db, self.program),
                         )
                     }))
                     .finish()
@@ -430,6 +438,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         struct DisplayCallArguments<'a, 'db> {
             call_arguments: &'a CallArguments<'a, 'db>,
             db: &'db dyn Db,
+            program: crate::Program,
         }
 
         impl std::fmt::Display for DisplayCallArguments<'_, '_> {
@@ -444,23 +453,55 @@ impl<'a, 'db> CallArguments<'a, 'db> {
                             write!(
                                 f,
                                 "self: {}",
-                                DisplayCallArgumentTypes { types, db: self.db }
+                                DisplayCallArgumentTypes {
+                                    types,
+                                    db: self.db,
+                                    program: self.program,
+                                }
                             )?;
                         }
                         Argument::Positional => {
-                            write!(f, "{}", DisplayCallArgumentTypes { types, db: self.db })?;
+                            write!(
+                                f,
+                                "{}",
+                                DisplayCallArgumentTypes {
+                                    types,
+                                    db: self.db,
+                                    program: self.program,
+                                }
+                            )?;
                         }
                         Argument::Variadic => {
-                            write!(f, "*{}", DisplayCallArgumentTypes { types, db: self.db })?;
+                            write!(
+                                f,
+                                "*{}",
+                                DisplayCallArgumentTypes {
+                                    types,
+                                    db: self.db,
+                                    program: self.program,
+                                }
+                            )?;
                         }
                         Argument::Keyword(name) => write!(
                             f,
                             "{}={}",
                             name,
-                            DisplayCallArgumentTypes { types, db: self.db }
+                            DisplayCallArgumentTypes {
+                                types,
+                                db: self.db,
+                                program: self.program,
+                            }
                         )?,
                         Argument::Keywords => {
-                            write!(f, "**{}", DisplayCallArgumentTypes { types, db: self.db })?;
+                            write!(
+                                f,
+                                "**{}",
+                                DisplayCallArgumentTypes {
+                                    types,
+                                    db: self.db,
+                                    program: self.program,
+                                }
+                            )?;
                         }
                     }
                 }
@@ -471,6 +512,7 @@ impl<'a, 'db> CallArguments<'a, 'db> {
         DisplayCallArguments {
             call_arguments: self,
             db,
+            program,
         }
     }
 }
@@ -514,23 +556,29 @@ impl<'a, 'db> FromIterator<(Argument<'a>, Option<Type<'db>>)> for CallArguments<
 /// Returns `true` if the type can be expanded into its subtypes.
 ///
 /// In other words, it returns `true` if [`expand_type`] returns [`Some`] for the given type.
-pub(crate) fn is_expandable_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+pub(crate) fn is_expandable_type<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    ty: Type<'db>,
+) -> bool {
     match ty {
         Type::EnumComplement(_) => true,
-        Type::Intersection(intersection) => intersection.finite_alternatives(db).is_some(),
+        Type::Intersection(intersection) => intersection.finite_alternatives(db, program).is_some(),
         Type::NominalInstance(instance) => {
-            let class = instance.class(db);
+            let class = instance.class(db, program);
             class.is_known(db, KnownClass::Bool)
-                || instance.tuple_spec(db).is_some_and(|spec| match &*spec {
-                    Tuple::Fixed(fixed_length_tuple) => fixed_length_tuple
-                        .iter_all_elements()
-                        .any(|element| is_expandable_type(db, element)),
-                    Tuple::Variable(_) => false,
-                })
+                || instance
+                    .tuple_spec(db, program)
+                    .is_some_and(|spec| match &*spec {
+                        Tuple::Fixed(fixed_length_tuple) => fixed_length_tuple
+                            .iter_all_elements()
+                            .any(|element| is_expandable_type(db, program, element)),
+                        Tuple::Variable(_) => false,
+                    })
                 || enum_metadata(db, class.class_literal(db)).is_some()
         }
         Type::Union(_) => true,
-        Type::TypeAlias(alias) => is_expandable_type(db, alias.value_type(db)),
+        Type::TypeAlias(alias) => is_expandable_type(db, program, alias.value_type(db)),
         _ => false,
     }
 }

--- a/crates/ty_python_semantic/src/types/call/bind.rs
+++ b/crates/ty_python_semantic/src/types/call/bind.rs
@@ -17,7 +17,6 @@ use std::collections::HashSet;
 use std::fmt;
 
 use itertools::Itertools;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -25,10 +24,10 @@ use smallvec::{SmallVec, smallvec, smallvec_inline};
 
 use self::constructor::{ConstructorBinding, ConstructorContext};
 use super::{Argument, CallArguments, CallError, CallErrorKind, InferContext, Signature, Type};
+use crate::Program;
 use crate::db::Db;
 use crate::dunder_all::dunder_all_names;
 use crate::place::{DefinedPlace, Definedness, Place};
-use crate::subscript::PyIndex;
 use crate::types::call::arguments::{CallArgumentTypes, Expansion, is_expandable_type};
 use crate::types::callable::CallableTypeKind;
 use crate::types::constraints::{
@@ -53,8 +52,8 @@ use crate::types::generics::{
 use crate::types::infer::original_class_type;
 use crate::types::known_instance::FieldInstance;
 use crate::types::signatures::{
-    CallableSignature, Parameter, ParameterDisplayName, ParameterKind, Parameters, ParametersKind,
-    PartialApplication, PartialSignatureApplication,
+    CallableSignature, Parameter, ParameterKind, Parameters, ParametersKind, PartialApplication,
+    PartialSignatureApplication,
 };
 use crate::types::tuple::{TupleLength, TupleSpec, TupleType};
 use crate::types::typed_dict::{TypedDictOpenness, extract_unpacked_typed_dict_from_value_type};
@@ -68,7 +67,7 @@ use crate::types::{
     TypeAliasType, TypeContext, TypeMapping, TypeVarBoundOrConstraints, TypeVarVariance,
     UnionAccumulator, UnionBuilder, UnionType, WrapperDescriptorKind, enums, list_members,
 };
-use crate::{DisplaySettings, FxOrderSet, Program};
+use crate::{DisplaySettings, FxOrderSet};
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic, SubDiagnosticSeverity};
 use ruff_python_ast::{self as ast, AnyNodeRef, ArgOrKeyword, PythonVersion};
 use ty_python_core::semantic_index;
@@ -77,6 +76,7 @@ pub(crate) use self::constructor::ConstructorCallableKind;
 
 fn generic_contexts_mentioned_in_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
 ) -> FxOrderSet<GenericContext<'db>> {
     struct GenericContextCollector<'db> {
@@ -85,17 +85,22 @@ fn generic_contexts_mentioned_in_type<'db>(
     }
 
     impl<'db> GenericContextCollector<'db> {
-        fn visit_signature(&self, db: &'db dyn Db, signature: &Signature<'db>) {
+        fn visit_signature(
+            &self,
+            db: &'db dyn Db,
+            program: crate::Program,
+            signature: &Signature<'db>,
+        ) {
             if let Some(generic_context) = signature.generic_context {
                 self.generic_contexts.borrow_mut().insert(generic_context);
             }
             for parameter in signature.parameters() {
-                self.visit_type(db, parameter.annotated_type());
+                self.visit_type(db, program, parameter.annotated_type());
                 if let Some(default_ty) = parameter.default_type() {
-                    self.visit_type(db, default_ty);
+                    self.visit_type(db, program, default_ty);
                 }
             }
-            self.visit_type(db, signature.return_ty);
+            self.visit_type(db, program, signature.return_ty);
         }
     }
 
@@ -104,21 +109,31 @@ fn generic_contexts_mentioned_in_type<'db>(
             false
         }
 
-        fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
+        fn visit_callable_type(
+            &self,
+            db: &'db dyn Db,
+            program: crate::Program,
+            callable: CallableType<'db>,
+        ) {
             for signature in &callable.signatures(db).overloads {
-                self.visit_signature(db, signature);
+                self.visit_signature(db, program, signature);
             }
         }
 
-        fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
+        fn visit_function_type(
+            &self,
+            db: &'db dyn Db,
+            program: crate::Program,
+            function: FunctionType<'db>,
+        ) {
             for signature in &function.signature(db).overloads {
-                self.visit_signature(db, signature);
+                self.visit_signature(db, program, signature);
             }
-            self.visit_signature(db, function.last_definition_signature(db));
+            self.visit_signature(db, program, function.last_definition_signature(db));
         }
 
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        fn visit_type(&self, db: &'db dyn Db, program: crate::Program, ty: Type<'db>) {
+            walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
         }
     }
 
@@ -126,12 +141,13 @@ fn generic_contexts_mentioned_in_type<'db>(
         generic_contexts: RefCell::default(),
         recursion_guard: TypeCollector::default(),
     };
-    collector.visit_type(db, ty);
+    collector.visit_type(db, program, ty);
     collector.generic_contexts.into_inner()
 }
 
 fn freshen_generic_contexts_in_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     generic_contexts: FxOrderSet<GenericContext<'db>>,
     nonce_generator: &TypeVarNonceGenerator<'db>,
@@ -141,6 +157,7 @@ fn freshen_generic_contexts_in_type<'db>(
         .fold(ty, |ty, generic_context| {
             ty.apply_type_mapping(
                 db,
+                program,
                 &TypeMapping::FreshenBoundTypeVars {
                     generic_context,
                     delta: nonce_generator.next().value(),
@@ -194,34 +211,52 @@ impl<'db> CallableItem<'db> {
         }
     }
 
-    fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
+    fn return_type(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             CallableItem::Regular(binding) => binding.return_type(),
-            CallableItem::Constructor(binding) => binding.return_type(db),
+            CallableItem::Constructor(binding) => binding.return_type(db, program),
         }
     }
 
     fn check_types(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
     ) {
         match self {
             CallableItem::Regular(binding) => {
-                binding.check_types(db, constraints, argument_types, call_expression_tcx);
+                binding.check_types(
+                    db,
+                    program,
+                    constraints,
+                    argument_types,
+                    call_expression_tcx,
+                );
             }
             CallableItem::Constructor(binding) => {
-                binding.check_types(db, constraints, argument_types, call_expression_tcx);
+                binding.check_types(
+                    db,
+                    program,
+                    constraints,
+                    argument_types,
+                    call_expression_tcx,
+                );
             }
         }
     }
 
-    fn match_parameters(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
+    fn match_parameters(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
         match self {
-            CallableItem::Regular(binding) => binding.match_parameters(db, arguments),
-            CallableItem::Constructor(binding) => binding.match_parameters(db, arguments),
+            CallableItem::Regular(binding) => binding.match_parameters(db, program, arguments),
+            CallableItem::Constructor(binding) => binding.match_parameters(db, program, arguments),
         }
     }
 
@@ -248,11 +283,12 @@ impl<'db> CallableItem<'db> {
     fn freshen_generic_contexts_in_place(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         nonce_generator: &TypeVarNonceGenerator<'db>,
     ) {
         match self {
             CallableItem::Regular(binding) => {
-                binding.freshen_generic_contexts_in_place(db, nonce_generator);
+                binding.freshen_generic_contexts_in_place(db, program, nonce_generator);
             }
             // TODO: Constructor freshening also has to keep constructor instance context in sync
             // with `__new__`/`__init__` signatures.
@@ -293,12 +329,14 @@ impl<'db> CallableItem<'db> {
     fn functools_partial_callable<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         partial_overload: &mut Binding<'db>,
         bound_call_arguments: &CallArguments<'a, 'db>,
     ) -> Option<CallableType<'db>> {
         match self {
             CallableItem::Regular(binding) => CallableType::partially_apply(
                 db,
+                program,
                 binding.partial_signature_applications(
                     db,
                     partial_overload,
@@ -364,14 +402,15 @@ impl<'db> BindingsElement<'db> {
         self.items.len() > 1
     }
 
-    fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
+    fn return_type(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         if self.is_callable() {
             IntersectionType::from_elements(
                 db,
+                program,
                 self.items
                     .iter()
                     .filter(|item| item.is_callable())
-                    .map(|item| item.return_type(db)),
+                    .map(|item| item.return_type(db, program)),
             )
         } else {
             Type::unknown()
@@ -382,12 +421,19 @@ impl<'db> BindingsElement<'db> {
     fn check_types(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
     ) {
         for item in &mut self.items {
-            item.check_types(db, constraints, call_arguments, call_expression_tcx);
+            item.check_types(
+                db,
+                program,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+            );
         }
     }
 
@@ -809,6 +855,7 @@ impl<'db> Bindings<'db> {
     pub(crate) fn map_types(
         &self,
         db: &'db dyn Db,
+        program: Program,
         mut map: impl FnMut(&CallableBinding<'db>) -> Option<Type<'db>>,
     ) -> Type<'db> {
         let mut element_types = Vec::with_capacity(self.elements.len());
@@ -821,11 +868,11 @@ impl<'db> Bindings<'db> {
             }
 
             if !binding_types.is_empty() {
-                element_types.push(IntersectionType::from_elements(db, binding_types));
+                element_types.push(IntersectionType::from_elements(db, program, binding_types));
             }
         }
 
-        UnionType::from_elements(db, element_types)
+        UnionType::from_elements(db, program, element_types)
     }
 
     /// Maps each `CallableItem` to a type and combines results while preserving
@@ -836,6 +883,7 @@ impl<'db> Bindings<'db> {
     fn map_item_types(
         &self,
         db: &'db dyn Db,
+        program: Program,
         mut map: impl FnMut(&CallableItem<'db>) -> Option<Type<'db>>,
     ) -> Type<'db> {
         let mut element_types = Vec::with_capacity(self.elements.len());
@@ -848,11 +896,11 @@ impl<'db> Bindings<'db> {
             }
 
             if !item_types.is_empty() {
-                element_types.push(IntersectionType::from_elements(db, item_types));
+                element_types.push(IntersectionType::from_elements(db, program, item_types));
             }
         }
 
-        UnionType::from_elements(db, element_types)
+        UnionType::from_elements(db, program, element_types)
     }
 
     /// Builds matched bindings for the callable wrapped by `functools.partial(...)`.
@@ -861,18 +909,21 @@ impl<'db> Bindings<'db> {
     /// normalization) used by both inference and known-call evaluation.
     pub(crate) fn functools_partial_matched_bindings<'a>(
         db: &'db dyn Db,
+        program: Program,
         wrapped_callable_ty: Type<'db>,
         call_arguments: &CallArguments<'a, 'db>,
     ) -> Option<(CallArguments<'a, 'db>, Bindings<'db>, bool)> {
         // We can only infer bound-argument context from an actual callable.
-        wrapped_callable_ty.try_upcast_to_callable(db)?;
+        wrapped_callable_ty.try_upcast_to_callable(db, program)?;
 
         let (bound_call_arguments, can_synthesize_signature) =
-            call_arguments.functools_partial_bound_arguments(db)?;
+            call_arguments.functools_partial_bound_arguments(db, program)?;
 
-        let mut partial_bindings = wrapped_callable_ty
-            .bindings(db)
-            .match_parameters(db, &bound_call_arguments);
+        let mut partial_bindings = wrapped_callable_ty.bindings(db, program).match_parameters(
+            db,
+            program,
+            &bound_call_arguments,
+        );
         for binding in partial_bindings.iter_flat_mut() {
             binding.clear_missing_argument_errors_for_partial_application();
         }
@@ -896,14 +947,15 @@ impl<'db> Bindings<'db> {
     fn functools_partial_type<'a>(
         &self,
         db: &'db dyn Db,
+        program: Program,
         wrapped_callable_ty: Type<'db>,
         partial_overload: &mut Binding<'db>,
         bound_call_arguments: &CallArguments<'a, 'db>,
     ) -> Type<'db> {
         if wrapped_callable_ty.is_union() || wrapped_callable_ty.is_intersection() {
-            return self.map_item_types(db, |partial_item| {
+            return self.map_item_types(db, program, |partial_item| {
                 partial_item
-                    .functools_partial_callable(db, partial_overload, bound_call_arguments)
+                    .functools_partial_callable(db, program, partial_overload, bound_call_arguments)
                     .map(|callable| {
                         callable.into_precise_functools_partial_instance(db, wrapped_callable_ty)
                     })
@@ -913,7 +965,12 @@ impl<'db> Bindings<'db> {
         let partial_callables: SmallVec<[CallableType<'db>; 1]> = self
             .iter_callable_items()
             .filter_map(|partial_item| {
-                partial_item.functools_partial_callable(db, partial_overload, bound_call_arguments)
+                partial_item.functools_partial_callable(
+                    db,
+                    program,
+                    partial_overload,
+                    bound_call_arguments,
+                )
             })
             .collect();
 
@@ -951,6 +1008,7 @@ impl<'db> Bindings<'db> {
     fn freshen_generic_contexts_in_place(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         nonce_generator: &TypeVarNonceGenerator<'db>,
     ) {
         let enclosing_binding_contexts = self.enclosing_binding_contexts.take();
@@ -959,7 +1017,7 @@ impl<'db> Bindings<'db> {
                 .record_enclosing_binding_contexts(enclosing_binding_contexts.iter().copied());
         }
         for item in self.iter_callable_items_mut() {
-            item.freshen_generic_contexts_in_place(db, nonce_generator);
+            item.freshen_generic_contexts_in_place(db, program, nonce_generator);
         }
         self.enclosing_binding_contexts = enclosing_binding_contexts;
     }
@@ -976,17 +1034,23 @@ impl<'db> Bindings<'db> {
     pub(crate) fn match_parameters(
         mut self,
         db: &'db dyn Db,
+        program: Program,
         arguments: &CallArguments<'_, 'db>,
     ) -> Self {
         let nonce_generator = TypeVarNonceGenerator::default();
-        self.freshen_generic_contexts_in_place(db, &nonce_generator);
-        self.match_parameters_in_place(db, arguments);
+        self.freshen_generic_contexts_in_place(db, program, &nonce_generator);
+        self.match_parameters_in_place(db, program, arguments);
         self
     }
 
-    fn match_parameters_in_place(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
+    fn match_parameters_in_place(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
         for item in self.iter_callable_items_mut() {
-            item.match_parameters(db, arguments);
+            item.match_parameters(db, program, arguments);
         }
     }
 
@@ -1005,6 +1069,7 @@ impl<'db> Bindings<'db> {
     pub(crate) fn check_types(
         mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -1012,6 +1077,7 @@ impl<'db> Bindings<'db> {
     ) -> Result<Self, CallError<'db>> {
         match self.check_types_impl(
             db,
+            program,
             constraints,
             call_arguments,
             call_expression_tcx,
@@ -1025,6 +1091,7 @@ impl<'db> Bindings<'db> {
     pub(crate) fn check_types_impl(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -1032,16 +1099,23 @@ impl<'db> Bindings<'db> {
     ) -> Result<(), CallErrorKind> {
         // Check types for each element (union variant)
         for element in &mut self.elements {
-            element.check_types(db, constraints, call_arguments, call_expression_tcx);
+            element.check_types(
+                db,
+                program,
+                constraints,
+                call_arguments,
+                call_expression_tcx,
+            );
         }
 
-        self.evaluate_known_cases(db, call_arguments, dataclass_field_specifiers);
+        self.evaluate_known_cases(db, program, call_arguments, dataclass_field_specifiers);
 
         // For constructor bindings with deferred downstream checks: validate downstream bindings
         // if the matched overload is instance-returning.
         for constructor in self.iter_constructor_items_mut() {
             constructor.check_downstream_constructor(
                 db,
+                program,
                 constraints,
                 call_arguments,
                 call_expression_tcx,
@@ -1093,10 +1167,13 @@ impl<'db> Bindings<'db> {
     /// Returns the return type of the call. For successful calls, this is the actual return type.
     /// For calls with binding errors, this is a type that best approximates the return type. For
     /// types that are not callable, returns `Type::Unknown`.
-    pub(crate) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn return_type(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         UnionType::from_elements(
             db,
-            self.elements.iter().map(|element| element.return_type(db)),
+            program,
+            self.elements
+                .iter()
+                .map(|element| element.return_type(db, program)),
         )
     }
 
@@ -1132,13 +1209,14 @@ impl<'db> Bindings<'db> {
         context: &InferContext<'db, '_>,
         node: ast::AnyNodeRef,
     ) {
+        let program = context.program();
         // If all elements are not callable, report that the type as a whole is not callable.
         if self.elements.iter().all(|e| !e.is_callable()) {
             let range = all_arguments_range(node);
             if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, range) {
                 builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable",
-                    self.callable_type().display(context.db())
+                    self.callable_type().display(context.db(), program)
                 ));
             }
             return;
@@ -1177,6 +1255,7 @@ impl<'db> Bindings<'db> {
         node: ast::AnyNodeRef,
         element: &BindingsElement<'db>,
     ) {
+        let program = context.program();
         // If this element succeeded, no diagnostics to report
         if element.as_result(context.db()).is_ok() {
             return;
@@ -1192,6 +1271,7 @@ impl<'db> Bindings<'db> {
             // Construct the intersection type from the bindings
             let intersection_type = IntersectionType::from_elements(
                 context.db(),
+                program,
                 element.items.iter().map(CallableItem::callable_type),
             );
 
@@ -1244,6 +1324,7 @@ impl<'db> Bindings<'db> {
     fn evaluate_known_cases(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         call_arguments: &CallArguments<'_, 'db>,
         dataclass_field_specifiers: &[Type<'db>],
     ) {
@@ -1274,7 +1355,7 @@ impl<'db> Bindings<'db> {
                                         BoundMethodType::new(
                                             db,
                                             function,
-                                            instance.to_meta_type(db),
+                                            instance.to_meta_type(db, program),
                                         ),
                                     ));
                                 }
@@ -1283,7 +1364,7 @@ impl<'db> Bindings<'db> {
                         } else if function.is_staticmethod(db) {
                             overload.set_return_type(Type::FunctionLiteral(function));
                         } else if let [Some(first), _] = overload.parameter_types() {
-                            if first.is_none(db) {
+                            if first.is_none(db, program) {
                                 overload.set_return_type(Type::FunctionLiteral(function));
                             } else {
                                 overload.set_return_type(Type::BoundMethod(BoundMethodType::new(
@@ -1310,7 +1391,7 @@ impl<'db> Bindings<'db> {
                                             BoundMethodType::new(
                                                 db,
                                                 *function,
-                                                instance.to_meta_type(db),
+                                                instance.to_meta_type(db, program),
                                             ),
                                         ));
                                     }
@@ -1321,7 +1402,7 @@ impl<'db> Bindings<'db> {
                                 overload.set_return_type(*function_ty);
                             } else {
                                 match overload.parameter_types() {
-                                    [_, Some(instance), _] if instance.is_none(db) => {
+                                    [_, Some(instance), _] if instance.is_none(db, program) => {
                                         overload.set_return_type(*function_ty);
                                     }
                                     [_, Some(instance), _] => {
@@ -1342,7 +1423,7 @@ impl<'db> Bindings<'db> {
                                 Some(property @ Type::PropertyInstance(_)),
                                 Some(instance),
                                 ..,
-                            ] if instance.is_none(db) => {
+                            ] if instance.is_none(db, program) => {
                                 overload.set_return_type(*property);
                             }
                             [
@@ -1380,7 +1461,7 @@ impl<'db> Bindings<'db> {
                                         overload.set_return_type(
                                             typevar
                                                 .upper_bound(db)
-                                                .unwrap_or_else(|| Type::none(db)),
+                                                .unwrap_or_else(|| Type::none(db, program)),
                                         );
                                     }
                                     Some("__constraints__") => {
@@ -1390,11 +1471,18 @@ impl<'db> Bindings<'db> {
                                         ));
                                     }
                                     Some("__default__") => {
-                                        overload.set_return_type(
-                                            typevar.default_type(db).unwrap_or_else(|| {
-                                                KnownClass::NoDefaultType.to_instance(db)
-                                            }),
-                                        );
+                                        if let Some(program) = property
+                                            .getter(db)
+                                            .and_then(Type::as_function_literal)
+                                            .map(|function| function.program(db))
+                                        {
+                                            overload.set_return_type(
+                                                typevar.default_type(db).unwrap_or_else(|| {
+                                                    KnownClass::NoDefaultType
+                                                        .to_instance(db, program)
+                                                }),
+                                            );
+                                        }
                                     }
                                     _ => {}
                                 }
@@ -1402,8 +1490,12 @@ impl<'db> Bindings<'db> {
                             [Some(Type::PropertyInstance(property)), Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
                                     if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
-                                        .map(|binding| binding.return_type(db))
+                                        .try_call(
+                                            db,
+                                            program,
+                                            &CallArguments::positional([*instance]),
+                                        )
+                                        .map(|binding| binding.return_type(db, program))
                                     {
                                         overload.set_return_type(return_ty);
                                     } else {
@@ -1425,14 +1517,18 @@ impl<'db> Bindings<'db> {
 
                     Type::KnownBoundMethod(KnownBoundMethodType::PropertyDunderGet(property)) => {
                         match overload.parameter_types() {
-                            [Some(instance), ..] if instance.is_none(db) => {
+                            [Some(instance), ..] if instance.is_none(db, program) => {
                                 overload.set_return_type(Type::PropertyInstance(property));
                             }
                             [Some(instance), ..] => {
                                 if let Some(getter) = property.getter(db) {
                                     if let Ok(return_ty) = getter
-                                        .try_call(db, &CallArguments::positional([*instance]))
-                                        .map(|binding| binding.return_type(db))
+                                        .try_call(
+                                            db,
+                                            program,
+                                            &CallArguments::positional([*instance]),
+                                        )
+                                        .map(|binding| binding.return_type(db, program))
                                     {
                                         overload.set_return_type(return_ty);
                                     } else {
@@ -1462,15 +1558,19 @@ impl<'db> Bindings<'db> {
                         {
                             if let Some(setter) = property.setter(db) {
                                 if let Ok(return_ty) = setter
-                                    .try_call(db, &CallArguments::positional([*instance, *value]))
-                                    .map(|binding| binding.return_type(db))
+                                    .try_call(
+                                        db,
+                                        program,
+                                        &CallArguments::positional([*instance, *value]),
+                                    )
+                                    .map(|binding| binding.return_type(db, program))
                                 {
                                     // `property.__set__` returns `None` for ordinary setters, but
                                     // preserving `Never` keeps non-returning setters divergent.
                                     overload.set_return_type(if return_ty.is_never() {
                                         return_ty
                                     } else {
-                                        Type::none(db)
+                                        Type::none(db, program)
                                     });
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
@@ -1492,15 +1592,15 @@ impl<'db> Bindings<'db> {
                         {
                             if let Some(deleter) = property.deleter(db) {
                                 if let Ok(return_ty) = deleter
-                                    .try_call(db, &CallArguments::positional([*instance]))
-                                    .map(|binding| binding.return_type(db))
+                                    .try_call(db, program, &CallArguments::positional([*instance]))
+                                    .map(|binding| binding.return_type(db, program))
                                 {
                                     // `property.__delete__` returns `None` for ordinary deleters,
                                     // but preserving `Never` keeps non-returning deleters divergent.
                                     overload.set_return_type(if return_ty.is_never() {
                                         return_ty
                                     } else {
-                                        Type::none(db)
+                                        Type::none(db, program)
                                     });
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
@@ -1520,15 +1620,19 @@ impl<'db> Bindings<'db> {
                         if let [Some(instance), Some(value), ..] = overload.parameter_types() {
                             if let Some(setter) = property.setter(db) {
                                 if let Ok(return_ty) = setter
-                                    .try_call(db, &CallArguments::positional([*instance, *value]))
-                                    .map(|binding| binding.return_type(db))
+                                    .try_call(
+                                        db,
+                                        program,
+                                        &CallArguments::positional([*instance, *value]),
+                                    )
+                                    .map(|binding| binding.return_type(db, program))
                                 {
                                     // `property.__set__` returns `None` for ordinary setters, but
                                     // preserving `Never` keeps non-returning setters divergent.
                                     overload.set_return_type(if return_ty.is_never() {
                                         return_ty
                                     } else {
-                                        Type::none(db)
+                                        Type::none(db, program)
                                     });
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
@@ -1550,15 +1654,15 @@ impl<'db> Bindings<'db> {
                         if let [Some(instance), ..] = overload.parameter_types() {
                             if let Some(deleter) = property.deleter(db) {
                                 if let Ok(return_ty) = deleter
-                                    .try_call(db, &CallArguments::positional([*instance]))
-                                    .map(|binding| binding.return_type(db))
+                                    .try_call(db, program, &CallArguments::positional([*instance]))
+                                    .map(|binding| binding.return_type(db, program))
                                 {
                                     // `property.__delete__` returns `None` for ordinary deleters,
                                     // but preserving `Never` keeps non-returning deleters divergent.
                                     overload.set_return_type(if return_ty.is_never() {
                                         return_ty
                                     } else {
-                                        Type::none(db)
+                                        Type::none(db, program)
                                     });
                                 } else {
                                     overload.errors.push(BindingError::InternalCallError(
@@ -1678,17 +1782,21 @@ impl<'db> Bindings<'db> {
                         if bound_method.function(db).name(db) == "__iter__"
                             && is_enum_class(db, bound_method.self_instance(db)) =>
                     {
-                        if let Some(enum_instance) = bound_method.self_instance(db).to_instance(db)
+                        if let Some(enum_instance) =
+                            bound_method.self_instance(db).to_instance(db, program)
                         {
-                            overload.set_return_type(
-                                KnownClass::Iterator.to_specialized_instance(db, &[enum_instance]),
-                            );
+                            overload.set_return_type(KnownClass::Iterator.to_specialized_instance(
+                                db,
+                                program,
+                                &[enum_instance],
+                            ));
                         }
                     }
 
                     function @ Type::FunctionLiteral(function_type)
                         if dataclass_field_specifiers.contains(&function) =>
                     {
+                        let python_version = function_type.program(db).python_version(db);
                         // Helper to get the type of a keyword argument by name. We first try to get it from
                         // the parameter binding (for explicit parameters), and then fall back to checking the
                         // call site arguments (for field-specifier functions that use a `**kwargs` parameter,
@@ -1713,7 +1821,12 @@ impl<'db> Bindings<'db> {
                             .is_some()
                             || get_argument_type("factory", false).is_some()
                             || default.is_some_and(|default| {
-                                pydantic::field_provides_default(db, function_type, default)
+                                pydantic::field_provides_default(
+                                    db,
+                                    program,
+                                    function_type,
+                                    default,
+                                )
                             });
 
                         let init = get_argument_type("init", true);
@@ -1726,7 +1839,7 @@ impl<'db> Bindings<'db> {
                         let strict = get_argument_type("strict", false).map_or(
                             ConfigBoolean::Unspecified,
                             |strict| {
-                                if strict.is_none(db) {
+                                if strict.is_none(db, program) {
                                     ConfigBoolean::Unspecified
                                 } else {
                                     ConfigBoolean::from_type(strict)
@@ -1747,11 +1860,10 @@ impl<'db> Bindings<'db> {
                         };
 
                         let init = init
-                            .map(|init| !init.bool(db).is_always_false())
+                            .map(|init| !init.bool(db, program).is_always_false())
                             .unwrap_or(true);
 
-                        let kw_only = if Program::get(db).python_version(db) >= PythonVersion::PY310
-                        {
+                        let kw_only = if python_version >= PythonVersion::PY310 {
                             match kw_only.and_then(Type::as_literal_value_kind) {
                                 // We are more conservative here when turning the type for `kw_only`
                                 // into a bool, because a field specifier in a stub might use
@@ -1779,10 +1891,10 @@ impl<'db> Bindings<'db> {
                         // instances (`my_model.field = …`). The output type is used to validate
                         // that the converter's return type is assignable to the field's declared type.
                         let converter = converter.and_then(|converter_ty| {
-                            let mut input_types = UnionBuilder::new(db);
-                            let mut output_types = UnionBuilder::new(db);
+                            let mut input_types = UnionBuilder::new(db, program);
+                            let mut output_types = UnionBuilder::new(db, program);
                             let mut found_any = false;
-                            let bindings = converter_ty.bindings(db);
+                            let bindings = converter_ty.bindings(db, program);
                             // Note: `iter_callable_items` collapses the union/intersection
                             // structure. In principle, if the converter is a union of callables,
                             // we should only accept the intersection of all first parameter
@@ -1803,7 +1915,7 @@ impl<'db> Bindings<'db> {
                                 let class_default_specialization = item
                                     .as_constructor()
                                     .map(ConstructorBinding::constructed_instance_type)
-                                    .and_then(|ty| ty.class_specialization(db))
+                                    .and_then(|ty| ty.class_specialization(db, program))
                                     .map(|(_, specialization)| {
                                         specialization
                                             .generic_context(db)
@@ -1873,686 +1985,740 @@ impl<'db> Bindings<'db> {
                         )));
                     }
 
-                    Type::FunctionLiteral(function_type) => match function_type.known(db) {
-                        Some(KnownFunction::IsEquivalentTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_equivalent_to(db, ty_b, constraints)
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
+                    Type::FunctionLiteral(function_type) => {
+                        match function_type.known(db) {
+                            Some(KnownFunction::IsEquivalentTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db, program);
+                                    let ty_b = ty_b.project_type_form(db, program);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_equivalent_to(db, program, ty_b, constraints)
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
                             }
-                        }
 
-                        Some(KnownFunction::IsSubtypeOf) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_subtype_of(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsAssignableTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_assignable_to(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsConstraintSetAssignableTo) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_constraint_set_assignable_to(db, ty_b, constraints)
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsDisjointFrom) => {
-                            if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
-                                let ty_a = ty_a.project_type_form(db);
-                                let ty_b = ty_b.project_type_form(db);
-                                let constraints = ConstraintSetBuilder::new();
-                                let result = constraints.into_owned(|constraints| {
-                                    ty_a.when_disjoint_from(
-                                        db,
-                                        ty_b,
-                                        constraints,
-                                        InferableTypeVars::None,
-                                    )
-                                });
-                                let tracked = InternedConstraintSet::new(db, result);
-                                overload.set_return_type(Type::KnownInstance(
-                                    KnownInstanceType::ConstraintSet(tracked),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsSingleton) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.project_type_form(db).is_singleton(db),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::IsSingleValued) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.project_type_form(db).is_single_valued(db),
-                                ));
-                            }
-                        }
-
-                        Some(KnownFunction::GenericContext) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                let wrap_generic_context = |generic_context| {
-                                    Type::KnownInstance(KnownInstanceType::GenericContext(
-                                        generic_context,
-                                    ))
-                                };
-
-                                let signature_generic_context =
-                                    |signature: &CallableSignature<'db>| {
-                                        UnionType::try_from_elements(
+                            Some(KnownFunction::IsSubtypeOf) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db, program);
+                                    let ty_b = ty_b.project_type_form(db, program);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_subtype_of(
                                             db,
-                                            signature.overloads.iter().map(|signature| {
-                                                signature.generic_context.map(wrap_generic_context)
-                                            }),
+                                            program,
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
                                         )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsAssignableTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db, program);
+                                    let ty_b = ty_b.project_type_form(db, program);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_assignable_to(
+                                            db,
+                                            program,
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsConstraintSetAssignableTo) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db, program);
+                                    let ty_b = ty_b.project_type_form(db, program);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_constraint_set_assignable_to(
+                                            db,
+                                            program,
+                                            ty_b,
+                                            constraints,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsDisjointFrom) => {
+                                if let [Some(ty_a), Some(ty_b)] = overload.parameter_types() {
+                                    let ty_a = ty_a.project_type_form(db, program);
+                                    let ty_b = ty_b.project_type_form(db, program);
+                                    let constraints = ConstraintSetBuilder::new();
+                                    let result = constraints.into_owned(|constraints| {
+                                        ty_a.when_disjoint_from(
+                                            db,
+                                            program,
+                                            ty_b,
+                                            constraints,
+                                            InferableTypeVars::None,
+                                        )
+                                    });
+                                    let tracked = InternedConstraintSet::new(db, result);
+                                    overload.set_return_type(Type::KnownInstance(
+                                        KnownInstanceType::ConstraintSet(tracked),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsSingleton) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.project_type_form(db, program).is_singleton(db, program),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::IsSingleValued) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.project_type_form(db, program)
+                                            .is_single_valued(db, program),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::GenericContext) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    let wrap_generic_context = |generic_context| {
+                                        Type::KnownInstance(KnownInstanceType::GenericContext(
+                                            generic_context,
+                                        ))
                                     };
 
-                                let generic_context_for_simple_type = |ty: Type<'db>| match ty {
-                                    Type::ClassLiteral(class) => {
-                                        class.generic_context(db).map(wrap_generic_context)
-                                    }
-
-                                    Type::FunctionLiteral(function) => {
-                                        signature_generic_context(function.signature(db))
-                                    }
-
-                                    Type::BoundMethod(bound_method) => signature_generic_context(
-                                        bound_method.function(db).signature(db),
-                                    ),
-
-                                    Type::Callable(callable) => {
-                                        signature_generic_context(callable.signatures(db))
-                                    }
-
-                                    Type::KnownInstance(KnownInstanceType::TypeAliasType(
-                                        TypeAliasType::PEP695(alias),
-                                    )) => alias.generic_context(db).map(wrap_generic_context),
-
-                                    _ => None,
-                                };
-
-                                let generic_context = match ty {
-                                    Type::Union(union_type) => UnionType::try_from_elements(
-                                        db,
-                                        union_type
-                                            .elements(db)
-                                            .iter()
-                                            .map(|ty| generic_context_for_simple_type(*ty)),
-                                    ),
-                                    _ => generic_context_for_simple_type(*ty),
-                                };
-
-                                overload.set_return_type(
-                                    generic_context.unwrap_or_else(|| Type::none(db)),
-                                );
-                            }
-                        }
-
-                        Some(
-                            into_callable @ (KnownFunction::IntoCallable
-                            | KnownFunction::IntoRegularCallable),
-                        ) => {
-                            let [Some(ty)] = overload.parameter_types() else {
-                                continue;
-                            };
-                            let Some(callables) = ty.try_upcast_to_callable(db).map(|callables| {
-                                if into_callable == KnownFunction::IntoRegularCallable {
-                                    callables.map(|callable| callable.into_regular(db))
-                                } else {
-                                    callables
-                                }
-                            }) else {
-                                continue;
-                            };
-                            overload.set_return_type(callables.into_type(db));
-                        }
-
-                        Some(KnownFunction::DunderAllNames) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(match ty {
-                                    Type::ModuleLiteral(module_literal) => {
-                                        let all_names = module_literal
-                                            .module(db)
-                                            .file(db)
-                                            .map(|file| dunder_all_names(db, file))
-                                            .unwrap_or_default();
-                                        match all_names {
-                                            Some(names) => {
-                                                let mut names = names.iter().collect::<Vec<_>>();
-                                                names.sort();
-                                                Type::heterogeneous_tuple(
-                                                    db,
-                                                    names.iter().map(|name| {
-                                                        Type::string_literal(db, *name)
-                                                    }),
-                                                )
-                                            }
-                                            None => Type::none(db),
-                                        }
-                                    }
-                                    _ => Type::none(db),
-                                });
-                            }
-                        }
-
-                        Some(KnownFunction::EnumMembers) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                let return_ty = match ty {
-                                    Type::ClassLiteral(class) => {
-                                        if let Some(metadata) = enums::enum_metadata(db, *class)
-                                            && metadata.aliases_are_known
-                                        {
-                                            Type::heterogeneous_tuple(
+                                    let signature_generic_context =
+                                        |signature: &CallableSignature<'db>| {
+                                            UnionType::try_from_elements(
                                                 db,
-                                                metadata
-                                                    .members
-                                                    .keys()
-                                                    .map(|member| Type::string_literal(db, member)),
+                                                program,
+                                                signature.overloads.iter().map(|signature| {
+                                                    signature
+                                                        .generic_context
+                                                        .map(wrap_generic_context)
+                                                }),
                                             )
-                                        } else {
-                                            Type::unknown()
+                                        };
+
+                                    let generic_context_for_simple_type = |ty: Type<'db>| match ty {
+                                        Type::ClassLiteral(class) => {
+                                            class.generic_context(db).map(wrap_generic_context)
                                         }
-                                    }
-                                    _ => Type::unknown(),
-                                };
 
-                                overload.set_return_type(return_ty);
-                            }
-                        }
+                                        Type::FunctionLiteral(function) => {
+                                            signature_generic_context(function.signature(db))
+                                        }
 
-                        Some(KnownFunction::AllMembers) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                overload.set_return_type(Type::heterogeneous_tuple(
-                                    db,
-                                    list_members::all_members(db, *ty)
-                                        .into_iter()
-                                        .sorted()
-                                        .map(|member| Type::string_literal(db, &member.name)),
-                                ));
-                            }
-                        }
+                                        Type::BoundMethod(bound_method) => {
+                                            signature_generic_context(
+                                                bound_method.function(db).signature(db),
+                                            )
+                                        }
 
-                        Some(KnownFunction::Len) => {
-                            if let [Some(first_arg)] = overload.parameter_types() {
-                                if let Some(len_ty) = first_arg.len(db) {
-                                    overload.set_return_type(len_ty);
-                                }
-                            }
-                        }
+                                        Type::Callable(callable) => {
+                                            signature_generic_context(callable.signatures(db))
+                                        }
 
-                        Some(KnownFunction::Repr) => {
-                            if let [Some(first_arg)] = overload.parameter_types() {
-                                overload.set_return_type(first_arg.repr(db));
-                            }
-                        }
+                                        Type::KnownInstance(KnownInstanceType::TypeAliasType(
+                                            TypeAliasType::PEP695(alias),
+                                        )) => alias.generic_context(db).map(wrap_generic_context),
 
-                        Some(KnownFunction::Cast) => {
-                            if let [Some(casted_ty), Some(_)] = overload.parameter_types() {
-                                overload.set_return_type(casted_ty.project_type_form(db));
-                            }
-                        }
+                                        _ => None,
+                                    };
 
-                        Some(KnownFunction::IsProtocol) => {
-                            if let [Some(ty)] = overload.parameter_types() {
-                                // We evaluate this to `Literal[True]` only if the runtime function `typing.is_protocol`
-                                // would return `True` for the given type. Internally we consider `SupportsAbs[int]` to
-                                // be a "(specialised) protocol class", but `typing.is_protocol(SupportsAbs[int])` returns
-                                // `False` at runtime, so we do not set the return type to `Literal[True]` in this case.
-                                overload.set_return_type(Type::bool_literal(
-                                    ty.as_class_literal()
-                                        .is_some_and(|class| class.is_protocol(db)),
-                                ));
-                            }
-                        }
+                                    let generic_context = match ty {
+                                        Type::Union(union_type) => UnionType::try_from_elements(
+                                            db,
+                                            program,
+                                            union_type
+                                                .elements(db)
+                                                .iter()
+                                                .map(|ty| generic_context_for_simple_type(*ty)),
+                                        ),
+                                        _ => generic_context_for_simple_type(*ty),
+                                    };
 
-                        Some(KnownFunction::GetProtocolMembers) => {
-                            // Similarly to `is_protocol`, we only evaluate to this a frozenset of literal strings if a
-                            // class-literal is passed in, not if a generic alias is passed in, to emulate the behaviour
-                            // of `typing.get_protocol_members` at runtime.
-                            if let [Some(Type::ClassLiteral(class))] = overload.parameter_types() {
-                                if let Some(protocol_class) = class.into_protocol_class(db) {
-                                    let member_names = protocol_class
-                                        .interface(db)
-                                        .members(db)
-                                        .map(|member| Type::string_literal(db, member.name()));
-                                    let specialization = UnionType::from_elements(db, member_names);
                                     overload.set_return_type(
-                                        KnownClass::FrozenSet
-                                            .to_specialized_instance(db, &[specialization]),
+                                        generic_context.unwrap_or_else(|| Type::none(db, program)),
                                     );
                                 }
                             }
-                        }
 
-                        Some(KnownFunction::GetattrStatic) => {
-                            let [Some(instance_ty), Some(attr_name), default] =
-                                overload.parameter_types()
-                            else {
-                                continue;
-                            };
-
-                            let Some(attr_name) = attr_name.as_string_literal() else {
-                                continue;
-                            };
-
-                            let default = if let Some(default) = default {
-                                *default
-                            } else {
-                                Type::Never
-                            };
-
-                            let union_with_default =
-                                |ty| UnionType::from_two_elements(db, ty, default);
-
-                            // TODO: we could emit a diagnostic here (if default is not set)
-                            overload.set_return_type(
-                                match instance_ty.static_member(db, attr_name.value(db)) {
-                                    Place::Defined(DefinedPlace {
-                                        ty,
-                                        definedness: Definedness::AlwaysDefined,
-                                        ..
-                                    }) => {
-                                        if ty.is_dynamic() {
-                                            // Here, we attempt to model the fact that an attribute lookup on
-                                            // a dynamic type could fail
-
-                                            union_with_default(ty)
+                            Some(
+                                into_callable @ (KnownFunction::IntoCallable
+                                | KnownFunction::IntoRegularCallable),
+                            ) => {
+                                let [Some(ty)] = overload.parameter_types() else {
+                                    continue;
+                                };
+                                let Some(callables) =
+                                    ty.try_upcast_to_callable(db, program).map(|callables| {
+                                        if into_callable == KnownFunction::IntoRegularCallable {
+                                            callables.map(|callable| callable.into_regular(db))
                                         } else {
-                                            ty
+                                            callables
                                         }
-                                    }
-                                    Place::Defined(DefinedPlace {
-                                        ty,
-                                        definedness: Definedness::PossiblyUndefined,
-                                        ..
-                                    }) => union_with_default(ty),
-                                    Place::Undefined => default,
-                                },
-                            );
-                        }
-
-                        Some(KnownFunction::Dataclass) => {
-                            let parameter_types = overload.parameter_types();
-                            let (cls_argument, dataclass_parameter_types) = overload
-                                .signature
-                                .parameters()
-                                .positional_only_by_name("cls")
-                                .map(|(index, _)| {
-                                    (parameter_types[index], &parameter_types[index + 1..])
-                                })
-                                .unwrap_or((None, parameter_types));
-
-                            if let [
-                                init,
-                                repr,
-                                eq,
-                                order,
-                                unsafe_hash,
-                                frozen,
-                                versioned_parameters @ ..,
-                            ] = dataclass_parameter_types
-                            {
-                                let mut flags = DataclassFlags::empty();
-                                let invalid_order = to_bool(order, false) == Some(true)
-                                    && to_bool(eq, true) == Some(false);
-                                let mut invalid_weakref_slot = false;
-
-                                // TODO: Emit a diagnostic if a dataclass flag is not statically
-                                // known.
-                                if to_bool(init, true).unwrap_or(true) {
-                                    flags |= DataclassFlags::INIT;
-                                }
-                                if to_bool(repr, true).unwrap_or(true) {
-                                    flags |= DataclassFlags::REPR;
-                                }
-                                if to_bool(eq, true).unwrap_or(true) {
-                                    flags |= DataclassFlags::EQ;
-                                }
-                                if to_bool(order, false).unwrap_or(false) {
-                                    flags |= DataclassFlags::ORDER;
-                                }
-                                if to_bool(unsafe_hash, false).unwrap_or(false) {
-                                    flags |= DataclassFlags::UNSAFE_HASH;
-                                }
-                                if to_bool(frozen, false).unwrap_or(false) {
-                                    flags |= DataclassFlags::FROZEN;
-                                }
-                                match versioned_parameters {
-                                    // Python < 3.10.
-                                    [] => {}
-                                    // Python 3.10.
-                                    [match_args, kw_only, slots] => {
-                                        if to_bool(match_args, true).unwrap_or(true) {
-                                            flags |= DataclassFlags::MATCH_ARGS;
-                                        }
-                                        if to_bool(kw_only, false).unwrap_or(false) {
-                                            flags |= DataclassFlags::KW_ONLY;
-                                        }
-                                        if to_bool(slots, false).unwrap_or(false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
-                                    }
-                                    // Python >= 3.11.
-                                    [match_args, kw_only, slots, weakref_slot] => {
-                                        if to_bool(match_args, true).unwrap_or(true) {
-                                            flags |= DataclassFlags::MATCH_ARGS;
-                                        }
-                                        if to_bool(kw_only, false).unwrap_or(false) {
-                                            flags |= DataclassFlags::KW_ONLY;
-                                        }
-                                        if to_bool(slots, false).unwrap_or(false) {
-                                            flags |= DataclassFlags::SLOTS;
-                                        }
-                                        if to_bool(weakref_slot, false).unwrap_or(false) {
-                                            flags |= DataclassFlags::WEAKREF_SLOT;
-                                        }
-                                        if to_bool(weakref_slot, false) == Some(true)
-                                            && to_bool(slots, false) == Some(false)
-                                        {
-                                            invalid_weakref_slot = true;
-                                        }
-                                    }
-                                    _ => {}
-                                }
-
-                                let params = DataclassParams::from_flags(db, flags);
-
-                                if cls_argument.is_none_or(|cls_ty| cls_ty.is_none(db)) {
-                                    overload.set_return_type(Type::DataclassDecorator(params));
-                                }
-
-                                if invalid_order {
-                                    overload.errors.push(BindingError::InvalidDataclassArgument(
-                                        InvalidDataclassArgument::OrderRequiresEq,
-                                    ));
-                                }
-                                if invalid_weakref_slot {
-                                    overload.errors.push(BindingError::InvalidDataclassArgument(
-                                        InvalidDataclassArgument::WeakrefSlotRequiresSlots,
-                                    ));
-                                }
-
-                                // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`).
-                                if let Some(Type::ClassLiteral(class_literal)) =
-                                    cls_argument.as_ref()
-                                {
-                                    if let Some(target) =
-                                        invalid_dataclass_target(db, class_literal)
-                                    {
-                                        overload.errors.push(
-                                            BindingError::InvalidDataclassApplication(target),
-                                        );
-                                    } else {
-                                        overload.set_return_type(Type::from(
-                                            class_literal.with_dataclass_params(db, Some(params)),
-                                        ));
-                                    }
-                                }
-                            }
-                        }
-
-                        Some(KnownFunction::DataclassTransform) => {
-                            // Use named parameter lookup to handle custom
-                            // `__dataclass_transform__` functions that follow older versions
-                            // of the spec.
-                            let mut flags = DataclassTransformerFlags::empty();
-
-                            let eq_default = overload
-                                .parameter_type_by_name("eq_default", false)
-                                .ok()
-                                .flatten();
-                            let order_default = overload
-                                .parameter_type_by_name("order_default", false)
-                                .ok()
-                                .flatten();
-                            let kw_only_default = overload
-                                .parameter_type_by_name("kw_only_default", false)
-                                .ok()
-                                .flatten();
-                            let frozen_default = overload
-                                .parameter_type_by_name("frozen_default", false)
-                                .ok()
-                                .flatten();
-
-                            if to_bool(&eq_default, true).unwrap_or(true) {
-                                flags |= DataclassTransformerFlags::EQ_DEFAULT;
-                            }
-                            if to_bool(&order_default, false).unwrap_or(false) {
-                                flags |= DataclassTransformerFlags::ORDER_DEFAULT;
-                            }
-                            if to_bool(&kw_only_default, false).unwrap_or(false) {
-                                flags |= DataclassTransformerFlags::KW_ONLY_DEFAULT;
-                            }
-                            if to_bool(&frozen_default, false).unwrap_or(false) {
-                                flags |= DataclassTransformerFlags::FROZEN_DEFAULT;
+                                    })
+                                else {
+                                    continue;
+                                };
+                                overload.set_return_type(callables.into_type(db, program));
                             }
 
-                            // Accept both `field_specifiers` (current name) and
-                            // `field_descriptors` (legacy name).
-                            let field_specifiers_param = overload
-                                .parameter_type_by_name("field_specifiers", false)
-                                .ok()
-                                .flatten()
-                                .or_else(|| {
-                                    overload
-                                        .parameter_type_by_name("field_descriptors", false)
-                                        .ok()
-                                        .flatten()
-                                });
-
-                            let field_specifiers: Box<[Type<'db>]> = field_specifiers_param
-                                .map(|tuple_type| {
-                                    tuple_type
-                                        .exact_tuple_instance_spec(db)
-                                        .iter()
-                                        .flat_map(|tuple_spec| tuple_spec.fixed_elements())
-                                        .copied()
-                                        .collect::<Vec<_>>()
-                                        .into_boxed_slice()
-                                })
-                                .unwrap_or_default();
-
-                            let params =
-                                DataclassTransformerParams::new(db, flags, field_specifiers);
-
-                            overload.set_return_type(Type::DataclassTransformer(params));
-                        }
-
-                        Some(KnownFunction::Unpack) => {
-                            let [Some(format), Some(_buffer)] = overload.parameter_types() else {
-                                continue;
-                            };
-
-                            let Some(format_literal) = format.as_string_literal() else {
-                                continue;
-                            };
-
-                            let return_type = parse_struct_format(db, format_literal.value(db))
-                                .map(|elements| Type::heterogeneous_tuple(db, elements))
-                                .unwrap_or_else(|| Type::homogeneous_tuple(db, Type::unknown()));
-
-                            overload.set_return_type(return_type);
-                        }
-
-                        _ => {
-                            // Ideally, either the implementation, or exactly one of the overloads
-                            // of the function can have the dataclass_transform decorator applied.
-                            // However, we do not yet enforce this, and in the case of multiple
-                            // applications of the decorator, we will only consider the last one.
-                            let transformer_params = function_type
-                                .iter_overloads_and_implementation(db)
-                                .rev()
-                                .find_map(|function_overload| {
-                                    function_overload.dataclass_transformer_params(db)
-                                });
-
-                            if let Some(params) = transformer_params {
-                                // If this function was called with a keyword argument like
-                                // `order=False`, we extract the argument type and overwrite
-                                // the corresponding flag in `dataclass_params`.
-                                let dataclass_params =
-                                    DataclassParams::from_transformer_params(db, params);
-                                let mut flags = dataclass_params.flags(db);
-
-                                for (param, flag) in DATACLASS_FLAGS {
-                                    if let Some(ty) =
-                                        call_arguments.iter().find_map(|(arg, arg_types)| {
-                                            if let Argument::Keyword(arg_name) = arg
-                                                && *arg_name == **param
-                                            {
-                                                arg_types.get_default()
-                                            } else {
-                                                None
+                            Some(KnownFunction::DunderAllNames) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(match ty {
+                                        Type::ModuleLiteral(module_literal) => {
+                                            let all_names = module_literal
+                                                .module_program_file(db)
+                                                .map(|file| dunder_all_names(db, file))
+                                                .unwrap_or_default();
+                                            match all_names {
+                                                Some(names) => {
+                                                    let mut names =
+                                                        names.iter().collect::<Vec<_>>();
+                                                    names.sort();
+                                                    Type::heterogeneous_tuple(
+                                                        db,
+                                                        names.iter().map(|name| {
+                                                            Type::string_literal(db, name.as_str())
+                                                        }),
+                                                    )
+                                                }
+                                                None => Type::none(db, program),
                                             }
-                                        })
-                                        && let Some(LiteralValueTypeKind::Bool(value)) =
-                                            ty.as_literal_value_kind()
-                                    {
-                                        flags.set(*flag, value);
-                                    }
+                                        }
+                                        _ => Type::none(db, program),
+                                    });
                                 }
+                            }
 
-                                let dataclass_params = DataclassParams::new(
-                                    db,
-                                    flags,
-                                    dataclass_params.field_specifiers(db),
-                                );
-
-                                // The dataclass_transform spec doesn't clarify how to tell whether
-                                // a decorated function is a decorator or a decorator factory. We
-                                // use heuristics based on the number and type of positional arguments:
-                                //
-                                // - Zero positional arguments: assume it's a decorator factory.
-                                // - More than one positional argument: assume it's a decorator factory.
-                                // - Exactly one positional argument that's a class: ambiguous, so check
-                                //   the return type to disambiguate (class-like means decorate directly).
-                                let mut positional_args = overload
-                                    .signature
-                                    .parameters()
-                                    .iter()
-                                    .zip(overload.parameter_types())
-                                    .filter(|(param, ty)| ty.is_some() && !param.is_keyword_only())
-                                    .map(|(_, ty)| ty);
-
-                                let first_positional = positional_args.next();
-                                let has_more = positional_args.next().is_some();
-
-                                // Only attempt direct decoration if exactly one positional argument.
-                                if !has_more {
-                                    // Helper to check if return type is class-like.
-                                    let returns_class = || {
-                                        matches!(
-                                            overload.return_type(),
-                                            Type::ClassLiteral(_)
-                                                | Type::GenericAlias(_)
-                                                | Type::SubclassOf(_)
-                                        )
+                            Some(KnownFunction::EnumMembers) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    let return_ty = match ty {
+                                        Type::ClassLiteral(class) => {
+                                            if let Some(metadata) = enums::enum_metadata(db, *class)
+                                                && metadata.aliases_are_known
+                                            {
+                                                Type::heterogeneous_tuple(
+                                                    db,
+                                                    metadata.members.keys().map(|member| {
+                                                        Type::string_literal(db, member)
+                                                    }),
+                                                )
+                                            } else {
+                                                Type::unknown()
+                                            }
+                                        }
+                                        _ => Type::unknown(),
                                     };
 
-                                    match first_positional {
-                                        Some(Some(Type::ClassLiteral(class_literal)))
-                                            if returns_class() =>
-                                        {
-                                            overload.set_return_type(Type::from(
-                                                class_literal.with_dataclass_params(
-                                                    db,
-                                                    Some(dataclass_params),
-                                                ),
-                                            ));
-                                            continue;
+                                    overload.set_return_type(return_ty);
+                                }
+                            }
+
+                            Some(KnownFunction::AllMembers) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    overload.set_return_type(Type::heterogeneous_tuple(
+                                        db,
+                                        list_members::all_members(db, program, *ty)
+                                            .into_iter()
+                                            .sorted()
+                                            .map(|member| Type::string_literal(db, &member.name)),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::Len) => {
+                                if let [Some(first_arg)] = overload.parameter_types() {
+                                    if let Some(len_ty) = first_arg.len(db, program) {
+                                        overload.set_return_type(len_ty);
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::Repr) => {
+                                if let [Some(first_arg)] = overload.parameter_types() {
+                                    overload.set_return_type(first_arg.repr(db, program));
+                                }
+                            }
+
+                            Some(KnownFunction::Cast) => {
+                                if let [Some(casted_ty), Some(_)] = overload.parameter_types() {
+                                    overload
+                                        .set_return_type(casted_ty.project_type_form(db, program));
+                                }
+                            }
+
+                            Some(KnownFunction::IsProtocol) => {
+                                if let [Some(ty)] = overload.parameter_types() {
+                                    // We evaluate this to `Literal[True]` only if the runtime function `typing.is_protocol`
+                                    // would return `True` for the given type. Internally we consider `SupportsAbs[int]` to
+                                    // be a "(specialised) protocol class", but `typing.is_protocol(SupportsAbs[int])` returns
+                                    // `False` at runtime, so we do not set the return type to `Literal[True]` in this case.
+                                    overload.set_return_type(Type::bool_literal(
+                                        ty.as_class_literal()
+                                            .is_some_and(|class| class.is_protocol(db)),
+                                    ));
+                                }
+                            }
+
+                            Some(KnownFunction::GetProtocolMembers) => {
+                                // Similarly to `is_protocol`, we only evaluate to this a frozenset of literal strings if a
+                                // class-literal is passed in, not if a generic alias is passed in, to emulate the behaviour
+                                // of `typing.get_protocol_members` at runtime.
+                                if let [Some(Type::ClassLiteral(class))] =
+                                    overload.parameter_types()
+                                {
+                                    if let Some(protocol_class) = class.into_protocol_class(db) {
+                                        let member_names = protocol_class
+                                            .interface(db)
+                                            .members(db)
+                                            .map(|member| Type::string_literal(db, member.name()));
+                                        let specialization =
+                                            UnionType::from_elements(db, program, member_names);
+                                        overload.set_return_type(
+                                            KnownClass::FrozenSet.to_specialized_instance(
+                                                db,
+                                                program,
+                                                &[specialization],
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::GetattrStatic) => {
+                                let [Some(instance_ty), Some(attr_name), default] =
+                                    overload.parameter_types()
+                                else {
+                                    continue;
+                                };
+
+                                let Some(attr_name) = attr_name.as_string_literal() else {
+                                    continue;
+                                };
+
+                                let default = if let Some(default) = default {
+                                    *default
+                                } else {
+                                    Type::Never
+                                };
+
+                                let union_with_default =
+                                    |ty| UnionType::from_two_elements(db, program, ty, default);
+
+                                // TODO: we could emit a diagnostic here (if default is not set)
+                                overload.set_return_type(
+                                    match instance_ty.static_member(
+                                        db,
+                                        program,
+                                        attr_name.value(db),
+                                    ) {
+                                        Place::Defined(DefinedPlace {
+                                            ty,
+                                            definedness: Definedness::AlwaysDefined,
+                                            ..
+                                        }) => {
+                                            if ty.is_dynamic() {
+                                                // Here, we attempt to model the fact that an attribute lookup on
+                                                // a dynamic type could fail
+
+                                                union_with_default(ty)
+                                            } else {
+                                                ty
+                                            }
                                         }
-                                        Some(Some(Type::GenericAlias(generic_alias)))
-                                            if returns_class() =>
-                                        {
-                                            let new_origin = generic_alias
-                                                .origin(db)
-                                                .with_dataclass_params(db, Some(dataclass_params));
-                                            overload.set_return_type(Type::GenericAlias(
-                                                GenericAlias::new(
-                                                    db,
-                                                    new_origin,
-                                                    generic_alias.specialization(db),
-                                                ),
-                                            ));
-                                            continue;
+                                        Place::Defined(DefinedPlace {
+                                            ty,
+                                            definedness: Definedness::PossiblyUndefined,
+                                            ..
+                                        }) => union_with_default(ty),
+                                        Place::Undefined => default,
+                                    },
+                                );
+                            }
+
+                            Some(KnownFunction::Dataclass) => {
+                                let parameter_types = overload.parameter_types();
+                                let (cls_argument, dataclass_parameter_types) = overload
+                                    .signature
+                                    .parameters()
+                                    .positional_only_by_name("cls")
+                                    .map(|(index, _)| {
+                                        (parameter_types[index], &parameter_types[index + 1..])
+                                    })
+                                    .unwrap_or((None, parameter_types));
+
+                                if let [
+                                    init,
+                                    repr,
+                                    eq,
+                                    order,
+                                    unsafe_hash,
+                                    frozen,
+                                    versioned_parameters @ ..,
+                                ] = dataclass_parameter_types
+                                {
+                                    let mut flags = DataclassFlags::empty();
+                                    let invalid_order = to_bool(order, false) == Some(true)
+                                        && to_bool(eq, true) == Some(false);
+                                    let mut invalid_weakref_slot = false;
+
+                                    // TODO: Emit a diagnostic if a dataclass flag is not statically
+                                    // known.
+                                    if to_bool(init, true).unwrap_or(true) {
+                                        flags |= DataclassFlags::INIT;
+                                    }
+                                    if to_bool(repr, true).unwrap_or(true) {
+                                        flags |= DataclassFlags::REPR;
+                                    }
+                                    if to_bool(eq, true).unwrap_or(true) {
+                                        flags |= DataclassFlags::EQ;
+                                    }
+                                    if to_bool(order, false).unwrap_or(false) {
+                                        flags |= DataclassFlags::ORDER;
+                                    }
+                                    if to_bool(unsafe_hash, false).unwrap_or(false) {
+                                        flags |= DataclassFlags::UNSAFE_HASH;
+                                    }
+                                    if to_bool(frozen, false).unwrap_or(false) {
+                                        flags |= DataclassFlags::FROZEN;
+                                    }
+                                    match versioned_parameters {
+                                        // Python < 3.10.
+                                        [] => {}
+                                        // Python 3.10.
+                                        [match_args, kw_only, slots] => {
+                                            if to_bool(match_args, true).unwrap_or(true) {
+                                                flags |= DataclassFlags::MATCH_ARGS;
+                                            }
+                                            if to_bool(kw_only, false).unwrap_or(false) {
+                                                flags |= DataclassFlags::KW_ONLY;
+                                            }
+                                            if to_bool(slots, false).unwrap_or(false) {
+                                                flags |= DataclassFlags::SLOTS;
+                                            }
+                                        }
+                                        // Python >= 3.11.
+                                        [match_args, kw_only, slots, weakref_slot] => {
+                                            if to_bool(match_args, true).unwrap_or(true) {
+                                                flags |= DataclassFlags::MATCH_ARGS;
+                                            }
+                                            if to_bool(kw_only, false).unwrap_or(false) {
+                                                flags |= DataclassFlags::KW_ONLY;
+                                            }
+                                            if to_bool(slots, false).unwrap_or(false) {
+                                                flags |= DataclassFlags::SLOTS;
+                                            }
+                                            if to_bool(weakref_slot, false).unwrap_or(false) {
+                                                flags |= DataclassFlags::WEAKREF_SLOT;
+                                            }
+                                            if to_bool(weakref_slot, false) == Some(true)
+                                                && to_bool(slots, false) == Some(false)
+                                            {
+                                                invalid_weakref_slot = true;
+                                            }
                                         }
                                         _ => {}
                                     }
+
+                                    let params = DataclassParams::from_flags(db, program, flags);
+
+                                    if cls_argument.is_none_or(|cls_ty| cls_ty.is_none(db, program))
+                                    {
+                                        overload.set_return_type(Type::DataclassDecorator(params));
+                                    }
+
+                                    if invalid_order {
+                                        overload.errors.push(
+                                            BindingError::InvalidDataclassArgument(
+                                                InvalidDataclassArgument::OrderRequiresEq,
+                                            ),
+                                        );
+                                    }
+                                    if invalid_weakref_slot {
+                                        overload.errors.push(
+                                            BindingError::InvalidDataclassArgument(
+                                                InvalidDataclassArgument::WeakrefSlotRequiresSlots,
+                                            ),
+                                        );
+                                    }
+
+                                    // `dataclass` being used as a non-decorator (i.e., `dataclass(SomeClass)`).
+                                    if let Some(Type::ClassLiteral(class_literal)) =
+                                        cls_argument.as_ref()
+                                    {
+                                        if let Some(target) =
+                                            invalid_dataclass_target(db, class_literal)
+                                        {
+                                            overload.errors.push(
+                                                BindingError::InvalidDataclassApplication(target),
+                                            );
+                                        } else {
+                                            overload.set_return_type(Type::from(
+                                                class_literal
+                                                    .with_dataclass_params(db, Some(params)),
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+
+                            Some(KnownFunction::DataclassTransform) => {
+                                // Use named parameter lookup to handle custom
+                                // `__dataclass_transform__` functions that follow older versions
+                                // of the spec.
+                                let mut flags = DataclassTransformerFlags::empty();
+
+                                let eq_default = overload
+                                    .parameter_type_by_name("eq_default", false)
+                                    .ok()
+                                    .flatten();
+                                let order_default = overload
+                                    .parameter_type_by_name("order_default", false)
+                                    .ok()
+                                    .flatten();
+                                let kw_only_default = overload
+                                    .parameter_type_by_name("kw_only_default", false)
+                                    .ok()
+                                    .flatten();
+                                let frozen_default = overload
+                                    .parameter_type_by_name("frozen_default", false)
+                                    .ok()
+                                    .flatten();
+
+                                if to_bool(&eq_default, true).unwrap_or(true) {
+                                    flags |= DataclassTransformerFlags::EQ_DEFAULT;
+                                }
+                                if to_bool(&order_default, false).unwrap_or(false) {
+                                    flags |= DataclassTransformerFlags::ORDER_DEFAULT;
+                                }
+                                if to_bool(&kw_only_default, false).unwrap_or(false) {
+                                    flags |= DataclassTransformerFlags::KW_ONLY_DEFAULT;
+                                }
+                                if to_bool(&frozen_default, false).unwrap_or(false) {
+                                    flags |= DataclassTransformerFlags::FROZEN_DEFAULT;
                                 }
 
-                                // Zero or more than one positional argument, or the argument is
-                                // not a class: assume it's a decorator factory.
-                                overload
-                                    .set_return_type(Type::DataclassDecorator(dataclass_params));
+                                // Accept both `field_specifiers` (current name) and
+                                // `field_descriptors` (legacy name).
+                                let field_specifiers_param = overload
+                                    .parameter_type_by_name("field_specifiers", false)
+                                    .ok()
+                                    .flatten()
+                                    .or_else(|| {
+                                        overload
+                                            .parameter_type_by_name("field_descriptors", false)
+                                            .ok()
+                                            .flatten()
+                                    });
+
+                                let field_specifiers: Box<[Type<'db>]> = field_specifiers_param
+                                    .map(|tuple_type| {
+                                        tuple_type
+                                            .exact_tuple_instance_spec(db)
+                                            .iter()
+                                            .flat_map(|tuple_spec| tuple_spec.fixed_elements())
+                                            .copied()
+                                            .collect::<Vec<_>>()
+                                            .into_boxed_slice()
+                                    })
+                                    .unwrap_or_default();
+
+                                let params =
+                                    DataclassTransformerParams::new(db, flags, field_specifiers);
+
+                                overload.set_return_type(Type::DataclassTransformer(params));
+                            }
+
+                            Some(KnownFunction::Unpack) => {
+                                let [Some(format), Some(_buffer)] = overload.parameter_types()
+                                else {
+                                    continue;
+                                };
+
+                                let Some(format_literal) = format.as_string_literal() else {
+                                    continue;
+                                };
+
+                                let python_version = function_type.program(db).python_version(db);
+                                let return_type = parse_struct_format(
+                                    db,
+                                    program,
+                                    python_version,
+                                    format_literal.value(db),
+                                )
+                                .map(|elements| Type::heterogeneous_tuple(db, elements))
+                                .unwrap_or_else(|| Type::homogeneous_tuple(db, Type::unknown()));
+
+                                overload.set_return_type(return_type);
+                            }
+
+                            _ => {
+                                // Ideally, either the implementation, or exactly one of the overloads
+                                // of the function can have the dataclass_transform decorator applied.
+                                // However, we do not yet enforce this, and in the case of multiple
+                                // applications of the decorator, we will only consider the last one.
+                                let transformer_params = function_type
+                                    .iter_overloads_and_implementation(db)
+                                    .rev()
+                                    .find_map(|function_overload| {
+                                        function_overload.dataclass_transformer_params(db)
+                                    });
+
+                                if let Some(params) = transformer_params {
+                                    // If this function was called with a keyword argument like
+                                    // `order=False`, we extract the argument type and overwrite
+                                    // the corresponding flag in `dataclass_params`.
+                                    let dataclass_params =
+                                        DataclassParams::from_transformer_params(db, params);
+                                    let mut flags = dataclass_params.flags(db);
+
+                                    for (param, flag) in DATACLASS_FLAGS {
+                                        if let Some(ty) =
+                                            call_arguments.iter().find_map(|(arg, arg_types)| {
+                                                if let Argument::Keyword(arg_name) = arg
+                                                    && *arg_name == **param
+                                                {
+                                                    arg_types.get_default()
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            && let Some(LiteralValueTypeKind::Bool(value)) =
+                                                ty.as_literal_value_kind()
+                                        {
+                                            flags.set(*flag, value);
+                                        }
+                                    }
+
+                                    let dataclass_params = DataclassParams::new(
+                                        db,
+                                        flags,
+                                        dataclass_params.field_specifiers(db),
+                                    );
+
+                                    // The dataclass_transform spec doesn't clarify how to tell whether
+                                    // a decorated function is a decorator or a decorator factory. We
+                                    // use heuristics based on the number and type of positional arguments:
+                                    //
+                                    // - Zero positional arguments: assume it's a decorator factory.
+                                    // - More than one positional argument: assume it's a decorator factory.
+                                    // - Exactly one positional argument that's a class: ambiguous, so check
+                                    //   the return type to disambiguate (class-like means decorate directly).
+                                    let mut positional_args = overload
+                                        .signature
+                                        .parameters()
+                                        .iter()
+                                        .zip(overload.parameter_types())
+                                        .filter(|(param, ty)| {
+                                            ty.is_some() && !param.is_keyword_only()
+                                        })
+                                        .map(|(_, ty)| ty);
+
+                                    let first_positional = positional_args.next();
+                                    let has_more = positional_args.next().is_some();
+
+                                    // Only attempt direct decoration if exactly one positional argument.
+                                    if !has_more {
+                                        // Helper to check if return type is class-like.
+                                        let returns_class = || {
+                                            matches!(
+                                                overload.return_type(),
+                                                Type::ClassLiteral(_)
+                                                    | Type::GenericAlias(_)
+                                                    | Type::SubclassOf(_)
+                                            )
+                                        };
+
+                                        match first_positional {
+                                            Some(Some(Type::ClassLiteral(class_literal)))
+                                                if returns_class() =>
+                                            {
+                                                overload.set_return_type(Type::from(
+                                                    class_literal.with_dataclass_params(
+                                                        db,
+                                                        Some(dataclass_params),
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            Some(Some(Type::GenericAlias(generic_alias)))
+                                                if returns_class() =>
+                                            {
+                                                let new_origin =
+                                                    generic_alias.origin(db).with_dataclass_params(
+                                                        db,
+                                                        Some(dataclass_params),
+                                                    );
+                                                overload.set_return_type(Type::GenericAlias(
+                                                    GenericAlias::new(
+                                                        db,
+                                                        new_origin,
+                                                        generic_alias.specialization(db),
+                                                    ),
+                                                ));
+                                                continue;
+                                            }
+                                            _ => {}
+                                        }
+                                    }
+
+                                    // Zero or more than one positional argument, or the argument is
+                                    // not a class: assume it's a decorator factory.
+                                    overload.set_return_type(Type::DataclassDecorator(
+                                        dataclass_params,
+                                    ));
+                                }
                             }
                         }
-                    },
+                    }
 
                     Type::KnownBoundMethod(KnownBoundMethodType::ConstraintSetRange) => {
                         let [Some(lower), Some(typevar), Some(upper)] = overload.parameter_types()
                         else {
                             return;
                         };
-                        let lower = lower.project_type_form(db);
-                        let typevar = typevar.project_type_form(db);
-                        let upper = upper.project_type_form(db);
+                        let lower = lower.project_type_form(db, program);
+                        let typevar = typevar.project_type_form(db, program);
+                        let upper = upper.project_type_form(db, program);
                         let Type::TypeVar(typevar) = typevar else {
                             return;
                         };
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
-                            ConstraintSet::constrain_typevar(db, constraints, typevar, lower, upper)
+                            ConstraintSet::constrain_typevar(
+                                db,
+                                program,
+                                constraints,
+                                typevar,
+                                lower,
+                                upper,
+                            )
                         });
                         let tracked = InternedConstraintSet::new(db, result);
                         overload.set_return_type(Type::KnownInstance(
@@ -2592,20 +2758,22 @@ impl<'db> Bindings<'db> {
                         let [Some(ty_a), Some(ty_b)] = overload.parameter_types() else {
                             continue;
                         };
-                        let ty_a = ty_a.project_type_form(db);
-                        let ty_b = ty_b.project_type_form(db);
+                        let ty_a = ty_a.project_type_form(db, program);
+                        let ty_b = ty_b.project_type_form(db, program);
 
                         let nonce_generator = TypeVarNonceGenerator::default();
                         let ty_a = freshen_generic_contexts_in_type(
                             db,
+                            program,
                             ty_a,
-                            generic_contexts_mentioned_in_type(db, ty_a),
+                            generic_contexts_mentioned_in_type(db, program, ty_a),
                             &nonce_generator,
                         );
                         let ty_b = freshen_generic_contexts_in_type(
                             db,
+                            program,
                             ty_b,
-                            generic_contexts_mentioned_in_type(db, ty_b),
+                            generic_contexts_mentioned_in_type(db, program, ty_b),
                             &nonce_generator,
                         );
 
@@ -2613,8 +2781,9 @@ impl<'db> Bindings<'db> {
                         let result = constraints.into_owned(|constraints| {
                             ty_a.when_subtype_of_assuming(
                                 db,
+                                program,
                                 ty_b,
-                                constraints.load(db, tracked.constraints(db)),
+                                constraints.load(db, program, tracked.constraints(db)),
                                 constraints,
                                 InferableTypeVars::None,
                             )
@@ -2638,9 +2807,9 @@ impl<'db> Bindings<'db> {
 
                         let constraints = ConstraintSetBuilder::new();
                         let result = constraints.into_owned(|constraints| {
-                            let lhs = constraints.load(db, tracked.constraints(db));
-                            let rhs = constraints.load(db, other.constraints(db));
-                            lhs.implies(db, constraints, || rhs)
+                            let lhs = constraints.load(db, program, tracked.constraints(db));
+                            let rhs = constraints.load(db, program, other.constraints(db));
+                            lhs.implies(db, program, constraints, || rhs)
                         });
                         let tracked = InternedConstraintSet::new(db, result);
                         overload.set_return_type(Type::KnownInstance(
@@ -2657,7 +2826,7 @@ impl<'db> Bindings<'db> {
                                 return Some(InferableTypeVars::None);
                             }
                             let typevars: Option<FxOrderSet<_>> = instance
-                                .tuple_spec(db)?
+                                .tuple_spec(db, program)?
                                 .fixed_elements()
                                 .map(|ty| {
                                     ty.as_typevar()
@@ -2671,7 +2840,8 @@ impl<'db> Bindings<'db> {
                             // Caller did not provide argument, so no typevars are inferable.
                             [None] => InferableTypeVars::None,
                             [Some(ty)] => {
-                                let Type::NominalInstance(instance) = ty.project_type_form(db)
+                                let Type::NominalInstance(instance) =
+                                    ty.project_type_form(db, program)
                                 else {
                                     continue;
                                 };
@@ -2684,8 +2854,9 @@ impl<'db> Bindings<'db> {
                         };
 
                         let constraints = ConstraintSetBuilder::new();
-                        let set = constraints.load(db, tracked.constraints(db));
-                        let result = set.satisfied_by_all_typevars(db, &constraints, inferable);
+                        let set = constraints.load(db, program, tracked.constraints(db));
+                        let result =
+                            set.satisfied_by_all_typevars(db, program, &constraints, inferable);
                         overload.set_return_type(Type::bool_literal(result));
                     }
 
@@ -2701,7 +2872,11 @@ impl<'db> Bindings<'db> {
                     Type::ClassLiteral(class) => match class.known(db) {
                         Some(KnownClass::Bool) => match overload.parameter_types() {
                             [Some(arg)] => {
-                                overload.set_return_type(Type::from_truthiness(db, arg.bool(db)));
+                                overload.set_return_type(Type::from_truthiness(
+                                    db,
+                                    program,
+                                    arg.bool(db, program),
+                                ));
                             }
                             [None] => overload.set_return_type(Type::bool_literal(false)),
                             _ => {}
@@ -2709,7 +2884,7 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownClass::Str) if overload_index == 0 => {
                             match overload.parameter_types() {
-                                [Some(arg)] => overload.set_return_type(arg.str(db)),
+                                [Some(arg)] => overload.set_return_type(arg.str(db, program)),
                                 [None] => {
                                     overload.set_return_type(Type::string_literal(db, ""));
                                 }
@@ -2719,15 +2894,15 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownClass::Type) if overload_index == 0 => {
                             if let [Some(arg)] = overload.parameter_types() {
-                                overload.set_return_type(arg.dunder_class(db));
+                                overload.set_return_type(arg.dunder_class(db, program));
                             }
                         }
 
                         Some(KnownClass::Property) => {
                             if let [getter, setter, deleter, ..] = overload.parameter_types() {
-                                let getter = getter.filter(|ty| !ty.is_none(db));
-                                let setter = setter.filter(|ty| !ty.is_none(db));
-                                let deleter = deleter.filter(|ty| !ty.is_none(db));
+                                let getter = getter.filter(|ty| !ty.is_none(db, program));
+                                let setter = setter.filter(|ty| !ty.is_none(db, program));
+                                let deleter = deleter.filter(|ty| !ty.is_none(db, program));
                                 overload.set_return_type(Type::PropertyInstance(
                                     PropertyInstanceType::new(db, getter, setter, deleter),
                                 ));
@@ -2736,7 +2911,7 @@ impl<'db> Bindings<'db> {
 
                         Some(KnownClass::FunctoolsPartial) => {
                             if let Some(new_return_type) =
-                                overload.functools_partial_return_type(db, call_arguments)
+                                overload.functools_partial_return_type(db, program, call_arguments)
                             {
                                 overload.set_return_type(new_return_type);
                             }
@@ -2753,11 +2928,14 @@ impl<'db> Bindings<'db> {
                                 // `__iter__ = None`, for example). That would be badly written Python code, but we still
                                 // need to be able to handle it without crashing.
                                 let return_type = if let Type::Union(union) = argument {
-                                    union.map(db, |element| {
-                                        Type::tuple(TupleType::new(db, &element.iterate(db)))
+                                    union.map(db, program, |element| {
+                                        Type::tuple(TupleType::new(
+                                            db,
+                                            &element.iterate(db, program),
+                                        ))
                                     })
                                 } else {
-                                    Type::tuple(TupleType::new(db, &argument.iterate(db)))
+                                    Type::tuple(TupleType::new(db, &argument.iterate(db, program)))
                                 };
                                 overload.set_return_type(return_type);
                             }
@@ -2772,7 +2950,7 @@ impl<'db> Bindings<'db> {
             }
         }
 
-        self.evaluate_enum_property_calls(db, call_arguments);
+        self.evaluate_enum_property_calls(db, program, call_arguments);
     }
 }
 
@@ -2943,7 +3121,11 @@ impl<'db> CallableBinding<'db> {
 
     /// Rewrites overload signatures as if an implicit bound receiver argument had already been
     /// consumed, preserving the corresponding source-parameter offset for diagnostics.
-    pub(crate) fn bake_bound_type_into_overloads(&mut self, db: &'db dyn Db) {
+    pub(crate) fn bake_bound_type_into_overloads(
+        &mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) {
         let Some(bound_self) = self.bound_type.take() else {
             return;
         };
@@ -2953,7 +3135,7 @@ impl<'db> CallableBinding<'db> {
                 .parameters()
                 .get(0)
                 .is_some_and(Parameter::is_positional);
-            overload.signature = overload.signature.bind_self(db, Some(bound_self));
+            overload.signature = overload.signature.bind_self(db, program, Some(bound_self));
             overload.return_ty = overload.initial_return_type(db);
             overload.source_parameter_index_offset += usize::from(removed_receiver);
         }
@@ -2962,6 +3144,7 @@ impl<'db> CallableBinding<'db> {
     fn freshen_generic_contexts_in_place(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         nonce_generator: &TypeVarNonceGenerator<'db>,
     ) {
         if self
@@ -2998,7 +3181,7 @@ impl<'db> CallableBinding<'db> {
                 continue;
             };
             if nonce_generator.should_freshen(db, generic_context) {
-                overload.freshen_bound_typevars(db, nonce.value());
+                overload.freshen_bound_typevars(db, program, nonce.value());
             }
         }
     }
@@ -3176,19 +3359,25 @@ impl<'db> CallableBinding<'db> {
         }
     }
 
-    fn match_parameters(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
+    fn match_parameters(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
         // If this callable is a bound method, prepend the self instance onto the arguments list
         // before checking.
         let bound_arguments = arguments.with_self(self.bound_type);
 
         for overload in &mut self.overloads {
-            overload.match_parameters(db, bound_arguments.as_ref());
+            overload.match_parameters(db, program, bound_arguments.as_ref());
         }
     }
 
     fn check_types(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         call_arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -3199,8 +3388,8 @@ impl<'db> CallableBinding<'db> {
 
         let _span = tracing::trace_span!(
             "CallableBinding::check_types",
-            arguments = %call_arguments.display(db),
-            signature = %self.signature_type.display(db),
+            arguments = %call_arguments.display(db, program),
+            signature = %self.signature_type.display(db, program),
         )
         .entered();
 
@@ -3221,9 +3410,9 @@ impl<'db> CallableBinding<'db> {
                 && self.matching_overload_index().len() < self.overloads.len()
                 && call_arguments.iter().any(|(argument, argument_types)| {
                     matches!(argument, Argument::Variadic)
-                        && argument_types
-                            .get_default()
-                            .is_some_and(|argument_type| is_expandable_type(db, argument_type))
+                        && argument_types.get_default().is_some_and(|argument_type| {
+                            is_expandable_type(db, program, argument_type)
+                        })
                 })
             {
                 // We will retry all overloads after argument expansion.
@@ -3237,6 +3426,7 @@ impl<'db> CallableBinding<'db> {
                         if let [overload] = self.overloads.as_mut_slice() {
                             overload.check_types(
                                 db,
+                                program,
                                 constraints,
                                 call_arguments.as_ref(),
                                 call_expression_tcx,
@@ -3250,6 +3440,7 @@ impl<'db> CallableBinding<'db> {
                         self.matching_overload_before_type_checking = Some(index);
                         self.overloads[index].check_types(
                             db,
+                            program,
                             constraints,
                             call_arguments.as_ref(),
                             call_expression_tcx,
@@ -3265,6 +3456,7 @@ impl<'db> CallableBinding<'db> {
         for (_, overload) in self.matching_overloads_mut() {
             overload.check_types(
                 db,
+                program,
                 constraints,
                 call_arguments.as_ref(),
                 call_expression_tcx,
@@ -3313,6 +3505,7 @@ impl<'db> CallableBinding<'db> {
                             // If two or more candidate overloads remain, proceed to step 5.
                             self.filter_overloads_using_any_or_unknown(
                                 db,
+                                program,
                                 constraints,
                                 call_arguments.as_ref(),
                                 &indexes,
@@ -3334,7 +3527,7 @@ impl<'db> CallableBinding<'db> {
 
         // Step 3: Perform "argument type expansion". Reference:
         // https://typing.python.org/en/latest/spec/overload.html#argument-type-expansion
-        let mut expansions = call_arguments.expand(db).peekable();
+        let mut expansions = call_arguments.expand(db, program).peekable();
 
         // Return early if there are no argument types to expand.
         if expansions.peek().is_none() {
@@ -3356,7 +3549,7 @@ impl<'db> CallableBinding<'db> {
             let Some(argument_type) = argument_types.get_default() else {
                 continue;
             };
-            if is_expandable_type(db, argument_type) {
+            if is_expandable_type(db, program, argument_type) {
                 continue;
             }
             let mut is_argument_assignable_to_any_overload = false;
@@ -3368,11 +3561,12 @@ impl<'db> CallableBinding<'db> {
                     if argument_type
                         .when_assignable_to(
                             db,
+                            program,
                             parameter_type,
                             constraints,
                             overload.inferable_typevars,
                         )
-                        .is_always_satisfied(db)
+                        .is_always_satisfied(db, program)
                     {
                         is_argument_assignable_to_any_overload = true;
                         break 'overload;
@@ -3383,7 +3577,7 @@ impl<'db> CallableBinding<'db> {
                 tracing::debug!(
                     "Argument at {argument_index} (`{}`) is not assignable to any of the \
                     remaining overloads, skipping argument type expansion",
-                    argument_type.display(db)
+                    argument_type.display(db, program)
                 );
                 return;
             }
@@ -3427,7 +3621,7 @@ impl<'db> CallableBinding<'db> {
                 for overload in &mut self.overloads {
                     // Clear the state of all overloads before re-evaluating from step 1
                     overload.reset(db);
-                    overload.match_parameters(db, expanded_arguments);
+                    overload.match_parameters(db, program, expanded_arguments);
                 }
 
                 tracing::trace!(
@@ -3437,7 +3631,13 @@ impl<'db> CallableBinding<'db> {
                 );
 
                 for (_, overload) in self.matching_overloads_mut() {
-                    overload.check_types(db, constraints, expanded_arguments, call_expression_tcx);
+                    overload.check_types(
+                        db,
+                        program,
+                        constraints,
+                        expanded_arguments,
+                        call_expression_tcx,
+                    );
                 }
 
                 tracing::trace!(
@@ -3471,6 +3671,7 @@ impl<'db> CallableBinding<'db> {
                             MatchingOverloadIndex::Multiple(indexes) => {
                                 self.filter_overloads_using_any_or_unknown(
                                     db,
+                                    program,
                                     constraints,
                                     expanded_arguments,
                                     &indexes,
@@ -3525,7 +3726,7 @@ impl<'db> CallableBinding<'db> {
                 // union to determine the final return type.
                 self.overload_call_return_type =
                     Some(OverloadCallReturnType::ArgumentTypeExpansion(
-                        UnionType::from_elements(db, return_types),
+                        UnionType::from_elements(db, program, return_types),
                     ));
 
                 return;
@@ -3580,6 +3781,7 @@ impl<'db> CallableBinding<'db> {
     fn filter_overloads_using_any_or_unknown(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         arguments: &CallArguments<'_, 'db>,
         matching_overload_indexes: &[usize],
@@ -3636,8 +3838,8 @@ impl<'db> CallableBinding<'db> {
                 match (first_parameter_type, current_parameter_type) {
                     (Some(first_parameter_type), Some(current_parameter_type)) => {
                         if !first_parameter_type
-                            .when_equivalent_to(db, current_parameter_type, constraints)
-                            .is_always_satisfied(db)
+                            .when_equivalent_to(db, program, current_parameter_type, constraints)
+                            .is_always_satisfied(db, program)
                         {
                             participating_slot_indices.insert(slot_index);
                         }
@@ -3663,9 +3865,10 @@ impl<'db> CallableBinding<'db> {
                 continue;
             }
 
-            let mut union_argument_type_builders = std::iter::repeat_with(|| UnionBuilder::new(db))
-                .take(max_slot_count)
-                .collect::<Vec<_>>();
+            let mut union_argument_type_builders =
+                std::iter::repeat_with(|| UnionBuilder::new(db, program))
+                    .take(max_slot_count)
+                    .collect::<Vec<_>>();
 
             let (_, current_slots) = &matching_overload_slots[upto];
 
@@ -3678,7 +3881,7 @@ impl<'db> CallableBinding<'db> {
                                 .map_or(Type::unknown(), |slot| slot.argument)
                         });
                         union_argument_type_builders[slot_index]
-                            .add_in_place(argument_type.top_materialization(db));
+                            .add_in_place(argument_type.top_materialization(db, program));
                     }
                 }
             }
@@ -3696,9 +3899,10 @@ impl<'db> CallableBinding<'db> {
                     }),
             );
 
-            let mut union_parameter_types = std::iter::repeat_with(|| UnionBuilder::new(db))
-                .take(max_slot_count)
-                .collect::<Vec<_>>();
+            let mut union_parameter_types =
+                std::iter::repeat_with(|| UnionBuilder::new(db, program))
+                    .take(max_slot_count)
+                    .collect::<Vec<_>>();
             for (_, slots) in &matching_overload_slots[..=upto] {
                 for (slot_index, slot) in slots.iter().enumerate() {
                     if participating_slot_indices.contains(&slot_index) {
@@ -3718,7 +3922,7 @@ impl<'db> CallableBinding<'db> {
                 }),
             );
 
-            if top_materialized_argument_type.is_assignable_to(db, parameter_types) {
+            if top_materialized_argument_type.is_assignable_to(db, program, parameter_types) {
                 filter_remaining_overloads = true;
             }
         }
@@ -3735,8 +3939,8 @@ impl<'db> CallableBinding<'db> {
                 matching_overloads.all(|(_, overload)| {
                     overload
                         .return_type()
-                        .when_equivalent_to(db, first_overload_return_type, constraints)
-                        .is_always_satisfied(db)
+                        .when_equivalent_to(db, program, first_overload_return_type, constraints)
+                        .is_always_satisfied(db, program)
                 })
             } else {
                 // No matching overload
@@ -3895,15 +4099,16 @@ impl<'db> CallableBinding<'db> {
         node: ast::AnyNodeRef,
         compound_diag: Option<&dyn CompoundDiagnostic>,
     ) {
+        let program = context.program();
         if !self.is_callable() {
             let range = all_arguments_range(node);
             if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, range) {
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable",
-                    self.callable_type.display(context.db()),
+                    self.callable_type.display(context.db(), program),
                 ));
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
             }
             return;
@@ -3914,10 +4119,10 @@ impl<'db> CallableBinding<'db> {
             if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, range) {
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Object of type `{}` is not callable (possibly missing `__call__` method)",
-                    self.callable_type.display(context.db()),
+                    self.callable_type.display(context.db(), program),
                 ));
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
             }
             return;
@@ -4056,7 +4261,10 @@ impl<'db> CallableBinding<'db> {
                             "First overload defined here",
                         );
                         let file = function.file(context.db());
-                        let module = parsed_module(context.db(), file).load(context.db());
+                        let module = function
+                            .program_file(context.db())
+                            .parsed(context.db())
+                            .load(context.db());
                         let node =
                             overload.node(context.db(), function.file(context.db()), &module);
                         let span = if node.body.len() == 1 {
@@ -4078,7 +4286,9 @@ impl<'db> CallableBinding<'db> {
                     for overload in possible_overloads.iter().take(MAXIMUM_OVERLOADS) {
                         diag.info(format_args!(
                             "  {}",
-                            overload.signature(context.db()).display(context.db())
+                            overload
+                                .signature(context.db())
+                                .display(context.db(), program)
                         ));
                     }
                     if possible_overloads.len() > MAXIMUM_OVERLOADS {
@@ -4101,7 +4311,7 @@ impl<'db> CallableBinding<'db> {
                 }
 
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
             }
         }
@@ -4354,6 +4564,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
     fn match_variadic(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         argument_index: usize,
         argument: Argument<'a>,
         argument_type: Option<Type<'db>>,
@@ -4399,8 +4610,11 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                         if self.parameters.variadic().is_none()
                             && !self.has_later_positional_input(argument_index) =>
                     {
-                        let tuple_specs: Vec<_> =
-                            union.elements(db).iter().map(|ty| ty.iterate(db)).collect();
+                        let tuple_specs: Vec<_> = union
+                            .elements(db)
+                            .iter()
+                            .map(|ty| ty.iterate(db, program))
+                            .collect();
 
                         let min_len = tuple_specs
                             .iter()
@@ -4423,7 +4637,9 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             if var_types.is_empty() {
                                 None
                             } else {
-                                Some(UnionType::from_elements_leave_aliases(db, var_types))
+                                Some(UnionType::from_elements_leave_aliases(
+                                    db, program, var_types,
+                                ))
                             }
                         };
 
@@ -4432,13 +4648,16 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                         for index in 0..max_elements {
                             let positional_types: Vec<_> = tuple_specs
                                 .iter()
-                                .filter_map(|s| s.py_index(db, index).ok())
+                                .filter_map(|s| s.py_index(db, program, index).ok())
                                 .collect();
                             if positional_types.is_empty() {
                                 break;
                             }
-                            argument_types_vec
-                                .push(UnionType::from_elements_leave_aliases(db, positional_types));
+                            argument_types_vec.push(UnionType::from_elements_leave_aliases(
+                                db,
+                                program,
+                                positional_types,
+                            ));
                         }
 
                         let length = if any_variable || argument_types_vec.len() > min_len {
@@ -4453,7 +4672,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                             variable_element,
                         }
                     }
-                    _ => VariadicArgumentType::Other(argument_type.iterate(db)),
+                    _ => VariadicArgumentType::Other(argument_type.iterate(db, program)),
                 },
             },
             None => VariadicArgumentType::None,
@@ -4574,11 +4793,12 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
     fn match_keyword_variadic(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         argument_index: usize,
         argument_type: Option<Type<'db>>,
     ) {
-        if let Some(unpacked) =
-            argument_type.and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, ty))
+        if let Some(unpacked) = argument_type
+            .and_then(|ty| extract_unpacked_typed_dict_from_value_type(db, program, ty))
         {
             let openness = unpacked.openness;
 
@@ -4613,7 +4833,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
                 let value_type = match argument_type {
                     Some(argument_type) => argument_type
                         .as_paramspec_typevar(db)
-                        .or_else(|| argument_type.getitem_dunder_call(db, parameter_name))
+                        .or_else(|| argument_type.getitem_dunder_call(db, program, parameter_name))
                         .unwrap_or(Type::unknown()),
 
                     None => Type::unknown(),
@@ -4739,6 +4959,7 @@ impl<'a, 'db> ArgumentMatcher<'a, 'db> {
 
 struct ArgumentTypeChecker<'a, 'db> {
     db: &'db dyn Db,
+    program: crate::Program,
     signature_type: Type<'db>,
     signature: &'a Signature<'db>,
     arguments: &'a CallArguments<'a, 'db>,
@@ -4774,6 +4995,7 @@ enum KeywordUnpackKeyTypeCheck<'db> {
 /// Validate the key type of a keyword-unpack argument without checking its value type.
 fn validate_keyword_unpack_key_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     constraints: &ConstraintSetBuilder<'db>,
     argument_type: Type<'db>,
     inferable_typevars: InferableTypeVars<'db>,
@@ -4784,18 +5006,19 @@ fn validate_keyword_unpack_key_type<'db>(
         return KeywordUnpackKeyTypeCheck::NotApplicable;
     }
 
-    let Some((key_type, _)) = argument_type.unpack_keys_and_items(db) else {
+    let Some((key_type, _)) = argument_type.unpack_keys_and_items(db, program) else {
         return KeywordUnpackKeyTypeCheck::NotApplicable;
     };
 
     if key_type
         .when_assignable_to(
             db,
-            KnownClass::Str.to_instance(db),
+            program,
+            KnownClass::Str.to_instance(db, program),
             constraints,
             inferable_typevars,
         )
-        .is_always_satisfied(db)
+        .is_always_satisfied(db, program)
     {
         KeywordUnpackKeyTypeCheck::Valid
     } else {
@@ -4807,6 +5030,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     #[expect(clippy::too_many_arguments)]
     fn new(
         db: &'db dyn Db,
+        program: crate::Program,
         signature_type: Type<'db>,
         signature: &'a Signature<'db>,
         arguments: &'a CallArguments<'a, 'db>,
@@ -4818,6 +5042,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     ) -> Self {
         Self {
             db,
+            program,
             signature_type,
             signature,
             arguments,
@@ -4890,6 +5115,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
     }
 
     fn infer_specialization(&mut self, constraints: &ConstraintSetBuilder<'db>) {
+        let program = self.program;
         let Some(generic_context) = self.signature.generic_context else {
             return;
         };
@@ -4897,7 +5123,8 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let return_with_tcx = Some(self.return_ty).zip(self.call_expression_tcx.annotation);
 
         self.inferable_typevars = generic_context.inferable_typevars(self.db);
-        let mut builder = SpecializationBuilder::new(self.db, constraints, self.inferable_typevars);
+        let mut builder =
+            SpecializationBuilder::new(self.db, self.program, constraints, self.inferable_typevars);
 
         // Type variables for which we inferred a declared type based on a partially specialized
         // type from an outer generic context. For these type variables, we may infer types that
@@ -4927,21 +5154,32 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let preferred_type_mappings = return_with_tcx
             .and_then(|(return_ty, tcx)| {
                 if !tcx
-                    .filter_union(self.db, |ty| ty.may_prefer_declared_type(self.db))
-                    .may_prefer_declared_type(self.db)
+                    .filter_union(self.db, |ty| {
+                        ty.may_prefer_declared_type(self.db, self.program)
+                    })
+                    .may_prefer_declared_type(self.db, self.program)
                 {
                     return None;
                 }
 
-                let return_ty =
-                    return_ty.filter_disjoint_elements(self.db, tcx, self.inferable_typevars);
-                let tcx = tcx.filter_disjoint_elements(self.db, return_ty, self.inferable_typevars);
-                let path_bounds = return_ty.assignable_solutions_with_inferable(
+                let return_ty = return_ty.filter_disjoint_elements(
                     self.db,
+                    self.program,
                     tcx,
                     self.inferable_typevars,
                 );
-
+                let tcx = tcx.filter_disjoint_elements(
+                    self.db,
+                    self.program,
+                    return_ty,
+                    self.inferable_typevars,
+                );
+                let path_bounds = return_ty.assignable_solutions_with_inferable(
+                    self.db,
+                    self.program,
+                    tcx,
+                    self.inferable_typevars,
+                );
                 // Use `solutions_with` to determine per-typevar variance from the raw
                 // lower/upper bounds on each BDD path.
                 let mut variance_map: FxHashMap<BoundTypeVarIdentity<'_>, TypeVarVariance> =
@@ -4952,7 +5190,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         .entry(identity)
                         .and_modify(|current| *current = current.join(variance))
                         .or_insert(variance);
-                    PathBounds::default_solve(self.db, constraints, path_bound)
+                    PathBounds::default_solve(self.db, program, constraints, path_bound)
                 });
 
                 let Solutions::Constrained(solutions) = solutions else {
@@ -4986,13 +5224,13 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                                 binding.solution,
                             )
                             .filter_union(self.db, |ty| {
-                                if ty.has_unspecialized_type_var(self.db) {
+                                if ty.has_unspecialized_type_var(self.db, program) {
                                     partially_specialized_declared_type.insert(identity);
                                     return false;
                                 }
                                 true
                             });
-                        if inferred_ty.has_unspecialized_type_var(self.db) {
+                        if inferred_ty.has_unspecialized_type_var(self.db, program) {
                             continue;
                         }
 
@@ -5000,22 +5238,25 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                         // deeply contains non-inferable typevars. Such types (e.g.,
                         // `T@h | list[T@h]` from an outer generic scope) don't provide
                         // useful concrete information and would cause over-expansion.
-                        let concrete_content =
-                            inferred_ty.filter_union(self.db, |ty| !ty.has_typevar(self.db));
-                        if concrete_content.is_never() && inferred_ty.has_typevar(self.db) {
+                        let concrete_content = inferred_ty
+                            .filter_union(self.db, |ty| !ty.has_typevar(self.db, self.program));
+                        if concrete_content.is_never() && inferred_ty.has_typevar(self.db, program)
+                        {
                             continue;
                         }
 
                         preferred
                             .entry(identity)
-                            .and_modify(|existing| existing.add(self.db, inferred_ty))
+                            .and_modify(|existing| existing.add(self.db, self.program, inferred_ty))
                             .or_insert_with(|| UnionAccumulator::new(inferred_ty));
                     }
                 }
 
                 let preferred: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> = preferred
                     .into_iter()
-                    .map(|(identity, accumulator)| (identity, accumulator.into_type(self.db)))
+                    .map(|(identity, accumulator)| {
+                        (identity, accumulator.into_type(self.db, self.program))
+                    })
                     .collect();
 
                 // Add preferred types to the builder so they serve as the base mapping
@@ -5051,7 +5292,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         // Note that this will still lead to an invalid specialization, but may
         // produce more precise diagnostics.
         if !assignable_to_declared_type {
-            builder = SpecializationBuilder::new(self.db, constraints, self.inferable_typevars);
+            builder = SpecializationBuilder::new(
+                self.db,
+                self.program,
+                constraints,
+                self.inferable_typevars,
+            );
             specialization_errors.clear();
 
             self.infer_argument_constraints(
@@ -5084,7 +5330,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
 
             // Find all occurrences of the type variable in the return type.
             self.return_ty
-                .visit_specialization(self.db, |ty, variance| {
+                .visit_specialization(self.db, program, |ty, variance| {
                     if ty != Type::TypeVar(typevar) {
                         return;
                     }
@@ -5099,12 +5345,12 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             }
 
             let lower = bounds.lower?;
-            let promoted = lower.promote(self.db);
+            let promoted = lower.promote(self.db, self.program);
 
             // If the TypeVar has an upper bound, only use the promoted type if it
             // still satisfies the bound.
             if let Some(TypeVarBoundOrConstraints::UpperBound(bound)) = bound_or_constraints {
-                if !promoted.is_assignable_to(self.db, bound) {
+                if !promoted.is_assignable_to(self.db, self.program, bound) {
                     return None;
                 }
             }
@@ -5116,7 +5362,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             let bounds = bounds?;
             if let Some(lower) = bounds.lower
                 && let Some(&preferred_ty) = preferred_type_mappings.get(&typevar.identity(self.db))
-                && lower.is_assignable_to(self.db, preferred_ty)
+                && lower.is_assignable_to(self.db, self.program, preferred_ty)
             {
                 return Some(preferred_ty);
             }
@@ -5208,8 +5454,14 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         if !self.constraint_set_errors[argument_index]
             && !parameter.has_starred_annotation()
             && argument_type
-                .when_assignable_to(self.db, expected_ty, constraints, self.inferable_typevars)
-                .is_never_satisfied(self.db)
+                .when_assignable_to(
+                    self.db,
+                    self.program,
+                    expected_ty,
+                    constraints,
+                    self.inferable_typevars,
+                )
+                .is_never_satisfied(self.db, self.program)
         {
             let positional = matches!(argument, Argument::Positional | Argument::Synthetic)
                 && !parameter.is_variadic();
@@ -5240,7 +5492,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         {
             builder.add_in_place(argument_type);
         } else if let Some(existing) = self.parameter_tys[parameter_index] {
-            let mut builder = UnionBuilder::new(self.db);
+            let mut builder = UnionBuilder::new(self.db, self.program);
             builder.add_in_place(existing);
             builder.add_in_place(argument_type);
             if self.parameter_ty_builders.is_empty() {
@@ -5420,9 +5672,10 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         let callable_binding =
             CallableBinding::from_overloads(self.signature_type, signatures.iter().cloned());
         let bindings = match Bindings::from(callable_binding)
-            .match_parameters(self.db, &sub_arguments)
+            .match_parameters(self.db, self.program, &sub_arguments)
             .check_types(
                 self.db,
+                self.program,
                 constraints,
                 &sub_arguments,
                 self.call_expression_tcx,
@@ -5516,7 +5769,9 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
         argument_type: Type<'db>,
         paramspec_component_start: Option<usize>,
     ) {
-        if extract_unpacked_typed_dict_from_value_type(self.db, argument_type).is_some() {
+        if extract_unpacked_typed_dict_from_value_type(self.db, self.program, argument_type)
+            .is_some()
+        {
             self.check_variadic_argument_type(
                 constraints,
                 argument_index,
@@ -5533,6 +5788,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
             } else {
                 match validate_keyword_unpack_key_type(
                     self.db,
+                    self.program,
                     constraints,
                     argument_type,
                     self.inferable_typevars,
@@ -5564,7 +5820,7 @@ impl<'a, 'db> ArgumentTypeChecker<'a, 'db> {
                     .map(Name::as_str);
 
                 argument_type
-                    .getitem_dunder_call(self.db, parameter_name)
+                    .getitem_dunder_call(self.db, self.program, parameter_name)
                     .unwrap_or(Type::unknown())
             };
 
@@ -5746,6 +6002,7 @@ pub(crate) struct UnknownParameterNameError;
 #[derive(Clone, Copy)]
 struct ParamSpecArgumentContext<'a, 'call, 'db> {
     db: &'db dyn Db,
+    program: crate::Program,
     constraints: &'a ConstraintSetBuilder<'db>,
     binding: &'a CallableBinding<'db>,
     callable: CallableType<'db>,
@@ -5767,9 +6024,6 @@ pub(crate) struct Binding<'db> {
     source_overload_index: usize,
 
     /// The number of leading source parameters consumed while constructing this binding.
-    ///
-    /// Parameter matching uses indexes into the rewritten signature, while diagnostic spans use
-    /// this offset to recover indexes into the original function definition.
     source_parameter_index_offset: usize,
 
     /// The type that is (hopefully) callable.
@@ -5789,7 +6043,7 @@ pub(crate) struct Binding<'db> {
     /// The inferable typevars in this signature.
     inferable_typevars: InferableTypeVars<'db>,
 
-    /// The type-variable inference result for this binding, if the callable is generic.
+    /// The specialization that was inferred from the argument types, if the callable is generic.
     inference: Option<TypeVarInference<'db>>,
 
     /// Information about which parameter(s) each argument was matched with, in argument source
@@ -5886,9 +6140,11 @@ impl<'db> Binding<'db> {
     /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args, **kwargs: P.kwargs) -> R: ...
     /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # infers `P` from `put_tags`
     /// ```
+    #[expect(clippy::too_many_arguments)]
     fn inferred_paramspec_callable(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         constraints: &ConstraintSetBuilder<'db>,
         binding: &CallableBinding<'db>,
         paramspec: BoundTypeVarInstance<'db>,
@@ -5905,15 +6161,15 @@ impl<'db> Binding<'db> {
         // been inferred. This avoids duplicating specialization logic here; the current
         // `P.args`/`P.kwargs` argument is still uninferred, so it only contributes `Unknown`.
         let mut specialized_bindings =
-            Bindings::from(specialized_binding).match_parameters(db, arguments_types);
+            Bindings::from(specialized_binding).match_parameters(db, program, arguments_types);
         let _ = specialized_bindings.check_types_impl(
             db,
+            program,
             constraints,
             arguments_types,
             call_expression_tcx,
             &[],
         );
-
         let Type::Callable(callable) = specialized_bindings
             .single_element()
             .and_then(|binding| binding.matching_overloads().exactly_one().ok())
@@ -5943,6 +6199,7 @@ impl<'db> Binding<'db> {
     ) -> Option<Type<'db>> {
         let ParamSpecArgumentContext {
             db,
+            program,
             constraints,
             binding,
             callable,
@@ -5963,15 +6220,15 @@ impl<'db> Binding<'db> {
         );
         let sub_arguments = arguments_types.select(&paramspec_argument_indices);
         let mut specialized_bindings =
-            Bindings::from(specialized_binding).match_parameters(db, &sub_arguments);
+            Bindings::from(specialized_binding).match_parameters(db, program, &sub_arguments);
         let _ = specialized_bindings.check_types_impl(
             db,
+            program,
             constraints,
             &sub_arguments,
             call_expression_tcx,
             &[],
         );
-
         let specialized_binding = specialized_bindings.single_element()?;
         let (_, specialized_overload) = specialized_binding
             .matching_overloads()
@@ -5993,7 +6250,9 @@ impl<'db> Binding<'db> {
         // it can erase the concrete literal type that should later specialize the wrapped
         // callable. Check the parameter before applying the sub-call specialization so an
         // earlier forwarded argument cannot turn `list[T@g]` into apparently-safe `list[int]`.
-        if parameter_type.has_dynamic(db) || parameter_type.has_typevar_or_typevar_instance(db) {
+        if parameter_type.has_dynamic(db, program)
+            || parameter_type.has_typevar_or_typevar_instance(db, program)
+        {
             return None;
         }
 
@@ -6003,8 +6262,9 @@ impl<'db> Binding<'db> {
                 parameter_type.apply_specialization(db, specialization)
             });
 
-        (!parameter_type.has_dynamic(db) && !parameter_type.has_typevar_or_typevar_instance(db))
-            .then_some(parameter_type)
+        (!parameter_type.has_dynamic(db, program)
+            && !parameter_type.has_typevar_or_typevar_instance(db, program))
+        .then_some(parameter_type)
     }
 
     /// Returns the wrapper parameter type that can bind the `ParamSpec` used by forwarded arguments.
@@ -6020,6 +6280,7 @@ impl<'db> Binding<'db> {
     pub(crate) fn paramspec_binder_parameter_type(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding: &CallableBinding<'db>,
         argument_index: usize,
     ) -> Option<Type<'db>> {
@@ -6038,7 +6299,7 @@ impl<'db> Binding<'db> {
 
         let parameter_type = self.signature.parameters()[parameter.index].annotated_type();
         parameter_type
-            .references_typevar(db, paramspec.typevar(db).identity(db))
+            .references_typevar(db, program, paramspec.typevar(db).identity(db))
             .then_some(parameter_type)
     }
 
@@ -6053,9 +6314,11 @@ impl<'db> Binding<'db> {
     /// def wrapper[**P, R](func: Callable[P, R], /, *args: P.args) -> R: ...
     /// wrapper(put_tags, [{"Key": "k", "Value": "v"}])  # forwarded list gets `list[Tag]`
     /// ```
+    #[expect(clippy::too_many_arguments)]
     pub(crate) fn argument_type_context(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         constraints: &ConstraintSetBuilder<'db>,
         binding: &CallableBinding<'db>,
         arguments_types: &CallArguments<'_, 'db>,
@@ -6106,11 +6369,13 @@ impl<'db> Binding<'db> {
                     .unwrap_or(self.signature.return_ty);
                 let path_bounds = return_ty.assignable_solutions_with_inferable(
                     db,
+                    program,
                     declared_return_ty,
                     generic_context.inferable_typevars(db),
                 );
-
-                if let Solutions::Constrained(solutions) = path_bounds.solve(db, constraints) {
+                if let Solutions::Constrained(solutions) =
+                    path_bounds.solve(db, program, constraints)
+                {
                     for solution in solutions {
                         for binding in solution {
                             let identity = binding.bound_typevar.identity(db);
@@ -6119,6 +6384,7 @@ impl<'db> Binding<'db> {
                                 .and_modify(|existing| {
                                     *existing = UnionType::from_two_elements(
                                         db,
+                                        program,
                                         *existing,
                                         binding.solution,
                                     );
@@ -6156,6 +6422,7 @@ impl<'db> Binding<'db> {
             if let Some(paramspec) = paramspec
                 && let Some(callable) = self.inferred_paramspec_callable(
                     db,
+                    program,
                     constraints,
                     binding,
                     paramspec,
@@ -6165,6 +6432,7 @@ impl<'db> Binding<'db> {
                 && let Some(specialized_parameter_type) =
                     self.paramspec_argument_context(ParamSpecArgumentContext {
                         db,
+                        program,
                         constraints,
                         binding,
                         callable,
@@ -6205,16 +6473,21 @@ impl<'db> Binding<'db> {
         }
     }
 
-    fn freshen_bound_typevars(&mut self, db: &'db dyn Db, delta: u32) {
+    fn freshen_bound_typevars(&mut self, db: &'db dyn Db, program: crate::Program, delta: u32) {
         if self.signature.generic_context.is_none() {
             return;
         }
 
-        self.signature = self.signature.freshen_bound_typevars(db, delta);
+        self.signature = self.signature.freshen_bound_typevars(db, program, delta);
         self.return_ty = self.initial_return_type(db);
     }
 
-    fn match_parameters(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
+    fn match_parameters(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
         let parameters = self.signature.parameters();
         let mut matcher = ArgumentMatcher::new(arguments, parameters, &mut self.errors);
         let mut keywords_arguments = vec![];
@@ -6229,6 +6502,7 @@ impl<'db> Binding<'db> {
                 Argument::Variadic => {
                     let _ = matcher.match_variadic(
                         db,
+                        program,
                         argument_index,
                         argument,
                         // Splatted arguments are inferred without type context.
@@ -6243,8 +6517,8 @@ impl<'db> Binding<'db> {
         for (keywords_index, keywords_type) in keywords_arguments {
             matcher.match_keyword_variadic(
                 db,
+                program,
                 keywords_index,
-                // Splatted arguments are inferred without type context.
                 keywords_type.get_default(),
             );
         }
@@ -6257,6 +6531,7 @@ impl<'db> Binding<'db> {
     fn check_types(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         constraints: &ConstraintSetBuilder<'db>,
         arguments: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -6275,12 +6550,13 @@ impl<'db> Binding<'db> {
                 .iter()
                 .all(|parameter| parameter.is_variadic() || parameter.is_keyword_variadic())
         {
-            self.check_keyword_unpack_key_types(db, constraints, arguments);
+            self.check_keyword_unpack_key_types(db, program, constraints, arguments);
             return;
         }
 
         let mut checker = ArgumentTypeChecker::new(
             db,
+            program,
             self.signature_type,
             &self.signature,
             arguments,
@@ -6302,6 +6578,7 @@ impl<'db> Binding<'db> {
     fn check_keyword_unpack_key_types(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         constraints: &ConstraintSetBuilder<'db>,
         arguments: &CallArguments<'_, 'db>,
     ) {
@@ -6323,6 +6600,7 @@ impl<'db> Binding<'db> {
             if let KeywordUnpackKeyTypeCheck::Invalid(provided_ty) =
                 validate_keyword_unpack_key_type(
                     db,
+                    program,
                     constraints,
                     argument_type,
                     InferableTypeVars::None,
@@ -6354,6 +6632,7 @@ impl<'db> Binding<'db> {
     fn functools_partial_return_type<'a>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         call_arguments: &CallArguments<'a, 'db>,
     ) -> Option<Type<'db>> {
         // `partial(...)` receives the wrapped callable as its first explicit argument (after
@@ -6364,15 +6643,16 @@ impl<'db> Binding<'db> {
         };
         let imprecise_return_type = self.return_ty;
         let failed_synthesis_return_type =
-            KnownClass::FunctoolsPartial.to_specialized_instance(db, &[Type::unknown()]);
+            KnownClass::FunctoolsPartial.to_specialized_instance(db, program, &[Type::unknown()]);
 
         let (bound_call_arguments, partial_bindings, can_synthesize_signature) =
-            Bindings::functools_partial_matched_bindings(db, func_ty, call_arguments)?;
+            Bindings::functools_partial_matched_bindings(db, program, func_ty, call_arguments)?;
 
         // Reuse call-binding machinery to resolve which wrapped overloads are compatible with
         // bound arguments and to surface binding diagnostics.
         let partial_bindings = match partial_bindings.check_types(
             db,
+            program,
             &ConstraintSetBuilder::new(),
             &bound_call_arguments,
             TypeContext::default(),
@@ -6381,8 +6661,13 @@ impl<'db> Binding<'db> {
             Ok(bindings) => bindings,
             Err(CallError(_, bindings)) => *bindings,
         };
-        let new_return_type =
-            partial_bindings.functools_partial_type(db, func_ty, self, &bound_call_arguments);
+        let new_return_type = partial_bindings.functools_partial_type(
+            db,
+            program,
+            func_ty,
+            self,
+            &bound_call_arguments,
+        );
 
         Some(if !can_synthesize_signature {
             imprecise_return_type
@@ -6740,9 +7025,9 @@ impl<'db> CallableDescription<'db> {
             db: &'db dyn Db,
             function: FunctionType<'db>,
         ) -> Cow<'db, str> {
-            let file = function.file(db);
-            let semantic_index = semantic_index(db, file);
-            let enclosing_scope = semantic_index.scope(function.definition(db).file_scope(db));
+            let definition = function.definition(db);
+            let semantic_index = semantic_index(db, definition.program_file(db));
+            let enclosing_scope = semantic_index.scope(definition.file_scope(db));
             if let Some(class_node) = enclosing_scope.node().as_class()
                 && let Some(class) =
                     original_class_type(db, semantic_index.expect_single_definition(class_node))
@@ -6823,7 +7108,7 @@ impl std::fmt::Display for CallableDescription<'_> {
 /// Information needed to emit a diagnostic regarding a parameter.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ParameterContext {
-    name: Option<ParameterDisplayName<Name>>,
+    name: Option<ast::name::Name>,
     index: usize,
 
     /// Was the argument for this parameter passed positionally, and matched to a non-variadic
@@ -6835,9 +7120,7 @@ pub(crate) struct ParameterContext {
 impl ParameterContext {
     fn new(parameter: &Parameter, index: usize, positional: bool) -> Self {
         Self {
-            name: parameter
-                .display_name()
-                .map(ParameterDisplayName::into_owned),
+            name: parameter.display_name(),
             index,
             positional,
         }
@@ -7139,6 +7422,7 @@ impl<'db> BindingError<'db> {
         matching_overload: Option<&MatchingOverloadLiteral<'_>>,
         source_parameter_index_offset: usize,
     ) {
+        let program = context.program();
         let callable_kind = match callable_ty {
             Type::FunctionLiteral(_) => "Function",
             Type::BoundMethod(_) => "Method",
@@ -7190,11 +7474,13 @@ impl<'db> BindingError<'db> {
 
                 let display_settings = DisplaySettings::from_possibly_ambiguous_types(
                     context.db(),
+                    program,
                     [provided_ty, expected_ty],
                 );
                 let provided_ty_display =
-                    provided_ty.display_with(context.db(), display_settings.clone());
-                let expected_ty_display = expected_ty.display_with(context.db(), display_settings);
+                    provided_ty.display_with(context.db(), program, display_settings.clone());
+                let expected_ty_display =
+                    expected_ty.display_with(context.db(), program, display_settings);
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
@@ -7217,8 +7503,8 @@ impl<'db> BindingError<'db> {
                 }
 
                 let error_context =
-                    provided_ty.assignability_error_context(context.db(), *expected_ty);
-                error_context.attach_to(context.db(), &mut diag);
+                    provided_ty.assignability_error_context(context.db(), program, *expected_ty);
+                error_context.attach_to(context.db(), program, &mut diag);
 
                 if let Some(matching_overload) = matching_overload {
                     if let Some(overload_literal) = matching_overload.get(context.db()) {
@@ -7250,7 +7536,9 @@ impl<'db> BindingError<'db> {
                             }
                             diag.info(format_args!(
                                 "  {}",
-                                overload.signature(context.db()).display(context.db())
+                                overload
+                                    .signature(context.db())
+                                    .display(context.db(), program)
                             ));
                         }
                         if matching_overload.candidate_count() > MAXIMUM_OVERLOADS {
@@ -7276,25 +7564,32 @@ impl<'db> BindingError<'db> {
                 }
 
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
 
                 // If the type comes from first-party code, the user may have some control over
                 // the parameter annotation; provide additional context to help them fix it.
                 if callable_ty
-                    .definition(context.db())
+                    .definition(context.db(), program)
                     .and_then(|definition| definition.file(context.db()))
                     .is_some_and(|file| context.db().should_check_file(file))
                 {
                     note_numbers_module_not_supported(
                         context.db(),
+                        program,
                         &mut diag,
                         *expected_ty,
                         *provided_ty,
                     );
                 }
 
-                add_invariant_generic_hints(context.db(), &mut diag, *expected_ty, *provided_ty);
+                add_invariant_generic_hints(
+                    context.db(),
+                    program,
+                    &mut diag,
+                    *expected_ty,
+                    *provided_ty,
+                );
             }
 
             Self::InvalidKeyType {
@@ -7306,14 +7601,14 @@ impl<'db> BindingError<'db> {
                     return;
                 };
 
-                let provided_ty_display = provided_ty.display(context.db());
+                let provided_ty_display = provided_ty.display(context.db(), program);
                 let mut diag = builder.into_diagnostic(
                     "Argument expression after ** must be a mapping with `str` key type",
                 );
                 diag.set_primary_message(format_args!("Found `{provided_ty_display}`"));
 
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
             }
 
@@ -7332,7 +7627,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     } else if let Some(spans) = callable_ty.function_spans(context.db()) {
                         let mut sub = SubDiagnostic::new(
                             SubDiagnosticSeverity::Info,
@@ -7358,7 +7653,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     } else {
                         let span = callable_ty.parameter_span(
                             context.db(),
@@ -7400,7 +7695,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     } else if let Some(spans) = callable_ty.function_spans(context.db()) {
                         let mut sub = SubDiagnostic::new(
                             SubDiagnosticSeverity::Info,
@@ -7422,7 +7717,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     } else if let Some(spans) = callable_ty.function_spans(context.db()) {
                         let mut sub = SubDiagnostic::new(
                             SubDiagnosticSeverity::Info,
@@ -7449,7 +7744,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     } else if let Some(spans) = callable_ty.function_spans(context.db()) {
                         let mut sub = SubDiagnostic::new(
                             SubDiagnosticSeverity::Info,
@@ -7474,7 +7769,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     }
                 }
             }
@@ -7489,7 +7784,7 @@ impl<'db> BindingError<'db> {
                 };
 
                 let argument_type = error.argument_type();
-                let argument_ty_display = argument_type.display(context.db());
+                let argument_ty_display = argument_type.display(context.db(), program);
 
                 let mut diag = builder.into_diagnostic(format_args!(
                     "Argument{} is incorrect",
@@ -7510,7 +7805,7 @@ impl<'db> BindingError<'db> {
                                 .expect(
                                     "type variable should have an upper bound if this error occurs"
                                 )
-                                .display(context.db())
+                                .display(context.db(), program)
                         ));
                     }
                     SpecializationError::MismatchedConstraint { bound_typevar, .. } => {
@@ -7527,7 +7822,7 @@ impl<'db> BindingError<'db> {
                                 .iter()
                                 .format_with(", ", |ty, f| f(&format_args!(
                                     "`{}`",
-                                    ty.display(context.db())
+                                    ty.display(context.db(), program)
                                 )))
                         ));
                     }
@@ -7538,7 +7833,9 @@ impl<'db> BindingError<'db> {
                     .typevar(context.db())
                     .definition(context.db())
                 {
-                    let module = parsed_module(context.db(), typevar_definition.file(context.db()))
+                    let module = typevar_definition
+                        .program_file(context.db())
+                        .parsed(context.db())
                         .load(context.db());
                     let typevar_range = typevar_definition.full_range(context.db(), &module);
                     let mut sub = SubDiagnostic::new(
@@ -7550,7 +7847,7 @@ impl<'db> BindingError<'db> {
                 }
 
                 if let Some(compound_diag) = compound_diag {
-                    compound_diag.add_context(context.db(), &mut diag);
+                    compound_diag.add_context(context.db(), program, &mut diag);
                 }
             }
 
@@ -7588,7 +7885,7 @@ impl<'db> BindingError<'db> {
                             .unwrap_or_default()
                     ));
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     }
                 }
             }
@@ -7598,7 +7895,7 @@ impl<'db> BindingError<'db> {
             Self::CalledTopCallable(callable_ty) => {
                 let node = Self::get_node(node, None);
                 if let Some(builder) = context.report_lint(&CALL_TOP_CALLABLE, node) {
-                    let callable_ty_display = callable_ty.display(context.db());
+                    let callable_ty_display = callable_ty.display(context.db(), program);
                     let mut diag = builder.into_diagnostic(format_args!(
                         "Object of type `{callable_ty_display}` is not safe to call; \
                         its signature is not known"
@@ -7608,7 +7905,7 @@ impl<'db> BindingError<'db> {
                         because there is no valid set of arguments for it",
                     );
                     if let Some(compound_diag) = compound_diag {
-                        compound_diag.add_context(context.db(), &mut diag);
+                        compound_diag.add_context(context.db(), program, &mut diag);
                     }
                 }
             }
@@ -7706,7 +8003,7 @@ impl<'db> BindingError<'db> {
 /// Trait for adding context about compound types (unions/intersections) to diagnostics.
 trait CompoundDiagnostic {
     /// Adds context about any relevant compound type function types to the given diagnostic.
-    fn add_context(&self, db: &dyn Db, diag: &mut Diagnostic);
+    fn add_context(&self, db: &dyn Db, program: crate::Program, diag: &mut Diagnostic);
 }
 
 /// Contains additional context for union specific diagnostics.
@@ -7722,12 +8019,12 @@ struct UnionDiagnostic<'b, 'db> {
 }
 
 impl CompoundDiagnostic for UnionDiagnostic<'_, '_> {
-    fn add_context(&self, db: &dyn Db, diag: &mut Diagnostic) {
+    fn add_context(&self, db: &dyn Db, program: crate::Program, diag: &mut Diagnostic) {
         let sub = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Union variant `{callable_ty}` is incompatible with this call site",
-                callable_ty = self.binding.callable_type.display(db),
+                callable_ty = self.binding.callable_type.display(db, program),
             ),
         );
         diag.sub(sub);
@@ -7736,7 +8033,7 @@ impl CompoundDiagnostic for UnionDiagnostic<'_, '_> {
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Attempted to call union type `{}`",
-                self.callable_type.display(db)
+                self.callable_type.display(db, program)
             ),
         );
         diag.sub(sub);
@@ -7756,12 +8053,12 @@ struct IntersectionDiagnostic<'b, 'db> {
 }
 
 impl CompoundDiagnostic for IntersectionDiagnostic<'_, '_> {
-    fn add_context(&self, db: &dyn Db, diag: &mut Diagnostic) {
+    fn add_context(&self, db: &dyn Db, program: crate::Program, diag: &mut Diagnostic) {
         let sub = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Intersection element `{callable_ty}` is incompatible with this call site",
-                callable_ty = self.binding.callable_type.display(db),
+                callable_ty = self.binding.callable_type.display(db, program),
             ),
         );
         diag.sub(sub);
@@ -7770,7 +8067,7 @@ impl CompoundDiagnostic for IntersectionDiagnostic<'_, '_> {
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Attempted to call intersection type `{}`",
-                self.callable_type.display(db)
+                self.callable_type.display(db, program)
             ),
         );
         diag.sub(sub);
@@ -7791,13 +8088,13 @@ struct LayeredDiagnostic<'b, 'db> {
 }
 
 impl CompoundDiagnostic for LayeredDiagnostic<'_, '_> {
-    fn add_context(&self, db: &dyn Db, diag: &mut Diagnostic) {
+    fn add_context(&self, db: &dyn Db, program: crate::Program, diag: &mut Diagnostic) {
         // Add intersection context first (more specific)
         let sub = SubDiagnostic::new(
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Intersection element `{callable_ty}` is incompatible with this call site",
-                callable_ty = self.binding.callable_type.display(db),
+                callable_ty = self.binding.callable_type.display(db, program),
             ),
         );
         diag.sub(sub);
@@ -7806,7 +8103,7 @@ impl CompoundDiagnostic for LayeredDiagnostic<'_, '_> {
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Attempted to call intersection type `{}`",
-                self.intersection_callable_type.display(db)
+                self.intersection_callable_type.display(db, program)
             ),
         );
         diag.sub(sub);
@@ -7816,7 +8113,7 @@ impl CompoundDiagnostic for LayeredDiagnostic<'_, '_> {
             SubDiagnosticSeverity::Info,
             format_args!(
                 "Attempted to call union type `{}`",
-                self.union_callable_type.display(db)
+                self.union_callable_type.display(db, program)
             ),
         );
         diag.sub(sub);
@@ -7905,7 +8202,12 @@ const STRUCT_FORMAT_MAX_REPETITION: usize = 32;
 ///
 /// Returns `None` if the format contains unsupported specifiers or
 /// repetition counts exceed the limit, indicating a fallback to `tuple[Unknown, ...]`.
-fn parse_struct_format<'db>(db: &'db dyn Db, format_string: &str) -> Option<Vec<Type<'db>>> {
+fn parse_struct_format<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    python_version: PythonVersion,
+    format_string: &str,
+) -> Option<Vec<Type<'db>>> {
     // Strip the byte order/size/alignment prefix
     let format = format_string.trim_start_matches(['@', '=', '<', '>', '!']);
     let mut chars = format.chars().peekable();
@@ -7933,15 +8235,15 @@ fn parse_struct_format<'db>(db: &'db dyn Db, format_string: &str) -> Option<Vec<
         // Map specifier to (type, repeat_count). For 's'/'p', count is byte length, not repetition.
         let (ty, repeat) = match specifier {
             'x' => continue, // Pad byte: no value produced
-            's' | 'p' => (KnownClass::Bytes.to_instance(db), 1),
-            'c' => (KnownClass::Bytes.to_instance(db), count),
+            's' | 'p' => (KnownClass::Bytes.to_instance(db, program), 1),
+            'c' => (KnownClass::Bytes.to_instance(db, program), count),
             'b' | 'B' | 'h' | 'H' | 'i' | 'I' | 'l' | 'L' | 'q' | 'Q' | 'n' | 'N' | 'P' => {
-                (KnownClass::Int.to_instance(db), count)
+                (KnownClass::Int.to_instance(db, program), count)
             }
-            '?' => (KnownClass::Bool.to_instance(db), count),
-            'e' | 'f' | 'd' => (KnownClass::Float.to_instance(db), count),
-            'F' | 'D' if Program::get(db).python_version(db) >= PythonVersion::PY314 => {
-                (KnownClass::Complex.to_instance(db), count)
+            '?' => (KnownClass::Bool.to_instance(db, program), count),
+            'e' | 'f' | 'd' => (KnownClass::Float.to_instance(db, program), count),
+            'F' | 'D' if python_version >= PythonVersion::PY314 => {
+                (KnownClass::Complex.to_instance(db, program), count)
             }
             _ => return None,
         };

--- a/crates/ty_python_semantic/src/types/call/bind/constructor.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/constructor.rs
@@ -1,4 +1,5 @@
 use super::{Binding, Bindings, CallableBinding, CallableItem};
+use crate::Program;
 use crate::db::Db;
 use crate::types::call::arguments::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
@@ -65,14 +66,19 @@ impl<'db> ConstructorBinding<'db> {
     }
 
     /// Match parameters for this constructor method and downstream constructors.
-    pub(super) fn match_parameters(&mut self, db: &'db dyn Db, arguments: &CallArguments<'_, 'db>) {
-        self.entry.match_parameters(db, arguments);
+    pub(super) fn match_parameters(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        arguments: &CallArguments<'_, 'db>,
+    ) {
+        self.entry.match_parameters(db, program, arguments);
 
         // We don't know at this point whether we'll need to check downstream constructors or not
         // (since we can't resolve return types yet), so we match parameters for all downstream
         // constructors; this may be needed for argument type contexts.
         if let Some(downstream) = self.downstream_constructor.as_mut() {
-            downstream.match_parameters_in_place(db, arguments);
+            downstream.match_parameters_in_place(db, program, arguments);
         }
     }
 
@@ -81,6 +87,7 @@ impl<'db> ConstructorBinding<'db> {
     pub(super) fn check_types(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -95,6 +102,7 @@ impl<'db> ConstructorBinding<'db> {
         fn should_check_downstream<'db>(
             binding: &ConstructorBinding<'db>,
             db: &'db dyn Db,
+            program: Program,
         ) -> bool {
             let constructor_kind = binding.constructor_kind();
             if constructor_kind.is_init() || binding.downstream_constructor().is_none() {
@@ -108,7 +116,7 @@ impl<'db> ConstructorBinding<'db> {
             }
 
             let constructed_instance_type = binding.constructed_instance_type();
-            let constructor_class_literal = binding.constructed_class_literal(db);
+            let constructor_class_literal = binding.constructed_class_literal(db, program);
 
             // If any matching overload returns the constructed instance type itself, or an instance of
             // the constructed class, we need to check downstream constructors.
@@ -120,12 +128,17 @@ impl<'db> ConstructorBinding<'db> {
             })
         }
 
-        self.entry
-            .check_types(db, constraints, argument_types, call_expression_tcx);
+        self.entry.check_types(
+            db,
+            program,
+            constraints,
+            argument_types,
+            call_expression_tcx,
+        );
 
         // Now that we've fully checked our own callable, we can determine whether downstream
         // constructors should be checked or not.
-        if !should_check_downstream(self, db) {
+        if !should_check_downstream(self, db, program) {
             // If not, we can discard the downstream constructor bindings entirely.
             self.downstream_constructor = None;
         }
@@ -135,6 +148,7 @@ impl<'db> ConstructorBinding<'db> {
     pub(super) fn check_downstream_constructor(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         constraints: &ConstraintSetBuilder<'db>,
         argument_types: &CallArguments<'_, 'db>,
         call_expression_tcx: TypeContext<'db>,
@@ -145,6 +159,7 @@ impl<'db> ConstructorBinding<'db> {
             // `as_result` that ultimately matter.
             let _ = downstream.check_types_impl(
                 db,
+                program,
                 constraints,
                 argument_types,
                 call_expression_tcx,
@@ -176,7 +191,7 @@ impl<'db> ConstructorBinding<'db> {
     }
 
     /// Compute the overall effective return type of this `ConstructorBinding`.
-    pub(super) fn return_type(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(super) fn return_type(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
         let constructed_instance_type = self.constructed_instance_type();
 
         // If we are checking downstream constructors, and the downstream constructor resolves to a
@@ -190,9 +205,9 @@ impl<'db> ConstructorBinding<'db> {
         // annotation. But no other type checker considers it an error, and it probably rarely if
         // ever comes up.)
         if let Some(downstream) = self.downstream_constructor()
-            && let Some(constructor_class_literal) = self.constructed_class_literal(db)
+            && let Some(constructor_class_literal) = self.constructed_class_literal(db, program)
         {
-            let downstream_return = downstream.return_type(db);
+            let downstream_return = downstream.return_type(db, program);
             if !constructor_returns_instance(db, constructor_class_literal, downstream_return) {
                 return downstream_return;
             }
@@ -200,12 +215,12 @@ impl<'db> ConstructorBinding<'db> {
 
         // If `__new__` or metaclass `__call__` produced an explicit return type, use it
         // directly rather than building an instance of the constructed class.
-        if let Some(return_ty) = self.explicit_return_type(db) {
+        if let Some(return_ty) = self.explicit_return_type(db, program) {
             return return_ty;
         }
 
         constructed_instance_type
-            .apply_optional_specialization(db, self.instance_return_specialization(db))
+            .apply_optional_specialization(db, self.instance_return_specialization(db, program))
     }
 
     fn first_matching_overload(&self) -> Option<&Binding<'db>> {
@@ -219,15 +234,20 @@ impl<'db> ConstructorBinding<'db> {
     /// resulting specialization can be applied either to the constructed instance type or to an
     /// explicit `__new__` / `__call__` return annotation that is an instance of the constructed
     /// type or a subclass.
-    fn instance_return_specialization(&self, db: &'db dyn Db) -> Option<Specialization<'db>> {
+    fn instance_return_specialization(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<Specialization<'db>> {
         let constructed_instance_type = self.constructed_instance_type();
         // This will be `None` if we're constructing a non-generic class. If we're constructing a
         // non-specialized generic class (`C(...)`), it'll be the identity specialization. If we're
         // constructing an already-specialized generic alias (`C[str](...)`), it'll be the
         // specialization of that alias.
-        let (_, class_specialization) = constructed_instance_type.class_specialization(db)?;
+        let (_, class_specialization) =
+            constructed_instance_type.class_specialization(db, program)?;
         let static_class_literal = self
-            .constructed_class_literal(db)
+            .constructed_class_literal(db, program)
             .and_then(ClassLiteral::as_static);
         let class_context = class_specialization.generic_context(db);
 
@@ -259,9 +279,8 @@ impl<'db> ConstructorBinding<'db> {
                 let self_param_ty = overload.signature.parameters().get(0)?.annotated_type();
                 let resolved_self_param_ty = overload
                     .specialization(db)
-                    .map_or(self_param_ty, |specialization| {
-                        self_param_ty.apply_specialization(db, specialization)
-                    });
+                    .map(|specialization| self_param_ty.apply_specialization(db, specialization))
+                    .unwrap_or(self_param_ty);
                 resolved_self_param_ty.specialization_of(db, lit)
             });
             let refined_self_parameter_specialization =
@@ -278,7 +297,7 @@ impl<'db> ConstructorBinding<'db> {
                             } else {
                                 without_unknown
                             };
-                            mapped_ty.promote(db)
+                            mapped_ty.promote(db, program)
                         })
                         .collect();
                     Specialization::new(
@@ -333,8 +352,10 @@ impl<'db> ConstructorBinding<'db> {
     ///
     /// This must be called only after downstream constructor bindings have been type-checked,
     /// because instance-returning constructor paths may incorporate downstream specializations.
-    fn explicit_return_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
-        if self.constructor_kind().is_init() || self.constructed_class_literal(db).is_none() {
+    fn explicit_return_type(&self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        if self.constructor_kind().is_init()
+            || self.constructed_class_literal(db, program).is_none()
+        {
             return None;
         }
 
@@ -347,9 +368,9 @@ impl<'db> ConstructorBinding<'db> {
         // consider all overloads' return types. (This increases the chances of an `Unknown`
         // return, but still preserves more precise returns in unambiguous cases.)
         if matching_overloads.clone().next().is_none() {
-            self.analyze_overload_returns(db, self.callable().overloads().iter())
+            self.analyze_overload_returns(db, program, self.callable().overloads().iter())
         } else {
-            self.analyze_overload_returns(db, matching_overloads)
+            self.analyze_overload_returns(db, program, matching_overloads)
         }
     }
 
@@ -358,6 +379,7 @@ impl<'db> ConstructorBinding<'db> {
     fn analyze_overload_returns<'a>(
         &self,
         db: &'db dyn Db,
+        program: Program,
         overloads: impl IntoIterator<Item = &'a Binding<'db>>,
     ) -> Option<Type<'db>>
     where
@@ -374,7 +396,8 @@ impl<'db> ConstructorBinding<'db> {
         let mut saw_instance_return = false;
         let mut non_instance_return = None;
         for overload in overloads {
-            let (return_ty, is_instance_return) = self.single_overload_return(db, overload);
+            let (return_ty, is_instance_return) =
+                self.single_overload_return(db, program, overload);
             if is_instance_return {
                 if saw_instance_return {
                     sole_instance_return = None;
@@ -409,6 +432,7 @@ impl<'db> ConstructorBinding<'db> {
     fn single_overload_return(
         &self,
         db: &'db dyn Db,
+        program: Program,
         overload: &Binding<'db>,
     ) -> (Type<'db>, bool) {
         let return_ty = overload
@@ -416,16 +440,18 @@ impl<'db> ConstructorBinding<'db> {
             .apply_optional_specialization(
                 db,
                 overload.specialization(db).map(|specialization| {
-                    self.unspecialize_class_type_variables(db, specialization)
+                    self.unspecialize_class_type_variables(db, program, specialization)
                 }),
             );
         if self
-            .constructed_class_literal(db)
+            .constructed_class_literal(db, program)
             .is_some_and(|class_literal| constructor_returns_instance(db, class_literal, return_ty))
         {
             return (
-                return_ty
-                    .apply_optional_specialization(db, self.instance_return_specialization(db)),
+                return_ty.apply_optional_specialization(
+                    db,
+                    self.instance_return_specialization(db, program),
+                ),
                 true,
             );
         }
@@ -448,11 +474,12 @@ impl<'db> ConstructorBinding<'db> {
     fn unspecialize_class_type_variables(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         specialization: Specialization<'db>,
     ) -> Specialization<'db> {
         let Some(class_context) = self
             .constructed_instance_type()
-            .class_specialization(db)
+            .class_specialization(db, program)
             .map(|(_, specialization)| specialization.generic_context(db))
         else {
             return specialization;
@@ -485,11 +512,15 @@ impl<'db> ConstructorBinding<'db> {
         )
     }
 
-    fn constructed_class_literal(&self, db: &'db dyn Db) -> Option<ClassLiteral<'db>> {
+    fn constructed_class_literal(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<ClassLiteral<'db>> {
         self.constructed_instance_type()
             .as_nominal_instance()
             // TODO may need to handle `Type::KnownInstance` here as well?
-            .map(|instance| instance.class(db).class_literal(db))
+            .map(|instance| instance.class(db, program).class_literal(db))
     }
 
     fn constructor_kind(&self) -> ConstructorCallableKind {
@@ -552,6 +583,7 @@ fn constructor_returns_instance<'db>(
     class_literal: ClassLiteral<'db>,
     return_ty: Type<'db>,
 ) -> bool {
+    let program = class_literal.program(db);
     match return_ty.resolve_type_alias(db) {
         Type::Union(union) => union
             .elements(db)
@@ -569,7 +601,7 @@ fn constructor_returns_instance<'db>(
         // A `Never` constructor return is terminal and does not run downstream construction.
         Type::Never => false,
         Type::NominalInstance(instance) => instance
-            .class(db)
+            .class(db, program)
             .is_subtype_of_class_literal(db, class_literal),
         // We don't need to handle `ProtocolInstance` here, since the only way a protocol can be
         // instantiated is if a nominal class inherits it. If the nominal class inherits a

--- a/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
+++ b/crates/ty_python_semantic/src/types/call/bind/enum_property.rs
@@ -11,15 +11,16 @@ impl<'db> Bindings<'db> {
     pub(super) fn evaluate_enum_property_calls(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         call_arguments: &CallArguments<'_, 'db>,
     ) {
         let property_instance =
             |getter: Option<Type<'db>>, setter: Option<Type<'db>>, deleter: Option<Type<'db>>| {
                 Type::PropertyInstance(PropertyInstanceType::new_enum_property(
                     db,
-                    getter.filter(|ty| !ty.is_none(db)),
-                    setter.filter(|ty| !ty.is_none(db)),
-                    deleter.filter(|ty| !ty.is_none(db)),
+                    getter.filter(|ty| !ty.is_none(db, program)),
+                    setter.filter(|ty| !ty.is_none(db, program)),
+                    deleter.filter(|ty| !ty.is_none(db, program)),
                 ))
             };
 
@@ -27,10 +28,11 @@ impl<'db> Bindings<'db> {
         // only a known property class, so this rewrite collapses subclass instances to
         // `enum.property`.
         for constructor in self.iter_constructor_items_mut() {
-            if !constructor
-                .constructed_instance_type()
-                .is_instance_of(db, KnownClass::EnumProperty)
-            {
+            if !constructor.constructed_instance_type().is_instance_of(
+                db,
+                program,
+                KnownClass::EnumProperty,
+            ) {
                 continue;
             }
 

--- a/crates/ty_python_semantic/src/types/callable.rs
+++ b/crates/ty_python_semantic/src/types/callable.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use smallvec::{SmallVec, smallvec_inline};
 
 use crate::{
-    Db, FxOrderSet,
+    Db, FxOrderSet, Program,
     place::Place,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarInstance, ClassType, FindLegacyTypeVarsVisitor,
@@ -41,17 +41,23 @@ impl<'db> Type<'db> {
         Type::Callable(CallableType::paramspec_value(db, parameters))
     }
 
-    pub(crate) fn try_upcast_to_callable(self, db: &'db dyn Db) -> Option<CallableTypes<'db>> {
-        self.try_upcast_to_callable_with_policy(db, UpcastPolicy::default())
+    pub(crate) fn try_upcast_to_callable(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<CallableTypes<'db>> {
+        self.try_upcast_to_callable_with_policy(db, program, UpcastPolicy::default())
     }
 
     pub(crate) fn try_upcast_to_callable_with_recursive_fallback(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         recursive_definition: Option<Definition<'db>>,
     ) -> Option<CallableTypes<'db>> {
         self.try_upcast_to_callable_with_policy_and_context(
             db,
+            program,
             UpcastPolicy::default(),
             CallableUpcastContext {
                 recursive_definition,
@@ -62,10 +68,12 @@ impl<'db> Type<'db> {
     pub(crate) fn try_upcast_to_callable_with_policy(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         policy: UpcastPolicy,
     ) -> Option<CallableTypes<'db>> {
         self.try_upcast_to_callable_with_policy_and_context(
             db,
+            program,
             policy,
             CallableUpcastContext::default(),
         )
@@ -74,11 +82,13 @@ impl<'db> Type<'db> {
     fn try_upcast_to_callable_with_policy_and_context(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         policy: UpcastPolicy,
         context: CallableUpcastContext<'db>,
     ) -> Option<CallableTypes<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.try_upcast_to_callable_with_policy_and_context(db, policy, context);
+            return fallback
+                .try_upcast_to_callable_with_policy_and_context(db, program, policy, context);
         }
 
         match self {
@@ -114,6 +124,7 @@ impl<'db> Type<'db> {
                 let call_symbol = self
                     .member_lookup_with_policy(
                         db,
+                        program,
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
@@ -124,7 +135,9 @@ impl<'db> Type<'db> {
                 {
                     place
                         .ty
-                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)
+                        .try_upcast_to_callable_with_policy_and_context(
+                            db, program, policy, context,
+                        )
                         // The callable instance itself doesn't inherit the descriptor behavior of
                         // its `__call__` method.
                         .map(|callables| callables.map(|callable| callable.into_regular(db)))
@@ -140,7 +153,7 @@ impl<'db> Type<'db> {
 
             Type::NewTypeInstance(newtype) => newtype
                 .concrete_base_type(db)
-                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                .try_upcast_to_callable_with_policy_and_context(db, program, policy, context),
 
             Type::SubclassOf(subclass_of_ty) if policy == UpcastPolicy::Sound => {
                 Some(CallableTypes::one(CallableType::function_like(
@@ -155,8 +168,10 @@ impl<'db> Type<'db> {
                 SubclassOfInner::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db) {
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
                         let upcast_callables = bound
-                            .to_meta_type(db)
-                            .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
+                            .to_meta_type(db, program)
+                            .try_upcast_to_callable_with_policy_and_context(
+                                db, program, policy, context,
+                            )?;
                         Some(upcast_callables.map(|callable| {
                             let signatures = callable
                                 .signatures(db)
@@ -174,9 +189,9 @@ impl<'db> Type<'db> {
                         let mut callables = SmallVec::new();
                         for constraint in constraints.elements(db) {
                             let element_upcast = constraint
-                                .to_meta_type(db)
+                                .to_meta_type(db, program)
                                 .try_upcast_to_callable_with_policy_and_context(
-                                    db, policy, context,
+                                    db, program, policy, context,
                                 )?;
                             for callable in element_upcast.into_inner() {
                                 let signatures = callable
@@ -207,8 +222,9 @@ impl<'db> Type<'db> {
             Type::Union(union) => {
                 let mut callables = SmallVec::new();
                 for element in union.elements(db) {
-                    let element_callable = element
-                        .try_upcast_to_callable_with_policy_and_context(db, policy, context)?;
+                    let element_callable = element.try_upcast_to_callable_with_policy_and_context(
+                        db, program, policy, context,
+                    )?;
                     callables.extend(element_callable.into_inner());
                 }
                 Some(CallableTypes::new(callables))
@@ -217,13 +233,13 @@ impl<'db> Type<'db> {
             Type::LiteralValue(literal) => match literal.kind() {
                 LiteralValueTypeKind::Enum(enum_literal) => enum_literal
                     .enum_class_instance(db)
-                    .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                    .try_upcast_to_callable_with_policy_and_context(db, program, policy, context),
                 _ => None,
             },
 
             Type::TypeAlias(alias) => alias
                 .value_type(db)
-                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                .try_upcast_to_callable_with_policy_and_context(db, program, policy, context),
 
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(function))
                 if context.is_recursive_reference(db, function) =>
@@ -233,7 +249,7 @@ impl<'db> Type<'db> {
 
             Type::KnownBoundMethod(method) => Some(CallableTypes::one(CallableType::new(
                 db,
-                CallableSignature::from_overloads(method.signatures(db)),
+                CallableSignature::from_overloads(method.signatures(db, program)),
                 CallableTypeKind::Regular,
                 CallableFunctionProvenance::None,
             ))),
@@ -241,7 +257,7 @@ impl<'db> Type<'db> {
             Type::WrapperDescriptor(wrapper_descriptor) => {
                 Some(CallableTypes::one(CallableType::new(
                     db,
-                    CallableSignature::from_overloads(wrapper_descriptor.signatures(db)),
+                    CallableSignature::from_overloads(wrapper_descriptor.signatures(db, program)),
                     CallableTypeKind::Regular,
                     CallableFunctionProvenance::None,
                 )))
@@ -252,7 +268,7 @@ impl<'db> Type<'db> {
                     db,
                     Signature::new(
                         Parameters::standard([Parameter::positional_only(None)
-                            .with_annotated_type(newtype.base(db).instance_type(db))]),
+                            .with_annotated_type(newtype.base(db).instance_type(db, program))]),
                         Type::NewTypeInstance(newtype),
                     ),
                 )))
@@ -272,17 +288,15 @@ impl<'db> Type<'db> {
                 | KnownInstanceType::FunctoolsPartialCall(partial),
             ) => Some(CallableTypes::one(partial.partial(db))),
 
-            Type::Intersection(intersection) => {
-                intersection
-                    .finite_alternative_union(db)
-                    .and_then(|alternatives| {
-                        alternatives.try_upcast_to_callable_with_policy(db, policy)
-                    })
-            }
+            Type::Intersection(intersection) => intersection
+                .finite_alternative_union(db, program)
+                .and_then(|alternatives| {
+                    alternatives.try_upcast_to_callable_with_policy(db, program, policy)
+                }),
 
             Type::EnumComplement(complement) => complement
                 .remaining_literal_union(db)
-                .try_upcast_to_callable_with_policy_and_context(db, policy, context),
+                .try_upcast_to_callable_with_policy_and_context(db, program, policy, context),
 
             // TODO
             Type::DataclassDecorator(_)
@@ -431,17 +445,17 @@ pub struct CallableType<'db> {
     /// ```python
     /// def decorator_factory() -> Callable[[type[object]], object]: ...
     /// ```
-    #[returns(copy)]
     pub(crate) provenance: CallableFunctionProvenance,
 }
 
 pub(super) fn walk_callable_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: CallableType<'db>,
     visitor: &V,
 ) {
     for signature in &ty.signatures(db).overloads {
-        walk_signature(db, signature, visitor);
+        walk_signature(db, program, signature, visitor);
     }
 }
 
@@ -526,20 +540,27 @@ impl<'db> CallableType<'db> {
     /// Returns the reduced callable produced by partially applying selected overloads.
     pub(crate) fn partially_apply(
         db: &'db dyn Db,
+        program: crate::Program,
         overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
     ) -> Option<Self> {
         Some(Self::new(
             db,
-            CallableSignature::partially_apply(db, overloads)?,
+            CallableSignature::partially_apply(db, program, overloads)?,
             CallableTypeKind::Regular,
             CallableFunctionProvenance::None,
         ))
     }
 
     /// Reifies this callable as the nominal `functools.partial[T]` instance for its return type.
-    pub(crate) fn into_functools_partial_instance(self, db: &'db dyn Db) -> Type<'db> {
-        let return_ty = self.signatures(db).overload_return_type_or_unknown(db);
-        KnownClass::FunctoolsPartial.to_specialized_instance(db, &[return_ty])
+    pub(crate) fn into_functools_partial_instance(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        let return_ty = self
+            .signatures(db)
+            .overload_return_type_or_unknown(db, program);
+        KnownClass::FunctoolsPartial.to_specialized_instance(db, program, &[return_ty])
     }
 
     /// Wraps this reduced callable as a synthetic `functools.partial(...)` instance type.
@@ -556,6 +577,7 @@ impl<'db> CallableType<'db> {
     pub(crate) fn bind_self(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         self_type: Option<Type<'db>>,
     ) -> CallableType<'db> {
         if self.is_dunder_paramspec(db) {
@@ -564,7 +586,7 @@ impl<'db> CallableType<'db> {
 
         CallableType::new(
             db,
-            self.signatures(db).bind_self(db, self_type),
+            self.signatures(db).bind_self(db, program, self_type),
             self.kind(db),
             self.provenance(db),
         )
@@ -588,10 +610,15 @@ impl<'db> CallableType<'db> {
         )
     }
 
-    pub(crate) fn apply_self(self, db: &'db dyn Db, self_type: Type<'db>) -> CallableType<'db> {
+    pub(crate) fn apply_self(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> CallableType<'db> {
         CallableType::new(
             db,
-            self.signatures(db).apply_self(db, self_type),
+            self.signatures(db).apply_self(db, program, self_type),
             self.kind(db),
             self.provenance(db),
         )
@@ -613,13 +640,14 @@ impl<'db> CallableType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(CallableType::new(
             db,
             self.signatures(db)
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
             self.kind(db),
             self.provenance(db),
         ))
@@ -628,6 +656,7 @@ impl<'db> CallableType<'db> {
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -639,7 +668,7 @@ impl<'db> CallableType<'db> {
         CallableType::new(
             db,
             self.signatures(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             self.kind(db),
             self.provenance(db),
         )
@@ -648,12 +677,18 @@ impl<'db> CallableType<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        self.signatures(db)
-            .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+        self.signatures(db).find_legacy_typevars_impl(
+            db,
+            program,
+            binding_context,
+            typevars,
+            visitor,
+        );
     }
 }
 
@@ -702,9 +737,9 @@ impl<'db> CallableTypes<'db> {
         self.0.iter()
     }
 
-    pub(crate) fn into_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn into_type(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         assert!(!self.0.is_empty(), "CallableTypes should not be empty");
-        UnionType::from_elements(db, self.0.into_iter().map(Type::Callable))
+        UnionType::from_elements(db, program, self.0.into_iter().map(Type::Callable))
     }
 
     pub(crate) fn map(self, mut f: impl FnMut(CallableType<'db>) -> CallableType<'db>) -> Self {
@@ -773,8 +808,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &CallableTypes<'db>,
         target: CallableType<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        source.iter().when_all(db, self.constraints, |element| {
-            self.check_callable_pair(db, *element, target)
-        })
+        source
+            .iter()
+            .when_all(db, self.program, self.constraints, |element| {
+                self.check_callable_pair(db, *element, target)
+            })
     }
 }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -403,12 +403,18 @@ impl<'db> GenericAlias<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        self.specialization(db)
-            .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+        self.specialization(db).find_legacy_typevars_impl(
+            db,
+            program,
+            binding_context,
+            typevars,
+            visitor,
+        );
     }
 
     pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
@@ -1269,6 +1275,7 @@ impl<'db> ClassType<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -1276,7 +1283,7 @@ impl<'db> ClassType<'db> {
         match self {
             Self::NonGeneric(_) => {}
             Self::Generic(generic) => {
-                generic.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                generic.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
         }
     }

--- a/crates/ty_python_semantic/src/types/class.rs
+++ b/crates/ty_python_semantic/src/types/class.rs
@@ -44,7 +44,7 @@ use crate::types::{
     UnionBuilder, VarianceInferable,
 };
 use crate::{
-    Db, FxIndexMap, FxOrderSet,
+    Db, FxIndexMap, FxOrderSet, Program,
     place::{
         Definedness, LookupError, LookupResult, Place, PlaceAndQualifiers, PublicTypePolicy,
         place_from_bindings, place_from_declarations,
@@ -129,6 +129,7 @@ impl<'db> CodeGeneratorKind<'db> {
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
         ) -> Option<CodeGeneratorKind<'db>> {
+            let program = class.program(db);
             // If a class is directly decorated as a dataclass, it's a dataclass.
             // If a class' metaclass is a dataclass transformer, it's a dataclass.
             // If a class inherits from a base class that is a dataclass
@@ -145,7 +146,7 @@ impl<'db> CodeGeneratorKind<'db> {
                     info.params,
                 ))
             } else if KnownClass::Type
-                .try_to_class_literal(db)
+                .try_to_class_literal(db, program)
                 .is_none_or(|type_class| {
                     !class.is_subclass_of(
                         db,
@@ -349,17 +350,19 @@ impl<'db> GenericAlias<'db> {
         ))
     }
 
-    pub(super) fn recursive_type_normalized_impl(
+    pub(super) fn recursive_type_normalized_impl_with_program(
         self,
         db: &'db dyn Db,
+        program: Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        debug_assert_eq!(program, self.origin(db).program(db));
         Some(Self::new(
             db,
             self.origin(db),
             self.specialization(db)
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
         ))
     }
 
@@ -367,13 +370,15 @@ impl<'db> GenericAlias<'db> {
         self.origin(db).definition(db)
     }
 
-    pub(super) fn apply_type_mapping_impl<'a>(
+    pub(super) fn apply_type_mapping_impl_with_program<'a>(
         self,
         db: &'db dyn Db,
+        program: Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        debug_assert_eq!(program, self.origin(db).program(db));
         let tcx = tcx
             .annotation
             .and_then(|ty| ty.specialization_of(db, self.origin(db)))
@@ -381,8 +386,13 @@ impl<'db> GenericAlias<'db> {
             .unwrap_or(&[]);
 
         let original_specialization = self.specialization(db);
-        let specialization =
-            original_specialization.apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        let specialization = original_specialization.apply_type_mapping_impl_with_program(
+            db,
+            program,
+            type_mapping,
+            tcx,
+            visitor,
+        );
         if specialization == original_specialization {
             self
         } else {
@@ -413,13 +423,18 @@ impl<'db> From<GenericAlias<'db>> for Type<'db> {
 }
 
 #[salsa::tracked]
-impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
+impl<'db> GenericAlias<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
         heap_size=ruff_memory_usage::heap_size
     )]
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn inferred_variance_of(
+        self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        let program = self.origin(db).program(db);
         let origin = self.origin(db);
 
         let specialization = self.specialization(db);
@@ -432,7 +447,8 @@ impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
             .zip(specialization.types(db))
             .map(|(generic_typevar, ty)| {
                 if let Some(explicit_variance) = generic_typevar.typevar(db).explicit_variance(db) {
-                    ty.with_polarity(explicit_variance).variance_of(db, typevar)
+                    ty.with_polarity(explicit_variance)
+                        .variance_of(db, program, typevar)
                 } else {
                     // `with_polarity` composes the passed variance with the
                     // inferred one. The inference is done lazily, as we can
@@ -445,13 +461,24 @@ impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
                     // If salsa let us look at the cache, we could check first
                     // to see if the class literal query was already run.
 
-                    let typevar_variance_in_substituted_type = ty.variance_of(db, typevar);
+                    let typevar_variance_in_substituted_type = ty.variance_of(db, program, typevar);
                     origin
                         .with_polarity(typevar_variance_in_substituted_type)
-                        .variance_of(db, generic_typevar.identity(db))
+                        .variance_of(db, program, generic_typevar.identity(db))
                 }
             })
             .collect()
+    }
+}
+
+impl<'db> VarianceInferable<'db> for GenericAlias<'db> {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        _program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.inferred_variance_of(db, typevar)
     }
 }
 
@@ -475,9 +502,9 @@ pub enum ClassLiteral<'db> {
 #[salsa::tracked]
 impl<'db> ClassLiteral<'db> {
     /// Return a `ClassLiteral` representing the class `builtins.object`
-    pub(super) fn object(db: &'db dyn Db) -> Self {
+    pub(super) fn object(db: &'db dyn Db, program: Program) -> Self {
         KnownClass::Object
-            .to_class_literal(db)
+            .to_class_literal(db, program)
             .as_class_literal()
             .expect("`object` should always be a non-generic class in typeshed")
     }
@@ -513,6 +540,16 @@ impl<'db> ClassLiteral<'db> {
             Self::DynamicNamedTuple(namedtuple) => namedtuple.name(db),
             Self::DynamicTypedDict(typeddict) => typeddict.name(db),
             Self::DynamicEnum(enum_lit) => enum_lit.name(db),
+        }
+    }
+
+    pub(crate) fn program(self, db: &'db dyn Db) -> Program {
+        match self {
+            Self::Static(class) => class.program(db),
+            Self::Dynamic(class) => class.scope(db).program(db),
+            Self::DynamicNamedTuple(class) => class.scope(db).program(db),
+            Self::DynamicTypedDict(class) => class.scope(db).program(db),
+            Self::DynamicEnum(class) => class.scope(db).program(db),
         }
     }
 
@@ -604,11 +641,15 @@ impl<'db> ClassLiteral<'db> {
             | Self::DynamicTypedDict(_)
             | Self::DynamicEnum(_) => {
                 // Dynamic classes don't have inherited generic context and are never `object`.
-                let result = MroLookup::new(db, mro_iter).class_member(name, policy, None, false);
+                let program = self.program(db);
+                let result =
+                    MroLookup::new(db, program, mro_iter).class_member(name, policy, None, false);
                 match result {
-                    ClassMemberResult::Done(result) => result.finalize(db),
+                    ClassMemberResult::Done(result) => result.finalize(db, program),
                     ClassMemberResult::TypedDict(module) => {
-                        typed_dict::typed_dict_fallback_class_member(db, module, policy, name)
+                        typed_dict::typed_dict_fallback_class_member(
+                            db, program, module, policy, name,
+                        )
                     }
                 }
             }
@@ -692,8 +733,9 @@ impl<'db> ClassLiteral<'db> {
 
     /// Return a type representing "the set of all instances of the metaclass of this class".
     pub(crate) fn metaclass_instance_type(self, db: &'db dyn Db) -> Type<'db> {
+        let program = self.program(db);
         self.metaclass(db)
-            .to_instance(db)
+            .to_instance(db, program)
             .expect("`Type::to_instance()` should always return `Some()` when called on the type of a metaclass")
     }
 
@@ -1015,8 +1057,8 @@ pub enum ClassType<'db> {
 #[salsa::tracked]
 impl<'db> ClassType<'db> {
     /// Return a `ClassType` representing the class `builtins.object`
-    pub(super) fn object(db: &'db dyn Db) -> Self {
-        ClassType::NonGeneric(ClassLiteral::object(db))
+    pub(super) fn object(db: &'db dyn Db, program: crate::Program) -> Self {
+        ClassType::NonGeneric(ClassLiteral::object(db, program))
     }
 
     pub(super) const fn is_generic(self) -> bool {
@@ -1036,12 +1078,23 @@ impl<'db> ClassType<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        self.recursive_type_normalized_impl_with_program(db, self.program(db), div, nested)
+    }
+
+    pub(super) fn recursive_type_normalized_impl_with_program(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        div: Type<'db>,
+        nested: bool,
+    ) -> Option<Self> {
+        debug_assert_eq!(program, self.program(db));
         match self {
             Self::NonGeneric(class) => Some(Self::NonGeneric(
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Generic(generic) => Some(Self::Generic(
-                generic.recursive_type_normalized_impl(db, div, nested)?,
+                generic.recursive_type_normalized_impl_with_program(db, program, div, nested)?,
             )),
         }
     }
@@ -1059,6 +1112,10 @@ impl<'db> ClassType<'db> {
             Self::NonGeneric(literal) => literal,
             Self::Generic(generic) => ClassLiteral::Static(generic.origin(db)),
         }
+    }
+
+    pub(crate) fn program(self, db: &'db dyn Db) -> Program {
+        self.class_literal(db).program(db)
     }
 
     /// Returns the underlying class literal and specialization, if any.
@@ -1111,14 +1168,17 @@ impl<'db> ClassType<'db> {
                 | ClassLiteral::DynamicTypedDict(_)
                 | ClassLiteral::DynamicEnum(_),
             ) => None,
-            Self::Generic(generic) => Some((
-                generic.origin(db),
-                Some(
-                    generic
-                        .specialization(db)
-                        .apply_optional_specialization(db, additional_specialization),
-                ),
-            )),
+            Self::Generic(generic) => {
+                let specialization =
+                    if let Some(additional_specialization) = additional_specialization {
+                        generic
+                            .specialization(db)
+                            .apply_optional_specialization(db, Some(additional_specialization))
+                    } else {
+                        generic.specialization(db)
+                    };
+                Some((generic.origin(db), Some(specialization)))
+            }
         }
     }
 
@@ -1182,11 +1242,27 @@ impl<'db> ClassType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        self.apply_type_mapping_impl_with_program(db, self.program(db), type_mapping, tcx, visitor)
+    }
+
+    pub(super) fn apply_type_mapping_impl_with_program<'a>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        type_mapping: &TypeMapping<'a, 'db>,
+        tcx: TypeContext<'db>,
+        visitor: &ApplyTypeMappingVisitor<'db>,
+    ) -> Self {
+        debug_assert_eq!(program, self.program(db));
         match self {
             Self::NonGeneric(_) => self,
-            Self::Generic(generic) => {
-                Self::Generic(generic.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Self::Generic(generic) => Self::Generic(generic.apply_type_mapping_impl_with_program(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            )),
         }
     }
 
@@ -1233,15 +1309,21 @@ impl<'db> ClassType<'db> {
     ) -> MroIterator<'db> {
         match self {
             Self::NonGeneric(class) => class.iter_mro(db),
-            Self::Generic(generic) => MroIterator::new(
-                db,
-                ClassLiteral::Static(generic.origin(db)),
-                Some(
-                    generic
-                        .specialization(db)
-                        .apply_optional_specialization(db, additional_specialization),
-                ),
-            ),
+            Self::Generic(generic) => {
+                let specialization =
+                    if let Some(additional_specialization) = additional_specialization {
+                        generic
+                            .specialization(db)
+                            .apply_optional_specialization(db, Some(additional_specialization))
+                    } else {
+                        generic.specialization(db)
+                    };
+                MroIterator::new(
+                    db,
+                    ClassLiteral::Static(generic.origin(db)),
+                    Some(specialization),
+                )
+            }
         }
     }
 
@@ -1286,6 +1368,7 @@ impl<'db> ClassType<'db> {
             }
         }
 
+        let program = self.class_literal(db).program(db);
         let mut abstract_methods: FxIndexMap<Name, _> = FxIndexMap::default();
 
         // Iterate through the MRO in reverse order,
@@ -1305,7 +1388,7 @@ impl<'db> ClassType<'db> {
 
             let scope = class_literal.body_scope(db);
             let place_table = place_table(db, scope);
-            let use_def_map = use_def_map(db, class_literal.body_scope(db));
+            let use_def_map = use_def_map(db, scope);
 
             // Treat abstract methods from superclasses as having been overridden
             // if this class has a synthesized method by that name,
@@ -1320,7 +1403,7 @@ impl<'db> ClassType<'db> {
 
                 place_table.symbol_id(name).is_none_or(|symbol_id| {
                     let declarations = use_def_map.end_of_scope_symbol_declarations(symbol_id);
-                    !place_from_declarations(db, declarations)
+                    !place_from_declarations(db, program, declarations)
                         .ignore_conflicting_declarations()
                         .qualifiers
                         .contains(TypeQualifiers::CLASS_VAR)
@@ -1329,7 +1412,7 @@ impl<'db> ClassType<'db> {
 
             for (symbol_id, bindings_iterator) in use_def_map.all_end_of_scope_symbol_bindings() {
                 let name = place_table.symbol(symbol_id).name();
-                let place_and_definition = place_from_bindings(db, bindings_iterator);
+                let place_and_definition = place_from_bindings(db, program, bindings_iterator);
                 let Place::Defined(DefinedPlace { ty, .. }) = place_and_definition.place else {
                     continue;
                 };
@@ -1366,12 +1449,14 @@ impl<'db> ClassType<'db> {
 
     /// Return `true` if `other` is present in this class's MRO.
     pub(super) fn is_subclass_of(self, db: &'db dyn Db, target: ClassType<'db>) -> bool {
+        let program = self.class_literal(db).program(db);
         let constraints = ConstraintSetBuilder::new();
         let relation_visitor = HasRelationToVisitor::default(&constraints);
         let disjointness_visitor = IsDisjointVisitor::default(&constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::subtyping(
+            program,
             &constraints,
             InferableTypeVars::None,
             &relation_visitor,
@@ -1381,7 +1466,7 @@ impl<'db> ClassType<'db> {
         );
         checker
             .check_class_pair(db, self, target)
-            .is_always_satisfied(db)
+            .is_always_satisfied(db, program)
     }
 
     /// Return the metaclass of this class, or `type[Unknown]` if the metaclass cannot be inferred.
@@ -1416,9 +1501,10 @@ impl<'db> ClassType<'db> {
         other: Self,
         constraints: &ConstraintSetBuilder<'db>,
     ) -> bool {
+        let program = self.class_literal_and_specialization(db).0.program(db);
         self.could_exist_in_mro_of_impl(db, other, |this, other| {
             this.is_disjoint_from(db, other, constraints, InferableTypeVars::None)
-                .is_always_satisfied(db)
+                .is_always_satisfied(db, program)
         })
     }
 
@@ -1430,10 +1516,11 @@ impl<'db> ClassType<'db> {
         other: Self,
         checker: &DisjointnessChecker<'_, 'c, 'db>,
     ) -> bool {
+        let program = checker.program;
         self.could_exist_in_mro_of_impl(db, other, |this, other| {
             checker
                 .check_specialization_pair(db, this, other)
-                .is_always_satisfied(db)
+                .is_always_satisfied(db, program)
         })
     }
 
@@ -1499,17 +1586,19 @@ impl<'db> ClassType<'db> {
         other: Self,
         constraints: &ConstraintSetBuilder<'db>,
     ) -> bool {
+        let program = self.class_literal_and_specialization(db).0.program(db);
         self.could_coexist_in_mro_with_impl(
             db,
+            program,
             other,
             |this, other| this.could_exist_in_mro_of(db, other, constraints),
             |this, other| {
                 this.is_disjoint_from(db, other, constraints, InferableTypeVars::None)
-                    .is_always_satisfied(db)
+                    .is_always_satisfied(db, program)
             },
             |this, other| {
-                this.when_disjoint_from(db, other, constraints, InferableTypeVars::None)
-                    .is_always_satisfied(db)
+                this.when_disjoint_from(db, program, other, constraints, InferableTypeVars::None)
+                    .is_always_satisfied(db, program)
             },
         )
     }
@@ -1520,21 +1609,23 @@ impl<'db> ClassType<'db> {
         other: Self,
         checker: &DisjointnessChecker<'_, 'c, 'db>,
     ) -> bool {
+        let program = checker.program;
         // Reuse the active disjointness checker for nested specialization and
         // metaclass checks so recursive class graphs keep the same cycle guard.
         self.could_coexist_in_mro_with_impl(
             db,
+            program,
             other,
             |this, other| this.could_exist_in_mro_of_with_disjointness_checker(db, other, checker),
             |this, other| {
                 checker
                     .check_specialization_pair(db, this, other)
-                    .is_always_satisfied(db)
+                    .is_always_satisfied(db, program)
             },
             |this, other| {
                 checker
                     .check_type_pair(db, this, other)
-                    .is_always_satisfied(db)
+                    .is_always_satisfied(db, program)
             },
         )
     }
@@ -1542,6 +1633,7 @@ impl<'db> ClassType<'db> {
     fn could_coexist_in_mro_with_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: Self,
         could_exist_in_mro_of: impl Fn(Self, Self) -> bool,
         specializations_are_disjoint: impl Fn(Specialization<'db>, Specialization<'db>) -> bool,
@@ -1583,7 +1675,7 @@ impl<'db> ClassType<'db> {
         // however, since we end up with infinite recursion in that case due to the fact
         // that `type` is its own metaclass (and we know that `type` can coexist in an MRO
         // with any other arbitrary class, anyway).
-        let type_class = KnownClass::Type.to_class_literal(db);
+        let type_class = KnownClass::Type.to_class_literal(db, program);
         let self_metaclass = self.metaclass(db);
         if self_metaclass == type_class {
             return true;
@@ -1592,10 +1684,10 @@ impl<'db> ClassType<'db> {
         if other_metaclass == type_class {
             return true;
         }
-        let Some(self_metaclass_instance) = self_metaclass.to_instance(db) else {
+        let Some(self_metaclass_instance) = self_metaclass.to_instance(db, program) else {
             return true;
         };
-        let Some(other_metaclass_instance) = other_metaclass.to_instance(db) else {
+        let Some(other_metaclass_instance) = other_metaclass.to_instance(db, program) else {
             return true;
         };
         if types_are_disjoint(self_metaclass_instance, other_metaclass_instance) {
@@ -1607,9 +1699,10 @@ impl<'db> ClassType<'db> {
 
     /// Return a type representing "the set of all instances of the metaclass of this class".
     pub(super) fn metaclass_instance_type(self, db: &'db dyn Db) -> Type<'db> {
+        let program = self.program(db);
         self
             .metaclass(db)
-            .to_instance(db)
+            .to_instance(db, program)
             .expect("`Type::to_instance()` should always return `Some()` when called on the type of a metaclass")
     }
 
@@ -1679,7 +1772,6 @@ impl<'db> ClassType<'db> {
             Self::NonGeneric(ClassLiteral::Static(class)) => (class, None),
             Self::Generic(generic) => (generic.origin(db), Some(generic.specialization(db))),
         };
-
         let fallback_member_lookup = || {
             class_literal
                 .own_class_member(db, inherited_generic_context, specialization, name)
@@ -1688,12 +1780,13 @@ impl<'db> ClassType<'db> {
 
         match name {
             "__len__" if class_literal.is_tuple(db) => {
+                let program = class_literal.program(db);
                 let return_type = specialization
                     .and_then(|spec| spec.tuple(db))
                     .and_then(|tuple| tuple.len().into_fixed_length())
                     .and_then(|len| i64::try_from(len).ok())
                     .map(Type::int_literal)
-                    .unwrap_or_else(|| KnownClass::Int.to_instance(db));
+                    .unwrap_or_else(|| KnownClass::Int.to_instance(db, program));
 
                 let parameters = Parameters::standard([Parameter::positional_only(Some(
                     Name::new_static("self"),
@@ -1710,6 +1803,7 @@ impl<'db> ClassType<'db> {
                 specialization
                     .and_then(|spec| spec.tuple(db))
                     .map(|tuple| {
+                        let program = class_literal.program(db);
                         let mut element_type_to_indices: FxIndexMap<Type<'db>, Vec<i64>> =
                             FxIndexMap::default();
 
@@ -1760,6 +1854,7 @@ impl<'db> ClassType<'db> {
                                     ) {
                                         let overload_return = UnionType::from_elements(
                                             db,
+                                            program,
                                             std::iter::once(variable_length_tuple.variable())
                                                 .chain(
                                                     variable_length_tuple
@@ -1794,6 +1889,7 @@ impl<'db> ClassType<'db> {
                                     ) {
                                         let overload_return = UnionType::from_elements(
                                             db,
+                                            program,
                                             std::iter::once(variable_length_tuple.variable())
                                                 .chain(
                                                     variable_length_tuple
@@ -1811,14 +1907,14 @@ impl<'db> ClassType<'db> {
                         }
 
                         let all_elements_unioned =
-                            UnionType::from_elements(db, tuple.all_elements());
+                            UnionType::from_elements(db, program, tuple.all_elements());
 
                         let mut overload_signatures =
                             Vec::with_capacity(element_type_to_indices.len().saturating_add(2));
 
                         overload_signatures.extend(element_type_to_indices.into_iter().filter_map(
                             |(return_type, mut indices)| {
-                                if return_type.is_equivalent_to(db, all_elements_unioned) {
+                                if return_type.is_equivalent_to(db, program, all_elements_unioned) {
                                     return None;
                                 }
 
@@ -1827,6 +1923,7 @@ impl<'db> ClassType<'db> {
 
                                 let index_annotation = UnionType::from_elements(
                                     db,
+                                    program,
                                     indices.into_iter().map(Type::int_literal),
                                 );
 
@@ -1848,17 +1945,22 @@ impl<'db> ClassType<'db> {
                         //    __getitem__(self, index: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | None], /) -> tuple[str | float | bytes, ...]
                         //
                         overload_signatures.push(synthesize_getitem_overload_signature(
-                            KnownClass::SupportsIndex.to_instance(db),
+                            KnownClass::SupportsIndex.to_instance(db, program),
                             all_elements_unioned,
                         ));
 
                         let slice_bound = UnionType::from_elements(
                             db,
-                            [KnownClass::SupportsIndex.to_instance(db), Type::none(db)],
+                            program,
+                            [
+                                KnownClass::SupportsIndex.to_instance(db, program),
+                                Type::none(db, program),
+                            ],
                         );
                         overload_signatures.push(synthesize_getitem_overload_signature(
                             KnownClass::Slice.to_specialized_instance(
                                 db,
+                                program,
                                 &[slice_bound, slice_bound, slice_bound],
                             ),
                             Type::homogeneous_tuple(db, all_elements_unioned),
@@ -1885,6 +1987,7 @@ impl<'db> ClassType<'db> {
             //     def __new__[T](cls: type[tuple[T, ...]], iterable: tuple[T, ...]) -> tuple[T, ...]: ...
             // ```
             "__new__" if class_literal.is_tuple(db) => {
+                let program = class_literal.program(db);
                 let mut iterable_parameter =
                     Parameter::positional_only(Some(Name::new_static("iterable")));
 
@@ -1901,8 +2004,11 @@ impl<'db> ClassType<'db> {
                             // any iterable is allowed as long as the iterable has the correct element type.
                             let mut tuple_elements = tuple.iter_all_elements();
                             iterable_parameter = iterable_parameter.with_annotated_type(
-                                KnownClass::Iterable
-                                    .to_specialized_instance(db, &[tuple_elements.next().unwrap()]),
+                                KnownClass::Iterable.to_specialized_instance(
+                                    db,
+                                    program,
+                                    &[tuple_elements.next().unwrap()],
+                                ),
                             );
                             assert_eq!(
                                 tuple_elements.next(),
@@ -1920,7 +2026,7 @@ impl<'db> ClassType<'db> {
                     None => {
                         // If the tuple isn't specialized at all, we allow any argument as long as it is iterable.
                         iterable_parameter = iterable_parameter
-                            .with_annotated_type(KnownClass::Iterable.to_instance(db));
+                            .with_annotated_type(KnownClass::Iterable.to_instance(db, program));
                     }
                 }
 
@@ -1935,7 +2041,7 @@ impl<'db> ClassType<'db> {
 
                 let parameters = Parameters::standard([
                     Parameter::positional_only(Some(Name::new_static("self")))
-                        .with_annotated_type(SubclassOfType::from(db, self)),
+                        .with_annotated_type(SubclassOfType::from(db, program, self)),
                     iterable_parameter,
                 ]);
 
@@ -2043,6 +2149,7 @@ impl<'db> ClassType<'db> {
         heap_size=ruff_memory_usage::heap_size
     )]
     pub(super) fn into_callable(self, db: &'db dyn Db) -> CallableTypes<'db> {
+        let program = self.class_literal_and_specialization(db).0.program(db);
         // TODO: This mimics a lot of the logic in Type::try_call_from_constructor. Can we
         // consolidate the two? Can we invoke a class by upcasting the class into a Callable, and
         // then relying on the call binding machinery to Just Work™?
@@ -2056,6 +2163,7 @@ impl<'db> ClassType<'db> {
         let metaclass_dunder_call_function_symbol = self_ty
             .member_lookup_with_policy(
                 db,
+                program,
                 "__call__".into(),
                 MemberLookupPolicy::NO_INSTANCE_FALLBACK
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
@@ -2083,8 +2191,7 @@ impl<'db> ClassType<'db> {
             }
         }
 
-        let dunder_new_function_symbol = self_ty.lookup_dunder_new(db);
-
+        let dunder_new_function_symbol = self_ty.lookup_dunder_new(db, program);
         let dunder_new_signature = dunder_new_function_symbol
             .and_then(|place_and_quals| place_and_quals.ignore_possibly_undefined())
             .and_then(|ty| match ty {
@@ -2099,8 +2206,9 @@ impl<'db> ClassType<'db> {
             let returns_non_subclass = dunder_new_signature.overloads.iter().any(|signature| {
                 !signature.return_ty.is_assignable_to(
                     db,
+                    program,
                     self_ty
-                        .to_instance(db)
+                        .to_instance(db, program)
                         .expect("ClassType should be instantiable"),
                 )
             });
@@ -2108,7 +2216,7 @@ impl<'db> ClassType<'db> {
             let instance_ty = Type::instance(db, self);
             let dunder_new_bound_method = CallableType::new(
                 db,
-                dunder_new_signature.bind_self(db, Some(instance_ty)),
+                dunder_new_signature.bind_self(db, program, Some(instance_ty)),
                 CallableTypeKind::Regular,
                 CallableFunctionProvenance::None,
             );
@@ -2124,13 +2232,16 @@ impl<'db> ClassType<'db> {
         let dunder_init_function_symbol = self_ty
             .member_lookup_with_policy(
                 db,
+                program,
                 "__init__".into(),
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
                     | MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .place;
 
-        let correct_return_type = self_ty.to_instance(db).unwrap_or_else(Type::unknown);
+        let correct_return_type = self_ty
+            .to_instance(db, program)
+            .unwrap_or_else(Type::unknown);
 
         // If the class defines an `__init__` method, then we synthesize a callable type with the
         // same parameters as the `__init__` method after it is bound, and with the return type of
@@ -2170,7 +2281,7 @@ impl<'db> ClassType<'db> {
                         return_type,
                     )
                     .with_definition(signature.definition())
-                    .bind_self(db, Some(instance_ty))
+                    .bind_self(db, program, Some(instance_ty))
                 };
 
                 let synthesized_dunder_init_signature = CallableSignature::from_overloads(
@@ -2206,6 +2317,7 @@ impl<'db> ClassType<'db> {
                 let new_function_symbol = self_ty
                     .member_lookup_with_policy(
                         db,
+                        program,
                         "__new__".into(),
                         MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
                     )
@@ -2288,16 +2400,23 @@ impl<'db> From<ClassType<'db>> for Type<'db> {
 }
 
 impl<'db> VarianceInferable<'db> for ClassType<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         match self {
-            Self::NonGeneric(ClassLiteral::Static(class)) => class.variance_of(db, typevar),
+            Self::NonGeneric(ClassLiteral::Static(class)) => {
+                class.variance_of(db, program, typevar)
+            }
             Self::NonGeneric(
                 ClassLiteral::Dynamic(_)
                 | ClassLiteral::DynamicNamedTuple(_)
                 | ClassLiteral::DynamicTypedDict(_)
                 | ClassLiteral::DynamicEnum(_),
             ) => TypeVarVariance::Bivariant,
-            Self::Generic(generic) => generic.variance_of(db, typevar),
+            Self::Generic(generic) => generic.variance_of(db, program, typevar),
         }
     }
 }
@@ -2309,6 +2428,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: ClassType<'db>,
         target: ClassType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // Fast path: if source and target are the same class (possibly with different
         // specializations), we can compare them directly without walking the MRO.
         match (source, target) {
@@ -2327,56 +2447,61 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             _ => {}
         }
 
-        source.iter_mro(db).when_any(db, self.constraints, |base| {
-            match base {
-                ClassBase::Any => ConstraintSet::from_bool(
-                    self.constraints,
-                    self.relation.is_assignability() || target.is_object(db),
-                ),
-                ClassBase::Dynamic(_) | ClassBase::Divergent(_) => match self.relation {
-                    TypeRelation::Subtyping
-                    | TypeRelation::Redundancy { .. }
-                    | TypeRelation::SubtypingAssuming => {
-                        ConstraintSet::from_bool(self.constraints, target.is_object(db))
-                    }
-                    TypeRelation::Assignability => {
-                        ConstraintSet::from_bool(self.constraints, !target.is_final(db))
-                    }
-                },
+        source
+            .iter_mro(db)
+            .when_any(db, self.program, self.constraints, |base| {
+                match base {
+                    ClassBase::Any => ConstraintSet::from_bool(
+                        self.constraints,
+                        self.relation.is_assignability() || target.is_object(db),
+                    ),
+                    ClassBase::Dynamic(_) | ClassBase::Divergent(_) => match self.relation {
+                        TypeRelation::Subtyping
+                        | TypeRelation::Redundancy { .. }
+                        | TypeRelation::SubtypingAssuming => {
+                            ConstraintSet::from_bool(self.constraints, target.is_object(db))
+                        }
+                        TypeRelation::Assignability => {
+                            ConstraintSet::from_bool(self.constraints, !target.is_final(db))
+                        }
+                    },
 
-                // Protocol, Generic, and TypedDict are special bases that don't match ClassType.
-                ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict(_) => self.never(),
-
-                ClassBase::Class(source) => match (source, target) {
-                    // Two non-generic classes match if they have the same class literal.
-                    (
-                        ClassType::NonGeneric(source_literal),
-                        ClassType::NonGeneric(target_literal),
-                    ) => {
-                        ConstraintSet::from_bool(self.constraints, source_literal == target_literal)
+                    // Protocol, Generic, and TypedDict are special bases that don't match ClassType.
+                    ClassBase::Protocol | ClassBase::Generic | ClassBase::TypedDict(_) => {
+                        self.never()
                     }
 
-                    // Two generic classes match if they have the same origin and compatible specializations.
-                    (ClassType::Generic(source), ClassType::Generic(target)) => {
-                        ConstraintSet::from_bool(
+                    ClassBase::Class(source) => match (source, target) {
+                        // Two non-generic classes match if they have the same class literal.
+                        (
+                            ClassType::NonGeneric(source_literal),
+                            ClassType::NonGeneric(target_literal),
+                        ) => ConstraintSet::from_bool(
                             self.constraints,
-                            source.origin(db) == target.origin(db),
-                        )
-                        .and(db, self.constraints, || {
-                            self.check_specialization_pair(
-                                db,
-                                source.specialization(db),
-                                target.specialization(db),
-                            )
-                        })
-                    }
+                            source_literal == target_literal,
+                        ),
 
-                    // Generic and non-generic classes don't match.
-                    (ClassType::Generic(_), ClassType::NonGeneric(_))
-                    | (ClassType::NonGeneric(_), ClassType::Generic(_)) => self.never(),
-                },
-            }
-        })
+                        // Two generic classes match if they have the same origin and compatible specializations.
+                        (ClassType::Generic(source), ClassType::Generic(target)) => {
+                            ConstraintSet::from_bool(
+                                self.constraints,
+                                source.origin(db) == target.origin(db),
+                            )
+                            .and(db, program, self.constraints, || {
+                                self.check_specialization_pair(
+                                    db,
+                                    source.specialization(db),
+                                    target.specialization(db),
+                                )
+                            })
+                        }
+
+                        // Generic and non-generic classes don't match.
+                        (ClassType::Generic(_), ClassType::NonGeneric(_))
+                        | (ClassType::NonGeneric(_), ClassType::Generic(_)) => self.never(),
+                    },
+                }
+            })
     }
 }
 
@@ -2502,15 +2627,21 @@ impl Field<'_> {
 impl<'db> Field<'db> {
     /// Returns true if this field is a `dataclasses.KW_ONLY` sentinel.
     /// <https://docs.python.org/3/library/dataclasses.html#dataclasses.KW_ONLY>
-    pub(crate) fn is_kw_only_sentinel(&self, db: &'db dyn Db) -> bool {
-        self.declared_ty.is_instance_of(db, KnownClass::KwOnly)
+    pub(crate) fn is_kw_only_sentinel(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.declared_ty
+            .is_instance_of(db, program, KnownClass::KwOnly)
     }
 }
 
 impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         match self {
-            Self::Static(class) => class.variance_of(db, typevar),
+            Self::Static(class) => class.variance_of(db, program, typevar),
             Self::Dynamic(_)
             | Self::DynamicNamedTuple(_)
             | Self::DynamicTypedDict(_)
@@ -2526,13 +2657,18 @@ impl<'db> VarianceInferable<'db> for ClassLiteral<'db> {
 /// use this to avoid duplicating the MRO traversal logic.
 pub(super) struct MroLookup<'db, I> {
     db: &'db dyn Db,
+    program: Program,
     mro_iter: I,
 }
 
 impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
     /// Create a new MRO lookup from a database and an MRO iterator.
-    pub(super) fn new(db: &'db dyn Db, mro_iter: I) -> Self {
-        Self { db, mro_iter }
+    pub(super) fn new(db: &'db dyn Db, program: Program, mro_iter: I) -> Self {
+        Self {
+            db,
+            program,
+            mro_iter,
+        }
     }
 
     /// Look up a class member by iterating through the MRO.
@@ -2557,6 +2693,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
         is_self_object: bool,
     ) -> ClassMemberResult<'db> {
         let db = self.db;
+        let program = self.program;
         let mut dynamic_type: Option<Type<'db>> = None;
         let mut lookup_result: LookupResult<'db> =
             Err(LookupError::Undefined(TypeQualifiers::empty()));
@@ -2600,6 +2737,7 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
                     lookup_result = lookup_result.or_else(|lookup_error| {
                         lookup_error.or_fall_back_to(
                             db,
+                            program,
                             class
                                 .own_class_member(db, inherited_generic_context, name)
                                 .inner,
@@ -2632,7 +2770,8 @@ impl<'db, I: Iterator<Item = ClassBase<'db>>> MroLookup<'db, I> {
     /// allowing the caller to handle this case specially.
     pub(super) fn instance_member(self, name: &str) -> InstanceMemberResult<'db> {
         let db = self.db;
-        let mut union = UnionBuilder::new(db);
+        let program = self.program;
+        let mut union = UnionBuilder::new(db, program);
         let mut union_qualifiers = TypeQualifiers::empty();
         let mut is_definitely_bound = false;
         let mut provenance = Provenance::Unknown;
@@ -2726,7 +2865,7 @@ pub(super) struct CompletedMemberLookup<'db> {
 
 impl<'db> CompletedMemberLookup<'db> {
     /// Finalize the lookup result by handling dynamic type intersection.
-    pub(super) fn finalize(self, db: &'db dyn Db) -> PlaceAndQualifiers<'db> {
+    pub(super) fn finalize(self, db: &'db dyn Db, program: Program) -> PlaceAndQualifiers<'db> {
         match (
             PlaceAndQualifiers::from(self.lookup_result),
             self.dynamic_type,
@@ -2739,9 +2878,11 @@ impl<'db> CompletedMemberLookup<'db> {
                     qualifiers,
                 },
                 Some(dynamic),
-            ) => Place::bound(IntersectionType::from_two_elements(db, ty, dynamic))
-                .with_provenance(provenance)
-                .with_qualifiers(qualifiers),
+            ) => Place::bound(IntersectionType::from_two_elements(
+                db, program, ty, dynamic,
+            ))
+            .with_provenance(provenance)
+            .with_qualifiers(qualifiers),
 
             (
                 PlaceAndQualifiers {
@@ -2790,7 +2931,7 @@ impl<'db> QualifiedClassName<'db> {
                 let body_scope = class.body_scope(self.db);
                 // Skip the class body scope itself.
                 (
-                    body_scope.file(self.db),
+                    body_scope.program_file(self.db),
                     body_scope.file_scope_id(self.db),
                     1,
                 )
@@ -2798,20 +2939,20 @@ impl<'db> QualifiedClassName<'db> {
             ClassLiteral::Dynamic(class) => {
                 // Dynamic classes don't have a body scope; start from the enclosing scope.
                 let scope = class.scope(self.db);
-                (scope.file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicNamedTuple(namedtuple) => {
                 // Dynamic namedtuples don't have a body scope; start from the enclosing scope.
                 let scope = namedtuple.scope(self.db);
-                (scope.file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicTypedDict(typeddict) => {
                 let scope = typeddict.scope(self.db);
-                (scope.file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
             ClassLiteral::DynamicEnum(enum_lit) => {
                 let scope = enum_lit.scope(self.db);
-                (scope.file(self.db), scope.file_scope_id(self.db), 0)
+                (scope.program_file(self.db), scope.file_scope_id(self.db), 0)
             }
         };
 
@@ -2951,13 +3092,13 @@ enum SlotsKind {
 }
 
 impl SlotsKind {
-    fn from(db: &dyn Db, base: StaticClassLiteral) -> Self {
+    fn from(db: &dyn Db, program: crate::Program, base: StaticClassLiteral) -> Self {
         let Place::Defined(DefinedPlace {
             ty: slots_ty,
             definedness: bound,
             ..
         }) = base
-            .own_class_member(db, base.inherited_generic_context(db), None, "__slots__")
+            .own_class_member(db, None, None, "__slots__")
             .inner
             .place
         else {
@@ -2971,7 +3112,7 @@ impl SlotsKind {
         match slots_ty {
             // __slots__ = ("a", "b")
             Type::NominalInstance(nominal) => match nominal
-                .tuple_spec(db)
+                .tuple_spec(db, program)
                 .and_then(|spec| spec.len().into_fixed_length())
             {
                 Some(0) => Self::Empty,

--- a/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/dynamic_literal.rs
@@ -122,10 +122,11 @@ impl<'db> DynamicClassAnchor<'db> {
                 offset,
                 explicit_bases,
             } => {
+                let program = scope.program(db);
                 let explicit_bases = explicit_bases
                     .iter()
                     .map(|base| {
-                        let base = base.recursive_type_normalized_impl(db, div, true);
+                        let base = base.recursive_type_normalized_impl(db, program, div, true);
                         if nested {
                             base
                         } else {
@@ -178,6 +179,10 @@ impl<'db> DynamicClassLiteral<'db> {
         }
     }
 
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.scope(db).program(db)
+    }
+
     /// Returns the explicit base classes of this dynamic class.
     ///
     /// For assigned calls, bases are computed lazily using deferred inference to handle
@@ -199,7 +204,9 @@ impl<'db> DynamicClassLiteral<'db> {
             db: &'db dyn Db,
             definition: Definition<'db>,
         ) -> Box<[Type<'db>]> {
-            let module = parsed_module(db, definition.file(db)).load(db);
+            let program_file = definition.program_file(db);
+            let program = program_file.program(db);
+            let module = program_file.parsed(db).load(db);
 
             let value = definition
                 .kind(db)
@@ -214,7 +221,7 @@ impl<'db> DynamicClassLiteral<'db> {
             };
 
             // Use `definition_expression_type` for deferred inference support.
-            extract_fixed_length_iterable_element_types(db, bases_arg, |expr| {
+            extract_fixed_length_iterable_element_types(db, program, bases_arg, |expr| {
                 definition_expression_type(db, definition, expr)
             })
             .unwrap_or_else(|| Box::from([Type::unknown()]))
@@ -238,8 +245,7 @@ impl<'db> DynamicClassLiteral<'db> {
     /// Returns the range of the `type()` call expression that created this class.
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let scope = self.scope(db);
-        let file = scope.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
 
         match self.anchor(db) {
             DynamicClassAnchor::Definition(definition) => {
@@ -290,13 +296,14 @@ impl<'db> DynamicClassLiteral<'db> {
         self,
         db: &'db dyn Db,
     ) -> Result<Type<'db>, DynamicMetaclassConflict<'db>> {
+        let program = self.program(db);
         let original_bases = self.explicit_bases(db);
 
         // If no bases, metaclass is `type`.
         // To dynamically create a class with no bases that has a custom metaclass,
         // you have to invoke that metaclass rather than `type()`.
         if original_bases.is_empty() {
-            return Ok(KnownClass::Type.to_class_literal(db));
+            return Ok(KnownClass::Type.to_class_literal(db, program));
         }
 
         // If there's an MRO error, return unknown to avoid cascading errors.
@@ -309,23 +316,23 @@ impl<'db> DynamicClassLiteral<'db> {
         // returned `Err(InvalidBases)` if any failed, causing us to return early.
         let bases: Vec<ClassBase<'db>> = original_bases
             .iter()
-            .filter_map(|base_type| ClassBase::try_from_type(db, *base_type, None))
+            .filter_map(|base_type| ClassBase::try_from_type(db, program, *base_type, None))
             .collect();
 
         // If all bases failed to convert, return type as the metaclass.
         if bases.is_empty() {
-            return Ok(KnownClass::Type.to_class_literal(db));
+            return Ok(KnownClass::Type.to_class_literal(db, program));
         }
 
         // Start with the first base's metaclass as the candidate.
-        let mut candidate = bases[0].metaclass(db);
+        let mut candidate = bases[0].metaclass(db, program);
 
         // Track which base the candidate metaclass came from.
         let (mut candidate_base, rest) = bases.split_first().unwrap();
 
         // Reconcile with other bases' metaclasses.
         for base in rest {
-            let base_metaclass = base.metaclass(db);
+            let base_metaclass = base.metaclass(db, program);
 
             // Get the ClassType for comparison.
             let Some(candidate_class) = candidate.to_class_type(db) else {
@@ -374,13 +381,14 @@ impl<'db> DynamicClassLiteral<'db> {
 
     /// Look up an instance member by iterating through the MRO.
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
-        match MroLookup::new(db, self.iter_mro(db)).instance_member(name) {
+        let program = self.scope(db).program(db);
+        match MroLookup::new(db, program, self.iter_mro(db)).instance_member(name) {
             InstanceMemberResult::Done(result) => result,
             InstanceMemberResult::TypedDict => {
                 // Simplified `TypedDict` handling without type mapping.
                 KnownClass::TypedDictFallback
-                    .to_instance(db)
-                    .instance_member(db, name)
+                    .to_instance(db, program)
+                    .instance_member(db, program, name)
             }
         }
     }
@@ -396,6 +404,7 @@ impl<'db> DynamicClassLiteral<'db> {
         name: &str,
         policy: MemberLookupPolicy,
     ) -> PlaceAndQualifiers<'db> {
+        let program = self.scope(db).program(db);
         // Check if this dynamic class is dataclass-like (via dataclass_transform inheritance).
         if CodeGeneratorKind::from_class(db, self.into())
             .is_some_and(CodeGeneratorKind::is_dataclass_like)
@@ -404,9 +413,10 @@ impl<'db> DynamicClassLiteral<'db> {
                 // Make this class look like a subclass of the `DataClassInstance` protocol.
                 return Place::declared(KnownClass::Dict.to_specialized_instance(
                     db,
+                    program,
                     &[
-                        KnownClass::Str.to_instance(db),
-                        KnownClass::Field.to_specialized_instance(db, &[Type::any()]),
+                        KnownClass::Str.to_instance(db, program),
+                        KnownClass::Field.to_specialized_instance(db, program, &[Type::any()]),
                     ],
                 ))
                 .with_qualifiers(TypeQualifiers::CLASS_VAR);
@@ -416,15 +426,15 @@ impl<'db> DynamicClassLiteral<'db> {
             }
         }
 
-        let result = MroLookup::new(db, self.iter_mro(db)).class_member(
+        let result = MroLookup::new(db, program, self.iter_mro(db)).class_member(
             name, policy, None,  // No inherited generic context.
             false, // Dynamic classes are never `object`.
         );
 
         match result {
-            ClassMemberResult::Done(result) => result.finalize(db),
+            ClassMemberResult::Done(result) => result.finalize(db, program),
             ClassMemberResult::TypedDict(module) => {
-                typed_dict_fallback_class_member(db, module, policy, name)
+                typed_dict_fallback_class_member(db, program, module, policy, name)
             }
         }
     }
@@ -459,9 +469,10 @@ impl<'db> DynamicClassLiteral<'db> {
     #[salsa::tracked(
         returns(ref),
         cycle_initial=|db, _, self_: DynamicClassLiteral<'db>| {
+            let program = self_.scope(db).program(db);
             Ok(Mro::from([
                 ClassBase::Class(ClassType::NonGeneric(ClassLiteral::Dynamic(self_))),
-                ClassBase::object(db),
+                ClassBase::object(db, program),
             ]))
         },
         heap_size=ruff_memory_usage::heap_size
@@ -478,15 +489,18 @@ impl<'db> DynamicClassLiteral<'db> {
     /// X = type("X", (), {"__slots__": ("a",)})
     /// ```
     pub(super) fn as_disjoint_base(self, db: &'db dyn Db) -> Option<DisjointBase<'db>> {
+        let program = self.program(db);
         // Check if __slots__ is in the members
         for (name, ty) in self.members(db) {
             if name.as_str() == "__slots__" {
                 // Check if the slots are non-empty
                 let is_non_empty = match ty {
                     // __slots__ = ("a", "b")
-                    Type::NominalInstance(nominal) => nominal.tuple_spec(db).is_some_and(|spec| {
-                        spec.len().into_fixed_length().is_some_and(|len| len > 0)
-                    }),
+                    Type::NominalInstance(nominal) => {
+                        nominal.tuple_spec(db, program).is_some_and(|spec| {
+                            spec.len().into_fixed_length().is_some_and(|len| len > 0)
+                        })
+                    }
                     // __slots__ = "abc"  # Same as ("abc",)
                     Type::LiteralValue(literal) if literal.is_string() => true,
                     // Other types are considered dynamic/unknown
@@ -539,6 +553,7 @@ impl<'db> DynamicClassLiteral<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let program = self.program(db);
         let anchor = self
             .anchor(db)
             .recursive_type_normalized_impl(db, div, nested)?;
@@ -546,13 +561,13 @@ impl<'db> DynamicClassLiteral<'db> {
             .members(db)
             .iter()
             .map(|(name, ty)| {
-                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                let ty = ty.recursive_type_normalized_impl(db, program, div, true);
                 let ty = if nested { ty? } else { ty.unwrap_or(div) };
                 Some((name.clone(), ty))
             })
             .collect::<Option<Box<_>>>()?;
         let dataclass_params = match self.dataclass_params(db) {
-            Some(params) => Some(params.recursive_type_normalized_impl(db, div, nested)?),
+            Some(params) => Some(params.recursive_type_normalized_impl(db, program, div, nested)?),
             None => None,
         };
 

--- a/crates/ty_python_semantic/src/types/class/enum_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/enum_literal.rs
@@ -28,6 +28,7 @@ impl<'db> EnumSpec<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -35,7 +36,7 @@ impl<'db> EnumSpec<'db> {
             .members(db)
             .iter()
             .map(|(name, ty)| {
-                let ty = ty.recursive_type_normalized_impl(db, div, true);
+                let ty = ty.recursive_type_normalized_impl(db, program, div, true);
                 let ty = if nested { ty? } else { ty.unwrap_or(div) };
                 Some((name.clone(), ty))
             })
@@ -73,19 +74,25 @@ impl<'db> DynamicEnumAnchor<'db> {
         nested: bool,
     ) -> Option<Self> {
         match self {
-            Self::Definition { definition, spec } => Some(Self::Definition {
-                definition: *definition,
-                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            Self::Definition { definition, spec } => {
+                let program = definition.program_file(db).program(db);
+                Some(Self::Definition {
+                    definition: *definition,
+                    spec: spec.recursive_type_normalized_impl(db, program, div, nested)?,
+                })
+            }
             Self::ScopeOffset {
                 scope,
                 offset,
                 spec,
-            } => Some(Self::ScopeOffset {
-                scope: *scope,
-                offset: *offset,
-                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            } => {
+                let program = scope.program(db);
+                Some(Self::ScopeOffset {
+                    scope: *scope,
+                    offset: *offset,
+                    spec: spec.recursive_type_normalized_impl(db, program, div, nested)?,
+                })
+            }
         }
     }
 }
@@ -112,9 +119,10 @@ impl<'db> DynamicEnumLiteral<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let program = self.scope(db).program(db);
         let mixin_type = match self.mixin_type(db) {
             Some(mixin) => {
-                let mixin = mixin.recursive_type_normalized_impl(db, div, true);
+                let mixin = mixin.recursive_type_normalized_impl(db, program, div, true);
                 Some(if nested { mixin? } else { mixin.unwrap_or(div) })
             }
             None => None,
@@ -147,6 +155,10 @@ impl<'db> DynamicEnumLiteral<'db> {
         }
     }
 
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.scope(db).program(db)
+    }
+
     pub(crate) fn spec(self, db: &'db dyn Db) -> EnumSpec<'db> {
         match self.anchor(db) {
             DynamicEnumAnchor::Definition { spec, .. }
@@ -155,18 +167,18 @@ impl<'db> DynamicEnumLiteral<'db> {
     }
 
     pub(crate) fn explicit_bases(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
+        let program = self.program(db);
         let mut bases = Vec::with_capacity(2);
         if let Some(mixin) = self.mixin_type(db) {
             bases.push(mixin);
         }
-        bases.push(self.base_class(db).to_class_literal(db));
+        bases.push(self.base_class(db).to_class_literal(db, program));
         bases.into_boxed_slice()
     }
 
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let scope = self.scope(db);
-        let file = scope.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
         match self.anchor(db) {
             DynamicEnumAnchor::Definition { definition, .. } => definition
                 .kind(db)
@@ -192,18 +204,18 @@ impl<'db> DynamicEnumLiteral<'db> {
         Span::from(self.scope(db).file(db)).with_range(self.header_range(db))
     }
 
-    #[expect(clippy::unused_self)]
     pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
-        KnownClass::EnumType.to_class_literal(db)
+        KnownClass::EnumType.to_class_literal(db, self.scope(db).program(db))
     }
 
     #[salsa::tracked(
         returns(ref),
         heap_size=ruff_memory_usage::heap_size,
         cycle_initial=|db, _, self_: DynamicEnumLiteral<'db>| {
+            let program = self_.scope(db).program(db);
             Ok(Mro::from([
                 ClassBase::Class(ClassType::NonGeneric(ClassLiteral::DynamicEnum(self_))),
-                ClassBase::object(db),
+                ClassBase::object(db, program),
             ]))
         }
     )]
@@ -216,8 +228,9 @@ impl<'db> DynamicEnumLiteral<'db> {
     }
 
     fn mixin_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
+        let program = self.program(db);
         let mixin = self.mixin_type(db)?;
-        let ClassBase::Class(class) = ClassBase::try_from_type(db, mixin, None)? else {
+        let ClassBase::Class(class) = ClassBase::try_from_type(db, program, mixin, None)? else {
             return None;
         };
         Some(class)
@@ -259,6 +272,7 @@ impl<'db> DynamicEnumLiteral<'db> {
     /// If members are unknown and nothing was found in the MRO, returns `Unknown`
     /// as a last resort to avoid false `unresolved-attribute` errors.
     pub(crate) fn class_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        let program = self.program(db);
         let own = self.own_class_member(db, name);
         if !own.is_undefined() {
             return own.inner;
@@ -271,7 +285,7 @@ impl<'db> DynamicEnumLiteral<'db> {
         }
         let result = self
             .base_class(db)
-            .to_class_literal(db)
+            .to_class_literal(db, program)
             .as_class_literal()
             .map(|cls| cls.class_member(db, name, MemberLookupPolicy::default()))
             .unwrap_or_else(|| Place::Undefined.into());
@@ -288,6 +302,7 @@ impl<'db> DynamicEnumLiteral<'db> {
     /// If members are unknown and nothing was found, returns `Unknown`
     /// as a last resort.
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        let program = self.program(db);
         if let Some(mixin_class) = self.mixin_class(db) {
             let result = mixin_class.instance_member(db, name);
             if !result.place.is_undefined() {
@@ -296,8 +311,8 @@ impl<'db> DynamicEnumLiteral<'db> {
         }
         let result = self
             .base_class(db)
-            .to_instance(db)
-            .instance_member(db, name);
+            .to_instance(db, program)
+            .instance_member(db, program, name);
 
         self.with_unknown_member_fallback(db, result)
     }

--- a/crates/ty_python_semantic/src/types/class/known.rs
+++ b/crates/ty_python_semantic/src/types/class/known.rs
@@ -13,7 +13,6 @@ use crate::{
         known_instance::DeprecatedInstance,
     },
 };
-use ruff_db::files::File;
 use ruff_python_ast as ast;
 use ruff_python_ast::PythonVersion;
 use rustc_hash::FxHashSet;
@@ -22,7 +21,9 @@ use std::{
     sync::{LazyLock, Mutex},
 };
 use ty_module_resolver::{KnownModule, file_to_module};
-use ty_python_core::{SemanticIndex, Truthiness, scope::NodeWithScopeKind};
+use ty_python_core::{
+    SemanticIndex, Truthiness, environment::ProgramFile, scope::NodeWithScopeKind,
+};
 
 /// Non-exhaustive enumeration of known classes (e.g. `builtins.int`, `typing.Any`, ...) to allow
 /// for easier syntax when interacting with very common classes.
@@ -863,7 +864,11 @@ impl KnownClass {
         }
     }
 
-    pub(crate) fn name(self, db: &dyn Db) -> &'static str {
+    pub(crate) fn name(self, db: &dyn Db, program: Program) -> &'static str {
+        self.name_for_version(program.python_version(db))
+    }
+
+    fn name_for_version(self, python_version: PythonVersion) -> &'static str {
         match self {
             Self::Bool => "bool",
             Self::Object => "object",
@@ -929,7 +934,7 @@ impl KnownClass {
             Self::Enum => "Enum",
             Self::EnumProperty => "property",
             Self::EnumType => {
-                if Program::get(db).python_version(db) >= PythonVersion::PY311 {
+                if python_version >= PythonVersion::PY311 {
                     "EnumType"
                 } else {
                     "EnumMeta"
@@ -984,9 +989,10 @@ impl KnownClass {
         }
     }
 
-    pub(crate) fn display(self, db: &dyn Db) -> impl std::fmt::Display + '_ {
+    pub(crate) fn display(self, db: &dyn Db, program: Program) -> impl std::fmt::Display + '_ {
         struct KnownClassDisplay<'db> {
             db: &'db dyn Db,
+            program: Program,
             class: KnownClass,
         }
 
@@ -995,17 +1001,22 @@ impl KnownClass {
                 let KnownClassDisplay {
                     class: known_class,
                     db,
+                    program,
                 } = *self;
                 write!(
                     f,
                     "{module}.{class}",
-                    module = known_class.canonical_module(db),
-                    class = known_class.name(db)
+                    module = known_class.canonical_module(db, program),
+                    class = known_class.name(db, program)
                 )
             }
         }
 
-        KnownClassDisplay { db, class: self }
+        KnownClassDisplay {
+            db,
+            program,
+            class: self,
+        }
     }
 
     /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing all
@@ -1014,39 +1025,39 @@ impl KnownClass {
     ///
     /// If the class cannot be found, a debug-level log message will be emitted stating this.
     #[track_caller]
-    pub fn to_instance(self, db: &dyn Db) -> Type<'_> {
+    pub fn to_instance(self, db: &dyn Db, program: Program) -> Type<'_> {
         debug_assert_ne!(
             self,
             KnownClass::Tuple,
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
-
         #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
         fn known_class_to_instance<'db>(
             db: &'db dyn Db,
             class: KnownClassArgument<'db>,
         ) -> Type<'db> {
+            let program = class.program(db);
             class
                 .class(db)
-                .to_class_literal(db)
+                .to_class_literal(db, program)
                 .to_class_type(db)
                 .map(|class| Type::instance(db, class))
                 .unwrap_or_else(Type::unknown)
         }
 
-        known_class_to_instance(db, KnownClassArgument::new(db, self))
+        known_class_to_instance(db, KnownClassArgument::new(db, program, self))
     }
 
     /// Similar to [`KnownClass::to_instance`], but returns the Unknown-specialization where each type
     /// parameter is specialized to `Unknown`.
     #[track_caller]
-    pub(crate) fn to_instance_unknown(self, db: &dyn Db) -> Type<'_> {
+    pub(crate) fn to_instance_unknown(self, db: &dyn Db, program: Program) -> Type<'_> {
         debug_assert_ne!(
             self,
             KnownClass::Tuple,
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
-        self.try_to_class_literal(db)
+        self.try_to_class_literal(db, program)
             .map(|literal| Type::instance(db, literal.unknown_specialization(db)))
             .unwrap_or_else(Type::unknown)
     }
@@ -1059,6 +1070,7 @@ impl KnownClass {
     pub(crate) fn to_specialized_class_type<'t, 'db, T>(
         self,
         db: &'db dyn Db,
+        program: Program,
         specialization: T,
     ) -> Option<ClassType<'db>>
     where
@@ -1078,10 +1090,11 @@ impl KnownClass {
                 static MESSAGES: LazyLock<Mutex<FxHashSet<KnownClass>>> =
                     LazyLock::new(Mutex::default);
                 if MESSAGES.lock().unwrap().insert(class) {
+                    let program = class_literal.program(db);
                     tracing::info!(
                         "Wrong number of types when specializing {}. \
                  Falling back to default specialization for the symbol instead.",
-                        class.display(db)
+                        class.display(db, program)
                     );
                 }
                 return class_literal.default_specialization(db);
@@ -1091,7 +1104,10 @@ impl KnownClass {
                 .apply_specialization(db, |_| generic_context.specialize(db, specialization))
         }
 
-        let class_literal = self.to_class_literal(db).as_class_literal()?.as_static()?;
+        let class_literal = self
+            .to_class_literal(db, program)
+            .as_class_literal()?
+            .as_static()?;
         let generic_context = class_literal.generic_context(db)?;
         let specialization = specialization.into();
 
@@ -1113,6 +1129,7 @@ impl KnownClass {
     pub(crate) fn to_specialized_instance<'t, 'db, T>(
         self,
         db: &'db dyn Db,
+        program: Program,
         specialization: T,
     ) -> Type<'db>
     where
@@ -1124,8 +1141,8 @@ impl KnownClass {
             KnownClass::Tuple,
             "Use `Type::heterogeneous_tuple` or `Type::homogeneous_tuple` to create `tuple` instances"
         );
-        self.to_specialized_class_type(db, specialization)
-            .and_then(|class_type| Type::from(class_type).to_instance(db))
+        self.to_specialized_class_type(db, program, specialization)
+            .and_then(|class_type| Type::from(class_type).to_instance(db, program))
             .unwrap_or_else(Type::unknown)
     }
 
@@ -1135,16 +1152,21 @@ impl KnownClass {
     fn lookup_class_literal(
         self,
         db: &dyn Db,
+        program: Program,
     ) -> Result<Option<StaticClassLiteral<'_>>, KnownClassLookupError<'_>> {
         #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| Ok(None), heap_size=ruff_memory_usage::heap_size)]
         fn known_class_to_class_literal<'db>(
             db: &'db dyn Db,
             class: KnownClassArgument<'db>,
         ) -> Result<Option<StaticClassLiteral<'db>>, KnownClassLookupError<'db>> {
+            let program = class.program(db);
             let class = class.class(db);
-            let module = class.canonical_module(db);
+            let python_version = program.python_version(db);
+            let module = class.canonical_module_for_version(python_version);
             let third_party = module.is_third_party();
-            let symbol = known_module_symbol(db, module, class.name(db)).place;
+            let symbol =
+                known_module_symbol(db, program, module, class.name_for_version(python_version))
+                    .place;
             let result = match symbol {
                 Place::Defined(DefinedPlace {
                     ty: Type::ClassLiteral(ClassLiteral::Static(class_literal)),
@@ -1173,11 +1195,14 @@ impl KnownClass {
                     lookup_error,
                     KnownClassLookupError::ClassPossiblyUnbound { .. }
                 ) {
-                    tracing::info!("{}", lookup_error.display(db, class));
+                    tracing::info!(
+                        "{}",
+                        lookup_error.display(db, program, class, python_version)
+                    );
                 } else {
                     tracing::info!(
                         "{}. Falling back to `Unknown` for the symbol instead.",
-                        lookup_error.display(db, class)
+                        lookup_error.display(db, program, class, python_version)
                     );
                 }
             }
@@ -1185,15 +1210,19 @@ impl KnownClass {
             result
         }
 
-        known_class_to_class_literal(db, KnownClassArgument::new(db, self))
+        known_class_to_class_literal(db, KnownClassArgument::new(db, program, self))
     }
 
     /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that
     /// class literal.
     ///
     /// If the class cannot be found, a debug-level log message will be emitted stating this.
-    pub(crate) fn try_to_class_literal(self, db: &dyn Db) -> Option<StaticClassLiteral<'_>> {
-        match self.lookup_class_literal(db) {
+    pub(crate) fn try_to_class_literal(
+        self,
+        db: &dyn Db,
+        program: Program,
+    ) -> Option<StaticClassLiteral<'_>> {
+        match self.lookup_class_literal(db, program) {
             Ok(class_literal) => class_literal,
             Err(KnownClassLookupError::ClassPossiblyUnbound { class_literal, .. }) => {
                 Some(class_literal)
@@ -1209,51 +1238,62 @@ impl KnownClass {
     /// class literal.
     ///
     /// If the class cannot be found, a debug-level log message will be emitted stating this.
-    pub(crate) fn to_class_literal(self, db: &dyn Db) -> Type<'_> {
-        self.try_to_class_literal(db)
+    pub(crate) fn to_class_literal(self, db: &dyn Db, program: Program) -> Type<'_> {
+        self.try_to_class_literal(db, program)
             .map(|class| Type::ClassLiteral(ClassLiteral::Static(class)))
             .unwrap_or_else(Type::unknown)
     }
 
-    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that class
-    /// and all possible subclasses of the class.
+    /// Look up a [`KnownClass`] in its canonical module and return a [`Type`] representing that
+    /// class and all possible subclasses of the class.
     ///
     /// If the class cannot be found, a debug-level log message will be emitted stating this.
-    pub fn to_subclass_of(self, db: &dyn Db) -> Type<'_> {
-        self.to_class_literal(db)
+    pub fn to_subclass_of(self, db: &dyn Db, program: Program) -> Type<'_> {
+        self.to_class_literal(db, program)
             .to_class_type(db)
-            .map(|class| SubclassOfType::from(db, class))
+            .map(|class| SubclassOfType::from(db, program, class))
             .unwrap_or_else(SubclassOfType::subclass_of_unknown)
     }
 
     pub(crate) fn to_specialized_subclass_of<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         specialization: &[Type<'db>],
     ) -> Type<'db> {
-        self.to_specialized_class_type(db, specialization)
-            .map(|class_type| SubclassOfType::from(db, class_type))
+        self.to_specialized_class_type(db, program, specialization)
+            .map(|class_type| SubclassOfType::from(db, program, class_type))
             .unwrap_or_else(SubclassOfType::subclass_of_unknown)
     }
 
     /// Return `true` if this symbol can be resolved to a class definition `class` in its canonical
     /// module, *and* `class` is a subclass of `other`.
-    pub(crate) fn is_subclass_of<'db>(self, db: &'db dyn Db, other: ClassType<'db>) -> bool {
-        self.lookup_class_literal(db)
+    pub(crate) fn is_subclass_of<'db>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        other: ClassType<'db>,
+    ) -> bool {
+        self.lookup_class_literal(db, program)
             .is_ok_and(|class| class.is_some_and(|class| class.is_subclass_of(db, None, other)))
     }
 
     pub(crate) fn when_subclass_of<'db, 'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: ClassType<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        ConstraintSet::from_bool(constraints, self.is_subclass_of(db, other))
+        ConstraintSet::from_bool(constraints, self.is_subclass_of(db, program, other))
     }
 
     /// Return the module in which we should look up the definition for this class
-    pub(super) fn canonical_module(self, db: &dyn Db) -> KnownModule {
+    pub(super) fn canonical_module(self, db: &dyn Db, program: Program) -> KnownModule {
+        self.canonical_module_for_version(program.python_version(db))
+    }
+
+    fn canonical_module_for_version(self, python_version: PythonVersion) -> KnownModule {
         match self {
             Self::Bool
             | Self::Object
@@ -1333,15 +1373,13 @@ impl KnownClass {
             | Self::ExtensionTypedDictFallback
             | Self::NewType => KnownModule::TypingExtensions,
             Self::Sentinel => {
-                if Program::get(db).python_version(db) >= PythonVersion::PY315 {
+                if python_version >= PythonVersion::PY315 {
                     KnownModule::Builtins
                 } else {
                     KnownModule::TypingExtensions
                 }
             }
             Self::NoDefaultType => {
-                let python_version = Program::get(db).python_version(db);
-
                 // typing_extensions has a 3.13+ re-export for the `typing.NoDefault`
                 // singleton, but not for `typing._NoDefaultType`. So we need to switch
                 // to `typing._NoDefaultType` for newer versions:
@@ -1604,11 +1642,13 @@ impl KnownClass {
         }
     }
 
-    pub(crate) fn try_from_file_and_name(
+    pub(crate) fn try_from_program_file_and_name(
         db: &dyn Db,
-        file: File,
+        program_file: ProgramFile<'_>,
         class_name: &str,
     ) -> Option<Self> {
+        let python_version = program_file.program(db).python_version(db);
+
         // We assert that this match is exhaustive over the right-hand side in the unit test
         // `known_class_roundtrip_from_str()`
         let candidates: &[Self] = match class_name {
@@ -1680,12 +1720,8 @@ impl KnownClass {
             "SupportsIndex" => &[Self::SupportsIndex],
             "Enum" => &[Self::Enum],
             "EnumMeta" => &[Self::EnumType],
-            "EnumType" if Program::get(db).python_version(db) >= PythonVersion::PY311 => {
-                &[Self::EnumType]
-            }
-            "StrEnum" if Program::get(db).python_version(db) >= PythonVersion::PY311 => {
-                &[Self::StrEnum]
-            }
+            "EnumType" if python_version >= PythonVersion::PY311 => &[Self::EnumType],
+            "StrEnum" if python_version >= PythonVersion::PY311 => &[Self::StrEnum],
             "IntEnum" => &[Self::IntEnum],
             "Flag" => &[Self::Flag],
             "IntFlag" => &[Self::IntFlag],
@@ -1718,16 +1754,16 @@ impl KnownClass {
             _ => return None,
         };
 
-        let module = file_to_module(db, file)?.known(db)?;
+        let module = file_to_module(db, program_file.resolver_file(db))?.known(db)?;
 
         candidates
             .iter()
             .copied()
-            .find(|&candidate| candidate.check_module(db, module))
+            .find(|&candidate| candidate.check_module_for_version(python_version, module))
     }
 
-    /// Return `true` if the module of `self` matches `module`
-    fn check_module(self, db: &dyn Db, module: KnownModule) -> bool {
+    /// Returns `true` if the module of `self` matches `module` for `python_version`.
+    fn check_module_for_version(self, python_version: PythonVersion, module: KnownModule) -> bool {
         match self {
             Self::Bool
             | Self::Object
@@ -1815,7 +1851,9 @@ impl KnownClass {
             | Self::PydanticBaseSettings
             | Self::PydanticConfigDict
             | Self::PydanticRootModel
-            | Self::PydanticStrict => module == self.canonical_module(db),
+            | Self::PydanticStrict => {
+                module == self.canonical_module_for_version(python_version)
+            }
             Self::NoneType => matches!(module, KnownModule::Typeshed | KnownModule::Types),
             Self::SpecialForm
             | Self::TypeAliasType
@@ -1846,6 +1884,7 @@ impl KnownClass {
         call_expression: &ast::ExprCall,
     ) {
         let db = context.db();
+        let program = context.program();
         let scope = context.scope();
         let module = context.module();
 
@@ -1907,6 +1946,7 @@ impl KnownClass {
 
                         let bound_super = BoundSuperType::build(
                             db,
+                            program,
                             Type::ClassLiteral(ClassLiteral::Static(enclosing_class)),
                             first_param,
                         )
@@ -1934,11 +1974,12 @@ impl KnownClass {
                             }
                         }
 
-                        let bound_super = BoundSuperType::build(db, *pivot_class_type, *owner_type)
-                            .unwrap_or_else(|err| {
-                                err.report_diagnostic(context, call_expression.into());
-                                Type::unknown()
-                            });
+                        let bound_super =
+                            BoundSuperType::build(db, program, *pivot_class_type, *owner_type)
+                                .unwrap_or_else(|err| {
+                                    err.report_diagnostic(context, call_expression.into());
+                                    Type::unknown()
+                                });
                         overload.set_return_type(bound_super);
                     }
                     _ => {}
@@ -1982,11 +2023,13 @@ impl KnownClass {
 #[salsa::interned(heap_size=ruff_memory_usage::heap_size)]
 struct KnownClassArgument {
     #[returns(copy)]
+    program: Program,
+    #[returns(copy)]
     class: KnownClass,
 }
 
 /// Enumeration of ways in which looking up a [`KnownClass`] in its canonical module could fail.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) enum KnownClassLookupError<'db> {
     /// There is no symbol by that name in the expected module.
     ClassNotFound { third_party: bool },
@@ -2012,19 +2055,36 @@ impl<'db> KnownClassLookupError<'db> {
         }
     }
 
-    fn display(&self, db: &'db dyn Db, class: KnownClass) -> impl std::fmt::Display + 'db {
+    fn display(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        class: KnownClass,
+        python_version: PythonVersion,
+    ) -> impl std::fmt::Display + 'db {
         struct ErrorDisplay<'db> {
             db: &'db dyn Db,
+            program: Program,
             class: KnownClass,
+            python_version: PythonVersion,
             error: KnownClassLookupError<'db>,
         }
 
         impl std::fmt::Display for ErrorDisplay<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                let ErrorDisplay { db, class, error } = *self;
+                let ErrorDisplay {
+                    db,
+                    program,
+                    class,
+                    python_version,
+                    error,
+                } = *self;
 
-                let class = class.display(db);
-                let python_version = Program::get(db).python_version(db);
+                let class = format_args!(
+                    "{}.{}",
+                    class.canonical_module_for_version(python_version),
+                    class.name_for_version(python_version)
+                );
                 let location = if error.is_third_party() {
                     ""
                 } else {
@@ -2040,7 +2100,7 @@ impl<'db> KnownClassLookupError<'db> {
                         f,
                         "Error looking up `{class}`{location}: expected to find a class definition \
                         on Python {python_version}, but found a symbol of type `{found_type}` instead",
-                        found_type = found_type.display(db),
+                        found_type = found_type.display(db, program),
                     ),
                     KnownClassLookupError::ClassPossiblyUnbound { .. } => write!(
                         f,
@@ -2053,7 +2113,9 @@ impl<'db> KnownClassLookupError<'db> {
 
         ErrorDisplay {
             db,
+            program,
             class,
+            python_version,
             error: *self,
         }
     }
@@ -2063,32 +2125,34 @@ impl<'db> KnownClassLookupError<'db> {
 mod tests {
     use super::*;
     use crate::db::tests::setup_db;
-    use crate::{PythonVersionSource, PythonVersionWithSource};
-    use salsa::Setter;
     use strum::IntoEnumIterator;
     use ty_module_resolver::resolve_module_confident;
+
+    fn set_python_version(db: &mut crate::db::tests::TestDb, version: PythonVersion) {
+        db.set_python_version(version);
+    }
 
     #[test]
     fn known_class_roundtrip_from_str() {
         let mut db = setup_db();
-        Program::get(&db)
-            .set_python_version_with_source(&mut db)
-            .to(PythonVersionWithSource {
-                version: PythonVersion::latest_preview(),
-                source: PythonVersionSource::default(),
-            });
+        set_python_version(&mut db, PythonVersion::latest_preview());
+        let program = db.program();
         for class in KnownClass::iter() {
-            if class.canonical_module(&db).is_third_party() {
+            if class.canonical_module(&db, program).is_third_party() {
                 continue;
             }
-            let class_name = class.name(&db);
-            let class_module =
-                resolve_module_confident(&db, &class.canonical_module(&db).name()).unwrap();
+            let class_name = class.name(&db, program);
+            let class_module = resolve_module_confident(
+                &db,
+                program.resolver(&db),
+                &class.canonical_module(&db, program).name(),
+            )
+            .unwrap();
 
             assert_eq!(
-                KnownClass::try_from_file_and_name(
+                KnownClass::try_from_program_file_and_name(
                     &db,
-                    class_module.file(&db).unwrap(),
+                    ProgramFile::new(&db, program, class_module.file(&db).unwrap()),
                     class_name
                 ),
                 Some(class),
@@ -2101,26 +2165,22 @@ mod tests {
     fn known_class_doesnt_fallback_to_unknown_unexpectedly_on_latest_version() {
         let mut db = setup_db();
 
-        Program::get(&db)
-            .set_python_version_with_source(&mut db)
-            .to(PythonVersionWithSource {
-                version: PythonVersion::latest_ty(),
-                source: PythonVersionSource::default(),
-            });
+        set_python_version(&mut db, PythonVersion::latest_ty());
+        let program = db.program();
 
         for class in KnownClass::iter() {
-            if class.canonical_module(&db).is_third_party() {
+            if class.canonical_module(&db, program).is_third_party() {
                 continue;
             }
             // Check the class can be looked up successfully
-            class.try_to_class_literal(&db).unwrap();
+            class.try_to_class_literal(&db, program).unwrap();
 
             // We can't call `KnownClass::Tuple.to_instance()`;
             // there are assertions to ensure that we always call `Type::homogeneous_tuple()`
             // or `Type::heterogeneous_tuple()` instead.`
             if class != KnownClass::Tuple {
                 assert_ne!(
-                    class.to_instance(&db),
+                    class.to_instance(&db, program),
                     Type::unknown(),
                     "Unexpectedly fell back to `Unknown` for `{class:?}`"
                 );
@@ -2136,8 +2196,9 @@ mod tests {
         // and sort them according to the version they were added in.
         // This makes the test far faster as it minimizes the number of times
         // we need to change the Python version in the loop.
+        let program = db.program();
         let mut classes: Vec<(KnownClass, PythonVersion)> = KnownClass::iter()
-            .filter(|class| !class.canonical_module(&db).is_third_party())
+            .filter(|class| !class.canonical_module(&db, program).is_third_party())
             .map(|class| {
                 let version_added = match class {
                     KnownClass::Template => PythonVersion::PY314,
@@ -2158,29 +2219,24 @@ mod tests {
 
         classes.sort_unstable_by_key(|(_, version)| *version);
 
-        let program = Program::get(&db);
-        let mut current_version = program.python_version(&db);
+        let mut current_version = db.program().python_version(&db);
 
         for (class, version_added) in classes {
             if version_added != current_version {
-                program
-                    .set_python_version_with_source(&mut db)
-                    .to(PythonVersionWithSource {
-                        version: version_added,
-                        source: PythonVersionSource::default(),
-                    });
+                set_python_version(&mut db, version_added);
                 current_version = version_added;
             }
+            let program = db.program();
 
             // Check the class can be looked up successfully
-            class.try_to_class_literal(&db).unwrap();
+            class.try_to_class_literal(&db, program).unwrap();
 
             // We can't call `KnownClass::Tuple.to_instance()`;
             // there are assertions to ensure that we always call `Type::homogeneous_tuple()`
             // or `Type::heterogeneous_tuple()` instead.`
             if class != KnownClass::Tuple {
                 assert_ne!(
-                    class.to_instance(&db),
+                    class.to_instance(&db, program),
                     Type::unknown(),
                     "Unexpectedly fell back to `Unknown` for `{class:?}` on Python {version_added}"
                 );

--- a/crates/ty_python_semantic/src/types/class/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/class/named_tuple.rs
@@ -4,7 +4,7 @@ use ruff_python_ast::{NodeIndex, PythonVersion, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 
 use crate::{
-    Db, Program,
+    Db,
     place::{Place, PlaceAndQualifiers},
     types::{
         BindingContext, BoundTypeVarInstance, ClassBase, ClassLiteral, ClassType, GenericContext,
@@ -24,16 +24,21 @@ use ty_python_core::{definition::Definition, scope::ScopeId};
 /// generic context in the synthesized `__new__` signature.
 pub(super) fn synthesize_namedtuple_class_member<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     name: &str,
     instance_ty: Type<'db>,
     fields: impl Iterator<Item = NamedTupleField<'db>>,
     inherited_generic_context: Option<GenericContext<'db>>,
+    python_version: PythonVersion,
 ) -> Option<Type<'db>> {
     match name {
         "__new__" => {
             // __new__(cls, field1, field2, ...) -> Self
-            let self_typevar =
-                BoundTypeVarInstance::synthetic_self(db, instance_ty, BindingContext::Synthetic);
+            let self_typevar = BoundTypeVarInstance::synthetic_self(
+                db,
+                instance_ty,
+                BindingContext::Synthetic(program),
+            );
             let self_ty = Type::TypeVar(self_typevar);
 
             let variables = inherited_generic_context
@@ -41,12 +46,12 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
                 .flat_map(|ctx| ctx.variables(db))
                 .chain(std::iter::once(self_typevar));
 
-            let generic_context = GenericContext::from_typevar_instances(db, variables);
+            let generic_context = GenericContext::from_typevar_instances(db, program, variables);
 
             // CPython generates namedtuple `__new__` as `(_cls, field1, ...)` so field names like
             // `cls` remain usable as keyword arguments at call sites.
             let first_parameter = Parameter::positional_or_keyword(Name::new_static("_cls"))
-                .with_annotated_type(SubclassOfType::from(db, self_typevar));
+                .with_annotated_type(SubclassOfType::from(db, program, self_typevar));
 
             let parameters = std::iter::once(first_parameter).chain(fields.map(|field| {
                 Parameter::positional_or_keyword(field.name)
@@ -63,7 +68,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
             Some(Type::function_like_callable(db, signature))
         }
         "__match_args__" => {
-            if Program::get(db).python_version(db) < PythonVersion::PY310 {
+            if python_version < PythonVersion::PY310 {
                 return None;
             }
 
@@ -81,7 +86,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
             Some(Type::empty_tuple(db))
         }
         "_replace" | "__replace__" => {
-            if name == "__replace__" && Program::get(db).python_version(db) < PythonVersion::PY313 {
+            if name == "__replace__" && python_version < PythonVersion::PY313 {
                 return None;
             }
 
@@ -89,7 +94,7 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
             let self_ty = Type::TypeVar(BoundTypeVarInstance::synthetic_self(
                 db,
                 instance_ty,
-                BindingContext::Synthetic,
+                BindingContext::Synthetic(program),
             ));
 
             let first_parameter = Parameter::positional_or_keyword(Name::new_static("self"))
@@ -112,10 +117,10 @@ pub(super) fn synthesize_namedtuple_class_member<'db>(
         _ => {
             // Fall back to NamedTupleFallback for other synthesized methods.
             KnownClass::NamedTupleFallback
-                .to_class_literal(db)
+                .to_class_literal(db, program)
                 .as_class_literal()?
                 .as_static()?
-                .own_class_member(db, inherited_generic_context, None, name)
+                .own_class_member(db, None, None, name)
                 .ignore_possibly_undefined()
         }
     }
@@ -197,6 +202,10 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         }
     }
 
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.scope(db).program(db)
+    }
+
     /// Returns an instance type for this dynamic namedtuple.
     pub(crate) fn to_instance(self, db: &'db dyn Db) -> Type<'db> {
         Type::instance(db, ClassType::NonGeneric(self.into()))
@@ -205,8 +214,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     /// Returns the range of the namedtuple call expression.
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let scope = self.scope(db);
-        let file = scope.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
 
         match self.anchor(db) {
             DynamicNamedTupleAnchor::CollectionsDefinition { definition, .. }
@@ -260,9 +268,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     #[salsa::tracked(
         returns(ref),
         heap_size=ruff_memory_usage::heap_size,
-        cycle_initial=|db, _, self_| Mro::from_error(
-            db, ClassType::NonGeneric(ClassLiteral::DynamicNamedTuple(self_)),
-        ),
+        cycle_initial=|db, _, self_: DynamicNamedTupleLiteral<'db>| Mro::from_error(db, ClassType::NonGeneric(ClassLiteral::DynamicNamedTuple(self_))),
     )]
     pub(crate) fn mro(self, db: &'db dyn Db) -> Mro<'db> {
         let self_base = ClassBase::Class(ClassType::NonGeneric(self.into()));
@@ -276,26 +282,28 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
     ///
     /// Namedtuples always have `type` as their metaclass.
     pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
+        let program = self.program(db);
         let _ = self;
-        KnownClass::Type.to_class_literal(db)
+        KnownClass::Type.to_class_literal(db, program)
     }
 
     /// Compute the specialized tuple class that this namedtuple inherits from.
     ///
     /// For example, `namedtuple("Point", [("x", int), ("y", int)])` inherits from `tuple[int, int]`.
     pub(crate) fn tuple_base_class(self, db: &'db dyn Db) -> ClassType<'db> {
+        let program = self.program(db);
         // If fields are unknown, return `tuple[Unknown, ...]` to avoid false positives
         // like index-out-of-bounds errors.
         if !self.has_known_fields(db) {
-            return TupleType::homogeneous(db, Type::unknown()).to_class_type(db);
+            return TupleType::homogeneous(db, Type::unknown()).to_class_type(db, program);
         }
 
         let field_types = self.fields(db).iter().map(|field| field.ty);
         TupleType::heterogeneous(db, field_types)
-            .map(|t| t.to_class_type(db))
+            .map(|t| t.to_class_type(db, program))
             .unwrap_or_else(|| {
                 KnownClass::Tuple
-                    .to_class_literal(db)
+                    .to_class_literal(db, program)
                     .as_class_literal()
                     .expect("tuple should be a class literal")
                     .default_specialization(db)
@@ -316,6 +324,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
 
     /// Look up an instance member by name (including superclasses).
     pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+        let program = self.program(db);
         // First check own instance members.
         let result = self.own_instance_member(db, name);
         if !result.is_undefined() {
@@ -323,7 +332,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
         }
 
         // Fall back to the tuple base type for other attributes.
-        Type::instance(db, self.tuple_base_class(db)).instance_member(db, name)
+        Type::instance(db, self.tuple_base_class(db)).instance_member(db, program, name)
     }
 
     /// Look up a class-level member by name.
@@ -376,6 +385,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
 
     /// Generate synthesized class members for namedtuples.
     fn synthesized_class_member(self, db: &'db dyn Db, name: &str) -> Option<Type<'db>> {
+        let program = self.program(db);
         let instance_ty = self.to_instance(db);
 
         // When fields are unknown, handle constructor and field-specific methods specially.
@@ -389,7 +399,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
                 // For other field-specific methods, fall through to NamedTupleFallback.
                 "__match_args__" | "_fields" | "_replace" | "__replace__" => {
                     return KnownClass::NamedTupleFallback
-                        .to_class_literal(db)
+                        .to_class_literal(db, program)
                         .as_class_literal()?
                         .as_static()?
                         .own_class_member(db, None, None, name)
@@ -397,6 +407,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
                         .map(|ty| {
                             ty.apply_type_mapping(
                                 db,
+                                program,
                                 &TypeMapping::ReplaceSelf {
                                     new_upper_bound: instance_ty,
                                 },
@@ -410,10 +421,12 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
 
         let result = synthesize_namedtuple_class_member(
             db,
+            program,
             name,
             instance_ty,
             self.fields(db).iter().cloned(),
             None,
+            program.python_version(db),
         );
         // For fallback members from NamedTupleFallback, apply type mapping to handle
         // `Self` types. The explicitly synthesized members (__new__, _fields, _replace,
@@ -427,6 +440,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
             result.map(|ty| {
                 ty.apply_type_mapping(
                     db,
+                    program,
                     &TypeMapping::ReplaceSelf {
                         new_upper_bound: instance_ty,
                     },
@@ -443,7 +457,7 @@ impl<'db> DynamicNamedTupleLiteral<'db> {
             heap_size=ruff_memory_usage::heap_size
         )]
         fn deferred_spec<'db>(db: &'db dyn Db, definition: Definition<'db>) -> NamedTupleSpec<'db> {
-            let module = parsed_module(db, definition.file(db)).load(db);
+            let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
             let node = definition
                 .kind(db)
                 .value(&module)
@@ -542,20 +556,26 @@ impl<'db> DynamicNamedTupleAnchor<'db> {
         nested: bool,
     ) -> Option<Self> {
         match self {
-            Self::CollectionsDefinition { definition, spec } => Some(Self::CollectionsDefinition {
-                definition: *definition,
-                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            Self::CollectionsDefinition { definition, spec } => {
+                let program = definition.program_file(db).program(db);
+                Some(Self::CollectionsDefinition {
+                    definition: *definition,
+                    spec: spec.recursive_type_normalized_impl(db, program, div, nested)?,
+                })
+            }
             Self::TypingDefinition(definition) => Some(Self::TypingDefinition(*definition)),
             Self::ScopeOffset {
                 scope,
                 offset,
                 spec,
-            } => Some(Self::ScopeOffset {
-                scope: *scope,
-                offset: *offset,
-                spec: spec.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            } => {
+                let program = scope.program(db);
+                Some(Self::ScopeOffset {
+                    scope: *scope,
+                    offset: *offset,
+                    spec: spec.recursive_type_normalized_impl(db, program, div, nested)?,
+                })
+            }
         }
     }
 }
@@ -585,6 +605,7 @@ impl<'db> NamedTupleSpec<'db> {
     pub(crate) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -592,11 +613,12 @@ impl<'db> NamedTupleSpec<'db> {
             .fields(db)
             .iter()
             .map(|f| {
-                let ty = f.ty.recursive_type_normalized_impl(db, div, true);
+                let ty = f.ty.recursive_type_normalized_impl(db, program, div, true);
                 let ty = if nested { ty? } else { ty.unwrap_or(div) };
                 let default = match f.default {
                     Some(default) => {
-                        let default = default.recursive_type_normalized_impl(db, div, true);
+                        let default =
+                            default.recursive_type_normalized_impl(db, program, div, true);
                         Some(if nested {
                             default?
                         } else {

--- a/crates/ty_python_semantic/src/types/class/static_literal.rs
+++ b/crates/ty_python_semantic/src/types/class/static_literal.rs
@@ -11,7 +11,7 @@ use ruff_text_size::{Ranged, TextRange};
 use std::cell::RefCell;
 
 use crate::{
-    Db, FxIndexMap, FxIndexSet, Program, TypeQualifiers,
+    Db, FxIndexMap, FxIndexSet, TypeQualifiers,
     place::{
         DefinedPlace, Definedness, Place, PlaceAndQualifiers, Provenance, PublicTypePolicy,
         TypeOrigin, place_from_bindings, place_from_declarations,
@@ -72,7 +72,7 @@ use ty_python_core::{
 ///
 /// This does not in itself represent a type, but can be transformed into a [`ClassType`] that
 /// does. (For generic classes, this requires specializing its generic context.)
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct StaticClassLiteral<'db> {
     /// Name of the class at definition
     #[returns(ref)]
@@ -120,6 +120,12 @@ pub struct StaticClassLiteral<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for StaticClassLiteral<'_> {}
 
+impl<'db> StaticClassLiteral<'db> {
+    pub(crate) fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.body_scope(db).program(db)
+    }
+}
+
 #[salsa::tracked]
 impl<'db> StaticClassLiteral<'db> {
     /// Return `true` if this class represents `known_class`
@@ -152,8 +158,10 @@ impl<'db> StaticClassLiteral<'db> {
     /// This specifically excludes Pydantic models, even though their metaclass also uses
     /// `dataclass_transform`.
     pub(crate) fn is_dataclass_like(self, db: &'db dyn Db) -> bool {
-        CodeGeneratorKind::from_class(db, ClassLiteral::Static(self))
-            .is_some_and(CodeGeneratorKind::is_dataclass_like)
+        matches!(
+            CodeGeneratorKind::from_class(db, ClassLiteral::Static(self)),
+            Some(CodeGeneratorKind::DataclassLike(_))
+        )
     }
 
     /// Returns `true` if this class is decorated with `@dataclass(order=True)`.
@@ -308,11 +316,11 @@ impl<'db> StaticClassLiteral<'db> {
     )]
     fn pep695_generic_context_inner(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let scope = self.body_scope(db);
-        let file = scope.file(db);
-        let parsed = parsed_module(db, file).load(db);
+        let program_file = scope.program_file(db);
+        let parsed = parsed_module(db, program_file.versioned_file(db)).load(db);
         let class_def_node = scope.node(db).expect_class().node(&parsed);
         class_def_node.type_params.as_ref().map(|type_params| {
-            let index = semantic_index(db, scope.file(db));
+            let index = semantic_index(db, program_file);
             let definition = index.expect_single_definition(class_def_node);
             GenericContext::from_type_params(db, index, definition, type_params)
         })
@@ -379,27 +387,34 @@ impl<'db> StaticClassLiteral<'db> {
             fn visit_bound_type_var_type(
                 &self,
                 _db: &'db dyn Db,
+                _program: crate::Program,
                 bound_typevar: BoundTypeVarInstance<'db>,
             ) {
                 self.typevars.borrow_mut().insert(bound_typevar);
             }
 
-            fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+            fn visit_generic_alias_type(
+                &self,
+                db: &'db dyn Db,
+                program: crate::Program,
+                alias: GenericAlias<'db>,
+            ) {
                 // The generic context contains the base class's formal type parameters, not type
                 // variables referenced by this class's base expression.
                 for ty in alias.specialization(db).types(db) {
-                    self.visit_type(db, *ty);
+                    self.visit_type(db, program, *ty);
                 }
             }
 
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            fn visit_type(&self, db: &'db dyn Db, program: crate::Program, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
             }
         }
 
+        let program = ClassLiteral::Static(self).program(db);
         let visitor = CollectTypeVars::default();
         for base in self.explicit_bases(db) {
-            visitor.visit_type(db, *base);
+            visitor.visit_type(db, program, *base);
         }
         visitor.typevars.into_inner()
     }
@@ -424,7 +439,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
-        let index = semantic_index(db, body_scope.file(db));
+        let index = semantic_index(db, body_scope.program_file(db));
         index.expect_single_definition(body_scope.node(db).expect_class())
     }
 
@@ -460,6 +475,7 @@ impl<'db> StaticClassLiteral<'db> {
                 .default_specialization(db, self.known(db))
                 .materialize_impl(
                     db,
+                    self.program(db),
                     MaterializationKind::Top,
                     &ApplyTypeMappingVisitor::default(),
                 )
@@ -515,11 +531,12 @@ impl<'db> StaticClassLiteral<'db> {
                 class.name(db)
             );
 
-            let module = parsed_module(db, class.file(db)).load(db);
+            let program_file = class.body_scope(db).program_file(db);
+            let module = parsed_module(db, program_file.versioned_file(db)).load(db);
             let class_stmt = class.node(db, &module);
 
             let class_definition =
-                semantic_index(db, class.file(db)).expect_single_definition(class_stmt);
+                semantic_index(db, program_file).expect_single_definition(class_stmt);
 
             expanded_class_base_entries(db, class.known(db), class_stmt, class_definition)
                 .into_iter()
@@ -535,6 +552,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     /// Return `Some()` if this class is known to be a [`DisjointBase`], or `None` if it is not.
     pub(super) fn as_disjoint_base(self, db: &'db dyn Db) -> Option<DisjointBase<'db>> {
+        let program = self.program(db);
         if self
             .known_function_decorators(db)
             .contains(&KnownFunction::DisjointBase)
@@ -542,7 +560,7 @@ impl<'db> StaticClassLiteral<'db> {
             && !self.is_protocol(db)
         {
             Some(DisjointBase::due_to_decorator(self))
-        } else if SlotsKind::from(db, self) == SlotsKind::NotEmpty {
+        } else if SlotsKind::from(db, program, self) == SlotsKind::NotEmpty {
             Some(DisjointBase::due_to_dunder_slots(ClassLiteral::Static(
                 self,
             )))
@@ -554,11 +572,12 @@ impl<'db> StaticClassLiteral<'db> {
     /// Iterate over this class's explicit bases, resolving them in the same way as MRO
     /// construction, filtering out any bases that are not fully static class objects.
     fn fully_static_explicit_bases(self, db: &'db dyn Db) -> impl Iterator<Item = ClassType<'db>> {
+        let program = self.program(db);
         self.explicit_bases(db)
             .iter()
             .copied()
             .filter_map(move |ty| {
-                ClassBase::try_from_type(db, ty, Some(ClassLiteral::Static(self)))
+                ClassBase::try_from_type(db, program, ty, Some(ClassLiteral::Static(self)))
                     .and_then(ClassBase::into_class)
             })
     }
@@ -605,7 +624,8 @@ impl<'db> StaticClassLiteral<'db> {
     fn decorators_inner(self, db: &'db dyn Db) -> Box<[Type<'db>]> {
         tracing::trace!("StaticClassLiteral::decorators: {}", self.name(db));
 
-        let module = parsed_module(db, self.file(db)).load(db);
+        let program_file = self.body_scope(db).program_file(db);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
 
         let class_stmt = self.node(db, &module);
         if class_stmt.decorator_list.is_empty() {
@@ -613,7 +633,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let class_definition =
-            semantic_index(db, self.file(db)).expect_single_definition(class_stmt);
+            semantic_index(db, program_file).expect_single_definition(class_stmt);
 
         class_stmt
             .decorator_list
@@ -637,10 +657,11 @@ impl<'db> StaticClassLiteral<'db> {
     /// Iterate through the decorators on this class, returning the index of the first one
     /// that is either `@dataclass` or `@dataclass(...)`.
     pub(crate) fn find_dataclass_decorator_position(self, db: &'db dyn Db) -> Option<usize> {
-        let module = parsed_module(db, self.file(db)).load(db);
+        let program_file = self.body_scope(db).program_file(db);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
         let class_stmt = self.node(db, &module);
         let class_definition =
-            semantic_index(db, self.file(db)).expect_single_definition(class_stmt);
+            semantic_index(db, program_file).expect_single_definition(class_stmt);
 
         class_stmt.decorator_list.iter().position(|decorator| {
             let decorator_callable = decorator
@@ -792,7 +813,8 @@ impl<'db> StaticClassLiteral<'db> {
             return None;
         }
 
-        let module = parsed_module(db, self.file(db)).load(db);
+        let module =
+            parsed_module(db, self.body_scope(db).program_file(db).versioned_file(db)).load(db);
         let class_stmt = self.node(db, &module);
         Some(typed_dict_params_from_class_def(class_stmt))
     }
@@ -816,7 +838,9 @@ impl<'db> StaticClassLiteral<'db> {
         // Dataclass transformer flags can be overwritten using class arguments.
         if let Some(transformer_params) = transformer_params.as_mut() {
             if let Some(class_def) = self.definition(db).kind(db).as_class() {
-                let module = parsed_module(db, self.file(db)).load(db);
+                let module =
+                    parsed_module(db, self.body_scope(db).program_file(db).versioned_file(db))
+                        .load(db);
 
                 if let Some(arguments) = &class_def.node(&module).arguments {
                     let mut flags = transformer_params.flags(db);
@@ -962,6 +986,7 @@ impl<'db> StaticClassLiteral<'db> {
             db: &'db dyn Db,
             class: StaticClassLiteral<'db>,
         ) -> Result<(Type<'db>, Option<MetaclassTransformInfo<'db>>), MetaclassError<'db>> {
+            let program = class.program(db);
             tracing::trace!("StaticClassLiteral::try_metaclass: {}", class.name(db));
 
             // Identify the class's own metaclass (or take the first base class's metaclass).
@@ -977,7 +1002,9 @@ impl<'db> StaticClassLiteral<'db> {
                 return Ok((SubclassOfType::subclass_of_unknown(), None));
             }
 
-            let module = parsed_module(db, class.file(db)).load(db);
+            let module =
+                parsed_module(db, class.body_scope(db).program_file(db).versioned_file(db))
+                    .load(db);
 
             let explicit_metaclass = class.explicit_metaclass(db, &module);
 
@@ -989,7 +1016,7 @@ impl<'db> StaticClassLiteral<'db> {
                     .specialization(db)
                     .types(db)
                     .iter()
-                    .any(|ty| ty.has_typevar_or_typevar_instance(db));
+                    .any(|ty| ty.has_typevar_or_typevar_instance(db, program));
                 if specialization_has_typevars {
                     return Err(MetaclassError {
                         kind: MetaclassErrorKind::GenericMetaclass,
@@ -1009,7 +1036,7 @@ impl<'db> StaticClassLiteral<'db> {
                     .unwrap_or(class);
                 (base_class.metaclass(db), base_class_literal)
             } else {
-                (KnownClass::Type.to_class_literal(db), class)
+                (KnownClass::Type.to_class_literal(db, program), class)
             };
 
             let mut candidate = if let Some(metaclass_ty) = metaclass.to_class_type(db) {
@@ -1020,14 +1047,17 @@ impl<'db> StaticClassLiteral<'db> {
             } else {
                 let name = Type::string_literal(db, class.name(db));
                 let bases = Type::heterogeneous_tuple(db, class.explicit_bases(db));
-                let namespace = KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
+                let namespace = KnownClass::Dict.to_specialized_instance(
+                    db,
+                    program,
+                    &[KnownClass::Str.to_instance(db, program), Type::any()],
+                );
 
                 // TODO: Other keyword arguments?
                 let arguments = CallArguments::positional([name, bases, namespace]);
 
-                let return_ty_result = match metaclass.try_call(db, &arguments) {
-                    Ok(bindings) => Ok(bindings.return_type(db)),
+                let return_ty_result = match metaclass.try_call(db, program, &arguments) {
+                    Ok(bindings) => Ok(bindings.return_type(db, program)),
 
                     Err(CallError(CallErrorKind::NotCallable, bindings)) => Err(MetaclassError {
                         kind: MetaclassErrorKind::NotCallable(bindings.callable_type()),
@@ -1036,7 +1066,7 @@ impl<'db> StaticClassLiteral<'db> {
                     // TODO we should also check for binding errors that would indicate the metaclass
                     // does not accept the right arguments
                     Err(CallError(CallErrorKind::BindingError, bindings)) => {
-                        Ok(bindings.return_type(db))
+                        Ok(bindings.return_type(db, program))
                     }
 
                     Err(CallError(CallErrorKind::PossiblyNotCallable, _)) => Err(MetaclassError {
@@ -1044,7 +1074,7 @@ impl<'db> StaticClassLiteral<'db> {
                     }),
                 };
 
-                return return_ty_result.map(|ty| (ty.to_meta_type(db), None));
+                return return_ty_result.map(|ty| (ty.to_meta_type(db, program), None));
             };
 
             // Reconcile all base classes' metaclasses with the candidate metaclass.
@@ -1099,7 +1129,10 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         if !self.has_explicit_bases(db) && !self.has_explicit_metaclass(db) {
-            return Ok((KnownClass::Type.to_class_literal(db), None));
+            return Ok((
+                KnownClass::Type.to_class_literal(db, self.program(db)),
+                None,
+            ));
         }
         try_metaclass_inner(db, self)
     }
@@ -1135,7 +1168,11 @@ impl<'db> StaticClassLiteral<'db> {
         policy: MemberLookupPolicy,
         mro_iter: impl Iterator<Item = ClassBase<'db>>,
     ) -> PlaceAndQualifiers<'db> {
-        fn into_function_like_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
+        fn into_function_like_callable<'d>(
+            db: &'d dyn Db,
+            program: crate::Program,
+            ty: Type<'d>,
+        ) -> Type<'d> {
             match ty {
                 Type::Callable(callable_ty)
                     if callable_ty.is_regular(db)
@@ -1143,16 +1180,20 @@ impl<'db> StaticClassLiteral<'db> {
                 {
                     Type::Callable(callable_ty.into_function_like(db))
                 }
-                Type::Union(union) => {
-                    union.map(db, |element| into_function_like_callable(db, *element))
+                Type::Union(union) => union.map(db, program, |element| {
+                    into_function_like_callable(db, program, *element)
+                }),
+                Type::Intersection(intersection) => {
+                    intersection.map_positive(db, program, |element| {
+                        into_function_like_callable(db, program, *element)
+                    })
                 }
-                Type::Intersection(intersection) => intersection
-                    .map_positive(db, |element| into_function_like_callable(db, *element)),
                 _ => ty,
             }
         }
 
-        let result = MroLookup::new(db, mro_iter).class_member(
+        let program = self.program(db);
+        let result = MroLookup::new(db, program, mro_iter).class_member(
             name,
             policy,
             self.inherited_generic_context(db),
@@ -1160,7 +1201,7 @@ impl<'db> StaticClassLiteral<'db> {
         );
 
         let mut member = match result {
-            ClassMemberResult::Done(result) => result.finalize(db),
+            ClassMemberResult::Done(result) => result.finalize(db, program),
             ClassMemberResult::TypedDict(module) => {
                 typed_dict_class_member(db, self.identity_specialization(db), module, policy, name)
             }
@@ -1169,7 +1210,7 @@ impl<'db> StaticClassLiteral<'db> {
         // We generally treat dunder attributes with `Callable` types as function-like callables.
         // See `callables_as_descriptors.md` for more details.
         if name.starts_with("__") && name.ends_with("__") {
-            member = member.map_type(|ty| into_function_like_callable(db, ty));
+            member = member.map_type(|ty| into_function_like_callable(db, program, ty));
         }
 
         member
@@ -1188,7 +1229,11 @@ impl<'db> StaticClassLiteral<'db> {
         specialization: Option<Specialization<'db>>,
         name: &str,
     ) -> Member<'db> {
-        fn into_dunder_paramspec_callable<'d>(db: &'d dyn Db, ty: Type<'d>) -> Type<'d> {
+        fn into_dunder_paramspec_callable<'d>(
+            db: &'d dyn Db,
+            program: crate::Program,
+            ty: Type<'d>,
+        ) -> Type<'d> {
             match ty {
                 Type::Callable(callable_ty)
                     if callable_ty.is_regular(db)
@@ -1196,27 +1241,33 @@ impl<'db> StaticClassLiteral<'db> {
                 {
                     Type::Callable(callable_ty.into_dunder_paramspec(db))
                 }
-                Type::Union(union) => {
-                    union.map(db, |element| into_dunder_paramspec_callable(db, *element))
+                Type::Union(union) => union.map(db, program, |element| {
+                    into_dunder_paramspec_callable(db, program, *element)
+                }),
+                Type::Intersection(intersection) => {
+                    intersection.map_positive(db, program, |element| {
+                        into_dunder_paramspec_callable(db, program, *element)
+                    })
                 }
-                Type::Intersection(intersection) => intersection
-                    .map_positive(db, |element| into_dunder_paramspec_callable(db, *element)),
                 _ => ty,
             }
         }
 
         // Check if this class is dataclass-like (either via @dataclass or via dataclass_transform)
-        if CodeGeneratorKind::from_class(db, self.into())
-            .is_some_and(CodeGeneratorKind::is_dataclass_like)
-        {
+        if matches!(
+            CodeGeneratorKind::from_class(db, self.into()),
+            Some(CodeGeneratorKind::DataclassLike(_))
+        ) {
             if name == "__dataclass_fields__" {
                 // Make this class look like a subclass of the `DataClassInstance` protocol
+                let program = self.program(db);
                 return Member {
                     inner: Place::declared(KnownClass::Dict.to_specialized_instance(
                         db,
+                        program,
                         &[
-                            KnownClass::Str.to_instance(db),
-                            KnownClass::Field.to_specialized_instance(db, &[Type::any()]),
+                            KnownClass::Str.to_instance(db, program),
+                            KnownClass::Field.to_specialized_instance(db, program, &[Type::any()]),
                         ],
                     ))
                     .with_qualifiers(TypeQualifiers::CLASS_VAR),
@@ -1249,7 +1300,7 @@ impl<'db> StaticClassLiteral<'db> {
         let body_scope = self.body_scope(db);
         let member = class_member(db, body_scope, name).map_type(|ty| {
             let ty = if name.starts_with("__") && name.ends_with("__") {
-                into_dunder_paramspec_callable(db, ty)
+                into_dunder_paramspec_callable(db, self.program(db), ty)
             } else {
                 ty
             };
@@ -1288,6 +1339,8 @@ impl<'db> StaticClassLiteral<'db> {
             return Self::implicit_attribute(db, body_scope, name, MethodDecorator::ClassMethod);
         }
 
+        let program = self.program(db);
+
         // For dataclass-like classes, `KW_ONLY` sentinel fields are not real
         // class attributes; they are markers used by the dataclass decorator to
         // indicate that subsequent fields are keyword-only. Treat them as
@@ -1296,9 +1349,9 @@ impl<'db> StaticClassLiteral<'db> {
             .inner
             .place
             .raw_type()
-            .is_some_and(|ty| ty.is_instance_of(db, KnownClass::KwOnly))
+            .is_some_and(|ty| ty.is_instance_of(db, program, KnownClass::KwOnly))
             && CodeGeneratorKind::from_static_class(db, self)
-                .is_some_and(CodeGeneratorKind::is_dataclass_like)
+                .is_some_and(|policy| matches!(policy, CodeGeneratorKind::DataclassLike(_)))
         {
             return Member::unbound();
         }
@@ -1307,7 +1360,7 @@ impl<'db> StaticClassLiteral<'db> {
         // At runtime, the enum metaclass unwraps the value, so accessing the attribute
         // returns the inner value, not the `nonmember` wrapper.
         if let Some(ty) = member.inner.place.raw_type() {
-            if let Some(value_ty) = try_unwrap_nonmember_value(db, ty) {
+            if let Some(value_ty) = try_unwrap_nonmember_value(db, program, ty) {
                 if is_enum_class_by_inheritance(db, self) {
                     return Member::definitely_declared(value_ty);
                 }
@@ -1349,34 +1402,40 @@ impl<'db> StaticClassLiteral<'db> {
                 })
             && self.has_ordering_method_in_mro(db, specialization)
             && let Some(root_method_ty) = self.total_ordering_root_method(db, specialization)
-            && let Some(callables) = root_method_ty.try_upcast_to_callable(db)
         {
-            let bool_ty = KnownClass::Bool.to_instance(db);
-            let synthesized_callables = callables.map(|callable| {
-                let signatures = CallableSignature::from_overloads(
-                    callable.signatures(db).iter().map(|signature| {
-                        // The generated methods return a union of the root method's return type
-                        // and `bool`. This is because `@total_ordering` synthesizes methods like:
-                        //     def __gt__(self, other): return not (self == other or self < other)
-                        // If `__lt__` returns `int`, then `__gt__` could return `int | bool`.
-                        let return_ty =
-                            UnionType::from_two_elements(db, signature.return_ty, bool_ty);
-                        Signature::new_generic(
-                            signature.generic_context,
-                            signature.parameters().clone(),
-                            return_ty,
-                        )
-                    }),
-                );
-                CallableType::new(
-                    db,
-                    signatures,
-                    CallableTypeKind::FunctionLike,
-                    CallableFunctionProvenance::None,
-                )
-            });
+            let program = self.program(db);
+            if let Some(callables) = root_method_ty.try_upcast_to_callable(db, program) {
+                let bool_ty = KnownClass::Bool.to_instance(db, program);
+                let synthesized_callables = callables.map(|callable| {
+                    let signatures = CallableSignature::from_overloads(
+                        callable.signatures(db).iter().map(|signature| {
+                            // The generated methods return a union of the root method's return type
+                            // and `bool`. This is because `@total_ordering` synthesizes methods like:
+                            //     def __gt__(self, other): return not (self == other or self < other)
+                            // If `__lt__` returns `int`, then `__gt__` could return `int | bool`.
+                            let return_ty = UnionType::from_two_elements(
+                                db,
+                                program,
+                                signature.return_ty,
+                                bool_ty,
+                            );
+                            Signature::new_generic(
+                                signature.generic_context,
+                                signature.parameters().clone(),
+                                return_ty,
+                            )
+                        }),
+                    );
+                    CallableType::new(
+                        db,
+                        signatures,
+                        CallableTypeKind::FunctionLike,
+                        CallableFunctionProvenance::None,
+                    )
+                });
 
-            return Some(synthesized_callables.into_type(db));
+                return Some(synthesized_callables.into_type(db, program));
+            }
         }
 
         // An ordinary subclass of a frozen dataclass is not itself dataclass-like, so the
@@ -1391,6 +1450,7 @@ impl<'db> StaticClassLiteral<'db> {
         }
 
         let field_policy = CodeGeneratorKind::from_class(db, self.into())?;
+        let program = self.program(db);
         let pydantic_constructor_fields_are_keyword_only =
             field_policy.is_pydantic() && pydantic::constructor_fields_are_keyword_only(db, self);
         let pydantic_constructor_fields_are_optional = name == "__init__"
@@ -1441,14 +1501,14 @@ impl<'db> StaticClassLiteral<'db> {
                     continue;
                 }
 
-                if field.is_kw_only_sentinel(db) {
+                if field.is_kw_only_sentinel(db, program) {
                     // Attributes annotated with `dataclass.KW_ONLY` are not present in the synthesized
                     // `__init__` method; they are used to indicate that the following parameters are
                     // keyword-only.
                     continue;
                 }
 
-                let dunder_set = field_ty.class_member(db, "__set__".into());
+                let dunder_set = field_ty.class_member(db, program, "__set__".into());
                 if let Place::Defined(DefinedPlace {
                     ty: dunder_set,
                     definedness: Definedness::AlwaysDefined,
@@ -1470,22 +1530,26 @@ impl<'db> StaticClassLiteral<'db> {
                         //
                         // We union parameter types across overloads of a single callable, intersect
                         // callable bindings inside an intersection element, and union outer elements.
-                        field_ty = dunder_set.bindings(db).map_types(db, |binding| {
-                            let mut value_types = UnionBuilder::new(db);
-                            let mut has_value_type = false;
-                            for overload in binding {
-                                if let Some(value_param) =
-                                    overload.signature.parameters().get_positional(2)
-                                {
-                                    value_types = value_types.add(value_param.annotated_type());
-                                    has_value_type = true;
-                                } else if overload.signature.parameters().is_gradual() {
-                                    value_types = value_types.add(Type::unknown());
-                                    has_value_type = true;
-                                }
-                            }
-                            has_value_type.then(|| value_types.build())
-                        });
+                        field_ty =
+                            dunder_set
+                                .bindings(db, program)
+                                .map_types(db, program, |binding| {
+                                    let mut value_types = UnionBuilder::new(db, program);
+                                    let mut has_value_type = false;
+                                    for overload in binding {
+                                        if let Some(value_param) =
+                                            overload.signature.parameters().get_positional(2)
+                                        {
+                                            value_types =
+                                                value_types.add(value_param.annotated_type());
+                                            has_value_type = true;
+                                        } else if overload.signature.parameters().is_gradual() {
+                                            value_types = value_types.add(Type::unknown());
+                                            has_value_type = true;
+                                        }
+                                    }
+                                    has_value_type.then(|| value_types.build())
+                                });
 
                         // The default value of the attribute is *not* determined by the right hand side
                         // of the class-body assignment. Instead, the runtime invokes `__get__` on the
@@ -1494,7 +1558,7 @@ impl<'db> StaticClassLiteral<'db> {
 
                         if let Some(ref mut default_ty) = default_ty {
                             *default_ty = default_ty
-                                .try_call_dunder_get(db, None, Type::from(self))
+                                .try_call_dunder_get(db, program, None, Type::from(self))
                                 .map(|(return_ty, _)| return_ty)
                                 .unwrap_or_else(Type::unknown);
                         }
@@ -1508,7 +1572,9 @@ impl<'db> StaticClassLiteral<'db> {
                 if name == "__init__"
                     && let Some(metadata) = field_policy.pydantic_metadata()
                 {
-                    field_ty = pydantic::constructor_parameter_type(db, field_ty, strict, metadata);
+                    field_ty = pydantic::constructor_parameter_type(
+                        db, program, field_ty, strict, metadata,
+                    );
                 }
 
                 if pydantic_constructor_fields_are_optional && default_ty.is_none() {
@@ -1553,13 +1619,6 @@ impl<'db> StaticClassLiteral<'db> {
                             if alias == *field_name {
                                 add_parameter_with_name(field_name.clone(), default_ty);
                             } else {
-                                // A normal signature cannot express that at least one of two
-                                // differently named parameters is required. We could solve
-                                // this with overloads, but the number of overloads would grow
-                                // exponentially in the number of parameters. So for now, we
-                                // treat both the alias and the field name as optional
-                                // parameters, which leads to false negatives if none of them
-                                // is provided.
                                 let default_ty = Some(default_ty.unwrap_or_else(Type::unknown));
                                 add_parameter_with_name(alias, default_ty);
                                 add_parameter_with_name(field_name.clone(), default_ty);
@@ -1574,7 +1633,6 @@ impl<'db> StaticClassLiteral<'db> {
                         (false, false) => {}
                     }
                 } else {
-                    // Use the alias name if provided, otherwise use the field name.
                     let parameter_name =
                         Name::new(alias.map(|alias| &**alias).unwrap_or(&**field_name));
                     add_parameter_with_name(parameter_name, default_ty);
@@ -1605,6 +1663,8 @@ impl<'db> StaticClassLiteral<'db> {
             Some(Type::function_like_callable(db, signature))
         };
 
+        let python_version = program.python_version(db);
+
         match (field_policy, name) {
             (field_policy, "__init__")
                 if field_policy.synthesizes_constructor_signature_from_fields() =>
@@ -1618,7 +1678,7 @@ impl<'db> StaticClassLiteral<'db> {
                 let self_parameter = Parameter::positional_or_keyword(Name::new_static("self"))
                     // TODO: could be `Self`.
                     .with_annotated_type(instance_ty);
-                signature_from_fields(vec![self_parameter], Type::none(db))
+                signature_from_fields(vec![self_parameter], Type::none(db, program))
             }
             (
                 CodeGeneratorKind::NamedTuple,
@@ -1627,14 +1687,15 @@ impl<'db> StaticClassLiteral<'db> {
                 // When the namedtuple base has unknown fields, fall back to NamedTupleFallback
                 // which has generic signatures that accept any arguments.
                 KnownClass::NamedTupleFallback
-                    .to_class_literal(db)
+                    .to_class_literal(db, program)
                     .as_class_literal()?
                     .as_static()?
-                    .own_class_member(db, inherited_generic_context, None, name)
+                    .own_class_member(db, None, None, name)
                     .ignore_possibly_undefined()
                     .map(|ty| {
                         ty.apply_type_mapping(
                             db,
+                            program,
                             &TypeMapping::ReplaceSelf {
                                 new_upper_bound: instance_ty,
                             },
@@ -1661,10 +1722,12 @@ impl<'db> StaticClassLiteral<'db> {
                 });
                 synthesize_namedtuple_class_member(
                     db,
+                    program,
                     name,
                     instance_ty,
                     fields_iter,
                     specialization.map(|s| s.generic_context(db)),
+                    python_version,
                 )
             }
             (
@@ -1684,7 +1747,7 @@ impl<'db> StaticClassLiteral<'db> {
                             // TODO: could be `Self`.
                             .with_annotated_type(instance_ty),
                     ]),
-                    KnownClass::Bool.to_instance(db),
+                    KnownClass::Bool.to_instance(db, program),
                 );
 
                 Some(Type::function_like_callable(db, signature))
@@ -1701,19 +1764,19 @@ impl<'db> StaticClassLiteral<'db> {
                             "self",
                         ))
                         .with_annotated_type(instance_ty)]),
-                        KnownClass::Int.to_instance(db),
+                        KnownClass::Int.to_instance(db, program),
                     );
 
                     Some(Type::function_like_callable(db, signature))
                 } else if eq && !frozen {
-                    Some(Type::none(db))
+                    Some(Type::none(db, program))
                 } else {
                     // No `__hash__` is generated, fall back to `object.__hash__`
                     None
                 }
             }
             (field_policy @ CodeGeneratorKind::DataclassLike(_), "__match_args__")
-                if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
+                if python_version >= PythonVersion::PY310 =>
             {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::MATCH_ARGS) {
                     return None;
@@ -1736,7 +1799,7 @@ impl<'db> StaticClassLiteral<'db> {
                 Some(Type::heterogeneous_tuple(db, match_args))
             }
             (field_policy @ CodeGeneratorKind::DataclassLike(_), "__weakref__")
-                if Program::get(db).python_version(db) >= PythonVersion::PY311 =>
+                if python_version >= PythonVersion::PY311 =>
             {
                 if !self.has_dataclass_param(db, field_policy, DataclassFlags::WEAKREF_SLOT)
                     || !self.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS)
@@ -1748,20 +1811,22 @@ impl<'db> StaticClassLiteral<'db> {
                 // model it precisely.
                 Some(UnionType::from_two_elements(
                     db,
+                    program,
                     Type::any(),
-                    Type::none(db),
+                    Type::none(db, program),
                 ))
             }
             (CodeGeneratorKind::NamedTuple, name) if name != "__init__" => {
                 KnownClass::NamedTupleFallback
-                    .to_class_literal(db)
+                    .to_class_literal(db, program)
                     .as_class_literal()?
                     .as_static()?
-                    .own_class_member(db, self.inherited_generic_context(db), None, name)
+                    .own_class_member(db, None, None, name)
                     .ignore_possibly_undefined()
                     .map(|ty| {
                         ty.apply_type_mapping(
                             db,
+                            program,
                             &TypeMapping::ReplaceSelf {
                                 new_upper_bound: determine_upper_bound(
                                     db,
@@ -1777,7 +1842,7 @@ impl<'db> StaticClassLiteral<'db> {
                     })
             }
             (CodeGeneratorKind::DataclassLike(_), "__replace__")
-                if Program::get(db).python_version(db) >= PythonVersion::PY313 =>
+                if python_version >= PythonVersion::PY313 =>
             {
                 let self_parameter = Parameter::positional_or_keyword(Name::new_static("self"))
                     .with_annotated_type(instance_ty);
@@ -1807,7 +1872,7 @@ impl<'db> StaticClassLiteral<'db> {
                 None
             }
             (field_policy @ CodeGeneratorKind::DataclassLike(_), "__slots__")
-                if Program::get(db).python_version(db) >= PythonVersion::PY310 =>
+                if python_version >= PythonVersion::PY310 =>
             {
                 self.has_dataclass_param(db, field_policy, DataclassFlags::SLOTS)
                     .then(|| {
@@ -1818,6 +1883,7 @@ impl<'db> StaticClassLiteral<'db> {
             }
             (CodeGeneratorKind::TypedDict, name) => synthesize_typed_dict_method(
                 db,
+                program,
                 instance_ty
                     .as_typed_dict()
                     .expect("TypedDict code generation should use a TypedDict instance"),
@@ -1844,6 +1910,7 @@ impl<'db> StaticClassLiteral<'db> {
 
         let frozen_base_fields =
             self.inherited_non_slotted_frozen_dataclass_fields(db, specialization)?;
+        let program = self.program(db);
 
         let instance_ty =
             Type::instance(db, self.apply_optional_specialization(db, specialization));
@@ -1864,8 +1931,8 @@ impl<'db> StaticClassLiteral<'db> {
             .keys()
             .map(|field| setattr_signature(Type::string_literal(db, field), Type::Never))
             .chain([setattr_signature(
-                KnownClass::Str.to_instance(db),
-                Type::none(db),
+                KnownClass::Str.to_instance(db, program),
+                Type::none(db, program),
             )]);
 
         Some(Type::Callable(CallableType::new(
@@ -1985,6 +2052,7 @@ impl<'db> StaticClassLiteral<'db> {
             DynamicTypedDict(DynamicTypedDictLiteral<'db>),
         }
 
+        let program = self.program(db);
         debug_assert_ne!(
             field_policy,
             CodeGeneratorKind::NamedTuple,
@@ -1998,8 +2066,6 @@ impl<'db> StaticClassLiteral<'db> {
                 let class = superclass.into_class()?;
 
                 if let Some((class_literal, specialization)) = class.static_class_literal(db) {
-                    // Pydantic collects annotated attributes from every class in the model's MRO,
-                    // including ordinary classes that are not themselves Pydantic models.
                     if field_policy.is_pydantic() || field_policy.matches(db, class_literal.into())
                     {
                         return Some(FieldSource::Static(class_literal, specialization));
@@ -2039,7 +2105,7 @@ impl<'db> StaticClassLiteral<'db> {
             })
             // KW_ONLY sentinels are markers, not real fields. Exclude them so
             // they cannot shadow an inherited field with the same name.
-            .filter(|(_, field)| !field.is_kw_only_sentinel(db))
+            .filter(|(_, field)| !field.is_kw_only_sentinel(db, program))
             // We collect into a FxOrderMap here to deduplicate attributes
             .collect();
 
@@ -2049,6 +2115,7 @@ impl<'db> StaticClassLiteral<'db> {
 
     pub(crate) fn validate_members(self, context: &InferContext<'db, '_>) {
         let db = context.db();
+        let program = context.program();
         let Some(field_policy) = CodeGeneratorKind::from_static_class(db, self) else {
             return;
         };
@@ -2056,7 +2123,7 @@ impl<'db> StaticClassLiteral<'db> {
         let table = place_table(db, class_body_scope);
         let use_def = use_def_map(db, class_body_scope);
         for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
-            let result = place_from_declarations(db, declarations.clone());
+            let result = place_from_declarations(db, program, declarations.clone());
             let attr = result.ignore_conflicting_declarations();
             let symbol = table.symbol(symbol_id);
             let name = symbol.name();
@@ -2068,7 +2135,7 @@ impl<'db> StaticClassLiteral<'db> {
 
             match name.as_str() {
                 "__setattr__" | "__delattr__" => {
-                    if field_policy.is_dataclass_like()
+                    if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
                         && self.is_frozen_dataclass(db) == Some(true)
                     {
                         if let Some(builder) = context.report_lint(
@@ -2085,7 +2152,7 @@ impl<'db> StaticClassLiteral<'db> {
                     }
                 }
                 "__lt__" | "__le__" | "__gt__" | "__ge__" => {
-                    if field_policy.is_dataclass_like()
+                    if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
                         && self.has_dataclass_param(db, field_policy, DataclassFlags::ORDER)
                     {
                         if let Some(builder) = context.report_lint(
@@ -2137,6 +2204,7 @@ impl<'db> StaticClassLiteral<'db> {
         specialization: Option<Specialization<'db>>,
         field_policy: CodeGeneratorKind<'db>,
     ) -> FxIndexMap<Name, Field<'db>> {
+        let program = self.program(db);
         let class_body_scope = self.body_scope(db);
         let table = place_table(db, class_body_scope);
 
@@ -2153,8 +2221,7 @@ impl<'db> StaticClassLiteral<'db> {
             } else {
                 false
             };
-        let dataclass_kw_only_default = field_policy
-            .is_dataclass_like()
+        let dataclass_kw_only_default = matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
             .then(|| self.has_dataclass_param(db, field_policy, DataclassFlags::KW_ONLY));
         let mut kw_only_sentinel_field_seen = false;
         let mut field_declarations = Vec::new();
@@ -2194,7 +2261,7 @@ impl<'db> StaticClassLiteral<'db> {
                 continue;
             };
 
-            let result = place_from_declarations(db, declarations.clone());
+            let result = place_from_declarations(db, program, declarations.clone());
             field_declarations.push((first_declaration_order, symbol_id, result));
         }
 
@@ -2215,7 +2282,7 @@ impl<'db> StaticClassLiteral<'db> {
                     None
                 } else {
                     let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-                    place_from_bindings(db, bindings)
+                    place_from_bindings(db, program, bindings)
                         .place
                         .ignore_possibly_undefined()
                 };
@@ -2257,8 +2324,6 @@ impl<'db> StaticClassLiteral<'db> {
                     },
                     CodeGeneratorKind::Pydantic(_) => FieldKind::Pydantic {
                         default_ty,
-                        // Pydantic treats underscore-prefixed annotations as private attributes,
-                        // which are instance attributes but never constructor parameters.
                         init: init && !symbol.name().starts_with('_'),
                         alias,
                         strict,
@@ -2289,7 +2354,9 @@ impl<'db> StaticClassLiteral<'db> {
                 };
 
                 // Check if this is a KW_ONLY sentinel and mark subsequent fields as keyword-only
-                if field_policy.is_dataclass_like() && field.is_kw_only_sentinel(db) {
+                if matches!(field_policy, CodeGeneratorKind::DataclassLike(_))
+                    && field.is_kw_only_sentinel(db, program)
+                {
                     kw_only_sentinel_field_seen = true;
                 }
 
@@ -2336,14 +2403,16 @@ impl<'db> StaticClassLiteral<'db> {
             return Place::Undefined.into();
         }
 
-        match MroLookup::new(db, self.iter_mro(db, specialization)).instance_member(name) {
+        let program = self.program(db);
+        match MroLookup::new(db, program, self.iter_mro(db, specialization)).instance_member(name) {
             InstanceMemberResult::Done(result) => result,
             InstanceMemberResult::TypedDict => KnownClass::TypedDictFallback
-                .to_instance(db)
-                .instance_member(db, name)
+                .to_instance(db, program)
+                .instance_member(db, program, name)
                 .map_type(|ty| {
                     ty.apply_type_mapping(
                         db,
+                        program,
                         &TypeMapping::ReplaceSelf {
                             new_upper_bound: Type::instance(db, self.unknown_specialization(db)),
                         },
@@ -2391,21 +2460,22 @@ impl<'db> StaticClassLiteral<'db> {
         attribute: ImplicitAttributeName<'db>,
     ) -> Member<'db> {
         let class_body_scope = attribute.class_body_scope(db);
+        let program_file = class_body_scope.program_file(db);
+        let program = program_file.program(db);
         let name = attribute.name(db);
         let target_method_decorator = attribute.target_method_decorator(db);
 
         // If we do not see any declarations of an attribute, neither in the class body nor in
         // any method, we build a union of the raw types inferred from all bindings of that
         // attribute, then apply public-type promotion to the final union.
-        let mut union_of_inferred_types = UnionBuilder::new(db);
+        let mut union_of_inferred_types = UnionBuilder::new(db, program);
         let mut qualifiers = TypeQualifiers::IMPLICIT_INSTANCE_ATTRIBUTE;
 
         let mut is_attribute_bound = false;
         let mut provenance = Provenance::Unknown;
 
-        let file = class_body_scope.file(db);
-        let module = parsed_module(db, file).load(db);
-        let index = semantic_index(db, file);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
+        let index = semantic_index(db, program_file);
         let class_map = use_def_map(db, class_body_scope);
         let class_table = place_table(db, class_body_scope);
         let is_valid_scope = |method_scope: &Scope| {
@@ -2619,7 +2689,11 @@ impl<'db> StaticClassLiteral<'db> {
                                 TypeContext::default(),
                             );
                             // TODO: Potential diagnostics resulting from the iterable are currently not reported.
-                            Some(iterable_ty.iterate(db).homogeneous_element_type(db))
+                            Some(
+                                iterable_ty
+                                    .iterate(db, program)
+                                    .homogeneous_element_type(db, program),
+                            )
                         }
                     },
                     DefinitionKind::WithItem(with_item) => match with_item.target_kind() {
@@ -2642,9 +2716,9 @@ impl<'db> StaticClassLiteral<'db> {
                                 TypeContext::default(),
                             );
                             Some(if with_item.is_async() {
-                                context_ty.aenter(db)
+                                context_ty.aenter(db, program)
                             } else {
-                                context_ty.enter(db)
+                                context_ty.enter(db, program)
                             })
                         }
                     },
@@ -2669,7 +2743,11 @@ impl<'db> StaticClassLiteral<'db> {
                                     TypeContext::default(),
                                 );
                                 // TODO: Potential diagnostics resulting from the iterable are currently not reported.
-                                Some(iterable_ty.iterate(db).homogeneous_element_type(db))
+                                Some(
+                                    iterable_ty
+                                        .iterate(db, program)
+                                        .homogeneous_element_type(db, program),
+                                )
                             }
                         }
                     }
@@ -2696,8 +2774,8 @@ impl<'db> StaticClassLiteral<'db> {
                 Place::bound(
                     union_of_inferred_types
                         .build()
-                        .promote(db)
-                        .promote_singletons(db),
+                        .promote(db, program)
+                        .promote_singletons(db, program),
                 )
                 .with_provenance(provenance)
                 .with_qualifiers(qualifiers)
@@ -2729,11 +2807,12 @@ impl<'db> StaticClassLiteral<'db> {
         let table = place_table(db, body_scope);
 
         if let Some(symbol_id) = table.symbol_id(name) {
+            let program = self.program(db);
             let use_def = use_def_map(db, body_scope);
 
             let declarations = use_def.end_of_scope_symbol_declarations(symbol_id);
-            let declared_and_qualifiers =
-                place_from_declarations(db, declarations).ignore_conflicting_declarations();
+            let declared_and_qualifiers = place_from_declarations(db, program, declarations)
+                .ignore_conflicting_declarations();
 
             match declared_and_qualifiers {
                 PlaceAndQualifiers {
@@ -2763,9 +2842,11 @@ impl<'db> StaticClassLiteral<'db> {
                     }
 
                     // `KW_ONLY` sentinels are markers, not real instance attributes.
-                    if declared_ty.is_instance_of(db, KnownClass::KwOnly)
-                        && CodeGeneratorKind::from_static_class(db, self)
-                            .is_some_and(CodeGeneratorKind::is_dataclass_like)
+                    if declared_ty.is_instance_of(db, program, KnownClass::KwOnly)
+                        && matches!(
+                            CodeGeneratorKind::from_static_class(db, self),
+                            Some(CodeGeneratorKind::DataclassLike(_))
+                        )
                     {
                         return Member::unbound();
                     }
@@ -2773,7 +2854,7 @@ impl<'db> StaticClassLiteral<'db> {
                     // The attribute is declared in the class body.
 
                     let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-                    let inferred = place_from_bindings(db, bindings).place;
+                    let inferred = place_from_bindings(db, program, bindings).place;
                     let has_binding = !inferred.is_undefined();
 
                     if has_binding {
@@ -2799,6 +2880,7 @@ impl<'db> StaticClassLiteral<'db> {
                                     inner: Place::Defined(DefinedPlace {
                                         ty: UnionType::from_two_elements(
                                             db,
+                                            program,
                                             declared_ty,
                                             implicit_ty,
                                         ),
@@ -2812,7 +2894,7 @@ impl<'db> StaticClassLiteral<'db> {
                             }
                         } else if self.is_own_dataclass_instance_field(db, name)
                             && declared_ty
-                                .class_member(db, "__get__".into())
+                                .class_member(db, program, "__get__".into())
                                 .place
                                 .is_undefined()
                         {
@@ -2866,6 +2948,7 @@ impl<'db> StaticClassLiteral<'db> {
                                     inner: Place::Defined(DefinedPlace {
                                         ty: UnionType::from_two_elements(
                                             db,
+                                            program,
                                             declared_ty,
                                             implicit_ty,
                                         ),
@@ -3043,7 +3126,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// ```
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let class_scope = self.body_scope(db);
-        let module = parsed_module(db, class_scope.file(db)).load(db);
+        let module = parsed_module(db, class_scope.program_file(db).versioned_file(db)).load(db);
         let class_node = self.node(db, &module);
         let class_name = &class_node.name;
         TextRange::new(
@@ -3059,7 +3142,7 @@ impl<'db> StaticClassLiteral<'db> {
     /// Returns the range of the class's name
     pub(crate) fn focus_range(self, db: &'db dyn Db) -> TextRange {
         let class_scope = self.body_scope(db);
-        let module = parsed_module(db, class_scope.file(db)).load(db);
+        let module = parsed_module(db, class_scope.program_file(db).versioned_file(db)).load(db);
         let class_node = self.node(db, &module);
         class_node.name.range()
     }
@@ -3153,12 +3236,13 @@ fn expanded_fixed_length_starred_class_base_tuple<'db>(
     class_definition: Definition<'db>,
     base_node: &ast::Expr,
 ) -> Option<FixedLengthTuple<Type<'db>>> {
+    let program = class_definition.program_file(db).program(db);
     let ast::Expr::Starred(starred) = base_node else {
         return None;
     };
 
     let starred_ty = definition_expression_type(db, class_definition, &starred.value);
-    let tuple_spec = starred_ty.tuple_instance_spec(db)?;
+    let tuple_spec = starred_ty.tuple_instance_spec(db, program)?;
     let Tuple::Fixed(tuple) = tuple_spec.into_owned() else {
         return None;
     };
@@ -3166,9 +3250,14 @@ fn expanded_fixed_length_starred_class_base_tuple<'db>(
 }
 
 #[salsa::tracked]
-impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
+impl<'db> StaticClassLiteral<'db> {
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant, heap_size=ruff_memory_usage::heap_size)]
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn inferred_variance_of(
+        self,
+        db: &'db dyn Db,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        let program = self.program(db);
         let typevar_in_generic_context = self
             .generic_context(db)
             .is_some_and(|generic_context| generic_context.contains(db, typevar));
@@ -3178,13 +3267,13 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
         }
         let class_body_scope = self.body_scope(db);
 
-        let file = class_body_scope.file(db);
-        let index = semantic_index(db, file);
+        let program_file = class_body_scope.program_file(db);
+        let index = semantic_index(db, program_file);
 
         let explicit_bases_variances = self
             .explicit_bases(db)
             .iter()
-            .map(|class| class.variance_of(db, typevar));
+            .map(|class| class.variance_of(db, program, typevar));
 
         let default_attribute_variance = {
             let is_namedtuple = CodeGeneratorKind::NamedTuple.matches(db, self.into());
@@ -3194,7 +3283,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             // not considered here, since they don't use field types in their signatures. TODO:
             // ideally we'd have a single source of truth for information about synthesized
             // methods, so we just look them up normally and don't hardcode this knowledge here.
-            let is_frozen_dataclass_prior_to_313 = Program::get(db).python_version(db)
+            let is_frozen_dataclass_prior_to_313 = program.python_version(db)
                 <= PythonVersion::PY312
                 && CodeGeneratorKind::from_static_class(db, self)
                     .is_some_and(|kind| self.has_dataclass_param(db, kind, DataclassFlags::FROZEN));
@@ -3215,13 +3304,16 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
             use_def_map
                 .all_end_of_scope_symbol_declarations()
                 .map(|(symbol_id, declarations)| {
-                    let place_and_qual =
-                        place_from_declarations(db, declarations).ignore_conflicting_declarations();
+                    let place_and_qual = place_from_declarations(db, program, declarations)
+                        .ignore_conflicting_declarations();
                     (symbol_id, place_and_qual)
                 })
                 .chain(use_def_map.all_end_of_scope_symbol_bindings().map(
                     |(symbol_id, bindings)| {
-                        (symbol_id, place_from_bindings(db, bindings).place.into())
+                        (
+                            symbol_id,
+                            place_from_bindings(db, program, bindings).place.into(),
+                        )
                     },
                 ))
                 .filter_map(|(symbol_id, place_and_qual)| {
@@ -3237,7 +3329,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
         // `__lt__`, etc.) but none of these will have field types type variables in their signatures, so we
         // don't need to consider them for variance.
 
-        let attribute_names = attribute_scopes(db, self.body_scope(db))
+        let attribute_names = attribute_scopes(db, class_body_scope)
             .flat_map(|function_scope_id| {
                 index
                     .place_table(function_scope_id)
@@ -3278,7 +3370,7 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
                     } else {
                         default_attribute_variance
                     };
-                    ty.with_polarity(variance).variance_of(db, typevar)
+                    ty.with_polarity(variance).variance_of(db, program, typevar)
                 })
             });
 
@@ -3293,13 +3385,24 @@ impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
                 extra_items
                     .declared_ty
                     .with_polarity(polarity)
-                    .variance_of(db, typevar)
+                    .variance_of(db, program, typevar)
             });
 
         attribute_variances
             .chain(explicit_bases_variances)
             .chain(extra_items_variance)
             .collect()
+    }
+}
+
+impl<'db> VarianceInferable<'db> for StaticClassLiteral<'db> {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        _program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.inferred_variance_of(db, typevar)
     }
 }
 
@@ -3324,7 +3427,11 @@ fn explicit_bases_cycle_initial<'db>(
     id: salsa::Id,
     literal: StaticClassLiteral<'db>,
 ) -> Box<[Type<'db>]> {
-    let module = parsed_module(db, literal.file(db)).load(db);
+    let module = parsed_module(
+        db,
+        literal.body_scope(db).program_file(db).versioned_file(db),
+    )
+    .load(db);
     let class_stmt = literal.node(db, &module);
     // Try to produce a list of `Divergent` types of the right length. However, if one or more of
     // the bases is a starred expression, we don't know how many entries that will eventually
@@ -3337,15 +3444,16 @@ fn explicit_bases_cycle_fn<'db>(
     cycle: &salsa::Cycle,
     previous: &[Type<'db>],
     current: Box<[Type<'db>]>,
-    _literal: StaticClassLiteral<'db>,
+    literal: StaticClassLiteral<'db>,
 ) -> Box<[Type<'db>]> {
+    let program = literal.program(db);
     if previous.len() == current.len() {
         // As long as the length of bases hasn't changed, use the same "monotonic widening"
         // strategy that we use with most types, to avoid oscillations.
         current
             .iter()
             .zip(previous.iter())
-            .map(|(curr, prev)| curr.cycle_normalized(db, *prev, cycle))
+            .map(|(curr, prev)| curr.cycle_normalized(db, program, *prev, cycle))
             .collect()
     } else {
         // The length of bases has changed, presumably because we expanded a starred expression. We
@@ -3371,7 +3479,7 @@ impl get_size2::GetSize for ImplicitAttributeName<'_> {}
 
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
 fn implicit_attribute_names<'db>(db: &'db dyn Db, class_body_scope: ScopeId<'db>) -> Box<[Name]> {
-    let index = semantic_index(db, class_body_scope.file(db));
+    let index = semantic_index(db, class_body_scope.program_file(db));
     let mut names = Vec::new();
 
     for function_scope_id in attribute_scopes(db, class_body_scope) {
@@ -3393,10 +3501,11 @@ fn implicit_attribute_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous_member: &Member<'db>,
     member: Member<'db>,
-    _attribute: ImplicitAttributeName<'db>,
+    attribute: ImplicitAttributeName<'db>,
 ) -> Member<'db> {
+    let program = attribute.class_body_scope(db).program(db);
     let inner = member
         .inner
-        .cycle_normalized(db, previous_member.inner, cycle);
+        .cycle_normalized(db, program, previous_member.inner, cycle);
     Member { inner }
 }

--- a/crates/ty_python_semantic/src/types/class/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/class/typed_dict.rs
@@ -10,6 +10,7 @@ use ruff_python_stdlib::identifiers::is_identifier;
 use ruff_text_size::{Ranged, TextRange};
 use ty_module_resolver::KnownModule;
 
+use crate::Program;
 use crate::place::PlaceAndQualifiers;
 use crate::place::known_module_symbol;
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
@@ -32,51 +33,91 @@ use ty_python_core::scope::ScopeId;
 
 pub(super) fn synthesize_typed_dict_method<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     method_name: &str,
     fields: impl Fn() -> TypedDictFields<'db>,
 ) -> Option<Type<'db>> {
     let instance_ty = Type::TypedDict(typed_dict);
     match method_name {
-        "__init__" => Some(synthesize_typed_dict_init(db, typed_dict, fields())),
-        "__getitem__" => Some(synthesize_typed_dict_getitem(db, typed_dict, fields())),
-        "__setitem__" => Some(synthesize_typed_dict_setitem(db, typed_dict, fields())),
-        "__delitem__" => Some(synthesize_typed_dict_delitem(db, typed_dict, fields())),
-        "get" => Some(synthesize_typed_dict_get(db, typed_dict, fields())),
-        "update" => Some(synthesize_typed_dict_update(db, typed_dict, fields())),
-        "pop" => Some(synthesize_typed_dict_pop(db, typed_dict, fields())),
-        "setdefault" => Some(synthesize_typed_dict_setdefault(db, typed_dict, fields())),
+        "__init__" => Some(synthesize_typed_dict_init(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
+        "__getitem__" => Some(synthesize_typed_dict_getitem(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
+        "__setitem__" => Some(synthesize_typed_dict_setitem(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
+        "__delitem__" => Some(synthesize_typed_dict_delitem(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
+        "get" => Some(synthesize_typed_dict_get(db, program, typed_dict, fields())),
+        "update" => Some(synthesize_typed_dict_update(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
+        "pop" => Some(synthesize_typed_dict_pop(db, program, typed_dict, fields())),
+        "setdefault" => Some(synthesize_typed_dict_setdefault(
+            db,
+            program,
+            typed_dict,
+            fields(),
+        )),
         "clear" if typed_dict.supports_arbitrary_key_deletion(db) => Some(
-            synthesize_typed_dict_no_argument_method(db, typed_dict, Type::none(db)),
+            synthesize_typed_dict_no_argument_method(db, typed_dict, Type::none(db, program)),
         ),
         "popitem" if typed_dict.supports_arbitrary_key_deletion(db) => {
             let return_ty = Type::heterogeneous_tuple(
                 db,
-                [KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+                [
+                    KnownClass::Str.to_instance(db, program),
+                    typed_dict.value_type(db, program),
+                ],
             );
             Some(synthesize_typed_dict_no_argument_method(
                 db, typed_dict, return_ty,
             ))
         }
         "__iter__" if typed_dict.openness(db).is_closed() => {
-            let return_ty =
-                KnownClass::Iterator.to_specialized_instance(db, &[typed_dict.key_type(db)]);
+            let return_ty = KnownClass::Iterator.to_specialized_instance(
+                db,
+                program,
+                &[typed_dict.key_type(db, program)],
+            );
             Some(synthesize_typed_dict_no_argument_method(
                 db, typed_dict, return_ty,
             ))
         }
         "items" if !typed_dict.openness(db).is_implicitly_open() => Some(
-            synthesize_typed_dict_view_method(db, typed_dict, "dict_items"),
+            synthesize_typed_dict_view_method(db, program, typed_dict, "dict_items"),
         ),
         "keys" if !typed_dict.openness(db).is_implicitly_open() => Some(
-            synthesize_typed_dict_view_method(db, typed_dict, "dict_keys"),
+            synthesize_typed_dict_view_method(db, program, typed_dict, "dict_keys"),
         ),
         "values" if !typed_dict.openness(db).is_implicitly_open() => Some(
-            synthesize_typed_dict_view_method(db, typed_dict, "dict_values"),
+            synthesize_typed_dict_view_method(db, program, typed_dict, "dict_values"),
         ),
-        "__or__" | "__ror__" | "__ior__" => {
-            Some(synthesize_typed_dict_merge(db, instance_ty, method_name))
-        }
+        "__or__" | "__ror__" | "__ior__" => Some(synthesize_typed_dict_merge(
+            db,
+            program,
+            instance_ty,
+            method_name,
+        )),
         _ => None,
     }
 }
@@ -125,6 +166,7 @@ impl<'db> TypedDictFields<'db> {
 ///    Keyword-only. Fields that are not valid Python identifiers are collapsed into `**kwargs`.
 fn synthesize_typed_dict_init<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -165,7 +207,7 @@ fn synthesize_typed_dict_init<'db>(
                 .chain(params_with_default)
                 .chain(keyword_rest_param.clone()),
         ),
-        Type::none(db),
+        Type::none(db, program),
     );
 
     let keyword_field_params = keyword_fields.iter().map(|(name, field)| {
@@ -185,7 +227,7 @@ fn synthesize_typed_dict_init<'db>(
                 .chain(keyword_field_params)
                 .chain(keyword_rest_param),
         ),
-        Type::none(db),
+        Type::none(db, program),
     );
 
     Type::Callable(CallableType::new(
@@ -199,6 +241,7 @@ fn synthesize_typed_dict_init<'db>(
 /// Synthesize the `__getitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_getitem<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -220,10 +263,10 @@ fn synthesize_typed_dict_getitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
             ]),
             if typed_dict.explicit_extra_items(db).is_some() {
-                typed_dict.value_type(db)
+                typed_dict.value_type(db, program)
             } else {
                 Type::object()
             },
@@ -240,6 +283,7 @@ fn synthesize_typed_dict_getitem<'db>(
 /// Synthesize the `__setitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_setitem<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -248,7 +292,7 @@ fn synthesize_typed_dict_setitem<'db>(
         .iter()
         .filter(|(_, field)| !field.is_read_only())
         .peekable();
-    let arbitrary_key_mutation_type = typed_dict.arbitrary_key_mutation_type(db);
+    let arbitrary_key_mutation_type = typed_dict.arbitrary_key_mutation_type(db, program);
 
     if writable_fields.peek().is_none() && arbitrary_key_mutation_type.is_none() {
         let parameters = [
@@ -259,7 +303,7 @@ fn synthesize_typed_dict_setitem<'db>(
             Parameter::positional_only(Some(Name::new_static("value")))
                 .with_annotated_type(Type::any()),
         ];
-        let signature = Signature::new(Parameters::standard(parameters), Type::none(db));
+        let signature = Signature::new(Parameters::standard(parameters), Type::none(db, program));
         return Type::function_like_callable(db, signature);
     }
 
@@ -274,18 +318,18 @@ fn synthesize_typed_dict_setitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(field.declared_ty),
             ];
-            Signature::new(Parameters::standard(parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db, program))
         })
         .chain(arbitrary_key_mutation_type.map(|value_ty| {
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
                 Parameter::positional_only(Some(Name::new_static("value")))
                     .with_annotated_type(value_ty),
             ];
-            Signature::new(Parameters::standard(parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db, program))
         }));
 
     Type::Callable(CallableType::new(
@@ -299,6 +343,7 @@ fn synthesize_typed_dict_setitem<'db>(
 /// Synthesize the `__delitem__` method for a `TypedDict`.
 fn synthesize_typed_dict_delitem<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -316,7 +361,7 @@ fn synthesize_typed_dict_delitem<'db>(
             Parameter::positional_only(Some(Name::new_static("key")))
                 .with_annotated_type(Type::Never),
         ];
-        let signature = Signature::new(Parameters::standard(parameters), Type::none(db));
+        let signature = Signature::new(Parameters::standard(parameters), Type::none(db, program));
         return Type::function_like_callable(db, signature);
     }
 
@@ -329,16 +374,16 @@ fn synthesize_typed_dict_delitem<'db>(
                 Parameter::positional_only(Some(Name::new_static("key")))
                     .with_annotated_type(key_type),
             ];
-            Signature::new(Parameters::standard(parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db, program))
         })
         .chain(supports_arbitrary_key_deletion.then(|| {
             let parameters = [
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
             ];
-            Signature::new(Parameters::standard(parameters), Type::none(db))
+            Signature::new(Parameters::standard(parameters), Type::none(db, program))
         }));
 
     Type::Callable(CallableType::new(
@@ -352,6 +397,7 @@ fn synthesize_typed_dict_delitem<'db>(
 /// Synthesize the `get` method for a `TypedDict`.
 fn synthesize_typed_dict_get<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -359,7 +405,7 @@ fn synthesize_typed_dict_get<'db>(
     let fallback_value_ty = if typed_dict.openness(db).is_implicitly_open() {
         Type::unknown()
     } else {
-        typed_dict.value_type(db)
+        typed_dict.value_type(db, program)
     };
     let overloads = fields
         .iter()
@@ -377,12 +423,18 @@ fn synthesize_typed_dict_get<'db>(
                 if field.is_required() {
                     field.declared_ty
                 } else {
-                    UnionType::from_two_elements(db, field.declared_ty, Type::none(db))
+                    UnionType::from_two_elements(
+                        db,
+                        program,
+                        field.declared_ty,
+                        Type::none(db, program),
+                    )
                 },
             );
 
             let t_default = BoundTypeVarInstance::synthetic(
                 db,
+                program,
                 Name::new_static("T"),
                 TypeVarVariance::Covariant,
             );
@@ -396,12 +448,21 @@ fn synthesize_typed_dict_get<'db>(
                     .with_annotated_type(Type::TypeVar(t_default)),
             ];
             let get_with_default_sig = Signature::new_generic(
-                Some(GenericContext::from_typevar_instances(db, [t_default])),
+                Some(GenericContext::from_typevar_instances(
+                    db,
+                    program,
+                    [t_default],
+                )),
                 Parameters::standard(get_with_default_sig_params),
                 if field.is_required() {
                     field.declared_ty
                 } else {
-                    UnionType::from_two_elements(db, field.declared_ty, Type::TypeVar(t_default))
+                    UnionType::from_two_elements(
+                        db,
+                        program,
+                        field.declared_ty,
+                        Type::TypeVar(t_default),
+                    )
                 },
             );
 
@@ -434,13 +495,14 @@ fn synthesize_typed_dict_get<'db>(
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
             ]),
-            UnionType::from_two_elements(db, fallback_value_ty, Type::none(db)),
+            UnionType::from_two_elements(db, program, fallback_value_ty, Type::none(db, program)),
         )))
         .chain(std::iter::once({
             let t_default = BoundTypeVarInstance::synthetic(
                 db,
+                program,
                 Name::new_static("T"),
                 TypeVarVariance::Covariant,
             );
@@ -449,15 +511,24 @@ fn synthesize_typed_dict_get<'db>(
                 Parameter::positional_only(Some(Name::new_static("self")))
                     .with_annotated_type(instance_ty),
                 Parameter::positional_only(Some(Name::new_static("key")))
-                    .with_annotated_type(KnownClass::Str.to_instance(db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(db, program)),
                 Parameter::positional_only(Some(Name::new_static("default")))
                     .with_annotated_type(Type::TypeVar(t_default)),
             ];
 
             Signature::new_generic(
-                Some(GenericContext::from_typevar_instances(db, [t_default])),
+                Some(GenericContext::from_typevar_instances(
+                    db,
+                    program,
+                    [t_default],
+                )),
                 Parameters::standard(parameters),
-                UnionType::from_two_elements(db, fallback_value_ty, Type::TypeVar(t_default)),
+                UnionType::from_two_elements(
+                    db,
+                    program,
+                    fallback_value_ty,
+                    Type::TypeVar(t_default),
+                ),
             )
         }));
 
@@ -472,6 +543,7 @@ fn synthesize_typed_dict_get<'db>(
 /// Synthesize the `update` method for a `TypedDict`.
 fn synthesize_typed_dict_update<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -501,16 +573,23 @@ fn synthesize_typed_dict_update<'db>(
 
     let update_patch_ty = Type::TypedDict(typed_dict.to_update_patch(db));
 
-    let mapping_ty = typed_dict.dict_value_type(db).map(|value_ty| {
-        KnownClass::Mapping
-            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
+    let mapping_ty = typed_dict.dict_value_type(db, program).map(|value_ty| {
+        KnownClass::Mapping.to_specialized_instance(
+            db,
+            program,
+            &[KnownClass::Str.to_instance(db, program), value_ty],
+        )
     });
-    let iterable_ty = typed_dict.arbitrary_key_mutation_type(db).map(|value_ty| {
-        let item_ty = Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db), value_ty]);
-        KnownClass::Iterable.to_specialized_instance(db, &[item_ty])
-    });
+    let iterable_ty = typed_dict
+        .arbitrary_key_mutation_type(db, program)
+        .map(|value_ty| {
+            let item_ty =
+                Type::heterogeneous_tuple(db, [KnownClass::Str.to_instance(db, program), value_ty]);
+            KnownClass::Iterable.to_specialized_instance(db, program, &[item_ty])
+        });
     let value_ty = UnionType::from_elements(
         db,
+        program,
         std::iter::once(update_patch_ty)
             .chain(mapping_ty)
             .chain(iterable_ty),
@@ -520,18 +599,20 @@ fn synthesize_typed_dict_update<'db>(
         Parameter::positional_only(Some(Name::new_static("self"))).with_annotated_type(instance_ty),
         Parameter::positional_only(Some(Name::new_static("value")))
             .with_annotated_type(value_ty)
-            .with_default_type(Type::none(db)),
+            .with_default_type(Type::none(db, program)),
     ]
     .into_iter()
     .chain(keyword_parameters);
 
-    let update_signature = Signature::new(Parameters::standard(parameters), Type::none(db));
+    let update_signature =
+        Signature::new(Parameters::standard(parameters), Type::none(db, program));
     Type::function_like_callable(db, update_signature)
 }
 
 /// Synthesize the `pop` method for a `TypedDict`.
 fn synthesize_typed_dict_pop<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -558,8 +639,12 @@ fn synthesize_typed_dict_pop<'db>(
             value_ty,
         );
 
-        let t_default =
-            BoundTypeVarInstance::synthetic(db, Name::new_static("T"), TypeVarVariance::Covariant);
+        let t_default = BoundTypeVarInstance::synthetic(
+            db,
+            program,
+            Name::new_static("T"),
+            TypeVarVariance::Covariant,
+        );
         let pop_with_default_parameters = [
             Parameter::positional_only(Some(Name::new_static("self")))
                 .with_annotated_type(instance_ty),
@@ -568,9 +653,13 @@ fn synthesize_typed_dict_pop<'db>(
                 .with_annotated_type(Type::TypeVar(t_default)),
         ];
         let pop_with_default_sig = Signature::new_generic(
-            Some(GenericContext::from_typevar_instances(db, [t_default])),
+            Some(GenericContext::from_typevar_instances(
+                db,
+                program,
+                [t_default],
+            )),
             Parameters::standard(pop_with_default_parameters),
-            UnionType::from_two_elements(db, value_ty, Type::TypeVar(t_default)),
+            UnionType::from_two_elements(db, program, value_ty, Type::TypeVar(t_default)),
         );
 
         [pop_sig, pop_with_typed_default_sig, pop_with_default_sig]
@@ -585,7 +674,12 @@ fn synthesize_typed_dict_pop<'db>(
         .chain(
             typed_dict
                 .supports_arbitrary_key_deletion(db)
-                .then(|| pop_overloads(KnownClass::Str.to_instance(db), typed_dict.value_type(db)))
+                .then(|| {
+                    pop_overloads(
+                        KnownClass::Str.to_instance(db, program),
+                        typed_dict.value_type(db, program),
+                    )
+                })
                 .into_iter()
                 .flatten(),
         );
@@ -601,6 +695,7 @@ fn synthesize_typed_dict_pop<'db>(
 /// Synthesize the `setdefault` method for a `TypedDict`.
 fn synthesize_typed_dict_setdefault<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     fields: TypedDictFields<'db>,
 ) -> Type<'db> {
@@ -623,17 +718,20 @@ fn synthesize_typed_dict_setdefault<'db>(
         })
         .chain(
             typed_dict
-                .arbitrary_key_mutation_type(db)
+                .arbitrary_key_mutation_type(db, program)
                 .map(|default_ty| {
                     let parameters = [
                         Parameter::positional_only(Some(Name::new_static("self")))
                             .with_annotated_type(instance_ty),
                         Parameter::positional_only(Some(Name::new_static("key")))
-                            .with_annotated_type(KnownClass::Str.to_instance(db)),
+                            .with_annotated_type(KnownClass::Str.to_instance(db, program)),
                         Parameter::positional_only(Some(Name::new_static("default")))
                             .with_annotated_type(default_ty),
                     ];
-                    Signature::new(Parameters::standard(parameters), typed_dict.value_type(db))
+                    Signature::new(
+                        Parameters::standard(parameters),
+                        typed_dict.value_type(db, program),
+                    )
                 }),
         );
 
@@ -663,21 +761,28 @@ fn synthesize_typed_dict_no_argument_method<'db>(
 /// Synthesize `items`, `keys`, or `values` for a closed or extra-items `TypedDict`.
 fn synthesize_typed_dict_view_method<'db>(
     db: &'db dyn Db,
+    program: Program,
     typed_dict: TypedDictType<'db>,
     view_name: &str,
 ) -> Type<'db> {
-    let return_ty = known_module_symbol(db, KnownModule::CollectionsAbcInternal, view_name)
-        .place
-        .ignore_possibly_undefined()
-        .and_then(Type::as_class_literal)
-        .map(|class| {
-            class.apply_specialization(db, |generic_context| {
-                generic_context
-                    .specialize(db, &[typed_dict.key_type(db), typed_dict.value_type(db)])
+    let return_ty =
+        known_module_symbol(db, program, KnownModule::CollectionsAbcInternal, view_name)
+            .place
+            .ignore_possibly_undefined()
+            .and_then(Type::as_class_literal)
+            .map(|class| {
+                class.apply_specialization(db, |generic_context| {
+                    generic_context.specialize(
+                        db,
+                        &[
+                            typed_dict.key_type(db, program),
+                            typed_dict.value_type(db, program),
+                        ],
+                    )
+                })
             })
-        })
-        .and_then(|class| Type::from(class).to_instance(db))
-        .unwrap_or_else(Type::unknown);
+            .and_then(|class| Type::from(class).to_instance(db, program))
+            .unwrap_or_else(Type::unknown);
 
     synthesize_typed_dict_no_argument_method(db, typed_dict, return_ty)
 }
@@ -685,6 +790,7 @@ fn synthesize_typed_dict_view_method<'db>(
 /// Synthesize a merge operator (`__or__`, `__ror__`, or `__ior__`) for a `TypedDict`.
 fn synthesize_typed_dict_merge<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     instance_ty: Type<'db>,
     name: &str,
 ) -> Type<'db> {
@@ -716,14 +822,18 @@ fn synthesize_typed_dict_merge<'db>(
             instance_ty
         };
 
-        let dict_param_ty = KnownClass::Dict
-            .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
+        let dict_param_ty = KnownClass::Dict.to_specialized_instance(
+            db,
+            program,
+            &[KnownClass::Str.to_instance(db, program), Type::any()],
+        );
 
         let dict_return_ty = KnownClass::Dict.to_specialized_instance(
             db,
+            program,
             &[
-                KnownClass::Str.to_instance(db),
-                KnownClass::Object.to_instance(db),
+                KnownClass::Str.to_instance(db, program),
+                KnownClass::Object.to_instance(db, program),
             ],
         );
 
@@ -802,12 +912,15 @@ impl<'db> DynamicTypedDictAnchor<'db> {
                 offset,
                 schema,
                 openness,
-            } => Some(Self::ScopeOffset {
-                scope: *scope,
-                offset: *offset,
-                schema: schema.recursive_type_normalized_impl(db, div, nested)?,
-                openness: openness.recursive_type_normalized_impl(db, div, nested)?,
-            }),
+            } => {
+                let program = scope.program(db);
+                Some(Self::ScopeOffset {
+                    scope: *scope,
+                    offset: *offset,
+                    schema: schema.recursive_type_normalized_impl(db, program, div, nested)?,
+                    openness: openness.recursive_type_normalized_impl(db, program, div, nested)?,
+                })
+            }
         }
     }
 }
@@ -872,8 +985,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     /// Returns the range of the `TypedDict` call expression.
     pub(crate) fn header_range(self, db: &'db dyn Db) -> TextRange {
         let scope = self.scope(db);
-        let file = scope.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
 
         match self.anchor(db) {
             DynamicTypedDictAnchor::Definition(definition) => {
@@ -934,8 +1046,9 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     /// [self, `TypedDict`, object]
     #[salsa::tracked(returns(ref), heap_size = ruff_memory_usage::heap_size)]
     pub(crate) fn mro(self, db: &'db dyn Db) -> Mro<'db> {
+        let program = self.scope(db).program(db);
         let self_base = ClassBase::Class(ClassType::NonGeneric(self.into()));
-        let object_class = ClassType::object(db);
+        let object_class = ClassType::object(db, program);
         Mro::from([
             self_base,
             ClassBase::TypedDict(self.typed_dict_module(db)),
@@ -946,16 +1059,15 @@ impl<'db> DynamicTypedDictLiteral<'db> {
     /// Get the metaclass of this `TypedDict`.
     ///
     /// `TypedDict`s use `type` as their metaclass.
-    #[expect(clippy::unused_self)]
     pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
-        KnownClass::Type.to_class_literal(db)
+        KnownClass::Type.to_class_literal(db, self.scope(db).program(db))
     }
 
     /// Look up a class-level member defined directly on this `TypedDict` (not inherited).
     pub(super) fn own_class_member(self, db: &'db dyn Db, name: &str) -> Member<'db> {
         let typed_dict =
             TypedDictType::new(ClassType::NonGeneric(ClassLiteral::DynamicTypedDict(self)));
-        synthesize_typed_dict_method(db, typed_dict, name, || {
+        synthesize_typed_dict_method(db, self.scope(db).program(db), typed_dict, name, || {
             TypedDictFields::Dynamic(self.items(db))
         })
         .map(Member::definitely_declared)
@@ -989,6 +1101,7 @@ impl<'db> DynamicTypedDictLiteral<'db> {
 
 pub(super) fn typed_dict_fallback_class_member<'db>(
     db: &'db dyn Db,
+    program: Program,
     module: TypedDictModule,
     lookup_policy: MemberLookupPolicy,
     name: &str,
@@ -999,8 +1112,8 @@ pub(super) fn typed_dict_fallback_class_member<'db>(
     };
 
     fallback
-        .to_class_literal(db)
-        .find_name_in_mro_with_policy(db, name, lookup_policy)
+        .to_class_literal(db, program)
+        .find_name_in_mro_with_policy(db, program, name, lookup_policy)
         .expect("Will return Some() when called on class literal")
 }
 
@@ -1011,20 +1124,24 @@ pub(super) fn typed_dict_class_member<'db>(
     lookup_policy: MemberLookupPolicy,
     name: &str,
 ) -> PlaceAndQualifiers<'db> {
+    let program = class.program(db);
     let self_class = class.class_literal(db);
-    let fallback_member = typed_dict_fallback_class_member(db, module, lookup_policy, name)
-        .map_type(|ty| {
+    let fallback_member =
+        typed_dict_fallback_class_member(db, program, module, lookup_policy, name).map_type(|ty| {
             let new_upper_bound = determine_upper_bound(db, self_class, ClassBase::is_typed_dict);
             let mapping = TypeMapping::ReplaceSelf { new_upper_bound };
-            ty.apply_type_mapping(db, &mapping, TypeContext::default())
+            ty.apply_type_mapping(db, program, &mapping, TypeContext::default())
         });
     if !fallback_member.is_undefined() {
         return fallback_member;
     }
 
-    if let Some(value_ty) = TypedDictType::new(class).dict_value_type(db)
-        && let Some(dict_class) = KnownClass::Dict
-            .to_specialized_class_type(db, &[KnownClass::Str.to_instance(db), value_ty])
+    if let Some(value_ty) = TypedDictType::new(class).dict_value_type(db, program)
+        && let Some(dict_class) = KnownClass::Dict.to_specialized_class_type(
+            db,
+            program,
+            &[KnownClass::Str.to_instance(db, program), value_ty],
+        )
     {
         let member = dict_class.class_member(db, name, lookup_policy);
         if !member.is_undefined() {

--- a/crates/ty_python_semantic/src/types/class_base.rs
+++ b/crates/ty_python_semantic/src/types/class_base.rs
@@ -7,7 +7,7 @@ use crate::types::{
     KnownInstanceType, MaterializationKind, SpecialFormType, StaticMroError, Type, TypeContext,
     TypeMapping, TypedDictModule, todo_type,
 };
-use crate::{Db, DisplaySettings};
+use crate::{Db, DisplaySettings, Program};
 
 /// Enumeration of the possible kinds of types we allow in class bases.
 ///
@@ -84,8 +84,8 @@ impl<'db> ClassBase<'db> {
     }
 
     /// Return a `ClassBase` representing the class `builtins.object`
-    pub(super) fn object(db: &'db dyn Db) -> Self {
-        Self::Class(ClassType::object(db))
+    pub(super) fn object(db: &'db dyn Db, program: crate::Program) -> Self {
+        Self::Class(ClassType::object(db, program))
     }
 
     pub(super) const fn is_typed_dict(self) -> bool {
@@ -118,13 +118,14 @@ impl<'db> ClassBase<'db> {
     /// Convert an explicit base while preserving a direct use of the `Any` special form.
     pub(super) fn try_from_explicit_base(
         db: &'db dyn Db,
+        program: Program,
         ty: Type<'db>,
         subclass: Option<ClassLiteral<'db>>,
     ) -> Option<Self> {
         if matches!(ty, Type::SpecialForm(SpecialFormType::Any)) {
             Some(Self::Any)
         } else {
-            Self::try_from_type(db, ty, subclass)
+            Self::try_from_type(db, program, ty, subclass)
         }
     }
 
@@ -133,6 +134,7 @@ impl<'db> ClassBase<'db> {
     /// Return `None` if `ty` is not an acceptable type for a class base.
     pub(super) fn try_from_type(
         db: &'db dyn Db,
+        program: Program,
         ty: Type<'db>,
         subclass: Option<ClassLiteral<'db>>,
     ) -> Option<Self> {
@@ -144,7 +146,7 @@ impl<'db> ClassBase<'db> {
             Type::NominalInstance(instance)
                 if instance.has_known_class(db, KnownClass::GenericAlias) =>
             {
-                Self::try_from_type(db, todo_type!("GenericAlias instance"), subclass)
+                Self::try_from_type(db, program, todo_type!("GenericAlias instance"), subclass)
             }
             Type::SubclassOf(subclass_of) => subclass_of
                 .subclass_of()
@@ -154,9 +156,9 @@ impl<'db> ClassBase<'db> {
                 let valid_element = inter
                     .positive(db)
                     .iter()
-                    .find_map(|elem| ClassBase::try_from_type(db, *elem, subclass))?;
+                    .find_map(|elem| ClassBase::try_from_type(db, program, *elem, subclass))?;
 
-                if ty.is_disjoint_from(db, KnownClass::Type.to_instance(db)) {
+                if ty.is_disjoint_from(db, program, KnownClass::Type.to_instance(db, program)) {
                     None
                 } else {
                     Some(valid_element)
@@ -185,7 +187,7 @@ impl<'db> ClassBase<'db> {
                 if union
                     .elements(db)
                     .iter()
-                    .all(|elem| ClassBase::try_from_type(db, *elem, subclass).is_some())
+                    .all(|elem| ClassBase::try_from_type(db, program, *elem, subclass).is_some())
                 {
                     Some(ClassBase::Dynamic(*dynamic))
                 } else {
@@ -198,10 +200,12 @@ impl<'db> ClassBase<'db> {
             // in which case we want to treat `Never` in a forgiving way and silence diagnostics
             Type::Never => Some(ClassBase::unknown()),
 
-            Type::TypeAlias(alias) => Self::try_from_type(db, alias.value_type(db), subclass),
+            Type::TypeAlias(alias) => {
+                Self::try_from_type(db, program, alias.value_type(db), subclass)
+            }
 
             Type::NewTypeInstance(newtype) => {
-                ClassBase::try_from_type(db, newtype.concrete_base_type(db), subclass)
+                ClassBase::try_from_type(db, program, newtype.concrete_base_type(db), subclass)
             }
 
             Type::PropertyInstance(_)
@@ -249,13 +253,18 @@ impl<'db> ClassBase<'db> {
                 | KnownInstanceType::FunctoolsPartial(_)
                 | KnownInstanceType::FunctoolsPartialCall(_) => None,
                 KnownInstanceType::TypeGenericAlias(_) => {
-                    Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
+                    Self::try_from_type(
+                        db,
+                        program,
+                        KnownClass::Type.to_class_literal(db, program),
+                        subclass,
+                    )
                 }
                 KnownInstanceType::Annotated(ty) => {
                     match ty.inner(db) {
                         Type::Dynamic(dynamic) => Some(Self::Dynamic(dynamic)),
                         Type::NominalInstance(instance) => {
-                            Some(Self::Class(instance.class(db)))
+                            Some(Self::Class(instance.class(db, program)))
                         }
                         _ => None,
                     }
@@ -302,32 +311,43 @@ impl<'db> ClassBase<'db> {
                     let fields = class.own_fields(db, None, CodeGeneratorKind::NamedTuple);
                     Self::try_from_type(
                         db,
+                        program,
                         TupleType::heterogeneous(
                             db,
                             fields.values().map(|field| field.declared_ty),
                         )?
-                        .to_class_type(db)
+                        .to_class_type(db, program)
                         .into(),
                         subclass,
                     )
                 }
 
                 // TODO: Classes inheriting from `typing.Type` also have `Generic` in their MRO
-                SpecialFormType::Type => {
-                    Self::try_from_type(db, KnownClass::Type.to_class_literal(db), subclass)
-                }
+                SpecialFormType::Type => Self::try_from_type(
+                    db,
+                    program,
+                    KnownClass::Type.to_class_literal(db, program),
+                    subclass,
+                ),
 
-                SpecialFormType::Tuple => {
-                    Self::try_from_type(db, KnownClass::Tuple.to_class_literal(db), subclass)
-                }
+                SpecialFormType::Tuple => Self::try_from_type(
+                    db,
+                    program,
+                    KnownClass::Tuple.to_class_literal(db, program),
+                    subclass,
+                ),
 
-                SpecialFormType::LegacyStdlibAlias(alias) => {
-                    Self::try_from_type(db, alias.aliased_class().to_class_literal(db), subclass)
-                }
+                SpecialFormType::LegacyStdlibAlias(alias) => Self::try_from_type(
+                    db,
+                    program,
+                    alias.aliased_class().to_class_literal(db, program),
+                    subclass,
+                ),
 
                 SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
                     Self::try_from_type(
                         db,
+                        program,
                         todo_type!("Support for Callable as a base class"),
                         subclass,
                     )
@@ -349,14 +369,16 @@ impl<'db> ClassBase<'db> {
     }
 
     /// Return the metaclass of this class base.
-    pub(crate) fn metaclass(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn metaclass(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             Self::Class(class) => class.metaclass(db),
             Self::Any => Type::Dynamic(DynamicType::Any),
             Self::Dynamic(dynamic) => Type::Dynamic(dynamic),
             Self::Divergent(divergent) => Type::Divergent(divergent),
             // TODO: all `Protocol` classes actually have `_ProtocolMeta` as their metaclass.
-            Self::Protocol | Self::Generic | Self::TypedDict(_) => KnownClass::Type.to_instance(db),
+            Self::Protocol | Self::Generic | Self::TypedDict(_) => {
+                KnownClass::Type.to_instance(db, program)
+            }
         }
     }
 
@@ -439,32 +461,41 @@ impl<'db> ClassBase<'db> {
     pub(super) fn mro(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         additional_specialization: Option<Specialization<'db>>,
     ) -> impl Iterator<Item = ClassBase<'db>> + Clone {
         match self {
-            ClassBase::Protocol => ClassBaseMroIterator::length_3(db, self, ClassBase::Generic),
+            ClassBase::Protocol => {
+                ClassBaseMroIterator::length_3(db, program, self, ClassBase::Generic)
+            }
             ClassBase::Any
             | ClassBase::Dynamic(_)
             | ClassBase::Divergent(_)
             | ClassBase::Generic
-            | ClassBase::TypedDict(_) => ClassBaseMroIterator::length_2(db, self),
+            | ClassBase::TypedDict(_) => ClassBaseMroIterator::length_2(db, program, self),
             ClassBase::Class(class) => {
                 ClassBaseMroIterator::from_class(db, class, additional_specialization)
             }
         }
     }
 
-    pub(super) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display {
-        self.display_with(db, DisplaySettings::default())
+    pub(super) fn display(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> impl std::fmt::Display {
+        self.display_with(db, program, DisplaySettings::default())
     }
 
     pub(super) fn display_with(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         display_settings: DisplaySettings<'db>,
     ) -> impl std::fmt::Display {
         struct ClassBaseDisplay<'db> {
             db: &'db dyn Db,
+            program: crate::Program,
             base: ClassBase<'db>,
             settings: DisplaySettings<'db>,
         }
@@ -476,7 +507,7 @@ impl<'db> ClassBase<'db> {
                     ClassBase::Dynamic(dynamic) => dynamic.fmt(f),
                     ClassBase::Divergent(_) => f.write_str("Divergent"),
                     ClassBase::Class(class) => Type::from(class)
-                        .display_with(self.db, self.settings.clone())
+                        .display_with(self.db, self.program, self.settings.clone())
                         .fmt(f),
                     ClassBase::Protocol => f.write_str("typing.Protocol"),
                     ClassBase::Generic => f.write_str("typing.Generic"),
@@ -487,6 +518,7 @@ impl<'db> ClassBase<'db> {
 
         ClassBaseDisplay {
             db,
+            program,
             base: self,
             settings: display_settings,
         }
@@ -529,13 +561,20 @@ enum ClassBaseMroIterator<'db> {
 
 impl<'db> ClassBaseMroIterator<'db> {
     /// Iterate over an MRO of length 2 that consists of `first_element` and then `object`.
-    fn length_2(db: &'db dyn Db, first_element: ClassBase<'db>) -> Self {
-        ClassBaseMroIterator::Length2([first_element, ClassBase::object(db)].into_iter())
+    fn length_2(db: &'db dyn Db, program: crate::Program, first_element: ClassBase<'db>) -> Self {
+        ClassBaseMroIterator::Length2([first_element, ClassBase::object(db, program)].into_iter())
     }
 
     /// Iterate over an MRO of length 3 that consists of `first_element`, then `second_element`, then `object`.
-    fn length_3(db: &'db dyn Db, element_1: ClassBase<'db>, element_2: ClassBase<'db>) -> Self {
-        ClassBaseMroIterator::Length3([element_1, element_2, ClassBase::object(db)].into_iter())
+    fn length_3(
+        db: &'db dyn Db,
+        program: crate::Program,
+        element_1: ClassBase<'db>,
+        element_2: ClassBase<'db>,
+    ) -> Self {
+        ClassBaseMroIterator::Length3(
+            [element_1, element_2, ClassBase::object(db, program)].into_iter(),
+        )
     }
 
     /// Iterate over the MRO of an arbitrary class. The MRO may be of any length.

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -111,7 +111,7 @@ use crate::types::{
     BoundTypeVarInstance, IntersectionType, Type, TypeVarBoundOrConstraints, TypeVarVariance,
     UnionType,
 };
-use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet};
+use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet, Program};
 
 /// An extension trait for building constraint sets from [`Option`] values.
 pub(crate) trait OptionConstraintsExtension<T> {
@@ -170,6 +170,7 @@ pub(crate) trait IteratorConstraintsExtension<T> {
     fn when_any<'db, 'c>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c>;
@@ -182,6 +183,7 @@ pub(crate) trait IteratorConstraintsExtension<T> {
     fn when_all<'db, 'c>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c>;
@@ -194,11 +196,13 @@ where
     fn when_any<'db, 'c>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let node = NodeId::distributed_or(
             db,
+            program,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -212,11 +216,13 @@ where
     fn when_all<'db, 'c>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         mut f: impl FnMut(T) -> ConstraintSet<'db, 'c>,
     ) -> ConstraintSet<'db, 'c> {
         let node = NodeId::distributed_and(
             db,
+            program,
             builder,
             self.map(|element| {
                 let constraint = f(element);
@@ -364,17 +370,19 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     /// Returns a constraint set that constrains a typevar to an explicit range of types.
     pub(crate) fn constrain_typevar(
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, builder, typevar, Some(lower), Some(upper))
+        Self::constrain_typevar_with_bounds(db, program, builder, typevar, Some(lower), Some(upper))
     }
 
     /// Returns a constraint set that constrains a typevar with explicit lower and/or upper bounds.
     pub(crate) fn constrain_typevar_with_bounds(
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Option<Type<'db>>,
@@ -382,28 +390,30 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     ) -> Self {
         Self::from_node(
             builder,
-            Constraint::new_node_with_bounds(db, builder, typevar, lower, upper),
+            Constraint::new_node_with_bounds(db, program, builder, typevar, lower, upper),
         )
     }
 
     /// Returns a constraint set that constrains a typevar to be a supertype of `lower`.
     pub(crate) fn constrain_typevar_lower_bound(
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, builder, typevar, Some(lower), None)
+        Self::constrain_typevar_with_bounds(db, program, builder, typevar, Some(lower), None)
     }
 
     /// Returns a constraint set that constrains a typevar to be a subtype of `upper`.
     pub(crate) fn constrain_typevar_upper_bound(
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         upper: Type<'db>,
     ) -> Self {
-        Self::constrain_typevar_with_bounds(db, builder, typevar, None, Some(upper))
+        Self::constrain_typevar_with_bounds(db, program, builder, typevar, None, Some(upper))
     }
 
     /// Verifies that this constraint set was created by `builder`
@@ -413,13 +423,13 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     }
 
     /// Returns whether this constraint set never holds
-    pub(crate) fn is_never_satisfied(self, db: &'db dyn Db) -> bool {
-        self.node.is_never_satisfied(db, self.builder)
+    pub(crate) fn is_never_satisfied(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.node.is_never_satisfied(db, program, self.builder)
     }
 
     /// Returns whether this constraint set always holds
-    pub(crate) fn is_always_satisfied(self, db: &'db dyn Db) -> bool {
-        self.node.is_always_satisfied(db, self.builder)
+    pub(crate) fn is_always_satisfied(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.node.is_always_satisfied(db, program, self.builder)
     }
 
     /// Returns the constraints under which `lhs` is a subtype of `rhs`, assuming that the
@@ -428,12 +438,16 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn implies_subtype_of(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         lhs: Type<'db>,
         rhs: Type<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.implies_subtype_of(db, builder, lhs, rhs))
+        Self::from_node(
+            builder,
+            self.node.implies_subtype_of(db, program, builder, lhs, rhs),
+        )
     }
 
     /// Returns whether this constraint set is satisfied by all of the typevars that it mentions.
@@ -453,11 +467,13 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn satisfied_by_all_typevars(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> bool {
         self.verify_builder(builder);
-        self.node.satisfied_by_all_typevars(db, builder, inferable)
+        self.node
+            .satisfied_by_all_typevars(db, program, builder, inferable)
     }
 
     /// Updates this constraint set to hold the union of itself and another constraint set.
@@ -505,11 +521,12 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn and(
         mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         other: impl FnOnce() -> Self,
     ) -> Self {
         self.verify_builder(builder);
-        if !self.is_never_satisfied(db) {
+        if !self.is_never_satisfied(db, program) {
             let other = other();
             other.verify_builder(builder);
             self.intersect(db, builder, other);
@@ -526,11 +543,12 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn or(
         mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         other: impl FnOnce() -> Self,
     ) -> Self {
         self.verify_builder(builder);
-        if !self.is_always_satisfied(db) {
+        if !self.is_always_satisfied(db, program) {
             let other = other();
             other.verify_builder(builder);
             self.union(db, builder, other);
@@ -545,10 +563,11 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn implies(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         other: impl FnOnce() -> Self,
     ) -> Self {
-        self.negate(db, builder).or(db, builder, other)
+        self.negate(db, builder).or(db, program, builder, other)
     }
 
     /// Returns a constraint set encoding that this constraint set is equivalent to another.
@@ -572,11 +591,34 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn reduce_inferable(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         to_remove: InferableTypeVars<'db>,
     ) -> Self {
         self.verify_builder(builder);
-        Self::from_node(builder, self.node.exists(db, builder, to_remove))
+        Self::from_node(builder, self.node.exists(db, program, builder, to_remove))
+    }
+
+    pub(crate) fn remove_noninferable(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &'c ConstraintSetBuilder<'db>,
+        inferable: InferableTypeVars<'db>,
+    ) -> Self {
+        self.verify_builder(builder);
+        if self
+            .node
+            .simple_lower_bound_conjunction(db, program, builder)
+            .all(|bound| bound.is_ok_and(|(typevar, _, _)| typevar.is_inferable(db, inferable)))
+        {
+            return self;
+        }
+        Self::from_node(
+            builder,
+            self.node
+                .remove_noninferable(db, program, builder, inferable),
+        )
     }
 
     /// Computes solutions for each BDD path, using a caller-provided hook to select solutions.
@@ -591,42 +633,43 @@ impl<'db, 'c> ConstraintSet<'db, 'c> {
     pub(crate) fn solutions(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
-        inferable: InferableTypeVars<'db>,
     ) -> Solutions<'db> {
-        self.solutions_with(db, builder, inferable, |_variance, path_bound| {
-            PathBounds::default_solve(db, builder, path_bound)
+        self.solutions_with(db, program, builder, |_variance, path_bound| {
+            PathBounds::default_solve(db, program, builder, path_bound)
         })
     }
 
     pub(crate) fn solutions_with(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
-        inferable: InferableTypeVars<'db>,
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
         self.verify_builder(builder);
-        self.node.solutions_with(db, builder, inferable, choose)
+        self.node.solutions_with(db, program, builder, choose)
     }
 
-    pub(crate) fn display(self, db: &'db dyn Db) -> impl Display {
+    pub(crate) fn display(self, db: &'db dyn Db, program: Program) -> impl Display {
         self.node
-            .simplify_for_display(db, self.builder)
-            .display(db, self.builder)
+            .simplify_for_display(db, program, self.builder)
+            .display(db, program, self.builder)
     }
 
     #[expect(dead_code)] // Keep this around for debugging purposes
     pub(crate) fn display_graph<'a>(
         self,
         db: &'db dyn Db,
+        program: Program,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a
     where
         'db: 'a,
         'c: 'a,
     {
-        self.node.display_graph(db, self.builder, prefix)
+        self.node.display_graph(db, program, self.builder, prefix)
     }
 }
 
@@ -846,6 +889,7 @@ impl<'db> ConstraintSetBuilder<'db> {
     pub(crate) fn load<'c>(
         &'c self,
         db: &'db dyn Db,
+        program: Program,
         other: &OwnedConstraintSet<'db>,
     ) -> ConstraintSet<'db, 'c> {
         fn rebuild_node<'db>(
@@ -903,6 +947,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             .map(|old_constraint| {
                 Constraint::new_node_with_bounds(
                     db,
+                    program,
                     self,
                     old_constraint.typevar,
                     old_constraint.bounds.lower,
@@ -932,7 +977,7 @@ impl<'db> ConstraintSetBuilder<'db> {
     }
 
     /// Interns all of the typevars mentioned in a type in a stable order.
-    fn intern_mentioned_typevars_in_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+    fn intern_mentioned_typevars_in_type(&self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
         struct InternMentionedTypevars<'a, 'db> {
             builder: &'a ConstraintSetBuilder<'db>,
             recursion_guard: TypeCollector<'db>,
@@ -946,20 +991,26 @@ impl<'db> ConstraintSetBuilder<'db> {
             fn visit_bound_type_var_type(
                 &self,
                 db: &'db dyn Db,
+                program: Program,
                 bound_typevar: BoundTypeVarInstance<'db>,
             ) {
                 self.builder.intern_typevar(db, bound_typevar);
-                walk_bound_type_var_type(db, bound_typevar, self);
+                walk_bound_type_var_type(db, program, bound_typevar, self);
             }
 
-            fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+            fn visit_generic_alias_type(
+                &self,
+                db: &'db dyn Db,
+                program: Program,
+                alias: GenericAlias<'db>,
+            ) {
                 for ty in alias.specialization(db).types(db) {
-                    self.visit_type(db, *ty);
+                    self.visit_type(db, program, *ty);
                 }
             }
 
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            fn visit_type(&self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
             }
         }
 
@@ -967,27 +1018,33 @@ impl<'db> ConstraintSetBuilder<'db> {
             builder: self,
             recursion_guard: TypeCollector::default(),
         }
-        .visit_type(db, ty);
+        .visit_type(db, program, ty);
     }
 
     /// Interns all of the typevars mentioned in a constraint in a stable order.
     fn intern_constraint_typevars(
         &self,
         db: &'db dyn Db,
+        program: Program,
         typevar: BoundTypeVarInstance<'db>,
         bounds: ConstraintBounds<'db>,
     ) {
         self.intern_typevar(db, typevar);
         if let Some(lower) = bounds.lower {
-            self.intern_mentioned_typevars_in_type(db, lower);
+            self.intern_mentioned_typevars_in_type(db, program, lower);
         }
         if let Some(upper) = bounds.upper {
-            self.intern_mentioned_typevars_in_type(db, upper);
+            self.intern_mentioned_typevars_in_type(db, program, upper);
         }
     }
 
-    fn intern_constraint(&self, db: &'db dyn Db, data: Constraint<'db>) -> ConstraintId {
-        self.intern_constraint_typevars(db, data.typevar, data.bounds);
+    fn intern_constraint(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        data: Constraint<'db>,
+    ) -> ConstraintId {
+        self.intern_constraint_typevars(db, program, data.typevar, data.bounds);
 
         let mut storage = self.storage.borrow_mut();
         storage.ensure_overlay_identity_caches();
@@ -1040,6 +1097,7 @@ impl<'db> ConstraintSetBuilder<'db> {
     fn cached_constraint_implies(
         &self,
         db: &'db dyn Db,
+        program: Program,
         ante: ConstraintId,
         post: ConstraintId,
     ) -> bool {
@@ -1048,7 +1106,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             return *result;
         }
 
-        let result = ante.implies(db, self, post);
+        let result = ante.implies(db, program, self, post);
         self.storage
             .borrow_mut()
             .constraint_implication_cache
@@ -1059,6 +1117,7 @@ impl<'db> ConstraintSetBuilder<'db> {
     fn cached_is_constraint_set_subtype_of(
         &self,
         db: &'db dyn Db,
+        program: Program,
         source: Type<'db>,
         target: Type<'db>,
     ) -> bool {
@@ -1067,7 +1126,7 @@ impl<'db> ConstraintSetBuilder<'db> {
             return *result;
         }
 
-        let result = source.is_constraint_set_subtype_of(db, target);
+        let result = source.is_constraint_set_subtype_of(db, program, target);
         self.storage
             .borrow_mut()
             .constraint_set_subtype_cache
@@ -1125,15 +1184,17 @@ impl IntersectionResult<'_> {
 
 /// The index of a bound typevar within a [`ConstraintSetStorage`].
 #[newtype_index]
-#[derive(Ord, PartialOrd, get_size2::GetSize)]
+#[derive(Ord, PartialOrd, salsa::SalsaValue, get_size2::GetSize)]
 pub struct TypeVarId;
 
 /// The index of an individual constraint (i.e. a BDD variable) within a [`ConstraintSetStorage`].
 #[newtype_index]
-#[derive(get_size2::GetSize)]
+#[derive(salsa::SalsaValue, get_size2::GetSize)]
 pub struct ConstraintId;
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, get_size2::GetSize)]
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::SalsaValue, get_size2::GetSize,
+)]
 enum NestedSubstitutionSide {
     Lower,
     Upper,
@@ -1146,7 +1207,9 @@ enum NestedSubstitutionSide {
 /// _for_, and the side. Each derived path assignment records the substitution shapes in its own
 /// derivation history. This lets independent derivations apply the same substitution while
 /// preventing one derivation chain from repeatedly unfolding the same recursive pattern.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, get_size2::GetSize)]
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, salsa::SalsaValue, get_size2::GetSize,
+)]
 struct NestedSubstitution {
     constrained_typevar: TypeVarId,
     substituted_typevar: TypeVarId,
@@ -1154,15 +1217,10 @@ struct NestedSubstitution {
 }
 
 /// The nested substitution shapes used to derive one path assignment.
-///
-/// The substitutions are kept sorted so that histories with the same substitutions compare and
-/// hash equally regardless of the order in which the antecedents were combined.
 #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 struct NestedSubstitutionHistory(SmallVec<[NestedSubstitution; 4]>);
 
 impl NestedSubstitutionHistory {
-    /// Merges two derivation histories and records `nested_substitution`. Returns `None` if either
-    /// history has already applied that substitution.
     fn merged(
         &self,
         other: &Self,
@@ -1201,7 +1259,7 @@ impl NestedSubstitutionHistory {
 
 /// A constraint derived from the sequent map, optionally annotated with the nested substitution
 /// step that produced it.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 struct DerivedConstraint {
     constraint: ConstraintId,
     nested_substitution: Option<NestedSubstitution>,
@@ -1302,11 +1360,12 @@ impl<'db> UpperBound<'db> {
     #[cfg(test)]
     pub(crate) fn from_clauses(
         db: &'db dyn Db,
+        program: Program,
         clauses: impl IntoIterator<Item = Type<'db>>,
     ) -> Self {
         let mut upper = Self::none();
         for clause in clauses {
-            upper.add_clause(db, clause);
+            upper.add_clause(db, program, clause);
         }
         upper
     }
@@ -1330,7 +1389,7 @@ impl<'db> UpperBound<'db> {
         self.clauses.len() == 1 && self.clauses.contains(&Type::Never)
     }
 
-    pub(crate) fn add_clause(&mut self, db: &'db dyn Db, clause: Type<'db>) {
+    pub(crate) fn add_clause(&mut self, db: &'db dyn Db, program: Program, clause: Type<'db>) {
         // This `Never` fast path is an optimization. The general redundancy-pruning loop below
         // should also handle it correctly, but spelling it out avoids unnecessary relation checks
         // and keeps the stored representation canonical.
@@ -1355,7 +1414,7 @@ impl<'db> UpperBound<'db> {
         if self
             .clauses
             .iter()
-            .any(|existing| existing.is_redundant_with(db, clause))
+            .any(|existing| existing.is_redundant_with(db, program, clause))
         {
             return;
         }
@@ -1363,7 +1422,7 @@ impl<'db> UpperBound<'db> {
         // Otherwise remove any existing clauses that are a supertype of the new type, since the
         // intersection will clip them to the new type.
         self.clauses
-            .retain(|existing| !clause.is_redundant_with(db, *existing));
+            .retain(|existing| !clause.is_redundant_with(db, program, *existing));
         self.clauses.insert(clause);
     }
 
@@ -1374,47 +1433,53 @@ impl<'db> UpperBound<'db> {
     /// Exact conversion to an ordinary [`Type`]. This may be expensive: if any stored clause is a
     /// union, [`IntersectionType::from_elements`] converts this factored CNF representation into
     /// ty's ordinary DNF representation by distributing intersections over unions.
-    pub(crate) fn materialize_exact(&self, db: &'db dyn Db) -> Type<'db> {
-        IntersectionType::from_elements(db, self.clauses.iter().copied())
+    pub(crate) fn materialize_exact(&self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        IntersectionType::from_elements(db, program, self.clauses.iter().copied())
     }
 
     fn has_visible_union_clause(&self) -> bool {
         self.clauses.iter().copied().any(Type::is_union)
     }
 
-    pub(crate) fn is_satisfied_by(&self, db: &'db dyn Db, ty: Type<'db>) -> bool {
+    pub(crate) fn is_satisfied_by(&self, db: &'db dyn Db, program: Program, ty: Type<'db>) -> bool {
         self.clauses
             .iter()
-            .all(|clause| ty.is_constraint_set_assignable_to(db, *clause))
+            .all(|clause| ty.is_constraint_set_assignable_to(db, program, *clause))
     }
 
     /// Returns the constraints under which `lower` is assignable to every stored upper clause.
     fn when_satisfied_by<'c>(
         &self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         lower: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.clauses.iter().when_all(db, builder, |clause| {
-            let when_clause = lower.when_constraint_set_assignable_to_owned(db, *clause);
-            builder.load(db, &when_clause)
-        })
+        self.clauses
+            .iter()
+            .when_all(db, program, builder, |clause| {
+                let when_clause =
+                    lower.when_constraint_set_assignable_to_owned(db, program, *clause);
+                builder.load(db, program, &when_clause)
+            })
     }
 }
 
 impl ConstraintId {
     fn new<'db>(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> ConstraintId {
-        Self::new_with_bounds(db, builder, typevar, Some(lower), Some(upper))
+        Self::new_with_bounds(db, program, builder, typevar, Some(lower), Some(upper))
     }
 
     fn new_with_bounds<'db>(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Option<Type<'db>>,
@@ -1422,6 +1487,7 @@ impl ConstraintId {
     ) -> ConstraintId {
         builder.intern_constraint(
             db,
+            program,
             Constraint {
                 typevar,
                 bounds: ConstraintBounds::new(lower, upper),
@@ -1436,12 +1502,13 @@ impl<'db> Constraint<'db> {
     /// Panics if `lower` and `upper` are not both fully static.
     fn new_node(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         lower: Type<'db>,
         upper: Type<'db>,
     ) -> NodeId {
-        Self::new_node_with_bounds(db, builder, typevar, Some(lower), Some(upper))
+        Self::new_node_with_bounds(db, program, builder, typevar, Some(lower), Some(upper))
     }
 
     /// Returns a new range constraint, preserving whether each bound was present explicitly.
@@ -1449,6 +1516,7 @@ impl<'db> Constraint<'db> {
     /// Panics if present `lower` and `upper` bounds are not fully static.
     fn new_node_with_bounds(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         typevar: BoundTypeVarInstance<'db>,
         mut lower: Option<Type<'db>>,
@@ -1473,6 +1541,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     Constraint::new_node_with_bounds(
                         db,
+                        program,
                         builder,
                         typevar,
                         Some(*lower_element),
@@ -1494,6 +1563,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     Constraint::new_node_with_bounds(
                         db,
+                        program,
                         builder,
                         typevar,
                         lower,
@@ -1506,16 +1576,16 @@ impl<'db> Constraint<'db> {
                     builder,
                     Constraint::new_node_with_bounds(
                         db,
+                        program,
                         builder,
                         typevar,
                         lower,
-                        Some(upper_element.negate(db)),
+                        Some(upper_element.negate(db, program)),
                     ),
                 );
             }
             return result;
         }
-
         // Two identical typevars must always solve to the same type, so it is not useful to have
         // an upper or lower bound that is the typevar being constrained.
         match lower {
@@ -1542,7 +1612,7 @@ impl<'db> Constraint<'db> {
             {
                 return Node::new_constraint(
                     builder,
-                    ConstraintId::new(db, builder, typevar, Type::Never, Type::object()),
+                    ConstraintId::new(db, program, builder, typevar, Type::Never, Type::object()),
                     1,
                 )
                 .negate(builder);
@@ -1567,7 +1637,12 @@ impl<'db> Constraint<'db> {
             _ => {}
         }
 
-        builder.intern_constraint_typevars(db, typevar, ConstraintBounds::new(lower, upper));
+        builder.intern_constraint_typevars(
+            db,
+            program,
+            typevar,
+            ConstraintBounds::new(lower, upper),
+        );
 
         // If `lower ≰ upper` for every possible assignment of typevars, then the constraint cannot
         // be satisfied, since there is no type that is both greater than `lower`, and less than
@@ -1576,8 +1651,9 @@ impl<'db> Constraint<'db> {
         // typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable when `int ≤ T`.
         let effective_lower = lower.unwrap_or(Type::Never);
         let effective_upper = upper.unwrap_or(Type::object());
-        let when = effective_lower.when_constraint_set_assignable_to_owned(db, effective_upper);
-        let is_never_satisfied = when.query(|_builder, when| when.is_never_satisfied(db));
+        let when =
+            effective_lower.when_constraint_set_assignable_to_owned(db, program, effective_upper);
+        let is_never_satisfied = when.query(|_builder, when| when.is_never_satisfied(db, program));
         if is_never_satisfied {
             return ALWAYS_FALSE;
         }
@@ -1600,6 +1676,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     ConstraintId::new(
                         db,
+                        program,
                         builder,
                         typevar,
                         Type::TypeVar(bound),
@@ -1618,6 +1695,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     ConstraintId::new_with_bounds(
                         db,
+                        program,
                         builder,
                         lower,
                         None,
@@ -1629,6 +1707,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     ConstraintId::new_with_bounds(
                         db,
+                        program,
                         builder,
                         upper,
                         Some(Type::TypeVar(typevar)),
@@ -1645,6 +1724,7 @@ impl<'db> Constraint<'db> {
                     builder,
                     ConstraintId::new_with_bounds(
                         db,
+                        program,
                         builder,
                         lower,
                         None,
@@ -1655,7 +1735,7 @@ impl<'db> Constraint<'db> {
                 let upper = if upper.is_none() {
                     ALWAYS_TRUE
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, None, upper)
+                    Constraint::new_node_with_bounds(db, program, builder, typevar, None, upper)
                 };
                 lower.and(builder, upper)
             }
@@ -1665,12 +1745,13 @@ impl<'db> Constraint<'db> {
                 let lower = if lower.is_none() {
                     ALWAYS_TRUE
                 } else {
-                    Constraint::new_node_with_bounds(db, builder, typevar, lower, None)
+                    Constraint::new_node_with_bounds(db, program, builder, typevar, lower, None)
                 };
                 let upper = Node::new_constraint(
                     builder,
                     ConstraintId::new_with_bounds(
                         db,
+                        program,
                         builder,
                         upper,
                         Some(Type::TypeVar(typevar)),
@@ -1683,7 +1764,7 @@ impl<'db> Constraint<'db> {
 
             _ => Node::new_constraint(
                 builder,
-                ConstraintId::new_with_bounds(db, builder, typevar, lower, upper),
+                ConstraintId::new_with_bounds(db, program, builder, typevar, lower, upper),
                 1,
             ),
         }
@@ -1738,6 +1819,7 @@ impl ConstraintId {
     fn implies<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         other: Self,
     ) -> bool {
@@ -1752,17 +1834,26 @@ impl ConstraintId {
         other_constraint
             .bounds
             .materialized_lower()
-            .is_constraint_set_assignable_to(db, self_constraint.bounds.materialized_lower())
+            .is_constraint_set_assignable_to(
+                db,
+                program,
+                self_constraint.bounds.materialized_lower(),
+            )
             && self_constraint
                 .bounds
                 .materialized_upper()
-                .is_constraint_set_assignable_to(db, other_constraint.bounds.materialized_upper())
+                .is_constraint_set_assignable_to(
+                    db,
+                    program,
+                    other_constraint.bounds.materialized_upper(),
+                )
     }
 
     /// Returns the intersection of two range constraints, or `None` if the intersection is empty.
     fn intersect<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         other: Self,
     ) -> IntersectionResult<'db> {
@@ -1771,16 +1862,18 @@ impl ConstraintId {
 
         // (s₁ ≤ α ≤ t₁) ∧ (s₂ ≤ α ≤ t₂) = (s₁ ∪ s₂) ≤ α ≤ (t₁ ∩ t₂))
         let lower = match (self_constraint.bounds.lower, other_constraint.bounds.lower) {
-            (Some(left), Some(right)) => Some(UnionType::from_two_elements(db, left, right)),
+            (Some(left), Some(right)) => {
+                Some(UnionType::from_two_elements(db, program, left, right))
+            }
             (Some(lower), None) | (None, Some(lower)) => Some(lower),
             (None, None) => None,
         };
         let mut merged_upper = UpperBound::none();
         if let Some(upper) = self_constraint.bounds.upper {
-            merged_upper.add_clause(db, upper);
+            merged_upper.add_clause(db, program, upper);
         }
         if let Some(upper) = other_constraint.bounds.upper {
-            merged_upper.add_clause(db, upper);
+            merged_upper.add_clause(db, program, upper);
         }
         let effective_lower = lower.unwrap_or(Type::Never);
 
@@ -1790,8 +1883,8 @@ impl ConstraintId {
         // rather than a universal check ("is `lower ≤ upper` for *all* assignments?"), because the
         // bounds may mention typevars — e.g., `Sequence[int] ≤ A ≤ Sequence[T]` is satisfiable
         // when `int ≤ T`, even though it's not universally true for all `T`.
-        let when = merged_upper.when_satisfied_by(db, builder, effective_lower);
-        if when.is_never_satisfied(db) {
+        let when = merged_upper.when_satisfied_by(db, program, builder, effective_lower);
+        if when.is_never_satisfied(db, program) {
             return IntersectionResult::Disjoint;
         }
 
@@ -1803,7 +1896,7 @@ impl ConstraintId {
             return IntersectionResult::CannotSimplify;
         }
 
-        let upper = (!merged_upper.is_empty()).then(|| merged_upper.materialize_exact(db));
+        let upper = (!merged_upper.is_empty()).then(|| merged_upper.materialize_exact(db, program));
 
         if upper.is_some_and(|upper| upper.is_nontrivial_intersection(db)) {
             return IntersectionResult::CannotSimplify;
@@ -1818,9 +1911,10 @@ impl ConstraintId {
     pub(crate) fn display<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
     ) -> impl Display {
-        self.when_true().display(db, builder)
+        self.when_true().display(db, program, builder)
     }
 }
 
@@ -1850,7 +1944,7 @@ impl ConstraintId {
 /// cannot use this ordering as our BDD variable ordering, since we calculate it from already
 /// constructed BDDs, and we need the BDD variable ordering to be fixed and available before
 /// construction starts.)
-#[derive(Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct NodeId(u32);
 
 /// A special ID that is used for an "always true" / "always visible" constraint.
@@ -1866,6 +1960,8 @@ enum Node {
     AlwaysFalse,
     Interior(InteriorNode),
 }
+
+type SimpleLowerBound<'db> = (BoundTypeVarInstance<'db>, Type<'db>, usize);
 
 impl NodeId {
     /// Creates a new BDD node, applying local TDD reductions.
@@ -2130,9 +2226,49 @@ impl NodeId {
         }
     }
 
+    /// Iterates over the concrete lower bounds in this BDD if it is a single positive conjunction.
+    /// Yields an error and terminates if the BDD does not have that shape.
+    fn simple_lower_bound_conjunction<'db, 'c>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &'c ConstraintSetBuilder<'db>,
+    ) -> impl Iterator<Item = Result<SimpleLowerBound<'db>, ()>> + use<'db, 'c> {
+        let mut node = Some(self);
+        std::iter::from_fn(move || {
+            let current = node.take()?;
+
+            match current.node() {
+                Node::AlwaysTrue => None,
+                Node::AlwaysFalse => Some(Err(())),
+                Node::Interior(_) => {
+                    let interior = builder.interior_node_data(current);
+                    if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
+                        return Some(Err(()));
+                    }
+
+                    let constraint = builder.constraint_data(interior.constraint);
+                    let Some(lower) = constraint.bounds.lower else {
+                        return Some(Err(()));
+                    };
+                    if constraint.bounds.upper.is_some()
+                        || lower.has_typevar(db, program)
+                        || lower.has_unspecialized_type_var(db, program)
+                    {
+                        return Some(Err(()));
+                    }
+
+                    node = Some(interior.if_true);
+                    Some(Ok((constraint.typevar, lower, interior.source_order)))
+                }
+            }
+        })
+    }
+
     fn for_each_path<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         mut f: impl FnMut(&PathAssignments),
     ) {
@@ -2141,7 +2277,7 @@ impl NodeId {
             Node::AlwaysFalse => {}
             Node::Interior(interior) => {
                 let mut path = interior.path_assignments(builder);
-                self.for_each_path_inner(db, builder, &mut f, &mut path);
+                self.for_each_path_inner(db, program, builder, &mut f, &mut path);
             }
         }
     }
@@ -2149,6 +2285,7 @@ impl NodeId {
     fn for_each_path_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         f: &mut dyn FnMut(&PathAssignments),
         path: &mut PathAssignments,
@@ -2160,31 +2297,38 @@ impl NodeId {
                 let interior = builder.interior_node_data(self);
                 path.walk_edge(
                     db,
+                    program,
                     builder,
                     interior.constraint.when_true(),
                     interior.source_order,
                     |path, _| {
-                        interior.if_true.for_each_path_inner(db, builder, f, path);
+                        interior
+                            .if_true
+                            .for_each_path_inner(db, program, builder, f, path);
                     },
                 );
                 path.walk_edge(
                     db,
+                    program,
                     builder,
                     interior.constraint.when_unconstrained(),
                     interior.source_order,
                     |path, _| {
                         interior
                             .if_uncertain
-                            .for_each_path_inner(db, builder, f, path);
+                            .for_each_path_inner(db, program, builder, f, path);
                     },
                 );
                 path.walk_edge(
                     db,
+                    program,
                     builder,
                     interior.constraint.when_false(),
                     interior.source_order,
                     |path, _| {
-                        interior.if_false.for_each_path_inner(db, builder, f, path);
+                        interior
+                            .if_false
+                            .for_each_path_inner(db, program, builder, f, path);
                     },
                 );
             }
@@ -2195,6 +2339,7 @@ impl NodeId {
     fn is_always_satisfied<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
     ) -> bool {
         match self.node() {
@@ -2202,7 +2347,7 @@ impl NodeId {
             Node::AlwaysFalse => false,
             Node::Interior(interior) => {
                 let mut path = interior.path_assignments(builder);
-                self.is_always_satisfied_inner(db, builder, &mut path)
+                self.is_always_satisfied_inner(db, program, builder, &mut path)
             }
         }
     }
@@ -2210,6 +2355,7 @@ impl NodeId {
     fn is_always_satisfied_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         path: &mut PathAssignments,
     ) -> bool {
@@ -2231,10 +2377,14 @@ impl NodeId {
                 let true_always_satisfied = path
                     .walk_edge(
                         db,
+                        program,
                         builder,
                         interior.constraint.when_true(),
                         interior.source_order,
-                        |path, _| if_true_or_uncertain.is_always_satisfied_inner(db, builder, path),
+                        |path, _| {
+                            if_true_or_uncertain
+                                .is_always_satisfied_inner(db, program, builder, path)
+                        },
                     )
                     .unwrap_or(true);
                 if !true_always_satisfied {
@@ -2245,10 +2395,13 @@ impl NodeId {
                 let if_false_or_uncertain = interior.if_false.or(builder, interior.if_uncertain);
                 path.walk_edge(
                     db,
+                    program,
                     builder,
                     interior.constraint.when_false(),
                     interior.source_order,
-                    |path, _| if_false_or_uncertain.is_always_satisfied_inner(db, builder, path),
+                    |path, _| {
+                        if_false_or_uncertain.is_always_satisfied_inner(db, program, builder, path)
+                    },
                 )
                 .unwrap_or(true)
             }
@@ -2256,7 +2409,12 @@ impl NodeId {
     }
 
     /// Returns whether this BDD represent the constant function `false`.
-    fn is_never_satisfied<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> bool {
+    fn is_never_satisfied<'db>(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> bool {
         match self.node() {
             Node::AlwaysTrue => false,
             Node::AlwaysFalse => true,
@@ -2266,7 +2424,7 @@ impl NodeId {
                 }
 
                 let mut path = interior.path_assignments(builder);
-                let result = self.is_never_satisfied_inner(db, builder, &mut path);
+                let result = self.is_never_satisfied_inner(db, program, builder, &mut path);
                 builder
                     .storage
                     .borrow_mut()
@@ -2280,6 +2438,7 @@ impl NodeId {
     fn is_never_satisfied_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         path: &mut PathAssignments,
     ) -> bool {
@@ -2298,10 +2457,15 @@ impl NodeId {
                 let true_never_satisfied = path
                     .walk_edge(
                         db,
+                        program,
                         builder,
                         interior.constraint.when_true(),
                         interior.source_order,
-                        |path, _| interior.if_true.is_never_satisfied_inner(db, builder, path),
+                        |path, _| {
+                            interior
+                                .if_true
+                                .is_never_satisfied_inner(db, program, builder, path)
+                        },
                     )
                     .unwrap_or(true);
                 if !true_never_satisfied {
@@ -2312,13 +2476,14 @@ impl NodeId {
                 let uncertain_never_satisfied = path
                     .walk_edge(
                         db,
+                        program,
                         builder,
                         interior.constraint.when_unconstrained(),
                         interior.source_order,
                         |path, _| {
                             interior
                                 .if_uncertain
-                                .is_never_satisfied_inner(db, builder, path)
+                                .is_never_satisfied_inner(db, program, builder, path)
                         },
                     )
                     .unwrap_or(true);
@@ -2329,13 +2494,14 @@ impl NodeId {
                 // Ditto for the if_false branch
                 path.walk_edge(
                     db,
+                    program,
                     builder,
                     interior.constraint.when_false(),
                     interior.source_order,
                     |path, _| {
                         interior
                             .if_false
-                            .is_never_satisfied_inner(db, builder, path)
+                            .is_never_satisfied_inner(db, program, builder, path)
                     },
                 )
                 .unwrap_or(true)
@@ -2346,11 +2512,11 @@ impl NodeId {
     fn solutions_with<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
-        inferable: InferableTypeVars<'db>,
         choose: impl FnMut(TypeVarVariance, &PathBound<'db>) -> Result<Option<Type<'db>>, ()>,
     ) -> Solutions<'db> {
-        let path_bounds = PathBounds::compute(db, builder, self, inferable);
+        let path_bounds = PathBounds::compute(db, program, builder, self);
         path_bounds.solve_with(choose)
     }
 
@@ -2506,6 +2672,7 @@ impl NodeId {
 
     fn distributed_or<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         nodes: impl Iterator<Item = NodeId>,
     ) -> Self {
@@ -2514,13 +2681,14 @@ impl NodeId {
             builder,
             nodes,
             ALWAYS_FALSE,
-            Self::is_always_satisfied,
+            |node, db, builder| node.is_always_satisfied(db, program, builder),
             Self::or_with_offset,
         )
     }
 
     fn distributed_and<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         nodes: impl Iterator<Item = NodeId>,
     ) -> Self {
@@ -2529,7 +2697,7 @@ impl NodeId {
             builder,
             nodes,
             ALWAYS_TRUE,
-            Self::is_never_satisfied,
+            |node, db, builder| node.is_never_satisfied(db, program, builder),
             Self::and_with_offset,
         )
     }
@@ -2685,6 +2853,7 @@ impl NodeId {
     fn implies_subtype_of<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         lhs: Type<'db>,
         rhs: Type<'db>,
@@ -2700,16 +2869,18 @@ impl NodeId {
         let constraint = match (lhs, rhs) {
             (Type::TypeVar(bound_typevar), _) => Constraint::new_node_with_bounds(
                 db,
+                program,
                 builder,
                 bound_typevar,
                 None,
-                Some(rhs.bottom_materialization(db)),
+                Some(rhs.bottom_materialization(db, program)),
             ),
             (_, Type::TypeVar(bound_typevar)) => Constraint::new_node_with_bounds(
                 db,
+                program,
                 builder,
                 bound_typevar,
-                Some(lhs.top_materialization(db)),
+                Some(lhs.top_materialization(db, program)),
                 None,
             ),
             _ => panic!("at least one type should be a typevar"),
@@ -2721,6 +2892,7 @@ impl NodeId {
     fn satisfied_by_all_typevars<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> bool {
@@ -2741,7 +2913,7 @@ impl NodeId {
             let when_satisfied = specializations
                 .implies(builder, self)
                 .and(builder, specializations);
-            !when_satisfied.is_never_satisfied(db, builder)
+            !when_satisfied.is_never_satisfied(db, program, builder)
         };
 
         // Returns if all specializations satisfy this constraint set.
@@ -2751,7 +2923,7 @@ impl NodeId {
                 .and(builder, specializations);
             when_satisfied
                 .iff(builder, specializations)
-                .is_always_satisfied(db, builder)
+                .is_always_satisfied(db, program, builder)
         };
 
         #[expect(
@@ -2762,7 +2934,7 @@ impl NodeId {
             if typevar.is_inferable(db, inferable) {
                 // If the typevar is in inferable position, we need to verify that some valid
                 // specialization satisfies the constraint set.
-                let valid_specializations = typevar.valid_specializations(db, builder);
+                let valid_specializations = typevar.valid_specializations(db, program, builder);
                 if !some_specialization_satisfies(valid_specializations) {
                     return false;
                 }
@@ -2779,7 +2951,7 @@ impl NodeId {
                 // constraint to refer to the synthetic typevar instead of the original gradual
                 // constraint.
                 let (static_specializations, gradual_constraints) =
-                    typevar.required_specializations(db, builder);
+                    typevar.required_specializations(db, program, builder);
                 if !all_specializations_satisfy(static_specializations) {
                     return false;
                 }
@@ -2800,6 +2972,7 @@ impl NodeId {
     fn exists<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: InferableTypeVars<'db>,
     ) -> Self {
@@ -2819,7 +2992,7 @@ impl NodeId {
         drop(storage);
 
         let mut path = interior.path_assignments(builder);
-        let result = self.exists_inner(db, builder, bound_typevars, &mut path);
+        let result = self.exists_inner(db, program, builder, bound_typevars, &mut path);
 
         let mut storage = builder.storage.borrow_mut();
         storage.exists_cache.insert(key, result);
@@ -2829,6 +3002,7 @@ impl NodeId {
     fn exists_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: InferableTypeVars<'db>,
         path: &mut PathAssignments,
@@ -2836,26 +3010,32 @@ impl NodeId {
         match self.node() {
             Node::AlwaysTrue => ALWAYS_TRUE,
             Node::AlwaysFalse => ALWAYS_FALSE,
-            Node::Interior(interior) => interior.exists_inner(db, builder, bound_typevars, path),
+            Node::Interior(interior) => {
+                interior.exists_inner(db, program, builder, bound_typevars, path)
+            }
         }
     }
 
     fn remove_noninferable<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> Self {
         match self.node() {
             Node::AlwaysTrue => ALWAYS_TRUE,
             Node::AlwaysFalse => ALWAYS_FALSE,
-            Node::Interior(interior) => interior.remove_noninferable(db, builder, inferable),
+            Node::Interior(interior) => {
+                interior.remove_noninferable(db, program, builder, inferable)
+            }
         }
     }
 
     fn abstract_one_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         should_remove: &mut dyn FnMut(ConstraintId) -> bool,
         path: &mut PathAssignments,
@@ -2864,7 +3044,7 @@ impl NodeId {
             Node::AlwaysTrue => ALWAYS_TRUE,
             Node::AlwaysFalse => ALWAYS_FALSE,
             Node::Interior(interior) => {
-                interior.abstract_one_inner(db, builder, should_remove, path)
+                interior.abstract_one_inner(db, program, builder, should_remove, path)
             }
         }
     }
@@ -3081,11 +3261,12 @@ impl NodeId {
     fn simplify_for_display<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
     ) -> Self {
         match self.node() {
             Node::AlwaysTrue | Node::AlwaysFalse => self,
-            Node::Interior(interior) => interior.simplify(db, builder),
+            Node::Interior(interior) => interior.simplify(db, program, builder),
         }
     }
 
@@ -3127,7 +3308,12 @@ impl NodeId {
         searcher.clauses
     }
 
-    fn display<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> impl Display {
+    fn display<'db>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> impl Display {
         // To render a BDD in DNF form, you perform a depth-first search of the BDD tree, looking
         // for any path that leads to the AlwaysTrue terminal. Each such path represents one of the
         // intersection clauses in the DNF form. The path traverses zero or more interior nodes,
@@ -3136,6 +3322,7 @@ impl NodeId {
         struct DisplayNode<'db, 'c> {
             node: NodeId,
             db: &'db dyn Db,
+            program: Program,
             builder: &'c ConstraintSetBuilder<'db>,
         }
 
@@ -3146,8 +3333,8 @@ impl NodeId {
                     Node::AlwaysFalse => f.write_str("never"),
                     Node::Interior(_) => {
                         let mut clauses = self.node.satisfied_clauses(self.builder);
-                        clauses.simplify(self.db, self.builder);
-                        Display::fmt(&clauses.display(self.db, self.builder), f)
+                        clauses.simplify(self.db, self.program, self.builder);
+                        Display::fmt(&clauses.display(self.db, self.program, self.builder), f)
                     }
                 }
             }
@@ -3156,6 +3343,7 @@ impl NodeId {
         DisplayNode {
             node: self,
             db,
+            program,
             builder,
         }
     }
@@ -3181,11 +3369,13 @@ impl NodeId {
     fn display_graph<'db, 'a>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'a ConstraintSetBuilder<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
         struct DisplayNode<'a, 'db> {
             db: &'db dyn Db,
+            program: Program,
             builder: &'a ConstraintSetBuilder<'db>,
             node: NodeId,
             prefix: &'a dyn Display,
@@ -3194,6 +3384,7 @@ impl NodeId {
 
         fn format_node<'db>(
             db: &'db dyn Db,
+            program: Program,
             builder: &ConstraintSetBuilder<'db>,
             node: NodeId,
             prefix: &dyn Display,
@@ -3212,7 +3403,7 @@ impl NodeId {
                     write!(
                         f,
                         "<{index}> {} {}/{}",
-                        interior.constraint.display(db, builder),
+                        interior.constraint.display(db, program, builder),
                         interior.source_order,
                         interior.max_source_order,
                     )?;
@@ -3221,6 +3412,7 @@ impl NodeId {
                     write!(f, "\n{prefix}┡━₁ ")?;
                     format_node(
                         db,
+                        program,
                         builder,
                         interior.if_true,
                         &format_args!("{prefix}│   "),
@@ -3230,6 +3422,7 @@ impl NodeId {
                     write!(f, "\n{prefix}├─? ")?;
                     format_node(
                         db,
+                        program,
                         builder,
                         interior.if_uncertain,
                         &format_args!("{prefix}│   "),
@@ -3239,6 +3432,7 @@ impl NodeId {
                     write!(f, "\n{prefix}└─₀ ")?;
                     format_node(
                         db,
+                        program,
                         builder,
                         interior.if_false,
                         &format_args!("{prefix}    "),
@@ -3252,12 +3446,21 @@ impl NodeId {
 
         impl Display for DisplayNode<'_, '_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                format_node(self.db, self.builder, self.node, self.prefix, &self.seen, f)
+                format_node(
+                    self.db,
+                    self.program,
+                    self.builder,
+                    self.node,
+                    self.prefix,
+                    &self.seen,
+                    f,
+                )
             }
         }
 
         DisplayNode {
             db,
+            program,
             builder,
             node: self,
             prefix,
@@ -3307,7 +3510,7 @@ impl Idx for NodeId {
 struct InteriorNode(NodeId);
 
 /// An interior node of a BDD
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
 struct InteriorNodeData {
     constraint: ConstraintId,
     if_true: NodeId,
@@ -3342,39 +3545,44 @@ struct ConstraintBoundsBuilder<'db> {
 }
 
 impl<'db> ConstraintBoundsBuilder<'db> {
-    fn classify_evidence(&mut self, db: &'db dyn Db, ty: Type<'db>) {
-        if ty.has_unspecialized_type_var(db) {
+    fn classify_evidence(&mut self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
+        if ty.has_unspecialized_type_var(db, program) {
             return;
         }
-        if ty.bottom_materialization(db) == ty.top_materialization(db) {
+        if ty.bottom_materialization(db, program) == ty.top_materialization(db, program) {
             self.has_static_evidence = true;
         } else {
             self.has_gradual_evidence = true;
         }
     }
 
-    fn add_lower(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+    fn add_lower(&mut self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
         // Lower bounds are unioned. Our type representation is in DNF, so unioning a new
         // element is typically cheap (in that it does not involve a combinatorial
         // explosion from distributing the clause through an existing disjunction). So we
         // don't need to be as clever here as in `add_upper`.
-        self.classify_evidence(db, ty);
+        self.classify_evidence(db, program, ty);
         self.lower.insert(ty);
     }
 
-    fn add_upper(&mut self, db: &'db dyn Db, ty: Type<'db>) {
-        self.classify_evidence(db, ty);
-        self.upper.add_clause(db, ty);
+    fn add_upper(&mut self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
+        self.classify_evidence(db, program, ty);
+        self.upper.add_clause(db, program, ty);
     }
 
-    fn finish(self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) -> PathBound<'db> {
+    fn finish(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) -> PathBound<'db> {
         let Self {
             lower,
             mut upper,
             has_gradual_evidence,
             has_static_evidence,
         } = self;
-        let lower = (!lower.is_empty()).then(|| UnionType::from_elements(db, lower));
+        let lower = (!lower.is_empty()).then(|| UnionType::from_elements(db, program, lower));
         upper.shrink_to_fit();
         PathBound {
             bound_typevar,
@@ -3433,41 +3641,46 @@ impl<'db> Type<'db> {
     pub(crate) fn assignable_solutions_with_inferable(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> &'db PathBounds<'db> {
         #[salsa::tracked(
             returns(ref),
-            cycle_initial=|_, _, _, _, _| PathBounds::Unsatisfiable,
+            cycle_initial=|_, _, _, _, _, _| PathBounds::Unsatisfiable,
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn assignable_solutions_impl<'db>(
             db: &'db dyn Db,
+            program: Program,
             source: Type<'db>,
             target: Type<'db>,
             inferable: InferableTypeVars<'db>,
         ) -> PathBounds<'db> {
-            let when = source.when_constraint_set_assignable_to_owned(db, target);
-            when.query(|builder, when| PathBounds::compute(db, builder, when.node, inferable))
+            let when = source.when_constraint_set_assignable_to_owned(db, program, target);
+            when.query(|builder, when| {
+                let when = when.remove_noninferable(db, program, builder, inferable);
+                PathBounds::compute(db, program, builder, when.node)
+            })
         }
 
-        assignable_solutions_impl(db, self, target, inferable)
+        assignable_solutions_impl(db, program, self, target, inferable)
     }
 }
 
 #[salsa::tracked(
-    returns(copy),
-    cycle_initial = |_, _, _, _| true,
+    cycle_initial = |_, _, _, _, _| true,
     heap_size = get_size2::GetSize::get_heap_size
 )]
 fn is_possibly_constraint_set_assignable<'db>(
     db: &'db dyn Db,
+    program: Program,
     source: Type<'db>,
     target: Type<'db>,
 ) -> bool {
     source
-        .when_constraint_set_assignable_to_owned(db, target)
-        .query(|_builder, when| !when.is_never_satisfied(db))
+        .when_constraint_set_assignable_to_owned(db, program, target)
+        .query(|_builder, when| !when.is_never_satisfied(db, program))
 }
 
 /// Per-path bounds for all typevars. Each element is the set of typevar bounds for one BDD path.
@@ -3485,21 +3698,20 @@ impl<'db> PathBounds<'db> {
     /// typevar that appears in the path's constraints.
     fn compute(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
-        inferable: InferableTypeVars<'db>,
     ) -> Self {
-        if let Some(path_bounds) =
-            Self::compute_simple_lower_bound_conjunction(db, builder, node, inferable)
-        {
-            return path_bounds;
-        }
-
-        let node = node.remove_noninferable(db, builder, inferable);
         match node.node() {
             Node::AlwaysTrue => return PathBounds::Unconstrained,
             Node::AlwaysFalse => return PathBounds::Unsatisfiable,
             Node::Interior(_) => {}
+        }
+
+        if let Some(path_bounds) =
+            Self::compute_simple_lower_bound_conjunction(db, program, builder, node)
+        {
+            return path_bounds;
         }
 
         // Sort the constraints in each path by their `source_order`s, to ensure that we construct
@@ -3508,7 +3720,7 @@ impl<'db> PathBounds<'db> {
         // "tied" constraints will still be ordered in a stable way. So we need a stable sort to
         // retain that stable per-tie ordering.
         let mut sorted_paths = Vec::new();
-        node.for_each_path(db, builder, |path| {
+        node.for_each_path(db, program, builder, |path| {
             let mut path: Vec<_> = path.positive_constraints().collect();
             path.sort_by_key(|(_, source_order)| *source_order);
             sorted_paths.push(path);
@@ -3530,28 +3742,28 @@ impl<'db> PathBounds<'db> {
                 let typevar = constraint.typevar;
                 if let Some(lower) = constraint.bounds.lower {
                     let bounds = mappings.entry(typevar).or_default();
-                    bounds.add_lower(db, lower);
+                    bounds.add_lower(db, program, lower);
 
                     if let Type::TypeVar(lower_bound_typevar) = lower {
                         let bounds = mappings.entry(lower_bound_typevar).or_default();
-                        bounds.add_upper(db, Type::TypeVar(typevar));
+                        bounds.add_upper(db, program, Type::TypeVar(typevar));
                     }
                 }
 
                 if let Some(upper) = constraint.bounds.upper {
                     let bounds = mappings.entry(typevar).or_default();
-                    bounds.add_upper(db, upper);
+                    bounds.add_upper(db, program, upper);
 
                     if let Type::TypeVar(upper_bound_typevar) = upper {
                         let bounds = mappings.entry(upper_bound_typevar).or_default();
-                        bounds.add_lower(db, Type::TypeVar(typevar));
+                        bounds.add_lower(db, program, Type::TypeVar(typevar));
                     }
                 }
             }
 
             let path_bounds = mappings
                 .drain()
-                .map(|(bound_typevar, bounds)| bounds.finish(db, bound_typevar))
+                .map(|(bound_typevar, bounds)| bounds.finish(db, program, bound_typevar))
                 .collect();
             result.push(path_bounds);
         }
@@ -3568,57 +3780,28 @@ impl<'db> PathBounds<'db> {
     /// declared bound or constraints.
     fn compute_simple_lower_bound_conjunction(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         node: NodeId,
-        inferable: InferableTypeVars<'db>,
     ) -> Option<Self> {
-        match node.node() {
-            Node::AlwaysTrue => return Some(PathBounds::Unconstrained),
-            Node::AlwaysFalse => return Some(PathBounds::Unsatisfiable),
-            Node::Interior(_) => {}
-        }
-
-        let mut constraints = Vec::default();
-        let mut current = node;
-        loop {
-            match current.node() {
-                Node::AlwaysTrue => break,
-                Node::AlwaysFalse => return None,
-                Node::Interior(_) => {
-                    let interior = builder.interior_node_data(current);
-                    if interior.if_uncertain != ALWAYS_FALSE || interior.if_false != ALWAYS_FALSE {
-                        return None;
-                    }
-
-                    let constraint = builder.constraint_data(interior.constraint);
-                    if !constraint.typevar.is_inferable(db, inferable) {
-                        return None;
-                    }
-
-                    let lower = constraint.bounds.lower?;
-                    if constraint.bounds.upper.is_some()
-                        || lower.has_typevar(db)
-                        || lower.has_unspecialized_type_var(db)
-                    {
-                        return None;
-                    }
-
-                    current = interior.if_true;
-                    constraints.push((constraint.typevar, lower, interior.source_order));
-                }
-            }
-        }
+        let mut constraints = node
+            .simple_lower_bound_conjunction(db, program, builder)
+            .collect::<Result<Vec<_>, _>>()
+            .ok()?;
+        constraints.sort_by_key(|(_, _, source_order)| *source_order);
 
         let mut mappings: FxHashMap<BoundTypeVarInstance<'db>, ConstraintBoundsBuilder<'db>> =
             FxHashMap::default();
-        constraints.sort_by_key(|(_, _, source_order)| *source_order);
         for (typevar, lower, _) in constraints {
-            mappings.entry(typevar).or_default().add_lower(db, lower);
+            mappings
+                .entry(typevar)
+                .or_default()
+                .add_lower(db, program, lower);
         }
 
         let path = mappings
             .drain()
-            .map(|(bound_typevar, bounds)| bounds.finish(db, bound_typevar))
+            .map(|(bound_typevar, bounds)| bounds.finish(db, program, bound_typevar))
             .collect();
         Some(PathBounds::Constrained(Box::new([path])))
     }
@@ -3626,9 +3809,12 @@ impl<'db> PathBounds<'db> {
     pub(crate) fn solve(
         &self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
     ) -> Solutions<'db> {
-        self.solve_with(|_variance, path_bound| PathBounds::default_solve(db, builder, path_bound))
+        self.solve_with(|_variance, path_bound| {
+            PathBounds::default_solve(db, program, builder, path_bound)
+        })
     }
 
     /// Solves each path by applying a per-typevar solver function, collecting valid solutions.
@@ -3682,6 +3868,7 @@ impl<'db> PathBounds<'db> {
     /// - `Err(())` if the path is invalid (bounds violate the typevar's declared constraints)
     pub(crate) fn default_solve(
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         path_bound: &PathBound<'db>,
     ) -> Result<Option<Type<'db>>, ()> {
@@ -3695,22 +3882,24 @@ impl<'db> PathBounds<'db> {
 
         match bound_typevar.typevar(db).require_bound_or_constraints(db) {
             TypeVarBoundOrConstraints::UpperBound(bound) => {
-                let declared_upper = bound.top_materialization(db);
+                let declared_upper = bound.top_materialization(db, program);
 
                 // Prefer the lower bound (often the concrete actual type seen) over the
                 // upper bound (which may include TypeVar bounds/constraints). The upper bound
                 // should only be used as a fallback when no concrete type was inferred.
                 if let Some(lower) = path_bound.lower {
-                    if !path_bound.upper.is_satisfied_by(db, lower) {
-                        let when_upper = path_bound.upper.when_satisfied_by(db, builder, lower);
-                        if when_upper.is_never_satisfied(db) {
+                    if !path_bound.upper.is_satisfied_by(db, program, lower) {
+                        let when_upper = path_bound
+                            .upper
+                            .when_satisfied_by(db, program, builder, lower);
+                        if when_upper.is_never_satisfied(db, program) {
                             // This path does not satisfy the accumulated upper bound, and is
                             // therefore not a valid specialization.
                             return Err(());
                         }
                     }
 
-                    if !is_possibly_constraint_set_assignable(db, lower, declared_upper) {
+                    if !is_possibly_constraint_set_assignable(db, program, lower, declared_upper) {
                         // This path does not satisfy the typevar's declared upper bound, and is
                         // therefore not a valid specialization.
                         return Err(());
@@ -3722,6 +3911,7 @@ impl<'db> PathBounds<'db> {
                 if path_bound.has_upper() {
                     return Ok(IntersectionType::bounded_from_elements(
                         db,
+                        program,
                         path_bound
                             .upper
                             .clauses
@@ -3772,27 +3962,31 @@ impl<'db> PathBounds<'db> {
                     // equivalent or incomparable, keep the current best to preserve the TypeVar's
                     // declared constraint order.
                     if path_bound.lower.is_some() {
-                        candidate.is_subtype_of(db, current_best)
-                            && !current_best.is_subtype_of(db, candidate)
+                        candidate.is_subtype_of(db, program, current_best)
+                            && !current_best.is_subtype_of(db, program, candidate)
                     } else {
-                        current_best.is_subtype_of(db, candidate)
-                            && !candidate.is_subtype_of(db, current_best)
+                        current_best.is_subtype_of(db, program, candidate)
+                            && !candidate.is_subtype_of(db, program, current_best)
                     }
                 };
 
                 for constraint in constraints.elements(db).iter().copied() {
-                    let constraint_lower = constraint.bottom_materialization(db);
-                    let constraint_upper = constraint.top_materialization(db);
-                    let when_lower =
-                        lower.when_constraint_set_assignable_to_owned(db, constraint_lower);
+                    let constraint_lower = constraint.bottom_materialization(db, program);
+                    let constraint_upper = constraint.top_materialization(db, program);
+                    let when_lower = lower.when_constraint_set_assignable_to_owned(
+                        db,
+                        program,
+                        constraint_lower,
+                    );
                     let when_upper =
                         path_bound
                             .upper
-                            .when_satisfied_by(db, builder, constraint_upper);
-                    let when = builder
-                        .load(db, &when_lower)
-                        .and(db, builder, || when_upper);
-                    if when.is_never_satisfied(db) {
+                            .when_satisfied_by(db, program, builder, constraint_upper);
+                    let when =
+                        builder
+                            .load(db, program, &when_lower)
+                            .and(db, program, builder, || when_upper);
+                    if when.is_never_satisfied(db, program) {
                         continue;
                     }
 
@@ -3837,6 +4031,7 @@ impl<'db> PathBounds<'db> {
                     } else if path_bound.has_upper() {
                         Ok(IntersectionType::bounded_from_elements(
                             db,
+                            program,
                             path_bound.upper.clauses.iter().copied(),
                         ))
                     } else {
@@ -4057,6 +4252,7 @@ impl InteriorNode {
     fn exists_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         bound_typevars: InferableTypeVars<'db>,
         path: &mut PathAssignments,
@@ -4067,6 +4263,7 @@ impl InteriorNode {
         };
         self.abstract_one_inner(
             db,
+            program,
             builder,
             // Remove any node that constrains one of `bound_typevars`, or that has a lower/upper
             // bound that mentions one of them. Removed constraints are still added to `path`, so
@@ -4075,14 +4272,12 @@ impl InteriorNode {
             &mut |constraint| {
                 let constraint = builder.constraint_data(constraint);
                 constraint.typevar.is_inferable(db, bound_typevars)
-                    || constraint
-                        .bounds
-                        .lower
-                        .is_some_and(|lower| any_over_type(db, lower, false, mentions_typevar))
-                    || constraint
-                        .bounds
-                        .upper
-                        .is_some_and(|upper| any_over_type(db, upper, false, mentions_typevar))
+                    || constraint.bounds.lower.is_some_and(|lower| {
+                        any_over_type(db, program, lower, false, mentions_typevar)
+                    })
+                    || constraint.bounds.upper.is_some_and(|upper| {
+                        any_over_type(db, program, upper, false, mentions_typevar)
+                    })
             },
             path,
         )
@@ -4091,6 +4286,7 @@ impl InteriorNode {
     fn remove_noninferable<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> NodeId {
@@ -4101,6 +4297,7 @@ impl InteriorNode {
         };
         self.abstract_one_inner(
             db,
+            program,
             builder,
             // We only want to keep constraints on inferable typevars. If the constraint's typevar
             // is itself inferable, we keep it. We also need to keep some constraints in
@@ -4130,6 +4327,7 @@ impl InteriorNode {
     fn abstract_one_inner<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         should_remove: &mut dyn FnMut(ConstraintId) -> bool,
         path: &mut PathAssignments,
@@ -4151,12 +4349,14 @@ impl InteriorNode {
             let if_true = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_true(),
                     self_interior.source_order,
                     |path, new_range| {
                         let branch = self_interior.if_true.abstract_one_inner(
                             db,
+                            program,
                             builder,
                             should_remove,
                             path,
@@ -4184,12 +4384,14 @@ impl InteriorNode {
             let if_false = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_false(),
                     self_interior.source_order,
                     |path, new_range| {
                         let branch = self_interior.if_false.abstract_one_inner(
                             db,
+                            program,
                             builder,
                             should_remove,
                             path,
@@ -4217,12 +4419,14 @@ impl InteriorNode {
             let if_uncertain = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_unconstrained(),
                     self_interior.source_order,
                     |path, new_range| {
                         let branch = self_interior.if_uncertain.abstract_one_inner(
                             db,
+                            program,
                             builder,
                             should_remove,
                             path,
@@ -4249,25 +4453,32 @@ impl InteriorNode {
             let if_true = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_true(),
                     self_interior.source_order,
                     |path, _| {
-                        self_interior
-                            .if_true
-                            .abstract_one_inner(db, builder, should_remove, path)
+                        self_interior.if_true.abstract_one_inner(
+                            db,
+                            program,
+                            builder,
+                            should_remove,
+                            path,
+                        )
                     },
                 )
                 .unwrap_or(ALWAYS_FALSE);
             let if_uncertain = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_unconstrained(),
                     self_interior.source_order,
                     |path, _| {
                         self_interior.if_uncertain.abstract_one_inner(
                             db,
+                            program,
                             builder,
                             should_remove,
                             path,
@@ -4278,13 +4489,18 @@ impl InteriorNode {
             let if_false = path
                 .walk_edge(
                     db,
+                    program,
                     builder,
                     self_interior.constraint.when_false(),
                     self_interior.source_order,
                     |path, _| {
-                        self_interior
-                            .if_false
-                            .abstract_one_inner(db, builder, should_remove, path)
+                        self_interior.if_false.abstract_one_inner(
+                            db,
+                            program,
+                            builder,
+                            should_remove,
+                            path,
+                        )
                     },
                 )
                 .unwrap_or(ALWAYS_FALSE);
@@ -4404,7 +4620,12 @@ impl InteriorNode {
     /// This is calculated by looking at the relationships that exist between the constraints that
     /// are mentioned in the BDD. For instance, if one constraint implies another (`x → y`), then
     /// `x ∧ ¬y` is not a valid input, and we can rewrite any occurrences of `x ∨ y` into `y`.
-    fn simplify<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
+    fn simplify<'db>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> NodeId {
         let key = self.node();
         let storage = builder.storage.borrow();
         if let Some(result) = storage.simplify_cache.get(&key) {
@@ -4517,6 +4738,7 @@ impl InteriorNode {
 
                 let new_constraint = ConstraintId::new_with_bounds(
                     db,
+                    program,
                     builder,
                     constrained_typevar,
                     new_lower,
@@ -4570,14 +4792,15 @@ impl InteriorNode {
 
             // Containment: The range of one constraint might completely contain the range of the
             // other. If so, there are several potential simplifications.
-            let larger_smaller = if left_constraint.implies(db, builder, right_constraint) {
+            let larger_smaller = if left_constraint.implies(db, program, builder, right_constraint)
+            {
                 Some((
                     right_constraint,
                     right_source_order,
                     left_constraint,
                     left_source_order,
                 ))
-            } else if right_constraint.implies(db, builder, left_constraint) {
+            } else if right_constraint.implies(db, program, builder, left_constraint) {
                 Some((
                     left_constraint,
                     left_source_order,
@@ -4655,10 +4878,10 @@ impl InteriorNode {
             // There are some simplifications we can make when the intersection of the two
             // constraints is empty, and others that we can make when the intersection is
             // non-empty.
-            match left_constraint.intersect(db, builder, right_constraint) {
+            match left_constraint.intersect(db, program, builder, right_constraint) {
                 IntersectionResult::Simplified(intersection_constraint_data) => {
                     let intersection_constraint =
-                        builder.intern_constraint(db, intersection_constraint_data);
+                        builder.intern_constraint(db, program, intersection_constraint_data);
 
                     // If the intersection is non-empty, we need to create a new constraint to
                     // represent that intersection. We also need to add the new constraint to our
@@ -4913,6 +5136,7 @@ impl ConstraintAssignment {
     fn implies<'db>(
         self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         other: Self,
     ) -> bool {
@@ -4925,7 +5149,7 @@ impl ConstraintAssignment {
             (
                 ConstraintAssignment::Positive(self_constraint),
                 ConstraintAssignment::Positive(other_constraint),
-            ) => self_constraint.implies(db, builder, other_constraint),
+            ) => self_constraint.implies(db, program, builder, other_constraint),
 
             // For two negative constraints, one range has to fully contain the other; the ranges
             // represent "holes", though, so the constraint with the larger range implies the one
@@ -4936,7 +5160,7 @@ impl ConstraintAssignment {
             (
                 ConstraintAssignment::Negative(self_constraint),
                 ConstraintAssignment::Negative(other_constraint),
-            ) => other_constraint.implies(db, builder, self_constraint),
+            ) => other_constraint.implies(db, program, builder, self_constraint),
 
             // For a positive and negative constraint, the ranges have to be disjoint, and the
             // positive range implies the negative range.
@@ -4947,7 +5171,7 @@ impl ConstraintAssignment {
                 ConstraintAssignment::Positive(self_constraint),
                 ConstraintAssignment::Negative(other_constraint),
             ) => self_constraint
-                .intersect(db, builder, other_constraint)
+                .intersect(db, program, builder, other_constraint)
                 .is_disjoint(),
 
             // It's theoretically possible for a negative constraint to imply a positive constraint
@@ -4972,10 +5196,16 @@ impl ConstraintAssignment {
         }
     }
 
-    fn display<'db>(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> impl Display {
+    fn display<'db>(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> impl Display {
         struct DisplayConstraintAssignment<'db, 'c> {
             assignment: ConstraintAssignment,
             db: &'db dyn Db,
+            program: Program,
             builder: &'c ConstraintSetBuilder<'db>,
         }
 
@@ -4999,11 +5229,12 @@ impl ConstraintAssignment {
 
         impl Display for DisplayConstraintAssignment<'_, '_> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                let program = self.program;
                 let constraint_data = self.builder.constraint_data(self.assignment.constraint());
                 let lower = constraint_data.bounds.materialized_lower();
                 let upper = constraint_data.bounds.materialized_upper();
                 let typevar = constraint_data.typevar;
-                if lower.is_equivalent_to(self.db, upper) {
+                if lower.is_equivalent_to(self.db, program, upper) {
                     // If this typevar is equivalent to another, output the constraint in a
                     // consistent alphabetical order, regardless of the salsa ordering that we are
                     // using the in BDD.
@@ -5023,7 +5254,7 @@ impl ConstraintAssignment {
                         "({} {} {})",
                         typevar.identity(self.db).display(self.db),
                         self.equality_sign(),
-                        lower.display(self.db)
+                        lower.display(self.db, program)
                     );
                 }
 
@@ -5039,11 +5270,11 @@ impl ConstraintAssignment {
                 f.write_str(self.range_prefix())?;
                 f.write_str("(")?;
                 if !lower.is_never() {
-                    write!(f, "{} ≤ ", lower.display(self.db))?;
+                    write!(f, "{} ≤ ", lower.display(self.db, program))?;
                 }
                 typevar.identity(self.db).display(self.db).fmt(f)?;
                 if !upper.is_object() {
-                    write!(f, " ≤ {}", upper.display(self.db))?;
+                    write!(f, " ≤ {}", upper.display(self.db, program))?;
                 }
                 f.write_str(")")
             }
@@ -5052,6 +5283,7 @@ impl ConstraintAssignment {
         DisplayConstraintAssignment {
             assignment: self,
             db,
+            program,
             builder,
         }
     }
@@ -5108,6 +5340,7 @@ impl SequentMap {
     /// constraint.
     fn for_constraint<'db, 'c>(
         db: &'db dyn Db,
+        program: Program,
         builder: &'c ConstraintSetBuilder<'db>,
         constraint: ConstraintId,
     ) -> Ref<'c, Self> {
@@ -5120,11 +5353,11 @@ impl SequentMap {
 
         tracing::trace!(
             target: "ty_python_semantic::types::constraints::SequentMap",
-            constraint = %constraint.display(db, builder),
+            constraint = %constraint.display(db, program, builder),
             "add sequents for constraint",
         );
         let mut map = SequentMap::default();
-        map.add_sequents_for_single(db, builder, constraint);
+        map.add_sequents_for_single(db, program, builder, constraint);
 
         let mut storage = builder.storage.borrow_mut();
         storage.single_sequent_cache.insert(key, map);
@@ -5142,6 +5375,7 @@ impl SequentMap {
     /// that retain that ordering.)
     fn for_constraint_pair<'db, 'c>(
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &'c ConstraintSetBuilder<'db>,
         left: ConstraintId,
         right: ConstraintId,
@@ -5154,12 +5388,12 @@ impl SequentMap {
 
         tracing::trace!(
             target: "ty_python_semantic::types::constraints::SequentMap",
-            left = %left.display(db, builder),
-            right = %right.display(db, builder),
+            left = %left.display(db, program, builder),
+            right = %right.display(db, program, builder),
             "add sequents for constraint pair",
         );
         let mut map = SequentMap::default();
-        map.add_sequents_for_pair(db, builder, left, right);
+        map.add_sequents_for_pair(db, program, builder, left, right);
 
         let mut storage = builder.storage.borrow_mut();
         storage.pair_sequent_cache.insert(key, map);
@@ -5199,13 +5433,14 @@ impl SequentMap {
     fn add_single_tautology<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         ante: ConstraintId,
     ) {
         if self.single_tautologies.insert(ante) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::SequentMap",
-                sequent = %format_args!("¬{} → false", ante.display(db, builder)),
+                sequent = %format_args!("¬{} → false", ante.display(db, program, builder)),
                 "add sequent",
             );
         }
@@ -5214,6 +5449,7 @@ impl SequentMap {
     fn add_pair_impossibility<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
@@ -5226,8 +5462,8 @@ impl SequentMap {
                 target: "ty_python_semantic::types::constraints::SequentMap",
                 sequent = %format_args!(
                     "{} ∧ {} → false",
-                    ante1.display(db, builder),
-                    ante2.display(db, builder),
+                    ante1.display(db, program, builder),
+                    ante2.display(db, program, builder),
                 ),
                 "add sequent",
             );
@@ -5237,17 +5473,20 @@ impl SequentMap {
     fn add_pair_implication<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
         post: ConstraintId,
     ) {
-        self.add_pair_implication_with_provenance(db, builder, ante1, ante2, post, None);
+        self.add_pair_implication_with_provenance(db, program, builder, ante1, ante2, post, None);
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn add_pair_implication_with_provenance<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         ante1: ConstraintId,
         ante2: ConstraintId,
@@ -5259,14 +5498,19 @@ impl SequentMap {
         let when = post_data
             .bounds
             .materialized_lower()
-            .when_constraint_set_assignable_to(db, post_data.bounds.materialized_upper(), builder);
-        if when.is_never_satisfied(db) {
-            self.add_pair_impossibility(db, builder, ante1, ante2);
+            .when_constraint_set_assignable_to(
+                db,
+                program,
+                post_data.bounds.materialized_upper(),
+                builder,
+            );
+        if when.is_never_satisfied(db, program) {
+            self.add_pair_impossibility(db, program, builder, ante1, ante2);
             return;
         }
 
         // If either antecedent implies the consequent on its own, this new sequent is redundant.
-        if ante1.implies(db, builder, post) || ante2.implies(db, builder, post) {
+        if ante1.implies(db, program, builder, post) || ante2.implies(db, program, builder, post) {
             return;
         }
         let derived = DerivedConstraint {
@@ -5283,9 +5527,9 @@ impl SequentMap {
                 target: "ty_python_semantic::types::constraints::SequentMap",
                 sequent = %format_args!(
                     "{} ∧ {} → {}",
-                    ante1.display(db, builder),
-                    ante2.display(db, builder),
-                    post.display(db, builder),
+                    ante1.display(db, program, builder),
+                    ante2.display(db, program, builder),
+                    post.display(db, program, builder),
                 ),
                 "add sequent",
             );
@@ -5295,6 +5539,7 @@ impl SequentMap {
     fn add_single_implication<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         ante: ConstraintId,
         post: ConstraintId,
@@ -5312,8 +5557,8 @@ impl SequentMap {
                 target: "ty_python_semantic::types::constraints::SequentMap",
                 sequent = %format_args!(
                     "{} → {}",
-                    ante.display(db, builder),
-                    post.display(db, builder),
+                    ante.display(db, program, builder),
+                    post.display(db, program, builder),
                 ),
                 "add sequent",
             );
@@ -5323,6 +5568,7 @@ impl SequentMap {
     fn add_sequents_for_single<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         constraint: ConstraintId,
     ) {
@@ -5332,7 +5578,7 @@ impl SequentMap {
         let lower = constraint_data.bounds.materialized_lower();
         let upper = constraint_data.bounds.materialized_upper();
         if lower.is_never() && upper.is_object() {
-            self.add_single_tautology(db, builder, constraint);
+            self.add_single_tautology(db, program, builder, constraint);
             return;
         }
 
@@ -5380,11 +5626,11 @@ impl SequentMap {
             return;
         }
 
-        let when = lower.when_constraint_set_assignable_to(db, upper, builder);
+        let when = lower.when_constraint_set_assignable_to(db, program, upper, builder);
 
         // If L is _never_ assignable to U, this constraint would violate transitivity, and should
         // never have been added.
-        debug_assert!(!when.is_never_satisfied(db));
+        debug_assert!(!when.is_never_satisfied(db, program));
 
         // Fast path: If L is trivially always assignable to U, there are no derived constraints
         // that we can infer. This would be handled correctly by the logic below, but this is a
@@ -5438,10 +5684,22 @@ impl SequentMap {
                 Node::Interior(interior) => {
                     let interior = builder.interior_node_data(interior.node());
                     if interior.if_true != ALWAYS_FALSE {
-                        self.add_single_implication(db, builder, constraint, interior.constraint);
+                        self.add_single_implication(
+                            db,
+                            program,
+                            builder,
+                            constraint,
+                            interior.constraint,
+                        );
                         node = interior.if_true;
                     } else {
-                        self.add_pair_impossibility(db, builder, constraint, interior.constraint);
+                        self.add_pair_impossibility(
+                            db,
+                            program,
+                            builder,
+                            constraint,
+                            interior.constraint,
+                        );
                         node = interior.if_false;
                     }
                 }
@@ -5452,6 +5710,7 @@ impl SequentMap {
     fn add_sequents_for_pair<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
@@ -5485,11 +5744,18 @@ impl SequentMap {
         if !left_typevar.is_same_typevar_as(db, right_typevar) {
             self.add_mutual_sequents_for_different_typevars(
                 db,
+                program,
                 builder,
                 left_constraint,
                 right_constraint,
             );
-            self.add_nested_typevar_sequents(db, builder, left_constraint, right_constraint);
+            self.add_nested_typevar_sequents(
+                db,
+                program,
+                builder,
+                left_constraint,
+                right_constraint,
+            );
         } else if left_constraint_data
             .bounds
             .lower
@@ -5509,18 +5775,20 @@ impl SequentMap {
         {
             self.add_mutual_sequents_for_same_typevars(
                 db,
+                program,
                 builder,
                 left_constraint,
                 right_constraint,
             );
         } else {
-            self.add_concrete_sequents(db, builder, left_constraint, right_constraint);
+            self.add_concrete_sequents(db, program, builder, left_constraint, right_constraint);
         }
     }
 
     fn add_mutual_sequents_for_different_typevars<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
@@ -5593,8 +5861,9 @@ impl SequentMap {
                     && !constrained_upper.is_object()
                     && builder.cached_is_constraint_set_subtype_of(
                         db,
-                        constrained_upper.top_materialization(db),
-                        bound_lower.bottom_materialization(db),
+                        program,
+                        constrained_upper.top_materialization(db, program),
+                        bound_lower.bottom_materialization(db, program),
                     ) =>
             {
                 (constrained_lower, Some(Type::TypeVar(bound_typevar)))
@@ -5606,8 +5875,9 @@ impl SequentMap {
                     && !constrained_lower.is_object()
                     && builder.cached_is_constraint_set_subtype_of(
                         db,
-                        bound_upper.top_materialization(db),
-                        constrained_lower.bottom_materialization(db),
+                        program,
+                        bound_upper.top_materialization(db, program),
+                        constrained_lower.bottom_materialization(db, program),
                     ) =>
             {
                 (Some(Type::TypeVar(bound_typevar)), constrained_upper)
@@ -5644,6 +5914,7 @@ impl SequentMap {
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
+                program,
                 builder,
                 lower_bound_typevar,
                 None,
@@ -5657,6 +5928,7 @@ impl SequentMap {
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
+                program,
                 builder,
                 upper_bound_typevar,
                 Some(Type::TypeVar(constrained_typevar)),
@@ -5670,6 +5942,7 @@ impl SequentMap {
         {
             post_constraints.push(ConstraintId::new_with_bounds(
                 db,
+                program,
                 builder,
                 constrained_typevar,
                 constrained_lower,
@@ -5680,6 +5953,7 @@ impl SequentMap {
         for post_constraint in post_constraints {
             self.add_pair_implication(
                 db,
+                program,
                 builder,
                 left_constraint,
                 right_constraint,
@@ -5700,6 +5974,7 @@ impl SequentMap {
     fn add_nested_typevar_sequents<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
@@ -5708,10 +5983,10 @@ impl SequentMap {
         let has_typevar_bound = |bounds: ConstraintBounds<'db>| {
             bounds
                 .lower
-                .is_some_and(|bound| any_over_type(db, bound, true, Type::is_type_var))
+                .is_some_and(|bound| any_over_type(db, program, bound, true, Type::is_type_var))
                 || bounds
                     .upper
-                    .is_some_and(|bound| any_over_type(db, bound, true, Type::is_type_var))
+                    .is_some_and(|bound| any_over_type(db, program, bound, true, Type::is_type_var))
         };
         if !has_typevar_bound(builder.constraint_data(left_constraint).bounds)
             && !has_typevar_bound(builder.constraint_data(right_constraint).bounds)
@@ -5740,8 +6015,9 @@ impl SequentMap {
                 // instead of calling `variance_of` on them. This avoids a large number of tiny
                 // tracked `variance_of` queries in hot paths.
                 let replacement_mentions_bound_or_constrained = |replacement: Type<'db>| {
-                    replacement.variance_of(db, bound_identity) != TypeVarVariance::Bivariant
-                        || replacement.variance_of(db, constrained_identity)
+                    replacement.variance_of(db, program, bound_identity)
+                        != TypeVarVariance::Bivariant
+                        || replacement.variance_of(db, program, constrained_identity)
                             != TypeVarVariance::Bivariant
                 };
 
@@ -5755,7 +6031,7 @@ impl SequentMap {
                 // need an alternative representation for "typevar not present"
                 // (e.g., `Option<TypeVarVariance>`).
                 let upper_replacement = match (
-                    constrained_upper.variance_of(db, bound_identity),
+                    constrained_upper.variance_of(db, program, bound_identity),
                     bound_data.bounds.lower,
                     bound_data.bounds.upper,
                 ) {
@@ -5796,11 +6072,16 @@ impl SequentMap {
                     !replacement_mentions_bound_or_constrained(*replacement)
                 });
                 if let Some(replacement) = upper_replacement {
-                    let new_upper =
-                        constrained_upper.substitute_one_typevar(db, bound_typevar, replacement);
+                    let new_upper = constrained_upper.substitute_one_typevar(
+                        db,
+                        program,
+                        bound_typevar,
+                        replacement,
+                    );
                     if new_upper != constrained_upper {
                         let post = ConstraintId::new_with_bounds(
                             db,
+                            program,
                             builder,
                             constrained_typevar,
                             constrained_data.bounds.lower,
@@ -5808,6 +6089,7 @@ impl SequentMap {
                         );
                         self.add_pair_implication_with_provenance(
                             db,
+                            program,
                             builder,
                             bound_constraint,
                             constrained_constraint,
@@ -5825,7 +6107,7 @@ impl SequentMap {
 
                 // Check the lower bound of the constrained constraint for nested occurrences.
                 let lower_replacement = match (
-                    constrained_lower.variance_of(db, bound_identity),
+                    constrained_lower.variance_of(db, program, bound_identity),
                     bound_data.bounds.lower,
                     bound_data.bounds.upper,
                 ) {
@@ -5864,11 +6146,16 @@ impl SequentMap {
                     !replacement_mentions_bound_or_constrained(*replacement)
                 });
                 if let Some(replacement) = lower_replacement {
-                    let new_lower =
-                        constrained_lower.substitute_one_typevar(db, bound_typevar, replacement);
+                    let new_lower = constrained_lower.substitute_one_typevar(
+                        db,
+                        program,
+                        bound_typevar,
+                        replacement,
+                    );
                     if new_lower != constrained_lower {
                         let post = ConstraintId::new_with_bounds(
                             db,
+                            program,
                             builder,
                             constrained_typevar,
                             Some(new_lower),
@@ -5876,6 +6163,7 @@ impl SequentMap {
                         );
                         self.add_pair_implication_with_provenance(
                             db,
+                            program,
                             builder,
                             bound_constraint,
                             constrained_constraint,
@@ -5951,7 +6239,11 @@ impl SequentMap {
                         && !constrained_upper.is_never()
                         && !constrained_upper.is_object()
                         && !constrained_upper.is_dynamic()
-                        && match constrained_upper.variance_of(db, nested_typevar.identity(db)) {
+                        && match constrained_upper.variance_of(
+                            db,
+                            program,
+                            nested_typevar.identity(db),
+                        ) {
                             TypeVarVariance::Bivariant => false,
                             TypeVarVariance::Covariant => !is_upper_bound,
                             TypeVarVariance::Contravariant => is_upper_bound,
@@ -5963,12 +6255,14 @@ impl SequentMap {
                     if should_weaken_upper {
                         let new_upper = constrained_upper.substitute_one_typevar(
                             db,
+                            program,
                             nested_typevar,
                             replacement,
                         );
                         if new_upper != constrained_upper {
                             let post = ConstraintId::new_with_bounds(
                                 db,
+                                program,
                                 builder,
                                 constrained_typevar,
                                 constrained_data.bounds.lower,
@@ -5976,6 +6270,7 @@ impl SequentMap {
                             );
                             self.add_pair_implication_with_provenance(
                                 db,
+                                program,
                                 builder,
                                 bound_constraint,
                                 constrained_constraint,
@@ -5996,7 +6291,11 @@ impl SequentMap {
                         && !constrained_lower.is_never()
                         && !constrained_lower.is_object()
                         && !constrained_lower.is_dynamic()
-                        && match constrained_lower.variance_of(db, nested_typevar.identity(db)) {
+                        && match constrained_lower.variance_of(
+                            db,
+                            program,
+                            nested_typevar.identity(db),
+                        ) {
                             TypeVarVariance::Bivariant => false,
                             TypeVarVariance::Covariant => is_upper_bound,
                             TypeVarVariance::Contravariant => !is_upper_bound,
@@ -6008,12 +6307,14 @@ impl SequentMap {
                     if should_weaken_lower {
                         let new_lower = constrained_lower.substitute_one_typevar(
                             db,
+                            program,
                             nested_typevar,
                             replacement,
                         );
                         if new_lower != constrained_lower {
                             let post = ConstraintId::new_with_bounds(
                                 db,
+                                program,
                                 builder,
                                 constrained_typevar,
                                 Some(new_lower),
@@ -6021,6 +6322,7 @@ impl SequentMap {
                             );
                             self.add_pair_implication_with_provenance(
                                 db,
+                                program,
                                 builder,
                                 bound_constraint,
                                 constrained_constraint,
@@ -6056,6 +6358,7 @@ impl SequentMap {
     fn add_mutual_sequents_for_same_typevars<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
@@ -6100,6 +6403,7 @@ impl SequentMap {
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
+                                program,
                                 builder,
                                 lower_bound_typevar,
                                 None,
@@ -6113,6 +6417,7 @@ impl SequentMap {
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
+                                program,
                                 builder,
                                 upper_bound_typevar,
                                 Some(Type::TypeVar(bound_typevar)),
@@ -6126,6 +6431,7 @@ impl SequentMap {
                         {
                             post_constraints.push(ConstraintId::new_with_bounds(
                                 db,
+                                program,
                                 builder,
                                 bound_typevar,
                                 constrained_lower,
@@ -6153,6 +6459,7 @@ impl SequentMap {
                 for post_constraint in post_constraints {
                     self.add_pair_implication(
                         db,
+                        program,
                         builder,
                         left_constraint,
                         right_constraint,
@@ -6168,6 +6475,7 @@ impl SequentMap {
     fn add_concrete_sequents<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         builder: &ConstraintSetBuilder<'db>,
         left_constraint: ConstraintId,
         right_constraint: ConstraintId,
@@ -6177,45 +6485,58 @@ impl SequentMap {
         // identify constraints that are identical besides e.g. ordering of union/intersection
         // elements. (For instance, when processing `T ≤ τ₁ & τ₂` and `T ≤ τ₂ & τ₁`, these clauses
         // would add sequents for `(T ≤ τ₁ & τ₂) → (T ≤ τ₂ & τ₁)` and vice versa.)
-        if builder.cached_constraint_implies(db, left_constraint, right_constraint) {
+        if builder.cached_constraint_implies(db, program, left_constraint, right_constraint) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::SequentMap",
-                left = %left_constraint.display(db, builder),
-                right = %right_constraint.display(db, builder),
+                left = %left_constraint.display(db, program, builder),
+                right = %right_constraint.display(db, program, builder),
                 "left implies right",
             );
-            self.add_single_implication(db, builder, left_constraint, right_constraint);
+            self.add_single_implication(db, program, builder, left_constraint, right_constraint);
         }
-        if builder.cached_constraint_implies(db, right_constraint, left_constraint) {
+        if builder.cached_constraint_implies(db, program, right_constraint, left_constraint) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::SequentMap",
-                left = %left_constraint.display(db, builder),
-                right = %right_constraint.display(db, builder),
+                left = %left_constraint.display(db, program, builder),
+                right = %right_constraint.display(db, program, builder),
                 "right implies left",
             );
-            self.add_single_implication(db, builder, right_constraint, left_constraint);
+            self.add_single_implication(db, program, builder, right_constraint, left_constraint);
         }
 
-        match left_constraint.intersect(db, builder, right_constraint) {
+        match left_constraint.intersect(db, program, builder, right_constraint) {
             IntersectionResult::Simplified(intersection_constraint_data) => {
                 let intersection_constraint =
-                    builder.intern_constraint(db, intersection_constraint_data);
+                    builder.intern_constraint(db, program, intersection_constraint_data);
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::SequentMap",
-                    left = %left_constraint.display(db, builder),
-                    right = %right_constraint.display(db, builder),
-                    intersection = %intersection_constraint.display(db, builder),
+                    left = %left_constraint.display(db, program, builder),
+                    right = %right_constraint.display(db, program, builder),
+                    intersection = %intersection_constraint.display(db, program, builder),
                     "left and right overlap",
                 );
                 self.add_pair_implication(
                     db,
+                    program,
                     builder,
                     left_constraint,
                     right_constraint,
                     intersection_constraint,
                 );
-                self.add_single_implication(db, builder, intersection_constraint, left_constraint);
-                self.add_single_implication(db, builder, intersection_constraint, right_constraint);
+                self.add_single_implication(
+                    db,
+                    program,
+                    builder,
+                    intersection_constraint,
+                    left_constraint,
+                );
+                self.add_single_implication(
+                    db,
+                    program,
+                    builder,
+                    intersection_constraint,
+                    right_constraint,
+                );
             }
 
             // The sequent map only needs to include constraints that might appear in a BDD. If the
@@ -6226,11 +6547,17 @@ impl SequentMap {
             IntersectionResult::Disjoint => {
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::SequentMap",
-                    left = %left_constraint.display(db, builder),
-                    right = %right_constraint.display(db, builder),
+                    left = %left_constraint.display(db, program, builder),
+                    right = %right_constraint.display(db, program, builder),
                     "left and right are disjoint",
                 );
-                self.add_pair_impossibility(db, builder, left_constraint, right_constraint);
+                self.add_pair_impossibility(
+                    db,
+                    program,
+                    builder,
+                    left_constraint,
+                    right_constraint,
+                );
             }
         }
     }
@@ -6239,6 +6566,7 @@ impl SequentMap {
     fn display<'db, 'a>(
         &'a self,
         db: &'db dyn Db,
+        program: Program,
         builder: &'a ConstraintSetBuilder<'db>,
         prefix: &'a dyn Display,
     ) -> impl Display + 'a {
@@ -6246,6 +6574,7 @@ impl SequentMap {
             map: &'a SequentMap,
             prefix: &'a dyn Display,
             db: &'db dyn Db,
+            program: Program,
             builder: &'a ConstraintSetBuilder<'db>,
         }
 
@@ -6270,8 +6599,8 @@ impl SequentMap {
                     write!(
                         f,
                         "{} ∧ {} → false",
-                        ante1.display(self.db, self.builder),
-                        ante2.display(self.db, self.builder),
+                        ante1.display(self.db, self.program, self.builder),
+                        ante2.display(self.db, self.program, self.builder),
                     )?;
                 }
 
@@ -6281,9 +6610,9 @@ impl SequentMap {
                         write!(
                             f,
                             "{} ∧ {} → {}",
-                            ante1.display(self.db, self.builder),
-                            ante2.display(self.db, self.builder),
-                            post.constraint.display(self.db, self.builder),
+                            ante1.display(self.db, self.program, self.builder),
+                            ante2.display(self.db, self.program, self.builder),
+                            post.constraint.display(self.db, self.program, self.builder),
                         )?;
                     }
                 }
@@ -6294,8 +6623,8 @@ impl SequentMap {
                         write!(
                             f,
                             "{} → {}",
-                            ante.display(self.db, self.builder),
-                            post.display(self.db, self.builder)
+                            ante.display(self.db, self.program, self.builder),
+                            post.display(self.db, self.program, self.builder)
                         )?;
                     }
                 }
@@ -6311,6 +6640,7 @@ impl SequentMap {
             map: self,
             prefix,
             db,
+            program,
             builder,
         }
     }
@@ -6322,12 +6652,8 @@ impl SequentMap {
 pub(crate) struct PathAssignments {
     map: SequentMap,
     /// Each assignment's source order and the first nested-substitution history that produced it.
-    /// (Most assignments have exactly one history, and so we save space and iteration overhead by
-    /// storing the first history here.)
     assignments: FxIndexMap<ConstraintAssignment, (usize, NestedSubstitutionHistory)>,
     /// Additional histories that can produce an assignment, keyed by its index in `assignments`.
-    /// These are stored separately so that branch-local additions can be rolled back by truncating
-    /// the set.
     additional_substitution_histories: FxIndexSet<(usize, NestedSubstitutionHistory)>,
     /// Constraints that we have discovered, mapped to whether we have processed them yet. (This
     /// ensures a stable order for all of the derived constraints that we create, while still
@@ -6374,6 +6700,7 @@ impl PathAssignments {
     fn walk_edge<'db, R>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
         source_order: usize,
@@ -6391,14 +6718,15 @@ impl PathAssignments {
             before = %format_args!(
                 "[{}]",
                 self.assignments[..start].iter().map(|(assignment, _)| {
-                    assignment.display(db, builder)
+                    assignment.display(db, program, builder)
                 }).format(", "),
             ),
-            edge = %assignment.display(db, builder),
+            edge = %assignment.display(db, program, builder),
             "walk edge",
         );
         let found_conflict = self.add_assignment(
             db,
+            program,
             builder,
             assignment,
             source_order,
@@ -6420,7 +6748,7 @@ impl PathAssignments {
                 new = %format_args!(
                     "[{}]",
                     self.assignments[start..].iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, program, builder)
                     }).format(", "),
                 ),
                 "new assignments",
@@ -6456,17 +6784,10 @@ impl PathAssignments {
             || self.assignment_holds(constraint.when_unconstrained())
     }
 
-    /// If `assignment` holds on this path, returns an iterator of its substitution histories.
-    /// Otherwise returns `None`.
     fn histories_for(
         &self,
         assignment: ConstraintAssignment,
     ) -> Option<impl Iterator<Item = &NestedSubstitutionHistory> + Clone> {
-        // This is complicated by the fact that we store each assignment's first history inline in
-        // the `assignments` field, and the others in `additional_substitution_histories`; and
-        // moreover that `additional_substitution_histories` interleaves histories from all
-        // assignments on this path. Assignments will typically have a single history, so it
-        // should™ be fine that we're scanning and filtering that entire list.
         let (index, _, (_, history)) = self.assignments.get_full(&assignment)?;
         let first = std::iter::once(history);
         let rest = self
@@ -6474,7 +6795,7 @@ impl PathAssignments {
             .iter()
             .filter(move |(history_index, _)| *history_index == index)
             .map(|(_, history)| history);
-        Some(std::iter::chain(first, rest))
+        Some(first.chain(rest))
     }
 
     /// Update our sequent map to ensure that it holds all of the sequents that involve the given
@@ -6485,6 +6806,7 @@ impl PathAssignments {
     fn discover_constraint<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         constraint: ConstraintId,
     ) {
@@ -6495,12 +6817,13 @@ impl PathAssignments {
             return;
         }
 
-        let single_map = SequentMap::for_constraint(db, builder, constraint);
+        let single_map = SequentMap::for_constraint(db, program, builder, constraint);
         self.map.merge(&single_map);
         drop(single_map);
 
         for existing in self.discovered.keys().dropping_back(1) {
-            let pair_map = SequentMap::for_constraint_pair(db, builder, *existing, constraint);
+            let pair_map =
+                SequentMap::for_constraint_pair(db, program, builder, *existing, constraint);
             self.map.merge(&pair_map);
         }
     }
@@ -6508,9 +6831,14 @@ impl PathAssignments {
     /// Adds a new assignment, along with any derived information that we can infer from the new
     /// assignment combined with the assignments we've already seen. If any of this causes the path
     /// to become invalid, due to a contradiction, returns a [`PathAssignmentConflict`] error.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "Program is required to keep derived constraints in the correct analysis environment"
+    )]
     fn add_assignment<'db>(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
         assignment: ConstraintAssignment,
         source_order: usize,
@@ -6537,11 +6865,11 @@ impl PathAssignments {
         if self.assignments.contains_key(&assignment.negated()) {
             tracing::trace!(
                 target: "ty_python_semantic::types::constraints::PathAssignment",
-                assignment = %assignment.display(db, builder),
+                assignment = %assignment.display(db, program, builder),
                 facts = %format_args!(
                     "[{}]",
                     self.assignments.iter().map(|(assignment, _)| {
-                        assignment.display(db, builder)
+                        assignment.display(db, program, builder)
                     }).format(", "),
                 ),
                 "found contradiction",
@@ -6556,7 +6884,6 @@ impl PathAssignments {
             Entry::Occupied(mut entry) => {
                 let index = entry.index();
                 let (existing_source_order, existing_history) = entry.get_mut();
-
                 // If a constraint appears both as an "origin" constraint (it actually appears in
                 // the BDD structure) and as a "derived" constraint (we infer it from other
                 // constraints), we should prefer the origin source_order, regardless of which
@@ -6565,9 +6892,6 @@ impl PathAssignments {
                     *existing_source_order = source_order;
                 }
 
-                // A smaller history blocks fewer future substitutions, so it preserves every
-                // derivation available from a larger history. If an existing history is a subset
-                // of this one, this one is redundant and does not need to be processed.
                 if existing_history.is_subset_of(&history)
                     || self.additional_substitution_histories.iter().any(
                         |(history_index, existing_history)| {
@@ -6595,7 +6919,7 @@ impl PathAssignments {
         // don't anticipate the sequent maps to be very large. We might consider avoiding the
         // brute-force search.
 
-        self.discover_constraint(db, builder, assignment.constraint());
+        self.discover_constraint(db, program, builder, assignment.constraint());
 
         #[expect(
             clippy::iter_over_hash_type,
@@ -6607,11 +6931,11 @@ impl PathAssignments {
                 // it's false.
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante = %ante.display(db, builder),
+                    ante = %ante.display(db, program, builder),
                     facts = %format_args!(
                         "[{}]",
                         self.assignments.iter().map(|(assignment, _)| {
-                            assignment.display(db, builder)
+                            assignment.display(db, program, builder)
                         }).format(", "),
                     ),
                     "found contradiction",
@@ -6631,12 +6955,12 @@ impl PathAssignments {
                 // current path asserts that both are true.
                 tracing::trace!(
                     target: "ty_python_semantic::types::constraints::PathAssignment",
-                    ante1 = %ante1.display(db, builder),
-                    ante2 = %ante2.display(db, builder),
+                    ante1 = %ante1.display(db, program, builder),
+                    ante2 = %ante2.display(db, program, builder),
                     facts = %format_args!(
                         "[{}]",
                         self.assignments.iter().map(|(assignment, _)| {
-                            assignment.display(db, builder)
+                            assignment.display(db, program, builder)
                         }).format(", "),
                     ),
                     "found contradiction",
@@ -6655,15 +6979,6 @@ impl PathAssignments {
             };
 
             for post in posts {
-                // The number of histories can grow combinatorially because we consider every pair
-                // of antecedent histories. `add_assignment` partially prunes this growth by
-                // discarding a new history if an existing history for the same assignment is its
-                // subset. We do not yet remove existing histories that are supersets of a new
-                // history, because those removals would have to be restored when we backtrack out
-                // of the current BDD branch.
-                //
-                // TODO: Retain only subset-minimal histories for each assignment by adding support
-                // for rolling back histories removed by dominance pruning.
                 for history1 in histories1.clone() {
                     for history2 in histories2.clone() {
                         if let Some(history) = history1.merged(history2, post.nested_substitution) {
@@ -6688,6 +7003,7 @@ impl PathAssignments {
         for (new_constraint, history) in new_constraints {
             self.add_assignment(
                 db,
+                program,
                 builder,
                 new_constraint.when_true(),
                 source_order,
@@ -6747,7 +7063,12 @@ impl SatisfiedClause {
     /// want to remove the larger one and keep the smaller one.)
     ///
     /// Returns a boolean that indicates whether any simplifications were made.
-    fn simplify<'db>(&mut self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> bool {
+    fn simplify<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> bool {
         let mut changes_made = false;
         let mut i = 0;
         // Loop through each constraint, comparing it with any constraints that appear later in the
@@ -6755,7 +7076,7 @@ impl SatisfiedClause {
         'outer: while i < self.constraints.len() {
             let mut j = i + 1;
             while j < self.constraints.len() {
-                if self.constraints[j].implies(db, builder, self.constraints[i]) {
+                if self.constraints[j].implies(db, program, builder, self.constraints[i]) {
                     // If constraint `i` is removed, then we don't need to compare it with any
                     // later constraints in the list. Note that we continue the outer loop, instead
                     // of breaking from the inner loop, so that we don't bump index `i` below.
@@ -6764,7 +7085,7 @@ impl SatisfiedClause {
                     self.constraints.swap_remove(i);
                     changes_made = true;
                     continue 'outer;
-                } else if self.constraints[i].implies(db, builder, self.constraints[j]) {
+                } else if self.constraints[i].implies(db, program, builder, self.constraints[j]) {
                     // If constraint `j` is removed, then we can continue the inner loop. We will
                     // swap a new element into place at index `j`, and will continue comparing the
                     // constraint at index `i` with later constraints.
@@ -6779,7 +7100,12 @@ impl SatisfiedClause {
         changes_made
     }
 
-    fn display<'db>(&self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> String {
+    fn display<'db>(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> String {
         if self.constraints.is_empty() {
             return String::from("always");
         }
@@ -6790,7 +7116,7 @@ impl SatisfiedClause {
         let mut constraints: Vec<_> = self
             .constraints
             .iter()
-            .map(|constraint| constraint.display(db, builder).to_string())
+            .map(|constraint| constraint.display(db, program, builder).to_string())
             .collect();
         constraints.sort();
 
@@ -6826,11 +7152,16 @@ impl SatisfiedClauses {
     /// Simplifies the DNF representation, removing redundancies that do not change the underlying
     /// function. (This is used when displaying a BDD, to make sure that the representation that we
     /// show is as simple as possible while still producing the same results.)
-    fn simplify<'db>(&mut self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) {
+    fn simplify<'db>(
+        &mut self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) {
         // First simplify each clause individually, by removing constraints that are implied by
         // other constraints in the clause.
         for clause in &mut self.clauses {
-            clause.simplify(db, builder);
+            clause.simplify(db, program, builder);
         }
 
         while self.simplify_one_round() {
@@ -6902,7 +7233,12 @@ impl SatisfiedClauses {
         false
     }
 
-    fn display<'db>(&self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> String {
+    fn display<'db>(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> String {
         // This is a bit heavy-handed, but we need to output the clauses in a consistent order
         // even though Salsa IDs are assigned non-deterministically. This Display output is only
         // used in test cases, so we don't need to over-optimize it.
@@ -6913,7 +7249,7 @@ impl SatisfiedClauses {
         let mut clauses: Vec<_> = self
             .clauses
             .iter()
-            .map(|clause| clause.display(db, builder))
+            .map(|clause| clause.display(db, program, builder))
             .collect();
         clauses.sort();
         clauses.join(" ∨ ")
@@ -6924,7 +7260,12 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns the valid specializations of a typevar. This is used when checking a constraint set
     /// when this typevar is in inferable position, where we only need _some_ specialization to
     /// satisfy the constraint set.
-    fn valid_specializations(self, db: &'db dyn Db, builder: &ConstraintSetBuilder<'db>) -> NodeId {
+    fn valid_specializations(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        builder: &ConstraintSetBuilder<'db>,
+    ) -> NodeId {
         if self.paramspec_attr(db).is_some() {
             // P.args and P.kwargs are variadic, and do not have an upper bound or constraints.
             return ALWAYS_TRUE;
@@ -6943,17 +7284,24 @@ impl<'db> BoundTypeVarInstance<'db> {
         match self.typevar(db).bound_or_constraints(db) {
             None => ALWAYS_TRUE,
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                let bound = bound.top_materialization(db);
-                Constraint::new_node_with_bounds(db, builder, self, None, Some(bound))
+                let bound = bound.top_materialization(db, program);
+                Constraint::new_node_with_bounds(db, program, builder, self, None, Some(bound))
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                 let mut specializations = ALWAYS_FALSE;
                 for constraint in constraints.elements(db) {
-                    let constraint_lower = constraint.bottom_materialization(db);
-                    let constraint_upper = constraint.top_materialization(db);
+                    let constraint_lower = constraint.bottom_materialization(db, program);
+                    let constraint_upper = constraint.top_materialization(db, program);
                     specializations = specializations.or_with_offset(
                         builder,
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper),
+                        Constraint::new_node(
+                            db,
+                            program,
+                            builder,
+                            self,
+                            constraint_lower,
+                            constraint_upper,
+                        ),
                     );
                 }
                 specializations
@@ -6977,6 +7325,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     fn required_specializations(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         builder: &ConstraintSetBuilder<'db>,
     ) -> (NodeId, Vec<NodeId>) {
         // For upper bounds and constraints, we are free to choose any materialization that makes
@@ -6987,9 +7336,9 @@ impl<'db> BoundTypeVarInstance<'db> {
         match self.typevar(db).bound_or_constraints(db) {
             None => (ALWAYS_TRUE, Vec::new()),
             Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                let bound = bound.bottom_materialization(db);
+                let bound = bound.bottom_materialization(db, program);
                 (
-                    Constraint::new_node_with_bounds(db, builder, self, None, Some(bound)),
+                    Constraint::new_node_with_bounds(db, program, builder, self, None, Some(bound)),
                     Vec::new(),
                 )
             }
@@ -6997,10 +7346,16 @@ impl<'db> BoundTypeVarInstance<'db> {
                 let mut non_gradual_constraints = ALWAYS_FALSE;
                 let mut gradual_constraints = Vec::new();
                 for constraint in constraints.elements(db) {
-                    let constraint_lower = constraint.bottom_materialization(db);
-                    let constraint_upper = constraint.top_materialization(db);
-                    let constraint =
-                        Constraint::new_node(db, builder, self, constraint_lower, constraint_upper);
+                    let constraint_lower = constraint.bottom_materialization(db, program);
+                    let constraint_upper = constraint.top_materialization(db, program);
+                    let constraint = Constraint::new_node(
+                        db,
+                        program,
+                        builder,
+                        self,
+                        constraint_lower,
+                        constraint_upper,
+                    );
                     if constraint_lower == constraint_upper {
                         non_gradual_constraints =
                             non_gradual_constraints.or_with_offset(builder, constraint);
@@ -7021,72 +7376,83 @@ mod tests {
     use indoc::indoc;
     use pretty_assertions::assert_eq;
 
-    use crate::db::tests::setup_db;
+    use crate::db::tests::{TestDb, setup_db};
     use crate::types::{BoundTypeVarInstance, KnownClass, TypeVarVariance};
     use ruff_python_ast::name::Name;
 
-    fn create_typevar<'db>(db: &'db dyn Db, name: &'static str) -> BoundTypeVarInstance<'db> {
-        BoundTypeVarInstance::synthetic(db, Name::new_static(name), TypeVarVariance::Invariant)
+    fn create_typevar<'db>(db: &'db TestDb, name: &'static str) -> BoundTypeVarInstance<'db> {
+        BoundTypeVarInstance::synthetic(
+            db,
+            db.program(),
+            Name::new_static(name),
+            TypeVarVariance::Invariant,
+        )
     }
 
     fn create_constraint<'db, 'c>(
-        db: &'db dyn Db,
+        db: &'db TestDb,
         builder: &'c ConstraintSetBuilder<'db>,
         bound_typevar: BoundTypeVarInstance<'db>,
         bound: KnownClass,
     ) -> ConstraintSet<'db, 'c> {
-        let ty = bound.to_instance(db);
-        ConstraintSet::constrain_typevar(db, builder, bound_typevar, ty, ty)
+        let program = db.program();
+        let ty = bound.to_instance(db, program);
+        ConstraintSet::constrain_typevar(db, program, builder, bound_typevar, ty, ty)
     }
 
-    fn known_instance(db: &dyn Db, class: KnownClass) -> Type<'_> {
-        class.to_instance(db)
+    fn known_instance(db: &TestDb, class: KnownClass) -> Type<'_> {
+        let program = db.program();
+        class.to_instance(db, program)
     }
 
     #[test]
     fn upper_bound_prunes_duplicates_and_redundant_supertypes() {
         let db = setup_db();
+        let program = db.program();
         let int = known_instance(&db, KnownClass::Int);
         let bool = known_instance(&db, KnownClass::Bool);
         let str = known_instance(&db, KnownClass::Str);
 
-        let mut upper = UpperBound::from_clauses(&db, [int, str, int]);
+        let mut upper = UpperBound::from_clauses(&db, program, [int, str, int]);
         assert_eq!(upper.clauses, FxOrderSet::from_iter([int, str]));
 
         // `bool` is narrower than `int`, so it replaces the redundant `int` clause while
         // preserving the relative order of the remaining clauses.
-        upper.add_clause(&db, bool);
+        upper.add_clause(&db, program, bool);
         assert_eq!(upper.clauses, FxOrderSet::from_iter([str, bool]));
 
-        upper.add_clause(&db, int);
+        upper.add_clause(&db, program, int);
         assert_eq!(upper.clauses, FxOrderSet::from_iter([str, bool]));
     }
 
     #[test]
     fn upper_bound_collapses_never() {
         let db = setup_db();
+        let program = db.program();
         let int = known_instance(&db, KnownClass::Int);
 
         let mut upper = UpperBound::from_clause(int);
-        upper.add_clause(&db, Type::Never);
+        upper.add_clause(&db, program, Type::Never);
         assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
-        assert_eq!(upper.materialize_exact(&db), Type::Never);
+        assert_eq!(upper.materialize_exact(&db, program), Type::Never);
 
-        upper.add_clause(&db, int);
+        upper.add_clause(&db, program, int);
         assert_eq!(upper.clauses, FxOrderSet::from_iter([Type::Never]));
     }
 
     #[test]
     fn simple_lower_bound_conjunction_skips_sequent_analysis() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
-        let int = KnownClass::Int.to_instance(&db);
-        let str = KnownClass::Str.to_instance(&db);
-        let set = ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, int).and(
+        let int = KnownClass::Int.to_instance(&db, program);
+        let str = KnownClass::Str.to_instance(&db, program);
+        let set = ConstraintSet::constrain_typevar_lower_bound(&db, program, &builder, t, int).and(
             &db,
+            program,
             &builder,
-            || ConstraintSet::constrain_typevar_lower_bound(&db, &builder, t, str),
+            || ConstraintSet::constrain_typevar_lower_bound(&db, program, &builder, t, str),
         );
         let inferable =
             InferableTypeVars::from_typevars(&db, std::iter::once(t.identity(&db)).collect());
@@ -7098,12 +7464,13 @@ mod tests {
             )
         };
 
-        let solutions = set.solutions(&db, &builder, inferable);
+        let set = set.remove_noninferable(&db, program, &builder, inferable);
+        let solutions = set.solutions(&db, program, &builder);
         assert_eq!(
             solutions,
             Solutions::Constrained(vec![vec![TypeVarSolution {
                 bound_typevar: t,
-                solution: UnionType::from_elements(&db, [int, str]),
+                solution: UnionType::from_elements(&db, program, [int, str]),
             }]])
         );
 
@@ -7115,6 +7482,7 @@ mod tests {
     #[test]
     fn default_solve_leaves_unbounded_typevar_unsolved_without_bounds() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
         let path_bound = PathBound {
@@ -7125,7 +7493,7 @@ mod tests {
         };
 
         assert_eq!(
-            PathBounds::default_solve(&db, &builder, &path_bound),
+            PathBounds::default_solve(&db, program, &builder, &path_bound),
             Ok(None)
         );
     }
@@ -7133,22 +7501,31 @@ mod tests {
     #[test]
     fn constraint_intersection_detects_disjoint_union_upper_bounds() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
         let int = known_instance(&db, KnownClass::Int);
         let str = known_instance(&db, KnownClass::Str);
         let bytes = known_instance(&db, KnownClass::Bytes);
         let bytearray = known_instance(&db, KnownClass::Bytearray);
-        let int_or_str = UnionType::from_two_elements(&db, int, str);
-        let bytes_or_bytearray = UnionType::from_two_elements(&db, bytes, bytearray);
-        let left = ConstraintId::new_with_bounds(&db, &builder, t, Some(int), Some(int_or_str));
-        let right = ConstraintId::new_with_bounds(&db, &builder, t, None, Some(bytes_or_bytearray));
+        let int_or_str = UnionType::from_two_elements(&db, program, int, str);
+        let bytes_or_bytearray = UnionType::from_two_elements(&db, program, bytes, bytearray);
+        let left =
+            ConstraintId::new_with_bounds(&db, program, &builder, t, Some(int), Some(int_or_str));
+        let right = ConstraintId::new_with_bounds(
+            &db,
+            program,
+            &builder,
+            t,
+            None,
+            Some(bytes_or_bytearray),
+        );
 
         // Check satisfiability against each upper clause before punting on the union-bearing
         // merged upper bound. The old size heuristic returned `CannotSimplify` here before
         // discovering that `int` cannot satisfy the second upper clause.
         assert!(matches!(
-            left.intersect(&db, &builder, right),
+            left.intersect(&db, program, &builder, right),
             IntersectionResult::Disjoint
         ));
     }
@@ -7156,25 +7533,28 @@ mod tests {
     #[test]
     fn constraint_implications_are_cached() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
         let t_int = ConstraintId::new(
             &db,
+            program,
             &builder,
             t,
             Type::Never,
-            KnownClass::Int.to_instance(&db),
+            KnownClass::Int.to_instance(&db, program),
         );
         let t_bool = ConstraintId::new(
             &db,
+            program,
             &builder,
             t,
             Type::Never,
-            KnownClass::Bool.to_instance(&db),
+            KnownClass::Bool.to_instance(&db, program),
         );
 
-        assert!(builder.cached_constraint_implies(&db, t_bool, t_int));
-        assert!(builder.cached_constraint_implies(&db, t_bool, t_int));
+        assert!(builder.cached_constraint_implies(&db, program, t_bool, t_int));
+        assert!(builder.cached_constraint_implies(&db, program, t_bool, t_int));
 
         {
             let storage = builder.storage.borrow();
@@ -7185,8 +7565,8 @@ mod tests {
             assert_eq!(storage.constraint_implication_cache.len(), 1);
         }
 
-        assert!(!builder.cached_constraint_implies(&db, t_int, t_bool));
-        assert!(!builder.cached_constraint_implies(&db, t_int, t_bool));
+        assert!(!builder.cached_constraint_implies(&db, program, t_int, t_bool));
+        assert!(!builder.cached_constraint_implies(&db, program, t_int, t_bool));
 
         let storage = builder.storage.borrow();
         assert_eq!(
@@ -7199,18 +7579,19 @@ mod tests {
     #[test]
     fn never_satisfied_results_are_cached() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let builder = ConstraintSetBuilder::new();
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let t_str = create_constraint(&db, &builder, t, KnownClass::Str);
-        let impossible = t_int.and(&db, &builder, || t_str);
+        let impossible = t_int.and(&db, program, &builder, || t_str);
 
-        assert!(!t_int.is_never_satisfied(&db));
-        assert!(!t_int.is_never_satisfied(&db));
-        assert!(impossible.is_never_satisfied(&db));
-        assert!(impossible.is_never_satisfied(&db));
-        assert!(ConstraintSet::never(&builder).is_never_satisfied(&db));
-        assert!(!ConstraintSet::always(&builder).is_never_satisfied(&db));
+        assert!(!t_int.is_never_satisfied(&db, program));
+        assert!(!t_int.is_never_satisfied(&db, program));
+        assert!(impossible.is_never_satisfied(&db, program));
+        assert!(impossible.is_never_satisfied(&db, program));
+        assert!(ConstraintSet::never(&builder).is_never_satisfied(&db, program));
+        assert!(!ConstraintSet::always(&builder).is_never_satisfied(&db, program));
 
         {
             let storage = builder.storage.borrow();
@@ -7224,8 +7605,8 @@ mod tests {
 
         let owned = create_compacted_owned_set(&db);
         owned.query(|builder, set| {
-            assert!(!set.is_never_satisfied(&db));
-            assert!(!set.is_never_satisfied(&db));
+            assert!(!set.is_never_satisfied(&db, program));
+            assert!(!set.is_never_satisfied(&db, program));
             assert_eq!(
                 builder
                     .storage
@@ -7239,19 +7620,24 @@ mod tests {
 
     #[track_caller]
     fn check_display_graph<'db, 'c>(
-        db: &'db dyn Db,
+        db: &'db TestDb,
         builder: &'c ConstraintSetBuilder<'db>,
         set: ConstraintSet<'db, 'c>,
         expected: &str,
     ) {
+        let program = db.program();
         let expected = expected.trim_end();
-        let actual = set.node.display_graph(db, builder, &"").to_string();
+        let actual = set
+            .node
+            .display_graph(db, program, builder, &"")
+            .to_string();
         assert_eq!(expected, actual);
     }
 
     #[test]
     fn test_display_graph_output() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let constraints = ConstraintSetBuilder::new();
@@ -7261,8 +7647,12 @@ mod tests {
         let u_bool = create_constraint(&db, &constraints, u, KnownClass::Bool);
         // Construct this in a different order than above to make the source_orders more
         // interesting.
-        let set = (u_str.or(&db, &constraints, || u_bool))
-            .and(&db, &constraints, || t_str.or(&db, &constraints, || t_bool));
+        let set = (u_str.or(&db, program, &constraints, || u_bool)).and(
+            &db,
+            program,
+            &constraints,
+            || t_str.or(&db, program, &constraints, || t_bool),
+        );
         check_display_graph(
             &db,
             &constraints,
@@ -7312,6 +7702,7 @@ mod tests {
     #[test]
     fn tdd_union_creates_uncertain_branches() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -7321,7 +7712,7 @@ mod tests {
         // the union result.
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-        let union = t_int.or(&db, &builder, || u_str);
+        let union = t_int.or(&db, program, &builder, || u_str);
         check_display_graph(
             &db,
             &builder,
@@ -7343,6 +7734,7 @@ mod tests {
     #[test]
     fn tdd_intersection_preserves_uncertain() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
@@ -7353,9 +7745,9 @@ mod tests {
 
         // lhs and rhs both have uncertain branches (checked above). These uncertain branches are
         // carried through to the intersection result.
-        let lhs = t_int.or(&db, &builder, || u_str);
-        let rhs = t_bool.or(&db, &builder, || u_int);
-        let intersection = lhs.and(&db, &builder, || rhs);
+        let lhs = t_int.or(&db, program, &builder, || u_str);
+        let rhs = t_bool.or(&db, program, &builder, || u_int);
+        let intersection = lhs.and(&db, program, &builder, || rhs);
         check_display_graph(
             &db,
             &builder,
@@ -7382,12 +7774,13 @@ mod tests {
     #[test]
     fn tdd_negation_produces_flat_tdd() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-        let union = t_int.or(&db, &builder, || u_str);
+        let union = t_int.or(&db, program, &builder, || u_str);
         let negated = union.negate(&db, &builder);
         check_display_graph(
             &db,
@@ -7408,20 +7801,27 @@ mod tests {
     #[test]
     fn tdd_negation_correctness() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
 
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-        let tdd = t_int.or(&db, &builder, || u_str);
+        let tdd = t_int.or(&db, program, &builder, || u_str);
         let negated = tdd.negate(&db, &builder);
 
         // T ∧ ¬T == false
-        assert!(tdd.and(&db, &builder, || negated).is_never_satisfied(&db));
+        assert!(
+            tdd.and(&db, program, &builder, || negated)
+                .is_never_satisfied(&db, program)
+        );
 
         // T ∨ ¬T == true
-        assert!(tdd.or(&db, &builder, || negated).is_always_satisfied(&db));
+        assert!(
+            tdd.or(&db, program, &builder, || negated)
+                .is_always_satisfied(&db, program)
+        );
     }
 
     /// Double negation of a TDD with uncertain branches is semantically equivalent to the
@@ -7429,38 +7829,46 @@ mod tests {
     #[test]
     fn tdd_double_negation() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-        let tdd = t_int.or(&db, &builder, || u_str);
+        let tdd = t_int.or(&db, program, &builder, || u_str);
         let negated = tdd.negate(&db, &builder);
         let double_negated = negated.negate(&db, &builder);
         let equivalent = tdd.iff(&db, &builder, double_negated);
-        assert!(equivalent.is_always_satisfied(&db));
+        assert!(equivalent.is_always_satisfied(&db, program));
     }
 
     /// `iff(T, T)` is always satisfied for TDDs with uncertain branches.
     #[test]
     fn tdd_iff_self() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
         let builder = ConstraintSetBuilder::new();
         let t_int = create_constraint(&db, &builder, t, KnownClass::Int);
         let u_str = create_constraint(&db, &builder, u, KnownClass::Str);
-        let tdd = t_int.or(&db, &builder, || u_str);
+        let tdd = t_int.or(&db, program, &builder, || u_str);
 
         // iff(T, T) == true
-        assert!(tdd.iff(&db, &builder, tdd).is_always_satisfied(&db));
+        assert!(
+            tdd.iff(&db, &builder, tdd)
+                .is_always_satisfied(&db, program)
+        );
 
         // iff(T, ¬T) == false
         let negated = tdd.negate(&db, &builder);
-        assert!(tdd.iff(&db, &builder, negated).is_never_satisfied(&db));
+        assert!(
+            tdd.iff(&db, &builder, negated)
+                .is_never_satisfied(&db, program)
+        );
     }
 
-    fn create_compacted_owned_set(db: &dyn Db) -> OwnedConstraintSet<'_> {
+    fn create_compacted_owned_set(db: &TestDb) -> OwnedConstraintSet<'_> {
         let t = create_typevar(db, "T");
         let u = create_typevar(db, "U");
         let v = create_typevar(db, "V");
@@ -7524,6 +7932,7 @@ mod tests {
     #[test]
     fn owned_constraint_set_mutating_query_allocates_after_overlay() {
         let db = setup_db();
+        let program = db.program();
         let owned = create_compacted_owned_set(&db);
 
         owned.query(|builder, set| {
@@ -7551,8 +7960,8 @@ mod tests {
             assert!(new_constraint.index() >= constraint_split);
             assert!(builder.typevar_id(&db, w).index() >= typevar_split);
 
-            let combined = set.and(&db, builder, || w_str);
-            assert!(!combined.is_never_satisfied(&db));
+            let combined = set.and(&db, program, builder, || w_str);
+            assert!(!combined.is_never_satisfied(&db, program));
 
             let storage = builder.storage.borrow();
             assert!(!storage.nodes.is_empty());
@@ -7564,10 +7973,11 @@ mod tests {
     #[test]
     fn owned_constraint_set_load_reads_compacted_storage() {
         let db = setup_db();
+        let program = db.program();
         let owned = create_compacted_owned_set(&db);
 
         let builder = ConstraintSetBuilder::new();
-        let loaded = builder.load(&db, &owned);
+        let loaded = builder.load(&db, program, &owned);
         check_display_graph(
             &db,
             &builder,
@@ -7584,6 +7994,7 @@ mod tests {
     #[test]
     fn terminal_owned_constraint_set_discards_storage() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let owned = ConstraintSetBuilder::new().into_owned(|builder| {
             let _unused = create_constraint(&db, builder, t, KnownClass::Int);
@@ -7593,7 +8004,7 @@ mod tests {
         assert!(owned.inner.is_none());
 
         owned.query(|builder, set| {
-            assert!(set.is_always_satisfied(&db));
+            assert!(set.is_always_satisfied(&db, program));
             let storage = builder.storage.borrow();
             assert!(storage.compacted.is_none());
             assert!(storage.nodes.is_empty());
@@ -7602,8 +8013,8 @@ mod tests {
         });
 
         let builder = ConstraintSetBuilder::new();
-        let loaded = builder.load(&db, &owned);
-        assert!(loaded.is_always_satisfied(&db));
+        let loaded = builder.load(&db, program, &owned);
+        assert!(loaded.is_always_satisfied(&db, program));
     }
 
     /// Round-trip through `OwnedConstraintSet`: build a TDD with uncertain branches, convert to
@@ -7611,6 +8022,7 @@ mod tests {
     #[test]
     fn tdd_owned_round_trip() {
         let db = setup_db();
+        let program = db.program();
         let t = create_typevar(&db, "T");
         let u = create_typevar(&db, "U");
 
@@ -7619,7 +8031,7 @@ mod tests {
         let owned = builder.into_owned(|builder| {
             let t_int = create_constraint(&db, builder, t, KnownClass::Int);
             let u_str = create_constraint(&db, builder, u, KnownClass::Str);
-            let result = t_int.or(&db, builder, || u_str);
+            let result = t_int.or(&db, program, builder, || u_str);
             check_display_graph(
                 &db,
                 builder,
@@ -7639,7 +8051,7 @@ mod tests {
 
         // Load into a new builder
         let builder = ConstraintSetBuilder::new();
-        let loaded = builder.load(&db, &owned);
+        let loaded = builder.load(&db, program, &owned);
         check_display_graph(
             &db,
             &builder,

--- a/crates/ty_python_semantic/src/types/context.rs
+++ b/crates/ty_python_semantic/src/types/context.rs
@@ -14,16 +14,16 @@ use super::{Type, TypeCheckDiagnostics, infer_definition_types};
 use crate::diagnostic::DiagnosticGuard;
 use crate::lint::LintSource;
 use crate::reachability::is_range_reachable;
+use crate::suppression::suppressions;
 use crate::types::diagnostic::{INVALID_TYPE_FORM, UNBOUND_TYPE_VARIABLE};
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::InferenceFlags;
 use crate::{
-    Db,
+    Db, Program,
     lint::{LintId, LintMetadata},
-    suppression::suppressions,
 };
 use ty_python_core::scope::ScopeId;
-use ty_python_core::semantic_index;
+use ty_python_core::{environment::ProgramFile, semantic_index};
 
 /// Context for inferring the types of a single file.
 ///
@@ -40,6 +40,8 @@ use ty_python_core::semantic_index;
 pub(crate) struct InferContext<'db, 'ast> {
     db: &'db dyn Db,
     scope: ScopeId<'db>,
+    program_file: ProgramFile<'db>,
+    program: Program,
     file: File,
     module: &'ast ParsedModuleRef,
     diagnostics: std::cell::RefCell<TypeCheckDiagnostics>,
@@ -51,11 +53,14 @@ pub(crate) struct InferContext<'db, 'ast> {
 
 impl<'db, 'ast> InferContext<'db, 'ast> {
     pub(crate) fn new(db: &'db dyn Db, scope: ScopeId<'db>, module: &'ast ParsedModuleRef) -> Self {
+        let program_file = scope.program_file(db);
         Self {
             db,
             scope,
+            program_file,
+            program: program_file.program(db),
             module,
-            file: scope.file(db),
+            file: program_file.file(db),
             diagnostics: std::cell::RefCell::new(TypeCheckDiagnostics::default()),
             diagnostics_suppressed: false,
             inference_flags: InferenceFlags::empty(),
@@ -68,6 +73,14 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     /// The file for which the types are inferred.
     pub(crate) fn file(&self) -> File {
         self.file
+    }
+
+    pub(crate) fn program_file(&self) -> ProgramFile<'db> {
+        self.program_file
+    }
+
+    pub(crate) fn program(&self) -> Program {
+        self.program
     }
 
     /// The module for which the types are inferred.
@@ -187,7 +200,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
 
         // Accessing the semantic index here is fine because
         // the index belongs to the same file as for which we emit the diagnostic.
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
 
         let scope_id = self.scope.file_scope_id(self.db);
 
@@ -214,7 +227,7 @@ impl<'db, 'ast> InferContext<'db, 'ast> {
     /// This checks both whether the scope itself is reachable and whether the
     /// specific statement or expression containing this range is reachable.
     fn is_range_reachable(&self, range: TextRange) -> bool {
-        let index = semantic_index(self.db, self.file);
+        let index = semantic_index(self.db, self.program_file);
         let scope_id = self.scope.file_scope_id(self.db);
         is_range_reachable(self.db, index, scope_id, range)
     }
@@ -469,7 +482,7 @@ impl<'db, 'ctx> LintDiagnosticGuardBuilder<'db, 'ctx> {
 
         let (severity, source) = Self::severity_and_source(ctx, lint_id)?;
 
-        let suppressions = suppressions(ctx.db(), ctx.file());
+        let suppressions = suppressions(ctx.db(), ctx.program_file().versioned_file(ctx.db()));
         if let Some(suppression) = suppressions.find_suppression(range, lint_id) {
             ctx.diagnostics.borrow_mut().mark_used(suppression.id());
             return None;
@@ -549,6 +562,7 @@ impl<'db, 'ctx> DiagnosticGuardBuilder<'db, 'ctx> {
         if !ctx.db.should_check_file(ctx.file) {
             return None;
         }
+
         Some(DiagnosticGuardBuilder { ctx, id, severity })
     }
 

--- a/crates/ty_python_semantic/src/types/context_manager.rs
+++ b/crates/ty_python_semantic/src/types/context_manager.rs
@@ -13,18 +13,18 @@ impl<'db> Type<'db> {
     ///
     /// This method should only be used outside of type checking because it omits any errors.
     /// For type checking, use [`try_enter_with_mode`](Self::try_enter_with_mode) instead.
-    pub(super) fn enter(self, db: &'db dyn Db) -> Type<'db> {
-        self.try_enter_with_mode(db, EvaluationMode::Sync)
-            .unwrap_or_else(|err| err.fallback_enter_type(db))
+    pub(super) fn enter(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        self.try_enter_with_mode(db, program, EvaluationMode::Sync)
+            .unwrap_or_else(|err| err.fallback_enter_type(db, program))
     }
 
     /// Returns the type bound from a context manager with type `self`.
     ///
     /// This method should only be used outside of type checking because it omits any errors.
     /// For type checking, use [`try_enter_with_mode`](Self::try_enter_with_mode) instead.
-    pub(super) fn aenter(self, db: &'db dyn Db) -> Type<'db> {
-        self.try_enter_with_mode(db, EvaluationMode::Async)
-            .unwrap_or_else(|err| err.fallback_enter_type(db))
+    pub(super) fn aenter(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        self.try_enter_with_mode(db, program, EvaluationMode::Async)
+            .unwrap_or_else(|err| err.fallback_enter_type(db, program))
     }
 
     /// Given the type of an object that is used as a context manager (i.e. in a `with` statement),
@@ -38,6 +38,7 @@ impl<'db> Type<'db> {
     pub(super) fn try_enter_with_mode(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         mode: EvaluationMode,
     ) -> Result<Type<'db>, ContextManagerError<'db>> {
         let (enter_method, exit_method) = match mode {
@@ -47,32 +48,38 @@ impl<'db> Type<'db> {
 
         let enter = self.try_call_dunder(
             db,
+            program,
             enter_method,
             CallArguments::none(),
             TypeContext::default(),
         );
         let exit = self.try_call_dunder(
             db,
+            program,
             exit_method,
-            CallArguments::positional([Type::none(db), Type::none(db), Type::none(db)]),
+            CallArguments::positional([
+                Type::none(db, program),
+                Type::none(db, program),
+                Type::none(db, program),
+            ]),
             TypeContext::default(),
         );
 
         // TODO: Make use of Protocols when we support it (the manager be assignable to `contextlib.AbstractContextManager`).
         match (enter, exit) {
             (Ok(enter), Ok(_)) => {
-                let ty = enter.return_type(db);
+                let ty = enter.return_type(db, program);
                 Ok(if mode.is_async() {
-                    ty.try_await(db).unwrap_or(Type::unknown())
+                    ty.try_await(db, program).unwrap_or(Type::unknown())
                 } else {
                     ty
                 })
             }
             (Ok(enter), Err(exit_error)) => {
-                let ty = enter.return_type(db);
+                let ty = enter.return_type(db, program);
                 Err(ContextManagerError::Exit {
                     enter_return_type: if mode.is_async() {
-                        ty.try_await(db).unwrap_or(Type::unknown())
+                        ty.try_await(db, program).unwrap_or(Type::unknown())
                     } else {
                         ty
                     },
@@ -108,13 +115,17 @@ pub(super) enum ContextManagerError<'db> {
 }
 
 impl<'db> ContextManagerError<'db> {
-    pub(super) fn fallback_enter_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.enter_type(db).unwrap_or(Type::unknown())
+    pub(super) fn fallback_enter_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        self.enter_type(db, program).unwrap_or(Type::unknown())
     }
 
     /// Returns the `__enter__` or `__aenter__` return type if it is known,
     /// or `None` if the type never has a callable `__enter__` or `__aenter__` attribute
-    fn enter_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    fn enter_type(&self, db: &'db dyn Db, program: crate::Program) -> Option<Type<'db>> {
         match self {
             Self::Exit {
                 enter_return_type,
@@ -127,9 +138,13 @@ impl<'db> ContextManagerError<'db> {
                 exit_error: _,
                 mode: _,
             } => match enter_error {
-                CallDunderError::PossiblyUnbound { bindings, .. } => Some(bindings.return_type(db)),
+                CallDunderError::PossiblyUnbound { bindings, .. } => {
+                    Some(bindings.return_type(db, program))
+                }
                 CallDunderError::CallError(CallErrorKind::NotCallable, _, _) => None,
-                CallDunderError::CallError(_, bindings, _) => Some(bindings.return_type(db)),
+                CallDunderError::CallError(_, bindings, _) => {
+                    Some(bindings.return_type(db, program))
+                }
                 CallDunderError::MethodNotAvailable => None,
             },
         }
@@ -205,6 +220,7 @@ impl<'db> ContextManagerError<'db> {
         };
 
         let db = context.db();
+        let program = context.program();
 
         let formatted_errors = match self {
             Self::Exit {
@@ -229,7 +245,7 @@ impl<'db> ContextManagerError<'db> {
 
         let mut diag = builder.into_diagnostic(format_args!(
             "Object of type `{}` cannot be used with `{}` because {}",
-            context_expression_type.display(db),
+            context_expression_type.display(db, program),
             with_kw,
             formatted_errors,
         ));
@@ -240,7 +256,7 @@ impl<'db> ContextManagerError<'db> {
                 for ty in &exit_unbound_on {
                     diag.info(format_args!(
                         "`{}` does not implement `{exit_method}`",
-                        ty.display(db)
+                        ty.display(db, program)
                     ));
                 }
             }
@@ -249,7 +265,7 @@ impl<'db> ContextManagerError<'db> {
                 for ty in &enter_unbound_on {
                     diag.info(format_args!(
                         "`{}` does not implement `{enter_method}`",
-                        ty.display(db)
+                        ty.display(db, program)
                     ));
                 }
             }
@@ -265,12 +281,12 @@ impl<'db> ContextManagerError<'db> {
                     if exit_unbound_on.contains(ty) {
                         diag.info(format_args!(
                             "`{}` does not implement `{enter_method}` or `{exit_method}`",
-                            ty.display(db)
+                            ty.display(db, program)
                         ));
                     } else {
                         diag.info(format_args!(
                             "`{}` does not implement `{enter_method}`",
-                            ty.display(db)
+                            ty.display(db, program)
                         ));
                     }
                 }
@@ -279,7 +295,7 @@ impl<'db> ContextManagerError<'db> {
                     if !enter_unbound_on.contains(ty) {
                         diag.info(format_args!(
                             "`{}` does not implement `{exit_method}`",
-                            ty.display(db)
+                            ty.display(db, program)
                         ));
                     }
                 }
@@ -293,12 +309,14 @@ impl<'db> ContextManagerError<'db> {
 
         let alt_enter = context_expression_type.try_call_dunder(
             db,
+            program,
             alt_enter_method,
             CallArguments::none(),
             TypeContext::default(),
         );
         let alt_exit = context_expression_type.try_call_dunder(
             db,
+            program,
             alt_exit_method,
             CallArguments::positional([Type::unknown(), Type::unknown(), Type::unknown()]),
             TypeContext::default(),
@@ -309,7 +327,7 @@ impl<'db> ContextManagerError<'db> {
         {
             diag.info(format_args!(
                 "Objects of type `{}` can be used as {} context managers",
-                context_expression_type.display(db),
+                context_expression_type.display(db, program),
                 alt_mode
             ));
             diag.info(format!("Consider using `{alt_with_kw}` here"));

--- a/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
+++ b/crates/ty_python_semantic/src/types/dedicated/pydantic.rs
@@ -126,7 +126,8 @@ impl<'db> FieldMetadata<'db> {
         definition: Definition<'db>,
         specialization: Option<Specialization<'db>>,
     ) {
-        let module = parsed_module(db, definition.file(db)).load(db);
+        let program_file = definition.program_file(db);
+        let module = program_file.parsed(db).load(db);
         let DefinitionKind::AnnotatedAssignment(assignment) = definition.kind(db) else {
             return;
         };
@@ -144,7 +145,7 @@ impl<'db> FieldMetadata<'db> {
         // using `StrictInt = Annotated[int, Strict()]`. Since we don't retain the `Annotated`
         // metadata, we need to follow the alias back to its definition and parse the metadata
         // from there.
-        let model = SemanticModel::new(db, definition.file(db));
+        let model = SemanticModel::new(db, program_file);
         let Some(alias_definition) = definitions_for_name(
             &model,
             name.id.as_str(),
@@ -156,7 +157,8 @@ impl<'db> FieldMetadata<'db> {
             return;
         };
 
-        let module = parsed_module(db, alias_definition.file(db)).load(db);
+        let module =
+            parsed_module(db, alias_definition.program_file(db).versioned_file(db)).load(db);
         let kind = alias_definition.kind(db);
         let value = match &kind {
             DefinitionKind::Assignment(assignment) => assignment.value(&module),
@@ -260,9 +262,10 @@ impl<'db> FieldMetadata<'db> {
         call_type: Type<'db>,
         specialization: Option<Specialization<'db>>,
     ) {
+        let program = definition.program_file(db).program(db);
         if let Some(default) = call.arguments.find_argument_value("default", 0) {
             let default_type = definition_expression_type(db, definition, default);
-            if !default_type.is_instance_of(db, KnownClass::EllipsisType) {
+            if !default_type.is_instance_of(db, program, KnownClass::EllipsisType) {
                 self.default_ty =
                     Some(default_type.apply_optional_specialization(db, specialization));
             }
@@ -272,7 +275,7 @@ impl<'db> FieldMetadata<'db> {
 
         if let Some(init) = call.arguments.find_keyword("init") {
             let init = definition_expression_type(db, definition, &init.value);
-            self.init &= !init.bool(db).is_always_false();
+            self.init &= !init.bool(db, program).is_always_false();
         }
 
         if let Some(alias) = call
@@ -287,7 +290,7 @@ impl<'db> FieldMetadata<'db> {
 
         if let Some(strict) = call.arguments.find_keyword("strict") {
             let strict = definition_expression_type(db, definition, &strict.value);
-            if !strict.is_none(db) {
+            if !strict.is_none(db, program) {
                 self.merge_strict(ConfigBoolean::from_type(strict));
             }
         }
@@ -470,10 +473,11 @@ pub(in crate::types) fn is_model(db: &dyn Db, class: StaticClassLiteral<'_>) -> 
 /// a default value.
 pub(in crate::types) fn field_provides_default(
     db: &dyn Db,
+    program: crate::Program,
     function: FunctionType<'_>,
     default: Type<'_>,
 ) -> bool {
-    !default.is_instance_of(db, KnownClass::EllipsisType)
+    !default.is_instance_of(db, program, KnownClass::EllipsisType)
         || !function.is_known(db, KnownFunction::PydanticField)
 }
 
@@ -558,9 +562,8 @@ fn inherited_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<
 }
 
 fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelConfig> {
-    let model_config = class_member(db, class.body_scope(db), "model_config")
-        .inner
-        .place;
+    let body_scope = class.body_scope(db);
+    let model_config = class_member(db, body_scope, "model_config").inner.place;
     let Place::Defined(DefinedPlace {
         definedness: Definedness::AlwaysDefined,
         provenance: Provenance::SingleDefinition(definition),
@@ -574,7 +577,7 @@ fn own_model_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> Option<ModelC
         };
     };
 
-    let module = parsed_module(db, class.file(db)).load(db);
+    let module = body_scope.program_file(db).parsed(db).load(db);
     let kind = definition.kind(db);
     let value = match &kind {
         DefinitionKind::Assignment(assignment) => assignment.value(&module),
@@ -685,7 +688,8 @@ fn model_config_from_dict(db: &dyn Db, definition: Definition<'_>, dict: &ExprDi
 
 fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConfig {
     let definition = class.definition(db);
-    let module = parsed_module(db, class.file(db)).load(db);
+    let module =
+        parsed_module(db, class.body_scope(db).program_file(db).versioned_file(db)).load(db);
     let kind = definition.kind(db);
     let Some(class) = kind.as_class() else {
         return ModelConfig::default();
@@ -731,6 +735,7 @@ fn class_keyword_config(db: &dyn Db, class: StaticClassLiteral<'_>) -> ModelConf
 /// Return the input type accepted by a Pydantic field's synthesized constructor parameter.
 pub(in crate::types) fn constructor_parameter_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     field_type: Type<'db>,
     field_strict: ConfigBoolean,
     metadata: ModelMetadata<'db>,
@@ -739,20 +744,27 @@ pub(in crate::types) fn constructor_parameter_type<'db>(
         return field_type;
     }
 
-    lax_input_type(db, field_type)
+    lax_input_type(db, program, field_type)
 }
 
 /// Return the documented Python input type accepted by Pydantic for `field_type` in lax mode.
-fn lax_input_type<'db>(db: &'db dyn Db, field_type: Type<'db>) -> Type<'db> {
-    lax_input_type_impl(db, field_type, &mut FxHashSet::default())
+fn lax_input_type<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    field_type: Type<'db>,
+) -> Type<'db> {
+    lax_input_type_impl(db, program, field_type, &mut FxHashSet::default())
 }
 
 fn lax_input_type_impl<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     field_type: Type<'db>,
     expanding_types: &mut FxHashSet<Type<'db>>,
 ) -> Type<'db> {
-    if field_type.is_none(db) || matches!(field_type, Type::LiteralValue(_) | Type::SubclassOf(_)) {
+    if field_type.is_none(db, program)
+        || matches!(field_type, Type::LiteralValue(_) | Type::SubclassOf(_))
+    {
         return field_type;
     }
 
@@ -760,31 +772,32 @@ fn lax_input_type_impl<'db>(
         if !expanding_types.insert(field_type) {
             return Type::any();
         }
-        let result = lax_input_type_impl(db, alias.value_type(db), expanding_types);
+        let result = lax_input_type_impl(db, program, alias.value_type(db), expanding_types);
         expanding_types.remove(&field_type);
         return result;
     }
 
     if field_type.as_union().and_then(|union| union.known(db)) == Some(KnownUnion::Float) {
-        return lax_alias(db, "LaxFloat");
+        return lax_alias(db, program, "LaxFloat");
     }
 
     if let Type::Union(union) = field_type {
         return UnionType::from_elements_leave_aliases(
             db,
+            program,
             union
                 .elements(db)
                 .iter()
-                .map(|element| lax_input_type_impl(db, *element, expanding_types)),
+                .map(|element| lax_input_type_impl(db, program, *element, expanding_types)),
         );
     }
 
-    if let Some(input_type) = root_model_input_type(db, field_type, expanding_types) {
+    if let Some(input_type) = root_model_input_type(db, program, field_type, expanding_types) {
         return input_type;
     }
 
     let known_class = field_type
-        .nominal_class(db)
+        .nominal_class(db, program)
         .and_then(|class| class.known(db));
 
     if matches!(
@@ -799,25 +812,29 @@ fn lax_input_type_impl<'db>(
                 | KnownClass::Tuple
         )
     ) {
-        let Ok(elements) = field_type.try_iterate(db) else {
+        let Ok(elements) = field_type.try_iterate(db, program) else {
             return Type::any();
         };
-        let element_type =
-            lax_input_type_impl(db, elements.homogeneous_element_type(db), expanding_types);
-        return KnownClass::Iterable.to_specialized_instance(db, &[element_type]);
+        let element_type = lax_input_type_impl(
+            db,
+            program,
+            elements.homogeneous_element_type(db, program),
+            expanding_types,
+        );
+        return KnownClass::Iterable.to_specialized_instance(db, program, &[element_type]);
     }
 
     if matches!(known_class, Some(KnownClass::Dict | KnownClass::Mapping)) {
-        let Some(specialization) =
-            known_class.and_then(|known_class| field_type.known_specialization(db, known_class))
+        let Some(specialization) = known_class
+            .and_then(|known_class| field_type.known_specialization(db, program, known_class))
         else {
             return Type::any();
         };
         let [key_type, value_type] = specialization.types(db) else {
             return Type::any();
         };
-        let value_type = lax_input_type_impl(db, *value_type, expanding_types);
-        return KnownClass::Mapping.to_specialized_instance(db, &[*key_type, value_type]);
+        let value_type = lax_input_type_impl(db, program, *value_type, expanding_types);
+        return KnownClass::Mapping.to_specialized_instance(db, program, &[*key_type, value_type]);
     }
 
     let builtin_alias = match known_class {
@@ -830,10 +847,10 @@ fn lax_input_type_impl<'db>(
         _ => None,
     };
     if let Some(alias) = builtin_alias {
-        return lax_alias(db, alias);
+        return lax_alias(db, program, alias);
     }
 
-    let Some((module, symbol, class)) = instance_symbol(db, field_type) else {
+    let Some((module, symbol, class)) = instance_symbol(db, program, field_type) else {
         return Type::any();
     };
     let symbol_alias = match (module, symbol) {
@@ -853,7 +870,7 @@ fn lax_input_type_impl<'db>(
         _ => None,
     };
     if let Some(alias) = symbol_alias {
-        return lax_alias(db, alias);
+        return lax_alias(db, program, alias);
     }
 
     let alias = if (module, symbol) == (KnownModule::Re, "Pattern") {
@@ -864,12 +881,12 @@ fn lax_input_type_impl<'db>(
             return Type::any();
         };
         if pattern_type
-            .nominal_class(db)
+            .nominal_class(db, program)
             .is_some_and(|class| class.is_known(db, KnownClass::Str))
         {
             "LaxStrPattern"
         } else if pattern_type
-            .nominal_class(db)
+            .nominal_class(db, program)
             .is_some_and(|class| class.is_known(db, KnownClass::Bytes))
         {
             "LaxBytesPattern"
@@ -880,7 +897,7 @@ fn lax_input_type_impl<'db>(
         return Type::any();
     };
 
-    lax_alias(db, alias)
+    lax_alias(db, program, alias)
 }
 
 /// Return the input type accepted for a Pydantic root model field.
@@ -890,10 +907,13 @@ fn lax_input_type_impl<'db>(
 /// `IntList` instance and an `Iterable[LaxInt]`.
 fn root_model_input_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     field_type: Type<'db>,
     expanding_types: &mut FxHashSet<Type<'db>>,
 ) -> Option<Type<'db>> {
-    let (class, specialization) = field_type.nominal_class(db)?.static_class_literal(db)?;
+    let (class, specialization) = field_type
+        .nominal_class(db, program)?
+        .static_class_literal(db)?;
     if !is_root_model(db, class) {
         return None;
     }
@@ -910,11 +930,12 @@ fn root_model_input_type<'db>(
     if !expanding_types.insert(field_type) {
         return Some(Type::any());
     }
-    let root_input_type = lax_input_type_impl(db, root_field.declared_ty, expanding_types);
+    let root_input_type = lax_input_type_impl(db, program, root_field.declared_ty, expanding_types);
 
     expanding_types.remove(&field_type);
     Some(UnionType::from_two_elements(
         db,
+        program,
         field_type,
         root_input_type,
     ))
@@ -923,16 +944,21 @@ fn root_model_input_type<'db>(
 /// Return the known module, name, and class literal for an instance's nominal class.
 fn instance_symbol<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
 ) -> Option<(KnownModule, &'db str, StaticClassLiteral<'db>)> {
-    let class = ty.nominal_class(db)?.class_literal(db).as_static()?;
-    let module = file_to_module(db, class.file(db))?.known(db)?;
+    let class = ty
+        .nominal_class(db, program)?
+        .class_literal(db)
+        .as_static()?;
+    let module =
+        file_to_module(db, class.body_scope(db).program_file(db).resolver_file(db))?.known(db)?;
     Some((module, class.name(db).as_str(), class))
 }
 
 /// Return a lax-input alias like `LaxInt` from `ty_extensions.pydantic`.
-fn lax_alias<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
-    match known_module_symbol(db, KnownModule::TyExtensionsPydantic, name)
+fn lax_alias<'db>(db: &'db dyn Db, program: crate::Program, name: &str) -> Type<'db> {
+    match known_module_symbol(db, program, KnownModule::TyExtensionsPydantic, name)
         .place
         .ignore_possibly_undefined()
     {

--- a/crates/ty_python_semantic/src/types/definition.rs
+++ b/crates/ty_python_semantic/src/types/definition.rs
@@ -33,7 +33,8 @@ impl TypeDefinition<'_> {
             | Self::SpecialForm(definition)
             | Self::NewType(definition)
             | Self::EnumMember(definition) => {
-                let module = parsed_module(db, definition.file(db)).load(db);
+                let module =
+                    parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
                 Some(definition.focus_range(db, &module))
             }
         }
@@ -54,7 +55,8 @@ impl TypeDefinition<'_> {
             | Self::SpecialForm(definition)
             | Self::NewType(definition)
             | Self::EnumMember(definition) => {
-                let module = parsed_module(db, definition.file(db)).load(db);
+                let module =
+                    parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
                 Some(definition.full_range(db, &module))
             }
         }

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -5,6 +5,7 @@ use super::{
     CallArguments, CallDunderError, ClassBase, ClassLiteral, GenericAlias, KnownClass,
     StaticClassLiteral, add_inferred_python_version_hint_to_diagnostic,
 };
+use crate::Program;
 use crate::diagnostic::did_you_mean;
 use crate::diagnostic::format_enumeration;
 use crate::lint::{Level, LintRegistryBuilder, LintStatus};
@@ -31,7 +32,7 @@ use crate::types::{
     binding_type, protocol_class::ProtocolClass,
 };
 use crate::types::{KnownInstanceType, MemberLookupPolicy, TypeVarKind, TypedDictType, UnionType};
-use crate::{Db, DisplaySettings, FxIndexMap, Program, declare_lint};
+use crate::{Db, DisplaySettings, FxIndexMap, declare_lint};
 use itertools::Itertools;
 use ruff_db::source::source_text;
 use ruff_db::{
@@ -1279,7 +1280,7 @@ pub(crate) fn report_mismatched_type_name<'db>(
         } else {
             diagnostic.set_primary_message(format_args!(
                 "Expected \"{expected_name}\", got variable of type `{}`",
-                actual_name_ty.display(context.db())
+                actual_name_ty.display(context.db(), context.program())
             ));
         }
     }
@@ -1372,7 +1373,7 @@ pub(super) fn report_index_out_of_bounds(
     };
     builder.into_diagnostic(format_args!(
         "Index {index} is out of bounds for {kind} `{}` with length {length}",
-        tuple_ty.display(context.db())
+        tuple_ty.display(context.db(), context.program())
     ));
 }
 
@@ -1389,12 +1390,12 @@ pub(super) fn report_not_subscriptable(
     if method == "__delitem__" {
         builder.into_diagnostic(format_args!(
             "Cannot delete subscript on object of type `{}` with no `{method}` method",
-            not_subscriptable_ty.display(context.db())
+            not_subscriptable_ty.display(context.db(), context.program())
         ));
     } else {
         builder.into_diagnostic(format_args!(
             "Cannot subscript object of type `{}` with no `{method}` method",
-            not_subscriptable_ty.display(context.db())
+            not_subscriptable_ty.display(context.db(), context.program())
         ));
     }
 }
@@ -1431,6 +1432,7 @@ fn report_invalid_assignment_with_message<'db, 'ctx: 'db, T: Ranged>(
 
 pub(super) fn note_numbers_module_not_supported<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     diag: &mut Diagnostic,
     target_ty: Type<'db>,
     value_ty: Type<'db>,
@@ -1439,13 +1441,22 @@ pub(super) fn note_numbers_module_not_supported<'db>(
         [KnownClass::Int, KnownClass::Float, KnownClass::Complex];
 
     if let Type::NominalInstance(target_instance) = target_ty {
-        let file = target_instance.class(db).class_literal(db).file(db);
-        if let Some(module) = file_to_module(db, file)
-            && module.is_known(db, KnownModule::Numbers)
+        let class = target_instance.class(db, program).class_literal(db);
+        let program = class.program(db);
+        if let Some(module) = class.as_static().and_then(|class| {
+            file_to_module(db, class.body_scope(db).program_file(db).resolver_file(db))
+        }) && module.is_known(db, KnownModule::Numbers)
         {
             let is_numeric = value_ty.is_subtype_of(
                 db,
-                UnionType::from_elements(db, BUILTIN_NUMBERS.iter().map(|cls| cls.to_instance(db))),
+                program,
+                UnionType::from_elements(
+                    db,
+                    program,
+                    BUILTIN_NUMBERS
+                        .iter()
+                        .map(|cls| cls.to_instance(db, program)),
+                ),
             );
 
             if is_numeric {
@@ -1489,15 +1500,18 @@ fn covariant_supertype_hint<'db>(
 /// that fails due to invariance.
 pub(super) fn add_invariant_generic_hints<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     diag: &mut Diagnostic,
     expected_ty: Type<'db>,
     provided_ty: Type<'db>,
 ) {
-    let Some((expected_class, expected_specialization)) = expected_ty.class_specialization(db)
+    let Some((expected_class, expected_specialization)) =
+        expected_ty.class_specialization(db, program)
     else {
         return;
     };
-    let Some((provided_class, provided_specialization)) = provided_ty.class_specialization(db)
+    let Some((provided_class, provided_specialization)) =
+        provided_ty.class_specialization(db, program)
     else {
         return;
     };
@@ -1505,7 +1519,6 @@ pub(super) fn add_invariant_generic_hints<'db>(
     if expected_class != provided_class {
         return;
     }
-
     let generic_context = expected_specialization.generic_context(db);
     if generic_context != provided_specialization.generic_context(db) {
         return;
@@ -1517,14 +1530,14 @@ pub(super) fn add_invariant_generic_hints<'db>(
         .zip(provided_specialization.types(db))
         .enumerate()
         .filter_map(|(index, ((bound_typevar, expected_arg), provided_arg))| {
-            (bound_typevar.variance(db) == TypeVarVariance::Invariant
-                && !expected_arg.is_equivalent_to(db, *provided_arg))
+            (bound_typevar.variance(db, program) == TypeVarVariance::Invariant
+                && !expected_arg.is_equivalent_to(db, program, *provided_arg))
             .then_some((index, expected_arg, provided_arg))
         });
 
     let mut mismatch_indices = Vec::new();
     for (index, expected_arg, provided_arg) in mismatched_invariant_arguments {
-        if !provided_arg.is_assignable_to(db, *expected_arg) {
+        if !provided_arg.is_assignable_to(db, program, *expected_arg) {
             return;
         }
         mismatch_indices.push(index);
@@ -1578,8 +1591,11 @@ pub(super) fn report_invalid_assignment<'db>(
         return;
     }
 
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(context.db(), [target_ty, value_ty]);
+    let settings = DisplaySettings::from_possibly_ambiguous_types(
+        context.db(),
+        context.program(),
+        [target_ty, value_ty],
+    );
 
     let diagnostic_range = if let Some(value_node) = value_node {
         // Expand the range to include parentheses around the value, if any. This allows
@@ -1602,8 +1618,8 @@ pub(super) fn report_invalid_assignment<'db>(
         diagnostic_range,
         format_args!(
             "Object of type `{}` is not assignable to `{}`",
-            value_ty.display_with(context.db(), settings.clone()),
-            target_ty.display_with(context.db(), settings)
+            value_ty.display_with(context.db(), context.program(), settings.clone()),
+            target_ty.display_with(context.db(), context.program(), settings)
         ),
     ) else {
         return;
@@ -1641,18 +1657,19 @@ pub(super) fn report_invalid_assignment<'db>(
                 // Otherwise, annotate the target with its declared type.
                 diag.annotate(context.secondary(target_node).message(format_args!(
                     "Declared type `{}`",
-                    target_ty.display(context.db()),
+                    target_ty.display(context.db(), context.program()),
                 )));
             }
         }
 
         diag.set_primary_message(format_args!(
             "Incompatible value of type `{}`",
-            value_ty.display(context.db()),
+            value_ty.display(context.db(), context.program()),
         ));
 
-        let error_context = value_ty.assignability_error_context(context.db(), target_ty);
-        error_context.attach_to(context.db(), &mut diag);
+        let error_context =
+            value_ty.assignability_error_context(context.db(), context.program(), target_ty);
+        error_context.attach_to(context.db(), context.program(), &mut diag);
 
         // Overwrite the concise message to avoid showing the value type twice
         let message = diag.primary_message().to_string();
@@ -1660,8 +1677,20 @@ pub(super) fn report_invalid_assignment<'db>(
     }
 
     // special case message
-    note_numbers_module_not_supported(context.db(), &mut diag, target_ty, value_ty);
-    add_invariant_generic_hints(context.db(), &mut diag, target_ty, value_ty);
+    note_numbers_module_not_supported(
+        context.db(),
+        context.program(),
+        &mut diag,
+        target_ty,
+        value_ty,
+    );
+    add_invariant_generic_hints(
+        context.db(),
+        context.program(),
+        &mut diag,
+        target_ty,
+        value_ty,
+    );
 }
 
 pub(super) fn report_invalid_attribute_assignment(
@@ -1681,15 +1710,16 @@ pub(super) fn report_invalid_attribute_assignment(
         range,
         format_args!(
             "Object of type `{}` is not assignable to attribute `{attribute_name}` of type `{}`",
-            source_ty.display(context.db()),
-            target_ty.display(context.db()),
+            source_ty.display(context.db(), context.program()),
+            target_ty.display(context.db(), context.program()),
         ),
     ) else {
         return;
     };
 
-    let error_context = source_ty.assignability_error_context(context.db(), target_ty);
-    error_context.attach_to(context.db(), &mut diag);
+    let error_context =
+        source_ty.assignability_error_context(context.db(), context.program(), target_ty);
+    error_context.attach_to(context.db(), context.program(), &mut diag);
 }
 
 pub(super) fn report_bad_dunder_set_call<'db>(
@@ -1704,13 +1734,13 @@ pub(super) fn report_bad_dunder_set_call<'db>(
     };
     let db = context.db();
     if let Some(property) = dunder_set_failure.as_attempt_to_set_property_with_no_setter() {
-        let object_type = object_type.display(db);
+        let object_type = object_type.display(db, context.program());
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Cannot assign to read-only property `{attribute}` on object of type `{object_type}`",
         ));
         if let Some(file_range) = property
             .getter(db)
-            .and_then(|getter| getter.definition(db))
+            .and_then(|getter| getter.definition(db, context.program()))
             .and_then(|definition| definition.focus_range(db))
         {
             diagnostic.annotate(Annotation::secondary(Span::from(file_range)).message(
@@ -1726,7 +1756,7 @@ pub(super) fn report_bad_dunder_set_call<'db>(
         builder.into_diagnostic(format_args!(
             "Invalid assignment to data descriptor attribute \
             `{attribute}` on type `{}` with custom `__set__` method",
-            object_type.display(db)
+            object_type.display(db, context.program())
         ));
     }
 }
@@ -1743,14 +1773,18 @@ pub(super) fn report_bad_dunder_delete_call<'db>(
     };
     let db = context.db();
     if let Some(property) = dunder_delete_failure.as_attempt_to_delete_property_with_no_deleter() {
-        let object_type = object_type.display(db);
+        let object_type = object_type.display(db, context.program());
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Cannot delete read-only property `{attribute}` on object of type `{object_type}`",
         ));
         if let Some(file_range) = property
             .getter(db)
-            .and_then(|getter| getter.definition(db))
-            .or_else(|| property.setter(db).and_then(|setter| setter.definition(db)))
+            .and_then(|getter| getter.definition(db, context.program()))
+            .or_else(|| {
+                property
+                    .setter(db)
+                    .and_then(|setter| setter.definition(db, context.program()))
+            })
             .and_then(|definition| definition.focus_range(db))
         {
             diagnostic.annotate(Annotation::secondary(Span::from(file_range)).message(
@@ -1764,7 +1798,7 @@ pub(super) fn report_bad_dunder_delete_call<'db>(
         builder.into_diagnostic(format_args!(
             "Invalid deletion of data descriptor attribute \
             `{attribute}` on type `{}` with custom `__delete__` method",
-            object_type.display(db)
+            object_type.display(db, context.program())
         ));
     }
 }
@@ -1782,12 +1816,12 @@ pub(super) fn report_bad_dunder_delattr_call(
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Cannot delete attribute `{attribute}` on type `{}` with custom `__delattr__` method",
-        object_type.display(db),
+        object_type.display(db, context.program()),
     ));
     if binding_error {
         diagnostic.info(format_args!(
             "Type `{}` has a `__delattr__` method, but it cannot be called with the expected arguments",
-            object_type.display(db)
+            object_type.display(db, context.program())
         ));
         diagnostic.info(
             "Expected a signature at least as permissive as \
@@ -1807,25 +1841,29 @@ pub(super) fn report_invalid_return_type(
         return;
     };
 
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(context.db(), [expected_ty, actual_ty]);
+    let settings = DisplaySettings::from_possibly_ambiguous_types(
+        context.db(),
+        context.program(),
+        [expected_ty, actual_ty],
+    );
     let return_type_span = context.span(return_type_range);
 
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
     diag.set_primary_message(format_args!(
         "expected `{expected_ty}`, found `{actual_ty}`",
-        expected_ty = expected_ty.display_with(context.db(), settings.clone()),
-        actual_ty = actual_ty.display_with(context.db(), settings.clone()),
+        expected_ty = expected_ty.display_with(context.db(), context.program(), settings.clone()),
+        actual_ty = actual_ty.display_with(context.db(), context.program(), settings.clone()),
     ));
     diag.annotate(
         Annotation::secondary(return_type_span).message(format_args!(
             "Expected `{expected_ty}` because of return type",
-            expected_ty = expected_ty.display_with(context.db(), settings),
+            expected_ty = expected_ty.display_with(context.db(), context.program(), settings),
         )),
     );
 
-    let error_context = actual_ty.assignability_error_context(context.db(), expected_ty);
-    error_context.attach_to(context.db(), &mut diag);
+    let error_context =
+        actual_ty.assignability_error_context(context.db(), context.program(), expected_ty);
+    error_context.attach_to(context.db(), context.program(), &mut diag);
 }
 
 pub(super) fn report_invalid_generator_function_return_type(
@@ -1839,10 +1877,10 @@ pub(super) fn report_invalid_generator_function_return_type(
     };
 
     let mut diag = builder.into_diagnostic("Return type does not match returned value");
-    let inferred_ty = inferred_return.display(context.db());
+    let inferred_ty = inferred_return.display(context.db(), context.program());
     diag.set_primary_message(format_args!(
         "expected `{expected_ty}`, found `{inferred_ty}`",
-        expected_ty = expected_ty.display(context.db()),
+        expected_ty = expected_ty.display(context.db(), context.program()),
     ));
 
     let (description, link) = if inferred_return == KnownClass::AsyncGeneratorType {
@@ -1881,10 +1919,14 @@ pub(super) fn report_invalid_generator_yield_type(
         return;
     };
 
-    let settings =
-        DisplaySettings::from_possibly_ambiguous_types(context.db(), [expected_ty, actual_ty]);
-    let expected_display = expected_ty.display_with(context.db(), settings.clone());
-    let actual_display = actual_ty.display_with(context.db(), settings);
+    let settings = DisplaySettings::from_possibly_ambiguous_types(
+        context.db(),
+        context.program(),
+        [expected_ty, actual_ty],
+    );
+    let expected_display =
+        expected_ty.display_with(context.db(), context.program(), settings.clone());
+    let actual_display = actual_ty.display_with(context.db(), context.program(), settings);
 
     let (kind_name, title, concise) = match kind {
         GeneratorMismatchKind::YieldType => (
@@ -1921,8 +1963,9 @@ pub(super) fn report_invalid_generator_yield_type(
         )));
     }
 
-    let error_context = actual_ty.assignability_error_context(context.db(), expected_ty);
-    error_context.attach_to(context.db(), &mut diag);
+    let error_context =
+        actual_ty.assignability_error_context(context.db(), context.program(), expected_ty);
+    error_context.attach_to(context.db(), context.program(), &mut diag);
 }
 
 pub(super) fn report_implicit_return_type(
@@ -1934,7 +1977,6 @@ pub(super) fn report_implicit_return_type(
     no_return: bool,
 ) {
     let db = context.db();
-
     // Use EMPTY_BODY lint for functions with empty bodies, INVALID_RETURN_TYPE for others
     let lint_to_use = if has_empty_body {
         &EMPTY_BODY
@@ -1950,7 +1992,7 @@ pub(super) fn report_implicit_return_type(
     let mut diagnostic = if no_return {
         let mut diag = builder.into_diagnostic(format_args!(
             "Function always implicitly returns `None`, which is not assignable to return type `{}`",
-            expected_ty.display(db),
+            expected_ty.display(db, context.program()),
         ));
         diag.info(
             "Consider changing the return annotation to `-> None` or adding a `return` statement",
@@ -1959,7 +2001,7 @@ pub(super) fn report_implicit_return_type(
     } else {
         builder.into_diagnostic(format_args!(
             "Function can implicitly return `None`, which is not assignable to return type `{}`",
-            expected_ty.display(db),
+            expected_ty.display(db, context.program()),
         ))
     };
     if !has_empty_body {
@@ -2027,6 +2069,7 @@ pub(super) fn report_possibly_missing_attribute(
         return;
     };
     let db = context.db();
+    let program = context.program();
     match object_ty {
         Type::ModuleLiteral(module) => builder.into_diagnostic(format_args!(
             "Member `{attribute}` may be missing on module `{}`",
@@ -2042,7 +2085,7 @@ pub(super) fn report_possibly_missing_attribute(
         )),
         _ => builder.into_diagnostic(format_args!(
             "Attribute `{attribute}` may be missing on object of type `{}`",
-            object_ty.display(db),
+            object_ty.display(db, program),
         )),
     };
 }
@@ -2060,16 +2103,16 @@ pub(super) fn report_invalid_exception_tuple_caught<'db, 'ast>(
     let mut diagnostic = builder.into_diagnostic("Invalid tuple caught in an exception handler");
     diagnostic.set_concise_message(format_args!(
         "Cannot catch object of type `{}` in an exception handler",
-        node_type.display(context.db())
+        node_type.display(context.db(), context.program())
     ));
 
     for (sub_node, ty) in invalid_tuple_nodes {
         let span = context.span(sub_node);
         diagnostic.annotate(Annotation::secondary(span.clone()).message(format_args!(
             "Invalid element of type `{}`",
-            ty.display(context.db())
+            ty.display(context.db(), context.program())
         )));
-        if ty.is_notimplemented(context.db()) {
+        if ty.is_notimplemented(context.db(), context.program()) {
             diagnostic.annotate(
                 Annotation::secondary(span).message("Did you mean `NotImplementedError`?"),
             );
@@ -2086,7 +2129,7 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
         return;
     };
 
-    let mut diagnostic = if ty.is_notimplemented(context.db()) {
+    let mut diagnostic = if ty.is_notimplemented(context.db(), context.program()) {
         let mut diag =
             builder.into_diagnostic("Cannot catch `NotImplemented` in an exception handler");
         diag.set_primary_message("Did you mean `NotImplementedError`?");
@@ -2094,7 +2137,10 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
     } else {
         let mut diag = builder.into_diagnostic(format_args!(
             "Invalid {thing} caught in an exception handler",
-            thing = if ty.tuple_instance_spec(context.db()).is_some() {
+            thing = if ty
+                .tuple_instance_spec(context.db(), context.program())
+                .is_some()
+            {
                 "tuple"
             } else {
                 "object"
@@ -2102,7 +2148,7 @@ pub(super) fn report_invalid_exception_caught(context: &InferContext, node: &ast
         ));
         diag.set_primary_message(format_args!(
             "Object has type `{}`",
-            ty.display(context.db())
+            ty.display(context.db(), context.program())
         ));
         diag
     };
@@ -2120,14 +2166,14 @@ pub(crate) fn report_invalid_exception_raised(
     let Some(builder) = context.report_lint(&INVALID_RAISE, raised_node) else {
         return;
     };
-    if raise_type.is_notimplemented(context.db()) {
+    if raise_type.is_notimplemented(context.db(), context.program()) {
         let mut diagnostic = builder.into_diagnostic(format_args!("Cannot raise `NotImplemented`"));
         diagnostic.set_primary_message("Did you mean `NotImplementedError`?");
         diagnostic.info("Can only raise an instance or subclass of `BaseException`");
     } else {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Cannot raise object of type `{}`",
-            raise_type.display(context.db())
+            raise_type.display(context.db(), context.program())
         ));
         diagnostic.set_primary_message("Not an instance or subclass of `BaseException`");
     }
@@ -2137,7 +2183,7 @@ pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast:
     let Some(builder) = context.report_lint(&INVALID_RAISE, node) else {
         return;
     };
-    let mut diagnostic = if ty.is_notimplemented(context.db()) {
+    let mut diagnostic = if ty.is_notimplemented(context.db(), context.program()) {
         let mut diag = builder.into_diagnostic(format_args!(
             "Cannot use `NotImplemented` as an exception cause",
         ));
@@ -2146,7 +2192,7 @@ pub(crate) fn report_invalid_exception_cause(context: &InferContext, node: &ast:
     } else {
         builder.into_diagnostic(format_args!(
             "Cannot use object of type `{}` as an exception cause",
-            ty.display(context.db())
+            ty.display(context.db(), context.program())
         ))
     };
     diagnostic.info(
@@ -2483,7 +2529,7 @@ pub(crate) fn report_invalid_class_match_pattern<T: Ranged>(
         return;
     };
     let db = context.db();
-    let class_display = cls_ty.display(db);
+    let class_display = cls_ty.display(db, context.program());
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "`{class_display}` cannot be used in a class pattern because it is not a type"
     ));
@@ -2515,8 +2561,9 @@ pub(crate) fn report_invalid_match_args_type<T: Ranged>(
         return;
     };
     let db = context.db();
-    let class_display = cls_ty.display(db);
-    let match_args_display = match_args_ty.display(db);
+    let program = context.program();
+    let class_display = cls_ty.display(db, program);
+    let match_args_display = match_args_ty.display(db, program);
     builder.into_diagnostic(format_args!(
         "`__match_args__` for `{class_display}` must be an exact tuple, not `{match_args_display}`"
     ));
@@ -2582,8 +2629,7 @@ pub(crate) fn report_issubclass_check_against_protocol_with_non_method_members<'
             if it has non-method members",
         );
         if let Some(definition) = single_member.definition() {
-            let file = definition.file(db);
-            let module = parsed_module(db, file).load(db);
+            let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
             let span = Span::from(definition.focus_range(db, &module));
             sub.annotate(Annotation::primary(span).message(format_args!(
                 "Non-method member `{}` declared here",
@@ -2607,8 +2653,7 @@ pub(crate) fn report_issubclass_check_against_protocol_with_non_method_members<'
             .iter()
             .find_map(|member| Some((member.name(), member.definition()?)))
         {
-            let file = definition.file(db);
-            let module = parsed_module(db, file).load(db);
+            let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
             let span = Span::from(definition.focus_range(db, &module));
             sub.annotate(
                 Annotation::primary(span)
@@ -2756,7 +2801,7 @@ pub(super) fn abstract_method_span<'db>(
     };
 
     let file = function.file(db);
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, function.program_file(db).versioned_file(db)).load(db);
     let node = implementation.node(db, file, &module);
     let source_text = source_text(db, file);
 
@@ -2790,7 +2835,7 @@ pub(crate) fn report_undeclared_protocol_member(
     /// We want to avoid suggesting an annotation for e.g. `x = None`,
     /// because the user almost certainly doesn't want to write `x: None = None`.
     /// We also want to avoid suggesting invalid syntax such as `x: <class 'int'> = int`.
-    fn should_give_hint<'db>(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    fn should_give_hint<'db>(db: &'db dyn Db, program: crate::Program, ty: Type<'db>) -> bool {
         let class = match ty {
             Type::ProtocolInstance(ProtocolInstanceType {
                 inner: Protocol::FromClass(_),
@@ -2801,12 +2846,12 @@ pub(crate) fn report_undeclared_protocol_member(
                 SubclassOfInner::Dynamic(DynamicType::Any) => return true,
                 SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => return false,
             },
-            Type::NominalInstance(instance) => instance.class(db),
+            Type::NominalInstance(instance) => instance.class(db, program),
             Type::Union(union) => {
                 return union
                     .elements(db)
                     .iter()
-                    .all(|elem| should_give_hint(db, *elem));
+                    .all(|elem| should_give_hint(db, program, *elem));
             }
             _ => return false,
         };
@@ -2838,12 +2883,12 @@ pub(crate) fn report_undeclared_protocol_member(
     if definition.kind(db).is_unannotated_assignment() {
         let binding_type = binding_type(db, definition);
 
-        let suggestion = binding_type.promote(db);
+        let suggestion = binding_type.promote(db, context.program());
 
-        if should_give_hint(db, suggestion) {
+        if should_give_hint(db, context.program(), suggestion) {
             diagnostic.set_primary_message(format_args!(
                 "Consider adding an annotation, e.g. `{symbol_name}: {} = ...`",
-                suggestion.display(db)
+                suggestion.display(db, context.program())
             ));
         } else {
             diagnostic.set_primary_message(format_args!(
@@ -2963,9 +3008,10 @@ pub(crate) fn report_invalid_or_unsupported_base(
     class: StaticClassLiteral,
 ) {
     let db = context.db();
-    let instance_of_type = KnownClass::Type.to_instance(db);
+    let program = context.program();
+    let instance_of_type = KnownClass::Type.to_instance(db, program);
 
-    if base_type.is_assignable_to(db, instance_of_type) {
+    if base_type.is_assignable_to(db, program, instance_of_type) {
         report_unsupported_base(context, base_node, base_type, class);
         return;
     }
@@ -2999,12 +3045,16 @@ pub(crate) fn report_invalid_or_unsupported_base(
 
     match base_type.try_call_dunder(
         db,
+        program,
         "__mro_entries__",
         CallArguments::positional([tuple_of_types]),
         TypeContext::default(),
     ) {
         Ok(ret) => {
-            if ret.return_type(db).is_assignable_to(db, tuple_of_types) {
+            if ret
+                .return_type(db, program)
+                .is_assignable_to(db, program, tuple_of_types)
+            {
                 report_unsupported_base(context, base_node, base_type, class);
             } else {
                 let Some(mut diagnostic) =
@@ -3015,7 +3065,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
                 explain_mro_entries(&mut diagnostic);
                 diagnostic.info(format_args!(
                     "Type `{}` has an `__mro_entries__` method, but it does not return a tuple of types",
-                    base_type.display(db)
+                    base_type.display(db, program)
                 ));
             }
         }
@@ -3031,13 +3081,13 @@ pub(crate) fn report_invalid_or_unsupported_base(
                     explain_mro_entries(&mut diagnostic);
                     diagnostic.info(format_args!(
                         "Type `{}` may have an `__mro_entries__` attribute, but it may be missing",
-                        base_type.display(db)
+                        base_type.display(db, program)
                     ));
                     if let Some(unbound_on) = unbound_on {
                         for ty in unbound_on {
                             diagnostic.info(format_args!(
                                 "`{}` does not implement `__mro_entries__`",
-                                ty.display(db)
+                                ty.display(db, program)
                             ));
                         }
                     }
@@ -3046,7 +3096,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
                     explain_mro_entries(&mut diagnostic);
                     diagnostic.info(format_args!(
                         "Type `{}` has an `__mro_entries__` attribute, but it is not callable",
-                        base_type.display(db)
+                        base_type.display(db, program)
                     ));
                 }
                 CallDunderError::CallError(CallErrorKind::BindingError, _, _) => {
@@ -3054,7 +3104,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
                     diagnostic.info(format_args!(
                         "Type `{}` has an `__mro_entries__` method, \
                         but it cannot be called with the expected arguments",
-                        base_type.display(db)
+                        base_type.display(db, program)
                     ));
                     diagnostic.info(
                         "Expected a signature at least as permissive as \
@@ -3066,7 +3116,7 @@ pub(crate) fn report_invalid_or_unsupported_base(
                     diagnostic.info(format_args!(
                         "Type `{}` has an `__mro_entries__` method, \
                         but it may not be callable",
-                        base_type.display(db)
+                        base_type.display(db, program)
                     ));
                 }
             }
@@ -3085,10 +3135,13 @@ pub(crate) fn report_unsupported_base(
     };
     let db = context.db();
     let mut diagnostic = builder.into_diagnostic("Unsupported class base");
-    diagnostic.set_primary_message(format_args!("Has type `{}`", base_type.display(db)));
+    diagnostic.set_primary_message(format_args!(
+        "Has type `{}`",
+        base_type.display(db, context.program())
+    ));
     diagnostic.set_concise_message(format_args!(
         "Unsupported class base with type `{}`",
-        base_type.display(db)
+        base_type.display(db, context.program())
     ));
     diagnostic.info(format_args!(
         "ty cannot resolve a consistent method resolution order (MRO) for class `{}` due to this base",
@@ -3106,7 +3159,7 @@ fn report_invalid_base<'ctx, 'db>(
     let builder = context.report_lint(&INVALID_BASE, base_node)?;
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Invalid class base with type `{}`",
-        base_type.display(context.db())
+        base_type.display(context.db(), context.program())
     ));
     diagnostic.info(format_args!(
         "Definition of class `{}` will raise `TypeError` at runtime",
@@ -3125,11 +3178,12 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
     items: &TypedDictSchema<'db>,
 ) {
     let db = context.db();
+    let program = context.program();
     if let Some(builder) = context.report_lint(&INVALID_KEY, key_node) {
         match key_ty.as_string_literal() {
             Some(key) => {
                 let key = key.value(db);
-                let typed_dict_name = typed_dict_ty.display(db);
+                let typed_dict_name = typed_dict_ty.display(db, program);
 
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Unknown key \"{key}\" for TypedDict `{typed_dict_name}`",
@@ -3143,7 +3197,7 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                         } else {
                             "intersection"
                         },
-                        full_object_ty = full_object_ty.display(db)
+                        full_object_ty = full_object_ty.display(db, program)
                     ))
                 } else {
                     context
@@ -3180,7 +3234,7 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                     if let Some(full_ty) = full_object_ty {
                         diagnostic.set_concise_message(format_args!(
                             "Unknown key \"{key}\" for TypedDict `{typed_dict_name}` (subscripted object has type `{full_ty}`)",
-                            full_ty = full_ty.display(db),
+                            full_ty = full_ty.display(db, program),
                         ));
                     } else {
                         diagnostic.set_concise_message(format_args!(
@@ -3193,14 +3247,14 @@ pub(crate) fn report_invalid_key_on_typed_dict<'db>(
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "TypedDict `{}` can only be subscripted with a string literal key, \
                      got key of type `{}`",
-                    typed_dict_ty.display(db),
-                    key_ty.display(db),
+                    typed_dict_ty.display(db, program),
+                    key_ty.display(db, program),
                 ));
 
                 if let Some(full_object_ty) = full_object_ty {
                     diagnostic.info(format_args!(
                         "The full type of the subscripted object is `{}`",
-                        full_object_ty.display(db)
+                        full_object_ty.display(db, program)
                     ));
                 }
             }
@@ -3299,7 +3353,7 @@ pub(crate) fn report_missing_typed_dict_key<'db>(
 ) {
     let db = context.db();
     if let Some(builder) = context.report_lint(&MISSING_TYPED_DICT_KEY, constructor_node) {
-        let typed_dict_name = typed_dict_ty.display(db);
+        let typed_dict_name = typed_dict_ty.display(db, context.program());
         builder.into_diagnostic(format_args!(
             "Missing required key '{missing_field}' in TypedDict `{typed_dict_name}` constructor",
         ));
@@ -3314,7 +3368,7 @@ pub(crate) fn report_cannot_pop_required_field_on_typed_dict<'db>(
 ) {
     let db = context.db();
     if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, key_node) {
-        let typed_dict_name = typed_dict_ty.display(db);
+        let typed_dict_name = typed_dict_ty.display(db, context.program());
         builder.into_diagnostic(format_args!(
             "Cannot pop required field '{field_name}' from TypedDict `{typed_dict_name}`",
         ));
@@ -3345,7 +3399,7 @@ pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
         return;
     };
 
-    let typed_dict_name = Type::TypedDict(typed_dict_ty).display(db);
+    let typed_dict_name = Type::TypedDict(typed_dict_ty).display(db, context.program());
 
     let mut diagnostic = match error_kind {
         TypedDictDeleteErrorKind::RequiredKey => builder.into_diagnostic(format_args!(
@@ -3364,7 +3418,7 @@ pub(crate) fn report_cannot_delete_typed_dict_key<'db>(
         && let Some(declaration) = field.first_declaration()
     {
         let file = declaration.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, declaration.program_file(db).versioned_file(db)).load(db);
 
         let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Field defined here");
         for message in [
@@ -3473,11 +3527,11 @@ pub(crate) fn report_invalid_type_param_order<'db>(
         let Some(definition) = tvar.definition(db) else {
             continue;
         };
-        let file = definition.file(db);
         diagnostic.annotate(
-            Annotation::secondary(Span::from(
-                definition.full_range(db, &parsed_module(db, file).load(db)),
-            ))
+            Annotation::secondary(Span::from(definition.full_range(
+                db,
+                &parsed_module(db, definition.program_file(db).versioned_file(db)).load(db),
+            )))
             .message(format_args!("`{}` defined here", tvar.name(db))),
         );
     }
@@ -3520,11 +3574,11 @@ pub(crate) fn report_invalid_typevar_default_reference<'db>(
         let Some(definition) = tvar.definition(db) else {
             continue;
         };
-        let file = definition.file(db);
         diagnostic.annotate(
-            Annotation::secondary(Span::from(
-                definition.full_range(db, &parsed_module(db, file).load(db)),
-            ))
+            Annotation::secondary(Span::from(definition.full_range(
+                db,
+                &parsed_module(db, definition.program_file(db).versioned_file(db)).load(db),
+            )))
             .message(format_args!("`{}` defined here", tvar.name(db))),
         );
     }
@@ -3779,7 +3833,7 @@ pub(super) fn report_invalid_method_override<'db>(
         ));
     }
 
-    error_context().attach_to(context.db(), &mut diagnostic);
+    error_context().attach_to(context.db(), context.program(), &mut diagnostic);
 
     diagnostic.info("This violates the Liskov Substitution Principle");
 
@@ -3803,10 +3857,10 @@ pub(super) fn report_invalid_method_override<'db>(
                     .next()
                 && let Some(definition) = binding.binding.definition()
             {
-                let definition_span = Span::from(
-                    definition
-                        .full_range(db, &parsed_module(db, superclass_scope.file(db)).load(db)),
-                );
+                let definition_span = Span::from(definition.full_range(
+                    db,
+                    &parsed_module(db, definition.program_file(db).versioned_file(db)).load(db),
+                ));
 
                 let superclass_function_span = match superclass_type {
                     Type::FunctionLiteral(function) => Some(signature_span(function)),
@@ -3965,10 +4019,18 @@ pub(super) fn report_overridden_final_method<'db>(
     };
 
     sub.annotate(
-        Annotation::secondary(Span::from(superclass_function_literal.focus_range(
-            db,
-            &parsed_module(db, first_final_superclass_definition.file(db)).load(db),
-        )))
+        Annotation::secondary(Span::from(
+            superclass_function_literal.focus_range(
+                db,
+                &parsed_module(
+                    db,
+                    first_final_superclass_definition
+                        .program_file(db)
+                        .versioned_file(db),
+                )
+                .load(db),
+            ),
+        ))
         .message(format_args!("`{superclass_name}.{member}` defined here")),
     );
 
@@ -4118,10 +4180,10 @@ pub(super) fn report_overridden_final_variable<'db>(
             ),
         );
         sub.annotate(
-            Annotation::secondary(Span::from(
-                superclass_def
-                    .focus_range(db, &parsed_module(db, superclass_def.file(db)).load(db)),
-            ))
+            Annotation::secondary(Span::from(superclass_def.focus_range(
+                db,
+                &parsed_module(db, superclass_def.program_file(db).versioned_file(db)).load(db),
+            )))
             .message(format_args!("`{superclass_name}.{member}` defined here")),
         );
         diagnostic.sub(sub);
@@ -4142,6 +4204,7 @@ pub(super) fn report_unsupported_comparison<'db>(
     right_ty: Type<'db>,
 ) {
     let db = context.db();
+    let program = context.program();
 
     let Some(diagnostic_builder) = context.report_lint(&UNSUPPORTED_OPERATOR, range) else {
         return;
@@ -4149,36 +4212,37 @@ pub(super) fn report_unsupported_comparison<'db>(
 
     let display_settings = DisplaySettings::from_possibly_ambiguous_types(
         db,
+        program,
         [error.left_ty, error.right_ty, left_ty, right_ty],
     );
 
     let mut diagnostic =
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{}` operation", error.op));
 
-    if left_ty.is_equivalent_to(db, right_ty) {
+    if left_ty.is_equivalent_to(db, program, right_ty) {
         diagnostic.set_primary_message(format_args!(
             "Both operands have type `{}`",
-            left_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone())
         ));
         diagnostic.annotate(context.secondary(left));
         diagnostic.annotate(context.secondary(right));
         diagnostic.set_concise_message(format_args!(
             "Operator `{}` is not supported between two objects of type `{}`",
             error.op,
-            left_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone())
         ));
     } else {
         for (ty, expr) in [(left_ty, left), (right_ty, right)] {
             diagnostic.annotate(context.secondary(expr).message(format_args!(
                 "Has type `{}`",
-                ty.display_with(db, display_settings.clone())
+                ty.display_with(db, program, display_settings.clone())
             )));
         }
         diagnostic.set_concise_message(format_args!(
             "Operator `{}` is not supported between objects of type `{}` and `{}`",
             error.op,
-            left_ty.display_with(db, display_settings.clone()),
-            right_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone()),
+            right_ty.display_with(db, program, display_settings.clone())
         ));
     }
 
@@ -4191,8 +4255,10 @@ pub(super) fn report_unsupported_comparison<'db>(
     // - `error.left_ty` is `Literal["foo"]`
     // - `error.right_ty` is `Literal[3]`
     if (error.left_ty, error.right_ty) != (left_ty, right_ty) {
-        if let Some(TupleSpec::Fixed(lhs_spec)) = left_ty.tuple_instance_spec(db).as_deref()
-            && let Some(TupleSpec::Fixed(rhs_spec)) = right_ty.tuple_instance_spec(db).as_deref()
+        if let Some(TupleSpec::Fixed(lhs_spec)) =
+            left_ty.tuple_instance_spec(db, program).as_deref()
+            && let Some(TupleSpec::Fixed(rhs_spec)) =
+                right_ty.tuple_instance_spec(db, program).as_deref()
             && lhs_spec.len() == rhs_spec.len()
             && let Some(position) = lhs_spec
                 .all_elements()
@@ -4200,13 +4266,13 @@ pub(super) fn report_unsupported_comparison<'db>(
                 .zip(rhs_spec.all_elements())
                 .position(|tup| tup == (&error.left_ty, &error.right_ty))
         {
-            if error.left_ty.is_equivalent_to(db, error.right_ty) {
+            if error.left_ty.is_equivalent_to(db, program, error.right_ty) {
                 diagnostic.info(format_args!(
                     "Operation fails because operator `{}` is not supported between \
                     the tuple elements at index {} (both of type `{}`)",
                     error.op,
                     position + 1,
-                    error.left_ty.display_with(db, display_settings),
+                    error.left_ty.display_with(db, program, display_settings),
                 ));
             } else {
                 diagnostic.info(format_args!(
@@ -4214,25 +4280,29 @@ pub(super) fn report_unsupported_comparison<'db>(
                     the tuple elements at index {} (of type `{}` and `{}`)",
                     error.op,
                     position + 1,
-                    error.left_ty.display_with(db, display_settings.clone()),
-                    error.right_ty.display_with(db, display_settings),
+                    error
+                        .left_ty
+                        .display_with(db, program, display_settings.clone()),
+                    error.right_ty.display_with(db, program, display_settings),
                 ));
             }
         } else {
-            if error.left_ty.is_equivalent_to(db, error.right_ty) {
+            if error.left_ty.is_equivalent_to(db, program, error.right_ty) {
                 diagnostic.info(format_args!(
                     "Operation fails because operator `{}` is not supported \
                     between two objects of type `{}`",
                     error.op,
-                    error.left_ty.display_with(db, display_settings),
+                    error.left_ty.display_with(db, program, display_settings),
                 ));
             } else {
                 diagnostic.info(format_args!(
                     "Operation fails because operator `{}` is not supported \
                     between objects of type `{}` and `{}`",
                     error.op,
-                    error.left_ty.display_with(db, display_settings.clone()),
-                    error.right_ty.display_with(db, display_settings)
+                    error
+                        .left_ty
+                        .display_with(db, program, display_settings.clone()),
+                    error.right_ty.display_with(db, program, display_settings)
                 ));
             }
         }
@@ -4306,34 +4376,36 @@ fn report_unsupported_binary_operation_impl<'a>(
     operator: OperatorDisplay,
 ) -> Option<LintDiagnosticGuard<'a, 'a>> {
     let db = context.db();
+    let program = context.program();
     let diagnostic_builder = context.report_lint(&UNSUPPORTED_OPERATOR, range)?;
-    let display_settings = DisplaySettings::from_possibly_ambiguous_types(db, [left_ty, right_ty]);
+    let display_settings =
+        DisplaySettings::from_possibly_ambiguous_types(db, program, [left_ty, right_ty]);
 
     let mut diagnostic =
         diagnostic_builder.into_diagnostic(format_args!("Unsupported `{operator}` operation"));
 
-    if left_ty.is_equivalent_to(db, right_ty) {
+    if left_ty.is_equivalent_to(db, program, right_ty) {
         diagnostic.set_primary_message(format_args!(
             "Both operands have type `{}`",
-            left_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone())
         ));
         diagnostic.annotate(context.secondary(left));
         diagnostic.annotate(context.secondary(right));
         diagnostic.set_concise_message(format_args!(
             "Operator `{operator}` is not supported between two objects of type `{}`",
-            left_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone())
         ));
     } else {
         for (ty, expr) in [(left_ty, left), (right_ty, right)] {
             diagnostic.annotate(context.secondary(expr).message(format_args!(
                 "Has type `{}`",
-                ty.display_with(db, display_settings.clone())
+                ty.display_with(db, program, display_settings.clone())
             )));
         }
         diagnostic.set_concise_message(format_args!(
             "Operator `{operator}` is not supported between objects of type `{}` and `{}`",
-            left_ty.display_with(db, display_settings.clone()),
-            right_ty.display_with(db, display_settings.clone())
+            left_ty.display_with(db, program, display_settings.clone()),
+            right_ty.display_with(db, program, display_settings.clone())
         ));
     }
 
@@ -4407,11 +4479,12 @@ pub(super) fn report_bad_frozen_dataclass_inheritance<'db>(
                 .message(format_args!("`{}` definition", base_class.name(db))),
         );
 
-        let base_class_file = base_class.file(db);
-        let module = parsed_module(db, base_class_file).load(db);
+        let body_scope = base_class.body_scope(db);
+        let program_file = body_scope.program_file(db);
+        let base_class_file = program_file.file(db);
+        let module = program_file.parsed(db).load(db);
 
-        let decorator_range = base_class
-            .body_scope(db)
+        let decorator_range = body_scope
             .node(db)
             .expect_class()
             .node(&module)
@@ -4485,6 +4558,7 @@ pub(super) fn report_invalid_total_ordering_call(
 /// The function returns `true` if a hint was added, `false` otherwise.
 pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
     db: &dyn Db,
+    program: Program,
     diagnostic: &mut Diagnostic,
     full_submodule_name: &ModuleName,
     parent_module: Module,
@@ -4497,7 +4571,6 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
         return false;
     }
 
-    let program = Program::get(db);
     let typeshed_versions = program.search_paths(db).typeshed_versions();
 
     let Some(version_range) = typeshed_versions.exact(full_submodule_name) else {
@@ -4517,7 +4590,7 @@ pub(super) fn hint_if_stdlib_submodule_exists_on_other_versions(
         version_range = version_range.diagnostic_display(),
     ));
 
-    add_inferred_python_version_hint_to_diagnostic(db, diagnostic, "resolving modules");
+    add_inferred_python_version_hint_to_diagnostic(db, program, diagnostic, "resolving modules");
 
     true
 }
@@ -4544,6 +4617,7 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
         return;
     };
     let module = module_ty.module(db);
+    let program = module_ty.program(db);
     let Some(file) = module.file(db) else {
         return;
     };
@@ -4557,7 +4631,8 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // We populate place_table entries for stdlib items across all known versions and platforms,
     // so if this lookup succeeds then we know that this lookup *could* succeed with possible
     // configuration changes.
-    let symbol_table = place_table(db, global_scope(db, file));
+    let program_file = ty_python_core::environment::ProgramFile::new(db, program, file);
+    let symbol_table = place_table(db, global_scope(db, program_file));
     let Some(symbol) = symbol_table.symbol_by_name(attr) else {
         return;
     };
@@ -4572,7 +4647,7 @@ pub(super) fn hint_if_stdlib_attribute_exists_on_other_versions(
     // TODO: determine what version they need to be on
     // TODO: also mention the platform we're assuming
     // TODO: determine what platform they need to be on
-    add_inferred_python_version_hint_to_diagnostic(db, &mut diagnostic, action);
+    add_inferred_python_version_hint_to_diagnostic(db, program, &mut diagnostic, action);
 }
 
 pub(super) fn report_invalid_concatenate_last_arg<'db>(
@@ -4587,7 +4662,7 @@ pub(super) fn report_invalid_concatenate_last_arg<'db>(
         );
         diag.set_primary_message(format_args!(
             "Got `{}`",
-            last_arg_type.display(context.db())
+            last_arg_type.display(context.db(), context.program())
         ));
     }
 }
@@ -4621,7 +4696,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                     let symbol = place_table.symbol_id("__init_subclass__")?;
                     let use_def = use_def_map(db, scope);
                     let bindings = use_def.end_of_scope_bindings(ScopedPlaceId::Symbol(symbol));
-                    let place_with_def = place_from_bindings(db, bindings);
+                    let place_with_def = place_from_bindings(db, context.program(), bindings);
                     if place_with_def.place.is_undefined() {
                         return None;
                     }
@@ -4633,7 +4708,8 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                 diagnostic.set_primary_message(format_args!(
                     "Superclass `{superclass_name}` cannot be subclassed",
                 ));
-                let definition_module = parsed_module(db, definition.file(db));
+                let definition_module =
+                    parsed_module(db, definition.program_file(db).versioned_file(db));
                 let mut annotation = Annotation::secondary(Span::from(
                     definition.focus_range(db, &definition_module.load(db)),
                 ));
@@ -4645,7 +4721,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                     annotation = annotation.message(format_args!(
                         "`{superclass_name}.__init_subclass__` has type `{}`, \
                         which is not callable",
-                        bindings.callable_type().display(db)
+                        bindings.callable_type().display(db, context.program())
                     ));
                 } else {
                     diagnostic.set_concise_message(format_args!(
@@ -4655,7 +4731,7 @@ pub(super) fn report_subclass_of_class_with_non_callable_init_subclass<'db>(
                     annotation = annotation.message(format_args!(
                         "`{superclass_name}.__init_subclass__` has type `{}`, \
                         which may not be callable",
-                        bindings.callable_type().display(db)
+                        bindings.callable_type().display(db, context.program())
                     ));
                 }
                 diagnostic.annotate(annotation);

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -14,9 +14,6 @@ use ruff_source_file::LineColumn;
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use ruff_db::parsed::parsed_module;
-use ty_module_resolver::file_to_module;
-
 use crate::Db;
 use crate::place::{DefinedPlace, Place};
 use crate::types::callable::CallableTypeKind;
@@ -207,7 +204,11 @@ impl<'db> DisplaySettings<'db> {
     }
 
     #[must_use]
-    pub fn from_possibly_ambiguous_types<I, T>(db: &'db dyn Db, types: I) -> Self
+    pub fn from_possibly_ambiguous_types<I, T>(
+        db: &'db dyn Db,
+        program: crate::Program,
+        types: I,
+    ) -> Self
     where
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
@@ -228,7 +229,7 @@ impl<'db> DisplaySettings<'db> {
         let collector = AmbiguousNameCollector::default();
 
         for ty in types {
-            collector.visit_type(db, ty.into());
+            collector.visit_type(db, program, ty.into());
         }
 
         build_display_settings(&collector)
@@ -567,7 +568,7 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
         false
     }
 
-    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+    fn visit_type(&self, db: &'db dyn Db, program: crate::Program, ty: Type<'db>) {
         match ty {
             Type::ClassLiteral(class) => self.record_class(db, class),
             Type::LiteralValue(literal) => {
@@ -585,7 +586,7 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
             Type::ProtocolInstance(ProtocolInstanceType {
                 inner: Protocol::FromClass(class),
                 ..
-            }) => return self.visit_type(db, Type::from(class)),
+            }) => return self.visit_type(db, program, Type::from(class)),
             // no need to recurse into TypeVar bounds/constraints
             Type::TypeVar(_) => return,
             _ => {}
@@ -596,23 +597,30 @@ impl<'db> TypeVisitor<'db> for AmbiguousNameCollector<'db> {
                 // If we have already seen this type, we can skip it.
                 return;
             }
-            visitor::walk_non_atomic_type(db, t, self);
+            visitor::walk_non_atomic_type(db, program, t, self);
         }
     }
 }
 
 impl<'db> Type<'db> {
-    pub fn display(self, db: &'db dyn Db) -> DisplayType<'db> {
+    pub fn display(self, db: &'db dyn Db, program: crate::Program) -> DisplayType<'db> {
         DisplayType {
             ty: self,
-            settings: DisplaySettings::from_possibly_ambiguous_types(db, [self]),
+            program,
+            settings: DisplaySettings::from_possibly_ambiguous_types(db, program, [self]),
             db,
         }
     }
 
-    pub fn display_with(self, db: &'db dyn Db, settings: DisplaySettings<'db>) -> DisplayType<'db> {
+    pub fn display_with(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        settings: DisplaySettings<'db>,
+    ) -> DisplayType<'db> {
         DisplayType {
             ty: self,
+            program,
             db,
             settings,
         }
@@ -621,10 +629,12 @@ impl<'db> Type<'db> {
     fn representation(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayRepresentation<'db> {
         DisplayRepresentation {
             db,
+            program,
             ty: self,
             settings,
         }
@@ -634,6 +644,7 @@ impl<'db> Type<'db> {
 pub struct DisplayType<'db> {
     ty: Type<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -651,7 +662,9 @@ impl<'db> DisplayType<'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayType<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        let representation = self.ty.representation(self.db, self.settings.clone());
+        let representation = self
+            .ty
+            .representation(self.db, self.program, self.settings.clone());
         match self.ty.as_literal_value_kind() {
             Some(
                 LiteralValueTypeKind::Int(_)
@@ -715,11 +728,11 @@ fn fmt_file_location<'db>(
 /// A vector of path components in order (e.g., `["module", "OuterClass", "InnerClass"]`)
 pub(super) fn qualified_name_components_from_scope(
     db: &dyn Db,
-    file: ruff_db::files::File,
+    file: ty_python_core::environment::ProgramFile<'_>,
     file_scope_id: FileScopeId,
     skip_count: usize,
 ) -> Vec<String> {
-    let module_ast = parsed_module(db, file).load(db);
+    let module_ast = file.parsed(db).load(db);
     let index = semantic_index(db, file);
 
     let mut name_parts = vec![];
@@ -745,7 +758,7 @@ pub(super) fn qualified_name_components_from_scope(
         }
     }
 
-    if let Some(module) = file_to_module(db, file) {
+    if let Some(module) = ty_module_resolver::file_to_module(db, file.resolver_file(db)) {
         let module_name = module.name(db);
         name_parts.push(module_name.as_str().to_string());
     }
@@ -812,6 +825,7 @@ impl<'db> TypeAliasType<'db> {
 
     /// Returns a source-style display of this type alias's declaration.
     pub fn display_declaration(self, db: &'db dyn Db) -> impl Display + 'db {
+        let program = self.program(db);
         let value_ty = self.raw_value_type(db);
         DisplayTypeAliasDeclaration {
             db,
@@ -819,6 +833,7 @@ impl<'db> TypeAliasType<'db> {
             value_ty,
             settings: DisplaySettings::from_possibly_ambiguous_types(
                 db,
+                program,
                 [Type::TypeAlias(self), value_ty],
             ),
         }
@@ -850,7 +865,13 @@ impl<'db> FmtDetailed<'db> for TypeAliasDisplay<'db> {
             let definition = self.type_alias.definition(self.db);
             let file = definition.file(self.db);
             let offset = definition
-                .focus_range(self.db, &parsed_module(self.db, file).load(self.db))
+                .focus_range(
+                    self.db,
+                    &definition
+                        .program_file(self.db)
+                        .parsed(self.db)
+                        .load(self.db),
+                )
                 .range()
                 .start();
             fmt_file_location(self.db, file, offset, f)?;
@@ -875,6 +896,11 @@ struct DisplayTypeAliasDeclaration<'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayTypeAliasDeclaration<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self
+            .type_alias
+            .definition(self.db)
+            .program_file(self.db)
+            .program(self.db);
         let generic_context = self.type_alias.generic_context(self.db);
         let settings = self
             .settings
@@ -891,7 +917,7 @@ impl<'db> FmtDetailed<'db> for DisplayTypeAliasDeclaration<'db> {
         }
         f.write_str(" = ")?;
         self.value_ty
-            .display_with(self.db, settings)
+            .display_with(self.db, program, settings)
             .fmt_detailed(f)
     }
 }
@@ -905,6 +931,7 @@ impl Display for DisplayTypeAliasDeclaration<'_> {
 /// Helper for displaying `TypeGuardLike` types `TypeIs` and `TypeGuard`.
 fn fmt_type_guard_like<'db, T: TypeGuardLike<'db>>(
     db: &'db dyn Db,
+    program: crate::Program,
     guard: T,
     settings: &DisplaySettings<'db>,
     f: &mut TypeWriter<'_, '_, 'db>,
@@ -914,7 +941,7 @@ fn fmt_type_guard_like<'db, T: TypeGuardLike<'db>>(
     f.write_char('[')?;
     guard
         .type_argument(db)
-        .display_with(db, settings.singleline())
+        .display_with(db, program, settings.singleline())
         .fmt_detailed(f)?;
     if let Some(name) = guard.place_name(db) {
         f.set_invalid_type_annotation();
@@ -930,6 +957,7 @@ fn fmt_type_guard_like<'db, T: TypeGuardLike<'db>>(
 struct DisplayRepresentation<'db> {
     ty: Type<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -949,6 +977,7 @@ impl Display for DisplayRepresentation<'_> {
 
 impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         match self.ty {
             Type::Dynamic(dynamic) => {
                 if dynamic.is_todo() {
@@ -959,7 +988,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
             Type::Divergent(_) => f.with_type(self.ty).write_str("Divergent"),
             Type::Never => f.with_type(self.ty).write_str("Never"),
             Type::NominalInstance(instance) => {
-                let class = instance.class(self.db);
+                let class = instance.class(self.db, program);
 
                 match (class, class.known(self.db)) {
                     (_, Some(KnownClass::NoneType)) => f.with_type(self.ty).write_str("None"),
@@ -968,12 +997,14 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         .specialization(self.db)
                         .tuple(self.db)
                         .expect("Specialization::tuple() should always return `Some()` for `KnownClass::Tuple`")
-                        .display_with(self.db, self.settings.clone())
+                        .display_with(self.db, program, self.settings.clone())
                         .fmt_detailed(f),
                     (ClassType::NonGeneric(class), _) => {
                         class.display_with(self.db, self.settings.clone()).fmt_detailed(f)
                     },
-                    (ClassType::Generic(alias), _) => alias.display_with(self.db, self.settings.clone()).fmt_detailed(f),
+                    (ClassType::Generic(alias), _) => alias
+                        .display_with(self.db, self.settings.clone())
+                        .fmt_detailed(f),
                 }
             }
             Type::ProtocolInstance(protocol) => match protocol.inner {
@@ -1010,7 +1041,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
             Type::ModuleLiteral(module) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(KnownClass::ModuleType.to_class_literal(self.db))
+                f.with_type(KnownClass::ModuleType.to_class_literal(self.db, program))
                     .write_str("module")?;
                 f.write_str(" '")?;
                 f.with_type(self.ty)
@@ -1037,7 +1068,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
             }
             Type::SubclassOf(subclass_of_ty) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Class(ClassType::NonGeneric(class)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
+                    f.with_type(KnownClass::Type.to_class_literal(self.db, program))
                         .write_str("type")?;
                     f.write_char('[')?;
                     class
@@ -1046,7 +1077,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_char(']')
                 }
                 SubclassOfInner::Class(ClassType::Generic(alias)) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
+                    f.with_type(KnownClass::Type.to_class_literal(self.db, program))
                         .write_str("type")?;
                     f.write_char('[')?;
                     alias
@@ -1055,7 +1086,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     f.write_char(']')
                 }
                 SubclassOfInner::Dynamic(dynamic) => {
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
+                    f.with_type(KnownClass::Type.to_class_literal(self.db, program))
                         .write_str("type")?;
                     f.write_char('[')?;
                     write!(f.with_type(Type::Dynamic(dynamic)), "{dynamic}")?;
@@ -1063,7 +1094,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 }
                 SubclassOfInner::TypeVar(bound_typevar) => {
                     f.set_invalid_type_annotation();
-                    f.with_type(KnownClass::Type.to_class_literal(self.db))
+                    f.with_type(KnownClass::Type.to_class_literal(self.db, program))
                         .write_str("type")?;
                     f.write_char('[')?;
                     write!(
@@ -1081,13 +1112,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 write!(f.with_type(self.ty), "<special-form '{special_form}'>")
             }
             Type::KnownInstance(known_instance) => known_instance
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f),
             Type::FunctionLiteral(function) => function
                 .display_with(self.db, self.settings.clone())
                 .fmt_detailed(f),
             Type::Callable(callable) => callable
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f),
             Type::BoundMethod(bound_method) => {
                 let function = bound_method.function(self.db);
@@ -1096,7 +1127,8 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
 
                 match bound_signatures.overloads.as_slice() {
                     [signature] => {
-                        let hide_unused_self = signature.should_hide_self_from_display(self.db);
+                        let hide_unused_self =
+                            signature.should_hide_self_from_display(self.db, program);
                         let type_parameters = DisplayOptionalGenericContext {
                             generic_context: signature.generic_context.as_ref(),
                             db: self.db,
@@ -1108,6 +1140,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         DisplayMaybeParenthesizedType {
                             ty: self_ty,
                             db: self.db,
+                            program,
                             settings: self.settings.singleline(),
                         }
                         .fmt_detailed(f)?;
@@ -1115,7 +1148,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         f.with_type(self.ty).write_str(function.name(self.db))?;
                         type_parameters.fmt_detailed(f)?;
                         signature
-                            .display_with(self.db, self.settings.disallow_signature_name())
+                            .display_with(self.db, program, self.settings.disallow_signature_name())
                             .fmt_detailed(f)
                     }
                     signatures => {
@@ -1129,7 +1162,11 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                         let separator = if self.settings.multiline { "\n" } else { ", " };
                         let mut join = f.join(separator);
                         for signature in signatures {
-                            join.entry(&signature.display_with(self.db, self.settings.clone()));
+                            join.entry(&signature.display_with(
+                                self.db,
+                                program,
+                                self.settings.clone(),
+                            ));
                         }
                         join.finish()?;
                         if !self.settings.multiline {
@@ -1219,13 +1256,13 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                 };
 
-                let class_ty = cls.to_class_literal(self.db);
+                let class_ty = cls.to_class_literal(self.db, program);
                 f.write_char('<')?;
-                f.with_type(KnownClass::MethodWrapperType.to_class_literal(self.db))
+                f.with_type(KnownClass::MethodWrapperType.to_class_literal(self.db, program))
                     .write_str("method-wrapper")?;
                 f.write_str(" '")?;
                 if let Place::Defined(DefinedPlace { ty: member_ty, .. }) =
-                    class_ty.member(self.db, member_name).place
+                    class_ty.member(self.db, program, member_name).place
                 {
                     f.with_type(member_ty).write_str(member_name)?;
                 } else {
@@ -1258,12 +1295,12 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     }
                 };
                 f.write_char('<')?;
-                f.with_type(KnownClass::WrapperDescriptorType.to_class_literal(self.db))
+                f.with_type(KnownClass::WrapperDescriptorType.to_class_literal(self.db, program))
                     .write_str("wrapper-descriptor")?;
                 f.write_str(" '")?;
                 f.write_str(method)?;
                 f.write_str("' of '")?;
-                f.with_type(cls.to_class_literal(self.db))
+                f.with_type(cls.to_class_literal(self.db, program))
                     .write_str(object)?;
                 f.write_str("' objects>")
             }
@@ -1276,10 +1313,10 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 f.write_str("<decorator produced by typing.dataclass_transform>")
             }
             Type::Union(union) => union
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f),
             Type::Intersection(intersection) => intersection
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f),
             Type::EnumComplement(complement) => {
                 if let Some(literals) =
@@ -1288,13 +1325,14 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                     DisplayLiteralGroup {
                         literals,
                         db: self.db,
+                        program,
                         settings: self.settings.clone(),
                     }
                     .fmt_detailed(f)
                 } else {
                     complement
                         .to_intersection(self.db)
-                        .display_with(self.db, self.settings.clone())
+                        .display_with(self.db, program, self.settings.clone())
                         .fmt_detailed(f)
                 }
             }
@@ -1357,19 +1395,21 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 f.set_invalid_type_annotation();
                 f.write_str("<super: ")?;
                 Type::from(bound_super.pivot_class(self.db))
-                    .display_with(self.db, self.settings.singleline())
+                    .display_with(self.db, program, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(", ")?;
                 bound_super
                     .owner(self.db)
                     .owner_type()
-                    .display_with(self.db, self.settings.singleline())
+                    .display_with(self.db, program, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(">")
             }
-            Type::TypeIs(type_is) => fmt_type_guard_like(self.db, type_is, &self.settings, f),
+            Type::TypeIs(type_is) => {
+                fmt_type_guard_like(self.db, program, type_is, &self.settings, f)
+            }
             Type::TypeGuard(type_guard) => {
-                fmt_type_guard_like(self.db, type_guard, &self.settings, f)
+                fmt_type_guard_like(self.db, program, type_guard, &self.settings, f)
             }
             Type::TypeForm(typeform) => {
                 f.with_type(Type::SpecialForm(SpecialFormType::TypeForm))
@@ -1377,7 +1417,7 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 f.write_char('[')?;
                 typeform
                     .type_argument(self.db)
-                    .display_with(self.db, self.settings.clone())
+                    .display_with(self.db, program, self.settings.clone())
                     .fmt_detailed(f)?;
                 f.write_char(']')
             }
@@ -1414,7 +1454,12 @@ impl<'db> FmtDetailed<'db> for DisplayRepresentation<'db> {
                 match alias.specialization(self.db) {
                     None => Ok(()),
                     Some(specialization) => specialization
-                        .display_short(self.db, TupleSpecialization::No, self.settings.clone())
+                        .display_short(
+                            self.db,
+                            program,
+                            TupleSpecialization::No,
+                            self.settings.clone(),
+                        )
                         .fmt_detailed(f),
                 }
             }
@@ -1468,11 +1513,13 @@ impl<'db> TupleSpec<'db> {
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayTuple<'a, 'db> {
         DisplayTuple {
             tuple: self,
             db,
+            program,
             settings,
         }
     }
@@ -1481,12 +1528,14 @@ impl<'db> TupleSpec<'db> {
 struct DisplayTuple<'a, 'db> {
     tuple: &'a TupleSpec<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
-        f.with_type(KnownClass::Tuple.to_class_literal(self.db))
+        let program = self.program;
+        f.with_type(KnownClass::Tuple.to_class_literal(self.db, program))
             .write_str("tuple")?;
         f.write_char('[')?;
         match self.tuple {
@@ -1496,7 +1545,7 @@ impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
                     f.write_str("()")?;
                 } else {
                     elements
-                        .display_with(self.db, self.settings.singleline())
+                        .display_with(self.db, program, self.settings.singleline())
                         .fmt_detailed(f)?;
                 }
             }
@@ -1519,20 +1568,20 @@ impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
                 if !tuple.prefix_elements().is_empty() {
                     tuple
                         .prefix_elements()
-                        .display_with(self.db, self.settings.singleline())
+                        .display_with(self.db, program, self.settings.singleline())
                         .fmt_detailed(f)?;
                     f.write_str(", ")?;
                 }
                 if !tuple.prefix_elements().is_empty() || !tuple.suffix_elements().is_empty() {
                     f.write_char('*')?;
                     // Might as well link the type again here too
-                    f.with_type(KnownClass::Tuple.to_class_literal(self.db))
+                    f.with_type(KnownClass::Tuple.to_class_literal(self.db, program))
                         .write_str("tuple")?;
                     f.write_char('[')?;
                 }
                 tuple
                     .variable()
-                    .display_with(self.db, self.settings.singleline())
+                    .display_with(self.db, program, self.settings.singleline())
                     .fmt_detailed(f)?;
                 f.write_str(", ...")?;
                 if !tuple.prefix_elements().is_empty() || !tuple.suffix_elements().is_empty() {
@@ -1542,7 +1591,7 @@ impl<'db> FmtDetailed<'db> for DisplayTuple<'_, 'db> {
                     f.write_str(", ")?;
                     tuple
                         .suffix_elements()
-                        .display_with(self.db, self.settings.singleline())
+                        .display_with(self.db, program, self.settings.singleline())
                         .fmt_detailed(f)?;
                 }
             }
@@ -1585,8 +1634,9 @@ pub(crate) struct DisplayOverloadLiteral<'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayOverloadLiteral<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.literal.body_scope(self.db).program(self.db);
         let signature = self.literal.signature(self.db);
-        let hide_unused_self = signature.should_hide_self_from_display(self.db);
+        let hide_unused_self = signature.should_hide_self_from_display(self.db, program);
         let type_parameters = DisplayOptionalGenericContext {
             generic_context: signature.generic_context.as_ref(),
             db: self.db,
@@ -1599,7 +1649,7 @@ impl<'db> FmtDetailed<'db> for DisplayOverloadLiteral<'db> {
         write!(f, "{}", self.literal.name(self.db))?;
         type_parameters.fmt_detailed(f)?;
         signature
-            .display_with(self.db, self.settings.disallow_signature_name())
+            .display_with(self.db, program, self.settings.disallow_signature_name())
             .fmt_detailed(f)
     }
 }
@@ -1636,6 +1686,7 @@ impl<'db> FmtDetailed<'db> for DisplayFunctionType<'db> {
         // and limit display depth for chains of different function types
         // (e.g. multiple redefinitions with `TypeOf[foo]` return types).
         const MAX_FUNCTION_TYPE_DISPLAY_DEPTH: usize = 4;
+        let program = self.ty.program(self.db);
         if self.settings.visited_function_types.contains(&self.ty)
             || self.settings.visited_function_types.len() >= MAX_FUNCTION_TYPE_DISPLAY_DEPTH
         {
@@ -1654,7 +1705,7 @@ impl<'db> FmtDetailed<'db> for DisplayFunctionType<'db> {
 
         match signature.overloads.as_slice() {
             [signature] => {
-                let hide_unused_self = signature.should_hide_self_from_display(self.db);
+                let hide_unused_self = signature.should_hide_self_from_display(self.db, program);
 
                 let type_parameters = DisplayOptionalGenericContext {
                     generic_context: signature.generic_context.as_ref(),
@@ -1667,7 +1718,7 @@ impl<'db> FmtDetailed<'db> for DisplayFunctionType<'db> {
                 write!(f, "{}", self.ty.name(self.db))?;
                 type_parameters.fmt_detailed(f)?;
                 signature
-                    .display_with(self.db, settings.disallow_signature_name())
+                    .display_with(self.db, program, settings.disallow_signature_name())
                     .fmt_detailed(f)
             }
             signatures => {
@@ -1681,7 +1732,7 @@ impl<'db> FmtDetailed<'db> for DisplayFunctionType<'db> {
                 let separator = if settings.multiline { "\n" } else { ", " };
                 let mut join = f.join(separator);
                 for signature in signatures {
-                    join.entry(&signature.display_with(self.db, settings.clone()));
+                    join.entry(&signature.display_with(self.db, program, settings.clone()));
                 }
                 join.finish()?;
                 if !settings.multiline {
@@ -1727,9 +1778,10 @@ pub(crate) struct DisplayGenericAlias<'db> {
 
 impl<'db> FmtDetailed<'db> for DisplayGenericAlias<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.origin.program(self.db);
         if let Some(tuple) = self.specialization.tuple(self.db) {
             tuple
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f)
         } else {
             let prefix_details = match self.specialization.materialization_kind(self.db) {
@@ -1751,6 +1803,7 @@ impl<'db> FmtDetailed<'db> for DisplayGenericAlias<'db> {
             self.specialization
                 .display_short(
                     self.db,
+                    program,
                     TupleSpecialization::from_class(self.db, self.origin),
                     self.settings.clone(),
                 )
@@ -1909,10 +1962,11 @@ impl Display for DisplayGenericContext<'_, '_> {
 }
 
 impl<'db> Specialization<'db> {
-    fn display_full(self, db: &'db dyn Db) -> DisplaySpecialization<'db> {
+    fn display_full(self, db: &'db dyn Db, program: crate::Program) -> DisplaySpecialization<'db> {
         DisplaySpecialization {
             specialization: self,
             db,
+            program,
             tuple_specialization: TupleSpecialization::No,
             settings: DisplaySettings::default(),
             full: true,
@@ -1923,12 +1977,14 @@ impl<'db> Specialization<'db> {
     fn display_short(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         tuple_specialization: TupleSpecialization,
         settings: DisplaySettings<'db>,
     ) -> DisplaySpecialization<'db> {
         DisplaySpecialization {
             specialization: self,
             db,
+            program,
             tuple_specialization,
             settings,
             full: false,
@@ -1939,6 +1995,7 @@ impl<'db> Specialization<'db> {
 struct DisplaySpecialization<'db> {
     specialization: Specialization<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     tuple_specialization: TupleSpecialization,
     settings: DisplaySettings<'db>,
     full: bool,
@@ -1946,13 +2003,14 @@ struct DisplaySpecialization<'db> {
 
 impl<'db> DisplaySpecialization<'db> {
     fn fmt_normal(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         f.write_char('[')?;
         let types = self.specialization.types(self.db);
         for (idx, ty) in types.iter().enumerate() {
             if idx > 0 {
                 f.write_str(", ")?;
             }
-            ty.display_with(self.db, self.settings.clone())
+            ty.display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f)?;
         }
         if self.tuple_specialization.is_yes() {
@@ -1962,6 +2020,7 @@ impl<'db> DisplaySpecialization<'db> {
     }
 
     fn fmt_full(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         f.write_char('[')?;
         let variables = self
             .specialization
@@ -1975,7 +2034,7 @@ impl<'db> DisplaySpecialization<'db> {
             f.set_invalid_type_annotation();
             write!(f, "{}", bound_typevar.identity(self.db).display(self.db))?;
             f.write_str(" = ")?;
-            ty.display_with(self.db, self.settings.clone())
+            ty.display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f)?;
         }
         f.write_char(']')
@@ -2019,19 +2078,25 @@ impl TupleSpecialization {
 }
 
 impl<'db> CallableType<'db> {
-    pub(crate) fn display<'a>(&'a self, db: &'db dyn Db) -> DisplayCallableType<'a, 'db> {
-        Self::display_with(self, db, DisplaySettings::default())
+    pub(crate) fn display<'a>(
+        &'a self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> DisplayCallableType<'a, 'db> {
+        Self::display_with(self, db, program, DisplaySettings::default())
     }
 
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayCallableType<'a, 'db> {
         DisplayCallableType {
             signatures: self.signatures(db),
             kind: self.kind(db),
             db,
+            program,
             settings,
         }
     }
@@ -2041,11 +2106,13 @@ pub(crate) struct DisplayCallableType<'a, 'db> {
     signatures: &'a CallableSignature<'db>,
     kind: CallableTypeKind,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplayCallableType<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         match self.signatures.overloads.as_slice() {
             [signature] => {
                 if matches!(self.kind, CallableTypeKind::ParamSpecValue) {
@@ -2054,14 +2121,14 @@ impl<'db> FmtDetailed<'db> for DisplayCallableType<'_, 'db> {
                     }
                     signature
                         .parameters()
-                        .display_with(self.db, self.settings.clone())
+                        .display_with(self.db, program, self.settings.clone())
                         .fmt_detailed(f)?;
                     if signature.parameters().is_top() {
                         f.write_str("]")?;
                     }
                 } else {
                     signature
-                        .display_with(self.db, self.settings.clone())
+                        .display_with(self.db, program, self.settings.clone())
                         .fmt_detailed(f)?;
                 }
             }
@@ -2076,7 +2143,7 @@ impl<'db> FmtDetailed<'db> for DisplayCallableType<'_, 'db> {
                 let separator = if self.settings.multiline { "\n" } else { ", " };
                 let mut join = f.join(separator);
                 for signature in signatures {
-                    join.entry(&signature.display_with(self.db, self.settings.clone()));
+                    join.entry(&signature.display_with(self.db, program, self.settings.clone()));
                 }
                 join.finish()?;
                 if !self.settings.multiline {
@@ -2096,13 +2163,18 @@ impl Display for DisplayCallableType<'_, '_> {
 }
 
 impl<'db> Signature<'db> {
-    pub(crate) fn display<'a>(&'a self, db: &'db dyn Db) -> DisplaySignature<'a, 'db> {
-        Self::display_with(self, db, DisplaySettings::default())
+    pub(crate) fn display<'a>(
+        &'a self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> DisplaySignature<'a, 'db> {
+        Self::display_with(self, db, program, DisplaySettings::default())
     }
 
     pub(crate) fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplaySignature<'a, 'db> {
         DisplaySignature {
@@ -2111,6 +2183,7 @@ impl<'db> Signature<'db> {
             parameters: self.parameters(),
             return_ty: self.return_ty,
             db,
+            program,
             settings,
         }
     }
@@ -2122,6 +2195,7 @@ pub(crate) struct DisplaySignature<'a, 'db> {
     parameters: &'a Parameters<'db>,
     return_ty: Type<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -2137,17 +2211,17 @@ impl<'db> DisplaySignature<'_, 'db> {
         }
     }
 
-    fn should_hide_self_from_display(&self, db: &'db dyn Db) -> bool {
-        !self.return_ty.contains_self(db)
-            && !self
-                .parameters
-                .iter()
-                .any(|p| p.should_annotation_be_displayed() && p.annotated_type().contains_self(db))
+    fn should_hide_self_from_display(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        !self.return_ty.contains_self(db, program)
+            && !self.parameters.iter().any(|p| {
+                p.should_annotation_be_displayed() && p.annotated_type().contains_self(db, program)
+            })
     }
 }
 
 impl<'db> FmtDetailed<'db> for DisplaySignature<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         // Immediately write a marker signaling we're starting a signature
         let _ = f.with_detail(TypeDetail::SignatureStart);
         f.set_invalid_type_annotation();
@@ -2182,7 +2256,7 @@ impl<'db> FmtDetailed<'db> for DisplaySignature<'_, 'db> {
             .signature_name_display
             .allows_type_parameters()
         {
-            let hide_unused_self = self.should_hide_self_from_display(self.db);
+            let hide_unused_self = self.should_hide_self_from_display(self.db, program);
 
             DisplayOptionalGenericContext {
                 generic_context: self.generic_context,
@@ -2199,7 +2273,7 @@ impl<'db> FmtDetailed<'db> for DisplaySignature<'_, 'db> {
             ..settings.clone()
         };
         self.parameters
-            .display_with(self.db, param_settings)
+            .display_with(self.db, program, param_settings)
             .fmt_detailed(&mut f)?;
 
         // Return type
@@ -2212,7 +2286,7 @@ impl<'db> FmtDetailed<'db> for DisplaySignature<'_, 'db> {
                 f.write_char('(')?;
             }
             self.return_ty
-                .display_with(self.db, settings.singleline())
+                .display_with(self.db, program, settings.singleline())
                 .fmt_detailed(&mut f)?;
             if should_parenthesize_return_type {
                 f.write_char(')')?;
@@ -2248,11 +2322,13 @@ impl<'db> Parameters<'db> {
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayParameters<'a, 'db> {
         DisplayParameters {
             parameters: self,
             db,
+            program,
             settings,
         }
     }
@@ -2261,6 +2337,7 @@ impl<'db> Parameters<'db> {
 struct DisplayParameters<'a, 'db> {
     parameters: &'a Parameters<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -2308,7 +2385,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameters<'_, 'db> {
                     .map(|name| name.to_string())
                     .unwrap_or_default();
                 parameter
-                    .display_with(display.db, display.settings.singleline())
+                    .display_with(display.db, display.program, display.settings.singleline())
                     .fmt_detailed(&mut f.with_detail(TypeDetail::Parameter(param_name)))?;
 
                 first = false;
@@ -2405,11 +2482,13 @@ impl<'db> Parameter<'db> {
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayParameter<'a, 'db> {
         DisplayParameter {
             param: self,
             db,
+            program,
             settings,
         }
     }
@@ -2418,18 +2497,20 @@ impl<'db> Parameter<'db> {
 struct DisplayParameter<'a, 'db> {
     param: &'a Parameter<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         if let Some(name) = self.param.display_name() {
             write!(f, "{name}")?;
             if self.param.should_annotation_be_displayed() {
                 let annotated_type = self.param.annotated_type();
                 f.write_str(": ")?;
                 annotated_type
-                    .display_with(self.db, self.settings.clone())
+                    .display_with(self.db, program, self.settings.clone())
                     .fmt_detailed(f)?;
             }
             // Default value can only be specified if `name` is given.
@@ -2452,12 +2533,12 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
                     {
                         // For Literal types display the value without `Literal[..]` wrapping
                         let representation =
-                            default_type.representation(self.db, self.settings.clone());
+                            default_type.representation(self.db, program, self.settings.clone());
                         representation.fmt_detailed(f)?;
                     }
                     Type::NominalInstance(instance) => {
                         // Some key default types like `None` are worth showing
-                        let class = instance.class(self.db);
+                        let class = instance.class(self.db, program);
 
                         match (class, class.known(self.db)) {
                             (_, Some(KnownClass::NoneType)) => {
@@ -2478,7 +2559,7 @@ impl<'db> FmtDetailed<'db> for DisplayParameter<'_, 'db> {
             // have something visible in the parameter slot.
             self.param
                 .annotated_type()
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f)?;
         }
         Ok(())
@@ -2540,10 +2621,12 @@ impl<'db> UnionType<'db> {
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayUnionType<'a, 'db> {
         DisplayUnionType {
             db,
+            program,
             ty: self,
             settings,
         }
@@ -2553,6 +2636,7 @@ impl<'db> UnionType<'db> {
 struct DisplayUnionType<'a, 'db> {
     ty: &'a UnionType<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -2579,7 +2663,11 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
         ///
         /// # Color excluding RED displays through the literal-group path for BLUE.
         /// ```
-        fn condensable_literals<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+        fn condensable_literals<'db>(
+            db: &'db dyn Db,
+            program: crate::Program,
+            ty: Type<'db>,
+        ) -> Option<Vec<Type<'db>>> {
             match ty {
                 Type::LiteralValue(literal)
                     if matches!(
@@ -2597,7 +2685,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                     complement.remaining_literal_types_for_display(db, LITERAL_POLICY.max)
                 }
                 Type::Intersection(intersection) => {
-                    intersection.finite_alternatives_for_display(db, LITERAL_POLICY.max)
+                    intersection.finite_alternatives_for_display(db, program, LITERAL_POLICY.max)
                 }
                 _ => None,
             }
@@ -2605,10 +2693,13 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
 
         fn singleline_union_element_label<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             element: Type<'db>,
             settings: &DisplaySettings<'db>,
         ) -> String {
-            element.display_with(db, settings.singleline()).to_string()
+            element
+                .display_with(db, program, settings.singleline())
+                .to_string()
         }
 
         fn duplicate_ambiguous_labels(element_labels: &[Option<String>]) -> FxHashSet<&str> {
@@ -2624,6 +2715,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                 .collect()
         }
 
+        let program = self.program;
         let elements = self.ty.elements(self.db);
         let mut condensed_types = vec![];
         let mut condensed_element_count = 0usize;
@@ -2632,14 +2724,15 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
             .iter()
             .copied()
             .map(|element| {
-                (condensable_literals(self.db, element).is_none() && !element.is_subclass_of())
-                    .then(|| singleline_union_element_label(self.db, element, &self.settings))
+                (condensable_literals(self.db, program, element).is_none()
+                    && !element.is_subclass_of())
+                .then(|| singleline_union_element_label(self.db, program, element, &self.settings))
             })
             .collect();
         let duplicate_ambiguous_labels = duplicate_ambiguous_labels(&element_labels);
 
         for element in elements.iter().copied() {
-            if let Some(literals) = condensable_literals(self.db, element) {
+            if let Some(literals) = condensable_literals(self.db, program, element) {
                 condensed_element_count += 1;
                 for literal in literals {
                     if !condensed_types.contains(&literal) {
@@ -2672,12 +2765,13 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                 break;
             }
 
-            if condensable_literals(self.db, *element).is_some() {
+            if condensable_literals(self.db, program, *element).is_some() {
                 if let Some(condensed_types) = condensed_types.take() {
                     displayed_entries += 1;
                     join.entry(&DisplayLiteralGroup {
                         literals: condensed_types,
                         db: self.db,
+                        program,
                         settings: self.settings.singleline(),
                     });
                 }
@@ -2687,6 +2781,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                     join.entry(&DisplaySubclassOfGroup {
                         types: subclass_of_types,
                         db: self.db,
+                        program,
                         settings: self.settings.singleline(),
                     });
                 }
@@ -2703,6 +2798,7 @@ impl<'db> FmtDetailed<'db> for DisplayUnionType<'_, 'db> {
                 join.entry(&DisplayMaybeParenthesizedType {
                     ty: *element,
                     db: self.db,
+                    program,
                     settings,
                 });
             }
@@ -2737,11 +2833,13 @@ impl fmt::Debug for DisplayUnionType<'_, '_> {
 struct DisplaySubclassOfGroup<'db> {
     types: Vec<SubclassOfType<'db>>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         f.write_str("type[")?;
         let total_entries = self.types.len();
         let display_limit =
@@ -2756,13 +2854,19 @@ impl<'db> FmtDetailed<'db> for DisplaySubclassOfGroup<'db> {
                     join.entry(&alias.display_with(self.db, self.settings.singleline()));
                 }
                 SubclassOfInner::Dynamic(dynamic) => {
-                    let rep =
-                        Type::Dynamic(dynamic).representation(self.db, self.settings.singleline());
+                    let rep = Type::Dynamic(dynamic).representation(
+                        self.db,
+                        program,
+                        self.settings.singleline(),
+                    );
                     join.entry(&rep);
                 }
                 SubclassOfInner::TypeVar(bound_typevar) => {
-                    let rep = Type::TypeVar(bound_typevar)
-                        .representation(self.db, self.settings.singleline());
+                    let rep = Type::TypeVar(bound_typevar).representation(
+                        self.db,
+                        program,
+                        self.settings.singleline(),
+                    );
                     join.entry(&rep);
                 }
             }
@@ -2791,6 +2895,7 @@ impl Display for DisplaySubclassOfGroup<'_> {
 struct DisplayLiteralGroup<'db> {
     literals: Vec<Type<'db>>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -2801,6 +2906,7 @@ const LITERAL_POLICY: TruncationPolicy = TruncationPolicy {
 
 impl<'db> FmtDetailed<'db> for DisplayLiteralGroup<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         f.with_type(Type::SpecialForm(SpecialFormType::Literal))
             .write_str("Literal")?;
         f.write_char('[')?;
@@ -2813,7 +2919,7 @@ impl<'db> FmtDetailed<'db> for DisplayLiteralGroup<'db> {
         let mut join = f.join(", ");
 
         for lit in self.literals.iter().take(display_limit) {
-            let rep = lit.representation(self.db, self.settings.singleline());
+            let rep = lit.representation(self.db, program, self.settings.singleline());
             join.entry(&rep);
         }
 
@@ -2843,10 +2949,12 @@ impl<'db> IntersectionType<'db> {
     fn display_with<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayIntersectionType<'a, 'db> {
         DisplayIntersectionType {
             db,
+            program,
             ty: self,
             settings,
         }
@@ -2856,6 +2964,7 @@ impl<'db> IntersectionType<'db> {
 struct DisplayIntersectionType<'a, 'db> {
     ty: &'a IntersectionType<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
@@ -2868,6 +2977,7 @@ impl<'db> FmtDetailed<'db> for DisplayIntersectionType<'_, 'db> {
             .map(|&ty| DisplayMaybeNegatedType {
                 ty,
                 db: self.db,
+                program: self.program,
                 settings: self.settings.singleline(),
                 negated: false,
             })
@@ -2878,6 +2988,7 @@ impl<'db> FmtDetailed<'db> for DisplayIntersectionType<'_, 'db> {
                     .map(|&ty| DisplayMaybeNegatedType {
                         ty,
                         db: self.db,
+                        program: self.program,
                         settings: self.settings.singleline(),
                         negated: true,
                     }),
@@ -2903,6 +3014,7 @@ impl fmt::Debug for DisplayIntersectionType<'_, '_> {
 struct DisplayMaybeNegatedType<'db> {
     ty: Type<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     negated: bool,
     settings: DisplaySettings<'db>,
 }
@@ -2915,6 +3027,7 @@ impl<'db> FmtDetailed<'db> for DisplayMaybeNegatedType<'db> {
         DisplayMaybeParenthesizedType {
             ty: self.ty,
             db: self.db,
+            program: self.program,
             settings: self.settings.clone(),
         }
         .fmt_detailed(f)
@@ -2946,16 +3059,18 @@ fn should_parenthesize_callable_type(ty: Type<'_>, db: &dyn Db) -> bool {
 struct DisplayMaybeParenthesizedType<'db> {
     ty: Type<'db>,
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplayMaybeParenthesizedType<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         let write_parentheses = |f: &mut TypeWriter<'_, '_, 'db>| {
             f.set_invalid_type_annotation();
             f.write_char('(')?;
             self.ty
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f)?;
             f.write_char(')')
         };
@@ -2970,7 +3085,7 @@ impl<'db> FmtDetailed<'db> for DisplayMaybeParenthesizedType<'db> {
             }
             _ => self
                 .ty
-                .display_with(self.db, self.settings.clone())
+                .display_with(self.db, program, self.settings.clone())
                 .fmt_detailed(f),
         }
     }
@@ -2986,6 +3101,7 @@ trait TypeArrayDisplay<'db> {
     fn display_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayTypeArray<'_, 'db>;
 }
@@ -2994,11 +3110,13 @@ impl<'db> TypeArrayDisplay<'db> for Box<[Type<'db>]> {
     fn display_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray {
             types: self,
             db,
+            program,
             settings,
         }
     }
@@ -3008,11 +3126,13 @@ impl<'db> TypeArrayDisplay<'db> for Vec<Type<'db>> {
     fn display_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray {
             types: self,
             db,
+            program,
             settings,
         }
     }
@@ -3022,11 +3142,13 @@ impl<'db> TypeArrayDisplay<'db> for [Type<'db>] {
     fn display_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         settings: DisplaySettings<'db>,
     ) -> DisplayTypeArray<'_, 'db> {
         DisplayTypeArray {
             types: self,
             db,
+            program,
             settings,
         }
     }
@@ -3035,16 +3157,18 @@ impl<'db> TypeArrayDisplay<'db> for [Type<'db>] {
 struct DisplayTypeArray<'b, 'db> {
     types: &'b [Type<'db>],
     db: &'db dyn Db,
+    program: crate::Program,
     settings: DisplaySettings<'db>,
 }
 
 impl<'db> FmtDetailed<'db> for DisplayTypeArray<'_, 'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         f.join(", ")
             .entries(
                 self.types
                     .iter()
-                    .map(|ty| ty.display_with(self.db, self.settings.singleline())),
+                    .map(|ty| ty.display_with(self.db, program, self.settings.singleline())),
             )
             .finish()
     }
@@ -3093,17 +3217,20 @@ impl Display for DisplayStringLiteralType<'_> {
 pub(crate) struct DisplayKnownInstanceRepr<'db> {
     pub(crate) known_instance: KnownInstanceType<'db>,
     pub(crate) db: &'db dyn Db,
+    pub(crate) program: crate::Program,
 }
 
 impl<'db> KnownInstanceType<'db> {
     pub(crate) fn display_with(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         _settings: DisplaySettings<'db>,
     ) -> DisplayKnownInstanceRepr<'db> {
         DisplayKnownInstanceRepr {
             known_instance: self,
             db,
+            program,
         }
     }
 }
@@ -3116,6 +3243,7 @@ impl Display for DisplayKnownInstanceRepr<'_> {
 
 impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
     fn fmt_detailed(&self, f: &mut TypeWriter<'_, '_, 'db>) -> fmt::Result {
+        let program = self.program;
         let ty = Type::KnownInstance(self.known_instance);
         match self.known_instance {
             KnownInstanceType::SubscriptedProtocol(generic_context) => {
@@ -3140,7 +3268,12 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                     f.write_str("<type alias '")?;
                     f.with_type(ty).write_str(alias.name(self.db))?;
                     specialization
-                        .display_short(self.db, TupleSpecialization::No, DisplaySettings::default())
+                        .display_short(
+                            self.db,
+                            program,
+                            TupleSpecialization::No,
+                            DisplaySettings::default(),
+                        )
                         .fmt_detailed(f)?;
                     f.write_str("'>")
                 } else {
@@ -3168,7 +3301,11 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
 
                 if let Some(field_ty) = field_type {
                     f.write_char('[')?;
-                    write!(f.with_type(field_ty), "{}", field_ty.display(self.db))?;
+                    write!(
+                        f.with_type(field_ty),
+                        "{}",
+                        field_ty.display(self.db, program)
+                    )?;
                     f.write_char(']')?;
                 }
                 Ok(())
@@ -3176,12 +3313,12 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::ConstraintSet(interned_set) => {
                 f.with_type(ty).write_str("ConstraintSet")?;
                 let constraints = ConstraintSetBuilder::new();
-                let set = constraints.load(self.db, interned_set.constraints(self.db));
+                let set = constraints.load(self.db, program, interned_set.constraints(self.db));
                 if interned_set.detailed_display(self.db) {
-                    write!(f, "[{}]", set.display(self.db))
-                } else if set.is_always_satisfied(self.db) {
+                    write!(f, "[{}]", set.display(self.db, program))
+                } else if set.is_always_satisfied(self.db, program) {
                     f.write_str("[Literal[True]]")
-                } else if set.is_never_satisfied(self.db) {
+                } else if set.is_never_satisfied(self.db, program) {
                     f.write_str("[Literal[False]]")
                 } else {
                     f.write_str("[bool]")
@@ -3196,17 +3333,17 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 // Normalize for consistent output across CI platforms
                 f.with_type(ty)
                     .write_str("ty_extensions._internal.Specialization")?;
-                write!(f, "{}", specialization.display_full(self.db))
+                write!(f, "{}", specialization.display_full(self.db, program))
             }
             KnownInstanceType::UnionType(union) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(KnownClass::UnionType.to_class_literal(self.db))
+                f.with_type(KnownClass::UnionType.to_class_literal(self.db, program))
                     .write_str("types.UnionType")?;
                 f.write_str(" special-form")?;
                 if let Ok(ty) = union.union_type(self.db) {
                     f.write_str(" '")?;
-                    ty.display(self.db).fmt_detailed(f)?;
+                    ty.display(self.db, program).fmt_detailed(f)?;
                     f.write_char('\'')?;
                 }
                 f.write_char('>')
@@ -3214,7 +3351,10 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::Literal(inner) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<special-form '")?;
-                inner.inner(self.db).display(self.db).fmt_detailed(f)?;
+                inner
+                    .inner(self.db)
+                    .display(self.db, program)
+                    .fmt_detailed(f)?;
                 f.write_str("'>")
             }
             KnownInstanceType::Annotated(inner) => {
@@ -3223,7 +3363,10 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.with_type(Type::SpecialForm(SpecialFormType::Annotated))
                     .write_str("typing.Annotated")?;
                 f.write_char('[')?;
-                inner.inner(self.db).display(self.db).fmt_detailed(f)?;
+                inner
+                    .inner(self.db)
+                    .display(self.db, program)
+                    .fmt_detailed(f)?;
                 f.write_str(", <metadata>]'>")
             }
             KnownInstanceType::Callable(callable) => {
@@ -3236,25 +3379,28 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
                 f.with_type(Type::SpecialForm(SpecialFormType::TypingCallable))
                     .write_str("Callable")?;
                 f.write_str(" special-form '")?;
-                callable.display(self.db).fmt_detailed(f)?;
+                callable.display(self.db, program).fmt_detailed(f)?;
                 f.write_str("'>")
             }
             KnownInstanceType::TypeGenericAlias(inner) => {
                 f.set_invalid_type_annotation();
                 f.write_str("<special-form '")?;
-                f.with_type(KnownClass::Type.to_class_literal(self.db))
+                f.with_type(KnownClass::Type.to_class_literal(self.db, program))
                     .write_str("type")?;
                 f.write_char('[')?;
-                inner.inner(self.db).display(self.db).fmt_detailed(f)?;
+                inner
+                    .inner(self.db)
+                    .display(self.db, program)
+                    .fmt_detailed(f)?;
                 f.write_str("]'>")
             }
             KnownInstanceType::LiteralStringAlias(_) => f
-                .with_type(KnownClass::Str.to_class_literal(self.db))
+                .with_type(KnownClass::Str.to_class_literal(self.db, program))
                 .write_str("str"),
             KnownInstanceType::NewType(declaration) => {
                 f.set_invalid_type_annotation();
                 f.write_char('<')?;
-                f.with_type(KnownClass::NewType.to_class_literal(self.db))
+                f.with_type(KnownClass::NewType.to_class_literal(self.db, program))
                     .write_str("NewType")?;
                 f.write_str(" pseudo-class '")?;
                 f.with_type(ty).write_str(declaration.name(self.db))?;
@@ -3267,16 +3413,16 @@ impl<'db> FmtDetailed<'db> for DisplayKnownInstanceRepr<'db> {
             KnownInstanceType::FunctoolsPartial(partial) => {
                 f.write_str("partial[")?;
                 Type::Callable(partial.partial(self.db))
-                    .display_with(self.db, DisplaySettings::default().singleline())
+                    .display_with(self.db, program, DisplaySettings::default().singleline())
                     .fmt_detailed(f)?;
                 f.write_str("]")
             }
             KnownInstanceType::Range { .. } => f
-                .with_type(KnownClass::Range.to_class_literal(self.db))
+                .with_type(KnownClass::Range.to_class_literal(self.db, program))
                 .write_str("range"),
             KnownInstanceType::FunctoolsPartialCall(partial) => {
                 Type::Callable(partial.partial(self.db))
-                    .display_with(self.db, DisplaySettings::default().singleline())
+                    .display_with(self.db, program, DisplaySettings::default().singleline())
                     .fmt_detailed(f)
             }
         }
@@ -3288,64 +3434,73 @@ mod tests {
     use insta::assert_snapshot;
     use ruff_python_ast::name::Name;
 
-    use crate::Db;
-    use crate::db::tests::setup_db;
+    use crate::db::tests::{TestDb, setup_db};
     use crate::types::{KnownClass, Parameter, Parameters, Signature, Type};
 
     #[test]
     fn string_literal_display() {
         let db = setup_db();
+        let program = db.program();
 
         assert_eq!(
-            Type::string_literal(&db, r"\n").display(&db).to_string(),
+            Type::string_literal(&db, r"\n")
+                .display(&db, program)
+                .to_string(),
             r#"Literal["\\n"]"#
         );
         assert_eq!(
-            Type::string_literal(&db, "'").display(&db).to_string(),
+            Type::string_literal(&db, "'")
+                .display(&db, program)
+                .to_string(),
             r#"Literal["'"]"#
         );
         assert_eq!(
-            Type::string_literal(&db, r#"""#).display(&db).to_string(),
+            Type::string_literal(&db, r#"""#)
+                .display(&db, program)
+                .to_string(),
             r#"Literal["\""]"#
         );
     }
 
     fn display_signature<'db>(
-        db: &'db dyn Db,
+        db: &'db TestDb,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
         return_ty: Option<Type<'db>>,
     ) -> String {
+        let program = db.program();
         Signature::new(
             Parameters::from_annotation(db, parameters),
             return_ty.unwrap_or(Type::unknown()),
         )
-        .display(db)
+        .display(db, program)
         .to_string()
     }
 
     fn display_signature_multiline<'db>(
-        db: &'db dyn Db,
+        db: &'db TestDb,
         parameters: impl IntoIterator<Item = Parameter<'db>>,
         return_ty: Option<Type<'db>>,
     ) -> String {
+        let program = db.program();
         Signature::new(
             Parameters::from_annotation(db, parameters),
             return_ty.unwrap_or(Type::unknown()),
         )
-        .display_with(db, super::DisplaySettings::default().multiline())
+        .display_with(db, program, super::DisplaySettings::default().multiline())
         .to_string()
     }
 
     #[test]
     fn signature_display() {
         let db = setup_db();
+        let program = db.program();
 
         // Empty parameters with no return type.
         assert_snapshot!(display_signature(&db, [], None), @"() -> Unknown");
 
         // Empty parameters with a return type.
         assert_snapshot!(
-            display_signature(&db, [], Some(Type::none(&db))),
+            display_signature(&db, [], Some(Type::none(&db, program))),
             @"() -> None"
         );
 
@@ -3353,8 +3508,8 @@ mod tests {
         assert_snapshot!(
             display_signature(
                 &db,
-                [Parameter::positional_only(None).with_annotated_type(Type::none(&db))],
-                Some(Type::none(&db))
+                [Parameter::positional_only(None).with_annotated_type(Type::none(&db, program))],
+                Some(Type::none(&db, program))
             ),
             @"(None, /) -> None"
         );
@@ -3365,12 +3520,12 @@ mod tests {
                 &db,
                 [
                     Parameter::positional_or_keyword(Name::new_static("x"))
-                        .with_default_type(KnownClass::Int.to_instance(&db)),
+                        .with_default_type(KnownClass::Int.to_instance(&db, program)),
                     Parameter::positional_or_keyword(Name::new_static("y"))
-                        .with_annotated_type(KnownClass::Str.to_instance(&db))
-                        .with_default_type(KnownClass::Str.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Str.to_instance(&db, program))
+                        .with_default_type(KnownClass::Str.to_instance(&db, program)),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(x=..., y: str = ...) -> None"
         );
@@ -3383,7 +3538,7 @@ mod tests {
                     Parameter::positional_only(Some(Name::new_static("x"))),
                     Parameter::positional_only(Some(Name::new_static("y"))),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(x, y, /) -> None"
         );
@@ -3396,7 +3551,7 @@ mod tests {
                     Parameter::positional_only(Some(Name::new_static("x"))),
                     Parameter::positional_or_keyword(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(x, /, y) -> None"
         );
@@ -3409,7 +3564,7 @@ mod tests {
                     Parameter::keyword_only(Name::new_static("x")),
                     Parameter::keyword_only(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(*, x, y) -> None"
         );
@@ -3422,7 +3577,7 @@ mod tests {
                     Parameter::positional_or_keyword(Name::new_static("x")),
                     Parameter::keyword_only(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(x, *, y) -> None"
         );
@@ -3436,7 +3591,7 @@ mod tests {
                     Parameter::keyword_only(Name::new_static("x")),
                     Parameter::keyword_only(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"(a, /, *, x, y) -> None"
         );
@@ -3448,28 +3603,28 @@ mod tests {
                 [
                     Parameter::positional_only(Some(Name::new_static("a"))),
                     Parameter::positional_only(Some(Name::new_static("b")))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program)),
                     Parameter::positional_only(Some(Name::new_static("c")))
                         .with_default_type(Type::int_literal(1)),
                     Parameter::positional_only(Some(Name::new_static("d")))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(2)),
                     Parameter::positional_or_keyword(Name::new_static("e"))
                         .with_default_type(Type::int_literal(3)),
                     Parameter::positional_or_keyword(Name::new_static("f"))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(4)),
                     Parameter::variadic(Name::new_static("args"))
                         .with_annotated_type(Type::object()),
                     Parameter::keyword_only(Name::new_static("g"))
                         .with_default_type(Type::int_literal(5)),
                     Parameter::keyword_only(Name::new_static("h"))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(6)),
                     Parameter::keyword_variadic(Name::new_static("kwargs"))
-                        .with_annotated_type(KnownClass::Str.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Str.to_instance(&db, program)),
                 ],
-                Some(KnownClass::Bytes.to_instance(&db))
+                Some(KnownClass::Bytes.to_instance(&db, program))
             ),
             @"(a, b: int, c=1, d: int = 2, /, e=3, f: int = 4, *args: object, *, g=5, h: int = 6, **kwargs: str) -> bytes"
         );
@@ -3478,13 +3633,14 @@ mod tests {
     #[test]
     fn signature_display_multiline() {
         let db = setup_db();
+        let program = db.program();
 
         // Empty parameters with no return type.
         assert_snapshot!(display_signature_multiline(&db, [], None), @"() -> Unknown");
 
         // Empty parameters with a return type.
         assert_snapshot!(
-            display_signature_multiline(&db, [], Some(Type::none(&db))),
+            display_signature_multiline(&db, [], Some(Type::none(&db, program))),
             @"() -> None"
         );
 
@@ -3492,8 +3648,8 @@ mod tests {
         assert_snapshot!(
             display_signature_multiline(
                 &db,
-                [Parameter::positional_only(None).with_annotated_type(Type::none(&db))],
-                Some(Type::none(&db))
+                [Parameter::positional_only(None).with_annotated_type(Type::none(&db, program))],
+                Some(Type::none(&db, program))
             ),
             @"(None, /) -> None"
         );
@@ -3504,12 +3660,12 @@ mod tests {
                 &db,
                 [
                     Parameter::positional_or_keyword(Name::new_static("x"))
-                        .with_default_type(KnownClass::Int.to_instance(&db)),
+                        .with_default_type(KnownClass::Int.to_instance(&db, program)),
                     Parameter::positional_or_keyword(Name::new_static("y"))
-                        .with_annotated_type(KnownClass::Str.to_instance(&db))
-                        .with_default_type(KnownClass::Str.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Str.to_instance(&db, program))
+                        .with_default_type(KnownClass::Str.to_instance(&db, program)),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"
         (
@@ -3527,7 +3683,7 @@ mod tests {
                     Parameter::positional_only(Some(Name::new_static("x"))),
                     Parameter::positional_only(Some(Name::new_static("y"))),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"
         (
@@ -3546,7 +3702,7 @@ mod tests {
                     Parameter::positional_only(Some(Name::new_static("x"))),
                     Parameter::positional_or_keyword(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"
         (
@@ -3565,7 +3721,7 @@ mod tests {
                     Parameter::keyword_only(Name::new_static("x")),
                     Parameter::keyword_only(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"
         (
@@ -3584,7 +3740,7 @@ mod tests {
                     Parameter::positional_or_keyword(Name::new_static("x")),
                     Parameter::keyword_only(Name::new_static("y")),
                 ],
-                Some(Type::none(&db))
+                Some(Type::none(&db, program))
             ),
             @"
         (
@@ -3602,28 +3758,28 @@ mod tests {
                 [
                     Parameter::positional_only(Some(Name::new_static("a"))),
                     Parameter::positional_only(Some(Name::new_static("b")))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program)),
                     Parameter::positional_only(Some(Name::new_static("c")))
                         .with_default_type(Type::int_literal(1)),
                     Parameter::positional_only(Some(Name::new_static("d")))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(2)),
                     Parameter::positional_or_keyword(Name::new_static("e"))
                         .with_default_type(Type::int_literal(3)),
                     Parameter::positional_or_keyword(Name::new_static("f"))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(4)),
                     Parameter::variadic(Name::new_static("args"))
                         .with_annotated_type(Type::object()),
                     Parameter::keyword_only(Name::new_static("g"))
                         .with_default_type(Type::int_literal(5)),
                     Parameter::keyword_only(Name::new_static("h"))
-                        .with_annotated_type(KnownClass::Int.to_instance(&db))
+                        .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                         .with_default_type(Type::int_literal(6)),
                     Parameter::keyword_variadic(Name::new_static("kwargs"))
-                        .with_annotated_type(KnownClass::Str.to_instance(&db)),
+                        .with_annotated_type(KnownClass::Str.to_instance(&db, program)),
                 ],
-                Some(KnownClass::Bytes.to_instance(&db))
+                Some(KnownClass::Bytes.to_instance(&db, program))
             ),
             @"
         (

--- a/crates/ty_python_semantic/src/types/enums.rs
+++ b/crates/ty_python_semantic/src/types/enums.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 
 use crate::FxOrderSet;
 use crate::{
-    Db, FxIndexMap,
+    Db, FxIndexMap, Program,
     place::{
         DefinedPlace, Place, PlaceAndQualifiers, place_from_bindings, place_from_declarations,
     },
@@ -50,7 +50,7 @@ pub(super) enum ResolvedEnumMethod<'db> {
 ///
 /// User-defined data types are excluded because their construction, attribute access, equality, and
 /// hashing semantics can differ from the built-in scalar later in their MRO.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::SalsaValue)]
 enum KnownEnumDataTypeMixin {
     Int,
     Str,
@@ -61,9 +61,16 @@ impl KnownEnumDataTypeMixin {
     ///
     /// Literal conversions are preserved precisely, unions are normalized element-wise, and values
     /// whose conversion cannot be modeled precisely fall back to the mixin's instance type.
-    fn normalize_value<'db>(self, db: &'db dyn Db, value: Type<'db>) -> Type<'db> {
+    fn normalize_value<'db>(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        value: Type<'db>,
+    ) -> Type<'db> {
         if let Type::Union(union) = value {
-            return union.map(db, |element| self.normalize_value(db, *element));
+            return union.map(db, program, |element| {
+                self.normalize_value(db, program, *element)
+            });
         }
 
         match (self, value.as_literal_value_kind()) {
@@ -78,8 +85,8 @@ impl KnownEnumDataTypeMixin {
             (Self::Str, Some(LiteralValueTypeKind::Bool(value))) => {
                 Type::string_literal(db, if value { "True" } else { "False" })
             }
-            (Self::Int, _) => KnownClass::Int.to_instance(db),
-            (Self::Str, _) => KnownClass::Str.to_instance(db),
+            (Self::Int, _) => KnownClass::Int.to_instance(db, program),
+            (Self::Str, _) => KnownClass::Str.to_instance(db, program),
         }
     }
 }
@@ -160,13 +167,18 @@ impl<'db> EnumValueConstruction<'db> {
 
     /// Returns the payload after known built-in data-type construction, or `None` when the
     /// constructor may coerce it in a way that ty does not model.
-    fn normalize_value(self, db: &'db dyn Db, value: Type<'db>) -> Option<Type<'db>> {
+    fn normalize_value(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        value: Type<'db>,
+    ) -> Option<Type<'db>> {
         match self.data_type {
             InheritedEnumDataType::None => Some(value),
             InheritedEnumDataType::DeclaredValue(data_type) => {
-                value_has_exact_known_class(db, value, data_type).then_some(value)
+                value_has_exact_known_class(db, program, value, data_type).then_some(value)
             }
-            InheritedEnumDataType::Known(mixin) => Some(mixin.normalize_value(db, value)),
+            InheritedEnumDataType::Known(mixin) => Some(mixin.normalize_value(db, program, value)),
             InheritedEnumDataType::Opaque => None,
         }
     }
@@ -182,6 +194,7 @@ impl<'db> EnumValueConstruction<'db> {
     fn alias_detection_value(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         value_ty: Type<'db>,
         is_auto: bool,
     ) -> Option<Type<'db>> {
@@ -197,11 +210,13 @@ impl<'db> EnumValueConstruction<'db> {
         } else if self.generate_next_value.is_opaque() {
             return None;
         } else if let Some(function) = self.generate_next_value.function() {
-            function.signature(db).overload_return_type_or_unknown(db)
+            function
+                .signature(db)
+                .overload_return_type_or_unknown(db, program)
         } else {
             value_ty
         };
-        self.normalize_value(db, value)
+        self.normalize_value(db, program, value)
     }
 }
 
@@ -287,7 +302,6 @@ pub struct EnumClassLiteral<'db> {
     #[returns(ref)]
     pub(crate) aliases: Box<[(Name, Name)]>,
     /// Whether the canonical member and alias sets are known exactly.
-    #[returns(copy)]
     pub(super) aliases_are_known: bool,
     /// Whether the canonical members exhaust the runtime values of this enum class.
     ///
@@ -312,11 +326,16 @@ fn enum_class_literal<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 ) -> Option<EnumClassLiteral<'db>> {
+    let program = class.program(db);
     let metadata = enum_metadata(db, class)?;
     let members = metadata
         .members
         .keys()
-        .map(|name| metadata.value_type(db, name).map(|ty| (name.clone(), ty)))
+        .map(|name| {
+            metadata
+                .value_type(db, program, name)
+                .map(|ty| (name.clone(), ty))
+        })
         .collect::<Option<Box<[_]>>>()?;
     let mut aliases: Vec<_> = metadata
         .aliases
@@ -325,7 +344,11 @@ fn enum_class_literal<'db>(
         .collect();
     aliases.sort_unstable();
     let members_are_exhaustive = !metadata.value_construction.metaclass_may_transform_values
-        && !Type::ClassLiteral(class).is_subtype_of(db, KnownClass::Flag.to_subclass_of(db))
+        && !Type::ClassLiteral(class).is_subtype_of(
+            db,
+            program,
+            KnownClass::Flag.to_subclass_of(db, program),
+        )
         && !enum_has_custom_missing(db, class);
 
     Some(EnumClassLiteral::new(
@@ -383,8 +406,7 @@ impl<'db> EnumClassLiteral<'db> {
     /// Returns the type of `.name`/`._name_` for a given enum member.
     ///
     /// This is the canonical member name when alias detection is precise. When alias detection is
-    /// inconclusive, we intentionally favor useful literal inference and assume the declaration is
-    /// canonical, even though custom enum construction could make it an alias of another member.
+    /// inconclusive, favor useful literal inference and assume the declaration is canonical.
     pub(crate) fn name_type(self, db: &'db dyn Db, name: &Name) -> Option<Type<'db>> {
         self.resolve_member(db, name)
             .map(|name| Type::string_literal(db, name))
@@ -408,9 +430,10 @@ pub(super) fn instance_member_for_enum_complement<'db>(
     if let Some(member) = special_member_for_enum_complement(db, complement, name) {
         member
     } else {
+        let program = complement.enum_class(db).program(db);
         complement
             .remaining_literal_union(db)
-            .instance_member(db, name)
+            .instance_member(db, program, name)
     }
 }
 
@@ -427,9 +450,10 @@ pub(super) fn member_lookup_for_enum_complement<'db>(
     if let Some(member) = special_member_for_enum_complement(db, complement, name) {
         member
     } else {
+        let program = complement.enum_class(db).program(db);
         complement
             .remaining_literal_union(db)
-            .member_lookup_with_policy(db, name.into(), policy)
+            .member_lookup_with_policy(db, program, name.into(), policy)
     }
 }
 
@@ -461,16 +485,16 @@ fn special_member_for_enum_complement<'db>(
 /// are normalized to the annotated class by constructors such as `int.__new__`.
 fn known_constructor_preserves_value_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     value: Type<'db>,
     annotation: Type<'db>,
 ) -> bool {
     let annotation = annotation.resolve_type_alias(db);
     match value.resolve_type_alias(db) {
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| known_constructor_preserves_value_type(db, *element, annotation)),
-        Type::LiteralValue(literal) => literal.fallback_instance(db) == annotation,
+        Type::Union(union) => union.elements(db).iter().all(|element| {
+            known_constructor_preserves_value_type(db, program, *element, annotation)
+        }),
+        Type::LiteralValue(literal) => literal.fallback_instance(db, program) == annotation,
         value => value == annotation,
     }
 }
@@ -480,6 +504,7 @@ fn known_constructor_preserves_value_type<'db>(
 /// constructor may return an instance of the built-in base.
 fn value_has_exact_known_class<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     value: Type<'db>,
     data_type: KnownClass,
 ) -> bool {
@@ -487,8 +512,8 @@ fn value_has_exact_known_class<'db>(
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| value_has_exact_known_class(db, *element, data_type)),
-        Type::LiteralValue(literal) => match literal.fallback_instance(db) {
+            .all(|element| value_has_exact_known_class(db, program, *element, data_type)),
+        Type::LiteralValue(literal) => match literal.fallback_instance(db, program) {
             Type::NominalInstance(instance) => instance.has_known_class(db, data_type),
             _ => false,
         },
@@ -516,7 +541,12 @@ impl<'db> EnumMetadata<'db> {
     /// data types normalize the value directly. A literal is preserved when its runtime class
     /// matches an inherited `_value_` annotation; otherwise, the annotation describes the
     /// normalized value.
-    pub(crate) fn value_type(&self, db: &'db dyn Db, member_name: &Name) -> Option<Type<'db>> {
+    pub(crate) fn value_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        member_name: &Name,
+    ) -> Option<Type<'db>> {
         if !self.members.contains_key(member_name) {
             return None;
         }
@@ -524,12 +554,12 @@ impl<'db> EnumMetadata<'db> {
         if let Some(EnumValueAnnotation::UserDefined(annotation)) = self.value_annotation {
             return Some(annotation);
         }
-        let Some(value) = self.concrete_value_type(db, member_name) else {
+        let Some(value) = self.concrete_value_type(db, program, member_name) else {
             return Some(Type::Dynamic(DynamicType::Any));
         };
 
         if let Some(EnumValueAnnotation::StandardLibrary(annotation)) = self.value_annotation
-            && !known_constructor_preserves_value_type(db, value, annotation)
+            && !known_constructor_preserves_value_type(db, program, value, annotation)
         {
             Some(annotation)
         } else {
@@ -544,6 +574,7 @@ impl<'db> EnumMetadata<'db> {
     pub(super) fn concrete_value_type(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         member_name: &Name,
     ) -> Option<Type<'db>> {
         let declared_value = self.members.get(member_name).copied()?;
@@ -557,11 +588,13 @@ impl<'db> EnumMetadata<'db> {
                 .is_user_defined()
             && let Some(func_ty) = self.value_construction.generate_next_value.function()
         {
-            func_ty.signature(db).overload_return_type_or_unknown(db)
+            func_ty
+                .signature(db)
+                .overload_return_type_or_unknown(db, program)
         } else {
             declared_value
         };
-        self.value_construction.normalize_value(db, value)
+        self.value_construction.normalize_value(db, program, value)
     }
 
     /// Return whether enum construction may replace the value declared for `member_name`.
@@ -580,7 +613,11 @@ impl<'db> EnumMetadata<'db> {
     /// metaclass that may transform member values, returns `Any`.
     /// Otherwise, returns the union of each member's `value_type`, which
     /// applies `_generate_next_value_`'s return type to `auto()` members.
-    pub(crate) fn instance_value_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn instance_value_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<Type<'db>> {
         if self.members.is_empty() {
             return None;
         }
@@ -592,8 +629,8 @@ impl<'db> EnumMetadata<'db> {
             let union = self
                 .members
                 .keys()
-                .filter_map(|name| self.value_type(db, name))
-                .fold(UnionBuilder::new(db), UnionBuilder::add)
+                .filter_map(|name| self.value_type(db, program, name))
+                .fold(UnionBuilder::new(db, program), UnionBuilder::add)
                 .build();
             Some(union)
         }
@@ -608,7 +645,11 @@ impl<'db> EnumMetadata<'db> {
     /// narrowed to a specific member (e.g. `x: MyEnum` where `MyEnum` has multiple members).
     ///
     /// Returns the union of all member name string literals.
-    pub(crate) fn instance_name_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn instance_name_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<Type<'db>> {
         if self.members.is_empty() {
             return None;
         }
@@ -616,7 +657,7 @@ impl<'db> EnumMetadata<'db> {
             .members
             .keys()
             .map(|name| Type::string_literal(db, name))
-            .fold(UnionBuilder::new(db), UnionBuilder::add)
+            .fold(UnionBuilder::new(db, program), UnionBuilder::add)
             .build();
         Some(union)
     }
@@ -663,6 +704,7 @@ impl<'db> EnumComplementType<'db> {
     /// Recognize the compact enum-complement shape inside an intersection.
     pub(crate) fn from_intersection_parts(
         db: &'db dyn Db,
+        program: crate::Program,
         positive: &FxOrderSet<Type<'db>>,
         negative: &NegativeIntersectionElements<'db>,
     ) -> Option<Self> {
@@ -674,7 +716,8 @@ impl<'db> EnumComplementType<'db> {
                 continue;
             };
 
-            let Some(enum_class_literal) = instance.class_literal(db).into_enum_class(db) else {
+            let Some(enum_class_literal) = instance.class_literal(db, program).into_enum_class(db)
+            else {
                 rest.push(*positive);
                 continue;
             };
@@ -739,11 +782,12 @@ impl<'db> EnumComplementType<'db> {
     /// Enums that override equality are excluded because one remaining enum literal can still
     /// compare equal to non-identical values.
     pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+        let program = self.enum_class(db).program(db);
         self.is_singleton(db)
             && !self
                 .enum_class(db)
                 .to_non_generic_instance(db)
-                .overrides_equality(db)
+                .overrides_equality(db, program)
     }
 
     /// Expand this complement to the enum literals that remain possible.
@@ -772,13 +816,14 @@ impl<'db> EnumComplementType<'db> {
 
     /// Build the type for one remaining canonical member, preserving any positive rest components.
     fn remaining_literal_type(self, db: &'db dyn Db, name: &Name) -> Type<'db> {
+        let program = self.enum_class_literal(db).class_literal(db).program(db);
         let literal =
             Type::enum_literal(EnumLiteralType::new(db, self.enum_class_literal(db), name));
         if self.rest(db).is_empty() {
             return literal;
         }
 
-        let mut builder = IntersectionBuilder::new(db).add_positive(literal);
+        let mut builder = IntersectionBuilder::new(db, program).add_positive(literal);
         for rest in self.rest(db) {
             builder = builder.add_positive(*rest);
         }
@@ -812,9 +857,13 @@ impl<'db> EnumComplementType<'db> {
     /// attribute type from each remaining canonical enum member.
     pub(crate) fn member_type(self, db: &'db dyn Db, member_name: &str) -> Option<Type<'db>> {
         let enum_class_literal = self.enum_class_literal(db);
-        let is_enum_subclass = Type::ClassLiteral(self.enum_class(db))
-            .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db));
-        let mut builder = UnionBuilder::new(db);
+        let program = enum_class_literal.class_literal(db).program(db);
+        let is_enum_subclass = Type::ClassLiteral(self.enum_class(db)).is_subtype_of(
+            db,
+            program,
+            KnownClass::Enum.to_subclass_of(db, program),
+        );
+        let mut builder = UnionBuilder::new(db, program);
         let mut found_member = false;
 
         for name in self.remaining_member_names(db) {
@@ -864,6 +913,7 @@ impl<'db> EnumComplementType<'db> {
 /// Returns the set of names listed in an enum's `_ignore_` attribute.
 #[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
 pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -> FxHashSet<Name> {
+    let program = scope_id.program(db);
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
@@ -872,7 +922,7 @@ pub(crate) fn enum_ignored_names<'db>(db: &'db dyn Db, scope_id: ScopeId<'db>) -
     };
 
     let ignore_bindings = use_def_map.reachable_symbol_bindings(ignore);
-    let ignore_place = place_from_bindings(db, ignore_bindings).place;
+    let ignore_place = place_from_bindings(db, program, ignore_bindings).place;
 
     match ignore_place {
         Place::Defined(DefinedPlace { ty, .. }) => ty
@@ -925,6 +975,7 @@ pub(crate) fn enum_metadata<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 ) -> Option<EnumMetadata<'db>> {
+    let program = class.program(db);
     let class = match class {
         ClassLiteral::Static(class) => class,
         ClassLiteral::Dynamic(..) => {
@@ -954,7 +1005,7 @@ pub(crate) fn enum_metadata<'db>(
             let mut enum_values: FxHashMap<LiteralValueTypeKind<'db>, Name> = FxHashMap::default();
             for (name, ty) in spec.members(db) {
                 if value_construction
-                    .alias_detection_value(db, *ty, false)
+                    .alias_detection_value(db, program, *ty, false)
                     .and_then(|alias_value_ty| {
                         try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
                             // Identical raw literals remain aliases even when normalization widens.
@@ -1058,7 +1109,7 @@ pub(crate) fn enum_metadata<'db>(
                 return None;
             }
 
-            let inferred = place_from_bindings(db, bindings).place;
+            let inferred = place_from_bindings(db, program, bindings).place;
             let mut explicit_member_wrapper = false;
 
             let value_ty = match inferred {
@@ -1079,7 +1130,7 @@ pub(crate) fn enum_metadata<'db>(
                             Some(KnownClass::Member) => {
                                 explicit_member_wrapper = true;
                                 Some(
-                                    ty.member(db, "value")
+                                    ty.member(db, program, "value")
                                         .place
                                         .ignore_possibly_undefined()
                                         .unwrap_or(Type::unknown()),
@@ -1094,7 +1145,11 @@ pub(crate) fn enum_metadata<'db>(
                                 // `StrEnum`s have different `auto()` behaviour to enums inheriting from `(str, Enum)`
                                 let auto_value_ty =
                                     if Type::ClassLiteral(ClassLiteral::Static(class))
-                                        .is_subtype_of(db, KnownClass::StrEnum.to_subclass_of(db))
+                                        .is_subtype_of(
+                                            db,
+                                            program,
+                                            KnownClass::StrEnum.to_subclass_of(db, program),
+                                        )
                                     {
                                         Type::string_literal(db, &*name.to_lowercase())
                                     } else {
@@ -1106,7 +1161,9 @@ pub(crate) fn enum_metadata<'db>(
                                                 .filter(|class| {
                                                     !Type::from(*class).is_subtype_of(
                                                         db,
-                                                        KnownClass::Enum.to_subclass_of(db),
+                                                        program,
+                                                        KnownClass::Enum
+                                                            .to_subclass_of(db, program),
                                                     )
                                                 })
                                                 .map(|class| class.known(db))
@@ -1125,7 +1182,7 @@ pub(crate) fn enum_metadata<'db>(
                                             [] | [Some(KnownClass::Int)]
                                         ) {
                                             if prev_value_was_non_literal_int {
-                                                KnownClass::Int.to_instance(db)
+                                                KnownClass::Int.to_instance(db, program)
                                             } else if let Some(prev_bool_literal) =
                                                 prev_bool_literal
                                             {
@@ -1152,6 +1209,7 @@ pub(crate) fn enum_metadata<'db>(
                         let dunder_get = ty
                             .member_lookup_with_policy(
                                 db,
+                                program,
                                 "__get__".into(),
                                 MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                             )
@@ -1182,7 +1240,13 @@ pub(crate) fn enum_metadata<'db>(
                             declaration.kind(db),
                             DefinitionKind::AnnotatedAssignment(assignment)
                                 if assignment
-                                    .value(&parsed_module(db, declaration.file(db)).load(db))
+                                    .value(
+                                        &parsed_module(
+                                            db,
+                                            declaration.program_file(db).versioned_file(db),
+                                        )
+                                        .load(db),
+                                    )
                                     .is_some()
                         )
                     })
@@ -1194,7 +1258,7 @@ pub(crate) fn enum_metadata<'db>(
             // Track whether this member's value is a non-literal `int`, so a
             // following `auto()` knows to widen its result to `int`.
             prev_value_was_non_literal_int = value_ty.as_int_like_literal().is_none()
-                && value_ty.is_assignable_to(db, KnownClass::Int.to_instance(db));
+                && value_ty.is_assignable_to(db, program, KnownClass::Int.to_instance(db, program));
             prev_bool_literal =
                 value_ty
                     .as_literal_value_kind()
@@ -1204,7 +1268,7 @@ pub(crate) fn enum_metadata<'db>(
                     });
 
             match value_construction
-                .alias_detection_value(db, value_ty, auto_members.contains(name))
+                .alias_detection_value(db, program, value_ty, auto_members.contains(name))
                 .and_then(|alias_value_ty| {
                     try_register_alias(alias_value_ty, name, &mut enum_values, &mut aliases)
                 }) {
@@ -1299,9 +1363,10 @@ fn iter_parent_enum_classes<'db>(
 
 /// Returns the `_value_` annotation type if one is declared in the given scope.
 fn custom_value_annotation<'db>(db: &'db dyn Db, scope: ScopeId<'db>) -> Option<Type<'db>> {
+    let program = scope.program(db);
     let symbol_id = place_table(db, scope).symbol_id("_value_")?;
     let declarations = use_def_map(db, scope).end_of_scope_symbol_declarations(symbol_id);
-    place_from_declarations(db, declarations)
+    place_from_declarations(db, program, declarations)
         .ignore_conflicting_declarations()
         .ignore_possibly_undefined()
 }
@@ -1325,7 +1390,7 @@ fn inherited_user_defined_value_annotation<'db>(
         .find_map(|base| custom_value_annotation(db, base.body_scope(db)))
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, salsa::SalsaValue)]
 enum InheritedEnumDataType {
     #[default]
     None,
@@ -1537,11 +1602,16 @@ pub(crate) fn is_enum_class_by_inheritance<'db>(
     db: &'db dyn Db,
     class: StaticClassLiteral<'db>,
 ) -> bool {
-    Type::ClassLiteral(ClassLiteral::Static(class))
-        .is_subtype_of(db, KnownClass::Enum.to_subclass_of(db))
-        || class
-            .metaclass(db)
-            .is_subtype_of(db, KnownClass::EnumType.to_subclass_of(db))
+    let program = class.program(db);
+    Type::ClassLiteral(ClassLiteral::Static(class)).is_subtype_of(
+        db,
+        program,
+        KnownClass::Enum.to_subclass_of(db, program),
+    ) || class.metaclass(db).is_subtype_of(
+        db,
+        program,
+        KnownClass::EnumType.to_subclass_of(db, program),
+    )
 }
 
 /// Extracts the inner value type from an `enum.nonmember()` wrapper.
@@ -1550,11 +1620,15 @@ pub(crate) fn is_enum_class_by_inheritance<'db>(
 /// returns the inner value, not the `nonmember` wrapper.
 ///
 /// Returns `Some(value_type)` if the type is a `nonmember[T]`, otherwise `None`.
-pub(crate) fn try_unwrap_nonmember_value<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+pub(crate) fn try_unwrap_nonmember_value<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    ty: Type<'db>,
+) -> Option<Type<'db>> {
     match ty {
         Type::NominalInstance(instance) if instance.has_known_class(db, KnownClass::Nonmember) => {
             Some(
-                ty.member(db, "value")
+                ty.member(db, program, "value")
                     .place
                     .ignore_possibly_undefined()
                     .unwrap_or(Type::unknown()),

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -7,7 +7,7 @@
 use ruff_python_ast::name::Name;
 use rustc_hash::FxHashSet;
 
-use crate::{Db, place::PlaceAndQualifiers};
+use crate::{Db, Program, place::PlaceAndQualifiers};
 
 use super::{
     EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueType,
@@ -126,6 +126,7 @@ impl<'db> ComparisonResult<'db> {
 /// constrain `left`.
 pub(super) fn evaluate_type_equality<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     is_positive: bool,
@@ -136,6 +137,7 @@ pub(super) fn evaluate_type_equality<'db>(
         ComparisonOperator::Equality.condition_expects_equality(branch);
     enum_literal_constraint(
         db,
+        program,
         left,
         right,
         ComparisonOperator::Equality,
@@ -144,6 +146,7 @@ pub(super) fn evaluate_type_equality<'db>(
     .or_else(|| {
         builtin_literal_constraint(
             db,
+            program,
             left,
             right,
             ComparisonOperator::Equality,
@@ -151,14 +154,21 @@ pub(super) fn evaluate_type_equality<'db>(
         )
     })
     .or_else(|| {
-        evaluate_enum_domains(db, left, right, branch, ComparisonOperator::Equality)
-            .and_then(|result| result.constraint(branch))
+        evaluate_enum_domains(
+            db,
+            program,
+            left,
+            right,
+            branch,
+            ComparisonOperator::Equality,
+        )
+        .and_then(|result| result.constraint(branch))
     })
     .or_else(|| {
-        if comparison_domain(db, left, right, ComparisonOperator::Equality)
+        if comparison_domain(db, program, left, right, ComparisonOperator::Equality)
             == ComparisonDomain::Known
         {
-            ComparisonEvaluator::new(db, soundness_policy)
+            ComparisonEvaluator::new(db, program, soundness_policy)
                 .evaluate(left, right, branch, ComparisonOperator::Equality)
                 .constraint(branch)
         } else {
@@ -170,19 +180,23 @@ pub(super) fn evaluate_type_equality<'db>(
 /// Return a constraint excluding every value known to compare equal to `ty`.
 pub(super) fn equality_exclusion_constraint<'db>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
 ) -> Option<Type<'db>> {
     let ty = ty.resolve_type_alias(db);
-    builtin_literal_constraint(db, ty, ty, ComparisonOperator::Equality, false)
-        .or_else(|| ty.is_single_valued(db).then(|| ty.negate(db)))
+    builtin_literal_constraint(db, program, ty, ty, ComparisonOperator::Equality, false)
         .or_else(|| {
-            (ComparisonEvaluator::conservative(db).evaluate(
+            ty.is_single_valued(db, program)
+                .then(|| ty.negate(db, program))
+        })
+        .or_else(|| {
+            (ComparisonEvaluator::conservative(db, program).evaluate(
                 ty,
                 ty,
                 ComparisonBranch::Positive,
                 ComparisonOperator::Equality,
             ) == ComparisonResult::AlwaysTrue)
-                .then(|| ty.negate(db))
+                .then(|| ty.negate(db, program))
         })
 }
 
@@ -208,6 +222,7 @@ pub(super) fn equality_exclusion_constraint<'db>(
 /// ```
 pub(super) fn evaluate_type_inequality<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     is_positive: bool,
@@ -218,6 +233,7 @@ pub(super) fn evaluate_type_inequality<'db>(
         ComparisonOperator::Inequality.condition_expects_equality(branch);
     enum_literal_constraint(
         db,
+        program,
         left,
         right,
         ComparisonOperator::Inequality,
@@ -226,6 +242,7 @@ pub(super) fn evaluate_type_inequality<'db>(
     .or_else(|| {
         builtin_literal_constraint(
             db,
+            program,
             left,
             right,
             ComparisonOperator::Inequality,
@@ -233,7 +250,7 @@ pub(super) fn evaluate_type_inequality<'db>(
         )
     })
     .or_else(|| {
-        ComparisonEvaluator::new(db, soundness_policy)
+        ComparisonEvaluator::new(db, program, soundness_policy)
             .evaluate(left, right, branch, ComparisonOperator::Inequality)
             .constraint(branch)
     })
@@ -244,10 +261,11 @@ pub(super) fn evaluate_type_inequality<'db>(
 /// A result that only permits narrowing remains ambiguous because it can still evaluate either way.
 pub(crate) fn equality_truthiness<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    comparison_truthiness(db, left, right, ComparisonOperator::Equality)
+    comparison_truthiness(db, program, left, right, ComparisonOperator::Equality)
 }
 
 /// Return the truthiness of `left != right` when it is known for every represented runtime value.
@@ -255,19 +273,21 @@ pub(crate) fn equality_truthiness<'db>(
 /// A result that only permits narrowing remains ambiguous because it can still evaluate either way.
 pub(super) fn inequality_truthiness<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    comparison_truthiness(db, left, right, ComparisonOperator::Inequality)
+    comparison_truthiness(db, program, left, right, ComparisonOperator::Inequality)
 }
 
 fn comparison_truthiness<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
 ) -> Truthiness {
-    match ComparisonEvaluator::for_truthiness(db).evaluate(
+    match ComparisonEvaluator::for_truthiness(db, program).evaluate(
         left,
         right,
         ComparisonBranch::Positive,
@@ -339,28 +359,31 @@ struct ComparisonKey<'db> {
 /// Tracks comparisons that are already in progress so recursive evaluation terminates.
 struct ComparisonEvaluator<'db> {
     db: &'db dyn Db,
+    program: Program,
     active: FxHashSet<ComparisonKey<'db>>,
     goal: ComparisonGoal,
     soundness_policy: ComparisonSoundnessPolicy,
 }
 
 impl<'db> ComparisonEvaluator<'db> {
-    fn new(db: &'db dyn Db, soundness_policy: ComparisonSoundnessPolicy) -> Self {
+    fn new(db: &'db dyn Db, program: Program, soundness_policy: ComparisonSoundnessPolicy) -> Self {
         Self {
             db,
+            program,
             active: FxHashSet::default(),
             goal: ComparisonGoal::Constraint,
             soundness_policy,
         }
     }
 
-    fn conservative(db: &'db dyn Db) -> Self {
-        Self::new(db, ComparisonSoundnessPolicy::Conservative)
+    fn conservative(db: &'db dyn Db, program: Program) -> Self {
+        Self::new(db, program, ComparisonSoundnessPolicy::Conservative)
     }
 
-    fn for_truthiness(db: &'db dyn Db) -> Self {
+    fn for_truthiness(db: &'db dyn Db, program: Program) -> Self {
         Self {
             db,
+            program,
             active: FxHashSet::default(),
             goal: ComparisonGoal::Truthiness,
             soundness_policy: ComparisonSoundnessPolicy::Conservative,
@@ -426,15 +449,16 @@ fn evaluate_comparison_once<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
+    let program = evaluator.program;
 
-    if let Some(result) = evaluate_enum_domains(db, left, right, branch, operator) {
+    if let Some(result) = evaluate_enum_domains(db, program, left, right, branch, operator) {
         return result;
     }
 
-    if let Some(alternatives) = finite_alternatives(db, left, operator) {
+    if let Some(alternatives) = finite_alternatives(db, program, left, operator) {
         return evaluate_union_left(evaluator, &alternatives, right, branch, operator);
     }
-    if let Some(alternatives) = finite_alternatives(db, right, operator) {
+    if let Some(alternatives) = finite_alternatives(db, program, right, operator) {
         return evaluate_union_right(evaluator, left, &alternatives, branch, operator);
     }
 
@@ -467,7 +491,7 @@ fn evaluate_comparison_once<'db>(
                 && all_values_compare_equal(evaluator, other, operator)
             {
                 ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
+                    IntersectionBuilder::new(db, program)
                         .add_positive(left)
                         .add_negative(other)
                         .build(),
@@ -484,18 +508,18 @@ fn evaluate_comparison_once<'db>(
                 if !operator.condition_expects_equality(branch)
                     && all_values_compare_equal(evaluator, other, operator)
                 {
-                    ComparisonResult::CanNarrow(other.negate(db))
+                    ComparisonResult::CanNarrow(other.negate(db, program))
                 } else {
                     ComparisonResult::Ambiguous
                 }
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(constraints.as_type(db), other, branch, operator)
+                evaluator.evaluate(constraints.as_type(db, program), other, branch, operator)
             }
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(other, constraints.as_type(db), branch, operator)
+                evaluator.evaluate(other, constraints.as_type(db, program), branch, operator)
             }
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
@@ -523,10 +547,17 @@ fn evaluate_comparison_once<'db>(
         ),
 
         (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
-            match known_literal_equality(db, left_literal.kind(), right_literal.kind(), operator) {
+            match known_literal_equality(
+                db,
+                program,
+                left_literal.kind(),
+                right_literal.kind(),
+                operator,
+            ) {
                 Some(equal) => operator.result_from_equality(equal),
                 None => narrow_literal_comparison(
                     db,
+                    program,
                     left,
                     right,
                     left_literal.kind(),
@@ -557,7 +588,7 @@ fn evaluate_comparison_once<'db>(
 
         (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-            match KnownComparisonSemantics::of_type(db, other, operator) {
+            match KnownComparisonSemantics::of_type(db, program, other, operator) {
                 Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
                 Some(_) => operator.result_from_equality(false),
             }
@@ -586,20 +617,20 @@ fn evaluate_comparison_once<'db>(
         ) if left_function == right_function => operator.result_from_equality(true),
         (Type::KnownInstance(left_instance), Type::KnownInstance(right_instance))
             if left_instance == right_instance
-                && left.is_single_valued(db)
+                && left.is_single_valued(db, program)
                 && operator == ComparisonOperator::Equality =>
         {
             ComparisonResult::AlwaysTrue
         }
         (left, right)
-            if has_known_identity_comparison_semantics(db, left, operator)
-                && has_known_identity_comparison_semantics(db, right, operator) =>
+            if has_known_identity_comparison_semantics(db, program, left, operator)
+                && has_known_identity_comparison_semantics(db, program, right, operator) =>
         {
             operator.result_from_equality(left == right)
         }
 
         (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
-            compare_nominal_instances(db, left_instance, right_instance, operator)
+            compare_nominal_instances(db, program, left_instance, right_instance, operator)
         }
 
         _ => ComparisonResult::Ambiguous,
@@ -659,6 +690,7 @@ fn is_builtin_literal_type(db: &dyn Db, ty: Type) -> bool {
 /// both `Literal[0]` and `Literal[False]`, while `x != 1` excludes `Literal[1]` and `Literal[True]`.
 fn builtin_literal_constraint<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
@@ -668,18 +700,30 @@ fn builtin_literal_constraint<'db>(
         return None;
     };
 
-    let equal_to_right = builtin_literals_equal_to(db, Type::LiteralValue(right), right.kind())?;
+    let mut equal_to_right = match right.kind() {
+        LiteralValueTypeKind::Int(value) => {
+            let mut builder = UnionBuilder::new(db, program).add(Type::LiteralValue(right));
+            if matches!(value.as_i64(), 0 | 1) {
+                builder = builder.add(Type::bool_literal(value.as_i64() == 1));
+            }
+            builder
+        }
+        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db, program)
+            .add(Type::LiteralValue(right))
+            .add(Type::int_literal(i64::from(value))),
+        LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_) => {
+            UnionBuilder::new(db, program).add(Type::LiteralValue(right))
+        }
+        LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
+    };
 
     if !condition_expects_equality {
-        let equal_to_right = add_equal_enum_literals(
-            db,
-            left,
-            right.kind(),
-            operator,
-            UnionBuilder::new(db).add(equal_to_right),
-        );
-        return Some(equal_to_right.build().negate(db));
+        equal_to_right =
+            add_equal_enum_literals(db, program, left, right.kind(), operator, equal_to_right);
+        return Some(equal_to_right.build().negate(db, program));
     }
+
+    let equal_to_right = equal_to_right.build();
 
     match left.resolve_type_alias(db) {
         Type::Union(union) => union
@@ -695,22 +739,23 @@ fn builtin_literal_constraint<'db>(
 /// Return the builtin literal values that compare equal to `literal_type`.
 fn builtin_literals_equal_to<'db>(
     db: &'db dyn Db,
+    program: Program,
     literal_type: Type<'db>,
     literal: LiteralValueTypeKind<'db>,
 ) -> Option<Type<'db>> {
     let builder = match literal {
         LiteralValueTypeKind::Int(value) => {
-            let mut builder = UnionBuilder::new(db).add(literal_type);
+            let mut builder = UnionBuilder::new(db, program).add(literal_type);
             if matches!(value.as_i64(), 0 | 1) {
                 builder = builder.add(Type::bool_literal(value.as_i64() == 1));
             }
             builder
         }
-        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db)
+        LiteralValueTypeKind::Bool(value) => UnionBuilder::new(db, program)
             .add(literal_type)
             .add(Type::int_literal(i64::from(value))),
         LiteralValueTypeKind::String(_) | LiteralValueTypeKind::Bytes(_) => {
-            UnionBuilder::new(db).add(literal_type)
+            UnionBuilder::new(db, program).add(literal_type)
         }
         LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::Enum(_) => return None,
     };
@@ -720,6 +765,7 @@ fn builtin_literals_equal_to<'db>(
 /// Add finite enum members in `ty` that are known to compare equal to `right`.
 fn add_equal_enum_literals<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     right: LiteralValueTypeKind<'db>,
     operator: ComparisonOperator,
@@ -728,20 +774,22 @@ fn add_equal_enum_literals<'db>(
     match ty.resolve_type_alias(db) {
         Type::Union(union) => {
             for element in union.elements(db) {
-                builder = add_equal_enum_literals(db, *element, right, operator, builder);
+                builder = add_equal_enum_literals(db, program, *element, right, operator, builder);
             }
         }
         Type::LiteralValue(literal) => {
             if matches!(literal.kind(), LiteralValueTypeKind::Enum(_))
-                && known_literal_equality(db, literal.kind(), right, operator) == Some(true)
+                && known_literal_equality(db, program, literal.kind(), right, operator)
+                    == Some(true)
             {
                 builder = builder.add(Type::LiteralValue(literal));
             }
         }
         ty => {
-            if let Some(alternatives) = finite_alternatives(db, ty, operator) {
+            if let Some(alternatives) = finite_alternatives(db, program, ty, operator) {
                 for alternative in alternatives {
-                    builder = add_equal_enum_literals(db, alternative, right, operator, builder);
+                    builder =
+                        add_equal_enum_literals(db, program, alternative, right, operator, builder);
                 }
             }
         }
@@ -771,6 +819,7 @@ fn add_equal_enum_literals<'db>(
 /// because those methods can change whether two members compare equal.
 fn enum_literal_constraint<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
@@ -782,9 +831,14 @@ fn enum_literal_constraint<'db>(
     let LiteralValueTypeKind::Enum(right) = right_literal.kind() else {
         return None;
     };
-    if !is_same_enum_domain(db, left, right)
-        || KnownComparisonSemantics::of_instance(db, right.enum_class_instance(db), operator)
-            .is_none()
+    if !is_same_enum_domain(db, program, left, right)
+        || KnownComparisonSemantics::of_instance(
+            db,
+            program,
+            right.enum_class_instance(db),
+            operator,
+        )
+        .is_none()
     {
         return None;
     }
@@ -797,12 +851,13 @@ fn enum_literal_constraint<'db>(
         EnumLiteralType::new(db, enum_class_literal, name),
         right_literal.is_promotable(),
     ));
-    Some(equal_to_right.negate_if(db, !condition_expects_equality))
+    Some(equal_to_right.negate_if(db, program, !condition_expects_equality))
 }
 
 /// Return whether every possible value of `ty` belongs to the same enum as `right`.
 pub(super) fn is_same_enum_domain<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     right: EnumLiteralType<'db>,
 ) -> bool {
@@ -815,11 +870,13 @@ pub(super) fn is_same_enum_domain<'db>(
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| is_same_enum_domain(db, *element, right)),
-        Type::NominalInstance(instance) => instance.class_literal(db) == right.enum_class(db),
+            .all(|element| is_same_enum_domain(db, program, *element, right)),
+        Type::NominalInstance(instance) => {
+            instance.class_literal(db, program) == right.enum_class(db)
+        }
         Type::EnumComplement(complement) => complement.enum_class(db) == right.enum_class(db),
         Type::Intersection(intersection) => intersection
-            .enum_complement(db)
+            .enum_complement(db, program)
             .is_some_and(|complement| complement.enum_class(db) == right.enum_class(db)),
         _ => false,
     }
@@ -842,7 +899,7 @@ fn evaluate_union_left<'db>(
     }
 
     let db = evaluator.db;
-    evaluate_target_union(db, elements, branch, |element| {
+    evaluate_target_union(db, evaluator.program, elements, branch, |element| {
         evaluator.evaluate(element, other, branch, operator)
     })
 }
@@ -853,6 +910,7 @@ fn evaluate_union_left<'db>(
 /// negative constraints for removed arms so that the result still describes the branch predicate.
 fn evaluate_target_union<'db>(
     db: &'db dyn Db,
+    program: Program,
     elements: &[Type<'db>],
     branch: ComparisonBranch,
     mut evaluate: impl FnMut(Type<'db>) -> ComparisonResult<'db>,
@@ -864,7 +922,7 @@ fn evaluate_target_union<'db>(
     let mut all_true = true;
     let mut all_false = true;
     let mut narrowed = Vec::with_capacity(elements.len());
-    let mut removed = UnionBuilder::new(db);
+    let mut removed = UnionBuilder::new(db, program);
     let mut removed_any = false;
 
     for element in elements {
@@ -910,13 +968,13 @@ fn evaluate_target_union<'db>(
     }
 
     let removed = removed_any.then(|| removed.build());
-    let mut builder = UnionBuilder::new(db);
+    let mut builder = UnionBuilder::new(db, program);
     for narrowed in narrowed {
         let Some(mut narrowed) = narrowed else {
             continue;
         };
         if let Some(removed) = removed {
-            narrowed = IntersectionBuilder::new(db)
+            narrowed = IntersectionBuilder::new(db, program)
                 .add_positive(narrowed)
                 .add_negative(removed)
                 .build();
@@ -945,6 +1003,7 @@ fn evaluate_union_right<'db>(
     let db = evaluator.db;
     evaluate_against_results(
         db,
+        evaluator.program,
         left,
         branch,
         elements
@@ -987,13 +1046,14 @@ fn combine_definite_truthiness<'db>(
 /// truthiness is reported only when every alternative agrees.
 fn evaluate_against_results<'db>(
     db: &'db dyn Db,
+    program: Program,
     target: Type<'db>,
     branch: ComparisonBranch,
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
     let mut all_true = true;
     let mut all_false = true;
-    let mut builder = UnionBuilder::new(db);
+    let mut builder = UnionBuilder::new(db, program);
     let mut any = false;
 
     for result in results {
@@ -1053,11 +1113,12 @@ fn evaluate_intersection_left<'db>(
     }
 
     let db = evaluator.db;
+    let program = evaluator.program;
     let mut any_true = false;
     let mut any_false = false;
     let mut any_ambiguous = false;
     let mut any_narrowing = false;
-    let mut builder = IntersectionBuilder::new(db).add_positive(original);
+    let mut builder = IntersectionBuilder::new(db, program).add_positive(original);
 
     for element in positive {
         match evaluator.evaluate(*element, other, branch, operator) {
@@ -1089,16 +1150,19 @@ fn evaluate_intersection_left<'db>(
 /// may compare equal to values outside the enum domain.
 fn finite_alternatives<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     operator: ComparisonOperator,
 ) -> Option<Vec<Type<'db>>> {
     match ty {
-        Type::EnumComplement(complement) => KnownComparisonSemantics::of_type(db, ty, operator)
-            .is_some()
-            .then(|| complement.remaining_literal_types(db)),
+        Type::EnumComplement(complement) => {
+            KnownComparisonSemantics::of_type(db, program, ty, operator)
+                .is_some()
+                .then(|| complement.remaining_literal_types(db))
+        }
         Type::Intersection(intersection) => {
-            let complement = intersection.enum_complement(db)?;
-            KnownComparisonSemantics::of_type(db, ty, operator)
+            let complement = intersection.enum_complement(db, program)?;
+            KnownComparisonSemantics::of_type(db, program, ty, operator)
                 .is_some()
                 .then(|| complement.remaining_literal_types(db))
         }
@@ -1106,9 +1170,10 @@ fn finite_alternatives<'db>(
             Some(vec![Type::bool_literal(true), Type::bool_literal(false)])
         }
         Type::NominalInstance(instance)
-            if KnownComparisonSemantics::of_type(db, ty, operator).is_some() =>
+            if KnownComparisonSemantics::of_type(db, program, ty, operator).is_some() =>
         {
-            enum_member_literals(db, instance.class_literal(db), None).map(Iterator::collect)
+            enum_member_literals(db, instance.class_literal(db, program), None)
+                .map(Iterator::collect)
         }
         _ => None,
     }
@@ -1120,6 +1185,7 @@ fn finite_alternatives<'db>(
 /// or a string-valued enum member without having a single statically known runtime value.
 fn narrow_literal_comparison<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     left_literal: LiteralValueTypeKind<'db>,
@@ -1128,16 +1194,16 @@ fn narrow_literal_comparison<'db>(
 ) -> ComparisonResult<'db> {
     match (left_literal, right_literal) {
         (LiteralValueTypeKind::LiteralString, LiteralValueTypeKind::String(_)) => {
-            ComparisonResult::CanNarrow(right.negate_if(db, !equality_is_positive))
+            ComparisonResult::CanNarrow(right.negate_if(db, program, !equality_is_positive))
         }
         (LiteralValueTypeKind::String(_), LiteralValueTypeKind::LiteralString) => {
-            ComparisonResult::CanNarrow(left.negate_if(db, !equality_is_positive))
+            ComparisonResult::CanNarrow(left.negate_if(db, program, !equality_is_positive))
         }
         (LiteralValueTypeKind::LiteralString, LiteralValueTypeKind::Enum(enum_literal)) => {
-            narrow_literal_string_against_enum(db, enum_literal, equality_is_positive)
+            narrow_literal_string_against_enum(db, program, enum_literal, equality_is_positive)
         }
         (LiteralValueTypeKind::Enum(enum_literal), LiteralValueTypeKind::LiteralString) => {
-            narrow_literal_string_against_enum(db, enum_literal, equality_is_positive)
+            narrow_literal_string_against_enum(db, program, enum_literal, equality_is_positive)
         }
         _ => ComparisonResult::Ambiguous,
     }
@@ -1146,28 +1212,30 @@ fn narrow_literal_comparison<'db>(
 /// Narrow `LiteralString` against a string-valued enum member with inherited `str` semantics.
 fn narrow_literal_string_against_enum<'db>(
     db: &'db dyn Db,
+    program: Program,
     enum_literal: EnumLiteralType<'db>,
     equality_is_positive: bool,
 ) -> ComparisonResult<'db> {
     if KnownComparisonSemantics::of_type(
         db,
+        program,
         Type::enum_literal(enum_literal),
         ComparisonOperator::Equality,
     ) != Some(KnownComparisonSemantics::Str)
     {
         return ComparisonResult::Ambiguous;
     }
-    let Some(value @ Type::LiteralValue(_)) = enum_literal_value(db, enum_literal) else {
+    let Some(value @ Type::LiteralValue(_)) = enum_literal_value(db, program, enum_literal) else {
         return ComparisonResult::Ambiguous;
     };
     let Some(LiteralValueTypeKind::String(_)) = value.as_literal_value_kind() else {
         return ComparisonResult::Ambiguous;
     };
-    let narrowed = UnionBuilder::new(db)
+    let narrowed = UnionBuilder::new(db, program)
         .add(value)
         .add(Type::enum_literal(enum_literal))
         .build()
-        .negate_if(db, !equality_is_positive);
+        .negate_if(db, program, !equality_is_positive);
     ComparisonResult::CanNarrow(narrowed)
 }
 
@@ -1202,16 +1270,18 @@ fn compare_literal_to_other<'db>(
     literal_operand: LiteralOperand,
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
+    let program = evaluator.program;
 
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
-        return match KnownComparisonSemantics::of_type(db, other, operator) {
+        return match KnownComparisonSemantics::of_type(db, program, other, operator) {
             Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
             Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
             None => ComparisonResult::Ambiguous,
         };
     }
 
-    let Some(literal_semantics) = KnownComparisonSemantics::of_literal(db, literal, operator)
+    let Some(literal_semantics) =
+        KnownComparisonSemantics::of_literal(db, program, literal, operator)
     else {
         return ComparisonResult::Ambiguous;
     };
@@ -1223,7 +1293,8 @@ fn compare_literal_to_other<'db>(
     if evaluator.soundness_policy == ComparisonSoundnessPolicy::UnsafeLiteralNarrowing
         && condition_expects_equality
         && literal_operand == LiteralOperand::Other
-        && let Some(equal_to_literal) = builtin_literals_equal_to(db, literal_type, literal)
+        && let Some(equal_to_literal) =
+            builtin_literals_equal_to(db, program, literal_type, literal)
         && let Some(other_semantics) = unsafe_narrowable_builtin_semantics(db, other)
     {
         return if literal_semantics == other_semantics {
@@ -1233,13 +1304,13 @@ fn compare_literal_to_other<'db>(
         };
     }
 
-    match KnownComparisonSemantics::of_type(db, other, operator) {
+    match KnownComparisonSemantics::of_type(db, program, other, operator) {
         Some(other_semantics) if literal_semantics != other_semantics => {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
         Some(KnownComparisonSemantics::Object)
             if literal_semantics == KnownComparisonSemantics::Object
-                && other.is_disjoint_from(db, literal_type) =>
+                && other.is_disjoint_from(db, program, literal_type) =>
         {
             ComparisonResult::from_bool(operator == ComparisonOperator::Inequality)
         }
@@ -1247,17 +1318,21 @@ fn compare_literal_to_other<'db>(
         // `int` subclass can compare equal to `1` despite being disjoint from `Literal[1]`.
         Some(_)
             if literal_operand == LiteralOperand::Other
-                && literal_type.is_single_valued(db)
-                && !other.is_disjoint_from(db, literal_type) =>
+                && literal_type.is_single_valued(db, program)
+                && !other.is_disjoint_from(db, program, literal_type) =>
         {
-            ComparisonResult::CanNarrow(literal_type.negate_if(db, !condition_expects_equality))
+            ComparisonResult::CanNarrow(literal_type.negate_if(
+                db,
+                program,
+                !condition_expects_equality,
+            ))
         }
         Some(_) => ComparisonResult::Ambiguous,
         None if literal_operand == LiteralOperand::Other
             && !condition_expects_equality
-            && literal_type.is_single_valued(db) =>
+            && literal_type.is_single_valued(db, program) =>
         {
-            ComparisonResult::CanNarrow(literal_type.negate(db))
+            ComparisonResult::CanNarrow(literal_type.negate(db, program))
         }
         None => ComparisonResult::Ambiguous,
     }
@@ -1269,20 +1344,24 @@ fn compare_literal_to_other<'db>(
 /// denote the same singleton.
 fn compare_nominal_instances<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     left_instance: super::NominalInstanceType<'db>,
     right_instance: super::NominalInstanceType<'db>,
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     let left = Type::NominalInstance(left_instance);
     let right = Type::NominalInstance(right_instance);
-    let Some(left_semantics) = KnownComparisonSemantics::of_type(db, left, operator) else {
+    let Some(left_semantics) = KnownComparisonSemantics::of_type(db, program, left, operator)
+    else {
         return ComparisonResult::Ambiguous;
     };
-    let Some(right_semantics) = KnownComparisonSemantics::of_type(db, right, operator) else {
+    let Some(right_semantics) = KnownComparisonSemantics::of_type(db, program, right, operator)
+    else {
         return ComparisonResult::Ambiguous;
     };
 
-    let classes_differ = left_instance.class_literal(db) != right_instance.class_literal(db);
+    let classes_differ =
+        left_instance.class_literal(db, program) != right_instance.class_literal(db, program);
 
     if left_semantics != right_semantics
         || (left_semantics == KnownComparisonSemantics::Object && classes_differ)
@@ -1290,7 +1369,7 @@ fn compare_nominal_instances<'db>(
         return ComparisonResult::from_bool(operator == ComparisonOperator::Inequality);
     }
 
-    if left == right && left.is_singleton(db) {
+    if left == right && left.is_singleton(db, program) {
         ComparisonResult::from_bool(operator == ComparisonOperator::Equality)
     } else {
         ComparisonResult::Ambiguous
@@ -1332,7 +1411,7 @@ impl ComparisonOperator {
 ///
 /// Two types with different known semantics cannot compare equal. Types with custom or otherwise
 /// unknown comparison methods are not assigned a value of this enum.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 enum KnownComparisonSemantics {
     Object,
     Int,
@@ -1346,19 +1425,26 @@ impl KnownComparisonSemantics {
     /// Determine the builtin comparison implementation inherited by `ty`.
     ///
     /// Returns `None` when dunder lookup finds custom or conflicting comparison behavior.
-    fn of_type<'db>(db: &'db dyn Db, ty: Type<'db>, operator: ComparisonOperator) -> Option<Self> {
+    fn of_type<'db>(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+        operator: ComparisonOperator,
+    ) -> Option<Self> {
         match ty {
-            Type::LiteralValue(literal) => Self::of_literal(db, literal.kind(), operator),
+            Type::LiteralValue(literal) => Self::of_literal(db, program, literal.kind(), operator),
             Type::TypedDict(_) => Some(Self::Dict),
             Type::EnumComplement(complement) => Self::of_instance(
                 db,
+                program,
                 complement.enum_class(db).to_non_generic_instance(db),
                 operator,
             ),
             Type::Intersection(intersection) => {
-                if let Some(complement) = intersection.enum_complement(db) {
+                if let Some(complement) = intersection.enum_complement(db, program) {
                     return Self::of_instance(
                         db,
+                        program,
                         complement.enum_class(db).to_non_generic_instance(db),
                         operator,
                     );
@@ -1366,16 +1452,17 @@ impl KnownComparisonSemantics {
                 let mut semantics = intersection
                     .positive(db)
                     .iter()
-                    .filter_map(|element| Self::of_type(db, *element, operator));
+                    .filter_map(|element| Self::of_type(db, program, *element, operator));
                 let first = semantics.next()?;
                 semantics
                     .all(|semantics| semantics == first)
                     .then_some(first)
             }
             Type::NominalInstance(instance)
-                if instance.class(db).is_final(db) || instance.tuple_spec(db).is_some() =>
+                if instance.class(db, program).is_final(db)
+                    || instance.tuple_spec(db, program).is_some() =>
             {
-                Self::of_instance(db, ty, operator)
+                Self::of_instance(db, program, ty, operator)
             }
             _ => None,
         }
@@ -1384,6 +1471,7 @@ impl KnownComparisonSemantics {
     /// Return the builtin comparison implementation used by a literal value.
     fn of_literal<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         literal: LiteralValueTypeKind<'db>,
         operator: ComparisonOperator,
     ) -> Option<Self> {
@@ -1394,7 +1482,7 @@ impl KnownComparisonSemantics {
             }
             LiteralValueTypeKind::Bytes(_) => Some(Self::Bytes),
             LiteralValueTypeKind::Enum(enum_literal) => {
-                Self::of_instance(db, enum_literal.enum_class_instance(db), operator)
+                Self::of_instance(db, program, enum_literal.enum_class_instance(db), operator)
             }
         }
     }
@@ -1404,15 +1492,18 @@ impl KnownComparisonSemantics {
     /// Returns `None` when lookup finds custom comparison behavior.
     fn of_instance<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         instance: Type<'db>,
         operator: ComparisonOperator,
     ) -> Option<Self> {
-        let class = instance.to_meta_type(db);
-        let dunder = lookup_dunder(db, class, operator.dunder());
+        let class = instance.to_meta_type(db, program);
+        let dunder = lookup_dunder(db, program, class, operator.dunder());
 
         if dunder.place.is_undefined() {
             if operator == ComparisonOperator::Inequality
-                && !lookup_dunder(db, class, "__eq__").place.is_undefined()
+                && !lookup_dunder(db, program, class, "__eq__")
+                    .place
+                    .is_undefined()
             {
                 return None;
             }
@@ -1426,7 +1517,14 @@ impl KnownComparisonSemantics {
             (KnownClass::Tuple, Self::Tuple),
             (KnownClass::Dict, Self::Dict),
         ] {
-            if dunder == lookup_dunder(db, known_class.to_class_literal(db), operator.dunder()) {
+            if dunder
+                == lookup_dunder(
+                    db,
+                    program,
+                    known_class.to_class_literal(db, program),
+                    operator.dunder(),
+                )
+            {
                 return Some(semantics);
             }
         }
@@ -1449,6 +1547,7 @@ enum ComparisonDomain {
 /// analysis, which is only useful here when it can eliminate an arm from a union target.
 fn comparison_domain<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     target: Type<'db>,
     ty: Type<'db>,
     operator: ComparisonOperator,
@@ -1459,7 +1558,8 @@ fn comparison_domain<'db>(
     match ty {
         Type::Union(union) => {
             if union.elements(db).iter().all(|element| {
-                comparison_domain(db, target, *element, operator) == ComparisonDomain::Known
+                comparison_domain(db, program, target, *element, operator)
+                    == ComparisonDomain::Known
             }) {
                 ComparisonDomain::Known
             } else {
@@ -1469,22 +1569,22 @@ fn comparison_domain<'db>(
         Type::LiteralValue(_) | Type::EnumComplement(_) | Type::TypedDict(_) => {
             ComparisonDomain::Known
         }
-        Type::Intersection(intersection) if intersection.enum_complement(db).is_some() => {
+        Type::Intersection(intersection) if intersection.enum_complement(db, program).is_some() => {
             ComparisonDomain::Known
         }
         Type::NominalInstance(instance) => {
-            if instance.tuple_spec(db).is_some()
-                || ty.is_singleton(db)
+            if instance.tuple_spec(db, program).is_some()
+                || ty.is_singleton(db, program)
                 || instance.has_known_class(db, KnownClass::Bool)
                 || target.is_union()
-                    && KnownComparisonSemantics::of_type(db, ty, operator).is_some()
+                    && KnownComparisonSemantics::of_type(db, program, ty, operator).is_some()
             {
                 ComparisonDomain::Known
             } else {
                 ComparisonDomain::Unknown
             }
         }
-        _ if ty.is_single_valued(db) => ComparisonDomain::Known,
+        _ if ty.is_single_valued(db, program) => ComparisonDomain::Known,
         _ => ComparisonDomain::Unknown,
     }
 }
@@ -1492,18 +1592,23 @@ fn comparison_domain<'db>(
 /// Return whether `ty` is a singleton whose comparison uses object identity semantics.
 fn has_known_identity_comparison_semantics<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     operator: ComparisonOperator,
 ) -> bool {
     match ty {
         Type::FunctionLiteral(_) | Type::ModuleLiteral(_) | Type::SpecialForm(_) => true,
         Type::ClassLiteral(class) => {
-            KnownComparisonSemantics::of_instance(db, class.metaclass_instance_type(db), operator)
-                == Some(KnownComparisonSemantics::Object)
+            KnownComparisonSemantics::of_instance(
+                db,
+                program,
+                class.metaclass_instance_type(db),
+                operator,
+            ) == Some(KnownComparisonSemantics::Object)
         }
         _ => {
-            ty.is_singleton(db)
-                && KnownComparisonSemantics::of_type(db, ty, operator)
+            ty.is_singleton(db, program)
+                && KnownComparisonSemantics::of_type(db, program, ty, operator)
                     == Some(KnownComparisonSemantics::Object)
         }
     }
@@ -1512,11 +1617,13 @@ fn has_known_identity_comparison_semantics<'db>(
 /// Look up a comparison method without falling back to `object`.
 fn lookup_dunder<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     name: &'static str,
 ) -> PlaceAndQualifiers<'db> {
     ty.member_lookup_with_policy(
         db,
+        program,
         Name::new_static(name),
         MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
     )
@@ -1528,6 +1635,7 @@ fn lookup_dunder<'db>(
 /// or insufficiently known comparison behavior prevents a definitive result.
 fn known_literal_equality<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     left: LiteralValueTypeKind<'db>,
     right: LiteralValueTypeKind<'db>,
     operator: ComparisonOperator,
@@ -1550,10 +1658,18 @@ fn known_literal_equality<'db>(
             Some(left.value(db) == right.value(db))
         }
         (LiteralValueTypeKind::Enum(left), LiteralValueTypeKind::Enum(right)) => {
-            let left_semantics =
-                KnownComparisonSemantics::of_instance(db, left.enum_class_instance(db), operator)?;
-            let right_semantics =
-                KnownComparisonSemantics::of_instance(db, right.enum_class_instance(db), operator)?;
+            let left_semantics = KnownComparisonSemantics::of_instance(
+                db,
+                program,
+                left.enum_class_instance(db),
+                operator,
+            )?;
+            let right_semantics = KnownComparisonSemantics::of_instance(
+                db,
+                program,
+                right.enum_class_instance(db),
+                operator,
+            )?;
             if left_semantics != right_semantics {
                 return Some(false);
             }
@@ -1569,8 +1685,9 @@ fn known_literal_equality<'db>(
             }
             known_literal_equality(
                 db,
-                enum_literal_value(db, left)?.as_literal_value_kind()?,
-                enum_literal_value(db, right)?.as_literal_value_kind()?,
+                program,
+                enum_literal_value(db, program, left)?.as_literal_value_kind()?,
+                enum_literal_value(db, program, right)?.as_literal_value_kind()?,
                 ComparisonOperator::Equality,
             )
         }
@@ -1578,15 +1695,18 @@ fn known_literal_equality<'db>(
         | (other, LiteralValueTypeKind::Enum(enum_literal)) => {
             let enum_semantics = KnownComparisonSemantics::of_instance(
                 db,
+                program,
                 enum_literal.enum_class_instance(db),
                 operator,
             )?;
-            if enum_semantics != KnownComparisonSemantics::of_literal(db, other, operator)? {
+            if enum_semantics != KnownComparisonSemantics::of_literal(db, program, other, operator)?
+            {
                 return Some(false);
             }
             known_literal_equality(
                 db,
-                enum_literal_value(db, enum_literal)?.as_literal_value_kind()?,
+                program,
+                enum_literal_value(db, program, enum_literal)?.as_literal_value_kind()?,
                 other,
                 ComparisonOperator::Equality,
             )
@@ -1597,8 +1717,9 @@ fn known_literal_equality<'db>(
         )
         | (LiteralValueTypeKind::String(_), LiteralValueTypeKind::LiteralString) => None,
         (left, right) => {
-            let left_semantics = KnownComparisonSemantics::of_literal(db, left, operator)?;
-            let right_semantics = KnownComparisonSemantics::of_literal(db, right, operator)?;
+            let left_semantics = KnownComparisonSemantics::of_literal(db, program, left, operator)?;
+            let right_semantics =
+                KnownComparisonSemantics::of_literal(db, program, right, operator)?;
             (left_semantics != right_semantics).then_some(false)
         }
     }
@@ -1607,11 +1728,15 @@ fn known_literal_equality<'db>(
 /// Return the statically known runtime value of an enum member.
 ///
 /// Custom enum construction can replace the declared value, so members of such enums return `None`.
-fn enum_literal_value<'db>(db: &'db dyn Db, literal: EnumLiteralType<'db>) -> Option<Type<'db>> {
+fn enum_literal_value<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    literal: EnumLiteralType<'db>,
+) -> Option<Type<'db>> {
     let enum_class_literal = literal.enum_class_literal(db);
     let metadata = enum_metadata(db, enum_class_literal.class_literal(db))?;
     let name = enum_class_literal.resolve_member(db, literal.name(db))?;
-    metadata.concrete_value_type(db, name)
+    metadata.concrete_value_type(db, program, name)
 }
 
 /// Return whether two enum literals resolve to the same member, including aliases.

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -24,21 +24,23 @@ use super::{
 /// classes project their members onto runtime comparison keys.
 pub(super) fn evaluate_enum_domains<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     target: Type<'db>,
     other: Type<'db>,
     branch: ComparisonBranch,
     operator: ComparisonOperator,
 ) -> Option<ComparisonResult<'db>> {
-    let target = EnumDomainSet::from_type(db, target)?;
-    let other = EnumDomainSet::from_type(db, other)?;
+    let target = EnumDomainSet::from_type(db, program, target)?;
+    let other = EnumDomainSet::from_type(db, program, other)?;
     if let (Some(target), Some(other)) = (target.single(), other.single())
         && target.enum_class == other.enum_class
     {
         return SameEnumComparison::new(db, target.clone(), other.clone(), operator)
-            .evaluate(db, branch, operator);
+            .evaluate(db, program, branch, operator);
     }
 
-    ProjectedEnumComparison::new(db, target, &other, operator)?.evaluate(db, branch, operator)
+    ProjectedEnumComparison::new(db, target, &other, operator)?
+        .evaluate(db, program, branch, operator)
 }
 
 /// Two non-empty value domains from the same enum and the semantics used to compare them.
@@ -94,6 +96,7 @@ impl<'db> SameEnumComparison<'db> {
     fn evaluate(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         branch: ComparisonBranch,
         operator: ComparisonOperator,
     ) -> Option<ComparisonResult<'db>> {
@@ -103,15 +106,15 @@ impl<'db> SameEnumComparison<'db> {
             Truthiness::Ambiguous if !self.supports_domain_narrowing() => {
                 Some(ComparisonResult::Ambiguous)
             }
-            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => {
-                Some(ComparisonResult::CanNarrow(self.right.restriction_type(db)))
-            }
+            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => Some(
+                ComparisonResult::CanNarrow(self.right.restriction_type(db, program)),
+            ),
             Truthiness::Ambiguous => Some(self.right.singleton_type(db).map_or(
                 ComparisonResult::Ambiguous,
                 |singleton| {
                     ComparisonResult::CanNarrow(
-                        IntersectionBuilder::new(db)
-                            .add_positive(self.left.restriction_type(db))
+                        IntersectionBuilder::new(db, program)
+                            .add_positive(self.left.restriction_type(db, program))
                             .add_negative(singleton)
                             .build(),
                     )
@@ -165,11 +168,13 @@ impl<'db> EnumValueSet<'db> {
     /// enum but remains disjoint from the enum's literal members.
     fn from_type(
         db: &'db dyn Db,
+        program: crate::Program,
         ty: Type<'db>,
         active_types: &mut FxHashSet<Type<'db>>,
     ) -> Option<Self> {
         fn from_type_inner<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             active_types: &mut FxHashSet<Type<'db>>,
         ) -> Option<EnumValueSet<'db>> {
@@ -189,7 +194,7 @@ impl<'db> EnumValueSet<'db> {
                     }
                 }
                 Type::NominalInstance(instance) => EnumValueSet {
-                    enum_class: instance.class_literal(db).into_enum_class(db)?,
+                    enum_class: instance.class_literal(db, program).into_enum_class(db)?,
                     members: EnumValueSetMembers::All,
                 },
                 Type::EnumComplement(complement) => EnumValueSet {
@@ -197,10 +202,10 @@ impl<'db> EnumValueSet<'db> {
                     members: EnumValueSetMembers::AllExcept(complement),
                 },
                 Type::Union(union) => {
-                    EnumValueSet::from_union(db, union.elements(db), active_types)?
+                    EnumValueSet::from_union(db, program, union.elements(db), active_types)?
                 }
                 Type::Intersection(intersection) => {
-                    EnumValueSet::from_intersection(db, intersection, active_types)?
+                    EnumValueSet::from_intersection(db, program, intersection, active_types)?
                 }
                 _ => return None,
             };
@@ -211,7 +216,7 @@ impl<'db> EnumValueSet<'db> {
         if !active_types.insert(ty) {
             return None;
         }
-        let value_set = from_type_inner(db, ty, active_types);
+        let value_set = from_type_inner(db, program, ty, active_types);
         active_types.remove(&ty);
         value_set
     }
@@ -221,13 +226,14 @@ impl<'db> EnumValueSet<'db> {
     /// Whole-domain and complement arms are rejected because they are not exact included sets.
     fn from_union(
         db: &'db dyn Db,
+        program: crate::Program,
         elements: &[Type<'db>],
         active_types: &mut FxHashSet<Type<'db>>,
     ) -> Option<Self> {
         let mut enum_class = None;
         let mut included = FxOrderMap::default();
         for element in elements {
-            let value_set = Self::from_type(db, *element, active_types)?;
+            let value_set = Self::from_type(db, program, *element, active_types)?;
             if let Some(enum_class) = enum_class
                 && enum_class != value_set.enum_class
             {
@@ -288,11 +294,12 @@ impl<'db> EnumValueSet<'db> {
     /// Extract the enum restriction while discarding unrelated positive intersection state.
     fn from_intersection(
         db: &'db dyn Db,
+        program: crate::Program,
         intersection: IntersectionType<'db>,
         active_types: &mut FxHashSet<Type<'db>>,
     ) -> Option<Self> {
-        if let Some(complement) = intersection.enum_complement(db) {
-            return Self::from_type(db, Type::EnumComplement(complement), active_types);
+        if let Some(complement) = intersection.enum_complement(db, program) {
+            return Self::from_type(db, program, Type::EnumComplement(complement), active_types);
         }
 
         // Other intersection components can only reduce the represented enum values. Ignoring
@@ -300,7 +307,7 @@ impl<'db> EnumValueSet<'db> {
         let mut value_sets = intersection
             .positive(db)
             .iter()
-            .filter_map(|positive| Self::from_type(db, *positive, active_types));
+            .filter_map(|positive| Self::from_type(db, program, *positive, active_types));
         let value_set = value_sets.next()?;
         value_sets
             .all(|other| other.enum_class == value_set.enum_class)
@@ -389,7 +396,7 @@ impl<'db> EnumValueSet<'db> {
     }
 
     /// Reconstruct a constraint containing only this enum value restriction.
-    fn restriction_type(&self, db: &'db dyn Db) -> Type<'db> {
+    fn restriction_type(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match &self.members {
             EnumValueSetMembers::All => self
                 .enum_class
@@ -400,9 +407,12 @@ impl<'db> EnumValueSet<'db> {
             }
             EnumValueSetMembers::Included(members) => members
                 .iter()
-                .fold(UnionBuilder::new(db), |builder, (name, promotable)| {
-                    builder.add(self.member_type(db, name, *promotable))
-                })
+                .fold(
+                    UnionBuilder::new(db, program),
+                    |builder, (name, promotable)| {
+                        builder.add(self.member_type(db, name, *promotable))
+                    },
+                )
                 .build(),
             EnumValueSetMembers::AllExcept(complement) => {
                 if complement.rest(db).is_empty() {
@@ -459,14 +469,15 @@ struct EnumDomainSet<'db> {
 }
 
 impl<'db> EnumDomainSet<'db> {
-    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    fn from_type(db: &'db dyn Db, program: crate::Program, ty: Type<'db>) -> Option<Self> {
         fn collect<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             domains: &mut Vec<EnumValueSet<'db>>,
             active_types: &mut FxHashSet<Type<'db>>,
         ) -> Option<()> {
-            if let Some(domain) = EnumValueSet::from_type(db, ty, active_types) {
+            if let Some(domain) = EnumValueSet::from_type(db, program, ty, active_types) {
                 domains.push(domain);
                 return Some(());
             }
@@ -474,13 +485,14 @@ impl<'db> EnumDomainSet<'db> {
             if !active_types.insert(ty) {
                 return None;
             }
-            let result = collect_union(db, ty, domains, active_types);
+            let result = collect_union(db, program, ty, domains, active_types);
             active_types.remove(&ty);
             result
         }
 
         fn collect_union<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             domains: &mut Vec<EnumValueSet<'db>>,
             active_types: &mut FxHashSet<Type<'db>>,
@@ -489,14 +501,14 @@ impl<'db> EnumDomainSet<'db> {
                 return None;
             };
             for element in union.elements(db) {
-                collect(db, *element, domains, active_types)?;
+                collect(db, program, *element, domains, active_types)?;
             }
             Some(())
         }
 
         let mut domains = Vec::new();
         let mut active_types = FxHashSet::default();
-        collect(db, ty, &mut domains, &mut active_types)?;
+        collect(db, program, ty, &mut domains, &mut active_types)?;
         (!domains.is_empty()).then_some(Self { domains })
     }
 
@@ -519,11 +531,11 @@ impl<'db> EnumDomainSet<'db> {
         Some(projection)
     }
 
-    fn restriction_type(&self, db: &'db dyn Db) -> Type<'db> {
+    fn restriction_type(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         self.domains
             .iter()
-            .fold(UnionBuilder::new(db), |builder, domain| {
-                builder.add(domain.restriction_type(db))
+            .fold(UnionBuilder::new(db, program), |builder, domain| {
+                builder.add(domain.restriction_type(db, program))
             })
             .build()
     }
@@ -531,17 +543,18 @@ impl<'db> EnumDomainSet<'db> {
     fn restrict_for_equality(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         operator: ComparisonOperator,
         other: &EnumKeyProjection<'db>,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         for domain in &self.domains {
             let mut projection = EnumKeyProjection::default();
             domain.add_keys_to_projection(db, operator, &mut projection)?;
             if projection.unknowns_may_overlap(other) {
-                builder = builder.add(domain.restriction_type(db));
+                builder = builder.add(domain.restriction_type(db, program));
             } else if let Some(retained) = domain.retain_keys(db, operator, &other.keys).ok()? {
-                builder = builder.add(retained.restriction_type(db));
+                builder = builder.add(retained.restriction_type(db, program));
             }
         }
         Some(builder.build())
@@ -551,10 +564,11 @@ impl<'db> EnumDomainSet<'db> {
     fn known_equal_type(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         operator: ComparisonOperator,
         other: &EnumKeyProjection<'db>,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         for domain in &self.domains {
             let mut projection = EnumKeyProjection::default();
             domain.add_keys_to_projection(db, operator, &mut projection)?;
@@ -562,7 +576,7 @@ impl<'db> EnumDomainSet<'db> {
                 continue;
             }
             if let Some(retained) = domain.retain_keys(db, operator, &other.keys).ok()? {
-                builder = builder.add(retained.restriction_type(db));
+                builder = builder.add(retained.restriction_type(db, program));
             }
         }
         Some(builder.build())
@@ -610,25 +624,28 @@ impl<'db> ProjectedEnumComparison<'db> {
     fn evaluate(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         branch: ComparisonBranch,
         operator: ComparisonOperator,
     ) -> Option<ComparisonResult<'db>> {
         match self.truthiness(operator) {
             Truthiness::AlwaysTrue => Some(ComparisonResult::AlwaysTrue),
             Truthiness::AlwaysFalse => Some(ComparisonResult::AlwaysFalse),
-            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => {
-                Some(ComparisonResult::CanNarrow(
-                    self.left
-                        .restrict_for_equality(db, operator, &self.right_projection)?,
-                ))
-            }
+            Truthiness::Ambiguous if operator.condition_expects_equality(branch) => Some(
+                ComparisonResult::CanNarrow(self.left.restrict_for_equality(
+                    db,
+                    program,
+                    operator,
+                    &self.right_projection,
+                )?),
+            ),
             Truthiness::Ambiguous if self.right_projection.single_key().is_some() => {
                 let equal_left =
                     self.left
-                        .known_equal_type(db, operator, &self.right_projection)?;
+                        .known_equal_type(db, program, operator, &self.right_projection)?;
                 Some(ComparisonResult::CanNarrow(
-                    IntersectionBuilder::new(db)
-                        .add_positive(self.left.restriction_type(db))
+                    IntersectionBuilder::new(db, program)
+                        .add_positive(self.left.restriction_type(db, program))
                         .add_negative(equal_left)
                         .build(),
                 ))
@@ -797,8 +814,10 @@ fn enum_class_key_profile<'db>(
     enum_class: EnumClassLiteral<'db>,
     operator: ComparisonOperator,
 ) -> EnumClassKeyProfile<'db> {
+    let program = enum_class.class_literal(db).program(db);
     let semantics = KnownComparisonSemantics::of_instance(
         db,
+        program,
         enum_class.class_literal(db).to_non_generic_instance(db),
         operator,
     );
@@ -809,8 +828,12 @@ fn enum_class_key_profile<'db>(
             (
                 name.clone(),
                 semantics.and_then(|semantics| {
-                    enum_literal_value(db, EnumLiteralType::new(db, enum_class, name.clone()))
-                        .and_then(|value| enum_comparison_key(semantics, value))
+                    enum_literal_value(
+                        db,
+                        program,
+                        EnumLiteralType::new(db, enum_class, name.clone()),
+                    )
+                    .and_then(|value| enum_comparison_key(semantics, value))
                 }),
             )
         })

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -608,6 +608,7 @@ impl<'db> OverloadLiteral<'db> {
 
         let mut raw_signature = Signature::from_function(
             db,
+            program,
             pep695_ctx,
             definition,
             function_stmt_node,

--- a/crates/ty_python_semantic/src/types/function.rs
+++ b/crates/ty_python_semantic/src/types/function.rs
@@ -61,7 +61,7 @@ use ruff_python_ast::find_node::covering_node;
 use ruff_python_ast::{self as ast, OperatorPrecedence, ParameterWithDefault};
 use ruff_text_size::Ranged;
 use salsa::plumbing::AsId;
-use ty_module_resolver::{KnownModule, ModuleName, file_to_module, resolve_module};
+use ty_module_resolver::{KnownModule, ModuleName, file_to_module};
 
 use crate::place::{DefinedPlace, Definedness, Place, place_from_bindings};
 use crate::types::call::{Binding, CallArguments};
@@ -97,6 +97,7 @@ use crate::types::{
 use crate::{Db, FxOrderSet};
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::definition::Definition;
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::{FileScopeId, SemanticIndex, semantic_index};
 
@@ -211,7 +212,7 @@ bitflags! {
     /// arguments that were passed in. For the precise meaning of the fields, see [1].
     ///
     /// [1]: https://docs.python.org/3/library/typing.html#typing.dataclass_transform
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue)]
     pub struct DataclassTransformerFlags: u8 {
         const EQ_DEFAULT = 1 << 0;
         const ORDER_DEFAULT = 1 << 1;
@@ -381,17 +382,21 @@ impl<'db> OverloadLiteral<'db> {
     ) -> Option<Span> {
         let definition = self.definition(db);
         let file = definition.file(db);
-        self.node(db, file, &parsed_module(db, file).load(db))
-            .decorator_list
-            .iter()
-            .find(|decorator| {
-                predicate(definition_expression_type(
-                    db,
-                    definition,
-                    &decorator.expression,
-                ))
-            })
-            .map(|decorator| Span::from(file).with_range(decorator.range))
+        self.node(
+            db,
+            file,
+            &parsed_module(db, definition.program_file(db).versioned_file(db)).load(db),
+        )
+        .decorator_list
+        .iter()
+        .find(|decorator| {
+            predicate(definition_expression_type(
+                db,
+                definition,
+                &decorator.expression,
+            ))
+        })
+        .map(|decorator| Span::from(file).with_range(decorator.range))
     }
 
     /// Iterate through the decorators on this function, returning the span of the first one
@@ -430,7 +435,7 @@ impl<'db> OverloadLiteral<'db> {
     /// over-invalidation.
     fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let body_scope = self.body_scope(db);
-        let index = semantic_index(db, body_scope.file(db));
+        let index = semantic_index(db, body_scope.program_file(db));
         index.expect_single_definition(body_scope.node(db).expect_function())
     }
 
@@ -439,22 +444,25 @@ impl<'db> OverloadLiteral<'db> {
     fn previous_overload(self, db: &'db dyn Db) -> Option<FunctionLiteral<'db>> {
         // The semantic model records a use for each function on the name node. This is used
         // here to get the previous function definition with the same name.
-        let scope = self.definition(db).scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
-        let use_def = semantic_index(db, scope.file(db)).use_def_map(scope.file_scope_id(db));
+        let definition = self.definition(db);
+        let program_file = definition.program_file(db);
+        let program = program_file.program(db);
+        let scope = definition.scope(db);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
+        let use_def = semantic_index(db, program_file).use_def_map(scope.file_scope_id(db));
         let use_id = self
             .body_scope(db)
             .node(db)
             .expect_function()
             .node(&module)
             .name
-            .scoped_use_id(db, self.file(db));
+            .scoped_use_id(db, program_file);
 
         let Place::Defined(DefinedPlace {
             ty: Type::FunctionLiteral(previous_type),
             definedness: Definedness::AlwaysDefined,
             ..
-        }) = place_from_bindings(db, use_def.bindings_at_use(use_id)).place
+        }) = place_from_bindings(db, program, use_def.bindings_at_use(use_id)).place
         else {
             return None;
         };
@@ -492,14 +500,16 @@ impl<'db> OverloadLiteral<'db> {
         let mut signature = self.raw_signature(db, ReturnCallableTypeVarScope::Public);
 
         let scope = self.body_scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
+        let program_file = scope.program_file(db);
+        let program = program_file.program(db);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
         let function_node = scope.node(db).expect_function().node(&module);
-        let index = semantic_index(db, scope.file(db));
+        let index = semantic_index(db, program_file);
         let file_scope_id = scope.file_scope_id(db);
         let is_generator = file_scope_id.is_generator_function(index);
 
         if function_node.is_async && !is_generator {
-            signature = signature.wrap_coroutine_return_type(db);
+            signature = signature.wrap_coroutine_return_type(db, program);
         }
 
         signature
@@ -577,10 +587,12 @@ impl<'db> OverloadLiteral<'db> {
         }
 
         let scope = self.body_scope(db);
-        let module = parsed_module(db, self.file(db)).load(db);
+        let program_file = scope.program_file(db);
+        let program = program_file.program(db);
+        let module = parsed_module(db, program_file.versioned_file(db)).load(db);
         let function_stmt_node = scope.node(db).expect_function().node(&module);
         let definition = self.definition(db);
-        let index = semantic_index(db, scope.file(db));
+        let index = semantic_index(db, program_file);
         let pep695_ctx = function_stmt_node.type_params.as_ref().map(|type_params| {
             GenericContext::from_type_params(db, index, definition, type_params)
         });
@@ -644,7 +656,7 @@ impl<'db> OverloadLiteral<'db> {
             if method_has_explicit_self || class_is_generic || class_is_fallback {
                 let scope_id = definition.scope(db);
                 let typevar_binding_context = Some(definition);
-                let index = semantic_index(db, scope_id.file(db));
+                let index = semantic_index(db, scope_id.program_file(db));
                 let class = nearest_enclosing_class(db, index, scope_id).unwrap();
 
                 let typing_self = typing_self(db, scope_id, typevar_binding_context, class.into())
@@ -656,6 +668,7 @@ impl<'db> OverloadLiteral<'db> {
                 if self.is_classmethod(db) {
                     Some(SubclassOfType::from(
                         db,
+                        program,
                         SubclassOfInner::TypeVar(typing_self),
                     ))
                 } else {
@@ -667,6 +680,7 @@ impl<'db> OverloadLiteral<'db> {
                 if self.is_classmethod(db) {
                     Some(SubclassOfType::from(
                         db,
+                        program,
                         SubclassOfInner::Class(ClassType::NonGeneric(class_literal)),
                     ))
                 } else {
@@ -685,7 +699,8 @@ impl<'db> OverloadLiteral<'db> {
     ) -> (Span, Span) {
         let file = self.file(db);
         let span = Span::from(file);
-        let module = parsed_module(db, file).load(db);
+        let module =
+            parsed_module(db, self.body_scope(db).program_file(db).versioned_file(db)).load(db);
         let func_def = self.node(db, file, &module);
         let range = parameter_index
             .and_then(|parameter_index| {
@@ -704,7 +719,8 @@ impl<'db> OverloadLiteral<'db> {
     pub(crate) fn spans(self, db: &'db dyn Db) -> FunctionSpans {
         let file = self.file(db);
         let span = Span::from(file);
-        let module = parsed_module(db, self.file(db)).load(db);
+        let module =
+            parsed_module(db, self.body_scope(db).program_file(db).versioned_file(db)).load(db);
         let func_def = self.node(db, file, &module);
         let return_type_range = func_def.returns.as_ref().map(|returns| returns.range());
         let mut signature = func_def.name.range.cover(func_def.parameters.range);
@@ -724,7 +740,7 @@ impl<'db> OverloadLiteral<'db> {
 /// Representation of a function definition in the AST, along with any previous overloads of the
 /// function. Each overload can be separately generic or not, and each generic overload uses
 /// distinct typevars.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub struct FunctionLiteral<'db> {
     pub(crate) last_definition: OverloadLiteral<'db>,
     overloaded: bool,
@@ -737,6 +753,10 @@ impl<'db> FunctionLiteral<'db> {
             overloaded: last_definition.is_overload(db)
                 || last_definition.previous_overload(db).is_some(),
         }
+    }
+
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.last_definition.body_scope(db).program(db)
     }
 
     fn name(self, db: &'db dyn Db) -> &'db ast::name::Name {
@@ -903,7 +923,7 @@ impl<'db> FunctionLiteral<'db> {
         if self.has_known_decorator(db, FunctionDecorators::ABSTRACT_METHOD) {
             return Some(AbstractMethodKind::Explicit);
         }
-        if self.definition(db).file(db).is_stub(db) {
+        if self.last_definition.file(db).is_stub(db) {
             return None;
         }
         if !enclosing_class.is_protocol(db) {
@@ -928,11 +948,13 @@ impl<'db> FunctionLiteral<'db> {
             db: &'db dyn Db,
             implementation: OverloadLiteral<'db>,
         ) -> FunctionBodyKind {
+            let program_file = implementation.body_scope(db).program_file(db);
+            let program = program_file.program(db);
             let definition = implementation.definition(db);
-            let file = definition.file(db);
-            let module = parsed_module(db, file).load(db);
+            let file = program_file.file(db);
+            let module = program_file.parsed(db).load(db);
             let node = implementation.node(db, file, &module);
-            function_body_kind(db, node, |expr| {
+            function_body_kind(db, program, node, |expr| {
                 definition_expression_type(db, definition, expr)
             })
         }
@@ -952,7 +974,7 @@ impl<'db> FunctionLiteral<'db> {
     /// Methods defined in stub files are never considered to have trivial bodies,
     /// since stubs use `...` as a placeholder regardless of the runtime implementation.
     pub(crate) fn has_trivial_body(self, db: &'db dyn Db) -> bool {
-        !self.definition(db).file(db).is_stub(db)
+        !self.last_definition.file(db).is_stub(db)
             && matches!(
                 self.body_kind(db),
                 FunctionBodyKind::Stub | FunctionBodyKind::AlwaysRaisesNotImplementedError
@@ -978,7 +1000,7 @@ pub(super) fn same_module_uncached_raw_signature<'db>(
 }
 
 /// Indicates whether a method is explicitly or implicitly abstract.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) enum AbstractMethodKind {
     /// The method is explicitly marked as abstract using `@abstractmethod`.
     Explicit,
@@ -1004,7 +1026,7 @@ impl AbstractMethodKind {
 ///
 /// This uncommon payload is boxed so that ordinary function types only retain the literal and one
 /// optional pointer.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub struct UpdatedFunctionSignatures<'db> {
     /// Contains a potentially modified signature for this function literal, in case certain
     /// operations (like type mappings) have been applied to it.
@@ -1047,18 +1069,32 @@ pub struct FunctionType<'db> {
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for FunctionType<'_> {}
 
+impl<'db> FunctionType<'db> {
+    pub(crate) fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.literal(db).program(db)
+    }
+
+    pub(crate) fn program_file(self, db: &'db dyn Db) -> ProgramFile<'db> {
+        self.literal(db)
+            .last_definition
+            .body_scope(db)
+            .program_file(db)
+    }
+}
+
 pub(super) fn walk_function_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     function: FunctionType<'db>,
     visitor: &V,
 ) {
     if let Some(callable_signature) = function.updated_signature(db) {
         for signature in &callable_signature.overloads {
-            walk_signature(db, signature, visitor);
+            walk_signature(db, program, signature, visitor);
         }
     }
     if let Some(signature) = function.updated_implementation_signature(db) {
-        walk_signature(db, signature, visitor);
+        walk_signature(db, program, signature, visitor);
     }
 }
 
@@ -1107,6 +1143,7 @@ impl<'db> FunctionType<'db> {
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        let program = self.program(db);
         // Returned-callable rescoping and type-alias specialization should not rebuild signatures from the
         // function literal; doing so can re-enter recursive `TypeOf` evaluation.
         let literal = self.literal(db);
@@ -1122,21 +1159,25 @@ impl<'db> FunctionType<'db> {
         ) {
             (
                 self.updated_signature(db).map(|signature| {
-                    signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    signature.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
                 }),
                 self.updated_implementation_signature(db).map(|signature| {
-                    signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    signature.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
                 }),
             )
         } else {
             (
-                Some(
-                    self.signature(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                ),
+                Some(self.signature(db).apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                )),
                 literal.has_separate_implementation(db).then(|| {
                     self.last_definition_signature(db).apply_type_mapping_impl(
                         db,
+                        program,
                         type_mapping,
                         tcx,
                         visitor,
@@ -1389,8 +1430,8 @@ impl<'db> FunctionType<'db> {
     /// would depend on the function's AST and rerun for every change in that file.
     #[salsa::tracked(
         returns(ref),
-        cycle_initial=|db, id, _| CallableSignature::cycle_initial(db, id),
-        cycle_fn=|db, cycle, previous, value: CallableSignature<'db>, _| value.cycle_normalized(db, previous, cycle),
+        cycle_initial=|db, id, function: FunctionType<'db>| CallableSignature::cycle_initial(db, function.program(db), id),
+        cycle_fn=|db, cycle, previous, value: CallableSignature<'db>, function: FunctionType<'db>| value.cycle_normalized(db, function.program(db), previous, cycle),
         heap_size=ruff_memory_usage::heap_size,
     )]
     pub(crate) fn signature(self, db: &'db dyn Db) -> CallableSignature<'db> {
@@ -1404,7 +1445,6 @@ impl<'db> FunctionType<'db> {
     /// This is tracked because signatures can contain recursive `TypeOf` references back to the
     /// function itself. Class and generic-alias variance use the same `Bivariant` cycle fallback.
     #[salsa::tracked(
-        returns(copy),
         cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
         heap_size=ruff_memory_usage::heap_size,
     )]
@@ -1413,7 +1453,8 @@ impl<'db> FunctionType<'db> {
         db: &'db dyn Db,
         typevar: BoundTypeVarIdentity<'db>,
     ) -> TypeVarVariance {
-        self.signature(db).variance_of(db, typevar)
+        let program = self.program(db);
+        self.signature(db).variance_of(db, program, typevar)
     }
 
     /// Typed externally-visible signature of the last overload or implementation of this function.
@@ -1499,9 +1540,10 @@ impl<'db> FunctionType<'db> {
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
+        let program = self.program(db);
         let signatures = self.signature(db);
         for signature in &signatures.overloads {
-            signature.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            signature.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 
@@ -1511,6 +1553,7 @@ impl<'db> FunctionType<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let program = self.program(db);
         visit_recursive_type_normalization(
             self.literal(db),
             nested,
@@ -1519,15 +1562,15 @@ impl<'db> FunctionType<'db> {
                 let literal = self.literal(db);
                 let updated_signature = match self.updated_signature(db) {
                     Some(signature) => {
-                        Some(signature.recursive_type_normalized_impl(db, div, nested)?)
+                        Some(signature.recursive_type_normalized_impl(db, program, div, nested)?)
                     }
                     None => None,
                 };
                 let updated_implementation_signature =
                     match self.updated_implementation_signature(db) {
-                        Some(signature) => {
-                            Some(signature.recursive_type_normalized_impl(db, div, nested)?)
-                        }
+                        Some(signature) => Some(
+                            signature.recursive_type_normalized_impl(db, program, div, nested)?,
+                        ),
                         None => None,
                     };
                 Some(Self::new(
@@ -1576,6 +1619,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 /// (e.g., when it's stored in a variable).
 fn check_classinfo_in_isinstance<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     context: &InferContext<'db, '_>,
     call_expression: &ast::ExprCall,
     function: KnownFunction,
@@ -1627,7 +1671,7 @@ fn check_classinfo_in_isinstance<'db>(
             );
         }
         Type::NominalInstance(nominal) => {
-            if let Some(tuple_spec) = nominal.tuple_spec(db) {
+            if let Some(tuple_spec) = nominal.tuple_spec(db, program) {
                 let element_exprs = match classinfo_expr {
                     Some(ast::Expr::Tuple(tuple_expr)) => Some(&tuple_expr.elts),
                     _ => None,
@@ -1636,6 +1680,7 @@ fn check_classinfo_in_isinstance<'db>(
                     let element_expr = element_exprs.and_then(|elts| elts.get(index));
                     check_classinfo_in_isinstance(
                         db,
+                        program,
                         context,
                         call_expression,
                         function,
@@ -1661,6 +1706,7 @@ fn report_invalid_union_type_elements<'db>(
 ) {
     fn find_invalid_elements<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         function: KnownFunction,
         ty: Type<'db>,
         invalid_elements: &mut Vec<Type<'db>>,
@@ -1673,10 +1719,10 @@ fn report_invalid_union_type_elements<'db>(
             // `Any` can be used in `issubclass()` calls but not `isinstance()` calls
             Type::SpecialForm(SpecialFormType::Any) if function == KnownFunction::IsSubclass => {}
             Type::KnownInstance(KnownInstanceType::UnionType(instance)) => {
-                match instance.value_expression_types(db) {
+                match instance.value_expression_types(db, program) {
                     Ok(value_expression_types) => {
                         for element in value_expression_types {
-                            find_invalid_elements(db, function, element, invalid_elements);
+                            find_invalid_elements(db, program, function, element, invalid_elements);
                         }
                     }
                     Err(_) => {
@@ -1688,8 +1734,9 @@ fn report_invalid_union_type_elements<'db>(
         }
     }
 
+    let program = context.program();
     let mut invalid_elements = vec![];
-    find_invalid_elements(db, function, union_type, &mut invalid_elements);
+    find_invalid_elements(db, program, function, union_type, &mut invalid_elements);
 
     let Some((first_invalid_element, other_invalid_elements)) = invalid_elements.split_first()
     else {
@@ -1720,7 +1767,7 @@ fn report_invalid_union_type_elements<'db>(
     let union_suffix = match (&union_type_expr, union_type) {
         (None, Type::KnownInstance(KnownInstanceType::UnionType(instance))) => {
             match instance.union_type(db) {
-                Ok(ty) => format!(" `{}`", ty.display(db)),
+                Ok(ty) => format!(" `{}`", ty.display(db, program)),
                 Err(_) => String::new(),
             }
         }
@@ -1730,16 +1777,16 @@ fn report_invalid_union_type_elements<'db>(
     match other_invalid_elements {
         [] => diagnostic.info(format_args!(
             "Element `{}` in the union{union_suffix} is not a class object",
-            first_invalid_element.display(db)
+            first_invalid_element.display(db, program)
         )),
         [single] => diagnostic.info(format_args!(
             "Elements `{}` and `{}` in the union{union_suffix} are not class objects",
-            first_invalid_element.display(db),
-            single.display(db),
+            first_invalid_element.display(db, program),
+            single.display(db, program),
         )),
         _ => diagnostic.info(format_args!(
             "Element `{}` in the union{union_suffix}, and {} more elements, are not class objects",
-            first_invalid_element.display(db),
+            first_invalid_element.display(db, program),
             other_invalid_elements.len(),
         )),
     }
@@ -1754,9 +1801,13 @@ fn is_instance_truthiness<'db>(
     ty: Type<'db>,
     class: ClassLiteral<'db>,
 ) -> Truthiness {
+    let program = class.program(db);
     let is_instance = |ty: &Type<'_>| {
-        ty.as_nominal_instance()
-            .is_some_and(|instance| instance.class(db).is_subtype_of_class_literal(db, class))
+        ty.as_nominal_instance().is_some_and(|instance| {
+            instance
+                .class(db, program)
+                .is_subtype_of_class_literal(db, class)
+        })
     };
 
     let always_true_if = |test: bool| {
@@ -1779,7 +1830,7 @@ fn is_instance_truthiness<'db>(
         // Along the way, short-circuit to `AlwaysTrue` if we find any positive element
         // that is always true.
         Type::Intersection(intersection) => {
-            let mut effective = IntersectionBuilder::new(db);
+            let mut effective = IntersectionBuilder::new(db, program);
             let mut found_tvars_or_newtypes = false;
 
             for &positive in intersection.positive(db) {
@@ -1791,7 +1842,7 @@ fn is_instance_truthiness<'db>(
                             effective = effective.add_positive(bound);
                         }
                         Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                            effective = effective.add_positive(constraints.as_type(db));
+                            effective = effective.add_positive(constraints.as_type(db, program));
                         }
                         // A typevar without bounds/constraints has `object` as its implicit upper bound,
                         // and adding `object` to an intersection is a no-op
@@ -1838,13 +1889,15 @@ fn is_instance_truthiness<'db>(
 
         Type::LiteralValue(..) | Type::ModuleLiteral(..) | Type::FunctionLiteral(..) => {
             always_true_if(
-                ty.literal_fallback_instance(db)
+                ty.literal_fallback_instance(db, program)
                     .as_ref()
                     .is_some_and(is_instance),
             )
         }
 
-        Type::ClassLiteral(..) => always_true_if(is_instance(&KnownClass::Type.to_instance(db))),
+        Type::ClassLiteral(..) => {
+            always_true_if(is_instance(&KnownClass::Type.to_instance(db, program)))
+        }
 
         Type::TypeAlias(alias) => is_instance_truthiness(db, alias.value_type(db), class),
 
@@ -1911,6 +1964,7 @@ pub(crate) fn function_has_stub_body(node: &ast::StmtFunctionDef) -> bool {
 /// the analysis is only done on the remaining statements if the first is a docstring.
 pub(super) fn function_body_kind<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     node: &ast::StmtFunctionDef,
     infer_type: impl Fn(&ast::Expr) -> Type<'db>,
 ) -> FunctionBodyKind {
@@ -1930,10 +1984,12 @@ pub(super) fn function_body_kind<'db>(
         } = raise
         && infer_type(exc).is_subtype_of(
             db,
+            program,
             UnionType::from_two_elements(
                 db,
-                KnownClass::NotImplementedError.to_class_literal(db),
-                KnownClass::NotImplementedError.to_instance(db),
+                program,
+                KnownClass::NotImplementedError.to_class_literal(db, program),
+                KnownClass::NotImplementedError.to_instance(db, program),
             ),
         )
     {
@@ -2120,7 +2176,9 @@ impl KnownFunction {
 
         let candidate = Self::from_str(name).ok()?;
         candidate
-            .check_module(file_to_module(db, definition.file(db))?.known(db)?)
+            .check_module(
+                file_to_module(db, definition.program_file(db).resolver_file(db))?.known(db)?,
+            )
             .then_some(candidate)
     }
 
@@ -2198,13 +2256,16 @@ impl KnownFunction {
         file: File,
     ) {
         let db = context.db();
+        let program = context.program();
         let parameter_types = overload.parameter_types();
 
         match self {
             KnownFunction::RevealType => {
                 let revealed_type = overload
                     .arguments_for_parameter(call_arguments, 0)
-                    .fold(UnionBuilder::new(db), |builder, (_, ty)| builder.add(ty))
+                    .fold(UnionBuilder::new(db, program), |builder, (_, ty)| {
+                        builder.add(ty)
+                    })
                     .build();
                 report_revealed_type(
                     context,
@@ -2221,7 +2282,7 @@ impl KnownFunction {
                 let Some(member) = literal.as_string() else {
                     return;
                 };
-                let ty_members = all_members(db, *ty);
+                let ty_members = all_members(db, program, *ty);
                 overload.set_return_type(Type::bool_literal(
                     ty_members.iter().any(|m| m.name == member.value(db)),
                 ));
@@ -2231,20 +2292,21 @@ impl KnownFunction {
                 let [Some(actual_ty), Some(asserted_ty)] = parameter_types else {
                     return;
                 };
-                let asserted_ty = asserted_ty.project_type_form(db);
-                if actual_ty.is_equivalent_to(db, asserted_ty) {
+                let asserted_ty = asserted_ty.project_type_form(db, program);
+                if actual_ty.is_equivalent_to(db, program, asserted_ty) {
                     return;
                 }
-                let diagnostic =
-                    if actual_ty.is_spellable(db) || !actual_ty.is_subtype_of(db, asserted_ty) {
-                        &TYPE_ASSERTION_FAILURE
-                    } else {
-                        &ASSERT_TYPE_UNSPELLABLE_SUBTYPE
-                    };
+                let diagnostic = if actual_ty.is_spellable(db)
+                    || !actual_ty.is_subtype_of(db, program, asserted_ty)
+                {
+                    &TYPE_ASSERTION_FAILURE
+                } else {
+                    &ASSERT_TYPE_UNSPELLABLE_SUBTYPE
+                };
                 if let Some(builder) = context.report_lint(diagnostic, call_expression) {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Argument does not have asserted type `{}`",
-                        asserted_ty.display(db),
+                        asserted_ty.display(db, program),
                     ));
 
                     diagnostic.annotate(
@@ -2254,27 +2316,30 @@ impl KnownFunction {
                                     .unwrap_or_else(|| ast::AnyNodeRef::from(call_expression)),
                             ),
                         )
-                        .message(format_args!("Inferred type is `{}`", actual_ty.display(db))),
+                        .message(format_args!(
+                            "Inferred type is `{}`",
+                            actual_ty.display(db, program)
+                        )),
                     );
 
-                    if actual_ty.is_subtype_of(db, asserted_ty) {
+                    if actual_ty.is_subtype_of(db, program, asserted_ty) {
                         diagnostic.info(format_args!(
                             "`{inferred_type}` is a subtype of `{asserted_type}`, but they are not equivalent",
-                            asserted_type = asserted_ty.display(db),
-                            inferred_type = actual_ty.display(db),
+                            asserted_type = asserted_ty.display(db, program),
+                            inferred_type = actual_ty.display(db, program),
                         ));
                     } else {
                         diagnostic.info(format_args!(
                             "`{asserted_type}` and `{inferred_type}` are not equivalent types",
-                            asserted_type = asserted_ty.display(db),
-                            inferred_type = actual_ty.display(db),
+                            asserted_type = asserted_ty.display(db, program),
+                            inferred_type = actual_ty.display(db, program),
                         ));
                     }
 
                     diagnostic.set_concise_message(format_args!(
                         "Type `{}` does not match asserted type `{}`",
-                        actual_ty.display(db),
-                        asserted_ty.display(db),
+                        actual_ty.display(db, program),
+                        asserted_ty.display(db, program),
                     ));
                 }
             }
@@ -2283,7 +2348,7 @@ impl KnownFunction {
                 let [Some(actual_ty)] = parameter_types else {
                     return;
                 };
-                if actual_ty.is_equivalent_to(db, Type::Never) {
+                if actual_ty.is_equivalent_to(db, program, Type::Never) {
                     return;
                 }
                 if let Some(builder) = context.report_lint(&TYPE_ASSERTION_FAILURE, call_expression)
@@ -2299,17 +2364,17 @@ impl KnownFunction {
                         )
                         .message(format_args!(
                             "Inferred type of argument is `{}`",
-                            actual_ty.display(db)
+                            actual_ty.display(db, program)
                         )),
                     );
                     diagnostic.info(format_args!(
                         "`Never` and `{inferred_type}` are not equivalent types",
-                        inferred_type = actual_ty.display(db),
+                        inferred_type = actual_ty.display(db, program),
                     ));
 
                     diagnostic.set_concise_message(format_args!(
                         "Type `{}` is not equivalent to `Never`",
-                        actual_ty.display(db),
+                        actual_ty.display(db, program),
                     ));
                 }
             }
@@ -2318,7 +2383,7 @@ impl KnownFunction {
                 let [Some(parameter_ty), message] = parameter_types else {
                     return;
                 };
-                let truthiness = match parameter_ty.try_bool(db) {
+                let truthiness = match parameter_ty.try_bool(db, program) {
                     Ok(truthiness) => truthiness,
                     Err(err) => {
                         err.report_diagnostic(
@@ -2348,20 +2413,20 @@ impl KnownFunction {
                         builder.into_diagnostic(format_args!(
                             "Static assertion error: argument of type `{parameter_ty}` \
                             is always falsy",
-                            parameter_ty = parameter_ty.display(db)
+                            parameter_ty = parameter_ty.display(db, program)
                         ))
                     } else {
                         builder.into_diagnostic(format_args!(
                             "Static assertion error: argument of type `{parameter_ty}` \
                             has an ambiguous static truthiness",
-                            parameter_ty = parameter_ty.display(db)
+                            parameter_ty = parameter_ty.display(db, program)
                         ))
                     };
                     if let Some(condition) = call_argument_node(call_expression, "condition", 0) {
                         diagnostic.annotate(
                             Annotation::secondary(context.span(condition)).message(format_args!(
                                 "Inferred type of argument is `{}`",
-                                parameter_ty.display(db)
+                                parameter_ty.display(db, program)
                             )),
                         );
                     }
@@ -2372,17 +2437,17 @@ impl KnownFunction {
                 let [Some(casted_type), Some(source_type)] = parameter_types else {
                     return;
                 };
-                let casted_type = casted_type.project_type_form(db);
+                let casted_type = casted_type.project_type_form(db, program);
                 let contains_unknown_or_todo = |ty: Type<'_>| {
                     ty.is_dynamic() && !matches!(ty, Type::Dynamic(DynamicType::Any))
                 };
-                if source_type.is_equivalent_to(db, casted_type)
-                    && !any_over_type(db, *source_type, true, contains_unknown_or_todo)
-                    && !any_over_type(db, casted_type, true, contains_unknown_or_todo)
+                if source_type.is_equivalent_to(db, program, casted_type)
+                    && !any_over_type(db, program, *source_type, true, contains_unknown_or_todo)
+                    && !any_over_type(db, program, casted_type, true, contains_unknown_or_todo)
                 {
                     if let Some(builder) = context.report_lint(&REDUNDANT_CAST, call_expression) {
-                        let source_display = source_type.display(db).to_string();
-                        let casted_display = casted_type.display(db).to_string();
+                        let source_display = source_type.display(db, program).to_string();
+                        let casted_display = casted_type.display(db, program).to_string();
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Value is already of type `{casted_display}`",
                         ));
@@ -2455,7 +2520,7 @@ impl KnownFunction {
                     );
                     diag.annotate(Annotation::primary(span).message(format_args!(
                         "`{}`",
-                        protocol_class.interface(db).display(db)
+                        protocol_class.interface(db).display(db, program)
                     )));
                 }
             }
@@ -2516,6 +2581,7 @@ impl KnownFunction {
                     let mut message = String::new();
                     let display_settings = DisplaySettings::from_possibly_ambiguous_types(
                         db,
+                        program,
                         classes
                             .iter()
                             .flat_map(|class| class.iter_mro(db))
@@ -2525,7 +2591,9 @@ impl KnownFunction {
                         message.push('(');
                         for class in class.iter_mro(db) {
                             message.push_str(
-                                &class.display_with(db, display_settings.clone()).to_string(),
+                                &class
+                                    .display_with(db, program, display_settings.clone())
+                                    .to_string(),
                             );
                             // Omit the comma for the last element (which is always `object`)
                             if class
@@ -2558,6 +2626,7 @@ impl KnownFunction {
 
                 check_classinfo_in_isinstance(
                     db,
+                    program,
                     context,
                     call_expression,
                     self,
@@ -2570,6 +2639,7 @@ impl KnownFunction {
                 {
                     overload.set_return_type(Type::from_truthiness(
                         db,
+                        program,
                         is_instance_truthiness(db, *first_arg, *class),
                     ));
                 }
@@ -2600,11 +2670,15 @@ impl KnownFunction {
                 let Some(module_name) = ModuleName::new(module_name) else {
                     return;
                 };
-                let Some(module) = resolve_module(db, file, &module_name) else {
+                let Some(module) = ty_module_resolver::resolve_module(
+                    db,
+                    context.program_file().resolver_file(db),
+                    &module_name,
+                ) else {
                     return;
                 };
 
-                overload.set_return_type(Type::module_literal(db, file, module));
+                overload.set_return_type(Type::module_literal(db, context.program_file(), module));
             }
 
             KnownFunction::TotalOrdering => {
@@ -2644,6 +2718,7 @@ pub(super) fn report_revealed_type<'db>(
     revealed_type: Type<'db>,
     argument_node: impl Ranged,
 ) {
+    let program = context.program();
     if let Some(builder) = context.report_diagnostic(DiagnosticId::RevealedType, Severity::Info) {
         let mut diag = builder.into_diagnostic("Revealed type");
         diag.annotate(
@@ -2651,7 +2726,8 @@ pub(super) fn report_revealed_type<'db>(
                 "`{}`",
                 revealed_type.display_with(
                     context.db(),
-                    DisplaySettings::default().preserve_long_unions()
+                    program,
+                    DisplaySettings::default().preserve_long_unions(),
                 )
             )),
         );
@@ -2669,6 +2745,7 @@ pub(crate) mod tests {
     #[test]
     fn known_function_roundtrip_from_str() {
         let db = setup_db();
+        let program = db.program();
 
         for function in KnownFunction::iter() {
             let function_name = function.name();
@@ -2735,7 +2812,7 @@ pub(crate) mod tests {
                 continue;
             }
 
-            let function_definition = known_module_symbol(&db, module, function_name)
+            let function_definition = known_module_symbol(&db, program, module, function_name)
                 .place
                 .expect_type()
                 .expect_function_literal()

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -594,11 +594,11 @@ impl<'db> GenericContext<'db> {
     /// list.
     pub(crate) fn from_function_params(
         db: &'db dyn Db,
+        program: Program,
         definition: Definition<'db>,
         parameters: &Parameters<'db>,
         return_type: Type<'db>,
     ) -> Option<Self> {
-        let program = definition.program_file(db).program(db);
         // Find all of the legacy typevars mentioned in the function signature.
         let mut variables = FxOrderSet::default();
         for param in parameters {
@@ -663,6 +663,7 @@ impl<'db> GenericContext<'db> {
 
     pub(crate) fn remove_callable_only_typevars(
         db: &'db dyn Db,
+        program: Program,
         generic_context: Option<Self>,
         parameters: &Parameters<'db>,
         return_type: Type<'db>,
@@ -689,12 +690,12 @@ impl<'db> GenericContext<'db> {
             fn finalize(
                 self,
                 db: &'db dyn Db,
+                program: Program,
                 function_definition: Definition<'db>,
             ) -> (
                 FxHashSet<BoundTypeVarInstance<'db>>,
                 FxHashMap<CallableType<'db>, CallableType<'db>>,
             ) {
-                let program = function_definition.program_file(db).program(db);
                 let mut found_only_inside_callable_return = FxHashSet::default();
                 let replacements = self
                     .found_inside_callable_return
@@ -845,7 +846,6 @@ impl<'db> GenericContext<'db> {
         let Some(generic_context) = generic_context else {
             return (None, return_type);
         };
-        let program = function_definition.program_file(db).program(db);
 
         // Find whether each typevar appears inside and/or outside a return type Callable.
         let mut find_typevar_locations = FindTypeVarLocations::default();
@@ -860,7 +860,7 @@ impl<'db> GenericContext<'db> {
         let (found_only_inside_callable_return, replacements) = find_typevar_locations
             .locations
             .into_inner()
-            .finalize(db, function_definition);
+            .finalize(db, program, function_definition);
         let type_mapping = TypeMapping::RescopeReturnCallables(&replacements);
         let return_type =
             return_type.apply_type_mapping(db, program, &type_mapping, TypeContext::default());
@@ -1586,11 +1586,12 @@ impl<'db> Specialization<'db> {
     pub(crate) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
-        let program = self.program(db);
+        debug_assert_eq!(program, self.program(db));
         if let Some(tuple) = self.tuple_inner(db) {
             tuple.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         } else {

--- a/crates/ty_python_semantic/src/types/generics.rs
+++ b/crates/ty_python_semantic/src/types/generics.rs
@@ -35,7 +35,7 @@ use crate::types::{
     TypeVarKind, TypeVarVariance, UnionAccumulator, UnionType, binding_type,
     infer_definition_types, inferred_declaration,
 };
-use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet};
+use crate::{Db, FxIndexMap, FxOrderMap, FxOrderSet, Program};
 use ty_python_core::definition::{Definition, DefinitionKind};
 use ty_python_core::node_key::NodeKey;
 use ty_python_core::scope::{FileScopeId, NodeWithScopeKey, NodeWithScopeKind, ScopeId};
@@ -50,7 +50,9 @@ pub(crate) fn enclosing_generic_contexts<'db>(
 ) -> impl Iterator<Item = GenericContext<'db>> {
     index
         .ancestor_scopes(scope)
-        .filter_map(|(_, ancestor_scope)| GenericContext::of_node(db, ancestor_scope.node(), index))
+        .filter_map(move |(_, ancestor_scope)| {
+            GenericContext::of_node(db, ancestor_scope.node(), index)
+        })
 }
 
 /// Returns the binding contexts introduced by the given scope or any enclosing scope.
@@ -156,12 +158,11 @@ pub(crate) fn bind_typevar<'db>(
 /// Create a `typing.Self` type variable for a given class.
 pub(crate) fn typing_self<'db>(
     db: &'db dyn Db,
-    scope_id: ScopeId,
+    scope_id: ScopeId<'db>,
     typevar_binding_context: Option<Definition<'db>>,
     class: ClassLiteral<'db>,
 ) -> Option<BoundTypeVarInstance<'db>> {
-    let file = scope_id.file(db);
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, scope_id.program_file(db));
 
     let identity = TypeVarIdentity::new(
         db,
@@ -291,7 +292,7 @@ impl<'db> BoundTypeVarInstance<'db> {
 
 #[salsa::tracked]
 impl<'db> InferableTypeVars<'db> {
-    #[salsa::tracked(returns(copy), heap_size=ruff_memory_usage::heap_size)]
+    #[salsa::tracked(heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn merge(self, db: &'db dyn Db, other: Self) -> Self {
         match (self, other) {
             (InferableTypeVars::None, other) | (other, InferableTypeVars::None) => other,
@@ -333,6 +334,9 @@ impl<'db> InferableTypeVars<'db> {
 /// generic context can coexist without collapsing into each other.
 #[salsa::interned(debug, constructor=new_internal, heap_size=ruff_memory_usage::heap_size)]
 pub struct GenericContext<'db> {
+    #[returns(copy)]
+    pub(crate) program: Program,
+
     #[returns(ref)]
     variables_inner: FxOrderMap<BoundTypeVarIdentity<'db>, BoundTypeVarInstance<'db>>,
 }
@@ -342,8 +346,9 @@ pub(super) fn walk_generic_context<'db, V: TypeVisitor<'db> + ?Sized>(
     context: GenericContext<'db>,
     visitor: &V,
 ) {
+    let program = context.program(db);
     for bound_typevar in context.variables(db) {
-        visitor.visit_bound_type_var_type(db, bound_typevar);
+        visitor.visit_bound_type_var_type(db, program, bound_typevar);
     }
 }
 
@@ -358,11 +363,12 @@ impl<'db> GenericContext<'db> {
         binding_context: Definition<'db>,
         type_params_node: &ast::TypeParams,
     ) -> Self {
+        let program = binding_context.scope(db).program(db);
         let variables = type_params_node.iter().filter_map(|type_param| {
             Self::variable_from_type_param(db, index, binding_context, type_param)
         });
 
-        Self::from_typevar_instances(db, variables)
+        Self::from_typevar_instances(db, program, variables)
     }
 
     pub(crate) fn of_node(
@@ -396,12 +402,15 @@ impl<'db> GenericContext<'db> {
     /// Creates a generic context from a list of `BoundTypeVarInstance`s.
     pub(crate) fn from_typevar_instances(
         db: &'db dyn Db,
+        program: Program,
         type_params: impl IntoIterator<Item = BoundTypeVarInstance<'db>>,
     ) -> Self {
         Self::new_internal(
             db,
+            program,
             type_params
                 .into_iter()
+                .inspect(|variable| debug_assert_eq!(variable.program(db), program))
                 .map(|variable| (variable.identity(db), variable))
                 .collect::<FxOrderMap<_, _>>(),
         )
@@ -410,8 +419,11 @@ impl<'db> GenericContext<'db> {
     /// Merge this generic context with another, returning a new generic context that
     /// contains type variables from both contexts.
     pub(crate) fn merge(self, db: &'db dyn Db, other: Self) -> Self {
+        let program = self.program(db);
+        debug_assert_eq!(program, other.program(db));
         Self::from_typevar_instances(
             db,
+            program,
             self.variables_inner(db)
                 .values()
                 .chain(other.variables_inner(db).values())
@@ -438,6 +450,7 @@ impl<'db> GenericContext<'db> {
     ) -> Self {
         Self::from_typevar_instances(
             db,
+            self.program(db),
             self.variables(db).filter(|bound_typevar| {
                 !(bound_typevar.typevar(db).is_self(db)
                     && binding_context.is_none_or(|binding_context| {
@@ -474,6 +487,7 @@ impl<'db> GenericContext<'db> {
             fn visit_bound_type_var_type(
                 &self,
                 db: &'db dyn Db,
+                program: crate::Program,
                 bound_typevar: BoundTypeVarInstance<'db>,
             ) {
                 self.typevars
@@ -481,12 +495,12 @@ impl<'db> GenericContext<'db> {
                     .insert(bound_typevar.identity(db));
                 let typevar = bound_typevar.typevar(db);
                 if let Some(bound_or_constraints) = typevar.bound_or_constraints(db) {
-                    walk_type_var_bounds(db, bound_or_constraints, self);
+                    walk_type_var_bounds(db, program, bound_or_constraints, self);
                 }
             }
 
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            fn visit_type(&self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
             }
         }
 
@@ -499,9 +513,10 @@ impl<'db> GenericContext<'db> {
             db: &'db dyn Db,
             generic_context: GenericContext<'db>,
         ) -> InferableTypeVars<'db> {
+            let program = generic_context.program(db);
             let visitor = CollectTypeVars::default();
             for bound_typevar in generic_context.variables(db) {
-                visitor.visit_bound_type_var_type(db, bound_typevar);
+                visitor.visit_bound_type_var_type(db, program, bound_typevar);
             }
             InferableTypeVars::from_typevars(db, visitor.typevars.into_inner())
         }
@@ -583,22 +598,26 @@ impl<'db> GenericContext<'db> {
         parameters: &Parameters<'db>,
         return_type: Type<'db>,
     ) -> Option<Self> {
+        let program = definition.program_file(db).program(db);
         // Find all of the legacy typevars mentioned in the function signature.
         let mut variables = FxOrderSet::default();
         for param in parameters {
-            param
-                .annotated_type()
-                .find_legacy_typevars(db, Some(definition), &mut variables);
+            param.annotated_type().find_legacy_typevars(
+                db,
+                program,
+                Some(definition),
+                &mut variables,
+            );
             if let Some(ty) = param.default_type() {
-                ty.find_legacy_typevars(db, Some(definition), &mut variables);
+                ty.find_legacy_typevars(db, program, Some(definition), &mut variables);
             }
         }
-        return_type.find_legacy_typevars(db, Some(definition), &mut variables);
+        return_type.find_legacy_typevars(db, program, Some(definition), &mut variables);
 
         if variables.is_empty() {
             return None;
         }
-        Some(Self::from_typevar_instances(db, variables))
+        Some(Self::from_typevar_instances(db, program, variables))
     }
 
     pub(crate) fn merge_pep695_and_legacy(
@@ -631,14 +650,15 @@ impl<'db> GenericContext<'db> {
         definition: Definition<'db>,
         bases: impl Iterator<Item = Type<'db>>,
     ) -> Option<Self> {
+        let program = definition.program_file(db).program(db);
         let mut variables = FxOrderSet::default();
         for base in bases {
-            base.find_legacy_typevars(db, Some(definition), &mut variables);
+            base.find_legacy_typevars(db, program, Some(definition), &mut variables);
         }
         if variables.is_empty() {
             return None;
         }
-        Some(Self::from_typevar_instances(db, variables))
+        Some(Self::from_typevar_instances(db, program, variables))
     }
 
     pub(crate) fn remove_callable_only_typevars(
@@ -674,6 +694,7 @@ impl<'db> GenericContext<'db> {
                 FxHashSet<BoundTypeVarInstance<'db>>,
                 FxHashMap<CallableType<'db>, CallableType<'db>>,
             ) {
+                let program = function_definition.program_file(db).program(db);
                 let mut found_only_inside_callable_return = FxHashSet::default();
                 let replacements = self
                     .found_inside_callable_return
@@ -709,12 +730,14 @@ impl<'db> GenericContext<'db> {
                         let apply = ApplySpecialization::ReturnCallables(&typevar_replacements);
                         let signatures = callable.signatures(db).apply_type_mapping_impl(
                             db,
+                            program,
                             &TypeMapping::ApplySpecialization(apply),
                             TypeContext::default(),
                             &ApplyTypeMappingVisitor::default(),
                         );
                         let generic_context = GenericContext::from_typevar_instances(
                             db,
+                            program,
                             typevar_replacements.values().copied(),
                         );
                         let signatures =
@@ -752,6 +775,7 @@ impl<'db> GenericContext<'db> {
             fn visit_bound_type_var_type(
                 &self,
                 db: &'db dyn Db,
+                _program: Program,
                 bound_typevar: BoundTypeVarInstance<'db>,
             ) {
                 let bound_typevar = if bound_typevar.is_paramspec(db) {
@@ -776,33 +800,43 @@ impl<'db> GenericContext<'db> {
                 }
             }
 
-            fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
+            fn visit_callable_type(
+                &self,
+                db: &'db dyn Db,
+                program: Program,
+                callable: CallableType<'db>,
+            ) {
                 // Note: We only consider the outermost Callables in the return type.
                 if self.in_return_type && self.in_callable_type.get().is_none() {
                     self.in_callable_type.set(Some(callable));
-                    walk_callable_type(db, callable, self);
+                    walk_callable_type(db, program, callable, self);
                     self.in_callable_type.set(None);
                 } else {
-                    walk_callable_type(db, callable, self);
+                    walk_callable_type(db, program, callable, self);
                 }
             }
 
-            fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
+            fn visit_type_alias_type(
+                &self,
+                db: &'db dyn Db,
+                program: crate::Program,
+                type_alias: TypeAliasType<'db>,
+            ) {
                 // The default implementation would do this for us if we returned `true` from
                 // `should_visit_lazy_type_attributes`. However, this is the _only_ lazy type
                 // attribute that we want to recurse into, so we do it by hand.
                 match type_alias {
                     TypeAliasType::PEP695(type_alias) => {
-                        walk_pep_695_type_alias(db, type_alias, self);
+                        walk_pep_695_type_alias(db, program, type_alias, self);
                     }
                     TypeAliasType::ManualPEP695(type_alias) => {
-                        walk_manual_pep_695_type_alias(db, type_alias, self);
+                        walk_manual_pep_695_type_alias(db, program, type_alias, self);
                     }
                 }
             }
 
-            fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-                walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            fn visit_type(&self, db: &'db dyn Db, program: crate::Program, ty: Type<'db>) {
+                walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
             }
         }
 
@@ -811,14 +845,15 @@ impl<'db> GenericContext<'db> {
         let Some(generic_context) = generic_context else {
             return (None, return_type);
         };
+        let program = function_definition.program_file(db).program(db);
 
         // Find whether each typevar appears inside and/or outside a return type Callable.
         let mut find_typevar_locations = FindTypeVarLocations::default();
         for param in parameters {
-            find_typevar_locations.visit_type(db, param.annotated_type());
+            find_typevar_locations.visit_type(db, program, param.annotated_type());
         }
         find_typevar_locations.in_return_type = true;
-        find_typevar_locations.visit_type(db, return_type);
+        find_typevar_locations.visit_type(db, program, return_type);
 
         // Then update those return type Callables to be generic, with their generic context
         // containing the typevars that don't appear outside any return type Callable.
@@ -827,7 +862,8 @@ impl<'db> GenericContext<'db> {
             .into_inner()
             .finalize(db, function_definition);
         let type_mapping = TypeMapping::RescopeReturnCallables(&replacements);
-        let return_type = return_type.apply_type_mapping(db, &type_mapping, TypeContext::default());
+        let return_type =
+            return_type.apply_type_mapping(db, program, &type_mapping, TypeContext::default());
 
         // And lastly remove those typevars from the function's generic context.
         let mut kept_typevars = generic_context
@@ -837,7 +873,11 @@ impl<'db> GenericContext<'db> {
         let generic_context = if kept_typevars.peek().is_none() {
             None
         } else {
-            Some(GenericContext::from_typevar_instances(db, kept_typevars))
+            Some(GenericContext::from_typevar_instances(
+                db,
+                program,
+                kept_typevars,
+            ))
         };
 
         (generic_context, return_type)
@@ -958,6 +998,7 @@ impl<'db> GenericContext<'db> {
         db: &'db dyn Db,
         mut types: Box<[Type<'db>]>,
     ) -> Specialization<'db> {
+        let program = self.program(db);
         let len = types.len();
         let variables = self.variables(db).collect_vec();
         loop {
@@ -982,6 +1023,7 @@ impl<'db> GenericContext<'db> {
                 };
                 let updated = types[i].apply_type_mapping(
                     db,
+                    program,
                     &TypeMapping::ApplySpecialization(specialization),
                     TypeContext::default(),
                 );
@@ -1012,6 +1054,7 @@ impl<'db> GenericContext<'db> {
         I: IntoIterator<Item = Option<Type<'db>>>,
         I::IntoIter: ExactSizeIterator,
     {
+        let program = self.program(db);
         let types = types.into_iter();
         let variables = self.variables(db);
         assert_eq!(self.len(db), types.len());
@@ -1053,6 +1096,7 @@ impl<'db> GenericContext<'db> {
             };
             let default = default.apply_type_mapping(
                 db,
+                program,
                 &TypeMapping::ApplySpecialization(specialization),
                 TypeContext::default(),
             );
@@ -1108,16 +1152,24 @@ pub(super) fn walk_specialization<'db, V: TypeVisitor<'db> + ?Sized>(
     specialization: Specialization<'db>,
     visitor: &V,
 ) {
-    walk_generic_context(db, specialization.generic_context(db), visitor);
+    let generic_context = specialization.generic_context(db);
+    let program = generic_context.program(db);
+    for bound_typevar in generic_context.variables(db) {
+        visitor.visit_bound_type_var_type(db, program, bound_typevar);
+    }
     for ty in specialization.types(db) {
-        visitor.visit_type(db, *ty);
+        visitor.visit_type(db, program, *ty);
     }
     if let Some(tuple) = specialization.tuple_inner(db) {
-        walk_tuple_type(db, tuple, visitor);
+        walk_tuple_type(db, program, tuple, visitor);
     }
 }
 
 impl<'db> Specialization<'db> {
+    fn program(self, db: &'db dyn Db) -> Program {
+        self.generic_context(db).program(db)
+    }
+
     /// Merge cycle iterations that differ only by gradual `Unknown` type arguments.
     ///
     /// Known argument mismatches are not merged because doing so would be unsound for invariant
@@ -1242,14 +1294,19 @@ impl<'db> Specialization<'db> {
     /// That lets us produce the generic alias `A[int]`, which is the corresponding entry in the
     /// MRO of `B[int]`.
     pub(crate) fn apply_specialization(self, db: &'db dyn Db, other: Specialization<'db>) -> Self {
-        let new_specialization = self.apply_type_mapping(
+        let program = self.program(db);
+        let new_specialization = self.apply_type_mapping_impl_with_program(
             db,
+            program,
             &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(other)),
+            &[],
+            &ApplyTypeMappingVisitor::default(),
         );
         match other.materialization_kind(db) {
             None => new_specialization,
             Some(materialization_kind) => new_specialization.materialize_impl(
                 db,
+                program,
                 materialization_kind,
                 &ApplyTypeMappingVisitor::default(),
             ),
@@ -1270,29 +1327,23 @@ impl<'db> Specialization<'db> {
         )
     }
 
-    pub(crate) fn apply_type_mapping<'a>(
+    pub(crate) fn apply_type_mapping_impl_with_program<'a>(
         self,
         db: &'db dyn Db,
-        type_mapping: &TypeMapping<'a, 'db>,
-    ) -> Self {
-        self.apply_type_mapping_impl(db, type_mapping, &[], &ApplyTypeMappingVisitor::default())
-    }
-
-    pub(crate) fn apply_type_mapping_impl<'a>(
-        self,
-        db: &'db dyn Db,
+        program: Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: &[Type<'db>],
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        debug_assert_eq!(program, self.program(db));
         if let TypeMapping::Materialize(materialization_kind) = type_mapping {
-            return self.materialize_impl(db, *materialization_kind, visitor);
+            return self.materialize_impl(db, program, *materialization_kind, visitor);
         }
 
         let mut new_materialization_kind = self.materialization_kind(db);
         let types = self.map_types(db, |i, typevar, ty| {
             let tcx = TypeContext::new(tcx.get(i).copied());
-            match (typevar.variance(db), type_mapping) {
+            match (typevar.variance(db, program), type_mapping) {
                 (
                     TypeVarVariance::Invariant,
                     TypeMapping::ApplySpecializationWithMaterialization {
@@ -1300,21 +1351,17 @@ impl<'db> Specialization<'db> {
                         materialization_kind,
                     },
                 ) => {
-                    // An invariant type argument cannot be materialized in isolation. Keep the
-                    // specialized argument and record the materialization on this specialization.
-                    // Comparing both mappings distinguishes substituted gradual types from
-                    // unrelated gradual types already present in the argument. Use separate
-                    // visitors because their transformation caches are keyed only by type.
                     let specialized = ty.apply_type_mapping_impl(
                         db,
+                        program,
                         &TypeMapping::ApplySpecialization(*specialization),
                         tcx,
                         &ApplyTypeMappingVisitor::default(),
                     );
-
                     if new_materialization_kind.is_none() {
                         let materialized = ty.apply_type_mapping_impl(
                             db,
+                            program,
                             type_mapping,
                             tcx,
                             &ApplyTypeMappingVisitor::default(),
@@ -1323,19 +1370,24 @@ impl<'db> Specialization<'db> {
                             new_materialization_kind = Some(*materialization_kind);
                         }
                     }
-
                     specialized
                 }
                 (variance, _) if variance.is_covariant() => {
-                    ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                    ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
                 }
-                _ => ty.apply_type_mapping_impl(db, &type_mapping.flip(), tcx, visitor),
+                _ => ty.apply_type_mapping_impl(db, program, &type_mapping.flip(), tcx, visitor),
             }
         });
 
         let original_tuple_inner = self.tuple_inner(db);
         let tuple_inner = original_tuple_inner.and_then(|tuple| {
-            tuple.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
+            tuple.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                TypeContext::default(),
+                visitor,
+            )
         });
 
         // Keep this check in sync with every field that can be transformed above.
@@ -1374,6 +1426,7 @@ impl<'db> Specialization<'db> {
     ///
     /// Panics if the two specializations are not for the same generic context.
     pub(crate) fn combine(self, db: &'db dyn Db, other: Self) -> Self {
+        let program = self.program(db);
         let generic_context = self.generic_context(db);
         assert_eq!(other.generic_context(db), generic_context);
         // TODO special-casing Unknown to mean "no mapping" is not right here, and can give
@@ -1387,7 +1440,7 @@ impl<'db> Specialization<'db> {
             .zip(other.types(db))
             .map(|(self_type, other_type)| match (self_type, other_type) {
                 (unknown, known) | (known, unknown) if unknown.is_unknown() => *known,
-                _ => UnionType::from_two_elements(db, *self_type, *other_type),
+                _ => UnionType::from_two_elements(db, program, *self_type, *other_type),
             })
             .collect();
         // TODO: Combine the tuple specs too
@@ -1398,25 +1451,27 @@ impl<'db> Specialization<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        debug_assert_eq!(program, self.program(db));
         let types = if nested {
             self.types(db)
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
+                .map(|ty| ty.recursive_type_normalized_impl(db, program, div, true))
                 .collect::<Option<Box<[_]>>>()?
         } else {
             self.types(db)
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, div, true)
+                    ty.recursive_type_normalized_impl(db, program, div, true)
                         .unwrap_or(div)
                 })
                 .collect::<Box<[_]>>()
         };
         let tuple_inner = match self.tuple_inner(db) {
-            Some(tuple) => Some(tuple.recursive_type_normalized_impl(db, div, nested)?),
+            Some(tuple) => Some(tuple.recursive_type_normalized_impl(db, program, div, nested)?),
             None => None,
         };
         let context = self.generic_context(db);
@@ -1432,9 +1487,11 @@ impl<'db> Specialization<'db> {
     pub(super) fn materialize_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        debug_assert_eq!(program, self.program(db));
         // The top and bottom materializations are fully static types already, so materializing them
         // further does nothing.
         if self.materialization_kind(db).is_some() {
@@ -1442,22 +1499,27 @@ impl<'db> Specialization<'db> {
         }
         let mut has_dynamic_invariant_typevar = false;
         let types = self.map_types(db, |_, bound_typevar, vartype| {
-            match specialization_variance(db, bound_typevar) {
+            match specialization_variance(db, program, bound_typevar) {
                 TypeVarVariance::Bivariant => {
                     // With bivariance, all specializations are subtypes of each other,
                     // so any materialization is acceptable.
-                    vartype.materialize(db, MaterializationKind::Top, visitor)
+                    vartype.materialize(db, program, MaterializationKind::Top, visitor)
                 }
                 TypeVarVariance::Covariant => {
-                    vartype.materialize(db, materialization_kind, visitor)
+                    vartype.materialize(db, program, materialization_kind, visitor)
                 }
                 TypeVarVariance::Contravariant => {
-                    vartype.materialize(db, materialization_kind.flip(), visitor)
+                    vartype.materialize(db, program, materialization_kind.flip(), visitor)
                 }
                 TypeVarVariance::Invariant => {
                     let top_materialization =
-                        vartype.materialize(db, MaterializationKind::Top, visitor);
-                    if !visitor.is_equivalent_to_materialization(db, vartype, top_materialization) {
+                        vartype.materialize(db, program, MaterializationKind::Top, visitor);
+                    if !visitor.is_equivalent_to_materialization(
+                        db,
+                        program,
+                        vartype,
+                        top_materialization,
+                    ) {
                         has_dynamic_invariant_typevar = true;
                     }
                     vartype
@@ -1469,6 +1531,7 @@ impl<'db> Specialization<'db> {
             // Tuples are immutable, so tuple element types are always in covariant position.
             tuple.apply_type_mapping_impl(
                 db,
+                program,
                 &TypeMapping::Materialize(materialization_kind),
                 TypeContext::default(),
                 visitor,
@@ -1503,11 +1566,13 @@ impl<'db> Specialization<'db> {
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program(db);
         let relation_visitor = HasRelationToVisitor::default(constraints);
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker::new(
+            program,
             constraints,
             inferable,
             &relation_visitor,
@@ -1525,11 +1590,12 @@ impl<'db> Specialization<'db> {
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
+        let program = self.program(db);
         if let Some(tuple) = self.tuple_inner(db) {
-            tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            tuple.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         } else {
             for ty in self.types(db) {
-                ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
         }
     }
@@ -1542,6 +1608,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: Specialization<'db>,
         target: Specialization<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let generic_context = source.generic_context(db);
         if generic_context != target.generic_context(db) {
             return self.never();
@@ -1564,6 +1631,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         types.when_all(
             db,
+            program,
             self.constraints,
             |(bound_typevar, source_type, target_type)| {
                 // Subtyping/assignability of each type in the specialization depends on the variance
@@ -1572,7 +1640,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 //   - contravariant: verify that target_type <: source_type
                 //   - invariant: verify that source_type <: target_type AND target_type <: source_type
                 //   - bivariant: skip, can't make subtyping/assignability false
-                match specialization_variance(db, bound_typevar) {
+                match specialization_variance(db, program, bound_typevar) {
                     TypeVarVariance::Invariant => self.check_relation_in_invariant_position(
                         db,
                         *source_type,
@@ -1603,6 +1671,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: Option<MaterializationKind>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         match (
             source_materialization,
             target_materialization,
@@ -1629,32 +1698,34 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             // `Foo[list[Any]]` even if `Foo` is invariant, and even though `Any` is not equivalent to
             // `list[Any]`, because `Any` is assignable to `list[Any]` and `list[Any]` is assignable to
             // `Any`.
-            //
-            // For lazy type-variable evaluation, those two directions describe a single
-            // constraint. Constructing it directly avoids combinatorial path expansion when many
-            // invariant specializations are combined in a union. Subtyping uses the gradual
-            // type's materialization range, while assignability uses the type itself for both
-            // bounds.
             (None, None, _) => {
                 if self.typevar_evaluation == TypeVarEvaluation::Lazy
                     && let (Type::TypeVar(typevar), ty) | (ty, Type::TypeVar(typevar)) =
                         (source_type, target_type)
                     && !ty.is_type_var()
-                    // Preserve union distribution before constructing constraints. Storing the
-                    // entire union as an exact bound makes solving common generic calls involving
-                    // large unions significantly more expensive.
                     && !ty.is_union()
                 {
                     let ty = ty.materialized_divergent_fallback().unwrap_or(ty);
                     let (lower, upper) = if self.relation.is_subtyping() {
-                        (ty.top_materialization(db), ty.bottom_materialization(db))
+                        (
+                            ty.top_materialization(db, program),
+                            ty.bottom_materialization(db, program),
+                        )
                     } else {
                         (ty, ty)
                     };
-                    ConstraintSet::constrain_typevar(db, self.constraints, typevar, lower, upper)
+                    ConstraintSet::constrain_typevar(
+                        db,
+                        program,
+                        self.constraints,
+                        typevar,
+                        lower,
+                        upper,
+                    )
                 } else {
                     self.check_type_pair(db, target_type, source_type).and(
                         db,
+                        program,
                         self.constraints,
                         || self.check_type_pair(db, source_type, target_type),
                     )
@@ -1715,17 +1786,28 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_type: Type<'db>,
         target_materialization: MaterializationKind,
     ) -> ConstraintSet<'db, 'c> {
-        let source_top =
-            source_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
+        let program = self.program;
+        let source_top = source_type.materialize(
+            db,
+            program,
+            MaterializationKind::Top,
+            self.materialization_visitor,
+        );
         let source_bottom = source_type.materialize(
             db,
+            program,
             MaterializationKind::Bottom,
             self.materialization_visitor,
         );
-        let target_top =
-            target_type.materialize(db, MaterializationKind::Top, self.materialization_visitor);
+        let target_top = target_type.materialize(
+            db,
+            program,
+            MaterializationKind::Top,
+            self.materialization_visitor,
+        );
         let target_bottom = target_type.materialize(
             db,
+            program,
             MaterializationKind::Bottom,
             self.materialization_visitor,
         );
@@ -1747,41 +1829,51 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         match (source_materialization, target_materialization) {
             // `source` is a subtype of `target` if the range of materializations covered by `source`
             // is a subset of the range covered by `target`.
-            (MaterializationKind::Top, MaterializationKind::Top) => {
-                is_subtype_of(target_bottom, source_bottom).and(db, self.constraints, || {
-                    is_subtype_of(source_top, target_top)
-                })
-            }
+            (MaterializationKind::Top, MaterializationKind::Top) => is_subtype_of(
+                target_bottom,
+                source_bottom,
+            )
+            .and(db, program, self.constraints, || {
+                is_subtype_of(source_top, target_top)
+            }),
             // One bottom is a subtype of another if it covers a strictly larger set of materializations.
-            (MaterializationKind::Bottom, MaterializationKind::Bottom) => {
-                is_subtype_of(source_bottom, target_bottom).and(db, self.constraints, || {
-                    is_subtype_of(target_top, source_top)
-                })
-            }
+            (MaterializationKind::Bottom, MaterializationKind::Bottom) => is_subtype_of(
+                source_bottom,
+                target_bottom,
+            )
+            .and(db, program, self.constraints, || {
+                is_subtype_of(target_top, source_top)
+            }),
             // The bottom materialization of `source` is a subtype of the top materialization
             // of `target` if there is some type that is both within the
             // range of types covered by derived and within the range covered by base, because if such a type
             // exists, it's a subtype of `Top[target]` and a supertype of `Bottom[source]`.
             (MaterializationKind::Bottom, MaterializationKind::Top) => {
                 is_subtype_of(target_bottom, source_bottom)
-                    .and(db, self.constraints, || {
+                    .and(db, program, self.constraints, || {
                         is_subtype_of(source_bottom, target_top)
                     })
-                    .or(db, self.constraints, || {
-                        is_subtype_of(target_bottom, source_top).and(db, self.constraints, || {
-                            is_subtype_of(source_top, target_top)
-                        })
+                    .or(db, program, self.constraints, || {
+                        is_subtype_of(target_bottom, source_top).and(
+                            db,
+                            program,
+                            self.constraints,
+                            || is_subtype_of(source_top, target_top),
+                        )
                     })
-                    .or(db, self.constraints, || {
-                        is_subtype_of(target_top, source_top).and(db, self.constraints, || {
-                            is_subtype_of(source_bottom, target_top)
-                        })
+                    .or(db, program, self.constraints, || {
+                        is_subtype_of(target_top, source_top).and(
+                            db,
+                            program,
+                            self.constraints,
+                            || is_subtype_of(source_bottom, target_top),
+                        )
                     })
             }
             // A top materialization is a subtype of a bottom materialization only if both original
             // un-materialized types are the same fully static type.
             (MaterializationKind::Top, MaterializationKind::Bottom) => {
-                is_subtype_of(source_top, target_bottom).and(db, self.constraints, || {
+                is_subtype_of(source_top, target_bottom).and(db, program, self.constraints, || {
                     is_subtype_of(target_top, source_bottom)
                 })
             }
@@ -1791,9 +1883,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
 fn specialization_variance<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     bound_typevar: BoundTypeVarInstance<'db>,
 ) -> TypeVarVariance {
-    let variance = bound_typevar.variance(db);
+    let variance = bound_typevar.variance(db, program);
     if bound_typevar.is_paramspec(db) {
         // `ParamSpec` specializations are represented as callable-shaped values. Their relation
         // and materialization already use callable parameter contravariance, so flip the generic
@@ -1811,6 +1904,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: Specialization<'db>,
         right: Specialization<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let generic_context = left.generic_context(db);
         if generic_context != right.generic_context(db) {
             return self.always();
@@ -1829,8 +1923,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 
         types.when_any(
             db,
+            program,
             self.constraints,
-            |(bound_typevar, left_type, right_type)| match bound_typevar.variance(db) {
+            |(bound_typevar, left_type, right_type)| match bound_typevar.variance(db, program) {
                 TypeVarVariance::Invariant => {
                     let left_type = left_type.resolve_type_alias(db);
                     let right_type = right_type.resolve_type_alias(db);
@@ -1960,11 +2055,13 @@ impl<'db> Type<'db> {
     pub(crate) fn substitute_one_typevar(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         bound_typevar: BoundTypeVarInstance<'db>,
         replacement: Type<'db>,
     ) -> Type<'db> {
         self.apply_type_mapping(
             db,
+            program,
             &TypeMapping::ApplySpecialization(ApplySpecialization::Single(
                 bound_typevar,
                 replacement,
@@ -1978,6 +2075,7 @@ impl<'db> Type<'db> {
 /// specialization of a generic function.
 pub(crate) struct SpecializationBuilder<'db, 'c> {
     db: &'db dyn Db,
+    program: crate::Program,
     constraints: &'c ConstraintSetBuilder<'db>,
     inferable: InferableTypeVars<'db>,
     pending: ConstraintSet<'db, 'c>,
@@ -1986,9 +2084,6 @@ pub(crate) struct SpecializationBuilder<'db, 'c> {
 }
 
 /// The result of type variable inference before choosing how to handle unsolved type variables.
-///
-/// A `Some` entry means inference solved the corresponding type variable to that type. A `None`
-/// entry means the type variable was not solved and should be projected according to the use site.
 #[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
 pub(crate) struct TypeVarInference<'db> {
     #[returns(copy)]
@@ -1997,11 +2092,9 @@ pub(crate) struct TypeVarInference<'db> {
     types: Box<[Option<Type<'db>>]>,
 }
 
-// The Salsa heap is tracked separately.
 impl get_size2::GetSize for TypeVarInference<'_> {}
 
 impl<'db> TypeVarInference<'db> {
-    /// Project this inference result into a closed specialization.
     pub(crate) fn specialization(self, db: &'db dyn Db) -> Specialization<'db> {
         #[salsa::tracked(returns(copy))]
         fn specialization_inner<'db>(
@@ -2014,12 +2107,6 @@ impl<'db> TypeVarInference<'db> {
         specialization_inner(db, self)
     }
 
-    /// Project this inference result into a specialization with explicit handling for each
-    /// type variable.
-    ///
-    /// The hook receives the type variable and its inferred type, if any. Returning `Some` overrides
-    /// the projection for that variable. Returning `None` uses the inferred type if present,
-    /// otherwise the type variable's default.
     pub(crate) fn specialization_with(
         self,
         db: &'db dyn Db,
@@ -2038,11 +2125,13 @@ impl<'db> TypeVarInference<'db> {
 impl<'db, 'c> SpecializationBuilder<'db, 'c> {
     pub(crate) fn new(
         db: &'db dyn Db,
+        program: crate::Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> Self {
         Self {
             db,
+            program,
             constraints,
             inferable,
             pending: ConstraintSet::from_bool(constraints, true),
@@ -2081,7 +2170,6 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context.specialize_recursive(self.db, specialization)
     }
 
-    /// Build raw type-variable inference, preserving which type variables were left unsolved.
     pub(crate) fn build_inference_with(
         &mut self,
         generic_context: GenericContext<'db>,
@@ -2102,6 +2190,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         generic_context: GenericContext<'db>,
         choose: &mut impl FnMut(BoundTypeVarInstance<'db>, Option<&PathBound<'db>>) -> Option<Type<'db>>,
     ) -> FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> {
+        let program = self.program;
         if generic_context
             .variables_inner(self.db)
             .values()
@@ -2122,17 +2211,20 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // was not enough: `solutions_with` still performed the expensive path traversal, and the
         // skipped projection changed precision in LiteralString tests. See the
         // `ty_micro[pydantic_core_schema_dict]` benchmark for a minimized reproducer.
-        let solutions = match self.pending.solutions_with(
+        let pending =
+            self.pending
+                .remove_noninferable(self.db, program, self.constraints, self.inferable);
+        let solutions = match pending.solutions_with(
             self.db,
+            program,
             self.constraints,
-            self.inferable,
             |_variance, path_bound| {
                 let typevar = path_bound.bound_typevar;
                 if let Some(ty) = choose(typevar, Some(path_bound)) {
                     return Ok(Some(ty));
                 }
 
-                PathBounds::default_solve(self.db, self.constraints, path_bound)
+                PathBounds::default_solve(self.db, program, self.constraints, path_bound)
             },
         ) {
             Solutions::Unsatisfiable | Solutions::Unconstrained => {
@@ -2148,8 +2240,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 types
                     .entry(identity)
                     .and_modify(|existing| {
-                        *existing =
-                            UnionType::from_two_elements(self.db, *existing, binding.solution);
+                        *existing = UnionType::from_two_elements(
+                            self.db,
+                            self.program,
+                            *existing,
+                            binding.solution,
+                        );
                     })
                     .or_insert(binding.solution);
             }
@@ -2205,7 +2301,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 .iter_positive(self.db)
                 .chain(intersection.iter_negative(self.db))
                 .any(|element| self.has_expanding_cycle(generic_context, types, identity, element)),
-            _ => any_over_type(self.db, ty, false, |nested| {
+            _ => any_over_type(self.db, self.program, ty, false, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(self.db);
                     dependency != identity
@@ -2238,7 +2334,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         }
 
         types.get(&identity).is_some_and(|ty| {
-            any_over_type(self.db, *ty, false, |nested| {
+            any_over_type(self.db, self.program, *ty, false, |nested| {
                 nested.as_typevar().is_some_and(|dependency| {
                     let dependency = dependency.identity(self.db);
                     // Recursive specialization skips a typevar's own slot. Only references
@@ -2267,7 +2363,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // Relationships across binding contexts can intentionally remap one generic context
             // onto another, as with constructor `self` annotations. Synthetic contexts do not
             // identify a single source-level binding, so they are not safe to project either.
-            target_context != BindingContext::Synthetic
+            !matches!(target_context, BindingContext::Synthetic(_))
                 && typevar.is_inferable(self.db, self.inferable)
                 && typevar.binding_context(self.db) == target_context
         })
@@ -2315,7 +2411,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .iter_positive(self.db)
                     .any(|element| !self.is_inferable_typevar_artifact(target, element)) =>
             {
-                intersection.map_positive(self.db, |element| {
+                intersection.map_positive(self.db, self.program, |element| {
                     if self.is_inferable_typevar_artifact(target, *element) {
                         Type::object()
                     } else {
@@ -2339,7 +2435,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let mapped_ty = self
                     .types
                     .get_mut(identity)
-                    .map(|accumulator| accumulator.get_or_build(self.db));
+                    .map(|accumulator| accumulator.get_or_build(self.db, self.program));
                 let chosen = match mapped_ty {
                     Some(mapped_ty) => {
                         let path_bound = PathBound::exact(*variable, mapped_ty);
@@ -2370,7 +2466,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     return;
                 }
 
-                entry.get_mut().add(self.db, ty);
+                entry.get_mut().add(self.db, self.program, ty);
             }
             Entry::Vacant(entry) => {
                 entry.insert(UnionAccumulator::new(ty));
@@ -2390,6 +2486,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
         let constraint = ConstraintSet::constrain_typevar_with_bounds(
             self.db,
+            self.program,
             self.constraints,
             bound_typevar,
             bounds.lower,
@@ -2408,8 +2505,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             .get_mut(&bound_typevar)
             .is_some_and(|inferred_ty| {
                 inferred_ty
-                    .get_or_build(self.db)
-                    .is_assignable_to(self.db, ty)
+                    .get_or_build(self.db, self.program)
+                    .is_assignable_to(self.db, self.program, ty)
             })
     }
 
@@ -2452,7 +2549,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         &mut self,
         set: ConstraintSet<'db, 'c>,
     ) -> Result<(), ()> {
-        let solutions = match set.solutions(self.db, self.constraints, self.inferable) {
+        let program = self.program;
+        let set = set.remove_noninferable(self.db, program, self.constraints, self.inferable);
+        let solutions = match set.solutions(self.db, program, self.constraints) {
             Solutions::Unsatisfiable => return Err(()),
             Solutions::Unconstrained => return Ok(()),
             Solutions::Constrained(solutions) => solutions,
@@ -2516,6 +2615,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             result
         }
 
+        let program = self.program;
         let mut resolving = FxHashSet::default();
         let mut completed = FxHashMap::default();
         let mut typed_dicts = FxHashSet::default();
@@ -2534,20 +2634,25 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         // Use the read-only `Mapping[str, object]` as the fallback rather than `dict[str, object]`.
         // The current constraint solver can consider mutable protocol constraints equivalent even
         // when a `TypedDict` preserves more precise correlations between its keys and values.
-        let spec = &[KnownClass::Str.to_instance(self.db), Type::object()];
-        let mapping = KnownClass::Mapping.to_specialized_instance(self.db, spec);
-        let mapping_when = mapping.when_constraint_set_assignable_to_owned(self.db, formal);
-        let mapping_when = self.constraints.load(self.db, &mapping_when);
+        let spec = &[
+            KnownClass::Str.to_instance(self.db, self.program),
+            Type::object(),
+        ];
+        let mapping = KnownClass::Mapping.to_specialized_instance(self.db, self.program, spec);
+        let mapping_when =
+            mapping.when_constraint_set_assignable_to_owned(self.db, self.program, formal);
+        let mapping_when = self.constraints.load(self.db, program, &mapping_when);
         typed_dicts
             .into_iter()
             .all(|element| {
                 let element_when = self.constraints.load(
                     self.db,
-                    &element.when_constraint_set_assignable_to_owned(self.db, formal),
+                    program,
+                    &element.when_constraint_set_assignable_to_owned(self.db, self.program, formal),
                 );
                 element_when
                     .iff(self.db, self.constraints, mapping_when)
-                    .is_always_satisfied(self.db)
+                    .is_always_satisfied(self.db, program)
             })
             .then_some(mapping_when)
     }
@@ -2564,7 +2669,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             if formal_is_single_paramspec {
                 let when = actual_callable
                     .signatures(self.db)
-                    .when_constraint_set_assignable_to(self.db, formal_signature, self.constraints);
+                    .when_constraint_set_assignable_to(
+                        self.db,
+                        self.program,
+                        formal_signature,
+                        self.constraints,
+                    );
                 self.add_type_mappings_from_constraint_set(when)?;
                 self.pending.intersect(self.db, self.constraints, when);
             } else {
@@ -2572,6 +2682,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // least one of its overloads is. We collect type mappings from all satisfiable
                 // overloads, and only report an error if none of them are satisfiable.
                 let db = self.db;
+                let program = self.program;
                 let constraints = self.constraints;
                 let combined = actual_callable
                     .signatures(db)
@@ -2580,6 +2691,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                     .filter_map(|actual_signature| {
                         let when = actual_signature.when_constraint_set_assignable_to_signatures(
                             db,
+                            program,
                             formal_signature,
                             constraints,
                         );
@@ -2587,7 +2699,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             .ok()
                             .map(|()| when)
                     })
-                    .reduce(|lhs, rhs| lhs.or(db, constraints, || rhs));
+                    .reduce(|lhs, rhs| lhs.or(db, program, constraints, || rhs));
                 let Some(combined) = combined else {
                     return Err(());
                 };
@@ -2618,6 +2730,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         polarity: TypeVarVariance,
         seen: &mut FxHashSet<(Type<'db>, Type<'db>)>,
     ) -> Result<(), SpecializationError<'db>> {
+        let program = self.program;
         // TODO: Eventually, the builder will maintain a constraint set, instead of a hash-map of
         // type mappings, to represent the specialization that we are building up. At that point,
         // this method will just need to compare `actual ≤ formal`, using constraint set
@@ -2641,9 +2754,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
         //
         // For example, if `formal` is `list[T]` and `actual` is `list[int] | None`, we want to
         // specialize `T` to `int`, and so ignore the `None`.
-        let actual = actual.filter_disjoint_elements(self.db, formal, self.inferable);
-        let formal = formal.filter_disjoint_elements(self.db, actual, self.inferable);
-
+        let actual = actual.filter_disjoint_elements(self.db, self.program, formal, self.inferable);
+        let formal = formal.filter_disjoint_elements(self.db, self.program, actual, self.inferable);
         match (formal, actual) {
             // Expand PEP 695 type aliases in the formal type.
             // This is necessary for solving generics like `def head[T](my_list: MyList[T]) -> T`.
@@ -2666,7 +2778,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 actual @ (Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_)),
             ) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
-                if let Some(actual_instance) = actual.to_instance(self.db) {
+                if let Some(actual_instance) = actual.to_instance(self.db, self.program) {
                     return self.infer_map_impl(
                         formal_typeform.type_argument(self.db),
                         actual_instance,
@@ -2680,7 +2792,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if actual_instance.is_type_form_value() =>
             {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
-                if let Some(actual_argument) = actual_instance.type_form_argument(self.db) {
+                if let Some(actual_argument) =
+                    actual_instance.type_form_argument(self.db, self.program)
+                {
                     return self.infer_map_impl(
                         formal_typeform.type_argument(self.db),
                         actual_argument,
@@ -2692,7 +2806,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
             (Type::TypeForm(formal_typeform), Type::SpecialForm(actual_form)) => {
                 let variance = TypeVarVariance::Covariant.compose(polarity);
-                if let Some(actual_argument) = actual_form.type_form_argument(self.db) {
+                if let Some(actual_argument) = actual_form.type_form_argument(self.db, self.program)
+                {
                     return self.infer_map_impl(
                         formal_typeform.type_argument(self.db),
                         actual_argument,
@@ -2732,7 +2847,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let types_have_typevars = formal_union
                     .elements(self.db)
                     .iter()
-                    .filter(|ty| ty.has_typevar(self.db));
+                    .filter(|ty| ty.has_typevar(self.db, program));
                 let Ok(Type::TypeVar(formal_bound_typevar)) = types_have_typevars.exactly_one()
                 else {
                     return Ok(());
@@ -2744,8 +2859,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 {
                     return Ok(());
                 }
-                let remaining_actual =
-                    actual_union.filter(self.db, |ty| !ty.is_subtype_of(self.db, formal));
+                let remaining_actual = actual_union.filter(self.db, |ty| {
+                    !ty.is_subtype_of(self.db, self.program, formal)
+                });
                 if remaining_actual.is_never() {
                     return Ok(());
                 }
@@ -2779,8 +2895,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if !actual.is_never() {
                     let assignable_elements = union_formal.elements(self.db).iter().filter(|ty| {
                         actual
-                            .when_subtype_of(self.db, **ty, self.constraints, self.inferable)
-                            .is_always_satisfied(self.db)
+                            .when_subtype_of(
+                                self.db,
+                                self.program,
+                                **ty,
+                                self.constraints,
+                                self.inferable,
+                            )
+                            .is_always_satisfied(self.db, program)
                     });
                     if assignable_elements.exactly_one().is_ok() {
                         return Ok(());
@@ -2818,11 +2940,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         if !actual
                             .when_assignable_to(
                                 self.db,
+                                self.program,
                                 *formal_element,
                                 self.constraints,
                                 self.inferable,
                             )
-                            .is_never_satisfied(self.db)
+                            .is_never_satisfied(self.db, program)
                         {
                             found_matching_element = true;
                         }
@@ -2848,14 +2971,25 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             // check here.
                             self.add_type_mapping(
                                 bound_typevar,
-                                IntersectionType::from_two_elements(self.db, bound, ty),
+                                IntersectionType::from_two_elements(
+                                    self.db,
+                                    self.program,
+                                    bound,
+                                    ty,
+                                ),
                                 polarity,
                             );
                             return Ok(());
                         }
                         if !ty
-                            .when_assignable_to(self.db, bound, self.constraints, self.inferable)
-                            .is_always_satisfied(self.db)
+                            .when_assignable_to(
+                                self.db,
+                                self.program,
+                                bound,
+                                self.constraints,
+                                self.inferable,
+                            )
+                            .is_always_satisfied(self.db, program)
                         {
                             return Err(SpecializationError::MismatchedBound {
                                 bound_typevar,
@@ -2893,8 +3027,11 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                                 actual_constraints.iter().all(|actual_constraint| {
                                     typevar_constraints.elements(self.db).iter().any(
                                         |formal_constraint| {
-                                            actual_constraint
-                                                .is_equivalent_to(self.db, *formal_constraint)
+                                            actual_constraint.is_equivalent_to(
+                                                self.db,
+                                                self.program,
+                                                *formal_constraint,
+                                            )
                                         },
                                     )
                                 });
@@ -2909,19 +3046,21 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                                 constraint
                                     .when_assignable_to(
                                         self.db,
+                                        self.program,
                                         ty,
                                         self.constraints,
                                         self.inferable,
                                     )
-                                    .is_always_satisfied(self.db)
+                                    .is_always_satisfied(self.db, program)
                             } else {
                                 ty.when_assignable_to(
                                     self.db,
+                                    self.program,
                                     *constraint,
                                     self.constraints,
                                     self.inferable,
                                 )
-                                .is_always_satisfied(self.db)
+                                .is_always_satisfied(self.db, program)
                             };
 
                             if is_satisfied {
@@ -2985,8 +3124,14 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                         // The recursive call to `infer_map_impl` may succeed even if the actual
                         // type is not assignable to the formal element.
                         if !positive
-                            .when_assignable_to(self.db, formal, self.constraints, self.inferable)
-                            .is_never_satisfied(self.db)
+                            .when_assignable_to(
+                                self.db,
+                                self.program,
+                                formal,
+                                self.constraints,
+                                self.inferable,
+                            )
+                            .is_never_satisfied(self.db, program)
                         {
                             found_matching_element = true;
                         }
@@ -3001,7 +3146,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 if subclass_of.is_type_var() =>
             {
                 let formal_instance = Type::TypeVar(subclass_of.into_type_var().unwrap());
-                if let Some(actual_instance) = ty.to_instance(self.db) {
+                if let Some(actual_instance) = ty.to_instance(self.db, self.program) {
                     return self.infer_map_impl(formal_instance, actual_instance, polarity, seen);
                 }
             }
@@ -3012,7 +3157,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             ) => {
                 // Retry specialization with the literal's fallback instance so literals can
                 // contribute to generic inference for nominal and protocol formals.
-                let actual_instance = literal.fallback_instance(self.db);
+                let actual_instance = literal.fallback_instance(self.db, self.program);
                 return self.infer_map_impl(formal, actual_instance, polarity, seen);
             }
 
@@ -3024,7 +3169,7 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 // ordinary `range` instance when inferring through generic nominal/protocol types.
                 return self.infer_map_impl(
                     formal,
-                    known_instance.instance_fallback(self.db),
+                    known_instance.instance_fallback(self.db, self.program),
                     polarity,
                     seen,
                 );
@@ -3052,18 +3197,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             ) => {
                 // Special case: `formal` and `actual` are both tuples.
                 if let (Some(formal_tuple), Some(actual_tuple)) = (
-                    formal.tuple_instance_spec(self.db),
-                    actual_nominal.tuple_spec(self.db),
+                    formal.tuple_instance_spec(self.db, self.program),
+                    actual_nominal.tuple_spec(self.db, self.program),
                 ) {
                     let Some(most_precise_length) =
                         formal_tuple.len().most_precise(actual_tuple.len())
                     else {
                         return Ok(());
                     };
-                    let Ok(formal_tuple) = formal_tuple.resize(self.db, most_precise_length) else {
+                    let Ok(formal_tuple) =
+                        formal_tuple.resize(self.db, self.program, most_precise_length)
+                    else {
                         return Ok(());
                     };
-                    let Ok(actual_tuple) = actual_tuple.resize(self.db, most_precise_length) else {
+                    let Ok(actual_tuple) =
+                        actual_tuple.resize(self.db, self.program, most_precise_length)
+                    else {
                         return Ok(());
                     };
                     for (formal_element, actual_element) in formal_tuple
@@ -3079,17 +3228,21 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                 // Extract formal_alias if this is a generic class
                 let formal_alias = match formal {
-                    Type::NominalInstance(formal_nominal) => {
-                        formal_nominal.class(self.db).into_generic_alias()
-                    }
+                    Type::NominalInstance(formal_nominal) => formal_nominal
+                        .class(self.db, self.program)
+                        .into_generic_alias(),
 
                     Type::ProtocolInstance(_) => {
                         // TODO: For protocols, we use the new constraint set implementation, which
                         // will handle implicitly implemented protocols and generic protocols. We
                         // eventually want this logic to be used for _all_ nominal instances
                         // (replacing the logic below).
-                        let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
-                        let when = self.constraints.load(self.db, &when);
+                        let when = actual.when_constraint_set_assignable_to_owned(
+                            self.db,
+                            self.program,
+                            formal,
+                        );
+                        let when = self.constraints.load(self.db, program, &when);
                         // For protocol inference via constraint sets, we currently treat
                         // unsatisfiable results as "no inference" instead of an immediate
                         // specialization error. This matches the previous behavior (where
@@ -3107,7 +3260,10 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
 
                 if let Some(formal_alias) = formal_alias {
                     let formal_origin = formal_alias.origin(self.db);
-                    for base in actual_nominal.class(self.db).iter_mro(self.db) {
+                    for base in actual_nominal
+                        .class(self.db, self.program)
+                        .iter_mro(self.db)
+                    {
                         let ClassBase::Class(ClassType::Generic(base_alias)) = base else {
                             continue;
                         };
@@ -3126,7 +3282,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                             formal_specialization,
                             base_specialization
                         ) {
-                            let variance = typevar.variance_with_polarity(self.db, polarity);
+                            let variance =
+                                typevar.variance_with_polarity(self.db, program, polarity);
                             self.infer_map_impl(*formal_ty, *base_ty, variance, seen)?;
                         }
                         return Ok(());
@@ -3141,7 +3298,12 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
                 let when = self
                     .common_typed_dict_protocol_constraints(formal, actual_union)
                     .unwrap_or_else(|| {
-                        actual.when_constraint_set_assignable_to(self.db, formal, self.constraints)
+                        actual.when_constraint_set_assignable_to(
+                            self.db,
+                            self.program,
+                            formal,
+                            self.constraints,
+                        )
                     });
                 // For protocol inference via constraint sets, keep unsatisfiable results non-fatal
                 // for now, matching the protocol constraint-set path in the nominal-instance
@@ -3153,8 +3315,9 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (formal @ Type::ProtocolInstance(_), actual @ Type::TypedDict(_)) => {
-                let when = actual.when_constraint_set_assignable_to_owned(self.db, formal);
-                let when = self.constraints.load(self.db, &when);
+                let when =
+                    actual.when_constraint_set_assignable_to_owned(self.db, self.program, formal);
+                let when = self.constraints.load(self.db, program, &when);
                 // For protocol inference via constraint sets, keep unsatisfiable results non-fatal
                 // for now, matching the protocol constraint-set path in the nominal-instance
                 // arm above.
@@ -3168,17 +3331,22 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             // from matching the actual type's callable signature against the protocol's `__call__`
             // method signature.
             (Type::ProtocolInstance(formal_protocol), _) => {
-                let Some(call_method) = formal_protocol.interface(self.db).call_method(self.db)
+                let Some(call_method) = formal_protocol
+                    .interface(self.db)
+                    .call_method(self.db, self.program)
                 else {
                     return Ok(());
                 };
-                let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
+                let Some(actual_callables) = actual.try_upcast_to_callable(self.db, self.program)
+                else {
                     return Ok(());
                 };
 
                 // The `__call__` method is bound to `self`, so we need to bind it to get the
                 // callable signature that the actual type needs to match.
-                let formal_signature = call_method.bind_self(self.db, None).signatures(self.db);
+                let formal_signature = call_method
+                    .bind_self(self.db, self.program, None)
+                    .signatures(self.db);
 
                 // For callable-signature inference, keep unsatisfiable constraint-set
                 // comparisons non-fatal for now. The hybrid inference/checking pipeline still
@@ -3188,7 +3356,8 @@ impl<'db, 'c> SpecializationBuilder<'db, 'c> {
             }
 
             (Type::Callable(formal_callable), _) => {
-                let Some(actual_callables) = actual.try_upcast_to_callable(self.db) else {
+                let Some(actual_callables) = actual.try_upcast_to_callable(self.db, self.program)
+                else {
                     return Ok(());
                 };
                 let formal_signature = formal_callable.signatures(self.db);

--- a/crates/ty_python_semantic/src/types/ide_support.rs
+++ b/crates/ty_python_semantic/src/types/ide_support.rs
@@ -14,12 +14,12 @@ use crate::types::{
 use crate::{Db, DisplaySettings, HasDefinition, HasType, SemanticModel};
 use itertools::Either;
 use ruff_db::files::FileRange;
-use ruff_db::parsed::parsed_module;
 use ruff_db::source::source_text;
 use ruff_python_ast::{self as ast, AnyNodeRef, name::Name};
 use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::FxHashSet;
 use ty_python_core::definition::{Definition, DefinitionKind};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::{attribute_scopes, global_scope, semantic_index, use_def_map};
 
 mod unreachable_code;
@@ -60,8 +60,8 @@ pub fn definitions_for_name<'db>(
     alias_resolution: ImportAliasResolution,
 ) -> Vec<ResolvedDefinition<'db>> {
     let db = model.db();
-    let file = model.file();
-    let index = semantic_index(db, file);
+    let program_file = model.program_file();
+    let index = semantic_index(db, program_file);
 
     // Get the scope for this name expression
     let Some(file_scope) = model.scope(node) else {
@@ -92,7 +92,7 @@ pub fn definitions_for_name<'db>(
 
         // If marked as global, skip to global scope
         if is_global {
-            let global_scope_id = global_scope(db, file);
+            let global_scope_id = global_scope(db, program_file);
             let global_place_table = ty_python_core::place_table(db, global_scope_id);
 
             if let Some(global_symbol_id) = global_place_table.symbol_id(name_str) {
@@ -149,7 +149,7 @@ pub fn definitions_for_name<'db>(
 
     // If we didn't find any definitions in scopes, fallback to builtins
     if resolved_definitions.is_empty()
-        && let Some(builtins_scope) = builtins_module_scope(db)
+        && let Some(builtins_scope) = builtins_module_scope(db, program_file.program(db))
     {
         // Special cases for `float` and `complex` in type annotation positions.
         // We don't know whether we're in a type annotation position, so we'll just ask `Name`'s type,
@@ -174,7 +174,7 @@ pub fn definitions_for_name<'db>(
                 .rev()
                 .filter_map(|ty| ty.as_nominal_instance())
                 .filter_map(|instance| {
-                    let definition = instance.class_literal(db).definition(db)?;
+                    let definition = instance.class_literal(db, model.program()).definition(db)?;
                     Some(ResolvedDefinition::Definition(definition))
                 })
                 .collect();
@@ -239,7 +239,10 @@ pub fn definitions_for_attribute<'db>(
         // Handle modules
         if let Type::ModuleLiteral(module_literal) = ty {
             if let Some(module_file) = module_literal.module(db).file(db) {
-                let module_scope = global_scope(db, module_file);
+                let module_scope = global_scope(
+                    db,
+                    ProgramFile::new(db, module_literal.program(db), module_file),
+                );
                 for def in find_symbol_in_scope(db, module_scope, name_str) {
                     resolved.extend(resolve_definition(
                         db,
@@ -257,7 +260,7 @@ pub fn definitions_for_attribute<'db>(
             continue;
         }
 
-        let meta_type = ty.to_meta_type(db);
+        let meta_type = ty.to_meta_type(db, model.program());
 
         // Look up the attribute first on the meta-type, unless it's already a class-like type.
         let lookup_type = match ty {
@@ -267,13 +270,15 @@ pub fn definitions_for_attribute<'db>(
 
         let class_literal = match lookup_type {
             Type::ClassLiteral(class_literal) => class_literal,
-            Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                Some(cls) => match cls.static_class_literal(db) {
-                    Some((lit, _)) => ClassLiteral::Static(lit),
+            Type::SubclassOf(subclass) => {
+                match subclass.subclass_of().into_class(db, model.program()) {
+                    Some(cls) => match cls.static_class_literal(db) {
+                        Some((lit, _)) => ClassLiteral::Static(lit),
+                        None => continue,
+                    },
                     None => continue,
-                },
-                None => continue,
-            },
+                }
+            }
             _ => continue,
         };
 
@@ -291,13 +296,15 @@ pub fn definitions_for_attribute<'db>(
         if resolved.is_empty() && meta_type != lookup_type {
             let class_literal = match meta_type {
                 Type::ClassLiteral(class_literal) => class_literal,
-                Type::SubclassOf(subclass) => match subclass.subclass_of().into_class(db) {
-                    Some(cls) => match cls.static_class_literal(db) {
-                        Some((lit, _)) => ClassLiteral::Static(lit),
+                Type::SubclassOf(subclass) => {
+                    match subclass.subclass_of().into_class(db, model.program()) {
+                        Some(cls) => match cls.static_class_literal(db) {
+                            Some((lit, _)) => ClassLiteral::Static(lit),
+                            None => continue,
+                        },
                         None => continue,
-                    },
-                    None => continue,
-                },
+                    }
+                }
                 _ => continue,
             };
 
@@ -320,7 +327,7 @@ pub fn static_member_type_for_attribute<'db>(
 ) -> Option<Type<'db>> {
     let lhs_ty = attribute.value.inferred_type(model)?;
     lhs_ty
-        .static_member(model.db(), attribute.attr.as_str())
+        .static_member(model.db(), model.program(), attribute.attr.as_str())
         .ignore_possibly_undefined()
 }
 
@@ -361,8 +368,7 @@ fn definitions_for_attribute_in_class_hierarchy<'db>(
         }
 
         // Look for instance attributes in method scopes (e.g., self.x = 1)
-        let file = class_scope.file(db);
-        let index = semantic_index(db, file);
+        let index = semantic_index(db, class_scope.program_file(db));
 
         for function_scope_id in attribute_scopes(db, class_scope) {
             if let Some(place_id) = index
@@ -450,7 +456,7 @@ pub fn typed_dict_key_hover<'db>(
         .map(|literal| literal.value.to_str())?;
     let value_ty = subscript.value.inferred_type(model)?;
     let typed_dict = value_ty.as_typed_dict()?;
-    let owner = value_ty.display(model.db()).to_string();
+    let owner = value_ty.display(model.db(), model.program()).to_string();
     let field = typed_dict.items(model.db()).get(key)?;
     let docstring = field
         .first_declaration()
@@ -484,7 +490,7 @@ pub fn definitions_for_keyword_argument<'db>(
     let mut resolved_definitions = Vec::new();
 
     if let Some(callable_type) = func_type
-        .try_upcast_to_callable(db)
+        .try_upcast_to_callable(db, model.program())
         .and_then(CallableTypes::exactly_one)
     {
         let signatures = callable_type.signatures(db);
@@ -518,7 +524,7 @@ pub fn definitions_for_imported_symbol<'db>(
     let mut visited = FxHashSet::default();
     resolve_definition::resolve_from_import_definitions(
         model.db(),
-        model.file(),
+        model.program_file(),
         import_node,
         symbol_name,
         &mut visited,
@@ -596,11 +602,15 @@ pub struct CallSignatureParameter<'db> {
 }
 
 impl<'db> CallSignatureDetails<'db> {
-    fn from_binding(db: &'db dyn Db, binding: &crate::types::call::Binding<'db>) -> Self {
+    fn from_binding(
+        db: &'db dyn Db,
+        program: crate::Program,
+        binding: &crate::types::call::Binding<'db>,
+    ) -> Self {
         let argument_to_parameter_mapping = binding.argument_matches().to_vec();
         let specialization = binding.specialization(db);
         let signature = binding.signature.clone();
-        let display_details = signature.display(db).to_string_parts();
+        let display_details = signature.display(db, program).to_string_parts();
         let (parameters, parameter_to_displayed_parameter_mapping) =
             displayed_parameters_for_signature(db, &signature, &display_details, specialization);
         let argument_to_displayed_parameter_mapping = argument_to_parameter_mapping
@@ -741,8 +751,8 @@ pub fn call_signature_details<'db>(
 
     // Use into_callable to handle all the complex type conversions
     if let Some(callable_type) = func_type
-        .try_upcast_to_callable(db)
-        .map(|callables| callables.into_type(db))
+        .try_upcast_to_callable(db, model.program())
+        .map(|callables| callables.into_type(db, model.program()))
     {
         // Use from_arguments_typed so that check_types can infer TypeVar
         // specializations from the actual argument types at this call site.
@@ -753,8 +763,8 @@ pub fn call_signature_details<'db>(
                     .unwrap_or(Type::unknown())
             });
         let mut bindings = callable_type
-            .bindings(db)
-            .match_parameters(db, &call_arguments);
+            .bindings(db, model.program())
+            .match_parameters(db, model.program(), &call_arguments);
 
         // Run type checking to resolve TypeVar bindings from argument types.
         // For example, calling `dict[str, int].get("a")` resolves the `_KT`
@@ -763,6 +773,7 @@ pub fn call_signature_details<'db>(
         let constraints = ConstraintSetBuilder::new();
         let _ = bindings.check_types_impl(
             db,
+            model.program(),
             &constraints,
             &call_arguments,
             TypeContext::default(),
@@ -773,7 +784,7 @@ pub fn call_signature_details<'db>(
         bindings
             .iter_flat()
             .flatten()
-            .map(|binding| CallSignatureDetails::from_binding(db, binding))
+            .map(|binding| CallSignatureDetails::from_binding(db, model.program(), binding))
             .collect()
     } else {
         // Type is not callable, return empty signatures
@@ -789,7 +800,7 @@ fn resolve_single_overload<'db>(
     call_expr: &ast::ExprCall,
 ) -> Option<Signature<'db>> {
     let db = model.db();
-    let bindings = callable_type.bindings(db);
+    let bindings = callable_type.bindings(db, model.program());
 
     let args = CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
         splatted_value
@@ -799,8 +810,15 @@ fn resolve_single_overload<'db>(
 
     let constraints = ConstraintSetBuilder::new();
     let mut resolved: Vec<_> = bindings
-        .match_parameters(db, &args)
-        .check_types(db, &constraints, &args, TypeContext::default(), &[])
+        .match_parameters(db, model.program(), &args)
+        .check_types(
+            db,
+            model.program(),
+            &constraints,
+            &args,
+            TypeContext::default(),
+            &[],
+        )
         .iter()
         .flat_map(super::call::bind::Bindings::iter_flat)
         .flat_map(|binding| {
@@ -845,10 +863,11 @@ fn full_type_bindings_for_call<'db>(
     let constraints = ConstraintSetBuilder::new();
 
     func_type
-        .bindings(db)
-        .match_parameters(db, &call_arguments)
+        .bindings(db, model.program())
+        .match_parameters(db, model.program(), &call_arguments)
         .check_types(
             db,
+            model.program(),
             &constraints,
             &call_arguments,
             TypeContext::default(),
@@ -914,7 +933,7 @@ pub fn call_argument_forms(
 
     // Ordinary callables have only value-form arguments for IDE purposes, so skip full binding.
     if !func_type
-        .bindings(db)
+        .bindings(db, model.program())
         .iter_flat()
         .any(|binding| known_type_form_parameter_index(db, binding.callable_type).is_some())
     {
@@ -986,10 +1005,12 @@ pub fn call_type_simplified_by_overloads(
     let db = model.db();
     let func_type = call_expr.func.inferred_type(model)?;
 
-    let callable_type = func_type.try_upcast_to_callable(db)?.into_type(db);
+    let callable_type = func_type
+        .try_upcast_to_callable(db, model.program())?
+        .into_type(db, model.program());
 
     // If the callable is trivial this analysis is useless, bail out
-    if let Some(binding) = callable_type.bindings(db).single_element()
+    if let Some(binding) = callable_type.bindings(db, model.program()).single_element()
         && binding.overloads().len() < 2
     {
         return None;
@@ -998,7 +1019,7 @@ pub fn call_type_simplified_by_overloads(
     let signature = resolve_single_overload(model, callable_type, call_expr)?;
     Some(
         signature
-            .display_with(db, DisplaySettings::default().multiline())
+            .display_with(db, model.program(), DisplaySettings::default().multiline())
             .to_string(),
     )
 }
@@ -1011,11 +1032,13 @@ pub fn definitions_for_bin_op<'db>(
     let left_ty = binary_op.left.inferred_type(model)?;
     let right_ty = binary_op.right.inferred_type(model)?;
 
-    let Ok(bindings) = Type::try_call_bin_op(model.db(), left_ty, binary_op.op, right_ty) else {
+    let Ok(bindings) =
+        Type::try_call_bin_op(model.db(), model.program(), left_ty, binary_op.op, right_ty)
+    else {
         return None;
     };
 
-    let callable_type = promote_for_self(model.db(), bindings.callable_type());
+    let callable_type = promote_for_self(model.db(), model.program(), bindings.callable_type());
 
     let definitions: Vec<_> = bindings
         .iter_flat()
@@ -1046,6 +1069,7 @@ pub fn definitions_for_unary_op<'db>(
 
     let bindings = match operand_ty.try_call_dunder(
         model.db(),
+        model.program(),
         unary_dunder_method,
         CallArguments::none(),
         TypeContext::default(),
@@ -1055,6 +1079,7 @@ pub fn definitions_for_unary_op<'db>(
             // The runtime falls back to `__len__` for `not` if `__bool__` is not defined.
             match operand_ty.try_call_dunder(
                 model.db(),
+                model.program(),
                 "__len__",
                 CallArguments::none(),
                 TypeContext::default(),
@@ -1074,7 +1099,7 @@ pub fn definitions_for_unary_op<'db>(
         ) => *bindings,
     };
 
-    let callable_type = promote_for_self(model.db(), bindings.callable_type());
+    let callable_type = promote_for_self(model.db(), model.program(), bindings.callable_type());
 
     let definitions = bindings
         .iter_flat()
@@ -1092,14 +1117,18 @@ pub fn definitions_for_unary_op<'db>(
 /// Promotes types in `self` positions.
 ///
 /// This is so that we show e.g. `int.__add__` instead of `Literal[4].__add__`.
-fn promote_for_self<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+fn promote_for_self<'db>(db: &'db dyn Db, program: crate::Program, ty: Type<'db>) -> Type<'db> {
     match ty {
         Type::BoundMethod(method) => Type::BoundMethod(method.map_self_type(db, |self_ty| {
-            self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
+            self_ty
+                .literal_fallback_instance(db, program)
+                .unwrap_or(self_ty)
         })),
-        Type::Union(elements) => elements.map(db, |ty| match ty {
+        Type::Union(elements) => elements.map(db, program, |ty| match ty {
             Type::BoundMethod(method) => Type::BoundMethod(method.map_self_type(db, |self_ty| {
-                self_ty.literal_fallback_instance(db).unwrap_or(self_ty)
+                self_ty
+                    .literal_fallback_instance(db, program)
+                    .unwrap_or(self_ty)
             })),
             _ => *ty,
         }),
@@ -1158,7 +1187,9 @@ pub fn resolved_call_signature<'db>(
 ) -> Option<CallSignatureDetails<'db>> {
     let db = model.db();
     let func_type = call_expr.func.inferred_type(model)?;
-    let callable_type = func_type.try_upcast_to_callable(db)?.into_type(db);
+    let callable_type = func_type
+        .try_upcast_to_callable(db, model.program())?
+        .into_type(db, model.program());
 
     let args = CallArguments::from_arguments_typed(&call_expr.arguments, |splatted_value| {
         splatted_value
@@ -1169,16 +1200,23 @@ pub fn resolved_call_signature<'db>(
     // Extract the `Bindings` regardless of whether type checking succeeded or failed.
     let constraints = ConstraintSetBuilder::new();
     let bindings = callable_type
-        .bindings(db)
-        .match_parameters(db, &args)
-        .check_types(db, &constraints, &args, TypeContext::default(), &[])
+        .bindings(db, model.program())
+        .match_parameters(db, model.program(), &args)
+        .check_types(
+            db,
+            model.program(),
+            &constraints,
+            &args,
+            TypeContext::default(),
+            &[],
+        )
         .unwrap_or_else(|CallError(_, bindings)| *bindings);
 
     // First, try to find the matching overload after full type checking.
     let type_checked_details: Vec<_> = bindings
         .iter_flat()
         .flat_map(|binding| binding.matching_overloads().map(|(_, overload)| overload))
-        .map(|binding| CallSignatureDetails::from_binding(db, binding))
+        .map(|binding| CallSignatureDetails::from_binding(db, model.program(), binding))
         .collect();
 
     if !type_checked_details.is_empty() {
@@ -1192,7 +1230,7 @@ pub fn resolved_call_signature<'db>(
     let all_details: Vec<_> = bindings
         .iter_flat()
         .flatten()
-        .map(|binding| CallSignatureDetails::from_binding(db, binding))
+        .map(|binding| CallSignatureDetails::from_binding(db, model.program(), binding))
         .collect();
 
     if all_details.is_empty() {
@@ -1244,8 +1282,7 @@ pub fn inlay_hint_call_argument_details<'db>(
         };
 
         let parameter_label_offset = param.definition().map(|definition| {
-            let param_file = definition.file(db);
-            let module = parsed_module(db, param_file).load(db);
+            let module = definition.program_file(db).parsed(db).load(db);
             definition.focus_range(db, &module)
         });
 
@@ -1277,7 +1314,7 @@ mod resolve_definition {
 
     use indexmap::IndexSet;
     use ruff_db::files::{File, FileRange, vendored_path_to_file};
-    use ruff_db::parsed::{ParsedModuleRef, parsed_module};
+    use ruff_db::parsed::ParsedModuleRef;
     use ruff_db::system::SystemPath;
     use ruff_db::vendored::VendoredPathBuf;
     use ruff_python_ast as ast;
@@ -1291,6 +1328,8 @@ mod resolve_definition {
     use crate::module_docstring;
     use crate::types::binding_type;
     use ty_python_core::definition::{Definition, DefinitionCategory, DefinitionKind};
+    use ty_python_core::environment::ProgramFile;
+    use ty_python_core::program::Program;
     use ty_python_core::scope::{NodeWithScopeKind, ScopeId};
     use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
 
@@ -1304,7 +1343,7 @@ mod resolve_definition {
         /// The import resolved to a specific definition within a module
         Definition(Definition<'db>),
         /// The import resolved to an entire module
-        Module(File),
+        Module(ProgramFile<'db>),
         /// The import resolved to a file with a specific range
         FileWithRange(FileRange),
     }
@@ -1313,11 +1352,13 @@ mod resolve_definition {
         pub fn focus_range(&self, db: &dyn Db) -> FileRange {
             match self {
                 ResolvedDefinition::Definition(definition) => {
-                    let parsed = parsed_module(db, definition.file(db)).load(db);
+                    let parsed = definition.program_file(db).parsed(db).load(db);
                     definition.focus_range(db, &parsed)
                 }
                 // For modules, navigate to the start of the file
-                ResolvedDefinition::Module(module) => FileRange::new(*module, TextRange::default()),
+                ResolvedDefinition::Module(module) => {
+                    FileRange::new(module.file(db), TextRange::default())
+                }
                 ResolvedDefinition::FileWithRange(file_range) => *file_range,
             }
         }
@@ -1326,7 +1367,7 @@ mod resolve_definition {
             match self {
                 ResolvedDefinition::Definition(definition) => {
                     let file = definition.file(db);
-                    let parsed = parsed_module(db, file).load(db);
+                    let parsed = definition.program_file(db).parsed(db).load(db);
                     definition.kind(db).category(file.is_stub(db), &parsed)
                 }
                 ResolvedDefinition::Module(_) | ResolvedDefinition::FileWithRange(_) => {
@@ -1346,7 +1387,7 @@ mod resolve_definition {
         fn file(&self, db: &'db dyn Db) -> File {
             match self {
                 ResolvedDefinition::Definition(definition) => definition.file(db),
-                ResolvedDefinition::Module(file) => *file,
+                ResolvedDefinition::Module(file) => file.file(db),
                 ResolvedDefinition::FileWithRange(file_range) => file_range.file(),
             }
         }
@@ -1454,8 +1495,8 @@ mod resolve_definition {
 
         match kind {
             DefinitionKind::Import(import_def) => {
-                let file = definition.file(db);
-                let module = parsed_module(db, file).load(db);
+                let program_file = definition.program_file(db);
+                let module = program_file.parsed(db).load(db);
                 let alias = import_def.alias(&module);
 
                 if alias.asname.is_some()
@@ -1470,7 +1511,9 @@ mod resolve_definition {
                 };
 
                 // Resolve the module to its file
-                let Some(resolved_module) = resolve_module(db, file, &module_name) else {
+                let Some(resolved_module) =
+                    resolve_module(db, program_file.resolver_file(db), &module_name)
+                else {
                     return Vec::new(); // Module not found, return empty list
                 };
 
@@ -1480,12 +1523,16 @@ mod resolve_definition {
 
                 // For simple imports like "import os", we want to navigate to the module itself.
                 // Return the module file directly instead of trying to find definitions within it.
-                vec![ResolvedDefinition::Module(module_file)]
+                vec![ResolvedDefinition::Module(ProgramFile::new(
+                    db,
+                    program_file.program(db),
+                    module_file,
+                ))]
             }
 
             DefinitionKind::ImportFrom(import_from_def) => {
-                let file = definition.file(db);
-                let module = parsed_module(db, file).load(db);
+                let program_file = definition.program_file(db);
+                let module = program_file.parsed(db).load(db);
                 let import_node = import_from_def.import(&module);
                 let alias = import_from_def.alias(&module);
 
@@ -1499,7 +1546,7 @@ mod resolve_definition {
                 // (alias.name), not the local alias (symbol_name)
                 resolve_from_import_definitions(
                     db,
-                    file,
+                    program_file,
                     import_node,
                     &alias.name,
                     visited,
@@ -1509,15 +1556,15 @@ mod resolve_definition {
 
             // For star imports, try to resolve to the specific symbol being accessed
             DefinitionKind::StarImport(star_import_def) => {
-                let file = definition.file(db);
-                let module = parsed_module(db, file).load(db);
+                let program_file = definition.program_file(db);
+                let module = program_file.parsed(db).load(db);
                 let import_node = star_import_def.import(&module);
 
                 // If we have a symbol name, use the helper to resolve it in the target module
                 if let Some(symbol_name) = symbol_name {
                     resolve_from_import_definitions(
                         db,
-                        file,
+                        program_file,
                         import_node,
                         symbol_name,
                         visited,
@@ -1537,12 +1584,13 @@ mod resolve_definition {
     /// Helper function to resolve import definitions for `ImportFrom` and `StarImport` cases.
     pub(crate) fn resolve_from_import_definitions<'db>(
         db: &'db dyn Db,
-        file: File,
+        program_file: ProgramFile<'db>,
         import_node: &ast::StmtImportFrom,
         symbol_name: &str,
         visited: &mut FxHashSet<Definition<'db>>,
         alias_resolution: ImportAliasResolution,
     ) -> Vec<ResolvedDefinition<'db>> {
+        let file = program_file.file(db);
         if alias_resolution == ImportAliasResolution::PreserveAliases {
             for alias in &import_node.names {
                 if let Some(asname) = &alias.asname {
@@ -1557,11 +1605,13 @@ mod resolve_definition {
         }
 
         // Resolve the module being imported from (handles both relative and absolute imports)
-        let Some(module_name) = ModuleName::from_import_statement(db, file, import_node).ok()
+        let resolver_file = program_file.resolver_file(db);
+        let Some(module_name) =
+            ModuleName::from_import_statement(db, resolver_file, import_node).ok()
         else {
             return Vec::new();
         };
-        let Some(resolved_module) = resolve_module(db, file, &module_name) else {
+        let Some(resolved_module) = resolve_module(db, resolver_file, &module_name) else {
             return Vec::new();
         };
 
@@ -1572,14 +1622,17 @@ mod resolve_definition {
             // No file means this is a namespace package, try to import the submodule
             return Vec::from_iter(resolve_from_import_submodule_definitions(
                 db,
-                file,
+                program_file,
                 symbol_name,
                 module_name,
             ));
         };
 
         // Find the definition of this symbol in the imported module's global scope
-        let global_scope = global_scope(db, module_file);
+        let global_scope = global_scope(
+            db,
+            ProgramFile::new(db, program_file.program(db), module_file),
+        );
         let definitions_in_module = find_symbol_in_scope(db, global_scope, symbol_name);
 
         // Recursively resolve any import definitions found in the target module
@@ -1599,7 +1652,7 @@ mod resolve_definition {
             // `child` has no binding in `pkg/__init__.py`.
             Vec::from_iter(resolve_from_import_submodule_definitions(
                 db,
-                file,
+                program_file,
                 symbol_name,
                 module_name,
             ))
@@ -1611,17 +1664,21 @@ mod resolve_definition {
     // Helper to resolve `from x.y import z` assuming `x.y.z` is a module.
     fn resolve_from_import_submodule_definitions<'db>(
         db: &'db dyn Db,
-        file: File,
+        program_file: ProgramFile<'db>,
         symbol_name: &str,
         module_name: ModuleName,
     ) -> Option<ResolvedDefinition<'db>> {
         let submodule_name = ModuleName::new(symbol_name)?;
         let mut full_submodule_name = module_name;
         full_submodule_name.extend(&submodule_name);
-        let module = resolve_module(db, file, &full_submodule_name)?;
+        let module = resolve_module(db, program_file.resolver_file(db), &full_submodule_name)?;
         let file = module.file(db)?;
 
-        Some(ResolvedDefinition::Module(file))
+        Some(ResolvedDefinition::Module(ProgramFile::new(
+            db,
+            program_file.program(db),
+            file,
+        )))
     }
 
     /// Find definitions for a symbol name in a specific scope.
@@ -1661,6 +1718,7 @@ mod resolve_definition {
     #[tracing::instrument(skip_all)]
     pub fn map_stub_definition<'db>(
         db: &'db dyn Db,
+        program: Program,
         def: &ResolvedDefinition<'db>,
         cached_vendored_typeshed: Option<&SystemPath>,
     ) -> Option<Vec<ResolvedDefinition<'db>>> {
@@ -1697,7 +1755,8 @@ mod resolve_definition {
         }
 
         // It's definitely a stub, so now rerun module resolution but with stubs disabled.
-        let stub_module = file_to_module(db, stub_file_for_module_lookup)?;
+        let stub_module =
+            file_to_module(db, program.resolver_file(db, stub_file_for_module_lookup))?;
         trace!("Found stub module: {}", stub_module.name(db));
         // We need to pass an importing file to `resolve_real_module` which is a bit odd
         // here because there isn't really an importing file. However this `resolve_real_module`
@@ -1708,11 +1767,14 @@ mod resolve_definition {
         // into the interpreter. In which case, all we have are stubs.
         // `resolve_real_module` will always return `None` for this case, but
         // it will emit false positive logs. And this saves us some work.
-        if is_builtin_module(db.python_version().minor, stub_module.name(db)) {
+        if is_builtin_module(program.python_version(db).minor, stub_module.name(db)) {
             return None;
         }
-        let real_module =
-            resolve_real_module(db, stub_file_for_module_lookup, stub_module.name(db))?;
+        let real_module = resolve_real_module(
+            db,
+            program.resolver_file(db, stub_file_for_module_lookup),
+            stub_module.name(db),
+        )?;
         trace!("Found real module: {}", real_module.name(db));
         let real_file = real_module.file(db)?;
         trace!("Found real file: {}", real_file.path(db));
@@ -1735,7 +1797,8 @@ mod resolve_definition {
         let stub_ref;
         match *def {
             ResolvedDefinition::Definition(definition) => {
-                stub_parsed = parsed_module(db, stub_file);
+                let stub_program_file = definition.program_file(db);
+                stub_parsed = stub_program_file.parsed(db);
                 stub_ref = stub_parsed.load(db);
 
                 // Get the leaf of the path (the definition itself)
@@ -1747,7 +1810,7 @@ mod resolve_definition {
                 path.push(leaf);
 
                 // Get the ancestors of the path (all the definitions we're nested under)
-                let index = semantic_index(db, stub_file);
+                let index = semantic_index(db, stub_program_file);
                 for (_scope_id, scope) in index.ancestor_scopes(definition.file_scope(db)) {
                     let node = scope.node();
                     let component = definition_path_component_for_node(&stub_ref, node)
@@ -1767,7 +1830,9 @@ mod resolve_definition {
                     stub_file.path(db),
                     real_file.path(db)
                 );
-                return Some(vec![ResolvedDefinition::Module(real_file)]);
+                return Some(vec![ResolvedDefinition::Module(ProgramFile::new(
+                    db, program, real_file,
+                ))]);
             }
             ResolvedDefinition::FileWithRange(_) => {
                 // Not yet implemented -- in this case we want to recover something like a Definition
@@ -1779,11 +1844,12 @@ mod resolve_definition {
 
         // Walk down the Definition Path in the real file
         let mut definitions = Vec::new();
-        let index = semantic_index(db, real_file);
-        let real_parsed = parsed_module(db, real_file);
+        let real_program_file = ProgramFile::new(db, program, real_file);
+        let index = semantic_index(db, real_program_file);
+        let real_parsed = real_program_file.parsed(db);
         let real_ref = real_parsed.load(db);
         // Start our search in the module (global) scope
-        let mut scopes = vec![global_scope(db, real_file)];
+        let mut scopes = vec![global_scope(db, real_program_file)];
         while let Some(component) = path.pop() {
             trace!("Traversing definition path component: {}", component);
             // We're doing essentially a breadth-first traversal of the definitions.
@@ -1814,7 +1880,7 @@ mod resolve_definition {
                             definition_path_component_for_node(&real_ref, scope_node)
                         {
                             if real_component == component {
-                                scopes.push(child_scope_id.to_scope_id(db, real_file));
+                                scopes.push(child_scope_id.to_scope_id(db, real_program_file));
                             }
                         }
                         scope.node(db);
@@ -1929,8 +1995,12 @@ pub struct TypeHierarchyClass {
 /// This is meant to be used to "prepare" for a subtype or supertype request.
 /// That is, this effectively validates whether the given type can be used in
 /// subsequent requests for supertypes or subtypes.
-pub fn type_hierarchy_prepare(db: &dyn Db, ty: Type<'_>) -> Option<TypeHierarchyClass> {
-    let class_literal = extract_class_literal(db, ty)?;
+pub fn type_hierarchy_prepare(
+    db: &dyn Db,
+    program: crate::Program,
+    ty: Type<'_>,
+) -> Option<TypeHierarchyClass> {
+    let class_literal = extract_class_literal(db, program, ty)?;
     Some(class_literal_to_hierarchy_info(db, class_literal))
 }
 
@@ -1940,8 +2010,12 @@ pub fn type_hierarchy_prepare(db: &dyn Db, ty: Type<'_>) -> Option<TypeHierarchy
 /// returns an empty sequence.
 ///
 /// This includes `object` when the given class has no direct base classes.
-pub fn type_hierarchy_supertypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyClass> {
-    let Some(class_literal) = extract_class_literal(db, ty) else {
+pub fn type_hierarchy_supertypes<'db>(
+    db: &'db dyn Db,
+    program: ty_python_core::program::Program,
+    ty: Type<'db>,
+) -> Vec<TypeHierarchyClass> {
+    let Some(class_literal) = extract_class_literal(db, program, ty) else {
         return vec![];
     };
     if class_literal.is_known(db, KnownClass::Object) {
@@ -1951,7 +2025,7 @@ pub fn type_hierarchy_supertypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchy
     let mut supertypes: Vec<TypeHierarchyClass> = class_literal
         .explicit_bases(db)
         .into_iter()
-        .filter_map(|base| extract_class_literal(db, base))
+        .filter_map(|base| extract_class_literal(db, program, base))
         .map(|class_literal| class_literal_to_hierarchy_info(db, class_literal))
         .collect();
     // Every class implicitly inherits from `object` when no explicit
@@ -1959,7 +2033,10 @@ pub fn type_hierarchy_supertypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchy
     if supertypes.is_empty() {
         supertypes.push(class_literal_to_hierarchy_info(
             db,
-            ClassLiteral::object(db),
+            KnownClass::Object
+                .to_class_literal(db, program)
+                .as_class_literal()
+                .expect("`object` should always be a non-generic class in typeshed"),
         ));
     }
     supertypes
@@ -1973,8 +2050,12 @@ pub fn type_hierarchy_supertypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchy
 /// Note that this scans all modules in `db` to find classes that directly
 /// inherit from the given class. This could be quite expensive in large
 /// projects.
-pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyClass> {
-    let Some(target_class) = extract_class_literal(db, ty) else {
+pub fn type_hierarchy_subtypes<'db>(
+    db: &'db dyn Db,
+    program: ty_python_core::program::Program,
+    ty: Type<'db>,
+) -> Vec<TypeHierarchyClass> {
+    let Some(target_class) = extract_class_literal(db, program, ty) else {
         return vec![];
     };
     let target_name = target_class.name(db);
@@ -1982,7 +2063,7 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
     let mut subtypes = vec![];
 
     // Scan all modules in the workspace
-    for module in ty_module_resolver::all_modules(db) {
+    for module in ty_module_resolver::all_modules(db, program.resolver(db)) {
         let Some(file) = module.file(db) else {
             continue;
         };
@@ -2007,7 +2088,8 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
             continue;
         }
 
-        let index = semantic_index(db, file);
+        let program_file = ProgramFile::new(db, program, file);
+        let index = semantic_index(db, program_file);
         for scope_id in index.scope_ids() {
             let scope = scope_id.node(db);
             let Some(class_node) = scope.as_class() else {
@@ -2020,13 +2102,13 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
             }
 
             let file_scope_id = scope_id.file_scope_id(db);
-            let parsed = parsed_module(db, file).load(db);
+            let parsed = program_file.parsed(db).load(db);
             if !is_range_reachable(db, index, file_scope_id, class_node.node(&parsed).range()) {
                 continue;
             }
 
             let ty = crate::types::binding_type(db, def);
-            let Some(class_ty) = extract_class_literal(db, ty) else {
+            let Some(class_ty) = extract_class_literal(db, program, ty) else {
                 continue;
             };
 
@@ -2038,7 +2120,7 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
                 true
             } else {
                 bases.iter().any(|base| {
-                    extract_class_literal(db, *base)
+                    extract_class_literal(db, program, *base)
                         .is_some_and(|base_literal| base_literal == target_class)
                 })
             };
@@ -2051,7 +2133,11 @@ pub fn type_hierarchy_subtypes(db: &dyn Db, ty: Type<'_>) -> Vec<TypeHierarchyCl
 }
 
 /// Extract a `ClassLiteral` from a `Type`, handling various type forms.
-fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
+fn extract_class_literal<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    ty: Type<'db>,
+) -> Option<ClassLiteral<'db>> {
     match ty {
         Type::ClassLiteral(class_literal) => Some(class_literal),
         Type::SubclassOf(subclass_of) => {
@@ -2065,11 +2151,11 @@ fn extract_class_literal<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLit
             }
         }
         Type::GenericAlias(generic_alias) => Some(ClassLiteral::Static(generic_alias.origin(db))),
-        Type::NominalInstance(instance) => Some(instance.class(db).class_literal(db)),
+        Type::NominalInstance(instance) => Some(instance.class(db, program).class_literal(db)),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .find_map(|elem| extract_class_literal(db, *elem)),
+            .find_map(|elem| extract_class_literal(db, program, *elem)),
 
         _ => None,
     }
@@ -2085,10 +2171,11 @@ fn class_literal_to_hierarchy_info(
 ) -> TypeHierarchyClass {
     let name = class_literal.name(db).clone();
     let file = class_literal.file(db);
+    let program_file = ProgramFile::new(db, class_literal.program(db), file);
 
     let (full_range, selection_range) = match class_literal {
         ClassLiteral::Static(static_class) => {
-            let parsed = parsed_module(db, file).load(db);
+            let parsed = program_file.parsed(db).load(db);
             let header_range = static_class.header_range(db);
             let body_scope = static_class.body_scope(db);
 
@@ -2116,7 +2203,7 @@ fn class_literal_to_hierarchy_info(
         // (likely incorrectly) return the type hierarchy for `type` itself.
         ClassLiteral::Dynamic(dynamic_class) => {
             if let DynamicClassAnchor::Definition(definition) = dynamic_class.anchor(db) {
-                let parsed = parsed_module(db, file).load(db);
+                let parsed = program_file.parsed(db).load(db);
                 let kind = definition.kind(db);
                 (kind.full_range(&parsed), kind.target_range(&parsed))
             } else {
@@ -2128,7 +2215,7 @@ fn class_literal_to_hierarchy_info(
             if let DynamicNamedTupleAnchor::CollectionsDefinition { definition, .. }
             | DynamicNamedTupleAnchor::TypingDefinition(definition) = namedtuple.anchor(db)
             {
-                let parsed = parsed_module(db, file).load(db);
+                let parsed = program_file.parsed(db).load(db);
                 let kind = definition.kind(db);
                 (kind.full_range(&parsed), kind.target_range(&parsed))
             } else {
@@ -2142,7 +2229,7 @@ fn class_literal_to_hierarchy_info(
         }
         ClassLiteral::DynamicEnum(dynamic_enum) => {
             if let DynamicEnumAnchor::Definition { definition, .. } = dynamic_enum.anchor(db) {
-                let parsed = parsed_module(db, file).load(db);
+                let parsed = program_file.parsed(db).load(db);
                 let kind = definition.kind(db);
                 (kind.full_range(&parsed), kind.target_range(&parsed))
             } else {
@@ -2168,6 +2255,7 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
         let params = signature
             .display_with(
                 db,
+                model.program(),
                 DisplaySettings::default()
                     .multiline()
                     .disallow_signature_name()
@@ -2177,8 +2265,10 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
 
         format!("class {class_name}{params}")
     };
-    let callable_type = function_ty.try_upcast_to_callable(db)?.into_type(db);
-    let bindings = callable_type.bindings(db);
+    let callable_type = function_ty
+        .try_upcast_to_callable(db, model.program())?
+        .into_type(db, model.program());
+    let bindings = callable_type.bindings(db, model.program());
 
     if let Some(binding) = bindings.single_element()
         && binding.overloads().len() == 1
@@ -2209,10 +2299,13 @@ pub fn constructor_signature(model: &SemanticModel, call_expr: &ast::ExprCall) -
 #[cfg(test)]
 mod tests {
     use super::{CallArgumentForm, call_argument_forms};
-    use crate::SemanticModel;
-    use crate::db::tests::TestDbBuilder;
-    use ruff_db::files::system_path_to_file;
-    use ruff_db::parsed::parsed_module;
+    use crate::db::tests::{TestDb, TestDbBuilder};
+    use crate::{ProgramFile, SemanticModel};
+    use ruff_db::files::{File, system_path_to_file};
+
+    fn semantic_model(db: &TestDb, file: File) -> SemanticModel<'_> {
+        SemanticModel::new(db, ProgramFile::new(db, db.program(), file))
+    }
 
     #[test]
     fn keyword_call_argument_forms_follow_source_order() -> anyhow::Result<()> {
@@ -2228,7 +2321,9 @@ cast(val="", typ=int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2238,7 +2333,7 @@ cast(val="", typ=int)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),
@@ -2268,7 +2363,9 @@ f(y="", x=1)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2278,7 +2375,7 @@ f(y="", x=1)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),
@@ -2304,7 +2401,9 @@ f(val="", typ=int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2314,7 +2413,7 @@ f(val="", typ=int)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),
@@ -2341,7 +2440,9 @@ f("", int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2351,7 +2452,7 @@ f("", int)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),
@@ -2381,7 +2482,9 @@ f(int, x)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2391,7 +2494,7 @@ f(int, x)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),
@@ -2425,13 +2528,15 @@ TypeAliasType("Alias", int)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let calls: Vec<_> = parsed
             .suite()
             .iter()
             .filter_map(|stmt| stmt.as_expr_stmt()?.value.as_call_expr())
             .collect();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(calls.len(), 4);
         assert_eq!(
@@ -2470,7 +2575,9 @@ cast(*args)
             .build()?;
 
         let file = system_path_to_file(&db, "/src/foo.py").unwrap();
-        let parsed = parsed_module(&db, file).load(&db);
+        let parsed = ProgramFile::new(&db, db.program(), file)
+            .parsed(&db)
+            .load(&db);
         let call = parsed
             .suite()
             .last()
@@ -2480,7 +2587,7 @@ cast(*args)
             .value
             .as_call_expr()
             .unwrap();
-        let model = SemanticModel::new(&db, file);
+        let model = semantic_model(&db, file);
 
         assert_eq!(
             call_argument_forms(&model, call),

--- a/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unreachable_code.rs
@@ -2,8 +2,8 @@ use crate::Db;
 use crate::reachability::is_reachable;
 use get_size2::GetSize;
 use itertools::Itertools;
-use ruff_db::files::File;
 use ruff_text_size::TextRange;
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::reachability_constraints::ScopedReachabilityConstraintId;
 use ty_python_core::semantic_index;
 
@@ -45,8 +45,8 @@ pub enum UnreachableKind {
 /// `ALWAYS_FALSE` constraints are classified as unconditional; all others are
 /// unreachable only under the current analysis.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unreachable_ranges(db: &dyn Db, file: File) -> Box<[UnreachableRange]> {
-    let index = semantic_index(db, file);
+pub fn unreachable_ranges(db: &dyn Db, program_file: ProgramFile<'_>) -> Box<[UnreachableRange]> {
+    let index = semantic_index(db, program_file);
     let mut unreachable = Vec::new();
 
     for scope_id in index.scope_ids() {
@@ -147,7 +147,7 @@ mod tests {
 
     fn render_unreachable_diagnostics(db: &crate::db::tests::TestDb, path: &str) -> String {
         let file = system_path_to_file(db, path).unwrap();
-        let diagnostics = unreachable_ranges(db, file)
+        let diagnostics = unreachable_ranges(db, crate::ProgramFile::new(db, db.program(), file))
             .iter()
             .map(|range| {
                 let mut diagnostic = Diagnostic::new(

--- a/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
+++ b/crates/ty_python_semantic/src/types/ide_support/unused_bindings.rs
@@ -3,11 +3,11 @@ use crate::reachability::is_reachable;
 use crate::types::function::FunctionDecorators;
 use crate::types::infer::function_known_decorator_flags;
 use get_size2::GetSize;
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast::name::Name;
 use ruff_text_size::TextRange;
 use rustc_hash::FxHashSet;
 use ty_python_core::definition::{DefinitionCategory, DefinitionKind, DefinitionState};
+use ty_python_core::environment::ProgramFile;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::{FileScopeId, ScopeKind};
 use ty_python_core::{SemanticIndex, semantic_index};
@@ -72,10 +72,11 @@ pub struct UnusedBinding {
 /// without broader reference analysis. Bare local annotations (`x: int`) are also
 /// reported, but only if the symbol is neither bound nor used elsewhere in the scope.
 #[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
-pub fn unused_bindings(db: &dyn Db, file: ruff_db::files::File) -> Box<[UnusedBinding]> {
-    let parsed = parsed_module(db, file).load(db);
+pub fn unused_bindings(db: &dyn Db, program_file: ProgramFile<'_>) -> Box<[UnusedBinding]> {
+    let file = program_file.file(db);
+    let parsed = program_file.parsed(db).load(db);
     let is_stub_file = file.is_stub(db);
-    let index = semantic_index(db, file);
+    let index = semantic_index(db, program_file);
     let mut unused = Vec::new();
 
     for scope_id in index.scope_ids() {
@@ -199,7 +200,8 @@ mod tests {
     ) -> anyhow::Result<Vec<UnusedBinding>> {
         let db = TestDbBuilder::new().with_file(path, source).build()?;
         let file = system_path_to_file(&db, path).unwrap();
-        let mut bindings = unused_bindings(&db, file).to_vec();
+        let mut bindings =
+            unused_bindings(&db, crate::ProgramFile::new(&db, db.program(), file)).to_vec();
         bindings.sort_unstable_by_key(|binding| (binding.range.start(), binding.range.end()));
         Ok(bindings)
     }

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -69,7 +69,7 @@ use ty_python_core::expression::Expression;
 use ty_python_core::scope::ScopeId;
 use ty_python_core::statement::StatementInner;
 use ty_python_core::unpack::Unpack;
-use ty_python_core::{ExpressionNodeKey, SemanticIndex, Statement, semantic_index};
+use ty_python_core::{ExpressionNodeKey, SemanticIndex, Statement};
 
 mod builder;
 mod comparisons;
@@ -120,10 +120,19 @@ fn extend_collection_use_constraints<'db>(
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|db, id, definition: Definition<'db>| {
-        DefinitionInference::cycle_initial(db, definition, Type::divergent(id))
+        DefinitionInference::cycle_initial(
+            db,
+            definition,
+            Type::divergent(id),
+        )
     },
-    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, definition| {
-        inference.cycle_normalized(db, previous, cycle, definition)
+    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, definition: Definition<'db>| {
+        inference.cycle_normalized(
+            db,
+            previous,
+            cycle,
+            definition,
+        )
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -131,8 +140,9 @@ pub(crate) fn infer_definition_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
-    let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
+    let program_file = definition.program_file(db);
+    let file = program_file.file(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
     let _span = tracing::trace_span!(
         "infer_definition_types",
         range = ?definition.kind(db).target_range(&module),
@@ -140,7 +150,7 @@ pub(crate) fn infer_definition_types<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Definition(definition), index, &module)
         .finish_definition(definition)
@@ -181,9 +191,9 @@ pub(crate) fn function_known_decorators<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> FunctionDecoratorInference<'db> {
-    let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
-    let index = semantic_index(db, file);
+    let program_file = definition.program_file(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(
         db,
@@ -255,10 +265,19 @@ impl<'db> FunctionDecoratorInference<'db> {
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|db, id, definition: Definition<'db>| {
-        DefinitionInference::cycle_initial(db, definition, Type::divergent(id))
+        DefinitionInference::cycle_initial(
+            db,
+            definition,
+            Type::divergent(id),
+        )
     },
-    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, definition| {
-        inference.cycle_normalized(db, previous, cycle, definition)
+    cycle_fn=|db, cycle, previous: &DefinitionInference<'db>, inference: DefinitionInference<'db>, definition: Definition<'db>| {
+        inference.cycle_normalized(
+            db,
+            previous,
+            cycle,
+            definition,
+        )
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -266,8 +285,9 @@ pub(crate) fn infer_deferred_types<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> DefinitionInference<'db> {
-    let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
+    let program_file = definition.program_file(db);
+    let file = program_file.file(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
     let _span = tracing::trace_span!(
         "infer_deferred_types",
         definition = ?definition.as_id(),
@@ -276,7 +296,7 @@ pub(crate) fn infer_deferred_types<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Deferred(definition), index, &module)
         .finish_definition(definition)
@@ -295,13 +315,13 @@ pub(crate) fn infer_complete_scope_types<'db>(
     // Scopes that may require type context are inferred during the inference of
     // their outer scope.
     if scope.accepts_type_context(db) {
-        let file = scope.file(db);
-        let index = semantic_index(db, file);
+        let program_file = scope.program_file(db);
+        let index = ty_python_core::semantic_index(db, program_file);
 
         if let Some(parent_scope) = index.parent_scope_id(scope.file_scope_id(db)) {
             // Note that nested lambdas or comprehensions may require recursing until we reach
             // an outer scope that is independent of any type context.
-            return infer_complete_scope_types(db, parent_scope.to_scope_id(db, file));
+            return infer_complete_scope_types(db, parent_scope.to_scope_id(db, program_file));
         }
     }
 
@@ -327,8 +347,8 @@ pub(crate) fn infer_scope_types<'db>(
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|_, id, _| ScopeInference::cycle_initial(Type::divergent(id)),
-    cycle_fn=|db, cycle, previous: &ScopeInference<'db>, inference: ScopeInference<'db>, _| {
-        inference.cycle_normalized(db, previous, cycle)
+    cycle_fn=|db, cycle, previous: &ScopeInference<'db>, inference: ScopeInference<'db>, input: InferScope<'db>| {
+        inference.cycle_normalized(db, input.program(db), previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -337,14 +357,15 @@ pub(crate) fn infer_scope_types_impl<'db>(
     input: InferScope<'db>,
 ) -> ScopeInference<'db> {
     let (scope, tcx) = input.into_inner(db);
-    let file = scope.file(db);
+    let program_file = scope.program_file(db);
+    let file = program_file.file(db);
     let _span = tracing::trace_span!("infer_scope_types", scope=?scope.as_id(), ?file).entered();
 
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
 
     // Using the index here is fine because the code below depends on the AST anyway.
     // The isolation of the query is by the return inferred types.
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Scope(scope, tcx), index, &module).finish_scope()
 }
@@ -364,8 +385,8 @@ pub(crate) fn infer_expression_types<'db>(
 #[salsa::tracked(
     returns(ref),
     cycle_initial=expression_cycle_initial,
-    cycle_fn=|db, cycle, previous: &ExpressionInference<'db>, inference: ExpressionInference<'db>, _| {
-        inference.cycle_normalized(db, previous, cycle)
+    cycle_fn=|db, cycle, previous: &ExpressionInference<'db>, inference: ExpressionInference<'db>, input: InferExpression<'db>| {
+        inference.cycle_normalized(db, input.program(db), previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -375,8 +396,9 @@ pub(super) fn infer_expression_types_impl<'db>(
 ) -> ExpressionInference<'db> {
     let (expression, tcx) = input.into_inner(db);
 
-    let file = expression.file(db);
-    let module = parsed_module(db, file).load(db);
+    let program_file = expression.program_file(db);
+    let file = program_file.file(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
     let _span = tracing::trace_span!(
         "infer_expression_types",
         expression = ?expression.as_id(),
@@ -385,7 +407,7 @@ pub(super) fn infer_expression_types_impl<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(
         db,
@@ -438,8 +460,8 @@ pub(crate) fn infer_expression_type<'db>(
 #[salsa::tracked(
     returns(copy),
     cycle_initial=|_, id, _| Type::divergent(id),
-    cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _| {
-        result.cycle_normalized(db, *previous, cycle)
+    cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, input: InferExpression<'db>| {
+        result.cycle_normalized(db, input.program(db), *previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -478,8 +500,13 @@ pub(super) fn infer_statement_types<'db>(
     cycle_initial=|db, id, statement: StatementInner<'db>| {
         StatementInferenceInner::cycle_initial(statement.scope(db), Type::divergent(id))
     },
-    cycle_fn=|db, cycle, previous: &StatementInferenceInner<'db>, inference: StatementInferenceInner<'db>, _| {
-        inference.cycle_normalized(db, previous, cycle)
+    cycle_fn=|db, cycle, previous: &StatementInferenceInner<'db>, inference: StatementInferenceInner<'db>, statement: StatementInner<'db>| {
+        inference.cycle_normalized(
+            db,
+            statement.program_file(db).program(db),
+            previous,
+            cycle,
+        )
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -487,8 +514,9 @@ fn infer_statement_types_impl<'db>(
     db: &'db dyn Db,
     statement: StatementInner<'db>,
 ) -> StatementInferenceInner<'db> {
-    let file = statement.file(db);
-    let module = parsed_module(db, file).load(db);
+    let program_file = statement.program_file(db);
+    let file = program_file.file(db);
+    let module = parsed_module(db, program_file.versioned_file(db)).load(db);
     let _span = tracing::trace_span!(
         "infer_statement_types",
         statement = ?statement.as_id(),
@@ -497,7 +525,7 @@ fn infer_statement_types_impl<'db>(
     )
     .entered();
 
-    let index = semantic_index(db, file);
+    let index = ty_python_core::semantic_index(db, program_file);
 
     TypeInferenceBuilder::new(db, InferenceRegion::Statement(statement), index, &module)
         .finish_statement()
@@ -522,6 +550,15 @@ pub(super) struct ExpressionWithContext<'db> {
 }
 
 impl<'db> InferExpression<'db> {
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        match self {
+            InferExpression::Bare(expression) => expression.program_file(db).program(db),
+            InferExpression::WithContext(with_context) => {
+                with_context.expression(db).program_file(db).program(db)
+            }
+        }
+    }
+
     pub(super) fn new(
         db: &'db dyn Db,
         expression: Expression<'db>,
@@ -561,6 +598,13 @@ pub(super) struct ScopeWithContext<'db> {
 }
 
 impl<'db> InferScope<'db> {
+    fn program(self, db: &'db dyn Db) -> crate::Program {
+        match self {
+            InferScope::Bare(scope) => scope.program(db),
+            InferScope::WithContext(with_context) => with_context.scope(db).program(db),
+        }
+    }
+
     pub(super) fn new(
         db: &'db dyn Db,
         scope: ScopeId<'db>,
@@ -605,10 +649,11 @@ impl<'db> TypeContext<'db> {
     fn known_specialization(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         known_class: KnownClass,
     ) -> Option<Specialization<'db>> {
         self.annotation
-            .and_then(|ty| ty.known_specialization(db, known_class))
+            .and_then(|ty| ty.known_specialization(db, program, known_class))
     }
 
     pub(crate) fn map(self, f: impl FnOnce(Type<'db>) -> Type<'db>) -> Self {
@@ -623,11 +668,15 @@ impl<'db> TypeContext<'db> {
     }
 
     /// If the type annotation is a union, returns the target elements that it can be narrowed to.
-    pub(crate) fn narrow_targets(&self, db: &'db dyn Db) -> Option<Cow<'db, [Type<'db>]>> {
+    pub(crate) fn narrow_targets(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Cow<'db, [Type<'db>]>> {
         let union = self.annotation?.as_union_like(db)?;
 
         let targets = if union.has_aliases(db) {
-            let expanded = union.expand_aliases(db);
+            let expanded = union.expand_aliases(db, program);
             if let Some(union) = expanded.as_union_like(db) {
                 Cow::Borrowed(union.elements(db))
             } else {
@@ -659,14 +708,19 @@ impl<'db> From<Type<'db>> for TypeContext<'db> {
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|_, id, _| UnpackResult::cycle_initial(Type::divergent(id)),
-    cycle_fn=|db, cycle, previous: &UnpackResult<'db>, result: UnpackResult<'db>, _| {
-        result.cycle_normalized(db, previous, cycle)
+    cycle_fn=|db, cycle, previous: &UnpackResult<'db>, result: UnpackResult<'db>, unpack: Unpack<'db>| {
+        result.cycle_normalized(
+            db,
+            unpack.program_file(db).program(db),
+            previous,
+            cycle,
+        )
     },
     heap_size=ruff_memory_usage::heap_size
 )]
 pub(super) fn infer_unpack_types<'db>(db: &'db dyn Db, unpack: Unpack<'db>) -> UnpackResult<'db> {
     let file = unpack.file(db);
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, unpack.program_file(db).versioned_file(db)).load(db);
     let _span = tracing::trace_span!("infer_unpack_types", range=?unpack.range(db, &module), ?file)
         .entered();
 
@@ -823,11 +877,12 @@ impl<'db> ScopeInference<'db> {
     fn cycle_normalized(
         mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous_inference: &ScopeInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ScopeInference<'db> {
         self.expressions.map_values(|expr, ty| {
-            ty.cycle_normalized(db, previous_inference.expression_type(expr), cycle)
+            ty.cycle_normalized(db, program, previous_inference.expression_type(expr), cycle)
         });
 
         if cycle.iteration() > crate::TAINTED_CYCLES
@@ -1011,6 +1066,7 @@ impl<'db> DefinitionTypes<'db> {
 
     fn normalize_binding(
         db: &'db dyn Db,
+        program: crate::Program,
         previous: &DefinitionTypes<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
@@ -1018,14 +1074,15 @@ impl<'db> DefinitionTypes<'db> {
         ty: Type<'db>,
     ) -> Type<'db> {
         if let Some(previous_ty) = previous.binding_type(owner, definition) {
-            ty.cycle_normalized(db, previous_ty, cycle)
+            ty.cycle_normalized(db, program, previous_ty, cycle)
         } else {
-            ty.recursive_type_normalized(db, cycle)
+            ty.recursive_type_normalized(db, program, cycle)
         }
     }
 
     fn normalize_declaration(
         db: &'db dyn Db,
+        program: crate::Program,
         previous: &DefinitionTypes<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
@@ -1033,15 +1090,18 @@ impl<'db> DefinitionTypes<'db> {
         ty: TypeAndQualifiers<'db>,
     ) -> TypeAndQualifiers<'db> {
         if let Some(previous_ty) = previous.declaration_type(owner, definition) {
-            ty.map_type(|inner| inner.cycle_normalized(db, previous_ty.inner_type(), cycle))
+            ty.map_type(|inner| {
+                inner.cycle_normalized(db, program, previous_ty.inner_type(), cycle)
+            })
         } else {
-            ty.map_type(|inner| inner.recursive_type_normalized(db, cycle))
+            ty.map_type(|inner| inner.recursive_type_normalized(db, program, cycle))
         }
     }
 
     fn cycle_normalized(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous: &DefinitionTypes<'db>,
         cycle: &salsa::Cycle,
         owner: Definition<'db>,
@@ -1049,22 +1109,30 @@ impl<'db> DefinitionTypes<'db> {
         match self {
             Self::Empty => Self::Empty,
             Self::Binding(ty) => Self::Binding(Self::normalize_binding(
-                db, previous, cycle, owner, owner, ty,
+                db, program, previous, cycle, owner, owner, ty,
             )),
             Self::Declaration(ty) => Self::Declaration(Self::normalize_declaration(
-                db, previous, cycle, owner, owner, ty,
+                db, program, previous, cycle, owner, owner, ty,
             )),
             Self::BindingAndDeclaration(declaration_ty) => {
                 let binding_ty = Self::normalize_binding(
                     db,
+                    program,
                     previous,
                     cycle,
                     owner,
                     owner,
                     declaration_ty.inner_type(),
                 );
-                let declaration_ty =
-                    Self::normalize_declaration(db, previous, cycle, owner, owner, declaration_ty);
+                let declaration_ty = Self::normalize_declaration(
+                    db,
+                    program,
+                    previous,
+                    cycle,
+                    owner,
+                    owner,
+                    declaration_ty,
+                );
 
                 if binding_ty == declaration_ty.inner_type() {
                     Self::BindingAndDeclaration(declaration_ty)
@@ -1077,10 +1145,26 @@ impl<'db> DefinitionTypes<'db> {
             }
             Self::Other(mut other) => {
                 for (definition, ty) in &mut other.bindings {
-                    *ty = Self::normalize_binding(db, previous, cycle, owner, *definition, *ty);
+                    *ty = Self::normalize_binding(
+                        db,
+                        program,
+                        previous,
+                        cycle,
+                        owner,
+                        *definition,
+                        *ty,
+                    );
                 }
                 for (definition, ty) in &mut other.declarations {
-                    *ty = Self::normalize_declaration(db, previous, cycle, owner, *definition, *ty);
+                    *ty = Self::normalize_declaration(
+                        db,
+                        program,
+                        previous,
+                        cycle,
+                        owner,
+                        *definition,
+                        *ty,
+                    );
                 }
 
                 match (&*other.bindings, &*other.declarations) {
@@ -1273,12 +1357,14 @@ impl<'db> DefinitionInference<'db> {
         definition: Definition<'db>,
         cycle_recovery: Type<'db>,
     ) -> Self {
+        let program_file = definition.program_file(db);
+        let program = program_file.program(db);
         let mut types = DefinitionTypes::Empty;
 
         // Eagerly store more precise types for collection literals to avoid an extra
         // cycle iteration, i.e., by inferring `list[Divergent]` instead of `Divergent`.
         if let DefinitionKind::Assignment(assignment) = definition.kind(db) {
-            let module = parsed_module(db, definition.file(db)).load(db);
+            let module = program_file.parsed(db).load(db);
             let known_collection = match assignment.value(&module) {
                 ast::Expr::Set(_) => Some(KnownClass::Set),
                 ast::Expr::List(_) => Some(KnownClass::List),
@@ -1287,7 +1373,7 @@ impl<'db> DefinitionInference<'db> {
             };
 
             if let Some(collection_class) = known_collection
-                .and_then(|known_collection| known_collection.try_to_class_literal(db))
+                .and_then(|known_collection| known_collection.try_to_class_literal(db, program))
             {
                 let divergent_collection = collection_class
                     .apply_specialization(db, |generic_context| {
@@ -1319,12 +1405,14 @@ impl<'db> DefinitionInference<'db> {
         cycle: &salsa::Cycle,
         definition: Definition<'db>,
     ) -> DefinitionInference<'db> {
+        let program = definition.program_file(db).program(db);
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous_inference.expression_type(*expr);
-            *ty = ty.cycle_normalized(db, previous_ty, cycle);
+            *ty = ty.cycle_normalized(db, program, previous_ty, cycle);
         }
         self.types = std::mem::take(&mut self.types).cycle_normalized(
             db,
+            program,
             &previous_inference.types,
             cycle,
             definition,
@@ -1558,6 +1646,7 @@ impl<'db> ExpressionInference<'db> {
     fn cycle_normalized(
         mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous: &ExpressionInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ExpressionInference<'db> {
@@ -1569,16 +1658,17 @@ impl<'db> ExpressionInference<'db> {
                         .iter()
                         .find(|(previous_binding, _)| previous_binding == binding)
                 }) {
-                    *binding_ty = binding_ty.cycle_normalized(db, *previous_binding, cycle);
+                    *binding_ty =
+                        binding_ty.cycle_normalized(db, program, *previous_binding, cycle);
                 } else {
-                    *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
+                    *binding_ty = binding_ty.recursive_type_normalized(db, program, cycle);
                 }
             }
         }
 
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous.expression_type(*expr);
-            *ty = ty.cycle_normalized(db, previous_ty, cycle);
+            *ty = ty.cycle_normalized(db, program, previous_ty, cycle);
         }
 
         if cycle.iteration() > crate::TAINTED_CYCLES
@@ -1737,12 +1827,13 @@ impl<'db> StatementInferenceInner<'db> {
     fn cycle_normalized(
         mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous_inference: &StatementInferenceInner<'db>,
         cycle: &salsa::Cycle,
     ) -> StatementInferenceInner<'db> {
         for (expr, ty) in &mut self.expressions {
             let previous_ty = previous_inference.expression_type(*expr);
-            *ty = ty.cycle_normalized(db, previous_ty, cycle);
+            *ty = ty.cycle_normalized(db, program, previous_ty, cycle);
         }
         for (binding, binding_ty) in &mut self.bindings {
             if let Some((_, previous_binding)) = previous_inference
@@ -1750,9 +1841,9 @@ impl<'db> StatementInferenceInner<'db> {
                 .iter()
                 .find(|(previous_binding, _)| previous_binding == binding)
             {
-                *binding_ty = binding_ty.cycle_normalized(db, *previous_binding, cycle);
+                *binding_ty = binding_ty.cycle_normalized(db, program, *previous_binding, cycle);
             } else {
-                *binding_ty = binding_ty.recursive_type_normalized(db, cycle);
+                *binding_ty = binding_ty.recursive_type_normalized(db, program, cycle);
             }
         }
         for (declaration, declaration_ty) in &mut self.declarations {
@@ -1762,11 +1853,11 @@ impl<'db> StatementInferenceInner<'db> {
                 .find(|(previous_declaration, _)| previous_declaration == declaration)
             {
                 *declaration_ty = declaration_ty.map_type(|decl_ty| {
-                    decl_ty.cycle_normalized(db, previous_declaration.inner_type(), cycle)
+                    decl_ty.cycle_normalized(db, program, previous_declaration.inner_type(), cycle)
                 });
             } else {
-                *declaration_ty =
-                    declaration_ty.map_type(|decl_ty| decl_ty.recursive_type_normalized(db, cycle));
+                *declaration_ty = declaration_ty
+                    .map_type(|decl_ty| decl_ty.recursive_type_normalized(db, program, cycle));
             }
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -18,7 +18,7 @@ use ruff_text_size::{Ranged, TextRange};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use strum::IntoEnumIterator;
-use ty_module_resolver::{ModuleName, resolve_module};
+use ty_module_resolver::ModuleName;
 use ty_python_core::ast_ids::HasScopedUseId;
 use ty_python_core::statement::StatementInner;
 
@@ -112,7 +112,7 @@ use crate::types::{
     extract_fixed_length_iterable_element_types, infer_complete_scope_types, infer_scope_types,
     is_discarded_dict_key_assignment, todo_type,
 };
-use crate::{AnalysisSettings, Db, FxIndexSet, Program};
+use crate::{Db, FxIndexSet, Program};
 use ty_python_core::ast_ids::ScopedUseId;
 use ty_python_core::definition::{
     AnnotatedAssignmentDefinitionKind, AssignmentDefinitionKind, ComprehensionDefinitionKind,
@@ -240,6 +240,7 @@ const NUM_FIELD_SPECIFIERS_INLINE: usize = 1;
 /// don't infer its types more than once.
 pub(super) struct TypeInferenceBuilder<'db, 'ast> {
     context: InferContext<'db, 'ast>,
+    program: Program,
 
     index: &'db SemanticIndex<'db>,
     region: InferenceRegion<'db>,
@@ -376,8 +377,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         module: &'ast ParsedModuleRef,
     ) -> Self {
         let scope = region.scope(db);
+        let context = InferContext::new(db, scope, module);
         Self {
-            context: InferContext::new(db, scope, module),
+            program: context.program(),
+            context,
             index,
             region,
             scope,
@@ -445,8 +448,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(other) = other {
             match self.cycle_recovery {
                 Some(existing) => {
-                    self.cycle_recovery =
-                        Some(UnionType::from_two_elements(self.db(), existing, other));
+                    self.cycle_recovery = Some(UnionType::from_two_elements(
+                        self.db(),
+                        self.program,
+                        existing,
+                        other,
+                    ));
                 }
                 None => {
                     self.cycle_recovery = Some(other);
@@ -633,6 +640,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         self.context.file()
     }
 
+    fn program_file(&self) -> ty_python_core::environment::ProgramFile<'db> {
+        self.context.program_file()
+    }
+
     fn module(&self) -> &'ast ParsedModuleRef {
         self.context.module()
     }
@@ -652,15 +663,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn bindings_for_call(&self, callable_type: Type<'db>) -> Bindings<'db> {
         let db = self.db();
         callable_type
-            .bindings(db)
+            .bindings(db, self.program)
             .with_enclosing_binding_contexts(enclosing_binding_contexts(
                 self.index,
                 self.scope().file_scope_id(db),
             ))
     }
 
-    fn settings(&self) -> &AnalysisSettings {
-        self.db().analysis_settings(self.file())
+    fn replace_imports_with_any(&self) -> &ty_module_resolver::ModuleGlobSet {
+        &self.program.settings(self.db()).replace_imports_with_any
+    }
+
+    fn allowed_unresolved_imports(&self) -> &ty_module_resolver::ModuleGlobSet {
+        &self
+            .db()
+            .analysis_settings(self.file())
+            .allowed_unresolved_imports
     }
 
     fn is_in_type_checking_block(&self, scope: ScopeId<'db>, node: impl Ranged) -> bool {
@@ -722,7 +740,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn defer_annotations(&self) -> bool {
         self.index.has_future_annotations()
             || self.in_stub()
-            || Program::get(self.db()).python_version(self.db()) >= PythonVersion::PY314
+            || self.program.python_version(self.db()) >= PythonVersion::PY314
     }
 
     /// Are we currently in a context where name resolution should be deferred
@@ -832,7 +850,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// already in progress for that scope (further up the stack).
     fn file_expression_type(&self, expression: &ast::Expr) -> Type<'db> {
         let file_scope = self.index.expression_scope_id(expression);
-        let expr_scope = file_scope.to_scope_id(self.db(), self.file());
+        let expr_scope = file_scope.to_scope_id(self.db(), self.program_file());
         match self.region {
             InferenceRegion::Scope(scope, _) if scope == expr_scope => {
                 self.expression_type(expression)
@@ -844,7 +862,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     /// Get metadata for a type expression from any scope in the same file.
     fn file_type_expression_flags(&self, expression: &ast::Expr) -> TypeExpressionFlags {
         let file_scope = self.index.expression_scope_id(expression);
-        let expr_scope = file_scope.to_scope_id(self.db(), self.file());
+        let expr_scope = file_scope.to_scope_id(self.db(), self.program_file());
         match self.region {
             InferenceRegion::Scope(scope, _) if scope == expr_scope => {
                 self.type_expression_flags(expression)
@@ -1272,6 +1290,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let (mut place_and_quals, conflicting) = place_from_declarations_with_reachability_cache(
             self.db(),
+            self.program,
             declarations,
             self.reachability_cache(),
         )
@@ -1283,7 +1302,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(builder) = self.context.report_lint(&CONFLICTING_DECLARATIONS, node) {
                 builder.into_diagnostic(format_args!(
                     "Conflicting declared types for `{place}`: {}",
-                    format_enumeration(conflicting.iter().map(|ty| ty.display(db)))
+                    format_enumeration(conflicting.iter().map(|ty| ty.display(db, self.program)))
                 ));
             }
         }
@@ -1297,8 +1316,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if self.skip_non_global_scopes(file_scope_id, symbol_id)
                 || self.scope.file_scope_id(self.db()).is_global()
             {
-                place_and_quals = place_and_quals.or_fall_back_to(self.db(), || {
-                    module_type_implicit_global_declaration(self.db(), symbol.name())
+                place_and_quals = place_and_quals.or_fall_back_to(self.db(), self.program, || {
+                    module_type_implicit_global_declaration(self.db(), self.program, symbol.name())
                 });
             }
         }
@@ -1335,7 +1354,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ty,
                 definedness: Definedness::AlwaysDefined,
                 ..
-            }) = value_type.member(db, attr).place
+            }) = value_type.member(db, self.program, attr).place
             {
                 // TODO: also consider qualifiers on the attribute
                 Some(ty)
@@ -1463,12 +1482,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // unbound_ty is Never because for this check we don't care about unbound
         let inferred_ty = place_from_bindings_with_reachability_cache(
             self.db(),
+            self.program,
             prior_bindings,
             self.reachability_cache(),
         )
         .place
         .with_qualifiers(TypeQualifiers::empty())
-        .or_fall_back_to(self.db(), || {
+        .or_fall_back_to(self.db(), self.program, || {
             // Fallback to bindings declared on `types.ModuleType` if it's a global symbol
             let scope = self.scope().file_scope_id(self.db());
             let place = self
@@ -1479,7 +1499,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let PlaceExprRef::Symbol(symbol) = &place
                 && scope.is_global()
             {
-                module_type_implicit_global_symbol(self.db(), self.file(), symbol.name())
+                module_type_implicit_global_symbol(self.db(), self.program_file(), symbol.name())
             } else {
                 Place::Undefined.into()
             }
@@ -1487,14 +1507,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .place
         .ignore_possibly_undefined()
         .unwrap_or(Type::Never);
-        let ty = if inferred_ty.is_assignable_to(self.db(), ty.inner_type()) {
+        let ty = if inferred_ty.is_assignable_to(self.db(), self.program, ty.inner_type()) {
             ty
         } else {
             if let Some(builder) = self.context.report_lint(&INVALID_DECLARATION, node) {
                 builder.into_diagnostic(format_args!(
                     "Cannot declare type `{}` for inferred type `{}`",
-                    ty.inner_type().display(self.db()),
-                    inferred_ty.display(self.db())
+                    ty.inner_type().display(self.db(), self.program),
+                    inferred_ty.display(self.db(), self.program)
                 ));
             }
             TypeAndQualifiers::declared(Type::unknown())
@@ -1533,42 +1553,47 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if file_scope_id.is_global() {
                     let place_table = self.index.place_table(file_scope_id);
                     let place = place_table.place(definition.place(self.db()));
-                    let file = self.file();
                     if let Some(module_type_implicit_declaration) = place
                         .as_symbol()
                         .map(|symbol| {
-                            module_type_implicit_global_symbol(self.db(), file, symbol.name())
+                            module_type_implicit_global_symbol(
+                                self.db(),
+                                self.program_file(),
+                                symbol.name(),
+                            )
                         })
                         .and_then(|place| place.place.ignore_possibly_undefined())
                     {
                         let declared_type = declared_ty.inner_type();
-                        if !declared_type
-                            .is_assignable_to(self.db(), module_type_implicit_declaration)
-                        {
+                        if !declared_type.is_assignable_to(
+                            self.db(),
+                            self.program,
+                            module_type_implicit_declaration,
+                        ) {
                             if let Some(builder) =
                                 self.context.report_lint(&INVALID_DECLARATION, node)
                             {
                                 let mut diagnostic = builder.into_diagnostic(format_args!(
                                     "Cannot shadow implicit global attribute `{place}` with declaration of type `{}`",
-                                    declared_type.display(self.db())
+                                    declared_type.display(self.db(), self.program)
                                 ));
                                 diagnostic.info(format_args!("The global symbol `{}` must always have a type assignable to `{}`",
                                     place,
-                                    module_type_implicit_declaration.display(self.db())
+                                    module_type_implicit_declaration.display(self.db(), self.program)
                                 ));
                             }
                         }
                     }
                 }
                 let declared_type = declared_ty.inner_type();
-                if inferred_ty.is_assignable_to(self.db(), declared_type) {
+                if inferred_ty.is_assignable_to(self.db(), self.program, declared_type) {
                     if !should_preserve_inferred_binding_type(inferred_ty)
                         // TODO We currently can't distinguish here between "no declared type" and
                         // "declared types is `Unknown` (e.g. due to a bad annotation, missing
                         // import, etc.)". Ideally we would still prefer `Unknown` declared type,
                         // but use inferred type if there is no declared type.
                         && !matches!(declared_type, Type::Dynamic(DynamicType::Unknown))
-                        && declared_type.is_assignable_to(self.db(), inferred_ty)
+                        && declared_type.is_assignable_to(self.db(), self.program, inferred_ty)
                     {
                         (declared_ty, declared_type)
                     } else {
@@ -1657,7 +1682,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // type IntOrStr = int | StrOrInt  # It's redundant, but OK
         // type StrOrInt = str | IntOrStr  # It's redundant, but OK
         // ```
-        let expanded = value_ty.expand_eagerly(self.db());
+        let expanded = value_ty.expand_eagerly(self.db(), self.program);
         if expanded.is_divergent() {
             if let Some(builder) = self
                 .context
@@ -1713,7 +1738,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         };
         if protocol.interface(db).includes_member(db, target.attr.id())
-            || protocol.has_member_declaration(db, target.attr.id())
+            || protocol.has_member_declaration(db, self.program, target.attr.id())
         {
             return;
         }
@@ -1828,7 +1853,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     {
                         builder.into_diagnostic(format_args!(
                             "Object of type `{}` is not awaited",
-                            ty.display(self.db()),
+                            ty.display(self.db(), self.program),
                         ));
                     }
                 }
@@ -1901,7 +1926,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let rhs_scope = self
             .index
             .node_scope(NodeWithScopeRef::TypeAlias(type_alias))
-            .to_scope_id(self.db(), self.file());
+            .to_scope_id(self.db(), self.program_file());
 
         let type_alias_ty = Type::KnownInstance(KnownInstanceType::TypeAliasType(
             TypeAliasType::PEP695(PEP695TypeAliasType::new(
@@ -1932,7 +1957,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let test_ty = self.infer_standalone_expression(test, TypeContext::default());
 
-        if let Err(err) = test_ty.try_bool(self.db()) {
+        if let Err(err) = test_ty.try_bool(self.db(), self.program) {
             err.report_diagnostic(&self.context, &**test);
         }
 
@@ -1949,7 +1974,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(test) = &test {
                 let test_ty = self.infer_standalone_expression(test, TypeContext::default());
 
-                if let Err(err) = test_ty.try_bool(self.db()) {
+                if let Err(err) = test_ty.try_bool(self.db(), self.program) {
                     err.report_diagnostic(&self.context, test);
                 }
             }
@@ -1999,6 +2024,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_with_statement(&mut self, with_statement: &ast::StmtWith) {
+        let program = self.program;
         let ast::StmtWith {
             range: _,
             node_index: _,
@@ -2015,7 +2041,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     //  `with not_context_manager as a.x: ...
                     builder
                         .infer_standalone_expression(&item.context_expr, tcx)
-                        .enter(builder.db())
+                        .enter(builder.db(), program)
                 });
             } else {
                 // Call into the context expression inference to validate that it evaluates
@@ -2077,14 +2103,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         context_expression_type
-            .try_enter_with_mode(self.db(), eval_mode)
+            .try_enter_with_mode(self.db(), self.program, eval_mode)
             .unwrap_or_else(|err| {
                 err.report_diagnostic(
                     &self.context,
                     context_expression_type,
                     context_expression.into(),
                 );
-                err.fallback_enter_type(self.db())
+                err.fallback_enter_type(self.db(), self.program)
             })
     }
 
@@ -2094,82 +2120,87 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let node_ty = node.map_or(Type::unknown(), |ty| {
             self.infer_expression(ty, TypeContext::default())
         });
-        let type_base_exception = KnownClass::BaseException.to_subclass_of(self.db());
+        let type_base_exception = KnownClass::BaseException.to_subclass_of(self.db(), self.program);
 
         // If it's an `except*` handler, this won't actually be the type of the bound symbol;
         // it will actually be the type of the generic parameters to `BaseExceptionGroup` or `ExceptionGroup`.
-        let symbol_ty = if let Some(tuple_spec) = node_ty.tuple_instance_spec(self.db()) {
-            let mut builder = UnionBuilder::new(self.db());
-            let mut invalid_elements = vec![];
+        let symbol_ty =
+            if let Some(tuple_spec) = node_ty.tuple_instance_spec(self.db(), self.program) {
+                let mut builder = UnionBuilder::new(self.db(), self.program);
+                let mut invalid_elements = vec![];
 
-            for (index, element) in tuple_spec.all_elements().iter().enumerate() {
-                builder = builder.add(
-                    if element.is_assignable_to(self.db(), type_base_exception) {
-                        element.to_instance(self.db()).expect(
-                            "`Type::to_instance()` should always return `Some()` \
+                for (index, element) in tuple_spec.all_elements().iter().enumerate() {
+                    builder = builder.add(
+                        if element.is_assignable_to(self.db(), self.program, type_base_exception) {
+                            element.to_instance(self.db(), self.program).expect(
+                                "`Type::to_instance()` should always return `Some()` \
                                 if called on a type assignable to `type[BaseException]`",
-                        )
-                    } else {
-                        invalid_elements.push((index, element));
-                        Type::unknown()
-                    },
-                );
-            }
-
-            if !invalid_elements.is_empty()
-                && let Some(node) = node
-            {
-                if let ast::Expr::Tuple(tuple) = node
-                    && !tuple.iter().any(ast::Expr::is_starred_expr)
-                    && Some(tuple.len()) == tuple_spec.len().into_fixed_length()
-                {
-                    let invalid_elements = invalid_elements
-                        .iter()
-                        .map(|(index, ty)| (&tuple.elts[*index], **ty));
-
-                    report_invalid_exception_tuple_caught(
-                        &self.context,
-                        tuple,
-                        node_ty,
-                        invalid_elements,
+                            )
+                        } else {
+                            invalid_elements.push((index, element));
+                            Type::unknown()
+                        },
                     );
-                } else {
+                }
+
+                if !invalid_elements.is_empty()
+                    && let Some(node) = node
+                {
+                    if let ast::Expr::Tuple(tuple) = node
+                        && !tuple.iter().any(ast::Expr::is_starred_expr)
+                        && Some(tuple.len()) == tuple_spec.len().into_fixed_length()
+                    {
+                        let invalid_elements = invalid_elements
+                            .iter()
+                            .map(|(index, ty)| (&tuple.elts[*index], **ty));
+
+                        report_invalid_exception_tuple_caught(
+                            &self.context,
+                            tuple,
+                            node_ty,
+                            invalid_elements,
+                        );
+                    } else {
+                        report_invalid_exception_caught(&self.context, node, node_ty);
+                    }
+                }
+
+                builder.build()
+            } else if let Some(symbol_ty) =
+                self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
+            {
+                symbol_ty
+            } else if node_ty.is_assignable_to(
+                self.db(),
+                self.program,
+                UnionType::from_two_elements(
+                    self.db(),
+                    self.program,
+                    type_base_exception,
+                    Type::homogeneous_tuple(self.db(), type_base_exception),
+                ),
+            ) {
+                // TODO: Handle valid handler expressions that are opaque to the structural helper
+                // above, for example a type variable bounded by the full class-or-tuple union.
+                KnownClass::BaseException.to_instance(self.db(), self.program)
+            } else {
+                if let Some(node) = node {
                     report_invalid_exception_caught(&self.context, node, node_ty);
                 }
-            }
-
-            builder.build()
-        } else if let Some(symbol_ty) =
-            self.exception_handler_symbol_ty_from_valid_ty(node_ty, type_base_exception)
-        {
-            symbol_ty
-        } else if node_ty.is_assignable_to(
-            self.db(),
-            UnionType::from_two_elements(
-                self.db(),
-                type_base_exception,
-                Type::homogeneous_tuple(self.db(), type_base_exception),
-            ),
-        ) {
-            // TODO: Handle valid handler expressions that are opaque to the structural helper
-            // above, for example a type variable bounded by the full class-or-tuple union.
-            KnownClass::BaseException.to_instance(self.db())
-        } else {
-            if let Some(node) = node {
-                report_invalid_exception_caught(&self.context, node, node_ty);
-            }
-            Type::unknown()
-        };
+                Type::unknown()
+            };
 
         if is_star {
-            let class = if symbol_ty
-                .is_subtype_of(self.db(), KnownClass::Exception.to_instance(self.db()))
-            {
+            let class = if symbol_ty.is_subtype_of(
+                self.db(),
+                self.program,
+                KnownClass::Exception.to_instance(self.db(), self.program),
+            ) {
                 KnownClass::ExceptionGroup
             } else {
                 KnownClass::BaseExceptionGroup
             };
-            class.to_specialized_instance(self.db(), &[symbol_ty])
+            class.to_specialized_instance(self.db(), self.program, &[symbol_ty])
         } else {
             symbol_ty
         }
@@ -2180,13 +2211,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         ty: Type<'db>,
         type_base_exception: Type<'db>,
     ) -> Option<Type<'db>> {
-        if let Some(tuple_spec) = ty.tuple_instance_spec(self.db()) {
+        if let Some(tuple_spec) = ty.tuple_instance_spec(self.db(), self.program) {
             // `except (ValueError, TypeError) as e:`
             UnionType::try_from_elements(
                 self.db(),
+                self.program,
                 tuple_spec.all_elements().iter().map(|element| {
-                    if element.is_assignable_to(self.db(), type_base_exception) {
-                        Some(element.to_instance(self.db()).expect(
+                    if element.is_assignable_to(self.db(), self.program, type_base_exception) {
+                        Some(element.to_instance(self.db(), self.program).expect(
                             "`Type::to_instance()` should always return `Some()` \
                                 if called on a type assignable to `type[BaseException]`",
                         ))
@@ -2195,40 +2227,44 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }),
             )
-        } else if ty.is_assignable_to(self.db(), type_base_exception) {
+        } else if ty.is_assignable_to(self.db(), self.program, type_base_exception) {
             // `except ValueError as e:`
-            Some(ty.to_instance(self.db()).expect(
+            Some(ty.to_instance(self.db(), self.program).expect(
                 "`Type::to_instance()` should always return `Some()` \
                     if called on a type assignable to `type[BaseException]`",
             ))
         } else if ty.is_assignable_to(
             self.db(),
+            self.program,
             Type::homogeneous_tuple(self.db(), type_base_exception),
         ) {
             // `except exception_types as e:`, where
             // `exception_types: tuple[type[ValueError], ...]`
             Some(
-                ty.tuple_instance_spec(self.db())
+                ty.tuple_instance_spec(self.db(), self.program)
                     .and_then(|spec| {
                         let specialization = spec
-                            .homogeneous_element_type(self.db())
-                            .to_instance(self.db());
+                            .homogeneous_element_type(self.db(), self.program)
+                            .to_instance(self.db(), self.program);
 
                         debug_assert!(specialization.is_some_and(|specialization_type| {
                             specialization_type.is_assignable_to(
                                 self.db(),
-                                KnownClass::BaseException.to_instance(self.db()),
+                                self.program,
+                                KnownClass::BaseException.to_instance(self.db(), self.program),
                             )
                         }));
 
                         specialization
                     })
-                    .unwrap_or_else(|| KnownClass::BaseException.to_instance(self.db())),
+                    .unwrap_or_else(|| {
+                        KnownClass::BaseException.to_instance(self.db(), self.program)
+                    }),
             )
         } else if let Type::Union(union) = ty {
             // `except exception_types as e:`, where
             // `exception_types: type[ValueError] | tuple[type[ValueError], ...]`
-            union.try_map(self.db(), |element| {
+            union.try_map(self.db(), self.program, |element| {
                 self.exception_handler_symbol_ty_from_valid_ty(*element, type_base_exception)
             })
         } else {
@@ -2285,13 +2321,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let place = loop_header_kind.place();
 
-        let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
+        let mut union =
+            UnionBuilder::new(db, self.program).recursively_defined(RecursivelyDefined::Yes);
 
         for reachable_binding in &loop_header.reachable_bindings {
             let binding_ty = binding_type(db, reachable_binding.definition);
             let narrowed_ty = use_def
                 .narrowing_evaluator(reachable_binding.narrowing_constraint)
-                .narrow(db, binding_ty, place);
+                .narrow(db, self.program, binding_ty, place);
 
             union.add_in_place(narrowed_ty);
         }
@@ -2378,7 +2415,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        let mut union = UnionBuilder::new(db).recursively_defined(RecursivelyDefined::Yes);
+        let mut union =
+            UnionBuilder::new(db, self.program).recursively_defined(RecursivelyDefined::Yes);
         for declaration in visible_nested_declarations {
             assert!(
                 declaration.is_bound,
@@ -2391,6 +2429,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let use_def = self.index.use_def_map(declaration.file_scope_id);
             let Some(ty) = place_from_bindings_with_reachability_cache(
                 db,
+                self.program,
                 use_def.reachable_bindings(nested_symbol_id.into()),
                 self.reachability_cache(),
             )
@@ -2426,7 +2465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(guard) = guard.as_deref() {
                 let guard_ty = self.infer_standalone_expression(guard, TypeContext::default());
 
-                if let Err(err) = guard_ty.try_bool(self.db()) {
+                if let Err(err) = guard_ty.try_bool(self.db(), self.program) {
                     err.report_diagnostic(&self.context, guard);
                 }
             }
@@ -2489,7 +2528,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 first_excess_pattern,
                                 limit,
                                 positional_patterns.len(),
-                                cls_ty.display(self.db()),
+                                cls_ty.display(self.db(), self.program),
                             );
                         }
                     }
@@ -2503,7 +2542,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                 }
             }
-        } else if !cls_ty.is_assignable_to(self.db(), KnownClass::Type.to_instance(self.db())) {
+        } else if !cls_ty.is_assignable_to(
+            self.db(),
+            self.program,
+            KnownClass::Type.to_instance(self.db(), self.program),
+        ) {
             report_invalid_class_match_pattern(&self.context, &*pattern.cls, cls_ty);
         }
     }
@@ -2700,9 +2743,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         property_ty.as_property_instance().is_some_and(|property| {
             property.deleter(db).is_some_and(|deleter| {
-                match deleter.try_call(db, &CallArguments::positional([object_ty])) {
-                    Ok(result) => result.return_type(db).is_never(),
-                    Err(err) => err.return_type(db).is_never(),
+                match deleter.try_call(db, self.program, &CallArguments::positional([object_ty])) {
+                    Ok(result) => result.return_type(db, self.program).is_never(),
+                    Err(err) => err.return_type(db, self.program).is_never(),
                 }
             })
         })
@@ -2789,6 +2832,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             | Type::NewTypeInstance(_) => {
                 let delattr_dunder_call_result = object_ty.try_call_dunder_with_policy(
                     db,
+                    self.program,
                     "__delattr__",
                     &mut CallArguments::positional([Type::string_literal(db, attribute)]),
                     TypeContext::default(),
@@ -2796,8 +2840,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
 
                 let returns_never = match &delattr_dunder_call_result {
-                    Ok(result) => result.return_type(db).is_never(),
-                    Err(err) => err.return_type(db).is_some_and(|ty| ty.is_never()),
+                    Ok(result) => result.return_type(db, self.program).is_never(),
+                    Err(err) => err
+                        .return_type(db, self.program)
+                        .is_some_and(|ty| ty.is_never()),
                 };
                 if returns_never {
                     if emit_diagnostics
@@ -2806,7 +2852,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         builder.into_diagnostic(format_args!(
                             "Cannot delete attribute `{attribute}` on type `{}` \
                              whose `__delattr__` method returns `Never`/`NoReturn`",
-                            object_ty.display(db),
+                            object_ty.display(db, self.program),
                         ));
                     }
                     return false;
@@ -2856,12 +2902,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ..
                         }),
                     ..
-                }) = assignment_attribute_members(db, object_ty, attribute)
+                }) = assignment_attribute_members(db, self.program, object_ty, attribute)
                     .and_then(AssignmentAttributeMembers::type_member)
                 {
-                    let attr_ty = attr_ty.bind_self_typevars(db, object_ty);
+                    let attr_ty = attr_ty.bind_self_typevars(db, self.program, object_ty);
                     let delete_dunder_call_result = attr_ty.try_call_dunder(
                         db,
+                        self.program,
                         "__delete__",
                         CallArguments::positional([object_ty]),
                         TypeContext::default(),
@@ -2875,7 +2922,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             builder.into_diagnostic(format_args!(
                                 "Cannot delete attribute `{attribute}` on type `{}` \
                                  whose `__delete__` method returns `Never`/`NoReturn`",
-                                object_ty.display(db),
+                                object_ty.display(db, self.program),
                             ));
                         }
                         return false;
@@ -2937,7 +2984,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let assigned_ty = infer_assigned_ty.map(|f| f(self, TypeContext::default()));
 
                 if let Some(tuple_spec) =
-                    assigned_ty.and_then(|ty| ty.tuple_instance_spec(self.db()))
+                    assigned_ty.and_then(|ty| ty.tuple_instance_spec(self.db(), self.program))
                 {
                     let assigned_tys = tuple_spec.all_elements().to_vec();
 
@@ -3159,7 +3206,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if let Some(special_form) = target.as_name_expr().and_then(|name| {
-            SpecialFormType::try_from_file_and_name(self.db(), self.file(), &name.id)
+            SpecialFormType::try_from_program_file_and_name(
+                self.db(),
+                self.program_file(),
+                &name.id,
+            )
         }) {
             target_ty = Type::SpecialForm(special_form);
         }
@@ -3397,7 +3448,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let constraint = self.infer_type_expression(arg);
             constraint_tys.push(constraint);
 
-            if constraint.has_typevar_or_typevar_instance(self.db())
+            if constraint.has_typevar_or_typevar_instance(self.db(), self.program)
                 && let Some(builder) = self
                     .context
                     .report_lint(&INVALID_TYPE_VARIABLE_CONSTRAINTS, arg)
@@ -3416,7 +3467,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let bound_type = self.infer_type_expression(&bound.value);
             bound_or_constraints = Some(TypeVarBoundOrConstraints::UpperBound(bound_type));
 
-            if bound_type.has_typevar_or_typevar_instance(self.db())
+            if bound_type.has_typevar_or_typevar_instance(self.db(), self.program)
                 && let Some(builder) = self
                     .context
                     .report_lint(&INVALID_TYPE_VARIABLE_BOUND, bound)
@@ -3463,7 +3514,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn infer_newtype_assignment_deferred(&mut self, arguments: &ast::Arguments) {
         let inferred = self.infer_type_expression(&arguments.args[1]);
 
-        if inferred.has_typevar_or_typevar_instance(self.db()) {
+        if inferred.has_typevar_or_typevar_instance(self.db(), self.program) {
             if let Some(builder) = self
                 .context
                 .report_lint(&INVALID_NEWTYPE, &arguments.args[1])
@@ -3495,7 +3546,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .report_lint(&INVALID_NEWTYPE, &arguments.args[1])
         {
             let mut diag = builder.into_diagnostic("invalid base for `typing.NewType`");
-            diag.set_primary_message(format!("type `{}`", inferred.display(self.db())));
+            diag.set_primary_message(format!(
+                "type `{}`",
+                inferred.display(self.db(), self.program)
+            ));
             if matches!(inferred, Type::ProtocolInstance(_)) {
                 diag.info("The base of a `NewType` is not allowed to be a protocol class.");
             } else if matches!(inferred, Type::TypedDict(_)) {
@@ -3777,7 +3831,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // type, report an error and fall back to the annotated type.
             let target_ty = if let Some(value_ty) = value_ty {
                 let declared_ty = annotated.inner_type();
-                if value_ty.is_assignable_to(self.db(), declared_ty) {
+                if value_ty.is_assignable_to(self.db(), self.program, declared_ty) {
                     value_ty
                 } else {
                     if let Some(builder) = self
@@ -3786,8 +3840,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     {
                         let mut diag = builder.into_diagnostic(format_args!(
                             "Object of type `{}` is not assignable to `{}`",
-                            value_ty.display(self.db()),
-                            declared_ty.display(self.db()),
+                            value_ty.display(self.db(), self.program),
+                            declared_ty.display(self.db(), self.program),
                         ));
                         diag.annotate(
                             self.context
@@ -3796,7 +3850,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         );
                         diag.set_primary_message(format_args!(
                             "Incompatible value of type `{}`",
-                            value_ty.display(self.db()),
+                            value_ty.display(self.db(), self.program),
                         ));
                     }
                     declared_ty
@@ -4023,8 +4077,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .is_some_and(|name| &name.id == "TYPE_CHECKING")
         {
             if !KnownClass::Bool
-                .to_instance(self.db())
-                .is_assignable_to(self.db(), declared.inner_type())
+                .to_instance(self.db(), self.program)
+                .is_assignable_to(self.db(), self.program, declared.inner_type())
             {
                 // annotation not assignable from `bool` is an error
                 report_invalid_type_checking_constant(&self.context, target.into());
@@ -4048,8 +4102,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // Handle various singletons.
         if let Some(name_expr) = target.as_name_expr()
-            && let Some(special_form) =
-                SpecialFormType::try_from_file_and_name(self.db(), self.file(), &name_expr.id)
+            && let Some(special_form) = SpecialFormType::try_from_program_file_and_name(
+                self.db(),
+                self.program_file(),
+                &name_expr.id,
+            )
         {
             declared.inner = Type::SpecialForm(special_form);
         }
@@ -4090,7 +4147,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         Type::unknown()
                     }
                     Type::KnownInstance(KnownInstanceType::LiteralStringAlias(ty))
-                        if ty.inner(self.db()).contains_self(self.db()) =>
+                        if ty.inner(self.db()).contains_self(self.db(), self.program) =>
                     {
                         Type::KnownInstance(KnownInstanceType::LiteralStringAlias(
                             InternedType::new(self.db(), Type::unknown()),
@@ -4153,8 +4210,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // which are never members)
                     && !inferred_ty.is_subtype_of(
                         self.db(),
+                        self.program,
                         Type::Callable(CallableType::unknown(self.db()))
-                            .top_materialization(self.db()),
+                            .top_materialization(self.db(), self.program),
                     )
                 {
                     let current_scope_id = self.scope().file_scope_id(self.db());
@@ -4262,7 +4320,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // equally applicable type contexts for each union member.
                 infer_value_ty.infer_loud(self, TypeContext::default());
 
-                union.map(db, |&elem_type| {
+                union.map(db, self.program, |&elem_type| {
                     self.infer_augmented_op(
                         assignment,
                         elem_type,
@@ -4298,7 +4356,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 );
 
                 match call {
-                    Ok(outcome) => outcome.return_type(db),
+                    Ok(outcome) => outcome.return_type(db, self.program),
                     Err(CallDunderError::MethodNotAvailable) => {
                         let value_ty = infer_value_ty(self, TypeContext::default());
                         binary_return_ty(self, value_ty)
@@ -4309,7 +4367,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let value_ty = outcome.type_for_argument(&call_arguments, 0);
                         UnionType::from_two_elements(
                             db,
-                            outcome.return_type(db),
+                            self.program,
+                            outcome.return_type(db, self.program),
                             binary_return_ty(self, value_ty),
                         )
                     }
@@ -4321,7 +4380,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             target_type,
                             value_ty,
                         );
-                        bindings.return_type(db)
+                        bindings.return_type(db, self.program)
                     }
                 }
             }
@@ -4393,20 +4452,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         iterable: &ast::Expr,
         expression_type: impl FnMut(&ast::Expr) -> Type<'db>,
     ) -> Option<Type<'db>> {
-        let element_types =
-            extract_fixed_length_iterable_element_types(self.db(), iterable, expression_type)?;
+        let element_types = extract_fixed_length_iterable_element_types(
+            self.db(),
+            self.program,
+            iterable,
+            expression_type,
+        )?;
 
         if element_types.is_empty() {
             None
         } else {
             Some(UnionType::from_elements(
                 self.db(),
+                self.program,
                 element_types.iter().copied(),
             ))
         }
     }
 
     fn infer_for_statement(&mut self, for_statement: &ast::StmtFor) {
+        let program = self.program;
         let ast::StmtFor {
             range: _,
             node_index: _,
@@ -4429,8 +4494,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 element_type
             } else {
                 iterable_type
-                    .iterate(builder.db())
-                    .homogeneous_element_type(builder.db())
+                    .iterate(builder.db(), program)
+                    .homogeneous_element_type(builder.db(), program)
             }
         });
 
@@ -4470,12 +4535,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     iterable_type
                         .try_iterate_with_mode(
                             self.db(),
+                            self.program,
                             EvaluationMode::from_is_async(for_stmt.is_async()),
                         )
-                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                        .map(|tuple| tuple.homogeneous_element_type(self.db(), self.program))
                         .unwrap_or_else(|err| {
                             err.report_diagnostic(&self.context, iterable_type, iterable.into());
-                            err.fallback_element_type(self.db())
+                            err.fallback_element_type(self.db(), self.program)
                         })
                 }
             }
@@ -4497,7 +4563,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let test_ty = self.infer_standalone_expression(test, TypeContext::default());
 
-        if let Err(err) = test_ty.try_bool(self.db()) {
+        if let Err(err) = test_ty.try_bool(self.db(), self.program) {
             err.report_diagnostic(&self.context, &**test);
         }
 
@@ -4515,7 +4581,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let test_ty = self.infer_standalone_expression(test, TypeContext::default());
 
-        if let Err(err) = test_ty.try_bool(self.db()) {
+        if let Err(err) = test_ty.try_bool(self.db(), self.program) {
             err.report_diagnostic(&self.context, &**test);
         }
 
@@ -4530,18 +4596,27 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             cause,
         } = raise;
 
-        let base_exception_type = KnownClass::BaseException.to_subclass_of(self.db());
-        let base_exception_instance = KnownClass::BaseException.to_instance(self.db());
+        let base_exception_type = KnownClass::BaseException.to_subclass_of(self.db(), self.program);
+        let base_exception_instance =
+            KnownClass::BaseException.to_instance(self.db(), self.program);
 
-        let can_be_raised =
-            UnionType::from_two_elements(self.db(), base_exception_type, base_exception_instance);
-        let can_be_exception_cause =
-            UnionType::from_two_elements(self.db(), can_be_raised, Type::none(self.db()));
+        let can_be_raised = UnionType::from_two_elements(
+            self.db(),
+            self.program,
+            base_exception_type,
+            base_exception_instance,
+        );
+        let can_be_exception_cause = UnionType::from_two_elements(
+            self.db(),
+            self.program,
+            can_be_raised,
+            Type::none(self.db(), self.program),
+        );
 
         if let Some(raised) = exc {
             let raised_type = self.infer_expression(raised, TypeContext::default());
 
-            if !raised_type.is_assignable_to(self.db(), can_be_raised) {
+            if !raised_type.is_assignable_to(self.db(), self.program, can_be_raised) {
                 report_invalid_exception_raised(&self.context, raised, raised_type);
             }
         }
@@ -4549,7 +4624,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let Some(cause) = cause {
             let cause_type = self.infer_expression(cause, TypeContext::default());
 
-            if !cause_type.is_assignable_to(self.db(), can_be_exception_cause) {
+            if !cause_type.is_assignable_to(self.db(), self.program, can_be_exception_cause) {
                 report_invalid_exception_cause(&self.context, cause, cause_type);
             }
         }
@@ -4576,7 +4651,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let file_scope_id = self.scope().file_scope_id(self.db());
                     let context_ty = if file_scope_id.is_generator_function(self.index) {
                         return_ty
-                            .generator_return_type(self.db())
+                            .generator_return_type(self.db(), self.program)
                             .unwrap_or(return_ty)
                     } else {
                         return_ty
@@ -4595,7 +4670,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 .map_or(ret.range(), |value| value.range());
             self.record_return_type(ty, range);
         } else {
-            self.record_return_type(Type::none(self.db()), ret.range());
+            self.record_return_type(Type::none(self.db(), self.program), ret.range());
         }
     }
 
@@ -4641,7 +4716,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
             }
-            if !module_type_implicit_global_symbol(self.db(), self.file(), name)
+            if !module_type_implicit_global_symbol(self.db(), self.program_file(), name)
                 .place
                 .is_undefined()
             {
@@ -4666,8 +4741,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn module_type_from_name(&self, module_name: &ModuleName) -> Option<Type<'db>> {
-        resolve_module(self.db(), self.file(), module_name)
-            .map(|module| Type::module_literal(self.db(), self.file(), module))
+        ty_module_resolver::resolve_module(
+            self.db(),
+            self.program_file().resolver_file(self.db()),
+            module_name,
+        )
+        .map(|module| Type::module_literal(self.db(), self.program_file(), module))
     }
 
     fn infer_decorator(&mut self, decorator: &ast::Decorator) -> Type<'db> {
@@ -4692,6 +4771,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Type<'db> {
         fn propagate_callable_kind<'d>(
             db: &'d dyn Db,
+            program: crate::Program,
             ty: Type<'d>,
             kind: CallableTypeKind,
             provenance: CallableFunctionProvenance,
@@ -4703,11 +4783,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     kind,
                     provenance,
                 ))),
-                Type::Union(union) => union.try_map(db, |element| {
-                    propagate_callable_kind(db, *element, kind, provenance)
+                Type::Union(union) => union.try_map(db, program, |element| {
+                    propagate_callable_kind(db, program, *element, kind, provenance)
                 }),
                 Type::TypeAlias(alias) => {
-                    propagate_callable_kind(db, alias.value_type(db), kind, provenance)
+                    propagate_callable_kind(db, program, alias.value_type(db), kind, provenance)
                 }
                 // Intersections are currently not handled here because that would require
                 // the decorator to be explicitly annotated as returning an intersection.
@@ -4761,6 +4841,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         fn is_transparent_callable_decorator<'d>(
             db: &'d dyn Db,
+            program: crate::Program,
             decorator_ty: Type<'d>,
             decorated_ty: Type<'d>,
         ) -> bool {
@@ -4768,7 +4849,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return false;
             }
             let Some(decorator_callable) = decorator_ty
-                .try_upcast_to_callable(db)
+                .try_upcast_to_callable(db, program)
                 .and_then(CallableTypes::exactly_one)
             else {
                 return false;
@@ -4807,13 +4888,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ),
             )),
             _ => decorated_ty
-                .try_upcast_to_callable(self.db())
+                .try_upcast_to_callable(self.db(), self.program)
                 .and_then(CallableTypes::exactly_one)
                 .and_then(|callable| match callable.kind(self.db()) {
                     kind @ (CallableTypeKind::FunctionLike
                     | CallableTypeKind::StaticMethodLike
                     | CallableTypeKind::ClassMethodLike) => {
-                        Some((kind, callable.provenance(self.db())))
+                        Some((kind, *callable.provenance(self.db())))
                     }
                     _ => None,
                 }),
@@ -4822,20 +4903,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let call_arguments = CallArguments::positional([decorated_ty]);
         let mut decorator_call_succeeded = true;
         let return_ty = decorator_ty
-            .try_call(self.db(), &call_arguments)
-            .map(|bindings| bindings.return_type(self.db()))
+            .try_call(self.db(), self.program, &call_arguments)
+            .map(|bindings| bindings.return_type(self.db(), self.program))
             .unwrap_or_else(|CallError(_, bindings)| {
                 decorator_call_succeeded = false;
                 bindings.report_diagnostics(&self.context, decorator_node.into());
-                bindings.return_type(self.db())
+                bindings.return_type(self.db(), self.program)
             });
 
         // TODO: Remove this special case once the new constraint solver can preserve
         // per-overload ParamSpec/return correlations for `Callable[P, R] -> Callable[P, R]`.
         if decorator_call_succeeded
-            && is_transparent_callable_decorator(self.db(), decorator_ty, decorated_ty)
+            && is_transparent_callable_decorator(
+                self.db(),
+                self.program,
+                decorator_ty,
+                decorated_ty,
+            )
             && let Some(callable) = decorated_ty
-                .try_upcast_to_callable(self.db())
+                .try_upcast_to_callable(self.db(), self.program)
                 .and_then(CallableTypes::exactly_one)
         {
             return Type::Callable(callable);
@@ -4848,7 +4934,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // extended explanation.
         propagatable_kind
             .and_then(|(kind, provenance)| {
-                propagate_callable_kind(self.db(), return_ty, kind, provenance)
+                propagate_callable_kind(self.db(), self.program, return_ty, kind, provenance)
             })
             .unwrap_or(return_ty)
     }
@@ -4865,7 +4951,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         call_expression_tcx: TypeContext<'db>,
     ) -> Result<Bindings<'db>, CallDunderError<'db>> {
         match object
-            .member_lookup_with_policy(db, name.into(), MemberLookupPolicy::NO_INSTANCE_FALLBACK)
+            .member_lookup_with_policy(
+                db,
+                self.program,
+                name.into(),
+                MemberLookupPolicy::NO_INSTANCE_FALLBACK,
+            )
             .place
         {
             Place::Defined(DefinedPlace {
@@ -4874,9 +4965,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 provenance,
                 ..
             }) => {
-                let mut bindings = self
-                    .bindings_for_call(dunder_callable)
-                    .match_parameters(db, argument_types);
+                let mut bindings = self.bindings_for_call(dunder_callable).match_parameters(
+                    db,
+                    self.program,
+                    argument_types,
+                );
 
                 if let Err(call_error) = self.infer_and_check_argument_types(
                     ast_arguments,
@@ -4912,6 +5005,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         bindings: &mut Bindings<'db>,
         call_expression_tcx: TypeContext<'db>,
     ) -> Result<(), CallErrorKind> {
+        let program = self.program;
         let db = self.db();
         let constraints = ConstraintSetBuilder::new();
 
@@ -4922,7 +5016,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If the type context is a union, attempt to narrow to a specific element.
         let narrow_targets = call_expression_tcx
-            .narrow_targets(db)
+            .narrow_targets(db, program)
             // We only need to attempt narrowing on generic calls, otherwise the type
             // context has no effect.
             .filter(|_| has_generic_context)
@@ -4939,8 +5033,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 !overload
                     .return_ty
-                    .when_assignable_to(db, narrowed_ty, &constraints, inferable)
-                    .is_never_satisfied(db)
+                    .when_assignable_to(db, program, narrowed_ty, &constraints, inferable)
+                    .is_never_satisfied(db, program)
             }) {
                 return None;
             }
@@ -4963,6 +5057,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if speculative_bindings
                 .check_types_impl(
                     db,
+                    program,
                     &constraints,
                     argument_types,
                     narrowed_tcx,
@@ -4979,8 +5074,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // cases where the constraint solver is not smart enough to solve complex unions.
             // We should see revisit this after the new constraint solver is implemented.
             if !speculative_bindings
-                .return_type(db)
-                .is_assignable_to(db, narrowed_ty)
+                .return_type(db, program)
+                .is_assignable_to(db, program, narrowed_ty)
             {
                 return None;
             }
@@ -4989,6 +5084,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             self.extend(speculative_builder);
             Some(bindings.check_types_impl(
                 db,
+                program,
                 &constraints,
                 argument_types,
                 narrowed_tcx,
@@ -5002,7 +5098,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // performance improvement.
         for narrowed_ty in narrow_targets
             .iter()
-            .filter(|ty| ty.may_prefer_declared_type(db))
+            .filter(|ty| ty.may_prefer_declared_type(db, program))
         {
             if let Some(result) = try_narrow(*narrowed_ty) {
                 return result;
@@ -5010,7 +5106,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
         for narrowed_ty in narrow_targets
             .iter()
-            .filter(|ty| !ty.may_prefer_declared_type(db))
+            .filter(|ty| !ty.may_prefer_declared_type(db, program))
         {
             if let Some(result) = try_narrow(*narrowed_ty) {
                 return result;
@@ -5031,6 +5127,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         bindings.check_types_impl(
             db,
+            self.program,
             &constraints,
             argument_types,
             call_expression_tcx,
@@ -5096,7 +5193,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for declared_type in overloads_with_binding
                 .iter()
                 .filter_map(|(overload, binding)| {
-                    overload.paramspec_binder_parameter_type(db, binding, argument_index)
+                    overload.paramspec_binder_parameter_type(
+                        db,
+                        self.program,
+                        binding,
+                        argument_index,
+                    )
                 })
             {
                 if !inferred_declared_types.insert(declared_type) {
@@ -5130,6 +5232,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                  binding: &CallableBinding<'db>| {
                 overload.argument_type_context(
                     db,
+                    self.program,
                     &constraints,
                     binding,
                     arguments_types,
@@ -5429,7 +5532,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Expr::NoneLiteral(ast::ExprNoneLiteral {
                 range: _,
                 node_index: _,
-            }) => Type::none(self.db()),
+            }) => Type::none(self.db(), self.program),
             ast::Expr::NumberLiteral(literal) => self.infer_number_literal_expression(literal),
             ast::Expr::BooleanLiteral(literal) => self.infer_boolean_literal_expression(literal),
             ast::Expr::StringLiteral(literal) => self.infer_string_literal_expression(literal, tcx),
@@ -5507,7 +5610,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             && let literal_tcx @ (Type::Union(_) | Type::LiteralValue(_)) = tcx
                 .resolve_type_alias(self.db())
                 .filter_union(self.db(), |ty| ty.as_literal_value().is_some())
-            && ty.is_assignable_to(self.db(), literal_tcx)
+            && ty.is_assignable_to(self.db(), self.program, literal_tcx)
         {
             ty = Type::LiteralValue(literal.to_unpromotable());
         }
@@ -5583,7 +5686,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let Some(class_generic_context) = class.generic_context(db) else {
             return ty;
         };
-        let Some(source_callable) = ty.try_upcast_to_callable(db) else {
+        let Some(source_callable) = ty.try_upcast_to_callable(db, self.program) else {
             return ty;
         };
         // The callable relation existentially solves variables bound by each signature. Keep
@@ -5599,10 +5702,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 !class_generic_context.contains(db, typevar.identity(db))
                             })
                             .peekable();
-                        variables
-                            .peek()
-                            .is_some()
-                            .then(|| GenericContext::from_typevar_instances(db, variables))
+                        variables.peek().is_some().then(|| {
+                            GenericContext::from_typevar_instances(db, self.program, variables)
+                        })
                     });
                     Signature::new_generic(
                         signature_generic_context,
@@ -5617,9 +5719,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let inferable = class_generic_context.inferable_typevars(db);
         let constraints = ConstraintSetBuilder::new();
         let path_bounds = source_callable
-            .into_type(db)
-            .assignable_solutions_with_inferable(db, Type::Callable(target_callable), inferable);
-        let Solutions::Constrained(solutions) = path_bounds.solve(db, &constraints) else {
+            .into_type(db, self.program)
+            .assignable_solutions_with_inferable(
+                db,
+                self.program,
+                Type::Callable(target_callable),
+                inferable,
+            );
+        let Solutions::Constrained(solutions) = path_bounds.solve(db, self.program, &constraints)
+        else {
             return ty;
         };
 
@@ -5629,14 +5737,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for binding in solution {
                 let inferred_ty = binding
                     .solution
-                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db));
-                if inferred_ty.has_unspecialized_type_var(db) {
+                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db, self.program));
+                if inferred_ty.has_unspecialized_type_var(db, self.program) {
                     continue;
                 }
 
                 type_context_mappings
                     .entry(binding.bound_typevar.identity(db))
-                    .and_modify(|existing| existing.add(db, inferred_ty))
+                    .and_modify(|existing| existing.add(db, self.program, inferred_ty))
                     .or_insert_with(|| UnionAccumulator::new(inferred_ty));
             }
         }
@@ -5648,7 +5756,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let type_context_mappings: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> =
             type_context_mappings
                 .into_iter()
-                .map(|(identity, accumulator)| (identity, accumulator.into_type(db)))
+                .map(|(identity, accumulator)| (identity, accumulator.into_type(db, self.program)))
                 .collect();
         let specialized = Type::from(class.apply_specialization(db, |generic_context| {
             generic_context.specialize_recursive(
@@ -5658,7 +5766,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .map(|typevar| type_context_mappings.get(&typevar.identity(db)).copied()),
             )
         }));
-        if specialized.is_assignable_to(db, Type::Callable(target_callable)) {
+        if specialized.is_assignable_to(db, self.program, Type::Callable(target_callable)) {
             specialized
         } else {
             ty
@@ -5711,7 +5819,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for (expression, ty) in expected_types {
             self.expected_types
                 .entry(*expression)
-                .and_modify(|existing| *existing = UnionType::from_two_elements(db, *existing, *ty))
+                .and_modify(|existing| {
+                    *existing = UnionType::from_two_elements(db, self.program, *existing, *ty);
+                })
                 .or_insert(*ty);
         }
     }
@@ -5728,9 +5838,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ast::Number::Int(n) => n
                 .as_i64()
                 .map(Type::int_literal)
-                .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
-            ast::Number::Float(_) => KnownClass::Float.to_instance(db),
-            ast::Number::Complex { .. } => KnownClass::Complex.to_instance(db),
+                .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program)),
+            ast::Number::Float(_) => KnownClass::Float.to_instance(db, self.program),
+            ast::Number::Complex { .. } => KnownClass::Complex.to_instance(db, self.program),
         }
     }
 
@@ -5822,12 +5932,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 {
                                     collector.add_non_literal_string_expression();
                                 } else {
-                                    let str_ty = ty.str(self.db());
+                                    let str_ty = ty.str(self.db(), self.program);
                                     if let Some(literal) = str_ty.as_string_literal() {
                                         collector.push_str(literal.value(self.db()));
-                                    } else if str_ty
-                                        .is_subtype_of(self.db(), Type::literal_string())
-                                    {
+                                    } else if str_ty.is_subtype_of(
+                                        self.db(),
+                                        self.program,
+                                        Type::literal_string(),
+                                    ) {
                                         collector.add_literal_string_expression();
                                     } else {
                                         collector.add_non_literal_string_expression();
@@ -5842,7 +5954,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         }
-        collector.string_type(self.db())
+        collector.string_type(self.db(), self.program)
     }
 
     fn infer_tstring_expression(&mut self, tstring: &ast::ExprTString) -> Type<'db> {
@@ -5869,14 +5981,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         }
-        KnownClass::Template.to_instance(self.db())
+        KnownClass::Template.to_instance(self.db(), self.program)
     }
 
     fn infer_ellipsis_literal_expression(
         &mut self,
         _literal: &ast::ExprEllipsisLiteral,
     ) -> Type<'db> {
-        KnownClass::EllipsisType.to_instance(self.db())
+        KnownClass::EllipsisType.to_instance(self.db(), self.program)
     }
 
     fn infer_tuple_expression(
@@ -5900,12 +6012,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Remove any union elements of the annotation that are unrelated to the tuple type.
         let tcx = tcx.map(|annotation| {
             let inferable = KnownClass::Tuple
-                .try_to_class_literal(self.db())
+                .try_to_class_literal(self.db(), self.program)
                 .and_then(|class| class.generic_context(self.db()))
                 .map(|generic_context| generic_context.inferable_typevars(self.db()))
                 .unwrap_or(InferableTypeVars::None);
             annotation.filter_disjoint_elements(
                 self.db(),
+                self.program,
                 Type::homogeneous_tuple(self.db(), Type::unknown()),
                 inferable,
             )
@@ -5914,7 +6027,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut is_homogeneous_tuple_annotation = false;
 
         let annotated_tuple = tcx
-            .known_specialization(self.db(), KnownClass::Tuple)
+            .known_specialization(self.db(), self.program, KnownClass::Tuple)
             .and_then(|specialization| {
                 let spec = specialization
                     .tuple(self.db())
@@ -5927,7 +6040,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     is_homogeneous_tuple_annotation = true;
                 }
 
-                spec.resize(self.db(), TupleLength::Fixed(elts.len())).ok()
+                spec.resize(self.db(), self.program, TupleLength::Fixed(elts.len()))
+                    .ok()
             });
 
         // TODO: this is a simplification for now.
@@ -5945,6 +6059,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .iter()
             .copied();
 
+        let program = self.program;
         let db = self.db();
 
         let mut infer_element = |elt: &ast::Expr| {
@@ -5952,7 +6067,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let ctx = if can_use_type_context {
                 let expected = if elt.is_starred_expr() {
                     let expected_element = annotated_elt_ty.unwrap_or_else(Type::object);
-                    Some(KnownClass::Iterable.to_specialized_instance(db, &[expected_element]))
+                    Some(KnownClass::Iterable.to_specialized_instance(
+                        db,
+                        program,
+                        &[expected_element],
+                    ))
                 } else {
                     annotated_elt_ty
                 };
@@ -5963,7 +6082,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if tuple.len() > MAX_TUPLE_LENGTH_FOR_UNANNOTATED_LITERAL_INFERENCE {
                 // Promote literals for very large unannotated tuples,
                 // to avoid pathological performance issues
-                self.infer_expression(elt, ctx).promote(db)
+                self.infer_expression(elt, ctx).promote(db, program)
             } else {
                 self.infer_expression(elt, ctx)
             }
@@ -5977,7 +6096,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // Fine to use `iterate` rather than `try_iterate` here:
                 // errors from iterating over something not iterable will have been
                 // emitted in the `infer_element` call above.
-                let mut spec = element_type.iterate(db).into_owned();
+                let mut spec = element_type.iterate(db, program).into_owned();
 
                 let known_length = match &*starred.value {
                     ast::Expr::List(ast::ExprList { elts, .. })
@@ -5994,11 +6113,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 if let Some(known_length) = known_length {
                     spec = spec
-                        .resize(db, TupleLength::Fixed(known_length))
+                        .resize(db, program, TupleLength::Fixed(known_length))
                         .unwrap_or(spec);
                 }
 
-                builder = builder.concat(db, &spec);
+                builder = builder.concat(db, program, &spec);
             } else {
                 builder.push(infer_element(element));
             }
@@ -6026,7 +6145,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &mut infer_elt_ty,
             tcx,
         )
-        .unwrap_or_else(|| KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()]))
+        .unwrap_or_else(|| {
+            KnownClass::List.to_specialized_instance(self.db(), self.program, &[Type::unknown()])
+        })
     }
 
     fn infer_set_expression(&mut self, set: &ast::ExprSet, tcx: TypeContext<'db>) -> Type<'db> {
@@ -6050,7 +6171,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             &mut infer_elt_ty,
             tcx,
         )
-        .unwrap_or_else(|| KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()]))
+        .unwrap_or_else(|| {
+            KnownClass::Set.to_specialized_instance(self.db(), self.program, &[Type::unknown()])
+        })
     }
 
     /// Infers a set element, optionally with a fallback context for an incomplete `TypedDict` key.
@@ -6077,7 +6200,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         if let (Some(elt_ty), Some(fallback_ty)) = (elt_tcx.annotation, fallback_tcx.annotation) {
             self.store_expected_type(
                 elt,
-                UnionType::from_two_elements(self.db(), elt_ty, fallback_ty),
+                UnionType::from_two_elements(self.db(), self.program, elt_ty, fallback_ty),
             );
         }
 
@@ -6144,7 +6267,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let mut speculative_builder = self.speculate_without_diagnostics();
                         has_dict_compatible_fallback = speculative_builder
                             .infer_dict_expression(dict, TypeContext::new(Some(element)))
-                            .is_assignable_to(self.db(), element);
+                            .is_assignable_to(self.db(), self.program, element);
                     }
                 }
 
@@ -6193,7 +6316,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     // Successfully narrowed to a subset of typed dicts.
                     if !narrowed_tys.is_empty() {
-                        return UnionType::from_elements(self.db(), narrowed_tys);
+                        return UnionType::from_elements(self.db(), self.program, narrowed_tys);
                     }
                 }
             }
@@ -6223,7 +6346,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             tcx,
         )
         .unwrap_or_else(|| {
-            KnownClass::Dict.to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()])
+            KnownClass::Dict.to_specialized_instance(
+                self.db(),
+                self.program,
+                &[Type::unknown(), Type::unknown()],
+            )
         })
     }
 
@@ -6236,6 +6363,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_elt_expression: &mut dyn FnMut(&mut Self, ArgExpr<'db, 'expr>) -> Type<'db>,
         tcx: TypeContext<'db>,
     ) -> Option<Type<'db>> {
+        let program = self.program;
         let db = self.db();
 
         let mut try_narrow = |narrowed_ty| {
@@ -6251,7 +6379,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             )?;
 
             // Ensure the inferred return type is assignable to the narrowed declared type.
-            if !inferred_ty.is_assignable_to(db, narrowed_ty) {
+            if !inferred_ty.is_assignable_to(db, program, narrowed_ty) {
                 return None;
             }
 
@@ -6262,11 +6390,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         // If the type context is a union, attempt to narrow to a specific element.
         for narrowed_ty in tcx
-            .narrow_targets(db)
+            .narrow_targets(db, program)
             .as_deref()
             .into_iter()
             .flatten()
-            .filter(|ty| ty.class_specialization(db).is_some())
+            .filter(|ty| ty.class_specialization(db, program).is_some())
         {
             if let Some(result) = try_narrow(*narrowed_ty) {
                 return Some(result);
@@ -6294,7 +6422,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Extract the type variable `T` from `list[T]` in typeshed.
         let elt_tys = |collection_class: KnownClass| {
             let collection_alias = collection_class
-                .try_to_class_literal(self.db())?
+                .try_to_class_literal(self.db(), self.program)?
                 .identity_specialization(self.db())
                 .into_generic_alias()?;
 
@@ -6322,15 +6450,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let constraints = ConstraintSetBuilder::new();
         let inferable = generic_context.inferable_typevars(self.db());
         let identity_instance = Type::instance(self.db(), ClassType::Generic(collection_alias));
-        let mut builder = SpecializationBuilder::new(self.db(), &constraints, inferable);
+        let mut builder =
+            SpecializationBuilder::new(self.db(), self.program, &constraints, inferable);
 
         // Remove any union elements of that are unrelated to the collection type.
         //
         // For example, we only want the `list[int]` from `annotation: list[int] | None` if
         // `collection_ty` is `list`.
         let tcx = tcx.map(|annotation| {
-            let collection_ty = collection_class.to_instance(self.db());
-            annotation.filter_disjoint_elements(self.db(), collection_ty, inferable)
+            let collection_ty = collection_class.to_instance(self.db(), self.program);
+            annotation.filter_disjoint_elements(self.db(), self.program, collection_ty, inferable)
         });
 
         // Collect type constraints from the declared element types.
@@ -6348,7 +6477,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             if let Some(tcx) = tcx.annotation.map(|tcx| tcx.resolve_type_alias(self.db()))
                 && matches!(tcx, Type::NominalInstance(_))
-                && let Some(specialization) = tcx.known_specialization(self.db(), collection_class)
+                && let Some(specialization) =
+                    tcx.known_specialization(self.db(), self.program, collection_class)
                 && specialization.generic_context(self.db()) == generic_context
                 && generic_context.variables(self.db()).all(|typevar| {
                     !typevar.is_paramspec(self.db())
@@ -6370,29 +6500,35 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             !ty.as_typevar()
                                 .is_some_and(|tv| tv.is_inferable(self.db(), inferable))
                         })
-                        .filter_union(self.db(), |ty| !ty.has_unspecialized_type_var(self.db()));
-                    if inferred_ty.has_unspecialized_type_var(self.db()) {
+                        .filter_union(self.db(), |ty| {
+                            !ty.has_unspecialized_type_var(self.db(), self.program)
+                        });
+                    if inferred_ty.has_unspecialized_type_var(self.db(), self.program) {
                         continue;
                     }
 
                     let identity = typevar.identity(self.db());
                     elt_tcx_constraints.insert(identity, UnionAccumulator::new(inferred_ty));
-                    elt_tcx_variance.insert(identity, typevar.variance(self.db()));
+                    elt_tcx_variance.insert(identity, typevar.variance(self.db(), self.program));
                 }
             } else if let Some(tcx) = tcx.annotation
-                && tcx.class_specialization(self.db()).is_some()
+                && tcx.class_specialization(self.db(), self.program).is_some()
             {
                 let db = self.db();
 
-                let path_bounds =
-                    identity_instance.assignable_solutions_with_inferable(db, tcx, inferable);
+                let path_bounds = identity_instance.assignable_solutions_with_inferable(
+                    db,
+                    self.program,
+                    tcx,
+                    inferable,
+                );
                 let solutions = path_bounds.solve_with(|variance, path_bound| {
                     let identity = path_bound.bound_typevar.identity(db);
                     elt_tcx_variance
                         .entry(identity)
                         .and_modify(|current| *current = current.join(variance))
                         .or_insert(variance);
-                    PathBounds::default_solve(db, &constraints, path_bound)
+                    PathBounds::default_solve(db, self.program, &constraints, path_bound)
                 });
 
                 match solutions {
@@ -6420,16 +6556,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 // Avoid inferring a preferred type based on partially specialized
                                 // type context from an outer generic call. If the type context is
                                 // a union, we try to keep any concrete elements.
-                                let inferred_ty = inferred_ty
-                                    .filter_union(db, |ty| !ty.has_unspecialized_type_var(db));
-                                if inferred_ty.has_unspecialized_type_var(db) {
+                                let inferred_ty = inferred_ty.filter_union(db, |ty| {
+                                    !ty.has_unspecialized_type_var(db, self.program)
+                                });
+                                if inferred_ty.has_unspecialized_type_var(db, self.program) {
                                     continue;
                                 }
 
                                 let identity = binding.bound_typevar.identity(db);
                                 elt_tcx_constraints
                                     .entry(identity)
-                                    .and_modify(|existing| existing.add(db, inferred_ty))
+                                    .and_modify(|existing| {
+                                        existing.add(db, self.program, inferred_ty);
+                                    })
                                     .or_insert_with(|| UnionAccumulator::new(inferred_ty));
                             }
                         }
@@ -6447,7 +6586,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let elt_tcx_constraints: FxHashMap<BoundTypeVarIdentity<'db>, Type<'db>> =
                 elt_tcx_constraints
                     .into_iter()
-                    .map(|(identity, accumulator)| (identity, accumulator.into_type(db)))
+                    .map(|(identity, accumulator)| {
+                        (identity, accumulator.into_type(db, self.program))
+                    })
                     .collect();
 
             (elt_tcx_constraints, elt_tcx_variance)
@@ -6506,7 +6647,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         infer_elt_expression(self, (i, elt, TypeContext::new(Some(elt_tcx))));
                     inferred_elt_tys[i] = Some(inferred_elt_ty);
 
-                    if !inferred_elt_ty.is_assignable_to(self.db(), elt_tcx) {
+                    if !inferred_elt_ty.is_assignable_to(self.db(), self.program, elt_tcx) {
                         compatible = false;
                     }
                 }
@@ -6521,7 +6662,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             .specialize_recursive(self.db(), specialization.into_iter().map(Some))
                     },
                 );
-                return Type::from(class_type).to_instance(self.db());
+                return Type::from(class_type).to_instance(self.db(), self.program);
             }
 
             pre_inferred_elt_tys = Some(inferred_elts);
@@ -6605,7 +6746,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     statement_use_types.collection_use_constraints(collection_def)
                 {
                     for constraint in constraints {
-                        if constraint.has_unspecialized_type_var(self.db()) {
+                        if constraint.has_unspecialized_type_var(self.db(), self.program) {
                             continue;
                         }
 
@@ -6621,7 +6762,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let unpack_ty = infer_elt_expression(self, (1, value_expr, tcx));
 
                 let Some((unpacked_key_ty, unpacked_value_ty)) =
-                    unpack_ty.unpack_keys_and_items(self.db())
+                    unpack_ty.unpack_keys_and_items(self.db(), self.program)
                 else {
                     if let Some(builder) =
                         self.context.report_lint(&INVALID_ARGUMENT_TYPE, value_expr)
@@ -6631,7 +6772,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                         diag.set_primary_message(format_args!(
                             "Found `{}`",
-                            unpack_ty.display(self.db())
+                            unpack_ty.display(self.db(), self.program)
                         ));
                     }
 
@@ -6642,13 +6783,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some((key_ty, value_ty)) = elt_tys.next_tuple() {
                     tuple_size_promotion_constraints.record_unpromotable_type(
                         self.db(),
+                        self.program,
                         key_ty.identity(self.db()),
-                        unpacked_key_ty.promote(self.db()),
+                        unpacked_key_ty.promote(self.db(), self.program),
                     );
                     tuple_size_promotion_constraints.record_unpromotable_type(
                         self.db(),
+                        self.program,
                         value_ty.identity(self.db()),
-                        unpacked_value_ty.promote(self.db()),
+                        unpacked_value_ty.promote(self.db(), self.program),
                     );
 
                     builder.infer(Type::TypeVar(key_ty), unpacked_key_ty).ok()?;
@@ -6694,25 +6837,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // Simplify the inference based on a non-covariant declared type.
                 if let Some(elt_tcx) =
                     elt_tcx.filter(|_| !elt_tcx_variance[&elt_ty_identity].is_covariant())
-                    && inferred_elt_ty.is_assignable_to(self.db(), elt_tcx)
+                    && inferred_elt_ty.is_assignable_to(self.db(), self.program, elt_tcx)
                 {
                     continue;
                 }
 
                 // We promote element literal types in invariant position by default, unless they were
                 // inferred with an explicit literal annotation.
-                let inferred_elt_ty = inferred_elt_ty.promote(self.db());
+                let inferred_elt_ty = inferred_elt_ty.promote(self.db(), self.program);
 
                 let inferred_type_for_typevar = if elt.is_starred_expr() {
                     inferred_elt_ty
-                        .iterate(self.db())
-                        .homogeneous_element_type(self.db())
+                        .iterate(self.db(), self.program)
+                        .homogeneous_element_type(self.db(), self.program)
                 } else {
                     inferred_elt_ty
                 };
 
                 tuple_size_promotion_constraints.record_inferred_expression_type(
                     self.db(),
+                    self.program,
                     elt_ty_identity,
                     elt,
                     inferred_type_for_typevar,
@@ -6734,7 +6878,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // Constraints learned from later collection uses should follow the same
                         // promotion policy as literal elements: promote element literal types in
                         // invariant position unless an explicit annotation made them unpromotable.
-                        lower.promote(self.db())
+                        lower.promote(self.db(), self.program)
                     } else {
                         lower
                     };
@@ -6742,7 +6886,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let lower = if tuple_size_promotion_constraints
                         .allow(current_typevar.identity(self.db()))
                     {
-                        lower.promote_tuple_size_in_union(self.db())
+                        lower.promote_tuple_size_in_union(self.db(), self.program)
                     } else {
                         lower
                     };
@@ -6751,7 +6895,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         lower
                             // Promote singleton types to `T | Unknown` in inferred type parameters,
                             // so that e.g. `[None]` is inferred as `list[None | Unknown]`.
-                            .promote_singletons_recursively(self.db())
+                            .promote_singletons_recursively(self.db(), self.program)
                     } else {
                         lower
                     };
@@ -6760,7 +6904,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 })
             });
 
-        Type::from(class_type).to_instance(self.db())
+        Type::from(class_type).to_instance(self.db(), self.program)
     }
 
     /// Infer the type of the `iter` expression of the first comprehension.
@@ -6792,25 +6936,37 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let yield_typevar = BoundTypeVarInstance::synthetic(
             db,
+            self.program,
             Name::new_static("_GeneratorYieldT"),
             TypeVarVariance::Covariant,
         );
         let yield_ty = Type::TypeVar(yield_typevar);
-        let none = Type::none(db);
+        let none = Type::none(db, self.program);
         let generator_ty = if evaluation_mode.is_async() {
-            KnownClass::AsyncGeneratorType.to_specialized_instance(db, &[yield_ty, none])
+            KnownClass::AsyncGeneratorType.to_specialized_instance(
+                db,
+                self.program,
+                &[yield_ty, none],
+            )
         } else {
-            KnownClass::GeneratorType.to_specialized_instance(db, &[yield_ty, none, none])
+            KnownClass::GeneratorType.to_specialized_instance(
+                db,
+                self.program,
+                &[yield_ty, none, none],
+            )
         };
 
-        let generic_context = GenericContext::from_typevar_instances(db, [yield_typevar]);
+        let generic_context =
+            GenericContext::from_typevar_instances(db, self.program, [yield_typevar]);
         let path_bounds = generator_ty.assignable_solutions_with_inferable(
             db,
+            self.program,
             annotation,
             generic_context.inferable_typevars(db),
         );
         let constraints = ConstraintSetBuilder::new();
-        let Solutions::Constrained(solutions) = path_bounds.solve(db, &constraints) else {
+        let Solutions::Constrained(solutions) = path_bounds.solve(db, self.program, &constraints)
+        else {
             return TypeContext::default();
         };
 
@@ -6821,13 +6977,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     continue;
                 }
                 match &mut yield_tcx {
-                    Some(accumulator) => accumulator.add(db, binding.solution),
+                    Some(accumulator) => accumulator.add(db, self.program, binding.solution),
                     None => yield_tcx = Some(UnionAccumulator::new(binding.solution)),
                 }
             }
         }
 
-        TypeContext::new(yield_tcx.map(|accumulator| accumulator.into_type(db)))
+        TypeContext::new(yield_tcx.map(|accumulator| accumulator.into_type(db, self.program)))
     }
 
     fn infer_generator_expression(
@@ -6854,18 +7010,26 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let evaluation_mode =
             EvaluationMode::from_is_async(scope_id.is_async_comprehension(self.index));
         let yield_tcx = self.generator_yield_type_context(tcx, evaluation_mode);
-        let scope = scope_id.to_scope_id(self.db(), self.file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, yield_tcx);
         self.extend_scope(inference);
         let yield_type = self.comprehension_element_type(elt, inference);
 
         if evaluation_mode.is_async() {
-            KnownClass::AsyncGeneratorType
-                .to_specialized_instance(self.db(), &[yield_type, Type::none(self.db())])
+            KnownClass::AsyncGeneratorType.to_specialized_instance(
+                self.db(),
+                self.program,
+                &[yield_type, Type::none(self.db(), self.program)],
+            )
         } else {
             KnownClass::GeneratorType.to_specialized_instance(
                 self.db(),
-                &[yield_type, Type::none(self.db()), Type::none(self.db())],
+                self.program,
+                &[
+                    yield_type,
+                    Type::none(self.db(), self.program),
+                    Type::none(self.db(), self.program),
+                ],
             )
         }
     }
@@ -6878,8 +7042,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let element_type = inference.expression_type(element);
         if element.is_starred_expr() {
             element_type
-                .iterate(self.db())
-                .homogeneous_element_type(self.db())
+                .iterate(self.db(), self.program)
+                .homogeneous_element_type(self.db(), self.program)
         } else {
             element_type
         }
@@ -6927,7 +7091,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -6938,7 +7102,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inference,
             tcx,
         )
-        .unwrap_or_else(|| KnownClass::List.to_specialized_instance(self.db(), &[Type::unknown()]))
+        .unwrap_or_else(|| {
+            KnownClass::List.to_specialized_instance(self.db(), self.program, &[Type::unknown()])
+        })
     }
 
     fn infer_set_comprehension_expression(
@@ -6961,7 +7127,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -6972,7 +7138,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             inference,
             tcx,
         )
-        .unwrap_or_else(|| KnownClass::Set.to_specialized_instance(self.db(), &[Type::unknown()]))
+        .unwrap_or_else(|| {
+            KnownClass::Set.to_specialized_instance(self.db(), self.program, &[Type::unknown()])
+        })
     }
 
     fn infer_dict_comprehension_expression(
@@ -6996,7 +7164,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         else {
             return Type::unknown();
         };
-        let scope = scope_id.to_scope_id(self.db(), self.file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
         let inference = infer_scope_types(self.db(), scope, tcx);
         self.extend_scope(inference);
 
@@ -7008,7 +7176,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             tcx,
         )
         .unwrap_or_else(|| {
-            KnownClass::Dict.to_specialized_instance(self.db(), &[Type::unknown(), Type::unknown()])
+            KnownClass::Dict.to_specialized_instance(
+                self.db(),
+                self.program,
+                &[Type::unknown(), Type::unknown()],
+            )
         })
     }
 
@@ -7026,7 +7198,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } = generator;
 
         let elt_tcx = if elt.is_starred_expr() {
-            tcx.map(|yield_ty| KnownClass::Iterable.to_specialized_instance(self.db(), &[yield_ty]))
+            tcx.map(|yield_ty| {
+                KnownClass::Iterable.to_specialized_instance(self.db(), self.program, &[yield_ty])
+            })
         } else {
             tcx
         };
@@ -7138,6 +7312,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_comprehension(&mut self, comprehension: &ast::Comprehension, is_first: bool) {
+        let program = self.program;
         let ast::Comprehension {
             range: _,
             node_index: _,
@@ -7156,8 +7331,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             } else {
                 builder.infer_maybe_standalone_expression(iter, tcx)
             }
-            .iterate(builder.db())
-            .homogeneous_element_type(builder.db())
+            .iterate(builder.db(), program)
+            .homogeneous_element_type(builder.db(), program)
         });
 
         for expr in ifs {
@@ -7216,12 +7391,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     iterable_type
                         .try_iterate_with_mode(
                             self.db(),
+                            self.program,
                             EvaluationMode::from_is_async(comprehension.is_async()),
                         )
-                        .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                        .map(|tuple| tuple.homogeneous_element_type(self.db(), self.program))
                         .unwrap_or_else(|err| {
                             err.report_diagnostic(&self.context, iterable_type, iterable.into());
-                            err.fallback_element_type(self.db())
+                            err.fallback_element_type(self.db(), self.program)
                         })
                 }
             }
@@ -7300,13 +7476,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 (body_ty, orelse_ty)
             };
 
-        match test_ty.try_bool(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, &**test);
-            err.fallback_truthiness()
-        }) {
+        match test_ty
+            .try_bool(self.db(), self.program)
+            .unwrap_or_else(|err| {
+                err.report_diagnostic(&self.context, &**test);
+                err.fallback_truthiness()
+            }) {
             Truthiness::AlwaysTrue => body_ty,
             Truthiness::AlwaysFalse => orelse_ty,
-            Truthiness::Ambiguous => UnionType::from_two_elements(self.db(), body_ty, orelse_ty),
+            Truthiness::Ambiguous => {
+                UnionType::from_two_elements(self.db(), self.program, body_ty, orelse_ty)
+            }
         }
     }
 
@@ -7363,7 +7543,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let parameter = Parameter::positional_only(Some(param.name().id.clone()))
                         .with_optional_default_type(param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
-                                .replace_parameter_defaults(self.db())
+                                .replace_parameter_defaults(self.db(), self.program)
                         }));
 
                     if let Some(annotated_type) = parameter_types.next() {
@@ -7380,7 +7560,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let parameter = Parameter::positional_or_keyword(param.name().id.clone())
                         .with_optional_default_type(param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
-                                .replace_parameter_defaults(self.db())
+                                .replace_parameter_defaults(self.db(), self.program)
                         }));
 
                     if let Some(annotated_type) = parameter_types.next() {
@@ -7401,7 +7581,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     Parameter::keyword_only(param.name().id.clone()).with_optional_default_type(
                         param.default().map(|default_expr| {
                             self.infer_expression(default_expr, TypeContext::default())
-                                .replace_parameter_defaults(self.db())
+                                .replace_parameter_defaults(self.db(), self.program)
                         }),
                     )
                 })
@@ -7432,7 +7612,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Type::unknown();
         };
 
-        let scope = scope_id.to_scope_id(self.db(), self.file());
+        let scope = scope_id.to_scope_id(self.db(), self.program_file());
 
         // If we have a direct `Callable` type context, we can infer the body with the annotated
         // return type as type context.
@@ -7501,9 +7681,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Collect the types of each distinct key.
         let mut elements: Vec<(&str, Type<'db>)> = Vec::new();
 
-        for bindings in use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.file())) {
+        for bindings in
+            use_def.multi_bindings_at_use(keyword.scoped_use_id(db, self.program_file()))
+        {
             let place = place_from_bindings_with_reachability_cache(
                 db,
+                self.program,
                 bindings.clone(),
                 self.reachability_cache(),
             );
@@ -7554,6 +7737,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // as it may contain keys that were not explicitly assigned to.
         Some(IntersectionType::from_elements(
             db,
+            self.program,
             [argument_type, getitem_protocol],
         ))
     }
@@ -7581,7 +7765,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         for arg in &arguments.args {
             if let ast::Expr::Starred(ast::ExprStarred { value, .. }) = arg {
                 let iterable_type = self.expression_type(value);
-                if let Err(err) = iterable_type.try_iterate(self.db()) {
+                if let Err(err) = iterable_type.try_iterate(self.db(), self.program) {
                     err.report_diagnostic(&self.context, iterable_type, value.as_ref().into());
                 }
             }
@@ -7595,7 +7779,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let mapping_type = self.expression_type(&keyword.value);
 
             if mapping_type.as_paramspec_typevar(self.db()).is_some()
-                || mapping_type.unpack_keys_and_items(self.db()).is_some()
+                || mapping_type
+                    .unpack_keys_and_items(self.db(), self.program)
+                    .is_some()
             {
                 continue;
             }
@@ -7609,7 +7795,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             builder
                 .into_diagnostic("Argument expression after ** must be a mapping type")
-                .set_primary_message(format_args!("Found `{}`", mapping_type.display(self.db())));
+                .set_primary_message(format_args!(
+                    "Found `{}`",
+                    mapping_type.display(self.db(), self.program)
+                ));
         }
 
         call_arguments
@@ -7633,7 +7822,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // types learned for the collection. Until collection-use constraints are represented as
         // projected constraint sets, avoid leaking those method-local typevars into the inferred
         // collection literal type.
-        if any_over_type(self.db(), constraint, false, |ty| {
+        if any_over_type(self.db(), self.program, constraint, false, |ty| {
             ty.as_typevar().is_some_and(|typevar| {
                 !receiver_generic_context.contains(self.db(), typevar.identity(self.db()))
             })
@@ -7741,6 +7930,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         fn report_missing_implicit_constructor_call<'db>(
             context: &InferContext<'db, '_>,
             db: &'db dyn Db,
+            program: crate::Program,
             callable_type: Type<'db>,
             call_expression: &ast::ExprCall,
             bindings: &Bindings<'db>,
@@ -7751,7 +7941,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     builder.into_diagnostic(format_args!(
                         "Method `__new__` on type `{}` may be missing.",
-                        callable_type.display(db),
+                        callable_type.display(db, program),
                     ));
                 }
             }
@@ -7762,7 +7952,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 {
                     builder.into_diagnostic(format_args!(
                         "Method `__init__` on type `{}` may be missing.",
-                        callable_type.display(db),
+                        callable_type.display(db, program),
                     ));
                 }
             }
@@ -7844,7 +8034,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return self.infer_type_form_call_expression(call_expression);
         }
 
-        if callable_type.is_notimplemented(self.db()) {
+        if callable_type.is_notimplemented(self.db(), self.program) {
             if let Some(builder) = self
                 .context
                 .report_lint(&CALL_NON_CALLABLE, call_expression)
@@ -7865,7 +8055,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let class = match callable_type {
             Type::ClassLiteral(class) => Some(ClassType::NonGeneric(class)),
             Type::GenericAlias(generic) => Some(ClassType::Generic(generic)),
-            Type::SubclassOf(subclass) => subclass.subclass_of().into_class(self.db()),
+            Type::SubclassOf(subclass) => {
+                subclass.subclass_of().into_class(self.db(), self.program)
+            }
             _ => None,
         };
 
@@ -7939,10 +8131,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 TypeContext::new(Some(field.declared_ty)),
                             )
                         } else {
-                            Type::none(self.db())
+                            Type::none(self.db(), self.program)
                         };
                         return UnionType::from_two_elements(
                             self.db(),
+                            self.program,
                             field.declared_ty,
                             default_ty,
                         );
@@ -7969,7 +8162,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 builder.into_diagnostic(format_args!(
                                     "Cannot {action} read-only extra item \"{key}\" {preposition} TypedDict `{}`",
-                                    Type::TypedDict(typed_dict_ty).display(self.db()),
+                                    Type::TypedDict(typed_dict_ty).display(self.db(), self.program),
                                 ));
                             }
                             return Type::unknown();
@@ -7989,6 +8182,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     |default| {
                                         UnionType::from_two_elements(
                                             self.db(),
+                                            self.program,
                                             field.declared_ty,
                                             self.get_or_infer_expression(
                                                 default,
@@ -8173,13 +8367,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
-        let mut bindings = self
-            .bindings_for_call(callable_type)
-            .match_parameters(self.db(), &call_arguments);
+        let mut bindings = self.bindings_for_call(callable_type).match_parameters(
+            self.db(),
+            self.program,
+            &call_arguments,
+        );
 
         report_missing_implicit_constructor_call(
             &self.context,
             self.db(),
+            self.program,
             callable_type,
             call_expression,
             &bindings,
@@ -8203,7 +8400,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             Ok(()) => bindings,
             Err(_) => {
                 bindings.report_diagnostics(&self.context, call_expression.into());
-                return bindings.return_type(self.db());
+                return bindings.return_type(self.db(), self.program);
             }
         };
 
@@ -8260,7 +8457,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let value_type = self.expression_type(value);
 
             if let Some(collection_def) = self.index.unannotated_collection_initializer(value)
-                && let Some((collection_literal, _)) = value_type.class_specialization(self.db())
+                && let Some((collection_literal, _)) =
+                    value_type.class_specialization(self.db(), self.program)
             {
                 let identity_instance = Type::instance(
                     self.db(),
@@ -8270,8 +8468,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 let mut identity_bindings = self
                     .infer_attribute_load_impl(attribute, identity_instance)
-                    .bindings(self.db())
-                    .match_parameters(self.db(), &call_arguments)
+                    .bindings(self.db(), self.program)
+                    .match_parameters(self.db(), self.program, &call_arguments)
                     // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(self.db(), collection_generic_context);
 
@@ -8327,11 +8525,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let db = self.db();
         let scope = self.scope();
-        let return_ty = bindings.return_type(db);
+        let return_ty = bindings.return_type(db, self.program);
         let return_ty = match collection_initializer_class {
             Some(collection_class @ (KnownClass::List | KnownClass::Set))
                 if return_ty
-                    .class_specialization(db)
+                    .class_specialization(db, self.program)
                     .is_some_and(|(class, _)| class.is_known(db, collection_class)) =>
             {
                 self.infer_empty_list_or_set_constructor(
@@ -8415,11 +8613,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let db = self.db();
         let iterable_type = self.infer_expression(value, tcx);
         iterable_type
-            .try_iterate(db)
+            .try_iterate(db, self.program)
             .map(|spec| Type::tuple(TupleType::new(db, &spec)))
             .unwrap_or_else(|err| {
                 err.report_diagnostic(&self.context, iterable_type, value.as_ref().into());
-                Type::homogeneous_tuple(db, err.fallback_element_type(db))
+                Type::homogeneous_tuple(db, err.fallback_element_type(db, self.program))
             })
     }
 
@@ -8443,7 +8641,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         .return_ty;
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
-        let Some(generator_type_params) = declared_return_ty.generator_types(self.db()) else {
+        let Some(generator_type_params) =
+            declared_return_ty.generator_types(self.db(), self.program)
+        else {
             let _ = self.infer_optional_expression(value.as_deref(), TypeContext::default());
             return Type::unknown();
         };
@@ -8452,13 +8652,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let tcx = TypeContext::new(expected_yield_ty);
         let yielded_ty = self
             .infer_optional_expression(value.as_deref(), tcx)
-            .unwrap_or_else(|| Type::none(self.db()));
+            .unwrap_or_else(|| Type::none(self.db(), self.program));
         let diagnostic_node: AnyNodeRef = value
             .as_deref()
             .map_or_else(|| yield_expression.into(), AnyNodeRef::from);
 
         if let Some(expected_yield_ty) = expected_yield_ty
-            && !yielded_ty.is_assignable_to(self.db(), expected_yield_ty)
+            && !yielded_ty.is_assignable_to(self.db(), self.program, expected_yield_ty)
         {
             report_invalid_generator_yield_type(
                 &self.context,
@@ -8493,27 +8693,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         )
         .return_ty;
 
-        let Some(outer_expected) = annotated_return_ty.generator_types(self.db()) else {
+        let Some(outer_expected) = annotated_return_ty.generator_types(self.db(), self.program)
+        else {
             let _ = self.infer_expression(value, TypeContext::default());
             return Type::unknown();
         };
         let return_type_span = enclosing_function.spans(self.db()).return_type;
 
         let tcx = TypeContext::new(outer_expected.yield_ty.map(|yielded_ty| {
-            KnownClass::Iterable.to_specialized_instance(self.db(), &[yielded_ty])
+            KnownClass::Iterable.to_specialized_instance(self.db(), self.program, &[yielded_ty])
         }));
         let iterable_type = self.infer_expression(value, tcx);
 
         let inner_yield_ty = iterable_type
-            .try_iterate(self.db())
-            .map(|tuple| tuple.homogeneous_element_type(self.db()))
+            .try_iterate(self.db(), self.program)
+            .map(|tuple| tuple.homogeneous_element_type(self.db(), self.program))
             .unwrap_or_else(|err| {
                 err.report_diagnostic(&self.context, iterable_type, value.as_ref().into());
-                err.fallback_element_type(self.db())
+                err.fallback_element_type(self.db(), self.program)
             });
 
         if let Some(outer_yield_ty) = outer_expected.yield_ty
-            && !inner_yield_ty.is_assignable_to(self.db(), outer_yield_ty)
+            && !inner_yield_ty.is_assignable_to(self.db(), self.program, outer_yield_ty)
         {
             report_invalid_generator_yield_type(
                 &self.context,
@@ -8527,9 +8728,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(outer_send_ty) = outer_expected.send_ty {
             let inner_send_ty = iterable_type
-                .generator_send_type(self.db())
-                .unwrap_or_else(|| Type::none(self.db()));
-            if !outer_send_ty.is_assignable_to(self.db(), inner_send_ty) {
+                .generator_send_type(self.db(), self.program)
+                .unwrap_or_else(|| Type::none(self.db(), self.program));
+            if !outer_send_ty.is_assignable_to(self.db(), self.program, inner_send_ty) {
                 report_invalid_generator_yield_type(
                     &self.context,
                     value.as_ref(),
@@ -8542,7 +8743,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         iterable_type
-            .generator_return_type(self.db())
+            .generator_return_type(self.db(), self.program)
             .unwrap_or_else(Type::unknown)
     }
 
@@ -8559,13 +8760,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let expr_type = self.infer_expression(
             value,
-            tcx.map(|tcx| KnownClass::Awaitable.to_specialized_instance(self.db(), &[tcx])),
+            tcx.map(|tcx| {
+                KnownClass::Awaitable.to_specialized_instance(self.db(), self.program, &[tcx])
+            }),
         );
 
-        expr_type.try_await(self.db()).unwrap_or_else(|err| {
-            err.report_diagnostic(&self.context, expr_type, value.as_ref().into());
-            Type::unknown()
-        })
+        expr_type
+            .try_await(self.db(), self.program)
+            .unwrap_or_else(|err| {
+                err.report_diagnostic(&self.context, expr_type, value.as_ref().into());
+                Type::unknown()
+            })
     }
 
     // Perform narrowing with applicable constraints between the current scope and the enclosing scope.
@@ -8588,7 +8793,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 self.index,
             ) {
                 ApplicableConstraints::UnboundBinding(constraint) => {
-                    ty = constraint.narrow(db, ty, place);
+                    ty = constraint.narrow(db, self.program, ty, place);
                 }
                 // Performs narrowing based on constrained bindings.
                 // This handling must be performed even if narrowing is attempted and failed using `infer_place_load`.
@@ -8608,7 +8813,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 ApplicableConstraints::ConstrainedBindings(bindings) => {
                     let reachability_constraints = bindings.reachability_constraints();
                     let predicates = bindings.predicates();
-                    let mut union = UnionBuilder::new(db);
+                    let mut union = UnionBuilder::new(db, self.program);
                     for binding in bindings {
                         let static_reachability = evaluate_reachability_with_cache(
                             db,
@@ -8625,15 +8830,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 if !is_discarded_dict_key_assignment(db, definition) =>
                             {
                                 let binding_ty = binding_type(db, definition);
-                                union = union.add(
-                                    binding.narrowing_constraint.narrow(db, binding_ty, place),
-                                );
+                                union = union.add(binding.narrowing_constraint.narrow(
+                                    db,
+                                    self.program,
+                                    binding_ty,
+                                    place,
+                                ));
                             }
                             DefinitionState::Defined(_)
                             | DefinitionState::Undefined
                             | DefinitionState::Deleted => {
-                                union =
-                                    union.add(binding.narrowing_constraint.narrow(db, ty, place));
+                                union = union.add(binding.narrowing_constraint.narrow(
+                                    db,
+                                    self.program,
+                                    ty,
+                                    place,
+                                ));
                             }
                         }
                     }
@@ -8718,26 +8930,28 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Not found in the module's explicitly declared global symbols?
             // Check the "implicit globals" such as `__doc__`, `__file__`, `__name__`, etc.
             // These are looked up as attributes on `types.ModuleType`.
-            .or_fall_back_to(db, || {
-                module_type_implicit_global_symbol(db, self.file(), symbol_name).map_type(|ty| {
-                    self.narrow_place_with_applicable_constraints(
-                        PlaceExprRef::from(&expr),
-                        ty,
-                        &constraint_keys,
-                    )
-                })
+            .or_fall_back_to(db, self.program, || {
+                module_type_implicit_global_symbol(db, self.program_file(), symbol_name).map_type(
+                    |ty| {
+                        self.narrow_place_with_applicable_constraints(
+                            PlaceExprRef::from(&expr),
+                            ty,
+                            &constraint_keys,
+                        )
+                    },
+                )
             })
             // Not found in globals? Fallback to builtins
             // (without infinite recursion if we're already in builtins.)
-            .or_fall_back_to(db, || {
-                if Some(self.scope()) == builtins_module_scope(db) {
+            .or_fall_back_to(db, self.program, || {
+                if Some(self.scope()) == builtins_module_scope(db, self.program) {
                     Place::Undefined.into()
                 } else {
-                    builtins_symbol(db, symbol_name)
+                    builtins_symbol(db, self.program, symbol_name)
                 }
             })
             // Still not found? It might be `reveal_type`...
-            .or_fall_back_to(db, || {
+            .or_fall_back_to(db, self.program, || {
                 if symbol_name == "reveal_type" {
                     if let Some(builder) = self.context.report_lint(&UNDEFINED_REVEAL, name_node) {
                         let mut diag =
@@ -8746,14 +8960,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             "This is allowed for debugging convenience but will fail at runtime",
                         );
                     }
-                    typing_extensions_symbol(db, symbol_name)
+                    typing_extensions_symbol(db, self.program, symbol_name)
                 } else {
                     Place::Undefined.into()
                 }
             });
 
-        let ty =
-            resolved_after_fallback.unwrap_with_diagnostic(db, |lookup_error| match lookup_error {
+        let ty = resolved_after_fallback.unwrap_with_diagnostic(db, self.program, |lookup_error| {
+            match lookup_error {
                 LookupError::Undefined(qualifiers) => {
                     self.report_unresolved_reference(name_node);
                     TypeAndQualifiers::new(Type::unknown(), TypeOrigin::Inferred, qualifiers)
@@ -8762,7 +8976,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     report_possibly_unresolved_reference(&self.context, name_node);
                     type_when_bound
                 }
-            });
+            }
+        });
 
         ty.inner_type()
     }
@@ -8783,6 +8998,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             let place = if let Some(place_id) = place_table.place_id(expr) {
                 place_from_bindings_with_reachability_cache(
                     db,
+                    self.program,
                     use_def.reachable_bindings(place_id),
                     self.reachability_cache(),
                 )
@@ -8816,9 +9032,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return (place, None);
             }
 
-            let use_id = expr_ref.scoped_use_id(db, self.file());
+            let use_id = expr_ref.scoped_use_id(db, self.program_file());
             let place = place_from_bindings_with_reachability_cache(
                 db,
+                self.program,
                 use_def.bindings_at_use(use_id),
                 self.reachability_cache(),
             )
@@ -8873,6 +9090,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 EnclosingSnapshotResult::FoundBindings(bindings) => {
                     let mut place_and_qualifiers = place_from_bindings_with_reachability_cache(
                         db,
+                        self.program,
                         bindings,
                         self.reachability_cache(),
                     );
@@ -8905,7 +9123,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return Place::Undefined.into();
         };
 
-        explicit_global_symbol(db, self.file(), symbol_name).map_type(|ty| {
+        explicit_global_symbol(db, self.program_file(), symbol_name).map_type(|ty| {
             self.narrow_place_with_applicable_constraints(place_expr, ty, constraint_keys)
         })
     }
@@ -8929,284 +9147,295 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             constraint_keys.push((file_scope_id, ConstraintKey::UseId(use_id)));
         }
 
-        let place = PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, || {
-            let mut symbol_resolves_locally = false;
-            if let Some(symbol) = place_expr.as_symbol()
-                && let Some(symbol_id) = place_table.symbol_id(symbol.name())
-            {
-                // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
-                // flags. We need to read the place table to get correct flags.
-                symbol_resolves_locally = place_table.symbol(symbol_id).is_local();
-                // If we try to access a variable in a class before it has been defined, the
-                // lookup will fall back to global. See the comment on `Symbol::is_local`.
-                let fallback_to_global =
-                    scope.node(db).scope_kind().is_class() && symbol_resolves_locally;
-                if self.skip_non_global_scopes(file_scope_id, symbol_id) || fallback_to_global {
-                    return self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        Some(symbol.name()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        fallback_to_global,
-                    );
-                }
-            }
-
-            // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
-            // `global`, never refer to an enclosing scope. (If you reference such a symbol before
-            // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
-            // enclosing scopes in this case. The one exception to this rule is the global fallback
-            // in class bodies, which we already handled above.
-            if symbol_resolves_locally {
-                return Place::Undefined.into();
-            }
-
-            if let PlaceExprRef::Symbol(symbol) = place_expr
-                && symbol.name() == "__class__"
-                && let Some(class) = self.dunder_class_cell_type()
-            {
-                return Place::bound(class).into();
-            }
-
-            for parent_id in place_table.parents(place_expr) {
-                let parent_expr = place_table.place(parent_id);
-                let mut expr_ref = expr_ref;
-                for _ in 0..(place_expr.num_member_segments() - parent_expr.num_member_segments()) {
-                    match expr_ref {
-                        ast::ExprRef::Attribute(attribute) => {
-                            expr_ref = ast::ExprRef::from(&attribute.value);
-                        }
-                        ast::ExprRef::Subscript(subscript) => {
-                            expr_ref = ast::ExprRef::from(&subscript.value);
-                        }
-                        _ => unreachable!(),
+        let place =
+            PlaceAndQualifiers::from(local_scope_place).or_fall_back_to(db, self.program, || {
+                let mut symbol_resolves_locally = false;
+                if let Some(symbol) = place_expr.as_symbol()
+                    && let Some(symbol_id) = place_table.symbol_id(symbol.name())
+                {
+                    // Footgun: `place_expr` and `symbol` were probably constructed with all-zero
+                    // flags. We need to read the place table to get correct flags.
+                    symbol_resolves_locally = place_table.symbol(symbol_id).is_local();
+                    // If we try to access a variable in a class before it has been defined, the
+                    // lookup will fall back to global. See the comment on `Symbol::is_local`.
+                    let fallback_to_global =
+                        scope.node(db).scope_kind().is_class() && symbol_resolves_locally;
+                    if self.skip_non_global_scopes(file_scope_id, symbol_id) || fallback_to_global {
+                        return self.infer_explicit_global_symbol_load(
+                            place_expr,
+                            Some(symbol.name()),
+                            file_scope_id,
+                            &mut constraint_keys,
+                            fallback_to_global,
+                        );
                     }
                 }
-                let (parent_place, _use_id) = self.infer_local_place_load(parent_expr, expr_ref);
-                if let Place::Defined(_) = parent_place {
+
+                // Symbols that are bound or declared in the local scope, and not marked `nonlocal` or
+                // `global`, never refer to an enclosing scope. (If you reference such a symbol before
+                // it's bound, you get an `UnboundLocalError`.) Short-circuit instead of walking
+                // enclosing scopes in this case. The one exception to this rule is the global fallback
+                // in class bodies, which we already handled above.
+                if symbol_resolves_locally {
                     return Place::Undefined.into();
                 }
-            }
 
-            // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
-            // There are two main ways we try to model these loads:
-            //
-            // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
-            //    just before a nested scope begins. For variables that aren't modified after that
-            //    point, that's the only value that the nested scope can see. If a variable is
-            //    reassigned later, lazy snapshots for that variable can be updated or swept.
-            //
-            // 2. Otherwise, we keep walking until we get to the variable's original defining
-            //    scope, and we use its "public type" there, which respects all reachable bindings,
-            //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
-            //    definitions that we install after each nested scope is closed, so it has
-            //    a complete view of the nested `global` and `nonlocal` writes beneath it.
-            //
-            // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
-            // local to the current scope never falls back to an enclosing scope, even if it's only
-            // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
-            //
-            // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
-            // definitely-locally-bound variables, we defer to the current scope's bindings instead
-            // of looking at enclosing scopes. Concretely:
-            //
-            // def f():
-            //     x = None
-            //
-            //     def g():
-            //         nonlocal x
-            //         if flag:
-            //             x = 42
-            //
-            //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
-            //         # public type in `f`.
-            //         reveal_type(x)  # revealed: Literal[42, 99] | None
-            //
-            //         x = 99
-            //         # But now `x` is definitely bound, so we don't do the walk.
-            //         reveal_type(x)  # revealed: Literal[99]
-            //
-            // Importantly, this approach isn't generally sound. The public type could include
-            // nested bindings from sibling scopes, which really could run at any time, and in some
-            // cases we're being too deferential to local bindings. Unfortunately the fully sound
-            // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
-            // which is too frustrating for users in practice.
-            for (enclosing_scope_file_id, _) in self.index.ancestor_scopes(file_scope_id).skip(1) {
-                // If the current enclosing scope is global, no place lookup is performed here,
-                // instead falling back to the module's explicit global lookup below.
-                if enclosing_scope_file_id.is_global() {
-                    break;
+                if let PlaceExprRef::Symbol(symbol) = place_expr
+                    && symbol.name() == "__class__"
+                    && let Some(class) = self.dunder_class_cell_type()
+                {
+                    return Place::bound(class).into();
                 }
 
-                // Class scopes are not visible to nested scopes, and we need to handle global
-                // scope differently (because an unbound name there falls back to builtins), so
-                // check only function-like scopes.
-                // There is one exception to this rule: annotation scopes can see
-                // names defined in an immediately-enclosing class scope.
-                let enclosing_scope = self.index.scope(enclosing_scope_file_id);
-
-                let is_immediately_enclosing_scope = scope.is_annotation(db)
-                    && scope
-                        .scope(db)
-                        .parent()
-                        .is_some_and(|parent| parent == enclosing_scope_file_id);
-
-                let has_root_place_been_reassigned = || {
-                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                    enclosing_place_table
-                        .parents(place_expr)
-                        .any(|enclosing_root_place_id| {
-                            enclosing_place_table
-                                .place(enclosing_root_place_id)
-                                .is_bound()
-                        })
-                };
-
-                // If the reference is in a nested eager scope, we need to look for the place at
-                // the point where the previous enclosing scope was defined, instead of at the end
-                // of the scope. (Note that the semantic index builder takes care of only
-                // registering eager bindings for nested scopes that are actually eager, and for
-                // enclosing scopes that actually contain bindings that we should use when
-                // resolving the reference.)
-                let mut eagerly_resolved_place = None;
-                if !self.is_deferred() {
-                    match self.index.enclosing_snapshot(
-                        enclosing_scope_file_id,
-                        place_expr,
-                        file_scope_id,
-                    ) {
-                        EnclosingSnapshotResult::FoundConstraint(constraint) => {
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NarrowingConstraint(constraint),
-                            ));
-                            // If the current scope is eager, it is certain that the place is undefined in the current scope.
-                            // Do not call the `place` query below as a fallback.
-                            if scope.scope(db).is_eager() {
-                                eagerly_resolved_place = Some(Place::Undefined.into());
+                for parent_id in place_table.parents(place_expr) {
+                    let parent_expr = place_table.place(parent_id);
+                    let mut expr_ref = expr_ref;
+                    for _ in
+                        0..(place_expr.num_member_segments() - parent_expr.num_member_segments())
+                    {
+                        match expr_ref {
+                            ast::ExprRef::Attribute(attribute) => {
+                                expr_ref = ast::ExprRef::from(&attribute.value);
                             }
-                        }
-                        EnclosingSnapshotResult::FoundBindings(bindings) => {
-                            let place = place_from_bindings_with_reachability_cache(
-                                db,
-                                bindings,
-                                self.reachability_cache(),
-                            )
-                            .place
-                            .map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                            constraint_keys.push((
-                                enclosing_scope_file_id,
-                                ConstraintKey::NestedScope(file_scope_id),
-                            ));
-                            return place.into();
-                        }
-                        // There are no visible bindings / constraint here.
-                        // Don't fall back to non-eager place resolution.
-                        EnclosingSnapshotResult::NotFound => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
+                            ast::ExprRef::Subscript(subscript) => {
+                                expr_ref = ast::ExprRef::from(&subscript.value);
                             }
-                            continue;
+                            _ => unreachable!(),
                         }
-                        EnclosingSnapshotResult::NoLongerInEagerContext => {
-                            if has_root_place_been_reassigned() {
-                                return Place::Undefined.into();
-                            }
-                        }
+                    }
+                    let (parent_place, _use_id) =
+                        self.infer_local_place_load(parent_expr, expr_ref);
+                    if let Place::Defined(_) = parent_place {
+                        return Place::Undefined.into();
                     }
                 }
 
-                if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope {
-                    continue;
-                }
+                // Walk enclosing scopes to resolve a free-variable load (`LOAD_DEREF` at runtime).
+                // There are two main ways we try to model these loads:
+                //
+                // 1. "Snapshots" record the bindings/constraints in the enclosing scope at the point
+                //    just before a nested scope begins. For variables that aren't modified after that
+                //    point, that's the only value that the nested scope can see. If a variable is
+                //    reassigned later, lazy snapshots for that variable can be updated or swept.
+                //
+                // 2. Otherwise, we keep walking until we get to the variable's original defining
+                //    scope, and we use its "public type" there, which respects all reachable bindings,
+                //    not just end-of-scope bindings. That includes the synthetic `NestedBindings`
+                //    definitions that we install after each nested scope is closed, so it has
+                //    a complete view of the nested `global` and `nonlocal` writes beneath it.
+                //
+                // This walk only resolves free variables and explicit `nonlocal`s. A symbol that is
+                // local to the current scope never falls back to an enclosing scope, even if it's only
+                // possibly bound at the current use: Python would raise `UnboundLocalError` instead.
+                //
+                // Note that we only get to this walk via `or_fall_back_to` above. In other words, for
+                // definitely-locally-bound variables, we defer to the current scope's bindings instead
+                // of looking at enclosing scopes. Concretely:
+                //
+                // def f():
+                //     x = None
+                //
+                //     def g():
+                //         nonlocal x
+                //         if flag:
+                //             x = 42
+                //
+                //         # `x` is possibly unbound here, so we walk enclosing scopes and see the
+                //         # public type in `f`.
+                //         reveal_type(x)  # revealed: Literal[42, 99] | None
+                //
+                //         x = 99
+                //         # But now `x` is definitely bound, so we don't do the walk.
+                //         reveal_type(x)  # revealed: Literal[99]
+                //
+                // Importantly, this approach isn't generally sound. The public type could include
+                // nested bindings from sibling scopes, which really could run at any time, and in some
+                // cases we're being too deferential to local bindings. Unfortunately the fully sound
+                // treatment would reveal `Literal[42, 99] | None` even immediately after `x = 99`,
+                // which is too frustrating for users in practice.
+                for (enclosing_scope_file_id, _) in
+                    self.index.ancestor_scopes(file_scope_id).skip(1)
+                {
+                    // If the current enclosing scope is global, no place lookup is performed here,
+                    // instead falling back to the module's explicit global lookup below.
+                    if enclosing_scope_file_id.is_global() {
+                        break;
+                    }
 
-                let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
-                let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr) else {
-                    continue;
-                };
+                    // Class scopes are not visible to nested scopes, and we need to handle global
+                    // scope differently (because an unbound name there falls back to builtins), so
+                    // check only function-like scopes.
+                    // There is one exception to this rule: annotation scopes can see
+                    // names defined in an immediately-enclosing class scope.
+                    let enclosing_scope = self.index.scope(enclosing_scope_file_id);
 
-                let enclosing_place = enclosing_place_table.place(enclosing_place_id);
+                    let is_immediately_enclosing_scope = scope.is_annotation(db)
+                        && scope
+                            .scope(db)
+                            .parent()
+                            .is_some_and(|parent| parent == enclosing_scope_file_id);
 
-                // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
-                // marks the variable `global`, whether or not that scope actually binds the
-                // variable. If we see a `global` declaration, stop walking scopes and proceed to
-                // the global handling below. (If we're walking from a prior/inner scope where this
-                // variable is `nonlocal`, then this is a semantic syntax error, but we don't
-                // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
-                    break;
-                }
+                    let has_root_place_been_reassigned = || {
+                        let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+                        enclosing_place_table
+                            .parents(place_expr)
+                            .any(|enclosing_root_place_id| {
+                                enclosing_place_table
+                                    .place(enclosing_root_place_id)
+                                    .is_bound()
+                            })
+                    };
 
-                // Keep walking until we reach the defining scope of the variable. The synthetic
-                // nested bindings definitions installed there will see everything below it.
-                if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
-                    continue;
-                }
-                if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
-                    // Note that this check includes members like `x.y` and `x[0]`, which aren't
-                    // symbols and can't be explicitly `nonlocal`.
-                    continue;
-                }
-
-                // We've reached the defining scope of the variable. Infer its public type.
-                debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
-                let enclosing_scope_id = enclosing_scope_file_id.to_scope_id(db, self.file());
-                return eagerly_resolved_place.unwrap_or_else(|| {
-                    place_by_id(
-                        db,
-                        enclosing_scope_id,
-                        enclosing_place_id,
-                        RequiresExplicitReExport::No,
-                        ConsideredDefinitions::AllReachable,
-                    )
-                    .map_type(|ty| {
-                        self.narrow_place_with_applicable_constraints(
+                    // If the reference is in a nested eager scope, we need to look for the place at
+                    // the point where the previous enclosing scope was defined, instead of at the end
+                    // of the scope. (Note that the semantic index builder takes care of only
+                    // registering eager bindings for nested scopes that are actually eager, and for
+                    // enclosing scopes that actually contain bindings that we should use when
+                    // resolving the reference.)
+                    let mut eagerly_resolved_place = None;
+                    if !self.is_deferred() {
+                        match self.index.enclosing_snapshot(
+                            enclosing_scope_file_id,
                             place_expr,
-                            ty,
-                            &constraint_keys,
+                            file_scope_id,
+                        ) {
+                            EnclosingSnapshotResult::FoundConstraint(constraint) => {
+                                constraint_keys.push((
+                                    enclosing_scope_file_id,
+                                    ConstraintKey::NarrowingConstraint(constraint),
+                                ));
+                                // If the current scope is eager, it is certain that the place is undefined in the current scope.
+                                // Do not call the `place` query below as a fallback.
+                                if scope.scope(db).is_eager() {
+                                    eagerly_resolved_place = Some(Place::Undefined.into());
+                                }
+                            }
+                            EnclosingSnapshotResult::FoundBindings(bindings) => {
+                                let place = place_from_bindings_with_reachability_cache(
+                                    db,
+                                    self.program,
+                                    bindings,
+                                    self.reachability_cache(),
+                                )
+                                .place
+                                .map_type(|ty| {
+                                    self.narrow_place_with_applicable_constraints(
+                                        place_expr,
+                                        ty,
+                                        &constraint_keys,
+                                    )
+                                });
+                                constraint_keys.push((
+                                    enclosing_scope_file_id,
+                                    ConstraintKey::NestedScope(file_scope_id),
+                                ));
+                                return place.into();
+                            }
+                            // There are no visible bindings / constraint here.
+                            // Don't fall back to non-eager place resolution.
+                            EnclosingSnapshotResult::NotFound => {
+                                if has_root_place_been_reassigned() {
+                                    return Place::Undefined.into();
+                                }
+                                continue;
+                            }
+                            EnclosingSnapshotResult::NoLongerInEagerContext => {
+                                if has_root_place_been_reassigned() {
+                                    return Place::Undefined.into();
+                                }
+                            }
+                        }
+                    }
+
+                    if !enclosing_scope.kind().is_function_like() && !is_immediately_enclosing_scope
+                    {
+                        continue;
+                    }
+
+                    let enclosing_place_table = self.index.place_table(enclosing_scope_file_id);
+                    let Some(enclosing_place_id) = enclosing_place_table.place_id(place_expr)
+                    else {
+                        continue;
+                    };
+
+                    let enclosing_place = enclosing_place_table.place(enclosing_place_id);
+
+                    // Reads of "free" or `nonlocal` variables terminate at any enclosing scope that
+                    // marks the variable `global`, whether or not that scope actually binds the
+                    // variable. If we see a `global` declaration, stop walking scopes and proceed to
+                    // the global handling below. (If we're walking from a prior/inner scope where this
+                    // variable is `nonlocal`, then this is a semantic syntax error, but we don't
+                    // enforce that here. See `SemanticIndexBuilder::pop_scope`.)
+                    if enclosing_place.as_symbol().is_some_and(Symbol::is_global) {
+                        break;
+                    }
+
+                    // Keep walking until we reach the defining scope of the variable. The synthetic
+                    // nested bindings definitions installed there will see everything below it.
+                    if enclosing_place.as_symbol().is_some_and(Symbol::is_nonlocal) {
+                        continue;
+                    }
+                    if !(enclosing_place.is_bound() || enclosing_place.is_declared()) {
+                        // Note that this check includes members like `x.y` and `x[0]`, which aren't
+                        // symbols and can't be explicitly `nonlocal`.
+                        continue;
+                    }
+
+                    // We've reached the defining scope of the variable. Infer its public type.
+                    debug_assert!(enclosing_place.is_bound() || enclosing_place.is_declared());
+                    let enclosing_scope_id =
+                        enclosing_scope_file_id.to_scope_id(db, self.program_file());
+                    return eagerly_resolved_place.unwrap_or_else(|| {
+                        place_by_id(
+                            db,
+                            enclosing_scope_id,
+                            enclosing_place_id,
+                            RequiresExplicitReExport::No,
+                            ConsideredDefinitions::AllReachable,
+                        )
+                        .map_type(|ty| {
+                            self.narrow_place_with_applicable_constraints(
+                                place_expr,
+                                ty,
+                                &constraint_keys,
+                            )
+                        })
+                    });
+                }
+
+                PlaceAndQualifiers::default()
+                    // If we're in a class body, check for implicit class body symbols first.
+                    // These take precedence over globals.
+                    .or_fall_back_to(db, self.program, || {
+                        if scope.node(db).scope_kind().is_class()
+                            && let Some(symbol) = place_expr.as_symbol()
+                        {
+                            let implicit =
+                                class_body_implicit_symbol(db, self.program, symbol.name());
+                            if implicit.place.is_definitely_bound() {
+                                return implicit.map_type(|ty| {
+                                    self.narrow_place_with_applicable_constraints(
+                                        place_expr,
+                                        ty,
+                                        &constraint_keys,
+                                    )
+                                });
+                            }
+                        }
+                        Place::Undefined.into()
+                    })
+                    // No nonlocal binding? Check the module's explicit globals.
+                    // Avoid infinite recursion if `self.scope` already is the module's global scope.
+                    .or_fall_back_to(db, self.program, || {
+                        self.infer_explicit_global_symbol_load(
+                            place_expr,
+                            place_expr.as_symbol().map(|symbol| symbol.name().as_str()),
+                            file_scope_id,
+                            &mut constraint_keys,
+                            false,
                         )
                     })
-                });
-            }
-
-            PlaceAndQualifiers::default()
-                // If we're in a class body, check for implicit class body symbols first.
-                // These take precedence over globals.
-                .or_fall_back_to(db, || {
-                    if scope.node(db).scope_kind().is_class()
-                        && let Some(symbol) = place_expr.as_symbol()
-                    {
-                        let implicit = class_body_implicit_symbol(db, symbol.name());
-                        if implicit.place.is_definitely_bound() {
-                            return implicit.map_type(|ty| {
-                                self.narrow_place_with_applicable_constraints(
-                                    place_expr,
-                                    ty,
-                                    &constraint_keys,
-                                )
-                            });
-                        }
-                    }
-                    Place::Undefined.into()
-                })
-                // No nonlocal binding? Check the module's explicit globals.
-                // Avoid infinite recursion if `self.scope` already is the module's global scope.
-                .or_fall_back_to(db, || {
-                    self.infer_explicit_global_symbol_load(
-                        place_expr,
-                        place_expr.as_symbol().map(|symbol| symbol.name().as_str()),
-                        file_scope_id,
-                        &mut constraint_keys,
-                        false,
-                    )
-                })
-        });
+            });
 
         if let Some(ty) = place.place.ignore_possibly_undefined() {
             self.check_deprecated(expr_ref, ty);
@@ -9236,6 +9465,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ));
             add_inferred_python_version_hint_to_diagnostic(
                 self.db(),
+                self.program,
                 &mut diagnostic,
                 "resolving types",
             );
@@ -9246,7 +9476,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // ===
         // We don't need to check for typing_extensions.Type,
         // because it's already caught by typing.Type.
-        if Program::get(self.db()).python_version(self.db()) >= PythonVersion::PY39 {
+        if self.program.python_version(self.db()) >= PythonVersion::PY39 {
             if let Some(("", builtin_name)) = as_pep_585_generic("typing", id) {
                 diagnostic.set_primary_message(format_args!("Did you mean `{builtin_name}`?"));
             }
@@ -9284,11 +9514,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let attribute_exists = match MethodDecorator::try_from_fn_type(self.db(), function_type) {
             Some(MethodDecorator::ClassMethod) => !Type::instance(self.db(), class)
-                .class_member(self.db(), id.clone())
+                .class_member(self.db(), self.program, id.clone())
                 .place
                 .is_undefined(),
             Some(MethodDecorator::None) => !Type::instance(self.db(), class)
-                .member(self.db(), id)
+                .member(self.db(), self.program, id)
                 .place
                 .is_undefined(),
             Some(MethodDecorator::StaticMethod) | None => false,
@@ -9347,15 +9577,22 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) -> Type<'db> {
         fn union_elements_missing_attribute<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             attr_name: &str,
             missing_types: &mut FxIndexSet<Type<'db>>,
         ) {
             if let Some(union) = ty.as_union_like(db) {
                 for element in union.elements(db) {
-                    union_elements_missing_attribute(db, *element, attr_name, missing_types);
+                    union_elements_missing_attribute(
+                        db,
+                        program,
+                        *element,
+                        attr_name,
+                        missing_types,
+                    );
                 }
-            } else if ty.member(db, attr_name).place.is_undefined() {
+            } else if ty.member(db, program, attr_name).place.is_undefined() {
                 missing_types.insert(ty);
             }
         }
@@ -9394,13 +9631,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 assigned_type = Some(ty);
             }
         }
-        let fallback_place = value_type.member(db, &attr.id).map_type(|ty| {
-            self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
-        });
+        let fallback_place = value_type
+            .member(db, self.program, &attr.id)
+            .map_type(|ty| {
+                self.narrow_expr_with_applicable_constraints(attribute, ty, &constraint_keys)
+            });
 
         let attr_name = &attr.id;
         let resolved_type =
-            fallback_place.unwrap_with_diagnostic(db, |lookup_err| match lookup_err {
+            fallback_place.unwrap_with_diagnostic(
+            db,
+            self.program,
+            |lookup_err| match lookup_err {
                 LookupError::Undefined(_) => {
                     let fallback = || {
                         TypeAndQualifiers::new(
@@ -9437,7 +9679,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut maybe_submodule_name = module_name.clone();
                             maybe_submodule_name.extend(&relative_submodule);
-                            if resolve_module(db, self.file(), &maybe_submodule_name).is_some() {
+                            if ty_module_resolver::resolve_module(
+                                db,
+                                self.program_file().resolver_file(db),
+                                &maybe_submodule_name,
+                            )
+                            .is_some()
+                            {
                                 if let Some(builder) = self
                                     .context
                                     .report_lint(&POSSIBLY_MISSING_SUBMODULE, attribute)
@@ -9463,10 +9711,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ));
                             if let Ok(defined_type) = value_type.in_type_expression(
                                 db,
+                                self.program,
                                 self.scope(),
                                 self.typevar_binding_context,
                                 self.inference_flags()
-                            ) && !defined_type.member(db, attr_name).place.is_undefined()
+                            ) && !defined_type.member(db, self.program, attr_name).place.is_undefined()
                             {
                                 diag.help(format_args!(
                                     "Objects with type `{ty}` have a{maybe_n} `{attr_name}` \
@@ -9477,7 +9726,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     } else {
                                         ""
                                     },
-                                    ty = defined_type.display(self.db())
+                                    ty = defined_type.display(self.db(), self.program)
                                 ));
                                 if is_dotted_name(value) {
                                     let source =
@@ -9502,7 +9751,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         builder.into_diagnostic(format_args!(
                             "Attribute `{attr_name}` can only be accessed on instances, \
                             not on the class object `{}` itself.",
-                            value_type.display(db)
+                            value_type.display(db, self.program)
                         ));
                         return fallback();
                     }
@@ -9526,14 +9775,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         )),
                         _ => builder.into_diagnostic(format_args!(
                             "Object of type `{}` has no attribute `{attr_name}`",
-                            value_type.display(db),
+                            value_type.display(db, self.program),
                         )),
                     };
 
                     if value_type.is_callable_type()
                         && KnownClass::FunctionType
-                            .to_instance(db)
-                            .member(db, attr_name)
+                            .to_instance(db, self.program)
+                            .member(db, self.program, attr_name)
                             .place
                             .is_definitely_bound()
                     {
@@ -9602,6 +9851,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         for element in union.elements(db) {
                             union_elements_missing_attribute(
                                 db,
+                                self.program,
                                 *element,
                                 attr_name,
                                 &mut elements_missing_the_attribute,
@@ -9614,14 +9864,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 let missing_types = elements_missing_the_attribute
                                     .iter()
-                                    .map(|ty| format!("`{}`", ty.display(db)))
+                                    .map(|ty| format!("`{}`", ty.display(db, self.program)))
                                     .collect::<Vec<_>>()
                                     .join(", ");
 
                                 builder.into_diagnostic(format_args!(
                                     "Attribute `{attr_name}` is not defined on {} in union `{union_like_type}`",
                                     missing_types,
-                                    union_like_type = union_like_type.display(db),
+                                    union_like_type = union_like_type.display(db, self.program),
                                 ));
                             }
                             return type_when_bound;
@@ -9637,7 +9887,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                     type_when_bound
                 }
-            });
+            },
+            );
 
         let resolved_type = resolved_type.inner_type();
 
@@ -9694,7 +9945,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Unary operator `{op}` is not supported for object of type `{}`",
-            operand_type.display(self.db()),
+            operand_type.display(self.db(), self.program),
         ));
 
         if let Some(CallDunderError::PossiblyUnbound {
@@ -9705,7 +9956,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for ty in unbound_on.iter().copied() {
                 diagnostic.info(format_args!(
                     "`{}` does not implement `{unary_dunder_method}`",
-                    ty.display(self.db())
+                    ty.display(self.db(), self.program)
                 ));
             }
         }
@@ -9742,11 +9993,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             match operand_type.try_call_dunder(
                 self.db(),
+                self.program,
                 unary_dunder_method,
                 CallArguments::none(),
                 TypeContext::default(),
             ) {
-                Ok(outcome) => outcome.return_type(self.db()),
+                Ok(outcome) => outcome.return_type(self.db(), self.program),
                 Err(e) => {
                     self.report_unsupported_unary_operator(
                         unary,
@@ -9755,7 +10007,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         unary_dunder_method,
                         Some(&e),
                     );
-                    e.fallback_return_type(self.db())
+                    e.fallback_return_type(self.db(), self.program)
                 }
             }
         };
@@ -9780,7 +10032,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .as_i64()
                     .checked_neg()
                     .map(Type::int_literal)
-                    .unwrap_or_else(|| KnownClass::Int.to_instance(self.db())),
+                    .unwrap_or_else(|| KnownClass::Int.to_instance(self.db(), self.program)),
                 LiteralValueTypeKind::Bool(value) => Type::int_literal(-i64::from(value)),
                 _ => fallback_unary_expression_type(),
             },
@@ -9794,7 +10046,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             (ast::UnaryOp::Invert, Type::KnownInstance(KnownInstanceType::ConstraintSet(set))) => {
                 let constraints = ConstraintSetBuilder::new();
                 let result = constraints.into_owned(|constraints| {
-                    let set = constraints.load(self.db(), set.constraints(self.db()));
+                    let set = constraints.load(self.db(), self.program, set.constraints(self.db()));
                     set.negate(self.db(), constraints)
                 });
                 Type::KnownInstance(KnownInstanceType::ConstraintSet(
@@ -9804,7 +10056,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
             (ast::UnaryOp::Not, ty) => Type::from_truthiness(
                 self.db(),
-                ty.try_bool(self.db())
+                self.program,
+                ty.try_bool(self.db(), self.program)
                     .unwrap_or_else(|err| {
                         err.report_diagnostic(&self.context, unary);
                         err.fallback_truthiness()
@@ -9831,17 +10084,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         let db = self.db();
                         match Self::map_constrained_typevar_constraints(
                             db,
+                            self.program,
                             operand_type,
                             constraints,
                             |constraint| {
                                 constraint
                                     .try_call_dunder(
                                         db,
+                                        self.program,
                                         unary_dunder_method,
                                         CallArguments::none(),
                                         TypeContext::default(),
                                     )
-                                    .map(|outcome| outcome.return_type(db))
+                                    .map(|outcome| outcome.return_type(db, self.program))
                                     .ok()
                             },
                         ) {
@@ -9858,13 +10113,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 operand_type
                                     .try_call_dunder(
                                         db,
+                                        self.program,
                                         unary_dunder_method,
                                         CallArguments::none(),
                                         TypeContext::default(),
                                     )
                                     .map_or_else(
-                                        |e| e.fallback_return_type(db),
-                                        |b| b.return_type(db),
+                                        |e| e.fallback_return_type(db, self.program),
+                                        |b| b.return_type(db, self.program),
                                     )
                             }
                         }
@@ -9877,11 +10133,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // For unconstrained TypeVars, fall through to default handling.
                     None => match operand_type.try_call_dunder(
                         self.db(),
+                        self.program,
                         unary_dunder_method,
                         CallArguments::none(),
                         TypeContext::default(),
                     ) {
-                        Ok(outcome) => outcome.return_type(self.db()),
+                        Ok(outcome) => outcome.return_type(self.db(), self.program),
                         Err(e) => {
                             self.report_unsupported_unary_operator(
                                 unary,
@@ -9890,7 +10147,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 unary_dunder_method,
                                 Some(&e),
                             );
-                            e.fallback_return_type(self.db())
+                            e.fallback_return_type(self.db(), self.program)
                         }
                     },
                 }
@@ -9986,6 +10243,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         NeedsPeerType: Fn(&Item) -> bool,
         InferType: Fn(&mut Self, Item, Option<Type<'db>>) -> (Type<'db>, TextRange),
     {
+        let program = self.program;
         let mut done = false;
         let mut peer_types: Option<UnionAccumulator<'db>> = None;
         let db = self.db();
@@ -9999,7 +10257,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 } else {
                     peer_types
                         .as_mut()
-                        .map(|peer_types| peer_types.get_or_build(db))
+                        .map(|peer_types| peer_types.get_or_build(db, program))
                 };
                 let (ty, range) = infer_ty(self, item, peer_ty);
 
@@ -10008,7 +10266,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if is_last {
                     if done { Type::Never } else { ty }
                 } else {
-                    let truthiness = ty.try_bool(self.db()).unwrap_or_else(|err| {
+                    let truthiness = ty.try_bool(self.db(), program).unwrap_or_else(|err| {
                         err.report_diagnostic(&self.context, range);
                         err.fallback_truthiness()
                     });
@@ -10030,11 +10288,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         (Truthiness::Ambiguous, _) => {
                             if track_peer_types {
                                 match &mut peer_types {
-                                    Some(peer_types) => peer_types.add(db, ty),
+                                    Some(peer_types) => peer_types.add(db, self.program, ty),
                                     None => peer_types = Some(UnionAccumulator::new(ty)),
                                 }
                             }
-                            IntersectionBuilder::new(db)
+                            IntersectionBuilder::new(db, self.program)
                                 .add_positive(ty)
                                 .add_negative(match op {
                                     ast::BoolOp::And => Type::AlwaysTruthy,
@@ -10046,10 +10304,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             });
 
-        UnionType::from_elements(db, elements)
+        UnionType::from_elements(db, program, elements)
     }
 
     fn infer_compare_expression(&mut self, compare: &ast::ExprCompare) -> Type<'db> {
+        let program = self.program;
         let ast::ExprCompare {
             range: _,
             node_index: _,
@@ -10103,7 +10362,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     match op {
                         // `in, not in, is, is not` always return bool instances
                         ast::CmpOp::In | ast::CmpOp::NotIn | ast::CmpOp::Is | ast::CmpOp::IsNot => {
-                            KnownClass::Bool.to_instance(builder.db())
+                            KnownClass::Bool.to_instance(builder.db(), program)
                         }
                         // Other operators can return arbitrary types
                         _ => Type::unknown(),
@@ -10135,6 +10394,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
+            program: _,
             expressions,
             qualifiers: _,
             type_expression_flags,
@@ -10216,6 +10476,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
+            program: _,
             expressions,
             qualifiers,
             type_expression_flags,
@@ -10327,6 +10588,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
+            program: _,
             expressions,
             bindings,
             called_functions,
@@ -10372,6 +10634,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
+            program: _,
             expressions,
             qualifiers,
             type_expression_flags,
@@ -10507,6 +10770,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let Self {
             context,
+            program: _,
             string_annotations,
             expected_types,
             type_expression_flags,
@@ -10590,6 +10854,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // These fields are type inference results, but do not affect the inference of a given
             // expression.
             context: _,
+            program: _,
             collection_use_constraints: _,
             expressions: _,
             string_annotations: _,
@@ -10638,6 +10903,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     fn extend(&mut self, other: Self) {
         let Self {
             context,
+            program: _,
             expressions,
             type_expression_flags,
             collection_use_constraints,
@@ -10983,9 +11249,9 @@ impl StringPartsCollector {
         self.contains_non_literal_str = true;
     }
 
-    fn string_type(self, db: &dyn Db) -> Type<'_> {
+    fn string_type(self, db: &dyn Db, program: Program) -> Type<'_> {
         if self.contains_non_literal_str {
-            KnownClass::Str.to_instance(db)
+            KnownClass::Str.to_instance(db, program)
         } else if let Some(concatenated) = self.concatenated {
             Type::string_literal(db, &concatenated)
         } else {
@@ -11235,7 +11501,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             }
         }
 
-        if !bound_ty.is_assignable_to(db, declared_ty) {
+        if !bound_ty.is_assignable_to(db, builder.program, declared_ty) {
             builder.discard_dict_key_assignments_for(self.binding);
             report_invalid_assignment(
                 &builder.context,
@@ -11255,10 +11521,10 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
             });
             // If the member is a data descriptor, the RHS value may differ from the value actually assigned.
             if value_ty
-                .class_member(db, attr.id.clone())
+                .class_member(db, builder.program, attr.id.clone())
                 .place
                 .ignore_possibly_undefined()
-                .is_some_and(|ty| ty.may_be_data_descriptor(db))
+                .is_some_and(|ty| ty.may_be_data_descriptor(db, builder.program))
             {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;
@@ -11268,7 +11534,9 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
                 .try_expression_type(value)
                 .unwrap_or_else(|| builder.infer_expression(value, TypeContext::default()));
 
-            if !value_ty.is_typed_dict() && !Self::is_safe_mutable_class(db, value_ty) {
+            if !value_ty.is_typed_dict()
+                && !Self::is_safe_mutable_class(db, builder.program, value_ty)
+            {
                 builder.discard_dict_key_assignments_for(self.binding);
                 bound_ty = declared_ty;
             }
@@ -11288,7 +11556,7 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
     /// pyright. TODO: Other standard library classes may also be considered safe. Also,
     /// subclasses of these safe classes that do not override `__getitem__/__setitem__`
     /// may be considered safe.
-    fn is_safe_mutable_class(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    fn is_safe_mutable_class(db: &'db dyn Db, program: Program, ty: Type<'db>) -> bool {
         const SAFE_MUTABLE_CLASSES: &[KnownClass] = &[
             KnownClass::List,
             KnownClass::Dict,
@@ -11302,12 +11570,12 @@ impl<'db, 'ast> AddBinding<'db, 'ast> {
 
         SAFE_MUTABLE_CLASSES
             .iter()
-            .map(|class| class.to_instance(db))
+            .map(|class| class.to_instance(db, program))
             .any(|safe_mutable_class| {
-                ty.is_equivalent_to(db, safe_mutable_class)
+                ty.is_equivalent_to(db, program, safe_mutable_class)
                     || ty
-                        .generic_origin(db)
-                        .zip(safe_mutable_class.generic_origin(db))
+                        .generic_origin(db, program)
+                        .zip(safe_mutable_class.generic_origin(db, program))
                         .is_some_and(|(l, r)| l == r)
             })
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/annotation_expression.rs
@@ -241,6 +241,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .inner_type()
                                 .in_type_expression(
                                     self.db(),
+                                    self.program,
                                     self.scope(),
                                     None,
                                     self.inference_flags(),
@@ -298,7 +299,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 if qualifier == TypeQualifier::ClassVar
                                     && type_and_qualifiers
                                         .inner_type()
-                                        .has_non_self_typevar(self.db())
+                                        .has_non_self_typevar(self.db(), self.program)
                                     && let Some(builder) =
                                         self.context.report_lint(&INVALID_TYPE_FORM, subscript)
                                 {

--- a/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/attribute_assignment.rs
@@ -29,7 +29,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         infer_value_ty: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostics: bool,
     ) -> bool {
-        let requirement = attribute_write_requirement(self.db(), object_ty, attribute);
+        let requirement =
+            attribute_write_requirement(self.db(), self.program, object_ty, attribute);
         let mut evaluator = AssignmentAttributeWriteEvaluator {
             builder: self,
             target,
@@ -107,8 +108,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 let value_ty = self.infer_value(TypeContext::default(), emit_diagnostics);
                 let mut valid = true;
                 for element_ty in *element_tys {
-                    let requirement =
-                        attribute_write_requirement(self.builder.db(), *element_ty, self.attribute);
+                    let requirement = attribute_write_requirement(
+                        self.builder.db(),
+                        self.builder.program,
+                        *element_ty,
+                        self.attribute,
+                    );
                     if !self.evaluate(&requirement, false) {
                         valid = false;
                         break;
@@ -135,8 +140,12 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
             } => {
                 let mut valid = false;
                 for element_ty in intersection.positive(self.builder.db()) {
-                    let requirement =
-                        attribute_write_requirement(self.builder.db(), *element_ty, self.attribute);
+                    let requirement = attribute_write_requirement(
+                        self.builder.db(),
+                        self.builder.program,
+                        *element_ty,
+                        self.attribute,
+                    );
                     if self.evaluate(&requirement, false) {
                         valid = true;
                         break;
@@ -228,7 +237,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         emit_diagnostics: bool,
     ) -> bool {
         let db = self.builder.db();
-        let assignable = value_ty.is_assignable_to(db, target_ty);
+        let assignable = value_ty.is_assignable_to(db, self.builder.program, target_ty);
         if !assignable && emit_diagnostics {
             report_invalid_attribute_assignment(
                 &self.builder.context,
@@ -282,19 +291,23 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
         // A terminal `__setattr__` blocks even explicitly declared attributes.
         let setattr_result = object_ty.try_call_dunder_with_policy(
             db,
+            self.builder.program,
             "__setattr__",
             &mut CallArguments::positional([Type::string_literal(db, self.attribute), value_ty]),
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
         let setattr_returns_never = match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+            Ok(bindings) => bindings.return_type(db, self.builder.program).is_never(),
+            Err(error) => error
+                .return_type(db, self.builder.program)
+                .is_some_and(|ty| ty.is_never()),
         };
         if setattr_returns_never {
             if emit_diagnostics {
                 let is_setattr_synthesized = match object_ty.class_member_with_policy(
                     db,
+                    self.builder.program,
                     "__setattr__".into(),
                     MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
                 ) {
@@ -304,7 +317,10 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     } => ty.is_callable_type(),
                     _ => false,
                 };
-                let member_exists = !object_ty.member(db, self.attribute).place.is_undefined();
+                let member_exists = !object_ty
+                    .member(db, self.builder.program, self.attribute)
+                    .place
+                    .is_undefined();
                 self.report(AssignmentAttributeWriteDiagnostic::TerminalSetAttr {
                     member_exists,
                     is_setattr_synthesized,
@@ -424,9 +440,16 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 let db = self.builder.db();
                 let result = setter_ty.try_call(
                     db,
+                    self.builder.program,
                     &CallArguments::positional([*descriptor_ty, object_ty, value_ty]),
                 );
-                if property_setter_returns_never(db, *descriptor_ty, object_ty, value_ty) {
+                if property_setter_returns_never(
+                    db,
+                    self.builder.program,
+                    *descriptor_ty,
+                    object_ty,
+                    value_ty,
+                ) {
                     if emit_diagnostics {
                         self.report(AssignmentAttributeWriteDiagnostic::TerminalDescriptor);
                     }
@@ -528,9 +551,9 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 {
                     builder.into_diagnostic(format_args!(
                         "Object of type `{}` is not assignable to attribute `{}` on type `{}`",
-                        value_ty.display(db),
+                        value_ty.display(db, self.builder.program),
                         self.attribute,
-                        object_ty.display(db),
+                        object_ty.display(db, self.builder.program),
                     ));
                 }
             }
@@ -543,7 +566,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     builder.into_diagnostic(format_args!(
                         "Cannot assign to attribute `{}` on type `{}`",
                         self.attribute,
-                        self.object_ty.display(db),
+                        self.object_ty.display(db, self.builder.program),
                     ));
                 }
             }
@@ -556,7 +579,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     builder.into_diagnostic(format_args!(
                         "Cannot assign to ClassVar `{}` from an instance of type `{}`",
                         self.attribute,
-                        self.object_ty.display(db),
+                        self.object_ty.display(db, self.builder.program),
                     ));
                 }
             }
@@ -573,19 +596,19 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         format!(
                             "Cannot assign to unresolved attribute `{}` on type `{}`",
                             self.attribute,
-                            self.object_ty.display(db)
+                            self.object_ty.display(db, self.builder.program)
                         )
                     } else if is_setattr_synthesized {
                         format!(
                             "Property `{}` defined in `{}` is read-only",
                             self.attribute,
-                            self.object_ty.display(db)
+                            self.object_ty.display(db, self.builder.program)
                         )
                     } else {
                         format!(
                             "Cannot assign to attribute `{}` on type `{}` whose `__setattr__` method returns `Never`/`NoReturn`",
                             self.attribute,
-                            self.object_ty.display(db)
+                            self.object_ty.display(db, self.builder.program)
                         )
                     };
                     builder.into_diagnostic(message);
@@ -600,7 +623,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     builder.into_diagnostic(format_args!(
                         "Cannot assign to attribute `{}` on type `{}` whose `__set__` method returns `Never`/`NoReturn`",
                         self.attribute,
-                        self.object_ty.display(db),
+                        self.object_ty.display(db, self.builder.program),
                     ));
                 }
             }
@@ -629,9 +652,9 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                 {
                     builder.into_diagnostic(format_args!(
                         "Cannot assign object of type `{}` to attribute `{}` on type `{}` with custom `__setattr__` method.",
-                        value_ty.display(db),
+                        value_ty.display(db, self.builder.program),
                         self.attribute,
-                        self.object_ty.display(db)
+                        self.object_ty.display(db, self.builder.program)
                     ));
                 }
             }
@@ -645,13 +668,13 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                         builder.into_diagnostic(format_args!(
                             "Unresolved attribute `{}` on type `{}`.",
                             self.attribute,
-                            self.object_ty.display(db)
+                            self.object_ty.display(db, self.builder.program)
                         ));
                     } else {
                         builder.into_diagnostic(format_args!(
                             "Unresolved attribute `{}` on type `{}`",
                             self.attribute,
-                            self.object_ty.display(db)
+                            self.object_ty.display(db, self.builder.program)
                         ));
                     }
                 }
@@ -665,7 +688,7 @@ impl<'db> AssignmentAttributeWriteEvaluator<'_, 'db, '_, '_> {
                     builder.into_diagnostic(format_args!(
                         "Cannot assign to instance attribute `{}` from the class object `{}`",
                         self.attribute,
-                        self.object_ty.display(db)
+                        self.object_ty.display(db, self.builder.program)
                     ));
                 }
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/binary_expressions.rs
@@ -2,7 +2,6 @@ use compact_str::CompactString;
 use ruff_python_ast::{self as ast, AnyNodeRef};
 
 use super::TypeInferenceBuilder;
-use crate::Db;
 use crate::types::call::CallArguments;
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::cyclic::CycleDetector;
@@ -16,6 +15,7 @@ use crate::types::{
     MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints, TypedDictType, UnionBuilder,
     UnionTypeInstance,
 };
+use crate::{Db, Program};
 
 enum BinaryExpressionOperandTypes<'db> {
     Inferred(Type<'db>, Type<'db>),
@@ -84,11 +84,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // `TypeAlias`, which uses `X | Y` syntax, where the returned type is not actually a union.
         // And attempting to enforce this more tightly showed a lot of potential false positives in
         // the ecosystem.
-        if left_ty.is_equivalent_to(db, right_ty) {
+        if left_ty.is_equivalent_to(db, self.program, right_ty) {
             left_ty
         } else {
             UnionTypeInstance::from_value_expression_types(
                 db,
+                self.program,
                 [left_ty, right_ty],
                 self.scope(),
                 self.typevar_binding_context,
@@ -191,12 +192,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         Type::TypedDict(result_typed_dict)
             .try_call_dunder(
                 db,
+                self.program,
                 dunder_name,
                 CallArguments::positional([update_ty]),
                 TypeContext::default(),
             )
             .ok()
-            .map(|bindings| bindings.return_type(db))
+            .map(|bindings| bindings.return_type(db, self.program))
     }
 
     /// Handle `TypedDict |= value` before the normal `__ior__` path runs.
@@ -256,16 +258,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// otherwise returns the union of all results.
     pub(super) fn map_constrained_typevar_constraints(
         db: &'db dyn Db,
+        program: Program,
         typevar: Type<'db>,
         constraints: TypeVarConstraints<'db>,
         mut op: impl FnMut(Type<'db>) -> Option<Type<'db>>,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         let mut any_different = false;
 
         for constraint in constraints.elements(db) {
             let result = op(*constraint)?;
-            if !result.is_equivalent_to(db, *constraint) {
+            if !result.is_equivalent_to(db, program, *constraint) {
                 any_different = true;
             }
             builder = builder.add(result);
@@ -322,26 +325,30 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
 
         match (left_ty, right_ty, op) {
-            (Type::Union(lhs_union), rhs, _) => lhs_union.try_map(db, |lhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    *lhs_element,
-                    rhs,
-                    op,
-                    visitor,
-                )
-            }),
-            (lhs, Type::Union(rhs_union), _) => rhs_union.try_map(db, |rhs_element| {
-                self.infer_binary_expression_type_impl(
-                    node,
-                    emitted_division_by_zero_diagnostic,
-                    lhs,
-                    *rhs_element,
-                    op,
-                    visitor,
-                )
-            }),
+            (Type::Union(lhs_union), rhs, _) => {
+                lhs_union.try_map(db, self.program, |lhs_element| {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        *lhs_element,
+                        rhs,
+                        op,
+                        visitor,
+                    )
+                })
+            }
+            (lhs, Type::Union(rhs_union), _) => {
+                rhs_union.try_map(db, self.program, |rhs_element| {
+                    self.infer_binary_expression_type_impl(
+                        node,
+                        emitted_division_by_zero_diagnostic,
+                        lhs,
+                        *rhs_element,
+                        op,
+                        visitor,
+                    )
+                })
+            }
 
             (Type::TypeAlias(alias), rhs, _) => visitor.visit((left_ty, op, right_ty), || {
                 self.infer_binary_expression_type_impl(
@@ -366,13 +373,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }),
 
             (Type::TypedDict(left_typed_dict), rhs, ast::Operator::BitOr)
-                if rhs.is_assignable_to(db, Type::TypedDict(left_typed_dict)) =>
+                if rhs.is_assignable_to(db, self.program, Type::TypedDict(left_typed_dict)) =>
             {
                 Some(Type::TypedDict(left_typed_dict))
             }
 
             (lhs, Type::TypedDict(right_typed_dict), ast::Operator::BitOr)
-                if lhs.is_assignable_to(db, Type::TypedDict(right_typed_dict)) =>
+                if lhs.is_assignable_to(db, self.program, Type::TypedDict(right_typed_dict)) =>
             {
                 Some(Type::TypedDict(right_typed_dict))
             }
@@ -420,6 +427,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
                             db,
+                            self.program,
                             left_ty,
                             constraints,
                             |constraint| {
@@ -434,7 +442,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty),
                 }
             }
 
@@ -450,6 +458,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
                             db,
+                            self.program,
                             left_ty,
                             constraints,
                             |constraint| {
@@ -465,7 +474,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty),
                 }
             }
 
@@ -476,6 +485,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                         Self::map_constrained_typevar_constraints(
                             db,
+                            self.program,
                             right_ty,
                             constraints,
                             |constraint| {
@@ -491,7 +501,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         )
                     }
                     // For bounded TypeVars or unconstrained TypeVars, fall through to the default handling.
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty),
                 }
             }
 
@@ -502,28 +512,32 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             // positional arguments get. In those cases we need to explicitly delegate to the base
             // type, so that it hits the `Type::Union` branches above.
             (Type::NewTypeInstance(newtype), rhs, _) => {
-                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
-                    self.infer_binary_expression_type_impl(
-                        node,
-                        emitted_division_by_zero_diagnostic,
-                        newtype.concrete_base_type(db),
-                        rhs,
-                        op,
-                        visitor,
-                    )
-                })
+                Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty).or_else(
+                    || {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            newtype.concrete_base_type(db),
+                            rhs,
+                            op,
+                            visitor,
+                        )
+                    },
+                )
             }
             (lhs, Type::NewTypeInstance(newtype), _) => {
-                Type::try_call_bin_op_return_type(db, left_ty, op, right_ty).or_else(|| {
-                    self.infer_binary_expression_type_impl(
-                        node,
-                        emitted_division_by_zero_diagnostic,
-                        lhs,
-                        newtype.concrete_base_type(db),
-                        op,
-                        visitor,
-                    )
-                })
+                Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty).or_else(
+                    || {
+                        self.infer_binary_expression_type_impl(
+                            node,
+                            emitted_division_by_zero_diagnostic,
+                            lhs,
+                            newtype.concrete_base_type(db),
+                            op,
+                            visitor,
+                        )
+                    },
+                )
             }
 
             (
@@ -566,7 +580,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         n.as_i64()
                             .checked_add(m.as_i64())
                             .map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program)),
                     ),
 
                     (
@@ -577,7 +591,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         n.as_i64()
                             .checked_sub(m.as_i64())
                             .map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program)),
                     ),
 
                     (
@@ -588,14 +602,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         n.as_i64()
                             .checked_mul(m.as_i64())
                             .map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program)),
                     ),
 
                     (
                         LiteralValueTypeKind::Int(_),
                         LiteralValueTypeKind::Int(_),
                         ast::Operator::Div,
-                    ) => Some(KnownClass::Float.to_instance(db)),
+                    ) => Some(KnownClass::Float.to_instance(db, self.program)),
 
                     (
                         LiteralValueTypeKind::Int(n),
@@ -612,7 +626,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             q = q.map(|q| q - 1);
                         }
                         q.map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db))
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program))
                     }),
 
                     (
@@ -630,7 +644,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             r = r.map(|x| x + m.as_i64());
                         }
                         r.map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db))
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program))
                     }),
 
                     (
@@ -639,13 +653,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ast::Operator::Pow,
                     ) => Some({
                         if m.as_i64() < 0 {
-                            KnownClass::Float.to_instance(db)
+                            KnownClass::Float.to_instance(db, self.program)
                         } else {
                             u32::try_from(m.as_i64())
                                 .ok()
                                 .and_then(|m| n.as_i64().checked_pow(m))
                                 .map(Type::int_literal)
-                                .unwrap_or_else(|| KnownClass::Int.to_instance(db))
+                                .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program))
                         }
                     }),
 
@@ -816,7 +830,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .filter(|&m| m <= headroom)
                                 .and_then(|m| n.checked_shl(m))
                                 .map(Type::int_literal)
-                                .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+                                .unwrap_or_else(|| KnownClass::Int.to_instance(db, self.program)),
                         )
                     }
 
@@ -831,12 +845,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             Err(_) if m.as_i64() > 0 => {
                                 Type::int_literal(if n >= 0 { 0 } else { -1 })
                             }
-                            Err(_) => KnownClass::Int.to_instance(db),
+                            Err(_) => KnownClass::Int.to_instance(db, self.program),
                         };
                         Some(result)
                     }
 
-                    _ => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+                    _ => Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty),
                 };
 
                 result.map(|result| match result {
@@ -854,9 +868,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ) => {
                 let constraints = ConstraintSetBuilder::new();
                 let result = constraints.into_owned(|constraints| {
-                    let left = constraints.load(db, left.constraints(db));
-                    let right = constraints.load(db, right.constraints(db));
-                    left.and(db, constraints, || right)
+                    let left = constraints.load(db, self.program, left.constraints(db));
+                    let right = constraints.load(db, self.program, right.constraints(db));
+                    left.and(db, self.program, constraints, || right)
                 });
                 Some(Type::KnownInstance(KnownInstanceType::ConstraintSet(
                     InternedConstraintSet::new(db, result),
@@ -870,9 +884,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ) => {
                 let constraints = ConstraintSetBuilder::new();
                 let result = constraints.into_owned(|constraints| {
-                    let left = constraints.load(db, left.constraints(db));
-                    let right = constraints.load(db, right.constraints(db));
-                    left.or(db, constraints, || right)
+                    let left = constraints.load(db, self.program, left.constraints(db));
+                    let right = constraints.load(db, self.program, right.constraints(db));
+                    left.or(db, self.program, constraints, || right)
                 });
                 Some(Type::KnownInstance(KnownInstanceType::ConstraintSet(
                     InternedConstraintSet::new(db, result),
@@ -911,11 +925,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ),
                 ast::Operator::BitOr,
             ) => {
-                if left_ty.is_equivalent_to(db, right_ty) {
+                if left_ty.is_equivalent_to(db, self.program, right_ty) {
                     Some(left_ty)
                 } else {
                     Some(UnionTypeInstance::from_value_expression_types(
                         db,
+                        self.program,
                         [left_ty, right_ty],
                         self.scope(),
                         self.typevar_binding_context,
@@ -943,6 +958,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ) if instance.has_known_class(db, KnownClass::NoneType) => {
                 Some(UnionTypeInstance::from_value_expression_types(
                     db,
+                    self.program,
                     [left_ty, right_ty],
                     self.scope(),
                     self.typevar_binding_context,
@@ -968,13 +984,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ast::Operator::BitOr,
             ) => Type::try_call_bin_op_with_policy(
                 db,
+                self.program,
                 left_ty,
                 ast::Operator::BitOr,
                 right_ty,
                 MemberLookupPolicy::META_CLASS_NO_TYPE_FALLBACK,
             )
             .ok()
-            .map(|binding| binding.return_type(db)),
+            .map(|binding| binding.return_type(db, self.program)),
 
             // We've handled all of the special cases that we support for literals, so we need to
             // fall back on looking for dunder methods on one of the operand types.
@@ -1034,7 +1051,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 | Type::TypeForm(_)
                 | Type::TypedDict(_),
                 op,
-            ) => Type::try_call_bin_op_return_type(db, left_ty, op, right_ty),
+            ) => Type::try_call_bin_op_return_type(db, self.program, left_ty, op, right_ty),
         }
     }
 
@@ -1072,7 +1089,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some(builder) = self.context.report_lint(&DIVISION_BY_ZERO, node) {
             builder.into_diagnostic(format_args!(
                 "Cannot {op} object of type `{}` {by_zero}",
-                left.display(db)
+                left.display(db, self.program)
             ));
         }
 

--- a/crates/ty_python_semantic/src/types/infer/builder/class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/class.rs
@@ -1,3 +1,4 @@
+use crate::Program;
 use crate::place::Place;
 use crate::types::{
     CallArguments, DataclassParams, KnownClass, KnownInstanceType, MemberLookupPolicy,
@@ -14,7 +15,7 @@ use crate::types::{
 };
 use ruff_python_ast::name::Name;
 use ruff_python_ast::{self as ast, helpers::any_over_expr};
-use ty_module_resolver::{KnownModule, file_to_module};
+use ty_module_resolver::KnownModule;
 use ty_python_core::{definition::Definition, scope::NodeWithScopeRef};
 
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -105,11 +106,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let body_scope = self
             .index
             .node_scope(NodeWithScopeRef::Class(class_node))
-            .to_scope_id(db, self.file());
+            .to_scope_id(db, self.program_file());
 
-        let maybe_known_class = KnownClass::try_from_file_and_name(db, self.file(), name);
+        let maybe_known_class =
+            KnownClass::try_from_program_file_and_name(db, self.program_file(), name);
 
-        let known_module = || file_to_module(db, self.file()).and_then(|module| module.known(db));
+        let known_module = || {
+            ty_module_resolver::file_to_module(db, self.program_file().resolver_file(db))
+                .and_then(|module| module.known(db))
+        };
         let in_typing_module = || {
             matches!(
                 known_module(),
@@ -182,7 +187,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .as_function_literal()
                 .is_some_and(|function| function.is_known(db, KnownFunction::Dataclass))
             {
-                dataclass_params = Some(DataclassParams::default_params(db));
+                dataclass_params = Some(DataclassParams::default_params(db, self.program));
                 continue;
             }
 
@@ -274,21 +279,28 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 dataclass_transformer_params,
                 total_ordering,
             );
-            let decorator_result = apply_class_decorator(db, decorator_ty, original_class_ty);
+            let decorator_result =
+                apply_class_decorator(db, self.program, decorator_ty, original_class_ty);
             let decorated_ty = match &decorator_result {
                 Ok(return_ty) => *return_ty,
-                Err(error) => error.return_type(db),
+                Err(error) => error.return_type(db, self.program),
             };
             if is_unknown_decorator_result(db, decorated_ty) {
                 if !preserve_binding_for_unknown_result(
                     db,
+                    self.program,
                     decorator_ty,
                     decorator_call_ty(decorator),
                     decorated_ty,
                 ) {
                     metadata_applies_to_original_class = false;
                 }
-            } else if !type_retains_original_class(db, original_class_ty, decorated_ty) {
+            } else if !type_retains_original_class(
+                db,
+                self.program,
+                original_class_ty,
+                decorated_ty,
+            ) {
                 metadata_applies_to_original_class = false;
             }
 
@@ -322,13 +334,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 {
                     decorator_result
                 }
-                _ => apply_class_decorator(db, decorator_ty, inferred_ty),
+                _ => apply_class_decorator(db, self.program, decorator_ty, inferred_ty),
             };
             let decorated_ty = match decorator_result {
                 Ok(return_ty) => return_ty,
                 Err(CallError(_, bindings)) => {
                     bindings.report_diagnostics(&self.context, decorator_node.into());
-                    bindings.return_type(db)
+                    bindings.return_type(db, self.program)
                 }
             };
             let decorated_ty = match decorated_ty {
@@ -340,15 +352,22 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let should_preserve_binding = is_unknown_decorator_result(db, decorated_ty)
                 && preserve_binding_for_unknown_result(
                     db,
+                    self.program,
                     decorator_ty,
                     decorator_call_ty(decorator_node),
                     decorated_ty,
                 );
             inferred_ty = if should_preserve_binding {
                 inferred_ty
-            } else if class_decorator_preserves_class_binding(db, original_class_ty, decorated_ty) {
+            } else if class_decorator_preserves_class_binding(
+                db,
+                self.program,
+                original_class_ty,
+                decorated_ty,
+            ) {
                 merge_class_preserving_decorator_result(
                     db,
+                    self.program,
                     original_class_ty,
                     inferred_ty,
                     decorated_ty,
@@ -450,13 +469,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
 fn apply_class_decorator<'db>(
     db: &'db dyn crate::Db,
+    program: Program,
     decorator_ty: Type<'db>,
     decorated_ty: Type<'db>,
 ) -> Result<Type<'db>, CallError<'db>> {
     let call_arguments = CallArguments::positional([decorated_ty]);
     decorator_ty
-        .try_call(db, &call_arguments)
-        .map(|bindings| bindings.return_type(db))
+        .try_call(db, program, &call_arguments)
+        .map(|bindings| bindings.return_type(db, program))
 }
 
 /// Return true if a decorator result still binds the name to the original class.
@@ -474,6 +494,7 @@ fn apply_class_decorator<'db>(
 /// original class object even if the decorator call produced a `SubclassOf` type internally.
 fn class_decorator_preserves_class_binding<'db>(
     db: &'db dyn crate::Db,
+    program: Program,
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
@@ -490,19 +511,21 @@ fn class_decorator_preserves_class_binding<'db>(
         }
         Type::SubclassOf(subclass_of) => subclass_of
             .subclass_of()
-            .into_class(db)
+            .into_class(db, program)
             .is_some_and(|class| class == original_literal.default_specialization(db)),
         Type::Divergent(_) => true,
-        Type::Union(union) => union
-            .elements(db)
-            .iter()
-            .all(|element| class_decorator_preserves_class_binding(db, original_class, *element)),
-        Type::TypeAlias(alias) => {
-            class_decorator_preserves_class_binding(db, original_class, alias.value_type(db))
-        }
-        _ => SubclassOfType::try_from_type(db, original_class).is_some_and(|original_meta_type| {
-            decorated_class.is_equivalent_to(db, original_meta_type)
+        Type::Union(union) => union.elements(db).iter().all(|element| {
+            class_decorator_preserves_class_binding(db, program, original_class, *element)
         }),
+        Type::TypeAlias(alias) => class_decorator_preserves_class_binding(
+            db,
+            program,
+            original_class,
+            alias.value_type(db),
+        ),
+        _ => SubclassOfType::try_from_type(db, program, original_class).is_some_and(
+            |original_meta_type| decorated_class.is_equivalent_to(db, program, original_meta_type),
+        ),
     }
 }
 
@@ -510,6 +533,7 @@ fn class_decorator_preserves_class_binding<'db>(
 /// intersection members.
 fn type_retains_original_class<'db>(
     db: &'db dyn crate::Db,
+    program: Program,
     original_class: Type<'db>,
     decorated_class: Type<'db>,
 ) -> bool {
@@ -517,15 +541,15 @@ fn type_retains_original_class<'db>(
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| type_retains_original_class(db, original_class, *element)),
+            .any(|element| type_retains_original_class(db, program, original_class, *element)),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| type_retains_original_class(db, original_class, *element)),
+            .all(|element| type_retains_original_class(db, program, original_class, *element)),
         Type::TypeAlias(alias) => {
-            type_retains_original_class(db, original_class, alias.value_type(db))
+            type_retains_original_class(db, program, original_class, alias.value_type(db))
         }
-        _ => class_decorator_preserves_class_binding(db, original_class, decorated_class),
+        _ => class_decorator_preserves_class_binding(db, program, original_class, decorated_class),
     }
 }
 
@@ -549,14 +573,19 @@ fn type_retains_original_class<'db>(
 /// be preserved.
 fn preserve_binding_for_unknown_result<'db>(
     db: &'db dyn crate::Db,
+    program: crate::Program,
     decorator_ty: Type<'db>,
     decorator_call_ty: Option<Type<'db>>,
     decorator_result_ty: Type<'db>,
 ) -> bool {
-    ClassDecoratorUnknownResultPolicy::from_decorator(db, decorator_ty, decorator_result_ty)
-        == ClassDecoratorUnknownResultPolicy::PreserveBinding
+    ClassDecoratorUnknownResultPolicy::from_decorator(
+        db,
+        program,
+        decorator_ty,
+        decorator_result_ty,
+    ) == ClassDecoratorUnknownResultPolicy::PreserveBinding
         || decorator_call_ty.is_some_and(|ty| {
-            ClassDecoratorUnknownResultPolicy::from_decorator(db, ty, decorator_result_ty)
+            ClassDecoratorUnknownResultPolicy::from_decorator(db, program, ty, decorator_result_ty)
                 == ClassDecoratorUnknownResultPolicy::PreserveBinding
         })
 }
@@ -612,6 +641,7 @@ impl ClassDecoratorUnknownResultPolicy {
     /// intent.
     fn from_decorator<'db>(
         db: &'db dyn crate::Db,
+        program: crate::Program,
         decorator_ty: Type<'db>,
         decorator_result_ty: Type<'db>,
     ) -> Self {
@@ -619,7 +649,7 @@ impl ClassDecoratorUnknownResultPolicy {
             return Self::ReplaceBinding;
         }
 
-        Self::known_from_decorator(db, decorator_ty, decorator_result_ty)
+        Self::known_from_decorator(db, program, decorator_ty, decorator_result_ty)
             .unwrap_or(Self::ReplaceBinding)
     }
 
@@ -642,6 +672,7 @@ impl ClassDecoratorUnknownResultPolicy {
     /// the decorator value itself is not the function that receives the class.
     fn known_from_decorator<'db>(
         db: &'db dyn crate::Db,
+        program: crate::Program,
         decorator_ty: Type<'db>,
         decorator_result_ty: Type<'db>,
     ) -> Option<Self> {
@@ -664,6 +695,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 let call_symbol = decorator_ty
                     .member_lookup_with_policy(
                         db,
+                        program,
                         Name::new_static("__call__"),
                         MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                     )
@@ -673,7 +705,7 @@ impl ClassDecoratorUnknownResultPolicy {
                     && place.is_definitely_defined()
                 {
                     Some(
-                        Self::known_from_decorator(db, place.ty, decorator_result_ty)
+                        Self::known_from_decorator(db, program, place.ty, decorator_result_ty)
                             .unwrap_or(Self::ReplaceBinding),
                     )
                 } else {
@@ -682,7 +714,7 @@ impl ClassDecoratorUnknownResultPolicy {
             }
             Type::Union(union) => Some(
                 if union.elements(db).iter().all(|element| {
-                    Self::known_from_decorator(db, *element, decorator_result_ty)
+                    Self::known_from_decorator(db, program, *element, decorator_result_ty)
                         == Some(Self::PreserveBinding)
                 }) {
                     Self::PreserveBinding
@@ -691,7 +723,7 @@ impl ClassDecoratorUnknownResultPolicy {
                 },
             ),
             Type::TypeAlias(alias) => Some(
-                Self::known_from_decorator(db, alias.value_type(db), decorator_result_ty)
+                Self::known_from_decorator(db, program, alias.value_type(db), decorator_result_ty)
                     .unwrap_or(Self::ReplaceBinding),
             ),
             Type::Callable(callable) => Some(match callable.provenance(db) {
@@ -747,12 +779,13 @@ impl ClassDecoratorUnknownResultPolicy {
 /// returns the original class object again.
 fn merge_class_preserving_decorator_result<'db>(
     db: &'db dyn crate::Db,
+    program: Program,
     original_class: Type<'db>,
     current_binding: Type<'db>,
     decorated_binding: Type<'db>,
 ) -> Type<'db> {
     if current_binding == original_class
-        || type_retains_original_class(db, original_class, current_binding)
+        || type_retains_original_class(db, program, original_class, current_binding)
     {
         current_binding
     } else {

--- a/crates/ty_python_semantic/src/types/infer/builder/dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dict.rs
@@ -47,13 +47,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .into_iter()
                 .flatten()
                 .all(|keyword_ty| {
-                    keyword_ty
-                        .is_assignable_to(speculative_builder.db(), Type::TypedDict(typed_dict))
-                        || extract_unpacked_typed_dict_keys_from_value_type(
-                            speculative_builder.db(),
-                            keyword_ty,
-                        )
-                        .is_some()
+                    keyword_ty.is_assignable_to(
+                        speculative_builder.db(),
+                        self.program,
+                        Type::TypedDict(typed_dict),
+                    ) || extract_unpacked_typed_dict_keys_from_value_type(
+                        speculative_builder.db(),
+                        self.program,
+                        keyword_ty,
+                    )
+                    .is_some()
                 })
             };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/dynamic_class.rs
@@ -52,11 +52,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let formal_parameter_type = match kind {
             DynamicClassKind::TypeCall => Type::homogeneous_tuple(db, Type::object()),
             DynamicClassKind::NewClass => {
-                KnownClass::Iterable.to_specialized_instance(db, &[Type::object()])
+                KnownClass::Iterable.to_specialized_instance(db, self.program, &[Type::object()])
             }
         };
 
-        if !bases_type.is_assignable_to(db, formal_parameter_type)
+        if !bases_type.is_assignable_to(db, self.program, formal_parameter_type)
             && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, bases_node)
         {
             let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -64,12 +64,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
             diagnostic.set_primary_message(format_args!(
                 "Expected `{}`, found `{}`",
-                formal_parameter_type.display(db),
-                bases_type.display(db)
+                formal_parameter_type.display(db, self.program),
+                bases_type.display(db, self.program)
             ));
         }
 
-        extract_fixed_length_iterable_element_types(db, bases_node, |expr| {
+        extract_fixed_length_iterable_element_types(db, self.program, bases_node, |expr| {
             self.expression_type(expr)
         })
     }
@@ -101,7 +101,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .and_then(|elts| elts.get(idx))
                 .unwrap_or(bases_node);
 
-            let Some(class_base) = ClassBase::try_from_type(db, *base, None) else {
+            let Some(class_base) = ClassBase::try_from_type(db, self.program, *base, None) else {
                 continue;
             };
 
@@ -112,8 +112,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid base for class created via `{fn_name}`"
                         ));
-                        diagnostic
-                            .set_primary_message(format_args!("Has type `{}`", base.display(db)));
+                        diagnostic.set_primary_message(format_args!(
+                            "Has type `{}`",
+                            base.display(db, self.program)
+                        ));
                         match class_base {
                             ClassBase::Generic => {
                                 diagnostic.info(format_args!(
@@ -143,8 +145,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Unsupported base for class created via `{fn_name}`"
                         ));
-                        diagnostic
-                            .set_primary_message(format_args!("Has type `{}`", base.display(db)));
+                        diagnostic.set_primary_message(format_args!(
+                            "Has type `{}`",
+                            base.display(db, self.program)
+                        ));
                         diagnostic.info(format_args!(
                             "Classes created via `{fn_name}` cannot be protocols",
                         ));
@@ -181,7 +185,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .into_diagnostic("Invalid base for class created via `type()`");
                             diagnostic.set_primary_message(format_args!(
                                 "Has type `{}`",
-                                base.display(db)
+                                base.display(db, self.program)
                             ));
                             diagnostic.info("Creating an enum class via `type()` is not supported");
                             diagnostic.info(format_args!(
@@ -216,6 +220,7 @@ pub(super) fn report_dynamic_mro_errors<'db>(
     bases: &ast::Expr,
 ) -> bool {
     let db = context.db();
+    let program = context.program();
     let Err(error) = dynamic_class.try_mro(db) else {
         return true;
     };
@@ -223,7 +228,7 @@ pub(super) fn report_dynamic_mro_errors<'db>(
     let bases_display = dynamic_class
         .explicit_bases(db)
         .iter()
-        .map(|base| base.display(db))
+        .map(|base| base.display(db, program))
         .join(", ");
     report_mro_error_kind(
         context,
@@ -290,20 +295,20 @@ pub(super) fn report_mro_error_kind<'db>(
             };
             let bases_tuple_elts = bases.as_tuple_expr().map(|tuple| tuple.elts.as_slice());
             for (idx, base_type) in invalid_bases {
-                let instance_of_type = KnownClass::Type.to_instance(db);
+                let instance_of_type = KnownClass::Type.to_instance(db, context.program());
                 let specific_base = bases_tuple_elts.and_then(|elts| elts.get(*idx));
                 let diagnostic_range = specific_base
                     .map(ast::Expr::range)
                     .unwrap_or_else(|| bases.range());
 
-                if base_type.is_assignable_to(db, instance_of_type) {
+                if base_type.is_assignable_to(db, context.program(), instance_of_type) {
                     if let Some(builder) =
                         context.report_lint(&UNSUPPORTED_DYNAMIC_BASE, diagnostic_range)
                     {
                         let mut diagnostic = builder.into_diagnostic("Unsupported class base");
                         diagnostic.set_primary_message(format_args!(
                             "Has type `{}`",
-                            base_type.display(db)
+                            base_type.display(db, context.program())
                         ));
                         diagnostic.info(format_args!(
                             "ty cannot determine a MRO for class `{class_name}` due to this base",
@@ -313,7 +318,7 @@ pub(super) fn report_mro_error_kind<'db>(
                 } else if let Some(builder) = context.report_lint(&INVALID_BASE, diagnostic_range) {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Invalid class base with type `{}`",
-                        base_type.display(db)
+                        base_type.display(db, context.program())
                     ));
                     if specific_base.is_none() {
                         diagnostic
@@ -334,7 +339,7 @@ pub(super) fn report_mro_error_kind<'db>(
                     maybe_s = if duplicates.len() == 1 { "" } else { "es" },
                     dupes = duplicates
                         .iter()
-                        .map(|base: &ClassBase<'_>| base.display(db))
+                        .map(|base: &ClassBase<'_>| base.display(db, context.program()))
                         .join(", "),
                 ));
             }

--- a/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/enum_call.rs
@@ -137,16 +137,18 @@ fn enum_functional_call_keyword_is_valid(name: &str, python_version: PythonVersi
 ///
 /// This includes the string form, iterables of strings, iterables of
 /// iterable-like `(name, value)` pairs, and mappings from `str` to values.
-fn enum_names_type(db: &dyn Db) -> Type<'_> {
-    let str_type = KnownClass::Str.to_instance(db);
-    let iterable_str = KnownClass::Iterable.to_specialized_instance(db, &[str_type]);
-    let iterable_object = KnownClass::Iterable.to_specialized_instance(db, &[Type::object()]);
+fn enum_names_type(db: &dyn Db, program: Program) -> Type<'_> {
+    let str_type = KnownClass::Str.to_instance(db, program);
+    let iterable_str = KnownClass::Iterable.to_specialized_instance(db, program, &[str_type]);
+    let iterable_object =
+        KnownClass::Iterable.to_specialized_instance(db, program, &[Type::object()]);
     let iterable_iterable_object =
-        KnownClass::Iterable.to_specialized_instance(db, &[iterable_object]);
-    let mapping_str_object = KnownClass::Mapping
-        .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::object()]);
+        KnownClass::Iterable.to_specialized_instance(db, program, &[iterable_object]);
+    let mapping_str_object =
+        KnownClass::Mapping.to_specialized_instance(db, program, &[str_type, Type::object()]);
     UnionType::from_elements(
         db,
+        program,
         [
             str_type,
             iterable_str,
@@ -162,6 +164,7 @@ fn enum_names_type(db: &dyn Db) -> Type<'_> {
 /// literal `start` value when available, and widen to `int` when `start` is a non-literal int.
 fn first_enum_auto_value<'db>(
     db: &'db dyn Db,
+    program: Program,
     base_class: KnownClass,
     name: &str,
     start: EnumStart,
@@ -170,7 +173,7 @@ fn first_enum_auto_value<'db>(
         KnownClass::StrEnum => Type::string_literal(db, &*name.to_lowercase()),
         _ => match start {
             EnumStart::Literal(start) => Type::int_literal(start),
-            EnumStart::DynamicInt => KnownClass::Int.to_instance(db),
+            EnumStart::DynamicInt => KnownClass::Int.to_instance(db, program),
         },
     }
 }
@@ -184,6 +187,7 @@ fn first_enum_auto_value<'db>(
 /// - Others: `last_value + 1`
 fn next_auto_value<'db>(
     db: &'db dyn Db,
+    program: Program,
     base_class: KnownClass,
     name: &str,
     last_int_value: Option<i64>,
@@ -192,7 +196,7 @@ fn next_auto_value<'db>(
         KnownClass::StrEnum => Type::string_literal(db, &*name.to_lowercase()),
         _ => {
             let Some(last) = last_int_value else {
-                return KnownClass::Int.to_instance(db);
+                return KnownClass::Int.to_instance(db, program);
             };
             match base_class {
                 KnownClass::Flag | KnownClass::IntFlag => {
@@ -205,13 +209,13 @@ fn next_auto_value<'db>(
                             .checked_shl(shift)
                             .and_then(|value| i64::try_from(value).ok())
                             .map(Type::int_literal)
-                            .unwrap_or_else(|| KnownClass::Int.to_instance(db))
+                            .unwrap_or_else(|| KnownClass::Int.to_instance(db, program))
                     }
                 }
                 _ => last
                     .checked_add(1)
                     .map(Type::int_literal)
-                    .unwrap_or_else(|| KnownClass::Int.to_instance(db)),
+                    .unwrap_or_else(|| KnownClass::Int.to_instance(db, program)),
             }
         }
     }
@@ -219,6 +223,7 @@ fn next_auto_value<'db>(
 
 fn enum_members_from_names(
     db: &dyn Db,
+    program: Program,
     names: Vec<Name>,
     start: EnumStart,
     base_class: KnownClass,
@@ -228,9 +233,9 @@ fn enum_members_from_names(
 
     for (index, name) in names.into_iter().enumerate() {
         let value = if index == 0 {
-            first_enum_auto_value(db, base_class, name.as_str(), start)
+            first_enum_auto_value(db, program, base_class, name.as_str(), start)
         } else {
-            next_auto_value(db, base_class, name.as_str(), last_int_value)
+            next_auto_value(db, program, base_class, name.as_str(), last_int_value)
         };
         last_int_value = value.as_int_literal();
         members.push((name, value));
@@ -248,6 +253,7 @@ fn enum_members_from_names(
 /// compatible with the corresponding builtin conversion.
 fn apply_generated_type_mixin_member_values<'db>(
     db: &'db dyn Db,
+    program: Program,
     mixin_type: Type<'_>,
     members: Vec<(Name, Type<'db>)>,
 ) -> Option<Vec<(Name, Type<'db>)>> {
@@ -262,8 +268,12 @@ fn apply_generated_type_mixin_member_values<'db>(
                 .map(|(name, value)| {
                     let value = if let Some(literal) = value.as_int_literal() {
                         Type::string_literal(db, literal.to_compact_string())
-                    } else if value.is_assignable_to(db, KnownClass::Int.to_instance(db)) {
-                        KnownClass::Str.to_instance(db)
+                    } else if value.is_assignable_to(
+                        db,
+                        program,
+                        KnownClass::Int.to_instance(db, program),
+                    ) {
+                        KnownClass::Str.to_instance(db, program)
                     } else {
                         return None;
                     };
@@ -275,8 +285,12 @@ fn apply_generated_type_mixin_member_values<'db>(
             members
                 .into_iter()
                 .map(|(name, value)| {
-                    let value = if value.is_assignable_to(db, KnownClass::Int.to_instance(db)) {
-                        KnownClass::Bytes.to_instance(db)
+                    let value = if value.is_assignable_to(
+                        db,
+                        program,
+                        KnownClass::Int.to_instance(db, program),
+                    ) {
+                        KnownClass::Bytes.to_instance(db, program)
                     } else {
                         return None;
                     };
@@ -288,8 +302,9 @@ fn apply_generated_type_mixin_member_values<'db>(
             members
                 .into_iter()
                 .map(|(name, value)| {
-                    if value.is_assignable_to(db, KnownClass::Int.to_instance(db)) {
-                        Some((name, KnownClass::Float.to_instance(db)))
+                    if value.is_assignable_to(db, program, KnownClass::Int.to_instance(db, program))
+                    {
+                        Some((name, KnownClass::Float.to_instance(db, program)))
                     } else {
                         None
                     }
@@ -315,8 +330,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             node_index: _,
         } = &call_expr.arguments;
 
-        let base_name = base_class.name(db);
-        let python_version = Program::get(db).python_version(db);
+        let program = self.program;
+        let base_name = base_class.name(db, program);
+        let python_version = program.python_version(db);
 
         for kw in keywords {
             if let Some(name) = &kw.arg
@@ -387,7 +403,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ));
             }
 
-            return Some(base_class.to_instance(db));
+            return Some(base_class.to_instance(db, program));
         };
 
         for arg in args {
@@ -423,7 +439,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .as_string_literal()
             .map(|name_literal| Name::new(name_literal.value(db)));
 
-        if (name.is_some() || name_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)))
+        if (name.is_some()
+            || name_ty.is_assignable_to(db, self.program, KnownClass::Str.to_instance(db, program)))
             && let Some(definition) = definition
             && let Some(assigned_name) = definition.name(db)
             && Some(assigned_name.as_str()) != name.as_deref()
@@ -449,7 +466,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // Non-literal names use the ordinary `type[EnumSubclass]` overload result
         // instead of synthesizing a `DynamicEnumLiteral`.
         let Some(name) = self.infer_enum_name_argument(name_arg, base_class) else {
-            return SubclassOfType::try_from_type(db, base_class.to_class_literal(db));
+            return SubclassOfType::try_from_type(
+                db,
+                program,
+                base_class.to_class_literal(db, program),
+            );
         };
 
         let anchor = self.create_dynamic_enum_anchor(call_expr, definition, spec);
@@ -473,19 +494,23 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) -> Option<Name> {
         let db = self.db();
-        let base_name = base_class.name(db);
+        let program = self.program;
+        let base_name = base_class.name(db, program);
         let name_type = self.expression_type(name_arg);
 
         let Some(name_literal) = name_type.as_string_literal() else {
-            if !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
+            if !name_type.is_assignable_to(
+                db,
+                self.program,
+                KnownClass::Str.to_instance(db, program),
+            ) && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Invalid argument to parameter `value` of `{base_name}()`"
                 ));
                 diagnostic.set_primary_message(format_args!(
                     "Expected `str`, found `{}`",
-                    name_type.display(db)
+                    name_type.display(db, program)
                 ));
             }
             return None;
@@ -496,19 +521,20 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     fn infer_enum_start_argument(&mut self, value: &ast::Expr) -> EnumStart {
         let db = self.db();
+        let program = self.program;
         let ty = self.expression_type(value);
         if let Some(literal) = ty.as_int_literal() {
             return EnumStart::Literal(literal);
         }
 
-        if ty.is_assignable_to(db, KnownClass::Int.to_instance(db)) {
+        if ty.is_assignable_to(db, self.program, KnownClass::Int.to_instance(db, program)) {
             return EnumStart::DynamicInt;
         }
 
         if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, value) {
             builder.into_diagnostic(format_args!(
                 "Expected `int` for `start` argument, got `{}`",
-                ty.display(db),
+                ty.display(db, program),
             ));
         }
 
@@ -521,6 +547,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) -> (Option<Type<'db>>, bool) {
         let db = self.db();
+        let program = self.program;
         let ty = self.expression_type(value);
         if let Some(class_lit) = ty.as_class_literal() {
             if class_lit.is_typed_dict(db)
@@ -528,7 +555,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 builder.into_diagnostic(format_args!(
                     "TypedDict class `{}` cannot be used as an enum mixin",
-                    ty.display(db),
+                    ty.display(db, program),
                 ));
                 return (None, false);
             }
@@ -536,7 +563,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let Some(mixin_class) = ty.to_class_type(db) else {
                 return (Some(ty), true);
             };
-            let Some(enum_base) = base_class.to_class_literal(db).to_class_type(db) else {
+            let Some(enum_base) = base_class.to_class_literal(db, program).to_class_type(db) else {
                 return (Some(ty), true);
             };
             let constraints = ConstraintSetBuilder::new();
@@ -546,7 +573,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 builder.into_diagnostic(format_args!(
                     "Class `{}` cannot be used as an enum mixin with `{}`",
                     mixin_class.name(db),
-                    base_class.name(db),
+                    base_class.name(db, program),
                 ));
                 return (None, false);
             }
@@ -560,7 +587,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, value) {
             builder.into_diagnostic(format_args!(
                 "Expected a class for `type` argument, got `{}`",
-                ty.display(db),
+                ty.display(db, program),
             ));
         }
 
@@ -576,6 +603,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         has_invalid_arguments: bool,
     ) -> EnumSpec<'db> {
         let db = self.db();
+        let program = self.program;
         let (members, has_known_members) = if has_invalid_arguments {
             (vec![], false)
         } else {
@@ -600,6 +628,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             TypeMixinMemberBehavior::ConvertedValues => {
                                 match apply_generated_type_mixin_member_values(
                                     db,
+                                    program,
                                     mixin_type,
                                     known_members.members,
                                 ) {
@@ -668,6 +697,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) -> EnumMembersArgParseResult<'db> {
         let db = self.db();
+        let program = self.program;
         let ty = self.expression_type(names_arg);
         if let Some(string_lit) = ty.as_string_literal() {
             let s = string_lit.value(db);
@@ -677,7 +707,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .filter(|s| !s.is_empty())
                 .map(Name::new)
                 .collect();
-            let members = enum_members_from_names(db, names, start, base_class);
+            let members = enum_members_from_names(db, program, names, start, base_class);
             return EnumMembersArgParseResult::Known(KnownEnumMembers {
                 members,
                 value_form: EnumMemberValueForm::Generated,
@@ -697,7 +727,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return self.parse_enum_members_from_dict(dict, base_class);
         }
 
-        if ty.is_dynamic() || ty.is_assignable_to(db, enum_names_type(db)) {
+        if ty.is_dynamic() || ty.is_assignable_to(db, self.program, enum_names_type(db, program)) {
             EnumMembersArgParseResult::Unknown
         } else {
             EnumMembersArgParseResult::Invalid
@@ -711,6 +741,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) -> EnumMembersArgParseResult<'db> {
         let db = self.db();
+        let program = self.program;
         let mut names = Vec::with_capacity(elts.len());
         let mut explicit_members = Vec::with_capacity(elts.len());
         let mut form = None;
@@ -759,7 +790,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         if matches!(form, Some(SequenceEnumMemberForm::Names)) {
             return EnumMembersArgParseResult::Known(KnownEnumMembers {
-                members: enum_members_from_names(db, names, start, base_class),
+                members: enum_members_from_names(db, program, names, start, base_class),
                 value_form: EnumMemberValueForm::Generated,
             });
         }
@@ -775,8 +806,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // still begins from the default seed of `1`.
         let mut last_int_value = Some(0);
         for (name, value) in explicit_members {
-            let value = if value.is_instance_of(db, KnownClass::Auto) {
-                next_auto_value(db, base_class, name.as_str(), last_int_value)
+            let value = if value.is_instance_of(db, program, KnownClass::Auto) {
+                next_auto_value(db, program, base_class, name.as_str(), last_int_value)
             } else {
                 value
             };
@@ -800,6 +831,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) -> EnumMembersArgParseResult<'db> {
         let db = self.db();
+        let program = self.program;
         let mut members = Vec::with_capacity(dict.items.len());
         let mut last_int_value = Some(0);
         let mut has_opaque_keys = false;
@@ -810,7 +842,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             let key_ty = self.expression_type(key);
             let Some(string_lit) = key_ty.as_string_literal() else {
                 if key_ty.is_dynamic()
-                    || key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+                    || key_ty.is_assignable_to(
+                        db,
+                        self.program,
+                        KnownClass::Str.to_instance(db, program),
+                    )
                 {
                     has_opaque_keys = true;
                     continue;
@@ -819,8 +855,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             let name = Name::new(string_lit.value(db));
             let raw_value = self.expression_type(&item.value);
-            let value = if raw_value.is_instance_of(db, KnownClass::Auto) {
-                next_auto_value(db, base_class, name.as_str(), last_int_value)
+            let value = if raw_value.is_instance_of(db, program, KnownClass::Auto) {
+                next_auto_value(db, program, base_class, name.as_str(), last_int_value)
             } else {
                 raw_value
             };
@@ -868,8 +904,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             return false;
         };
         let db = self.db();
+        let program = self.program;
         let name_ty = self.expression_type(name_expr);
-        name_ty.is_dynamic() || name_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+        name_ty.is_dynamic()
+            || name_ty.is_assignable_to(db, self.program, KnownClass::Str.to_instance(db, program))
     }
 
     /// Classifies one element from a sequence-form `names` argument.
@@ -878,6 +916,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     /// pairs, opaque explicit pairs, and definitely invalid elements.
     fn classify_sequence_enum_member(&mut self, elt: &ast::Expr) -> SequenceEnumMember<'db> {
         let db = self.db();
+        let program = self.program;
         let ty = self.expression_type(elt);
         if let Some(string_lit) = ty.as_string_literal() {
             return SequenceEnumMember::NameKnown(Name::new(string_lit.value(db)));
@@ -885,7 +924,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some((name, value)) = self.parse_explicit_enum_member(elt) {
             return SequenceEnumMember::PairKnown(name, value);
         }
-        if ty.is_dynamic() || ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
+        if ty.is_dynamic()
+            || ty.is_assignable_to(db, self.program, KnownClass::Str.to_instance(db, program))
+        {
             return SequenceEnumMember::NameOpaque;
         }
         if self.is_potential_explicit_enum_member(elt) {
@@ -900,7 +941,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         base_class: KnownClass,
     ) {
         let db = self.db();
-        let base_name = base_class.name(db);
+        let program = self.program;
+        let base_name = base_class.name(db, program);
         let names_ty = self.expression_type(names_arg);
         if let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, names_arg) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -908,8 +950,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
             diagnostic.set_primary_message(format_args!(
                 "Expected `{}`, found `{}`",
-                enum_names_type(db).display(db),
-                names_ty.display(db),
+                enum_names_type(db, program).display(db, program),
+                names_ty.display(db, program),
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/final_attribute.rs
@@ -26,7 +26,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
     ) {
         let db = self.db();
         let file = declaration.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, declaration.program_file(db).versioned_file(db)).load(db);
         let range = match declaration.kind(db) {
             DefinitionKind::AnnotatedAssignment(assignment) => {
                 assignment.annotation(&module).range()
@@ -50,7 +50,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         attribute: &str,
     ) -> Option<Definition<'db>> {
         let db = self.db();
-        let class_ty = object_ty.nominal_class(db)?;
+        let class_ty = object_ty.nominal_class(db, self.program)?;
 
         for base in class_ty.iter_mro(db) {
             let Some(class) = base.into_class() else {
@@ -62,7 +62,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             let class_body_scope = class_literal.body_scope(db);
             let class_scope_id = class_body_scope.file_scope_id(db);
-            let class_index = semantic_index(db, class_body_scope.file(db));
+            let class_index = semantic_index(db, class_body_scope.program_file(db));
             let place_table = class_index.place_table(class_scope_id);
             let Some(symbol_id) = place_table.symbol_id(attribute) else {
                 continue;
@@ -70,8 +70,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
             let use_def = class_index.use_def_map(class_scope_id);
 
-            let place_and_quals_result =
-                place_from_declarations(db, use_def.end_of_scope_symbol_declarations(symbol_id));
+            let place_and_quals_result = place_from_declarations(
+                db,
+                self.program,
+                use_def.end_of_scope_symbol_declarations(symbol_id),
+            );
 
             let Some(declaration) = place_and_quals_result.first_declaration else {
                 continue;
@@ -199,7 +202,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let report_not_in_init = || {
             let is_dataclass_like = object_ty
-                .nominal_class(db)
+                .nominal_class(db, self.program)
                 .or_else(|| object_ty.to_class_type(db))
                 .and_then(|cls| cls.static_class_literal(db))
                 .is_some_and(|(class_literal, _)| class_literal.is_dataclass_like(db));
@@ -211,7 +214,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             };
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Cannot assign to final attribute `{attribute}` on type `{}`",
-                object_ty.display(db)
+                object_ty.display(db, self.program)
             ));
             diagnostic.set_primary_message(if is_dataclass_like {
                 "`Final` attributes can only be assigned in the class body, `__init__`, or `__post_init__` on dataclass-like classes"
@@ -238,10 +241,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // that happens to have the right type.
         let is_self_parameter = self.is_instance_attribute_assignment(target);
 
-        let class_instance_ty = Type::instance(db, class_ty).top_materialization(db);
-        let object_instance_ty = object_ty.bind_self_typevars(db, class_instance_ty);
-        let is_current_class_instance =
-            is_self_parameter && object_instance_ty.is_subtype_of(db, class_instance_ty);
+        let class_instance_ty = Type::instance(db, class_ty).top_materialization(db, self.program);
+        let object_instance_ty = object_ty.bind_self_typevars(db, self.program, class_instance_ty);
+        let is_current_class_instance = is_self_parameter
+            && object_instance_ty.is_subtype_of(db, self.program, class_instance_ty);
         if !is_current_class_instance {
             report_not_in_init();
             return true;
@@ -250,7 +253,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if let Some((class_literal, _)) = class_ty.static_class_literal(db) {
             let class_body_scope = class_literal.body_scope(db);
             let class_scope_id = class_body_scope.file_scope_id(db);
-            let class_index = semantic_index(db, class_body_scope.file(db));
+            let class_index = semantic_index(db, class_body_scope.program_file(db));
             let pt = class_index.place_table(class_scope_id);
 
             if let Some(symbol) = pt.symbol_by_name(attribute)
@@ -299,7 +302,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Cannot delete final attribute `{attribute}` on type `{}`",
-                    object_ty.display(db)
+                    object_ty.display(db, self.program)
                 ));
                 diagnostic.set_primary_message("`Final` attributes cannot be deleted");
                 if let Some(final_declaration) = final_declaration {
@@ -317,7 +320,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         object_ty: Type<'db>,
         attribute: &str,
     ) {
-        let Some(members) = assignment_attribute_members(self.db(), object_ty, attribute) else {
+        let Some(members) =
+            assignment_attribute_members(self.db(), self.program, object_ty, attribute)
+        else {
             return;
         };
 
@@ -340,7 +345,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         attribute: &str,
         emit_diagnostics: bool,
     ) -> bool {
-        let Some(members) = assignment_attribute_members(self.db(), object_ty, attribute) else {
+        let Some(members) =
+            assignment_attribute_members(self.db(), self.program, object_ty, attribute)
+        else {
             return false;
         };
 

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Db,
+    Db, Program,
     reachability::ReachabilityConstraintsExtension,
     types::{
         KnownClass, KnownInstanceType, ParamSpecAttrKind, SubclassOfInner, SubclassOfType, Type,
@@ -72,21 +72,24 @@ impl<'db> ExpectedReturnType<'db> {
         function_node: &ast::StmtFunctionDef,
     ) -> Self {
         /// Normalizes special return annotations to the type actually returned by expressions.
-        fn normalize<'db>(db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        fn normalize<'db>(db: &'db dyn Db, program: Program, ty: Type<'db>) -> Type<'db> {
             match ty {
-                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_instance(db),
+                Type::TypeIs(_) | Type::TypeGuard(_) => KnownClass::Bool.to_instance(db, program),
                 ty => ty,
             }
         }
 
+        let program = function.program(db);
         let public = normalize(
             db,
+            program,
             same_module_uncached_raw_signature(db, function, ReturnCallableTypeVarScope::Public)
                 .return_ty,
         );
         let lexical = function_node.type_params.is_some().then(|| {
             normalize(
                 db,
+                program,
                 same_module_uncached_raw_signature(
                     db,
                     function,
@@ -106,11 +109,11 @@ impl<'db> ExpectedReturnType<'db> {
 
     /// Returns `true` if `ty` is accepted by either the public return type or the lexical return
     /// type.
-    fn accepts(self, db: &'db dyn Db, ty: Type<'db>) -> bool {
-        ty.is_assignable_to(db, self.public)
+    fn accepts(self, db: &'db dyn Db, program: Program, ty: Type<'db>) -> bool {
+        ty.is_assignable_to(db, program, self.public)
             || self
                 .lexical
-                .is_some_and(|lexical| ty.is_assignable_to(db, lexical))
+                .is_some_and(|lexical| ty.is_assignable_to(db, program, lexical))
     }
 }
 
@@ -145,8 +148,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(returns) = function.returns.as_deref() {
             let has_empty_body = self.return_types_and_ranges.is_empty()
-                && function_body_kind(db, function, |expr| self.expression_type(expr))
-                    == FunctionBodyKind::Stub;
+                && function_body_kind(db, self.program, function, |expr| {
+                    self.expression_type(expr)
+                }) == FunctionBodyKind::Stub;
 
             let mut enclosing_class_context = None;
 
@@ -197,8 +201,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 };
 
                 if !inferred_return
-                    .to_instance_unknown(db)
-                    .is_assignable_to(db, expected_ty)
+                    .to_instance_unknown(db, self.program)
+                    .is_assignable_to(db, self.program, expected_ty)
                 {
                     report_invalid_generator_function_return_type(
                         &self.context,
@@ -208,13 +212,19 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     );
                 }
 
-                if let Some(expected_return_ty) = declared_ty.generator_return_type(db) {
+                if let Some(expected_return_ty) =
+                    declared_ty.generator_return_type(db, self.program)
+                {
                     for invalid in
                         self.return_types_and_ranges
                             .iter()
                             .copied()
                             .filter(|actual_return_ty| {
-                                !actual_return_ty.ty.is_assignable_to(db, expected_return_ty)
+                                !actual_return_ty.ty.is_assignable_to(
+                                    db,
+                                    self.program,
+                                    expected_return_ty,
+                                )
                             })
                     {
                         report_invalid_return_type(
@@ -229,7 +239,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let use_def = self.index.use_def_map(scope_id);
 
                     if can_implicitly_return_none(db, use_def)
-                        && !Type::none(db).is_assignable_to(db, expected_return_ty)
+                        && !Type::none(db, self.program).is_assignable_to(
+                            db,
+                            self.program,
+                            expected_return_ty,
+                        )
                     {
                         let no_return = self.return_types_and_ranges.is_empty();
                         report_implicit_return_type(
@@ -254,13 +268,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // We skip `is_assignable_to` checks for `NotImplemented`,
                     // so we remove it beforehand.
                     Type::Union(union) => Some(TypeAndRange {
-                        ty: union.filter(db, |ty| !ty.is_notimplemented(db)),
+                        ty: union.filter(db, |ty| !ty.is_notimplemented(db, self.program)),
                         range: ty_range.range,
                     }),
-                    ty if ty.is_notimplemented(db) => None,
+                    ty if ty.is_notimplemented(db, self.program) => None,
                     _ => Some(ty_range),
                 })
-                .filter(|ty_range| !expected_return.accepts(db, ty_range.ty))
+                .filter(|ty_range| !expected_return.accepts(db, self.program, ty_range.ty))
             {
                 report_invalid_return_type(
                     &self.context,
@@ -272,7 +286,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             let use_def = self.index.use_def_map(scope_id);
             if can_implicitly_return_none(db, use_def)
-                && !Type::none(db).is_assignable_to(db, expected_ty)
+                && !Type::none(db, self.program).is_assignable_to(db, self.program, expected_ty)
             {
                 let no_return = self.return_types_and_ranges.is_empty();
                 report_implicit_return_type(
@@ -407,7 +421,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let body_scope = self
             .index
             .node_scope(NodeWithScopeRef::Function(function))
-            .to_scope_id(db, self.file());
+            .to_scope_id(db, self.program_file());
 
         let overload_literal = OverloadLiteral::new(
             db,
@@ -553,7 +567,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let type_params_scope = self
                     .index
                     .node_scope(NodeWithScopeRef::FunctionTypeParameters(function))
-                    .to_scope_id(db, self.file());
+                    .to_scope_id(db, self.program_file());
                 let type_params_inference =
                     infer_scope_types(db, type_params_scope, TypeContext::default());
 
@@ -679,7 +693,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 let diag = builder.into_diagnostic(format_args!(
                     "Unpacked value for `**kwargs` must be a TypedDict, not `{}`",
-                    annotated_type.display(self.db())
+                    annotated_type.display(self.db(), self.program)
                 ));
                 add_type_expression_reference_link(diag);
             }
@@ -833,7 +847,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 // Avoid duplicate diagnostics: invalid TypedDict literals already emit specific errors.
                 let suppress_invalid_default =
                     is_invalid_typed_dict_literal(db, declared_ty, default_expr.into());
-                if !default_ty.is_assignable_to(db, declared_ty)
+                if !default_ty.is_assignable_to(db, self.program, declared_ty)
                     && !suppress_invalid_default
                     && !((self.in_stub()
                         || self.in_function_overload_or_abstractmethod()
@@ -852,8 +866,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         builder.into_diagnostic(format_args!(
                             "Default value of type `{}` is not assignable \
                              to annotated parameter type `{}`",
-                            default_ty.display(db),
-                            declared_ty.display(db)
+                            default_ty.display(db, self.program),
+                            declared_ty.display(db, self.program)
                         ));
                     }
                 }
@@ -867,7 +881,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         } else {
             let ty = if let Some(default_expr) = default_expr {
                 let default_ty = self.file_expression_type(default_expr);
-                UnionType::from_two_elements(db, Type::unknown(), default_ty)
+                UnionType::from_two_elements(db, self.program, Type::unknown(), default_ty)
             } else if let Some(ty) = self.special_first_method_parameter_type(parameter) {
                 ty
             } else {
@@ -953,19 +967,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         parameter: &ast::Parameter,
     ) -> Option<Type<'db>> {
         let db = self.db();
-        let file = self.file();
 
         let function_scope_id = self.scope();
         let function_scope = function_scope_id.scope(db);
         let function = function_scope.node().as_function()?;
 
         let parent_file_scope_id = function_scope.parent()?;
-        let mut parent_scope_id = parent_file_scope_id.to_scope_id(db, file);
+        let mut parent_scope_id = parent_file_scope_id.to_scope_id(db, self.program_file());
 
         // Skip type parameter scopes, if the method itself is generic.
         if parent_scope_id.is_annotation(db) {
             let parent_scope = parent_scope_id.scope(db);
-            parent_scope_id = parent_scope.parent()?.to_scope_id(db, file);
+            parent_scope_id = parent_scope.parent()?.to_scope_id(db, self.program_file());
         }
 
         // Return early if this is not a method inside a class.
@@ -1009,8 +1022,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         let typing_self = typing_self(db, self.scope(), Some(method_definition), class_literal);
         if is_classmethod || function_name == "__new__" {
-            typing_self
-                .map(|typing_self| SubclassOfType::from(db, SubclassOfInner::TypeVar(typing_self)))
+            typing_self.map(|typing_self| {
+                SubclassOfType::from(db, self.program, SubclassOfInner::TypeVar(typing_self))
+            })
         } else {
             typing_self.map(Type::TypeVar)
         }
@@ -1051,7 +1065,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         }
                         KnownClass::Dict.to_specialized_instance(
                             db,
-                            &[KnownClass::Str.to_instance(db), Type::unknown()],
+                            self.program,
+                            &[
+                                KnownClass::Str.to_instance(db, self.program),
+                                Type::unknown(),
+                            ],
                         )
                     }
 
@@ -1063,7 +1081,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         // The diagnostic for this case is handled in `in_type_expression`.
                         KnownClass::Dict.to_specialized_instance(
                             db,
-                            &[KnownClass::Str.to_instance(db), Type::unknown()],
+                            self.program,
+                            &[
+                                KnownClass::Str.to_instance(db, self.program),
+                                Type::unknown(),
+                            ],
                         )
                     }
                 }
@@ -1076,8 +1098,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             {
                 annotated_type
             } else {
-                KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), annotated_type])
+                KnownClass::Dict.to_specialized_instance(
+                    db,
+                    self.program,
+                    &[
+                        KnownClass::Str.to_instance(db, self.program),
+                        annotated_type,
+                    ],
+                )
             };
             self.add_declaration_with_binding(
                 parameter.into(),
@@ -1085,8 +1113,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 &DeclaredAndInferredType::are_the_same_type(ty),
             );
         } else {
-            let inferred_ty = KnownClass::Dict
-                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::unknown()]);
+            let inferred_ty = KnownClass::Dict.to_specialized_instance(
+                db,
+                self.program,
+                &[
+                    KnownClass::Str.to_instance(db, self.program),
+                    Type::unknown(),
+                ],
+            );
 
             self.add_binding(parameter.into(), definition)
                 .insert(self, inferred_ty);
@@ -1114,7 +1148,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             parameter_type
         } else if let Some(default_expr) = default_expr {
             let default_ty = self.file_expression_type(default_expr);
-            UnionType::from_two_elements(self.db(), Type::unknown(), default_ty)
+            UnionType::from_two_elements(self.db(), self.program, Type::unknown(), default_ty)
         } else {
             Type::unknown()
         };
@@ -1152,7 +1186,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     ) {
         let inferred_ty = KnownClass::Dict.to_specialized_instance(
             self.db(),
-            &[KnownClass::Str.to_instance(self.db()), Type::unknown()],
+            self.program,
+            &[
+                KnownClass::Str.to_instance(self.db(), self.program),
+                Type::unknown(),
+            ],
         );
 
         self.add_binding(parameter.into(), definition)
@@ -1177,7 +1215,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         let parameter_type = signature.parameters().as_slice()[index as usize].annotated_type();
-        if parameter_type.is_unknown() || parameter_type.has_unspecialized_type_var(self.db()) {
+        if parameter_type.is_unknown()
+            || parameter_type.has_unspecialized_type_var(self.db(), self.program)
+        {
             None
         } else {
             Some(parameter_type)

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -1,11 +1,9 @@
 use ruff_python_ast as ast;
 use ruff_text_size::{Ranged, TextRange};
-use ty_module_resolver::{
-    ModuleName, ModuleNameResolutionError, ModuleResolveMode, resolve_module, search_paths,
-};
+use ty_module_resolver::{ModuleName, ModuleNameResolutionError, ModuleResolveMode};
 
 use crate::{
-    Program, TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
+    TypeQualifiers, add_inferred_python_version_hint_to_diagnostic,
     place::{DefinedPlace, Definedness, Place, PlaceAndQualifiers, TypeOrigin},
     types::{
         ModuleLiteralType, Type, TypeAndQualifiers,
@@ -45,13 +43,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if let Some(module_name) = &module_name
             && (self
-                .settings()
-                .allowed_unresolved_imports
+                .allowed_unresolved_imports()
                 .matches(module_name)
                 .is_include()
                 || self
-                    .settings()
-                    .replace_imports_with_any
+                    .replace_imports_with_any()
                     .matches(module_name)
                     .is_include())
         {
@@ -69,7 +65,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         if level == 0 {
             if let Some(module_name) = module_name {
-                let program = Program::get(db);
+                let program = self.program;
                 let typeshed_versions = program.search_paths(db).typeshed_versions();
 
                 // Loop over ancestors in case we have info on the parent module but not submodule
@@ -85,6 +81,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             ));
                             add_inferred_python_version_hint_to_diagnostic(
                                 db,
+                                program,
                                 &mut diagnostic,
                                 "resolving modules",
                             );
@@ -96,13 +93,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 }
             }
         } else {
+            let resolver_file = self.program_file().resolver_file(db);
             if let Some(better_level) = (0..level).rev().find(|reduced_level| {
                 let Ok(module_name) =
-                    ModuleName::from_identifier_parts(db, self.file(), module, *reduced_level)
+                    ModuleName::from_identifier_parts(db, resolver_file, module, *reduced_level)
                 else {
                     return false;
                 };
-                resolve_module(db, self.file(), &module_name).is_some()
+                ty_module_resolver::resolve_module(db, resolver_file, &module_name).is_some()
             }) {
                 diagnostic
                     .help("The module can be resolved if the number of leading dots is reduced");
@@ -121,7 +119,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Add search paths information to the diagnostic
         // Use the same search paths function that is used in actual module resolution
         let verbose = db.verbose();
-        let search_paths = search_paths(db, ModuleResolveMode::Typing);
+        let search_paths = ty_module_resolver::search_paths(
+            db,
+            self.program.resolver(db),
+            ModuleResolveMode::Typing,
+        );
 
         diagnostic.info(format_args!(
             "Searched in the following paths during module resolution:"
@@ -171,8 +173,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
 
         if self
-            .settings()
-            .replace_imports_with_any
+            .replace_imports_with_any()
             .matches(&full_module_name)
             .is_include()
         {
@@ -268,7 +269,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             format_import_from_module(*level, module),
             self.file().path(db),
         );
-        let module_name = ModuleName::from_import_statement(db, self.file(), import_from);
+        let resolver_file = self.program_file().resolver_file(db);
+        let module_name = ModuleName::from_import_statement(db, resolver_file, import_from);
 
         let module_name = match module_name {
             Ok(module_name) => module_name,
@@ -297,7 +299,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         };
 
-        if resolve_module(db, self.file(), &module_name).is_none() {
+        if ty_module_resolver::resolve_module(db, resolver_file, &module_name).is_none() {
             self.report_unresolved_import(module_ref.range(), *level, module, Some(&module_name));
         }
     }
@@ -309,16 +311,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) {
         let db = self.db();
+        let resolver_file = self.program_file().resolver_file(db);
 
-        let Ok(module_name) = ModuleName::from_import_statement(db, self.file(), import_from)
+        let Ok(module_name) = ModuleName::from_import_statement(db, resolver_file, import_from)
         else {
             self.add_unknown_declaration_with_binding(alias.into(), definition);
             return;
         };
 
         if self
-            .settings()
-            .replace_imports_with_any
+            .replace_imports_with_any()
             .matches(&module_name)
             .is_include()
         {
@@ -330,7 +332,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             return;
         }
 
-        let Some(module) = resolve_module(db, self.file(), &module_name) else {
+        let Some(module) = ty_module_resolver::resolve_module(db, resolver_file, &module_name)
+        else {
             self.add_unknown_declaration_with_binding(alias.into(), definition);
             return;
         };
@@ -338,6 +341,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let module_literal = ModuleLiteralType::new(
             db,
             module,
+            self.program,
             module.kind(db).is_package().then_some(self.file()),
         );
         let module_ty = Type::ModuleLiteral(module_literal);
@@ -473,8 +477,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         }
 
         if self
-            .settings()
-            .allowed_unresolved_imports
+            .allowed_unresolved_imports()
             .matches(full_submodule_name.as_ref().unwrap_or(&module_name))
             .is_include()
         {
@@ -491,12 +494,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Module `{module_name}` has no member `{name}`"
         ));
-
         let mut submodule_hint_added = false;
 
         if let Some(full_submodule_name) = full_submodule_name {
             submodule_hint_added = hint_if_stdlib_submodule_exists_on_other_versions(
                 db,
+                self.program,
                 &mut diagnostic,
                 &full_submodule_name,
                 module,
@@ -533,15 +536,17 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         definition: Definition<'db>,
     ) {
         let db = self.db();
+        let resolver_file = self.program_file().resolver_file(db);
 
         // Get this package's absolute module name by resolving `.`, and make sure it exists
-        let Ok(thispackage_name) = ModuleName::package_for_file(db, self.file()) else {
+        let Ok(thispackage_name) = ModuleName::package_for_file(db, resolver_file) else {
             self.add_binding(import_from.into(), definition)
                 .insert(self, Type::unknown());
             return;
         };
 
-        let Some(module) = resolve_module(db, self.file(), &thispackage_name) else {
+        let Some(module) = ty_module_resolver::resolve_module(db, resolver_file, &thispackage_name)
+        else {
             self.add_binding(import_from.into(), definition)
                 .insert(self, Type::unknown());
             return;
@@ -553,7 +558,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // First we normalize to `whatever.thispackage.x.y`
         let Some(final_part) = ModuleName::from_identifier_parts(
             db,
-            self.file(),
+            resolver_file,
             import_from.module.as_deref(),
             import_from.level,
         )
@@ -593,8 +598,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             .insert(self, Type::unknown());
 
         if self
-            .settings()
-            .allowed_unresolved_imports
+            .allowed_unresolved_imports()
             .matches(&full_submodule_name)
             .is_include()
         {
@@ -611,9 +615,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Module `{thispackage_name}` has no submodule `{final_part}`"
         ));
-
         hint_if_stdlib_submodule_exists_on_other_versions(
             db,
+            self.program,
             &mut diagnostic,
             &full_submodule_name,
             module,

--- a/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/named_tuple.rs
@@ -33,6 +33,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         kind: NamedTupleKind,
     ) -> Type<'db> {
         let db = self.db();
+        let program = self.program;
 
         // The fallback type reflects the fact that if the call were successful,
         // it would return a class that:
@@ -44,9 +45,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let fallback = || {
             IntersectionType::from_elements(
                 db,
+                program,
                 [
-                    Type::homogeneous_tuple(db, Type::unknown()).to_meta_type(db),
-                    KnownClass::NamedTupleLike.to_subclass_of(db),
+                    Type::homogeneous_tuple(db, Type::unknown()).to_meta_type(db, program),
+                    KnownClass::NamedTupleLike.to_subclass_of(db, program),
                     Type::unknown(),
                 ],
             )
@@ -217,11 +219,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             match arg.id.as_str() {
                 "defaults" if kind.is_collections() => {
                     defaults_kw = Some(kw);
-                    if let Some(element_types) =
-                        extract_fixed_length_iterable_element_types(db, &kw.value, |expr| {
-                            self.expression_type(expr)
-                        })
-                    {
+                    if let Some(element_types) = extract_fixed_length_iterable_element_types(
+                        db,
+                        self.program,
+                        &kw.value,
+                        |expr| self.expression_type(expr),
+                    ) {
                         default_types = element_types.into_vec();
                     } else {
                         // Can't determine individual types; use Any for each element.
@@ -232,10 +235,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         default_types = vec![Type::any(); count];
                     }
                     // Emit diagnostic for invalid types (not Iterable[Any] | None).
-                    let iterable_any =
-                        KnownClass::Iterable.to_specialized_instance(db, &[Type::any()]);
-                    let valid_type = UnionType::from_two_elements(db, iterable_any, Type::none(db));
-                    if !kw_type.is_assignable_to(db, valid_type)
+                    let iterable_any = KnownClass::Iterable.to_specialized_instance(
+                        db,
+                        self.program,
+                        &[Type::any()],
+                    );
+                    let valid_type = UnionType::from_two_elements(
+                        db,
+                        self.program,
+                        iterable_any,
+                        Type::none(db, self.program),
+                    );
+                    if !kw_type.is_assignable_to(db, self.program, valid_type)
                         && let Some(builder) =
                             self.context.report_lint(&INVALID_ARGUMENT_TYPE, &kw.value)
                     {
@@ -244,7 +255,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ));
                         diagnostic.set_primary_message(format_args!(
                             "Expected `Iterable[Any] | None`, found `{}`",
-                            kw_type.display(db)
+                            kw_type.display(db, self.program)
                         ));
                     }
                 }
@@ -252,16 +263,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     rename_type = Some(kw_type);
 
                     // Emit diagnostic for non-bool types.
-                    if !kw_type.is_assignable_to(db, KnownClass::Bool.to_instance(db))
-                        && let Some(builder) =
-                            self.context.report_lint(&INVALID_ARGUMENT_TYPE, &kw.value)
+                    if !kw_type.is_assignable_to(
+                        db,
+                        self.program,
+                        KnownClass::Bool.to_instance(db, self.program),
+                    ) && let Some(builder) =
+                        self.context.report_lint(&INVALID_ARGUMENT_TYPE, &kw.value)
                     {
                         let mut diagnostic = builder.into_diagnostic(format_args!(
                             "Invalid argument to parameter `rename` of `namedtuple()`"
                         ));
                         diagnostic.set_primary_message(format_args!(
                             "Expected `bool`, found `{}`",
-                            kw_type.display(db)
+                            kw_type.display(db, self.program)
                         ));
                     }
                 }
@@ -269,10 +283,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // Emit diagnostic for invalid types (not str | None).
                     let valid_type = UnionType::from_two_elements(
                         db,
-                        KnownClass::Str.to_instance(db),
-                        Type::none(db),
+                        self.program,
+                        KnownClass::Str.to_instance(db, self.program),
+                        Type::none(db, self.program),
                     );
-                    if !kw_type.is_assignable_to(db, valid_type)
+                    if !kw_type.is_assignable_to(db, self.program, valid_type)
                         && let Some(builder) =
                             self.context.report_lint(&INVALID_ARGUMENT_TYPE, &kw.value)
                     {
@@ -281,7 +296,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ));
                         diagnostic.set_primary_message(format_args!(
                             "Expected `str | None`, found `{}`",
-                            kw_type.display(db)
+                            kw_type.display(db, self.program)
                         ));
                     }
                 }
@@ -328,7 +343,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .map(|literal| Name::new(literal.value(db)));
 
         if name.is_none()
-            && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            && !name_type.is_assignable_to(
+                db,
+                self.program,
+                KnownClass::Str.to_instance(db, self.program),
+            )
             && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
         {
             let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -336,7 +355,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
             diagnostic.set_primary_message(format_args!(
                 "Expected `str`, found `{}`",
-                name_type.display(db)
+                name_type.display(db, self.program)
             ));
         } else if let Some(actual_name) = name.as_deref()
             && let Some(definition) = definition
@@ -424,7 +443,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         // Check for `rename=True`. Use `is_always_true()` to handle truthy values
         // (e.g., `rename=1`), though we'd still want a diagnostic for non-bool types.
-        let rename = rename_type.is_some_and(|ty| ty.bool(db).is_always_true());
+        let rename = rename_type.is_some_and(|ty| ty.bool(db, self.program).is_always_true());
 
         let fields_type = self.infer_expression(fields_arg, TypeContext::default());
 
@@ -441,7 +460,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         .collect(),
                 )
             } else {
-                extract_fixed_length_iterable_element_types(db, fields_arg, |expr| {
+                extract_fixed_length_iterable_element_types(db, self.program, fields_arg, |expr| {
                     self.expression_type(expr)
                 })
                 .and_then(|field_types| {
@@ -454,10 +473,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         if maybe_field_names.is_none() {
             // Emit diagnostic if the type is outright invalid (not str | Iterable[str]).
-            let iterable_str = KnownClass::Iterable.to_specialized_instance(db, &[Type::any()]);
-            let valid_type =
-                UnionType::from_two_elements(db, KnownClass::Str.to_instance(db), iterable_str);
-            if !fields_type.is_assignable_to(db, valid_type)
+            let iterable_str =
+                KnownClass::Iterable.to_specialized_instance(db, self.program, &[Type::any()]);
+            let valid_type = UnionType::from_two_elements(
+                db,
+                self.program,
+                KnownClass::Str.to_instance(db, self.program),
+                iterable_str,
+            );
+            if !fields_type.is_assignable_to(db, self.program, valid_type)
                 && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, fields_arg)
             {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -465,7 +489,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 ));
                 diagnostic.set_primary_message(format_args!(
                     "Expected `str` or an iterable of strings, found `{}`",
-                    fields_type.display(db)
+                    fields_type.display(db, self.program)
                 ));
             }
         }
@@ -585,7 +609,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         SequenceKind::List => {
                             self.store_expression_type(
                                 fields_arg,
-                                KnownClass::List.to_instance(db),
+                                KnownClass::List.to_instance(db, self.program),
                             );
                         }
                         SequenceKind::Tuple => self.store_expression_type(
@@ -614,7 +638,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 match field_arg_kind {
                     SequenceKind::List => {
-                        self.store_expression_type(fields_arg, KnownClass::List.to_instance(db));
+                        self.store_expression_type(
+                            fields_arg,
+                            KnownClass::List.to_instance(db, self.program),
+                        );
                     }
                     SequenceKind::Tuple => self.store_expression_type(
                         fields_arg,
@@ -639,7 +666,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 SequenceKind::Tuple => Type::heterogeneous_tuple(db, [name_type, declared_type]),
                 SequenceKind::List => KnownClass::List.to_specialized_instance(
                     db,
-                    &[UnionType::from_two_elements(db, name_type, declared_type)],
+                    self.program,
+                    &[UnionType::from_two_elements(
+                        db,
+                        self.program,
+                        name_type,
+                        declared_type,
+                    )],
                 ),
             };
 
@@ -651,7 +684,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 match field_arg_kind {
                     SequenceKind::List => {
-                        self.store_expression_type(fields_arg, KnownClass::List.to_instance(db));
+                        self.store_expression_type(
+                            fields_arg,
+                            KnownClass::List.to_instance(db, self.program),
+                        );
                     }
                     SequenceKind::Tuple => self.store_expression_type(
                         fields_arg,
@@ -663,7 +699,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         builder.into_diagnostic("Invalid `NamedTuple` field name definition");
                     diagnostic.set_primary_message(format_args!(
                         "Expected a string literal for the field name, found `{}`",
-                        name_type.display(db)
+                        name_type.display(db, self.program)
                     ));
                 }
                 return NamedTupleSpec::unknown(db);

--- a/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/new_class.rs
@@ -74,7 +74,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ast::name::Name::new(literal.value(db))
         } else {
             if let Some(name_node) = name_node
-                && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
+                && !name_type.is_assignable_to(
+                    db,
+                    self.program,
+                    KnownClass::Str.to_instance(db, self.program),
+                )
                 && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_node)
             {
                 let mut diagnostic = builder.into_diagnostic(
@@ -82,7 +86,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 );
                 diagnostic.set_primary_message(format_args!(
                     "Expected `str`, found `{}`",
-                    name_type.display(db)
+                    name_type.display(db, self.program)
                 ));
             }
             ast::name::Name::new_static("<unknown>")
@@ -189,9 +193,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     call_expr.into(),
                     dynamic_class.name(db),
                     metaclass1,
-                    base1.display(db),
+                    base1.display(db, self.program),
                     metaclass2,
-                    base2.display(db),
+                    base2.display(db, self.program),
                 );
             }
         }
@@ -255,21 +259,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         bases_arg: Option<&ast::Expr>,
         definition: Option<Definition<'db>>,
     ) {
+        let program = self.program;
         let db = self.db();
         let callable_type = self.expression_type(call_expr.func.as_ref());
-        let iterable_object = KnownClass::Iterable.to_specialized_instance(db, &[Type::object()]);
+        let iterable_object =
+            KnownClass::Iterable.to_specialized_instance(db, program, &[Type::object()]);
         let mut call_arguments = self.prepare_call_arguments(&call_expr.arguments);
 
-        let mut bindings = callable_type
-            .bindings(db)
-            .match_parameters(db, &call_arguments);
+        let mut bindings =
+            callable_type
+                .bindings(db, program)
+                .match_parameters(db, program, &call_arguments);
         let bindings_result = self.infer_and_check_argument_types(
             ArgumentsIter::from_ast(&call_expr.arguments),
             &mut call_arguments,
             &mut |builder, (_, expr, tcx)| {
                 if name_node.is_some_and(|name| std::ptr::eq(expr, name)) {
                     let _ = builder.infer_expression(expr, tcx);
-                    KnownClass::Str.to_instance(builder.db())
+                    KnownClass::Str.to_instance(builder.db(), program)
                 } else if bases_arg.is_some_and(|bases| std::ptr::eq(expr, bases)) {
                     if definition.is_none() {
                         let _ = builder.infer_expression(expr, tcx);

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/dynamic_class.rs
@@ -87,9 +87,9 @@ pub(crate) fn check_dynamic_class_definition<'db>(
             call_expr.into(),
             dynamic_class.name(db),
             metaclass1,
-            base1.display(db),
+            base1.display(db, context.program()),
             metaclass2,
-            base2.display(db),
+            base2.display(db, context.program()),
         );
     }
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/final_variable.rs
@@ -29,7 +29,7 @@ pub(crate) fn check_final_without_value<'db>(
     let place_table = index.place_table(file_scope_id);
 
     for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
-        let result = place_from_declarations(db, declarations);
+        let result = place_from_declarations(db, context.program(), declarations);
         let first_declaration = result.first_declaration;
         let (place_and_quals, _) = result.into_place_and_conflicting_declarations();
 
@@ -46,7 +46,7 @@ pub(crate) fn check_final_without_value<'db>(
 
         // Check if the symbol has any bindings in the current scope.
         let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-        let binding_place = place_from_bindings(db, bindings);
+        let binding_place = place_from_bindings(db, context.program(), bindings);
 
         if !binding_place.place.is_undefined() {
             continue;

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -98,6 +98,7 @@ fn check_pep695_function_legacy_typevars<'db>(
     };
     let Some(legacy_context) = GenericContext::from_function_params(
         db,
+        context.program(),
         definition,
         signature.parameters(),
         signature.return_ty,

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/function.rs
@@ -62,20 +62,26 @@ fn check_pep695_function_legacy_typevars<'db>(
 
     let mut has_legacy_default = false;
     for default in type_params.iter().filter_map(ast::TypeParam::default) {
-        let Some(typevar) = find_over_type(db, file_expression_type(default), false, |ty| {
-            if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
-                && matches!(
-                    typevar.kind(db),
-                    TypeVarKind::LegacyTypeVar
-                        | TypeVarKind::Pep613Alias
-                        | TypeVarKind::LegacyParamSpec
-                )
-            {
-                Some(typevar)
-            } else {
-                None
-            }
-        }) else {
+        let Some(typevar) = find_over_type(
+            db,
+            context.program(),
+            file_expression_type(default),
+            false,
+            |ty| {
+                if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = ty
+                    && matches!(
+                        typevar.kind(db),
+                        TypeVarKind::LegacyTypeVar
+                            | TypeVarKind::Pep613Alias
+                            | TypeVarKind::LegacyParamSpec
+                    )
+                {
+                    Some(typevar)
+                } else {
+                    None
+                }
+            },
+        ) else {
             continue;
         };
 
@@ -217,7 +223,7 @@ fn check_legacy_typevar_defaults<'db>(
             continue;
         };
 
-        let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
+        let first_bad_tvar = find_over_type(db, context.program(), default_ty, false, |t| {
             let tvar = match t {
                 Type::TypeVar(tvar) => tvar.typevar(db),
                 Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
@@ -272,11 +278,12 @@ fn check_legacy_typevar_defaults<'db>(
         }
 
         if let Some(typevar_definition) = typevar.definition(db) {
-            let file = typevar_definition.file(db);
+            let program_file = typevar_definition.program_file(db);
             diagnostic.annotate(
-                Annotation::secondary(Span::from(
-                    typevar_definition.full_range(db, &parsed_module(db, file).load(db)),
-                ))
+                Annotation::secondary(Span::from(typevar_definition.full_range(
+                    db,
+                    &parsed_module(db, program_file.versioned_file(db)).load(db),
+                )))
                 .message(format_args!("`{typevar_name}` defined here")),
             );
         }
@@ -298,7 +305,7 @@ fn find_typevar_annotation_range<'db>(
         .iter()
         .filter_map(ast::AnyParameterRef::annotation)
         .chain(node.returns.as_deref())
-        .find(|ann| file_expression_type(ann).references_typevar(db, typevar_id))
+        .find(|ann| file_expression_type(ann).references_typevar(db, context.program(), typevar_id))
         .map(Ranged::range)
         .unwrap_or_else(|| node.name.range())
 }
@@ -413,11 +420,12 @@ fn check_legacy_typevar_ordering<'db>(
         let Some(definition) = tvar.definition(db) else {
             continue;
         };
-        let file = definition.file(db);
+        let program_file = definition.program_file(db);
         diagnostic.annotate(
-            Annotation::secondary(Span::from(
-                definition.full_range(db, &parsed_module(db, file).load(db)),
-            ))
+            Annotation::secondary(Span::from(definition.full_range(
+                db,
+                &parsed_module(db, program_file.versioned_file(db)).load(db),
+            )))
             .message(format_args!("`{}` defined here", tvar.name(db))),
         );
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/overloaded_function.rs
@@ -67,6 +67,7 @@ pub(crate) fn check_overloaded_function<'db>(
         ..
     }) = place_from_bindings(
         db,
+        context.program(),
         use_def.end_of_scope_symbol_bindings(place.as_symbol().unwrap()),
     )
     .place
@@ -142,11 +143,13 @@ pub(crate) fn check_overloaded_function<'db>(
             )
         {
             if class.is_protocol(db)
-                || (Type::ClassLiteral(class)
-                    .is_subtype_of(db, KnownClass::ABCMeta.to_instance(db))
-                    && overloads.iter().all(|overload| {
-                        overload.has_known_decorator(db, FunctionDecorators::ABSTRACT_METHOD)
-                    }))
+                || (Type::ClassLiteral(class).is_subtype_of(
+                    db,
+                    context.program(),
+                    KnownClass::ABCMeta.to_instance(db, context.program()),
+                ) && overloads.iter().all(|overload| {
+                    overload.has_known_decorator(db, FunctionDecorators::ABSTRACT_METHOD)
+                }))
             {
                 implementation_required = false;
             }
@@ -254,7 +257,8 @@ pub(crate) fn check_overloaded_function<'db>(
                     diagnostic.annotate(Annotation::secondary(decorator));
                 }
                 let file = function.file(db);
-                let module = parsed_module(db, file).load(db);
+                let module =
+                    parsed_module(db, function.program_file(db).versioned_file(db)).load(db);
                 let node = first_overload.node(db, file, &module);
                 let span = if node.body.len() == 1 {
                     Span::from(file).with_range(node.range())
@@ -307,9 +311,17 @@ fn check_non_generic_overload_implementation_consistency<'db>(
     for (overload, overload_signature) in overload_signatures {
         let function_node = overload.node(db, context.file(), context.module());
         let parameter_consistency = implementation_signature
-            .non_generic_implementation_parameters_consistency_with(db, &overload_signature);
+            .non_generic_implementation_parameters_consistency_with(
+                db,
+                context.program(),
+                &overload_signature,
+            );
         let return_type_consistency = implementation_signature
-            .non_generic_implementation_return_type_consistency_with(db, &overload_signature);
+            .non_generic_implementation_return_type_consistency_with(
+                db,
+                context.program(),
+                &overload_signature,
+            );
 
         let (parameter_error_context, return_type_error_context, message) =
             match (parameter_consistency, return_type_consistency) {
@@ -347,18 +359,20 @@ fn check_non_generic_overload_implementation_consistency<'db>(
         if let Some(error_context) = parameter_error_context {
             diagnostic.info(format_args!(
                 "Implementation signature `{}` is not assignable to overload signature `{}`",
-                implementation_signature.display(db),
-                overload_signature.display(db),
+                implementation_signature.display(db, context.program()),
+                overload_signature.display(db, context.program()),
             ));
-            error_context.attach_to(db, &mut diagnostic);
+            error_context.attach_to(db, context.program(), &mut diagnostic);
         }
         if let Some(error_context) = return_type_error_context {
             diagnostic.info(format_args!(
                 "Overload returns `{}`, which is not assignable to implementation return type `{}`",
-                overload_signature.return_ty.display(db),
-                implementation_signature.return_ty.display(db),
+                overload_signature.return_ty.display(db, context.program()),
+                implementation_signature
+                    .return_ty
+                    .display(db, context.program()),
             ));
-            error_context.attach_to(db, &mut diagnostic);
+            error_context.attach_to(db, context.program(), &mut diagnostic);
         }
         diagnostic.annotate(
             context

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/static_class.rs
@@ -320,7 +320,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                                 return None;
                             }
                             let required_variance =
-                                base_alias.variance_of(db, typevar.identity(db));
+                                base_alias.variance_of(db, context.program(), typevar.identity(db));
                             if declared_variance.join(required_variance) != declared_variance {
                                 Some((typevar, declared_variance, required_variance))
                             } else {
@@ -436,7 +436,7 @@ pub(crate) fn check_static_class_definitions<'db>(
     for base in class_node.bases() {
         if let ast::Expr::Starred(starred) = base
             && let starred_ty = definition_expression_type(db, class_definition, &starred.value)
-            && let Some(tuple_spec) = starred_ty.tuple_instance_spec(db)
+            && let Some(tuple_spec) = starred_ty.tuple_instance_spec(db, context.program())
             && !matches!(tuple_spec.as_ref(), Tuple::Fixed(_))
         {
             report_unsupported_base(context, base, starred_ty, class);
@@ -468,7 +468,10 @@ pub(crate) fn check_static_class_definitions<'db>(
                         "Cannot create a consistent method resolution order (MRO) \
                                     for class `{}` with bases list `[{}]`",
                         class.name(db),
-                        bases_list.iter().map(|base| base.display(db)).join(", ")
+                        bases_list
+                            .iter()
+                            .map(|base| base.display(db, context.program()))
+                            .join(", ")
                     ));
                     let can_rewrite_bases = bases_list.len() == class_node.bases().len()
                         && !class_node.bases().iter().any(ast::Expr::is_starred_expr);
@@ -579,7 +582,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                 {
                     builder.into_diagnostic(format_args!(
                         "Metaclass type `{}` is not callable",
-                        ty.display(db)
+                        ty.display(db, context.program())
                     ));
                 }
             }
@@ -589,7 +592,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                 {
                     builder.into_diagnostic(format_args!(
                         "Metaclass type `{}` is partly not callable",
-                        ty.display(db)
+                        ty.display(db, context.program())
                     ));
                 }
             }
@@ -653,7 +656,7 @@ pub(crate) fn check_static_class_definitions<'db>(
                             ));
                             diagnostic.set_primary_message(format_args!(
                                 "Expected either `True` or `False`, got object of type `{}`",
-                                passed_type.display(db)
+                                passed_type.display(db, context.program())
                             ));
                         }
                     }
@@ -719,7 +722,7 @@ pub(crate) fn check_static_class_definitions<'db>(
 
             if let Some(init_subclass) = init_subclass_type {
                 let call_args = call_args.with_self(Some(Type::from(class)));
-                if let Err(call_error) = init_subclass.try_call(db, &call_args) {
+                if let Err(call_error) = init_subclass.try_call(db, context.program(), &call_args) {
                     report_subclass_of_class_with_non_callable_init_subclass(
                         context, call_error, class, class_node,
                     );
@@ -822,18 +825,19 @@ pub(crate) fn check_static_class_definitions<'db>(
                     continue;
                 };
 
-                let first_bad_tvar = find_over_type(db, default_ty, false, |t| {
-                    let tvar = match t {
-                        Type::TypeVar(tvar) => tvar.typevar(db),
-                        Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
-                        _ => return None,
-                    };
-                    if !typevars.clone().take(i).contains(&tvar) {
-                        Some(tvar)
-                    } else {
-                        None
-                    }
-                });
+                let first_bad_tvar =
+                    find_over_type(db, context.program(), default_ty, false, |t| {
+                        let tvar = match t {
+                            Type::TypeVar(tvar) => tvar.typevar(db),
+                            Type::KnownInstance(KnownInstanceType::TypeVar(tvar)) => tvar,
+                            _ => return None,
+                        };
+                        if !typevars.clone().take(i).contains(&tvar) {
+                            Some(tvar)
+                        } else {
+                            None
+                        }
+                    });
                 if let Some(bad_typevar) = first_bad_tvar {
                     let is_later_in_list = typevars.clone().skip(i).contains(&bad_typevar);
                     report_invalid_typevar_default_reference(
@@ -904,7 +908,7 @@ pub(crate) fn check_static_class_definitions<'db>(
         let mut has_seen_default_field = false;
 
         for (name, field) in class.own_fields(db, specialization, field_policy) {
-            if field.is_kw_only_sentinel(db) {
+            if field.is_kw_only_sentinel(db, context.program()) {
                 kw_only_sentinel_fields.push(name);
                 continue;
             }
@@ -1023,11 +1027,11 @@ fn check_class_namespace_against_metaclass_members<'db>(
 ) {
     let db = context.db();
     let metaclass = class.metaclass(db);
-    if metaclass == KnownClass::Type.to_class_literal(db) {
+    if metaclass == KnownClass::Type.to_class_literal(db, context.program()) {
         return;
     }
 
-    let Some(metaclass_instance) = metaclass.to_instance(db) else {
+    let Some(metaclass_instance) = metaclass.to_instance(db, context.program()) else {
         return;
     };
 
@@ -1049,23 +1053,23 @@ fn check_class_namespace_against_metaclass_members<'db>(
         .filter_map(|class| class.static_class_literal(db).map(|(literal, _)| literal))
     {
         let body_scope = metaclass.body_scope(db);
-        let metaclass_index = semantic_index(db, body_scope.file(db));
-        let body_scope = body_scope.file_scope_id(db);
-        let metaclass_table = metaclass_index.place_table(body_scope);
-        let metaclass_use_def = metaclass_index.use_def_map(body_scope);
+        let metaclass_index = semantic_index(db, body_scope.program_file(db));
+        let body_scope_id = body_scope.file_scope_id(db);
+        let metaclass_table = metaclass_index.place_table(body_scope_id);
+        let metaclass_use_def = metaclass_index.use_def_map(body_scope_id);
 
         for (symbol_id, _) in metaclass_use_def.all_end_of_scope_symbol_declarations() {
             metaclass_instance_members.insert(metaclass_table.symbol(symbol_id).name().clone());
         }
 
-        for function_scope in attribute_scopes(db, metaclass.body_scope(db)) {
+        for function_scope in attribute_scopes(db, body_scope) {
             for member in metaclass_index.place_table(function_scope).members() {
                 if let Some(name) = member.as_instance_attribute() {
                     // A method-scope member may only be declared, as in `cls.attr: int`.
                     // Only an assignment such as `cls.attr: int = 1` writes a value onto the
                     // newly created class object, potentially overwriting a class-body value.
-                    let is_assigned = attribute_assignments(db, metaclass.body_scope(db), name)
-                        .any(|(bindings, _)| {
+                    let is_assigned =
+                        attribute_assignments(db, body_scope, name).any(|(bindings, _)| {
                             bindings
                                 .into_iter()
                                 .any(|binding| binding.binding.definition().is_some())
@@ -1092,7 +1096,9 @@ fn check_class_namespace_against_metaclass_members<'db>(
             ty: metaclass_member_ty,
             origin,
             ..
-        }) = metaclass_instance.instance_member(db, name.as_str()).place
+        }) = metaclass_instance
+            .instance_member(db, context.program(), name.as_str())
+            .place
         else {
             continue;
         };
@@ -1109,7 +1115,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
                 }
 
                 let assigned_ty = binding_type(db, definition);
-                if !assigned_ty.is_assignable_to(db, metaclass_member_ty) {
+                if !assigned_ty.is_assignable_to(db, context.program(), metaclass_member_ty) {
                     reported_incompatible_binding = true;
                     report_invalid_attribute_assignment(
                         context,
@@ -1132,8 +1138,11 @@ fn check_class_namespace_against_metaclass_members<'db>(
             continue;
         }
 
-        let result =
-            place_from_declarations(db, use_def.end_of_scope_symbol_declarations(symbol_id));
+        let result = place_from_declarations(
+            db,
+            context.program(),
+            use_def.end_of_scope_symbol_declarations(symbol_id),
+        );
         let Some(definition) = result.first_declaration else {
             continue;
         };
@@ -1150,7 +1159,7 @@ fn check_class_namespace_against_metaclass_members<'db>(
         if !matches!(definition_kind, DefinitionKind::AnnotatedAssignment(_)) {
             continue;
         }
-        if !metaclass_member_ty.is_assignable_to(db, class_declared_ty) {
+        if !metaclass_member_ty.is_assignable_to(db, context.program(), class_declared_ty) {
             report_invalid_attribute_assignment(
                 context,
                 definition_kind.target_range(context.module()),
@@ -1329,14 +1338,21 @@ fn check_final_class_abstract_methods<'db>(
         if kind.is_implicit_due_to_stub_body() && db.should_check_file(definition.file(db)) {
             let function_type_as_callable = infer_definition_types(db, *definition)
                 .binding_type(*definition)
-                .try_upcast_to_callable(db);
+                .try_upcast_to_callable(db, context.program());
 
             if let Some(callables) = function_type_as_callable
                 && Type::function_like_callable(
                     db,
-                    Signature::new(Parameters::gradual_form(), Type::none(db)),
+                    Signature::new(
+                        Parameters::gradual_form(),
+                        Type::none(db, context.program()),
+                    ),
                 )
-                .is_assignable_to(db, callables.into_type(db))
+                .is_assignable_to(
+                    db,
+                    context.program(),
+                    callables.into_type(db, context.program()),
+                )
             {
                 diagnostic.help(format_args!(
                     "Change the body of `{first_method_name}` to `return` \
@@ -1374,7 +1390,7 @@ fn check_class_final_without_value<'db>(
     }
 
     for (symbol_id, declarations) in use_def.all_end_of_scope_symbol_declarations() {
-        let result = place_from_declarations(db, declarations);
+        let result = place_from_declarations(db, context.program(), declarations);
         let first_declaration = result.first_declaration;
         let (place_and_quals, _) = result.into_place_and_conflicting_declarations();
 
@@ -1384,7 +1400,7 @@ fn check_class_final_without_value<'db>(
 
         // Check if the symbol has any bindings at class level.
         let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-        let binding_place = place_from_bindings(db, bindings);
+        let binding_place = place_from_bindings(db, context.program(), bindings);
 
         if !binding_place.place.is_undefined() {
             continue;

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typed_dict.rs
@@ -7,7 +7,7 @@ use ruff_text_size::Ranged;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    Db,
+    Db, Program,
     types::{
         ClassType, StaticClassLiteral, Type, TypedDictType,
         class::CodeGeneratorKind,
@@ -112,9 +112,12 @@ fn validate_typed_dict_field_overrides<'db>(
                 continue;
             };
 
-            let Some(reason) =
-                TypedDictFieldOverrideReason::from_fields(db, child_field, base_field)
-            else {
+            let Some(reason) = TypedDictFieldOverrideReason::from_fields(
+                db,
+                context.program(),
+                child_field,
+                base_field,
+            ) else {
                 continue;
             };
 
@@ -217,17 +220,18 @@ fn validate_typed_dict_openness<'db>(
                     }
                     TypedDictOpenness::Closed => {}
                     TypedDictOpenness::Extra(child_extra_items) => {
-                        if !child_extra_items
-                            .declared_ty
-                            .is_assignable_to(db, base_extra_items.declared_ty)
-                        {
+                        if !child_extra_items.declared_ty.is_assignable_to(
+                            db,
+                            context.program(),
+                            base_extra_items.declared_ty,
+                        ) {
                             report_invalid_typed_dict_openness(
                                 context,
                                 class,
                                 format_args!(
                                     "Extra items type `{}` is not assignable to `{}` from base `{}`",
-                                    child_extra_items.declared_ty.display(db),
-                                    base_extra_items.declared_ty.display(db),
+                                    child_extra_items.declared_ty.display(db, context.program()),
+                                    base_extra_items.declared_ty.display(db, context.program()),
                                     base.name(db),
                                 ),
                             );
@@ -238,17 +242,19 @@ fn validate_typed_dict_openness<'db>(
 
                 if let Some((field_name, field)) = child_items.iter().find(|(field_name, field)| {
                     !base_items.contains_key(*field_name)
-                        && !field
-                            .declared_ty
-                            .is_assignable_to(db, base_extra_items.declared_ty)
+                        && !field.declared_ty.is_assignable_to(
+                            db,
+                            context.program(),
+                            base_extra_items.declared_ty,
+                        )
                 }) {
                     report_invalid_typed_dict_openness(
                         context,
                         class,
                         format_args!(
                             "Item `{field_name}` of type `{}` is not assignable to extra items type `{}` from base `{}`",
-                            field.declared_ty.display(db),
-                            base_extra_items.declared_ty.display(db),
+                            field.declared_ty.display(db, context.program()),
+                            base_extra_items.declared_ty.display(db, context.program()),
                             base.name(db),
                         ),
                     );
@@ -269,12 +275,16 @@ fn validate_typed_dict_openness<'db>(
                 };
 
                 if child_extra_items.is_read_only()
-                    || !child_extra_items
-                        .declared_ty
-                        .is_assignable_to(db, base_extra_items.declared_ty)
-                    || !base_extra_items
-                        .declared_ty
-                        .is_assignable_to(db, child_extra_items.declared_ty)
+                    || !child_extra_items.declared_ty.is_assignable_to(
+                        db,
+                        context.program(),
+                        base_extra_items.declared_ty,
+                    )
+                    || !base_extra_items.declared_ty.is_assignable_to(
+                        db,
+                        context.program(),
+                        child_extra_items.declared_ty,
+                    )
                 {
                     report_invalid_typed_dict_openness(
                         context,
@@ -282,7 +292,7 @@ fn validate_typed_dict_openness<'db>(
                         format_args!(
                             "TypedDict `{}` must preserve mutable extra items type `{}` from base `{}`",
                             class.name(db),
-                            base_extra_items.declared_ty.display(db),
+                            base_extra_items.declared_ty.display(db, context.program()),
                             base.name(db),
                         ),
                     );
@@ -293,19 +303,23 @@ fn validate_typed_dict_openness<'db>(
                     !base_items.contains_key(*field_name)
                         && (field.is_required()
                             || field.is_read_only()
-                            || !field
-                                .declared_ty
-                                .is_assignable_to(db, base_extra_items.declared_ty)
-                            || !base_extra_items
-                                .declared_ty
-                                .is_assignable_to(db, field.declared_ty))
+                            || !field.declared_ty.is_assignable_to(
+                                db,
+                                context.program(),
+                                base_extra_items.declared_ty,
+                            )
+                            || !base_extra_items.declared_ty.is_assignable_to(
+                                db,
+                                context.program(),
+                                field.declared_ty,
+                            ))
                 }) {
                     report_invalid_typed_dict_openness(
                         context,
                         class,
                         format_args!(
                             "Item `{field_name}` must be mutable, not required, and consistent with extra items type `{}` from base `{}`",
-                            base_extra_items.declared_ty.display(db),
+                            base_extra_items.declared_ty.display(db, context.program()),
                             base.name(db),
                         ),
                     );
@@ -338,12 +352,14 @@ enum TypedDictFieldOverrideReason<'db> {
     /// A read-only inherited field's new type is not assignable to the base type.
     ReadOnlyTypeNotAssignable {
         db: &'db dyn Db,
+        program: Program,
         child_ty: Type<'db>,
         base_ty: Type<'db>,
     },
     /// A mutable inherited field's new type is not mutually assignable with the base type.
     MutableTypeIncompatible {
         db: &'db dyn Db,
+        program: Program,
         child_ty: Type<'db>,
         base_ty: Type<'db>,
     },
@@ -372,23 +388,25 @@ impl std::fmt::Display for TypedDictFieldOverrideReason<'_> {
             }
             Self::ReadOnlyTypeNotAssignable {
                 db,
+                program,
                 child_ty,
                 base_ty,
             } => write!(
                 f,
                 "Inherited read-only field type `{}` is not assignable from `{}`",
-                base_ty.display(*db),
-                child_ty.display(*db),
+                base_ty.display(*db, *program),
+                child_ty.display(*db, *program),
             ),
             Self::MutableTypeIncompatible {
                 db,
+                program,
                 child_ty,
                 base_ty,
             } => write!(
                 f,
                 "Inherited mutable field type `{}` is incompatible with `{}`",
-                base_ty.display(*db),
-                child_ty.display(*db),
+                base_ty.display(*db, *program),
+                child_ty.display(*db, *program),
             ),
         }
     }
@@ -397,6 +415,7 @@ impl std::fmt::Display for TypedDictFieldOverrideReason<'_> {
 impl<'db> TypedDictFieldOverrideReason<'db> {
     fn from_fields(
         db: &'db dyn Db,
+        program: Program,
         child_field: &TypedDictField<'db>,
         base_field: &TypedDictField<'db>,
     ) -> Option<Self> {
@@ -417,14 +436,14 @@ impl<'db> TypedDictFieldOverrideReason<'db> {
         let types_are_compatible = if base_field.is_read_only() {
             child_field
                 .declared_ty
-                .is_assignable_to(db, base_field.declared_ty)
+                .is_assignable_to(db, program, base_field.declared_ty)
         } else {
             child_field
                 .declared_ty
-                .is_assignable_to(db, base_field.declared_ty)
+                .is_assignable_to(db, program, base_field.declared_ty)
                 && base_field
                     .declared_ty
-                    .is_assignable_to(db, child_field.declared_ty)
+                    .is_assignable_to(db, program, child_field.declared_ty)
         };
 
         if types_are_compatible {
@@ -434,12 +453,14 @@ impl<'db> TypedDictFieldOverrideReason<'db> {
         Some(if base_field.is_read_only() {
             Self::ReadOnlyTypeNotAssignable {
                 db,
+                program,
                 child_ty: child_field.declared_ty,
                 base_ty: base_field.declared_ty,
             }
         } else {
             Self::MutableTypeIncompatible {
                 db,
+                program,
                 child_ty: child_field.declared_ty,
                 base_ty: base_field.declared_ty,
             }
@@ -511,7 +532,7 @@ fn add_definition_subdiagnostic<'db>(
     };
 
     let file = definition.file(db);
-    let module = parsed_module(db, file).load(db);
+    let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
     let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Field declaration");
     sub.annotate(
         Annotation::secondary(

--- a/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/post_inference/typeguard.rs
@@ -20,22 +20,17 @@ pub(crate) fn check_type_guard_definition<'db>(
     let signature = overload.signature(db);
     let return_ty = signature.return_ty;
 
-    // Check if this is a `TypeIs` or `TypeGuard` return type.
     let (type_guard_form_name, narrowed_type) = match return_ty {
-        Type::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db))),
+        Type::TypeIs(type_is) => ("TypeIs", Some(type_is.return_type(db, context.program()))),
         Type::TypeGuard(_) => ("TypeGuard", None),
         _ => return,
     };
 
-    // The return type annotation must exist since we matched `TypeIs`/`TypeGuard`.
     let Some(returns_expr) = node.returns.as_deref() else {
         return;
     };
 
-    // Check if this is a non-static method (first parameter is implicit `self`/`cls`).
     let has_implicit_receiver = overload.has_implicit_receiver(db);
-
-    // Find the first positional parameter to narrow (skip implicit `self`/`cls`).
     let positional_params: Vec<_> = signature.parameters().positional().collect();
     let first_narrowed_param_index = usize::from(has_implicit_receiver);
     let first_narrowed_param = positional_params.get(first_narrowed_param_index);
@@ -49,17 +44,16 @@ pub(crate) fn check_type_guard_definition<'db>(
         return;
     };
 
-    // For `TypeIs`, check that the narrowed type is assignable to the parameter type.
     if let Some(narrowed_ty) = narrowed_type {
         let param_ty = first_narrowed_param.annotated_type();
-        if !narrowed_ty.is_assignable_to(db, param_ty)
+        if !narrowed_ty.is_assignable_to(db, context.program(), param_ty)
             && let Some(builder) = context.report_lint(&INVALID_TYPE_GUARD_DEFINITION, returns_expr)
         {
             builder.into_diagnostic(format_args!(
                 "Narrowed type `{narrowed}` is not assignable \
                     to the declared parameter type `{param}`",
-                narrowed = narrowed_ty.display(db),
-                param = param_ty.display(db)
+                narrowed = narrowed_ty.display(db, context.program()),
+                param = param_ty.display(db, context.program())
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/subscript.rs
@@ -6,6 +6,7 @@ use ruff_text_size::Ranged;
 use ty_module_resolver::file_to_module;
 
 use super::TypeInferenceBuilder;
+use crate::Program;
 use crate::place::{DefinedPlace, Definedness, Place};
 use crate::types::call::CallErrorKind;
 use crate::types::call::bind::CallableDescription;
@@ -68,45 +69,51 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         fn imp<'db>(
             db: &'db dyn Db,
+            program: Program,
             ty: Type<'db>,
             visitor: &TypedDictKeyExpectedTypeVisitor<'db>,
         ) -> Option<Type<'db>> {
             match ty {
                 Type::TypedDict(typed_dict) => {
                     if typed_dict.explicit_extra_items(db).is_some() {
-                        return Some(KnownClass::Str.to_instance(db));
+                        return Some(KnownClass::Str.to_instance(db, program));
                     }
                     let keys = typed_dict
                         .items(db)
                         .keys()
                         .map(|key| Type::string_literal(db, key))
                         .collect_vec();
-                    (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
+                    (!keys.is_empty()).then(|| UnionType::from_elements(db, program, keys))
                 }
                 Type::Union(union) => {
                     let keys = union
                         .elements(db)
                         .iter()
-                        .filter_map(|element| imp(db, *element, visitor))
+                        .filter_map(|element| imp(db, program, *element, visitor))
                         .collect_vec();
-                    (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
+                    (!keys.is_empty()).then(|| UnionType::from_elements(db, program, keys))
                 }
                 Type::Intersection(intersection) => {
                     let keys = intersection
                         .positive(db)
                         .iter()
-                        .filter_map(|element| imp(db, *element, visitor))
+                        .filter_map(|element| imp(db, program, *element, visitor))
                         .collect_vec();
-                    (!keys.is_empty()).then(|| UnionType::from_elements(db, keys))
+                    (!keys.is_empty()).then(|| UnionType::from_elements(db, program, keys))
                 }
                 Type::TypeAlias(alias) => {
-                    visitor.visit(ty, || imp(db, alias.value_type(db), visitor))
+                    visitor.visit(ty, || imp(db, program, alias.value_type(db), visitor))
                 }
                 _ => None,
             }
         }
 
-        imp(self.db(), ty, &TypedDictKeyExpectedTypeVisitor::default())
+        imp(
+            self.db(),
+            self.program,
+            ty,
+            &TypedDictKeyExpectedTypeVisitor::default(),
+        )
     }
 
     fn store_typed_dict_key_expected_type(&mut self, slice: &ast::Expr, value_ty: Type<'db>) {
@@ -207,9 +214,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
         }
 
+        let program = self.program;
         let tuple_generic_alias = |db: &'db dyn Db, tuple: Option<TupleType<'db>>| {
             let tuple = tuple.unwrap_or_else(|| TupleType::homogeneous(db, Type::unknown()));
-            Type::from(tuple.to_class_type(db))
+            Type::from(tuple.to_class_type(db, program))
         };
 
         match value_ty {
@@ -247,10 +255,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
                     db,
+                    self.program,
                     self.typevar_binding_context,
                     &mut variables,
                 );
-                let generic_context = GenericContext::from_typevar_instances(db, variables);
+                let generic_context =
+                    GenericContext::from_typevar_instances(db, self.program, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
             Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
@@ -308,7 +318,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     let ty = self.infer_type_expression(slice);
 
                     // `Optional[None]` is equivalent to `None`:
-                    if ty.is_none(db) {
+                    if ty.is_none(db, self.program) {
                         return ty;
                     }
 
@@ -316,19 +326,25 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         UnionTypeInstance::new(
                             db,
                             None,
-                            Ok(UnionType::from_two_elements(db, ty, Type::none(db))),
+                            Ok(UnionType::from_two_elements(
+                                db,
+                                self.program,
+                                ty,
+                                Type::none(db, self.program),
+                            )),
                         ),
                     ));
                 }
                 SpecialFormType::Union => match **slice {
                     ast::Expr::Tuple(ref tuple) => {
+                        let program = self.program;
                         let elements = tuple.iter().map(|elt| self.infer_type_expression(elt));
 
                         let union_type = Type::KnownInstance(KnownInstanceType::UnionType(
                             UnionTypeInstance::new(
                                 db,
                                 None,
-                                Ok(UnionType::from_elements(db, elements)),
+                                Ok(UnionType::from_elements(db, program, elements)),
                             ),
                         ));
 
@@ -397,7 +413,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         .collect();
 
                     return class
-                        .to_specialized_class_type(db, arg_types)
+                        .to_specialized_class_type(db, self.program, arg_types)
                         .map(Type::from)
                         .unwrap_or_else(Type::unknown);
                 }
@@ -417,10 +433,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
                     db,
+                    self.program,
                     self.typevar_binding_context,
                     &mut variables,
                 );
-                let generic_context = GenericContext::from_typevar_instances(db, variables);
+                let generic_context =
+                    GenericContext::from_typevar_instances(db, self.program, variables);
                 return Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
             }
             _ => {}
@@ -529,7 +547,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 return;
             };
             let file = definition.file(db);
-            let module = parsed_module(db, file).load(db);
+            let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
             let range = definition.focus_range(db, &module).range();
             diagnostic.annotate(
                 Annotation::secondary(Span::from(file).with_range(range))
@@ -719,7 +737,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     continue;
                                 };
                                 let file = definition.file(db);
-                                let module = parsed_module(db, file).load(db);
+                                let module = parsed_module(
+                                    db,
+                                    definition.program_file(db).versioned_file(db),
+                                )
+                                .load(db);
                                 let range = definition.focus_range(db, &module).range();
                                 diagnostic.annotate(
                                     Annotation::secondary(Span::from(file).with_range(range))
@@ -744,11 +766,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if provided_type
                                 .when_assignable_to(
                                     db,
+                                    self.program,
                                     bound,
                                     &constraints,
                                     InferableTypeVars::None,
                                 )
-                                .is_never_satisfied(db)
+                                .is_never_satisfied(db, self.program)
                             {
                                 if let Some(builder) = self
                                     .context
@@ -757,14 +780,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                         "Type `{}` is not assignable to upper bound `{}` \
                                             of type variable `{}`",
-                                        provided_type.display(db),
-                                        bound.display(db),
+                                        provided_type.display(db, self.program),
+                                        bound.display(db, self.program),
                                         typevar.identity(db).display(db),
                                     ));
                                     add_typevar_definition(db, &mut diagnostic, typevar);
                                     provided_type
-                                        .assignability_error_context(db, bound)
-                                        .attach_to(db, &mut diagnostic);
+                                        .assignability_error_context(db, self.program, bound)
+                                        .attach_to(db, self.program, &mut diagnostic);
                                 }
                                 error = Some(ExplicitSpecializationError::UnsatisfiedBound);
                                 specialization_types.push(Some(Type::unknown()));
@@ -780,11 +803,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             if provided_type
                                 .when_assignable_to(
                                     db,
-                                    typevar_constraints.as_type(db),
+                                    self.program,
+                                    typevar_constraints.as_type(db, self.program),
                                     &constraints,
                                     InferableTypeVars::None,
                                 )
-                                .is_never_satisfied(db)
+                                .is_never_satisfied(db, self.program)
                             {
                                 if let Some(builder) = self
                                     .context
@@ -793,11 +817,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                         "Type `{}` does not satisfy constraints `{}` \
                                             of type variable `{}`",
-                                        provided_type.display(db),
+                                        provided_type.display(db, self.program),
                                         typevar_constraints
                                             .elements(db)
                                             .iter()
-                                            .map(|c| c.display(db))
+                                            .map(|c| c.display(db, self.program))
                                             .format("`, `"),
                                         typevar.identity(db).display(db),
                                     ));
@@ -861,12 +885,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 if let Some(builder) = self.context.report_lint(&NOT_SUBSCRIPTABLE, subscript) {
                     let mut diagnostic = builder.into_diagnostic(format_args!(
                         "Cannot subscript non-generic type `{}`",
-                        value_ty.display(db)
+                        value_ty.display(db, self.program)
                     ));
                     let already_specialized = match value_ty {
                         Type::GenericAlias(_) => true,
                         Type::KnownInstance(KnownInstanceType::UnionType(union)) => union
-                            .value_expression_types(db)
+                            .value_expression_types(db, self.program)
                             .is_ok_and(|mut tys| tys.any(|ty| ty.is_generic_alias())),
                         _ => false,
                     };
@@ -1163,6 +1187,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let subscript_result = match value_ty {
             Type::SpecialForm(SpecialFormType::Generic) => infer_legacy_generic_subscript(
                 db,
+                self.program,
                 self.index,
                 self.scope().file_scope_id(db),
                 self.typevar_binding_context,
@@ -1172,6 +1197,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             ),
             Type::SpecialForm(SpecialFormType::Protocol) => infer_legacy_generic_subscript(
                 db,
+                self.program,
                 self.index,
                 self.scope().file_scope_id(db),
                 self.typevar_binding_context,
@@ -1184,13 +1210,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 let mut variables = FxOrderSet::default();
                 slice_ty.bind_and_find_all_legacy_typevars(
                     db,
+                    self.program,
                     self.typevar_binding_context,
                     &mut variables,
                 );
-                let generic_context = GenericContext::from_typevar_instances(db, variables);
+                let generic_context =
+                    GenericContext::from_typevar_instances(db, self.program, variables);
                 Ok(Type::Dynamic(DynamicType::UnknownGeneric(generic_context)))
             }
-            _ => value_ty.subscript(db, slice_ty, expr_context),
+            _ => value_ty.subscript(db, self.program, slice_ty, expr_context),
         };
 
         subscript_result.unwrap_or_else(|e| {
@@ -1216,10 +1244,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         KnownClass::Slice.to_specialized_instance(
             db,
+            self.program,
             &[
-                ty_lower.unwrap_or_else(|| Type::none(db)),
-                ty_upper.unwrap_or_else(|| Type::none(db)),
-                ty_step.unwrap_or_else(|| Type::none(db)),
+                ty_lower.unwrap_or_else(|| Type::none(db, self.program)),
+                ty_upper.unwrap_or_else(|| Type::none(db, self.program)),
+                ty_step.unwrap_or_else(|| Type::none(db, self.program)),
             ],
         )
     }
@@ -1259,7 +1288,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // unannotated collection initializer.
         if is_valid_assignment
             && let Some(collection_def) = self.index.unannotated_collection_initializer(object)
-            && let Some((class_literal, _)) = object_ty.class_specialization(db)
+            && let Some((class_literal, _)) = object_ty.class_specialization(db, self.program)
         {
             let identity_instance = Type::instance(db, class_literal.identity_specialization(db));
             let collection_generic_context = class_literal.generic_context(db);
@@ -1278,14 +1307,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }) = identity_instance
                 .member_lookup_with_policy(
                     db,
+                    self.program,
                     "__setitem__".into(),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
                 .place
             {
                 let mut identity_bindings = dunder_callable
-                    .bindings(db)
-                    .match_parameters(db, &call_arguments)
+                    .bindings(db, self.program)
+                    .match_parameters(db, self.program, &call_arguments)
                     // Perform inference against the type variables on the receiver's generic context.
                     .with_generic_context(db, collection_generic_context);
 
@@ -1346,13 +1376,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         infer_rhs_value: &mut dyn FnMut(&mut Self, TypeContext<'db>) -> Type<'db>,
         emit_diagnostic: bool,
     ) -> bool {
+        let program = self.program;
         let db = self.db();
 
         let attach_original_type_info = |diagnostic: &mut LintDiagnosticGuard| {
             if let Some(full_object_ty) = full_object_ty {
                 diagnostic.info(format_args!(
                     "The full type of the subscripted object is `{}`",
-                    full_object_ty.display(db)
+                    full_object_ty.display(db, program)
                 ));
             }
         };
@@ -1452,12 +1483,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         return true;
                     }
 
-                    if slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                        && let Some(expected_ty) = typed_dict.arbitrary_key_mutation_type(db)
+                    if slice_ty.is_assignable_to(
+                        db,
+                        self.program,
+                        KnownClass::Str.to_instance(db, self.program),
+                    ) && let Some(expected_ty) =
+                        typed_dict.arbitrary_key_mutation_type(db, self.program)
                     {
                         let rhs_value_ty =
                             infer_rhs_value(self, TypeContext::new(Some(expected_ty)));
-                        if rhs_value_ty.is_assignable_to(db, expected_ty) {
+                        if rhs_value_ty.is_assignable_to(db, self.program, expected_ty) {
                             return true;
                         }
 
@@ -1468,13 +1503,13 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Cannot assign value of type `{}` to key of type `{}` on TypedDict `{}`",
-                                rhs_value_ty.display(db),
-                                slice_ty.display(db),
-                                object_ty.display(db),
+                                rhs_value_ty.display(db, self.program),
+                                slice_ty.display(db, self.program),
+                                object_ty.display(db, self.program),
                             ));
                             diagnostic.set_primary_message(format_args!(
                                 "Expected value assignable to `{}`",
-                                expected_ty.display(db)
+                                expected_ty.display(db, self.program)
                             ));
                             attach_original_type_info(&mut diagnostic);
                         }
@@ -1482,11 +1517,11 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
 
                     let rhs_value_ty = infer_rhs_value(self, TypeContext::default());
-                    let assigned_d = rhs_value_ty.display(db);
-                    let value_d = object_ty.display(db);
+                    let assigned_d = rhs_value_ty.display(db, self.program);
+                    let value_d = object_ty.display(db, self.program);
 
-                    if slice_ty.is_assignable_to(db, Type::literal_string())
-                        && !slice_ty.is_equivalent_to(db, Type::literal_string())
+                    if slice_ty.is_assignable_to(db, self.program, Type::literal_string())
+                        && !slice_ty.is_equivalent_to(db, self.program, Type::literal_string())
                     {
                         if let Some(builder) = self
                             .context
@@ -1494,7 +1529,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Cannot assign value of type `{assigned_d}` to key of type `{}` on TypedDict `{value_d}`",
-                                slice_ty.display(db)
+                                slice_ty.display(db, self.program)
                             ));
                             attach_original_type_info(&mut diagnostic);
                         }
@@ -1505,7 +1540,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "TypedDict `{value_d}` can only be subscripted with a string literal key, got key of type `{}`.",
-                                slice_ty.display(db)
+                                slice_ty.display(db, self.program)
                             ));
                             attach_original_type_info(&mut diagnostic);
                         }
@@ -1593,7 +1628,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Method `__setitem__` of type `{}` may be missing",
-                                object_ty.display(db),
+                                object_ty.display(db, self.program),
                             ));
                             attach_original_type_info(&mut diagnostic);
                         }
@@ -1612,8 +1647,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                         "Method `__setitem__` of type `{}` is not callable \
                                              on object of type `{}`",
-                                        bindings.callable_type().display(db),
-                                        object_ty.display(db),
+                                        bindings.callable_type().display(db, self.program),
+                                        object_ty.display(db, self.program),
                                     ));
                                     attach_original_type_info(&mut diagnostic);
                                 }
@@ -1643,42 +1678,54 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             target.range.cover(rhs_value_node.range()),
                                         )
                                     {
-                                        let assigned_d = rhs_value_ty.display(db);
-                                        let object_d = object_ty.display(db);
+                                        let assigned_d = rhs_value_ty.display(db, self.program);
+                                        let object_d = object_ty.display(db, self.program);
 
                                         let mut diagnostic = builder.into_diagnostic(format_args!(
                                                     "Invalid subscript assignment with key of type `{}` and value of \
                                                      type `{assigned_d}` on object of type `{object_d}`",
-                                                    slice_ty.display(db),
+                                                    slice_ty.display(db, self.program),
                                                 ));
 
                                         // Special diagnostic for dictionaries
                                         if let Some([expected_key_ty, expected_value_ty]) =
                                             object_ty
-                                                .known_specialization(db, KnownClass::Dict)
+                                                .known_specialization(
+                                                    db,
+                                                    self.program,
+                                                    KnownClass::Dict,
+                                                )
                                                 .map(|s| s.types(db))
                                         {
-                                            if !slice_ty.is_assignable_to(db, *expected_key_ty) {
+                                            if !slice_ty.is_assignable_to(
+                                                db,
+                                                self.program,
+                                                *expected_key_ty,
+                                            ) {
                                                 diagnostic.annotate(
                                                     self.context
                                                         .secondary(target.slice.as_ref())
                                                         .message(format_args!(
                                                             "Expected key of type `{}`, got `{}`",
-                                                            expected_key_ty.display(db),
-                                                            slice_ty.display(db),
+                                                            expected_key_ty
+                                                                .display(db, self.program),
+                                                            slice_ty.display(db, self.program),
                                                         )),
                                                 );
                                             }
 
-                                            if !rhs_value_ty
-                                                .is_assignable_to(db, *expected_value_ty)
-                                            {
+                                            if !rhs_value_ty.is_assignable_to(
+                                                db,
+                                                self.program,
+                                                *expected_value_ty,
+                                            ) {
                                                 diagnostic.annotate(
                                                     self.context.secondary(rhs_value_node).message(
                                                         format_args!(
                                                             "Expected value of type `{}`, got `{}`",
-                                                            expected_value_ty.display(db),
-                                                            rhs_value_ty.display(db),
+                                                            expected_value_ty
+                                                                .display(db, self.program),
+                                                            rhs_value_ty.display(db, self.program),
                                                         ),
                                                     ),
                                                 );
@@ -1696,8 +1743,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 {
                                     let mut diagnostic = builder.into_diagnostic(format_args!(
                                             "Method `__setitem__` of type `{}` may not be callable on object of type `{}`",
-                                            bindings.callable_type().display(db),
-                                            object_ty.display(db),
+                                            bindings.callable_type().display(db, self.program),
+                                            object_ty.display(db, self.program),
                                         ));
                                     attach_original_type_info(&mut diagnostic);
                                 }
@@ -1712,28 +1759,36 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         {
                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                 "Cannot assign to a subscript on an object of type `{}`",
-                                object_ty.display(db),
+                                object_ty.display(db, self.program),
                             ));
                             attach_original_type_info(&mut diagnostic);
 
                             // If it's a user-defined class, suggest adding a `__setitem__` method.
                             if object_ty
                                 .as_nominal_instance()
-                                .and_then(|instance| instance.class(db).static_class_literal(db))
+                                .and_then(|instance| {
+                                    instance.class(db, self.program).static_class_literal(db)
+                                })
                                 .and_then(|(class_literal, _)| {
-                                    file_to_module(db, class_literal.file(db))
+                                    file_to_module(
+                                        db,
+                                        class_literal
+                                            .body_scope(db)
+                                            .program_file(db)
+                                            .resolver_file(db),
+                                    )
                                 })
                                 .and_then(|module| module.search_path(db))
                                 .is_some_and(ty_module_resolver::SearchPath::is_first_party)
                             {
                                 diagnostic.help(format_args!(
                                     "Consider adding a `__setitem__` method to `{}`.",
-                                    object_ty.display(db),
+                                    object_ty.display(db, self.program),
                                 ));
                             } else {
                                 diagnostic.info(format_args!(
                                     "`{}` does not have a `__setitem__` method.",
-                                    object_ty.display(db),
+                                    object_ty.display(db, self.program),
                                 ));
                             }
                         }
@@ -1767,7 +1822,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             if let Some(full_object_ty) = full_object_ty {
                 diagnostic.info(format_args!(
                     "The full type of the subscripted object is `{}`",
-                    full_object_ty.display(db)
+                    full_object_ty.display(db, self.program)
                 ));
             }
         };
@@ -1824,9 +1879,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         && string_literal_values(db, slice_ty).is_some_and(|mut literals| {
                             literals.all(|literal| !typed_dict.items(db).contains_key(literal))
                         });
-                    let can_delete_arbitrary_key = slice_ty
-                        .is_assignable_to(db, KnownClass::Str.to_instance(db))
-                        && typed_dict.supports_arbitrary_key_deletion(db);
+                    let can_delete_arbitrary_key = slice_ty.is_assignable_to(
+                        db,
+                        self.program,
+                        KnownClass::Str.to_instance(db, self.program),
+                    ) && typed_dict
+                        .supports_arbitrary_key_deletion(db);
                     if can_delete_extra_literals || can_delete_arbitrary_key {
                         return;
                     }
@@ -1834,6 +1892,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
                 match object_ty.try_call_dunder(
                     db,
+                    self.program,
                     "__delitem__",
                     CallArguments::positional([slice_ty]),
                     TypeContext::default(),
@@ -1847,7 +1906,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                             {
                                 let mut diagnostic = builder.into_diagnostic(format_args!(
                                     "Method `__delitem__` of type `{}` may be missing",
-                                    object_ty.display(db),
+                                    object_ty.display(db, self.program),
                                 ));
                                 attach_original_type_info(&mut diagnostic);
                             }
@@ -1861,8 +1920,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         let mut diagnostic = builder.into_diagnostic(format_args!(
                                             "Method `__delitem__` of type `{}` is not callable \
                                              on object of type `{}`",
-                                            bindings.callable_type().display(db),
-                                            object_ty.display(db),
+                                            bindings.callable_type().display(db, self.program),
+                                            object_ty.display(db, self.program),
                                         ));
                                         attach_original_type_info(&mut diagnostic);
                                     }
@@ -1919,9 +1978,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                                 let mut diagnostic = builder.into_diagnostic(format_args!(
                                                     "Method `__delitem__` of type `{}` cannot be called \
                                                      with key of type `{}` on object of type `{}`",
-                                                    bindings.callable_type().display(db),
-                                                    slice_ty.display(db),
-                                                    object_ty.display(db),
+                                                    bindings.callable_type().display(db, self.program),
+                                                    slice_ty.display(db, self.program),
+                                                    object_ty.display(db, self.program),
                                                 ));
                                                 attach_original_type_info(&mut diagnostic);
                                             }
@@ -1934,9 +1993,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             let mut diagnostic = builder.into_diagnostic(format_args!(
                                                 "Method `__delitem__` of type `{}` cannot be called \
                                                  with key of type `{}` on object of type `{}`",
-                                                bindings.callable_type().display(db),
-                                                slice_ty.display(db),
-                                                object_ty.display(db),
+                                                bindings.callable_type().display(db, self.program),
+                                                slice_ty.display(db, self.program),
+                                                object_ty.display(db, self.program),
                                             ));
                                             attach_original_type_info(&mut diagnostic);
                                         }
@@ -1949,8 +2008,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         let mut diagnostic = builder.into_diagnostic(format_args!(
                                             "Method `__delitem__` of type `{}` may not be callable \
                                              on object of type `{}`",
-                                            bindings.callable_type().display(db),
-                                            object_ty.display(db),
+                                            bindings.callable_type().display(db, self.program),
+                                            object_ty.display(db, self.program),
                                         ));
                                         attach_original_type_info(&mut diagnostic);
                                     }
@@ -1977,6 +2036,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         object_ty
             .try_call_dunder(
                 db,
+                self.program,
                 "__delitem__",
                 CallArguments::positional([slice_ty]),
                 TypeContext::default(),
@@ -2054,8 +2114,10 @@ impl<'db> LegacyGenericContextError<'db> {
 
 /// Validate the type arguments to `Generic[...]` or `Protocol[...]`, returning
 /// either the resulting [`GenericContext`] or a [`SubscriptError`].
+#[expect(clippy::too_many_arguments)]
 fn infer_legacy_generic_subscript<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     index: &'db SemanticIndex<'db>,
     file_scope_id: FileScopeId,
     typevar_binding_context: Option<Definition<'db>>,
@@ -2063,8 +2125,14 @@ fn infer_legacy_generic_subscript<'db>(
     origin: LegacyGenericOrigin,
     wrap_ok: impl FnOnce(GenericContext<'db>) -> KnownInstanceType<'db>,
 ) -> Result<Type<'db>, SubscriptError<'db>> {
-    match legacy_generic_class_context(db, index, file_scope_id, typevar_binding_context, slice_ty)
-    {
+    match legacy_generic_class_context(
+        db,
+        program,
+        index,
+        file_scope_id,
+        typevar_binding_context,
+        slice_ty,
+    ) {
         Ok(context) => Ok(Type::KnownInstance(wrap_ok(context))),
         Err(LegacyGenericContextError::InvalidArgument(argument_ty)) => Err(SubscriptError::new(
             Type::unknown(),
@@ -2095,6 +2163,7 @@ fn infer_legacy_generic_subscript<'db>(
 /// that each argument is a type variable.
 fn legacy_generic_class_context<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     index: &'db SemanticIndex<'db>,
     file_scope_id: FileScopeId,
     typevar_binding_context: Option<Definition<'db>>,
@@ -2128,7 +2197,7 @@ fn legacy_generic_class_context<'db>(
             && instance.has_known_class(db, KnownClass::TypeVarTuple)
         {
             return Err(LegacyGenericContextError::TypeVarTupleMustBeUnpacked);
-        } else if any_over_type(db, argument_ty, true, |inner_ty| match inner_ty {
+        } else if any_over_type(db, program, argument_ty, true, |inner_ty| match inner_ty {
             Type::Dynamic(DynamicType::TodoUnpack | DynamicType::TodoStarredExpression) => true,
             Type::NominalInstance(nominal) => nominal.has_known_class(db, KnownClass::TypeVarTuple),
             _ => false,
@@ -2140,6 +2209,7 @@ fn legacy_generic_class_context<'db>(
     }
     Ok(GenericContext::from_typevar_instances(
         db,
+        program,
         validated_typevars,
     ))
 }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_call.rs
@@ -50,7 +50,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let arg_type = self.infer_expression(single, TypeContext::default());
 
                 return if keywords.is_empty() {
-                    arg_type.dunder_class(db)
+                    arg_type.dunder_class(db, self.program)
                 } else {
                     if keywords.iter().any(|keyword| keyword.arg.is_some())
                         && let Some(builder) =
@@ -176,8 +176,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         if !matches!(namespace_type, Type::TypedDict(_))
             && !namespace_type.is_assignable_to(
                 db,
-                KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]),
+                self.program,
+                KnownClass::Dict.to_specialized_instance(
+                    db,
+                    self.program,
+                    &[KnownClass::Str.to_instance(db, self.program), Type::any()],
+                ),
             )
             && let Some(builder) = self
                 .context
@@ -187,7 +191,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .into_diagnostic("Invalid argument to parameter 3 (`namespace`) of `type()`");
             diagnostic.set_primary_message(format_args!(
                 "Expected `dict[str, Any]`, found `{}`",
-                namespace_type.display(db)
+                namespace_type.display(db, self.program)
             ));
         }
 
@@ -195,14 +199,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         let name = if let Some(literal) = name_type.as_string_literal() {
             Name::new(literal.value(db))
         } else {
-            if !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
-                && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
+            if !name_type.is_assignable_to(
+                db,
+                self.program,
+                KnownClass::Str.to_instance(db, self.program),
+            ) && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
             {
                 let mut diagnostic =
                     builder.into_diagnostic("Invalid argument to parameter 1 (`name`) of `type()`");
                 diagnostic.set_primary_message(format_args!(
                     "Expected `str`, found `{}`",
-                    name_type.display(db)
+                    name_type.display(db, self.program)
                 ));
             }
             Name::new_static("<unknown>")
@@ -296,9 +303,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     call_expr.into(),
                     dynamic_class.name(db),
                     metaclass1,
-                    base1.display(db),
+                    base1.display(db, self.program),
                     metaclass2,
-                    base2.display(db),
+                    base2.display(db, self.program),
                 );
             }
         }

--- a/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_expression.rs
@@ -26,7 +26,7 @@ use crate::types::{
     TypeFormType, TypeGuardType, TypeIsType, TypeMapping, TypeVarKind, UnionBuilder, UnionType,
     any_over_type, todo_type,
 };
-use crate::{FxOrderSet, Program, add_inferred_python_version_hint_to_diagnostic};
+use crate::{FxOrderSet, add_inferred_python_version_hint_to_diagnostic};
 
 /// Type expressions
 impl<'db> TypeInferenceBuilder<'db, '_> {
@@ -117,9 +117,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
         report_missing_type_arguments(&self.context, ty, annotation);
         let result_ty = ty
-            .default_specialize(self.db())
+            .default_specialize(self.db(), self.program)
             .in_type_expression(
                 self.db(),
+                self.program,
                 self.scope(),
                 self.typevar_binding_context,
                 self.inference_flags(),
@@ -182,7 +183,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
             }
 
-            ast::Expr::NoneLiteral(_literal) => Type::none(self.db()),
+            ast::Expr::NoneLiteral(_literal) => Type::none(self.db(), self.program),
 
             // https://typing.python.org/en/latest/spec/annotations.html#string-annotations
             ast::Expr::StringLiteral(string) => self.infer_string_type_expression(string),
@@ -237,6 +238,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
                             let dunder_fails = Type::try_call_bin_op(
                                 self.db(),
+                                self.program,
                                 left_type_value,
                                 ast::Operator::BitOr,
                                 right_type_value,
@@ -254,7 +256,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                     (Type::ClassLiteral(class), Type::LiteralValue(literal))
                                     | (Type::LiteralValue(literal), Type::ClassLiteral(class))
                                         if class.metaclass(self.db())
-                                            == KnownClass::Type.to_class_literal(self.db()) =>
+                                            == KnownClass::Type
+                                                .to_class_literal(self.db(), self.program) =>
                                     {
                                         Some(literal)
                                     }
@@ -274,15 +277,19 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 let mut diagnostic =
                                     builder.into_diagnostic("Unsupported `|` operation");
 
-                                if left_type_value.is_equivalent_to(self.db(), right_type_value) {
+                                if left_type_value.is_equivalent_to(
+                                    self.db(),
+                                    self.program,
+                                    right_type_value,
+                                ) {
                                     diagnostic.set_primary_message(format_args!(
                                         "Both operands have type `{}`",
-                                        left_type_value.display(self.db())
+                                        left_type_value.display(self.db(), self.program)
                                     ));
                                     diagnostic.set_concise_message(format_args!(
                                         "Operator `|` is unsupported between \
                                         two objects of type `{}`",
-                                        left_type_value.display(self.db())
+                                        left_type_value.display(self.db(), self.program)
                                     ));
                                 } else {
                                     for (operand, ty) in [
@@ -292,15 +299,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                         diagnostic.annotate(
                                             self.context.secondary(operand).message(format_args!(
                                                 "Has type `{}`",
-                                                ty.display(self.db())
+                                                ty.display(self.db(), self.program)
                                             )),
                                         );
                                     }
                                     diagnostic.set_concise_message(format_args!(
                                         "Operator `|` is unsupported between \
                                         objects of type `{}` and `{}`",
-                                        left_type_value.display(self.db()),
-                                        right_type_value.display(self.db())
+                                        left_type_value.display(self.db(), self.program),
+                                        right_type_value.display(self.db(), self.program)
                                     ));
                                 }
 
@@ -317,8 +324,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                         accessed",
                                     ),
                                     _ => {
-                                        let python_version =
-                                            Program::get(self.db()).python_version(self.db());
+                                        let python_version = self
+                                            .program_file()
+                                            .program(self.db())
+                                            .python_version(self.db());
 
                                         if python_version < PythonVersion::PY314 {
                                             diagnostic.info(format_args!(
@@ -328,6 +337,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                             ));
                                             add_inferred_python_version_hint_to_diagnostic(
                                                 self.db(),
+                                                self.program,
                                                 &mut diagnostic,
                                                 "inferring types",
                                             );
@@ -345,7 +355,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             }
                         }
 
-                        UnionType::from_elements_leave_aliases(self.db(), [left_ty, right_ty])
+                        UnionType::from_elements_leave_aliases(
+                            self.db(),
+                            self.program,
+                            [left_ty, right_ty],
+                        )
                     }
                     ast::Operator::BitAnd => {
                         if let Some(builder) =
@@ -367,6 +381,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 .infer_expression(&binary.right, TypeContext::default());
                             if Type::try_call_bin_op(
                                 self.db(),
+                                self.program,
                                 left_value,
                                 ast::Operator::BitAnd,
                                 right_value,
@@ -383,7 +398,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             }
                         }
 
-                        IntersectionType::from_two_elements(self.db(), left_ty, right_ty)
+                        IntersectionType::from_two_elements(
+                            self.db(),
+                            self.program,
+                            left_ty,
+                            right_ty,
+                        )
                     }
                     // anything else is an invalid annotation:
                     op => {
@@ -513,12 +533,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let inner_type = speculative_builder.infer_type_expression(single_element);
 
                     if inner_type.is_hintable(self.db()) {
-                        let hinted_type =
-                            KnownClass::List.to_specialized_instance(db, &[inner_type]);
+                        let hinted_type = KnownClass::List.to_specialized_instance(
+                            db,
+                            self.program,
+                            &[inner_type],
+                        );
 
                         diagnostic.set_primary_message(format_args!(
                             "Did you mean `{}`?",
-                            hinted_type.display(self.db()),
+                            hinted_type.display(self.db(), self.program),
                         ));
                     }
                 }
@@ -551,7 +574,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             let hinted_type = Type::heterogeneous_tuple(self.db(), inner_types);
                             diagnostic.set_primary_message(format_args!(
                                 "Did you mean `{}`?",
-                                hinted_type.display(self.db()),
+                                hinted_type.display(self.db(), self.program),
                             ));
                         }
                     }
@@ -611,6 +634,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         .infer_expression(operand, TypeContext::default());
                     if let Err(error) = operand_value.try_call_dunder(
                         self.db(),
+                        self.program,
                         "__invert__",
                         CallArguments::none(),
                         TypeContext::default(),
@@ -625,7 +649,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                 }
 
-                operand_ty.negate(self.db())
+                operand_ty.negate(self.db(), self.program)
             }
 
             ast::Expr::UnaryOp(unary) => {
@@ -691,11 +715,14 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let key_type = speculative.infer_type_expression(key);
                     let value_type = speculative.infer_type_expression(value);
                     if key_type.is_hintable(self.db()) && value_type.is_hintable(self.db()) {
-                        let hinted_type = KnownClass::Dict
-                            .to_specialized_instance(self.db(), &[key_type, value_type]);
+                        let hinted_type = KnownClass::Dict.to_specialized_instance(
+                            self.db(),
+                            self.program,
+                            &[key_type, value_type],
+                        );
                         diagnostic.set_primary_message(format_args!(
                             "Did you mean `{}`?",
-                            hinted_type.display(self.db()),
+                            hinted_type.display(self.db(), self.program),
                         ));
                     }
                 }
@@ -718,12 +745,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let inner_type = speculative_builder.infer_type_expression(single_element);
 
                     if inner_type.is_hintable(self.db()) {
-                        let hinted_type =
-                            KnownClass::Set.to_specialized_instance(self.db(), &[inner_type]);
+                        let hinted_type = KnownClass::Set.to_specialized_instance(
+                            self.db(),
+                            self.program,
+                            &[inner_type],
+                        );
 
                         diagnostic.set_primary_message(format_args!(
                             "Did you mean `{}`?",
-                            hinted_type.display(self.db()),
+                            hinted_type.display(self.db(), self.program),
                         ));
                     }
                 }
@@ -1146,7 +1176,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         };
 
                         if let Some(inner_tuple) = element_ty.exact_tuple_instance_spec(self.db()) {
-                            element_types = element_types.concat(self.db(), &inner_tuple);
+                            element_types =
+                                element_types.concat(self.db(), self.program, &inner_tuple);
 
                             if inner_tuple.is_variadic() {
                                 report_too_many_unpacked_tuples();
@@ -1216,6 +1247,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
     /// Given the slice of a `type[]` annotation, return the type that the annotation represents
     fn infer_subclass_of_type_expression(&mut self, slice: &ast::Expr) -> Type<'db> {
+        let program = self.program;
         let invalid_type_argument = |builder: &Self, slice: &ast::Expr| {
             builder.report_invalid_type_expression(
                 slice,
@@ -1229,15 +1261,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             if matches!(slice_ty, Type::ProtocolInstance(_)) {
                 return SubclassOfType::from(
                     builder.db(),
+                    program,
                     todo_type!("type[T] for protocols").expect_dynamic(),
                 );
             }
-            SubclassOfType::try_from_instance(builder.db(), slice_ty).unwrap_or_else(|| {
-                match slice_ty {
+            SubclassOfType::try_from_instance(builder.db(), program, slice_ty).unwrap_or_else(
+                || match slice_ty {
                     Type::Callable(_) => invalid_type_argument(builder, slice),
                     _ => todo_type!("unsupported type[X] special form"),
-                }
-            })
+                },
+            )
         };
 
         match slice {
@@ -1258,7 +1291,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             ast::Expr::NoneLiteral(_) => {
                 self.infer_expression(slice, TypeContext::default());
-                KnownClass::NoneType.to_subclass_of(self.db())
+                KnownClass::NoneType.to_subclass_of(self.db(), self.program)
             }
             ast::Expr::Subscript(
                 subscript @ ast::ExprSubscript {
@@ -1272,6 +1305,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ast::Expr::Tuple(tuple) => {
                             let ty = UnionType::from_elements_leave_aliases(
                                 self.db(),
+                                self.program,
                                 tuple
                                     .iter()
                                     .map(|element| self.infer_subclass_of_type_expression(element)),
@@ -1285,21 +1319,24 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         if class_literal.is_protocol(self.db()) {
                             SubclassOfType::from(
                                 self.db(),
+                                self.program,
                                 todo_type!("type[T] for protocols").expect_dynamic(),
                             )
                         } else if class_literal.is_tuple(self.db()) {
                             let class_type = self
                                 .infer_tuple_type_expression(subscript)
-                                .map(|tuple_type| tuple_type.to_class_type(self.db()))
+                                .map(|tuple_type| tuple_type.to_class_type(self.db(), self.program))
                                 .unwrap_or_else(|| class_literal.default_specialization(self.db()));
-                            SubclassOfType::from(self.db(), class_type)
+                            SubclassOfType::from(self.db(), self.program, class_type)
                         } else {
                             match class_literal.generic_context(self.db()) {
                                 Some(generic_context) => {
+                                    let program = self.program;
                                     let db = self.db();
                                     let specialize = &|types: &[Option<Type<'db>>]| {
                                         SubclassOfType::from(
                                             db,
+                                            program,
                                             class_literal.apply_specialization(db, |_| {
                                                 generic_context
                                                     .specialize_partial(db, types.iter().copied())
@@ -1353,6 +1390,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         mut value_ty: Type<'db>,
         in_type_expression: bool,
     ) -> Type<'db> {
+        let program = self.program;
         let db = self.db();
 
         if let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = value_ty
@@ -1360,14 +1398,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         {
             value_ty = value_ty.apply_type_mapping(
                 db,
+                program,
                 &TypeMapping::BindLegacyTypevars(BindingContext::Definition(definition)),
                 TypeContext::default(),
             );
         }
 
         let mut variables = FxOrderSet::default();
-        value_ty.find_legacy_typevars(db, None, &mut variables);
-        let generic_context = GenericContext::from_typevar_instances(db, variables);
+        value_ty.find_legacy_typevars(db, program, None, &mut variables);
+        let generic_context = GenericContext::from_typevar_instances(db, program, variables);
 
         let scope_id = self.scope();
         let current_typevar_binding_context = self.typevar_binding_context;
@@ -1381,7 +1420,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // instead of two. So until we properly support these, specialize all remaining type
         // variables with a `@Todo` type (since we don't know which of the type arguments
         // belongs to the remaining type variables).
-        if any_over_type(self.db(), value_ty, true, |ty| ty.is_divergent()) {
+        if any_over_type(self.db(), self.program, value_ty, true, |ty| {
+            ty.is_divergent()
+        }) {
             let value_ty = value_ty.apply_specialization(
                 db,
                 generic_context.specialize(
@@ -1397,6 +1438,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 value_ty
                     .in_type_expression(
                         db,
+                        program,
                         scope_id,
                         current_typevar_binding_context,
                         current_inference_flags,
@@ -1417,6 +1459,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 specialized
                     .in_type_expression(
                         db,
+                        program,
                         scope_id,
                         current_typevar_binding_context,
                         current_inference_flags,
@@ -1575,6 +1618,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             specialized_type_alias
                                 .in_type_expression(
                                     self.db(),
+                                    self.program,
                                     self.scope(),
                                     self.typevar_binding_context,
                                     self.inference_flags(),
@@ -1597,12 +1641,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                                 if value_type.is_specialized_generic(self.db()) {
                                     diagnostic.annotate(secondary.message(format_args!(
                                         "Alias to `{}`, which is already specialized",
-                                        value_type.display(self.db())
+                                        value_type.display(self.db(), self.program)
                                     )));
                                 } else {
                                     diagnostic.annotate(secondary.message(format_args!(
                                         "Alias to `{}`, which is not generic",
-                                        value_type.display(self.db())
+                                        value_type.display(self.db(), self.program)
                                     )));
                                 }
                             }
@@ -1617,11 +1661,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     let mut variables = FxOrderSet::default();
                     slice_ty.bind_and_find_all_legacy_typevars(
                         self.db(),
+                        self.program,
                         self.typevar_binding_context,
                         &mut variables,
                     );
                     let generic_context =
-                        GenericContext::from_typevar_instances(self.db(), variables);
+                        GenericContext::from_typevar_instances(self.db(), self.program, variables);
                     Type::Dynamic(DynamicType::UnknownGeneric(generic_context))
                 }
                 KnownInstanceType::LiteralStringAlias(_) => {
@@ -1635,7 +1680,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                         builder.into_diagnostic(format_args!(
                             "`{ty}` is not a generic class",
-                            ty = ty.inner(self.db()).display(self.db())
+                            ty = ty.inner(self.db()).display(self.db(), self.program)
                         ));
                     }
                     Type::unknown()
@@ -1752,6 +1797,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         specialized_class
                             .in_type_expression(
                                 self.db(),
+                                self.program,
                                 self.scope(),
                                 self.typevar_binding_context,
                                 self.inference_flags(),
@@ -1775,8 +1821,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             Type::Union(union) => {
                 let db = self.db();
-                let mut union_builder =
-                    UnionBuilder::new(db).recursively_defined(union.recursively_defined(db));
+                let mut union_builder = UnionBuilder::new(db, self.program)
+                    .recursively_defined(union.recursively_defined(db));
 
                 for (index, element) in union.elements(db).iter().enumerate() {
                     let mut speculative_builder = self.speculate();
@@ -1799,7 +1845,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if let Some(builder) = self.context.report_lint(&INVALID_TYPE_FORM, subscript) {
                     builder.into_diagnostic(format_args!(
                         "Invalid subscript of object of type `{}` in a {}",
-                        value_ty.display(self.db()),
+                        value_ty.display(self.db(), self.program),
                         self.type_expression_context()
                     ));
                 }
@@ -1841,6 +1887,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         }
         let ty = class.to_specialized_instance(
             self.db(),
+            self.program,
             args.iter()
                 .map(|node| self.infer_type_expression(node))
                 .collect::<Vec<_>>(),
@@ -1900,7 +1947,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     if let Some(returns) = return_type {
                         diagnostic.set_primary_message(format_args!(
                             "Did you mean `Callable[..., {}]`?",
-                            returns.display(db)
+                            returns.display(db, builder.program)
                         ));
                     }
                 }
@@ -1975,7 +2022,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     AnnotatedExprContext::TypeExpression,
                 )
                 .inner_type()
-                .in_type_expression(self.db(), self.scope(), None, self.inference_flags())
+                .in_type_expression(
+                    self.db(),
+                    self.program,
+                    self.scope(),
+                    None,
+                    self.inference_flags(),
+                )
                 .unwrap_or_else(|err| {
                     err.into_fallback_type(&self.context, subscript, self.inference_flags())
                 }),
@@ -1997,12 +2050,17 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             },
             SpecialFormType::Optional => {
                 let param_type = self.infer_type_expression(arguments_slice);
-                UnionType::from_elements_leave_aliases(db, [param_type, Type::none(db)])
+                UnionType::from_elements_leave_aliases(
+                    db,
+                    self.program,
+                    [param_type, Type::none(db, self.program)],
+                )
             }
             SpecialFormType::Union => match arguments_slice {
                 ast::Expr::Tuple(t) => {
                     let union_ty = UnionType::from_elements_leave_aliases(
                         db,
+                        self.program,
                         t.iter().map(|elt| self.infer_type_expression(elt)),
                     );
                     self.store_expression_type(arguments_slice, union_ty);
@@ -2023,7 +2081,8 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 };
                 let num_arguments = arguments.len();
                 let negated_type = if num_arguments == 1 {
-                    self.infer_type_expression(&arguments[0]).negate(db)
+                    self.infer_type_expression(&arguments[0])
+                        .negate(db, self.program)
                 } else {
                     if !self.in_string_annotation() {
                         for argument in arguments {
@@ -2051,9 +2110,12 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 };
 
                 let ty = elements
-                    .fold(IntersectionBuilder::new(db), |builder, element| {
-                        builder.add_positive(self.infer_type_expression(element))
-                    })
+                    .fold(
+                        IntersectionBuilder::new(db, self.program),
+                        |builder, element| {
+                            builder.add_positive(self.infer_type_expression(element))
+                        },
+                    )
                     .build();
 
                 if matches!(arguments_slice, ast::Expr::Tuple(_)) {
@@ -2085,7 +2147,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     );
                     Type::unknown()
                 };
-                arg.top_materialization(db)
+                arg.top_materialization(db, self.program)
             }
             SpecialFormType::Bottom => {
                 let arguments = if let ast::Expr::Tuple(tuple) = arguments_slice {
@@ -2111,7 +2173,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     );
                     Type::unknown()
                 };
-                arg.bottom_materialization(db)
+                arg.bottom_materialization(db, self.program)
             }
             SpecialFormType::TypeOf => {
                 let arguments = if let ast::Expr::Tuple(tuple) = arguments_slice {
@@ -2207,15 +2269,16 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 let Some(callable_type) = argument_type
                     .try_upcast_to_callable_with_recursive_fallback(
                         db,
+                        self.program,
                         self.recursive_type_expression_definition(),
                     )
                     .map(|callables| {
                         if special_form == SpecialFormType::RegularCallableTypeOf {
                             callables
                                 .map(|callable| callable.into_regular(db))
-                                .into_type(db)
+                                .into_type(db, self.program)
                         } else {
-                            callables.into_type(db)
+                            callables.into_type(db, self.program)
                         }
                     })
                 else {
@@ -2227,7 +2290,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             "Expected the first argument to `{special_form}` \
                                  to be a callable object, \
                                  but got an object of type `{actual_type}`",
-                            actual_type = argument_type.display(db)
+                            actual_type = argument_type.display(db, self.program)
                         ));
                     }
                     if arguments_slice.is_tuple_expr() {
@@ -2285,7 +2348,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 }
                 _ => {
                     let narrowed = self.infer_type_expression(arguments_slice);
-                    let expanded = narrowed.expand_eagerly(self.db());
+                    let expanded = narrowed.expand_eagerly(self.db(), self.program);
 
                     if expanded.is_divergent() {
                         expanded
@@ -2573,7 +2636,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             }
             ast::Expr::Tuple(tuple) if !tuple.parenthesized => {
                 let mut errors = vec![];
-                let mut builder = UnionBuilder::new(self.db());
+                let mut builder = UnionBuilder::new(self.db(), self.program);
                 for elt in tuple {
                     match self.infer_literal_parameter_type(elt) {
                         Ok(ty) => {
@@ -2629,7 +2692,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     // type aliases to literal types
                     Type::KnownInstance(KnownInstanceType::TypeAliasType(type_alias)) => {
                         let value_ty = type_alias.value_type(self.db());
-                        if value_ty.is_literal_or_union_of_literals(self.db()) {
+                        if value_ty.is_literal_or_union_of_literals(self.db(), self.program) {
                             return Ok(value_ty);
                         }
                     }
@@ -2643,7 +2706,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     }
                     // `Literal[SingletonEnum.Member]`, where `SingletonEnum.Member` simplifies to
                     // just `SingletonEnum`.
-                    Type::NominalInstance(_) if subscript_ty.is_enum(self.db()) => {
+                    Type::NominalInstance(_) if subscript_ty.is_enum(self.db(), self.program) => {
                         return Ok(subscript_ty);
                     }
                     // suppress false positives for e.g. members of functional-syntax enums
@@ -2759,7 +2822,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 if let Type::TypeVar(tvar) = parameters_type
                     && tvar.is_paramspec(self.db())
                 {
-                    return Some(Parameters::paramspec(self.db(), tvar));
+                    return Some(Parameters::paramspec(self.db(), self.program, tvar));
                 }
                 if parameters_type == Type::Dynamic(DynamicType::InvalidConcatenateUnknown) {
                     // Avoid emitting a confusing error here saying that the first argument to
@@ -2862,7 +2925,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
 
         let parameters = self
             .infer_concatenate_tail(last_arg)
-            .map(|tail| Parameters::concatenate(self.db(), prefix_params, tail));
+            .map(|tail| Parameters::concatenate(self.db(), self.program, prefix_params, tail));
 
         if arguments_slice.is_tuple_expr() {
             // TODO: What type to store for the argument slice in `Concatenate` because

--- a/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/type_form.rs
@@ -39,8 +39,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .infer_maybe_standalone_expression(expression, TypeContext::default());
         if matches!(value_ty.resolve_type_alias(self.db()), Type::Never)
             || self.contains_type_form_value(expression, value_ty)
-            || non_type_form_fallback
-                .is_some_and(|alternative| value_ty.is_assignable_to(self.db(), alternative))
+            || non_type_form_fallback.is_some_and(|alternative| {
+                value_ty.is_assignable_to(self.db(), self.program, alternative)
+            })
         {
             return None;
         }
@@ -58,7 +59,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                 .infer_value_expression_impl(expression, TypeContext::new(Some(target)));
             // TODO: Remove this exception once `Unpack` produces a precise type instead of a
             // dynamic placeholder in ordinary expression inference.
-            if contextual_ty.is_assignable_to(self.db(), target)
+            if contextual_ty.is_assignable_to(self.db(), self.program, target)
                 && contextual_ty != Type::Dynamic(DynamicType::TodoUnpack)
             {
                 return None;
@@ -114,7 +115,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             imp(
                                 builder,
                                 expression,
-                                bound_or_constraints.as_type(builder.db()),
+                                bound_or_constraints.as_type(builder.db(), builder.program),
                                 visitor,
                             )
                         })

--- a/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typed_dict.rs
@@ -75,6 +75,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         definition: Option<Definition<'db>>,
         typed_dict_module: TypedDictModule,
     ) -> Type<'db> {
+        let program = self.program;
         let db = self.db();
 
         let ast::Arguments {
@@ -93,9 +94,9 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
         // it would return a class that is a subclass of `Mapping[str, object]`
         // with an unknown set of fields.
         let fallback = || {
-            let spec = &[KnownClass::Str.to_instance(db), Type::object()];
-            let str_object_map = KnownClass::Mapping.to_specialized_subclass_of(db, spec);
-            IntersectionType::from_two_elements(db, str_object_map, Type::unknown())
+            let spec = &[KnownClass::Str.to_instance(db, program), Type::object()];
+            let str_object_map = KnownClass::Mapping.to_specialized_subclass_of(db, program, spec);
+            IntersectionType::from_two_elements(db, program, str_object_map, Type::unknown())
         };
 
         // Emit diagnostic for unsupported variadic arguments.
@@ -164,18 +165,18 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                         ));
                         diagnostic.set_primary_message(format_args!(
                             "Expected either `True` or `False`, got object of type `{}`",
-                            kw_type.display(db)
+                            kw_type.display(db, self.program)
                         ));
                     }
 
                     if arg_name == "total" {
-                        if kw_type.bool(db).is_always_false() {
+                        if kw_type.bool(db, self.program).is_always_false() {
                             total = false;
-                        } else if !kw_type.bool(db).is_always_true() {
+                        } else if !kw_type.bool(db, self.program).is_always_true() {
                             total = true;
                         }
                     } else {
-                        closed = kw_type.bool(db).is_always_true();
+                        closed = kw_type.bool(db, self.program).is_always_true();
                     }
                 }
                 "extra_items" => {
@@ -257,7 +258,11 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             .map(|literal| Name::new(literal.value(db)));
 
         if name.is_none()
-            && !name_type.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            && !name_type.is_assignable_to(
+                db,
+                self.program,
+                KnownClass::Str.to_instance(db, self.program),
+            )
             && let Some(builder) = self.context.report_lint(&INVALID_ARGUMENT_TYPE, name_arg)
         {
             let mut diagnostic = builder.into_diagnostic(format_args!(
@@ -265,7 +270,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             ));
             diagnostic.set_primary_message(format_args!(
                 "Expected `str`, found `{}`",
-                name_type.display(db)
+                name_type.display(db, self.program)
             ));
         } else if let Some(definition) = definition
             && let Some(assigned_name) = definition.name(db)
@@ -347,9 +352,13 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(field.declared_ty)))
             } else if key_ty.is_some_and(|key_ty| {
-                key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
+                key_ty.is_assignable_to(
+                    self.db(),
+                    self.program,
+                    KnownClass::Str.to_instance(self.db(), self.program),
+                )
             }) && let Some(value_ty) =
-                typed_dict.arbitrary_key_initialization_type(self.db())
+                typed_dict.arbitrary_key_initialization_type(self.db(), self.program)
             {
                 self.infer_expression(&item.value, TypeContext::new(Some(value_ty)))
             } else {
@@ -409,6 +418,7 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                     });
                 let keyword_keys = collect_guaranteed_keyword_keys(
                     self.db(),
+                    self.program,
                     typed_dict,
                     arguments,
                     &unpacked_keyword_types,
@@ -486,9 +496,15 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
             {
                 TypeContext::new(Some(field.declared_ty))
             } else if key_ty.is_some_and(|key_ty| {
-                key_ty.is_assignable_to(self.db(), KnownClass::Str.to_instance(self.db()))
+                key_ty.is_assignable_to(
+                    self.db(),
+                    self.program,
+                    KnownClass::Str.to_instance(self.db(), self.program),
+                )
             }) {
-                TypeContext::new(typed_dict.arbitrary_key_initialization_type(self.db()))
+                TypeContext::new(
+                    typed_dict.arbitrary_key_initialization_type(self.db(), self.program),
+                )
             } else {
                 TypeContext::default()
             };
@@ -638,8 +654,10 @@ impl<'db> TypeInferenceBuilder<'db, '_> {
                             "Expected a string-literal key \
                                 in the `fields` dict of `TypedDict()`",
                         );
-                        diagnostic
-                            .set_primary_message(format_args!("Found `{}`", key_type.display(db)));
+                        diagnostic.set_primary_message(format_args!(
+                            "Found `{}`",
+                            key_type.display(db, self.program)
+                        ));
                     }
                 } else {
                     self.infer_expression(value, TypeContext::default());

--- a/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/typevar.rs
@@ -1,5 +1,4 @@
 use crate::{
-    Program,
     reachability::is_reachable,
     types::{
         BindingContext, KnownClass, KnownInstanceType, LintDiagnosticGuard, Truthiness, Type,
@@ -107,7 +106,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     .iter()
                     .map(|expr| {
                         let constraint = self.infer_type_expression(expr);
-                        if constraint.has_typevar_or_typevar_instance(db)
+                        if constraint.has_typevar_or_typevar_instance(db, self.program)
                             && let Some(builder) = self
                                 .context
                                 .report_lint(&INVALID_TYPE_VARIABLE_CONSTRAINTS, expr)
@@ -133,7 +132,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             Some(expr) => {
                 let bound_ty = self.infer_type_expression(expr);
-                if bound_ty.has_typevar_or_typevar_instance(db)
+                if bound_ty.has_typevar_or_typevar_instance(db, self.program)
                     && let Some(builder) =
                         self.context.report_lint(&INVALID_TYPE_VARIABLE_BOUND, expr)
                 {
@@ -241,11 +240,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             // Annotate the diagnostic with the definition span of the default TypeVar.
             let annotate_default_definition = |diagnostic: &mut LintDiagnosticGuard<'_, '_>| {
                 if let Some(definition) = default_typevar.definition(db) {
-                    let file = definition.file(db);
+                    let program_file = definition.program_file(db);
                     diagnostic.annotate(
-                        Annotation::secondary(Span::from(
-                            definition.full_range(db, &parsed_module(db, file).load(db)),
-                        ))
+                        Annotation::secondary(Span::from(definition.full_range(
+                            db,
+                            &parsed_module(db, program_file.versioned_file(db)).load(db),
+                        )))
                         .message(format_args!("`{default_name}` defined here")),
                     );
                 }
@@ -258,7 +258,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     // to the outer bound.
                     if let Some(default_constraints) = default_typevar.constraints(db) {
                         for constraint in default_constraints {
-                            if !constraint.is_assignable_to(db, outer_bound) {
+                            if !constraint.is_assignable_to(db, self.program, outer_bound) {
                                 if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                                     annotate_default_definition(&mut diagnostic);
                                     if let Some(name) = name {
@@ -266,7 +266,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             "Constraint `{constraint}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of `{name}`",
-                                            constraint = constraint.display(db),
+                                            constraint = constraint.display(db, self.program),
                                         ));
                                         diagnostic.set_concise_message(format_args!(
                                             "Default `{default_name}` of TypeVar `{name}` \
@@ -274,23 +274,23 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             of `{name}` because constraint `{constraint}` \
                                             of `{default_name}` is not assignable to \
                                             `{bound}`",
-                                            bound = outer_bound.display(db),
-                                            constraint = constraint.display(db),
+                                            bound = outer_bound.display(db, self.program),
+                                            constraint = constraint.display(db, self.program),
                                         ));
                                     } else {
                                         diagnostic.set_primary_message(format_args!(
                                             "Constraint `{constraint}` of `{default_name}` is \
                                             not assignable to upper bound `{bound}` of \
                                             outer TypeVar",
-                                            constraint = constraint.display(db),
-                                            bound = outer_bound.display(db),
+                                            constraint = constraint.display(db, self.program),
+                                            bound = outer_bound.display(db, self.program),
                                         ));
                                         diagnostic.set_concise_message(format_args!(
                                             "Default of TypeVar is not assignable its upper \
                                             bound `{bound}` because constraint `{constraint}` \
                                             of `{default_name}` is not assignable to `{bound}`",
-                                            bound = outer_bound.display(db),
-                                            constraint = constraint.display(db),
+                                            bound = outer_bound.display(db, self.program),
+                                            constraint = constraint.display(db, self.program),
                                         ));
                                     }
                                 }
@@ -300,7 +300,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     } else {
                         let default_bound =
                             default_typevar.upper_bound(db).unwrap_or_else(Type::object);
-                        if !default_bound.is_assignable_to(db, outer_bound) {
+                        if !default_bound.is_assignable_to(db, self.program, outer_bound) {
                             if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                                 annotate_default_definition(&mut diagnostic);
                                 if let Some(name) = name {
@@ -308,7 +308,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                         "Upper bound `{default_bound}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of `{name}`",
-                                        default_bound = default_bound.display(db),
+                                        default_bound = default_bound.display(db, self.program),
                                     ));
                                     diagnostic.set_concise_message(format_args!(
                                         "Default `{default_name}` of TypeVar `{name}` \
@@ -316,15 +316,15 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             of `{name}` because its upper bound \
                                             `{default_bound}` is not assignable to \
                                             `{bound}`",
-                                        bound = outer_bound.display(db),
-                                        default_bound = default_bound.display(db),
+                                        bound = outer_bound.display(db, self.program),
+                                        default_bound = default_bound.display(db, self.program),
                                     ));
                                 } else {
                                     diagnostic.set_primary_message(format_args!(
                                         "Upper bound `{default_bound}` of default \
                                             `{default_name}` is not assignable to upper \
                                             bound of outer TypeVar",
-                                        default_bound = default_bound.display(db),
+                                        default_bound = default_bound.display(db, self.program),
                                     ));
                                     diagnostic.set_concise_message(format_args!(
                                         "TypeVar default `{default_name}` is not \
@@ -332,8 +332,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             because upper bound of `{default_name}`
                                             (`{default_bound}`) is not assignable
                                             to `{bound}`",
-                                        bound = outer_bound.display(db),
-                                        default_bound = default_bound.display(db),
+                                        bound = outer_bound.display(db, self.program),
+                                        default_bound = default_bound.display(db, self.program),
                                     ));
                                 }
                             }
@@ -348,7 +348,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                         for default_constraint in default_constraints {
                             if !outer
                                 .iter()
-                                .any(|o| default_constraint.is_equivalent_to(db, *o))
+                                .any(|o| default_constraint.is_equivalent_to(db, self.program, *o))
                             {
                                 if let Some(mut diagnostic) = inconsistent_with_constraints() {
                                     annotate_default_definition(&mut diagnostic);
@@ -357,7 +357,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             "Constraint `{constraint}` of default \
                                                 `{default_name}` is not one of the constraints \
                                                 of `{name}`",
-                                            constraint = default_constraint.display(db),
+                                            constraint =
+                                                default_constraint.display(db, self.program),
                                         ));
                                         diagnostic.set_concise_message(format_args!(
                                             "Default `{default_name}` of TypeVar `{name}` \
@@ -365,14 +366,16 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                                 `{name}` because constraint `{constraint}` of \
                                                 `{default_name}` is not one of the constraints \
                                                 of `{name}`",
-                                            constraint = default_constraint.display(db),
+                                            constraint =
+                                                default_constraint.display(db, self.program),
                                         ));
                                     } else {
                                         diagnostic.set_primary_message(format_args!(
                                             "Constraint `{constraint}` of outer TypeVar default \
                                                 `{default_name}` is not one of the constraints \
                                                 of the outer TypeVar",
-                                            constraint = default_constraint.display(db),
+                                            constraint =
+                                                default_constraint.display(db, self.program),
                                         ));
                                         diagnostic.set_concise_message(format_args!(
                                             "Default `{default_name}` of outer TypeVar is \
@@ -380,7 +383,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                             TypeVar because constraint `{constraint}` of \
                                             default `{default_name}` is not one of the \
                                             constraints of the outer TypeVar",
-                                            constraint = default_constraint.display(db),
+                                            constraint =
+                                                default_constraint.display(db, self.program),
                                         ));
                                     }
                                 }
@@ -399,7 +403,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                                 );
                                 diagnostic.info(format_args!(
                                     "`{default_name}` has bound `{default_bound}` but is not constrained",
-                                    default_bound = default_bound.display(db),
+                                    default_bound = default_bound.display(db, self.program),
                                 ));
                             } else {
                                 diagnostic.set_primary_message(
@@ -420,7 +424,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         // Concrete default type checks.
         match bound_or_constraints {
             TypeVarBoundOrConstraints::UpperBound(bound) => {
-                if !default_ty.is_assignable_to(db, bound) {
+                if !default_ty.is_assignable_to(db, self.program, bound) {
                     if let Some(mut diagnostic) = not_assignable_to_upper_bound() {
                         if let Some(name) = name {
                             diagnostic.set_primary_message(format_args!("Default of `{name}`"));
@@ -436,18 +440,18 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     && !constraints
                         .elements(db)
                         .iter()
-                        .any(|c| default_ty.is_equivalent_to(db, *c))
+                        .any(|c| default_ty.is_equivalent_to(db, self.program, *c))
                 {
                     if let Some(mut diagnostic) = inconsistent_with_constraints() {
                         if let Some(name) = name {
                             diagnostic.set_primary_message(format_args!(
                                 "`{default}` is not one of the constraints of `{name}`",
-                                default = default_ty.display(db),
+                                default = default_ty.display(db, self.program),
                             ));
                         } else {
                             diagnostic.set_primary_message(format_args!(
                                 "`{default}` is not one of the constraints",
-                                default = default_ty.display(db),
+                                default = default_ty.display(db, self.program),
                             ));
                         }
                     }
@@ -487,7 +491,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         };
         let expected_binding = BindingContext::Definition(expected_binding_def);
 
-        let outer_tv = find_over_type(db, default_ty, false, |ty| {
+        let outer_tv = find_over_type(db, self.program, default_ty, false, |ty| {
             if let Type::TypeVar(bound_tv) = ty
                 && bound_tv.binding_context(db) != expected_binding
             {
@@ -519,11 +523,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 outer-scope type parameter `{outer_name}` as its default"
         ));
         if let Some(definition) = outer_typevar.definition(db) {
-            let file = definition.file(db);
+            let program_file = definition.program_file(db);
             diagnostic.annotate(
-                Annotation::secondary(Span::from(
-                    definition.full_range(db, &parsed_module(db, file).load(db)),
-                ))
+                Annotation::secondary(Span::from(definition.full_range(
+                    db,
+                    &parsed_module(db, program_file.versioned_file(db)).load(db),
+                )))
                 .message(format_args!("`{outer_name}` defined here")),
             );
         }
@@ -693,14 +698,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             // If the call doesn't create a valid paramspec, we'll emit diagnostics and fall back to
             // just creating a regular instance of `typing.ParamSpec`.
-            KnownClass::ParamSpec.to_instance(context.db())
+            KnownClass::ParamSpec.to_instance(context.db(), context.program())
         }
 
         let db = self.db();
         let arguments = &call_expr.arguments;
         let is_typing_extensions = known_class == KnownClass::ExtensionsParamSpec;
         let assume_all_features = self.in_stub() || is_typing_extensions;
-        let python_version = Program::get(db).python_version(db);
+        let python_version = self.program.python_version(db);
         let have_features_from =
             |version: PythonVersion| assume_all_features || python_version >= version;
 
@@ -767,7 +772,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => infer_variance = true,
                         Truthiness::AlwaysFalse => {}
@@ -784,7 +789,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "covariant" => {
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => covariant = true,
                         Truthiness::AlwaysFalse => {}
@@ -801,7 +806,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "contravariant" => {
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => contravariant = true,
                         Truthiness::AlwaysFalse => {}
@@ -940,14 +945,14 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             }
             // If the call doesn't create a valid typevar, we'll emit diagnostics and fall back to
             // just creating a regular instance of `typing.TypeVar`.
-            KnownClass::TypeVar.to_instance(context.db())
+            KnownClass::TypeVar.to_instance(context.db(), context.program())
         }
 
         let db = self.db();
         let arguments = &call_expr.arguments;
         let is_typing_extensions = known_class == KnownClass::ExtensionsTypeVar;
         let assume_all_features = self.in_stub() || is_typing_extensions;
-        let python_version = Program::get(db).python_version(db);
+        let python_version = self.program.python_version(db);
         let have_features_from =
             |version: PythonVersion| assume_all_features || python_version >= version;
 
@@ -994,7 +999,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "covariant" => {
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => covariant = true,
                         Truthiness::AlwaysFalse => {}
@@ -1011,7 +1016,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                 "contravariant" => {
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => contravariant = true,
                         Truthiness::AlwaysFalse => {}
@@ -1050,7 +1055,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
                     }
                     match self
                         .infer_expression(&kwarg.value, TypeContext::default())
-                        .bool(db)
+                        .bool(db, self.program)
                     {
                         Truthiness::AlwaysTrue => infer_variance = true,
                         Truthiness::AlwaysFalse => {}

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -2,7 +2,6 @@ use ruff_python_ast as ast;
 use ruff_text_size::TextRange;
 use smallvec::SmallVec;
 
-use crate::Db;
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::InferContext;
@@ -14,6 +13,7 @@ use crate::types::{
     LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext,
     TypeVarBoundOrConstraints, UnionBuilder,
 };
+use crate::{Db, Program};
 use ty_python_core::Truthiness;
 
 /// Whether the intersection type is on the left or right side of the comparison.
@@ -128,13 +128,14 @@ pub(super) fn infer_binary_type_comparison<'db>(
     visitor: &BinaryComparisonVisitor<'db>,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
+    let program = context.program();
 
     // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
     // language spec.
     // - `[ast::CompOp::Is]`: return `false` if unequal, `bool` if equal
     // - `[ast::CompOp::IsNot]`: return `true` if unequal, `bool` if equal
     let try_dunder = |policy: MemberLookupPolicy| {
-        let rich_comparison = |op| infer_rich_comparison(db, left, right, op, policy);
+        let rich_comparison = |op| infer_rich_comparison(db, program, left, right, op, policy);
         let membership_test_comparison = |op, range: TextRange| {
             infer_membership_test_comparison(context, left, right, op, range)
         };
@@ -151,33 +152,37 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
             ast::CmpOp::Is => {
-                if left.is_disjoint_from(db, right) {
+                if left.is_disjoint_from(db, program, right) {
                     Ok(Type::bool_literal(false))
-                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
+                } else if left.is_singleton(db, program)
+                    && left.is_equivalent_to(db, program, right)
+                {
                     Ok(Type::bool_literal(true))
                 } else {
-                    Ok(KnownClass::Bool.to_instance(db))
+                    Ok(KnownClass::Bool.to_instance(db, program))
                 }
             }
             ast::CmpOp::IsNot => {
-                if left.is_disjoint_from(db, right) {
+                if left.is_disjoint_from(db, program, right) {
                     Ok(Type::bool_literal(true))
-                } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
+                } else if left.is_singleton(db, program)
+                    && left.is_equivalent_to(db, program, right)
+                {
                     Ok(Type::bool_literal(false))
                 } else {
-                    Ok(KnownClass::Bool.to_instance(db))
+                    Ok(KnownClass::Bool.to_instance(db, program))
                 }
             }
         }
     };
 
     let comparison_truthiness = match op {
-        ast::CmpOp::Eq => equality_truthiness(db, left, right),
-        ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
+        ast::CmpOp::Eq => equality_truthiness(db, program, left, right),
+        ast::CmpOp::NotEq => inequality_truthiness(db, program, left, right),
         _ => Truthiness::Ambiguous,
     };
     if comparison_truthiness != Truthiness::Ambiguous {
-        return Ok(Type::from_truthiness(db, comparison_truthiness));
+        return Ok(Type::from_truthiness(db, program, comparison_truthiness));
     }
 
     let comparison_result = match (left, right) {
@@ -199,7 +204,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         )),
 
         (Type::Union(union), other) => {
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
             for element in union.elements(db) {
                 builder = builder.add(infer_binary_type_comparison(
                     context, *element, op, other, range, visitor,
@@ -208,7 +213,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
             Some(Ok(builder.build()))
         }
         (other, Type::Union(union)) => {
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
             for element in union.elements(db) {
                 builder = builder.add(infer_binary_type_comparison(
                     context, other, op, *element, range, visitor,
@@ -222,7 +227,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
         {
             Some(infer_binary_type_comparison(
                 context,
-                intersection.with_expanded_typevars_and_newtypes(db),
+                intersection.with_expanded_typevars_and_newtypes(db, program),
                 op,
                 right,
                 range,
@@ -236,7 +241,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 context,
                 left,
                 op,
-                intersection.with_expanded_typevars_and_newtypes(db),
+                intersection.with_expanded_typevars_and_newtypes(db, program),
                 range,
                 visitor
             ))
@@ -342,7 +347,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 ),
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     // For constrained TypeVars, check each constraint paired with itself.
-                    let mut builder = UnionBuilder::new(db);
+                    let mut builder = UnionBuilder::new(db, program);
                     for &constraint in constraints.elements(db) {
                         builder = builder.add(infer_binary_type_comparison(
                             context, constraint, op, constraint, range, visitor,
@@ -367,7 +372,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     }),
                 ),
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    let mut builder = UnionBuilder::new(db);
+                    let mut builder = UnionBuilder::new(db, program);
                     for &constraint in constraints.elements(db) {
                         builder = builder.add(infer_binary_type_comparison(
                             context, constraint, op, right, range, visitor,
@@ -392,7 +397,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     }),
                 ),
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                    let mut builder = UnionBuilder::new(db);
+                    let mut builder = UnionBuilder::new(db, program);
                     for &constraint in constraints.elements(db) {
                         builder = builder.add(infer_binary_type_comparison(
                             context, left, op, constraint, range, visitor,
@@ -418,14 +423,14 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         // Even if they are the same value, they may not be the same object.
                         ast::CmpOp::Is => {
                             if n == m {
-                                Ok(KnownClass::Bool.to_instance(db))
+                                Ok(KnownClass::Bool.to_instance(db, program))
                             } else {
                                 Ok(Type::bool_literal(false))
                             }
                         }
                         ast::CmpOp::IsNot => {
                             if n == m {
-                                Ok(KnownClass::Bool.to_instance(db))
+                                Ok(KnownClass::Bool.to_instance(db, program))
                             } else {
                                 Ok(Type::bool_literal(true))
                             }
@@ -502,14 +507,14 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         ast::CmpOp::NotIn => Type::bool_literal(!s2.contains(s1)),
                         ast::CmpOp::Is => {
                             if s1 == s2 {
-                                KnownClass::Bool.to_instance(db)
+                                KnownClass::Bool.to_instance(db, program)
                             } else {
                                 Type::bool_literal(false)
                             }
                         }
                         ast::CmpOp::IsNot => {
                             if s1 == s2 {
-                                KnownClass::Bool.to_instance(db)
+                                KnownClass::Bool.to_instance(db, program)
                             } else {
                                 Type::bool_literal(true)
                             }
@@ -539,14 +544,14 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         }
                         ast::CmpOp::Is => {
                             if b1 == b2 {
-                                KnownClass::Bool.to_instance(db)
+                                KnownClass::Bool.to_instance(db, program)
                             } else {
                                 Type::bool_literal(false)
                             }
                         }
                         ast::CmpOp::IsNot => {
                             if b1 == b2 {
-                                KnownClass::Bool.to_instance(db)
+                                KnownClass::Bool.to_instance(db, program)
                             } else {
                                 Type::bool_literal(true)
                             }
@@ -592,10 +597,10 @@ pub(super) fn infer_binary_type_comparison<'db>(
             Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
         ) => {
             let constraints = ConstraintSetBuilder::new();
-            let left = constraints.load(db, left.constraints(db));
-            let right = constraints.load(db, right.constraints(db));
+            let left = constraints.load(db, program, left.constraints(db));
+            let right = constraints.load(db, program, right.constraints(db));
             let result = left.iff(db, &constraints, right);
-            let equivalent = result.is_always_satisfied(db);
+            let equivalent = result.is_always_satisfied(db, program);
             match op {
                 ast::CmpOp::Eq => Some(Ok(Type::bool_literal(equivalent))),
                 ast::CmpOp::NotEq => Some(Ok(Type::bool_literal(!equivalent))),
@@ -604,8 +609,8 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
 
         (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2)) => nominal1
-            .tuple_spec(db)
-            .and_then(|lhs_tuple| Some((lhs_tuple, nominal2.tuple_spec(db)?)))
+            .tuple_spec(db, program)
+            .and_then(|lhs_tuple| Some((lhs_tuple, nominal2.tuple_spec(db, program)?)))
             .map(|(lhs_tuple, rhs_tuple)| {
                 let tuple_rich_comparison = |rich_op| {
                     visitor.visit((left, op, right), || {
@@ -642,7 +647,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                                 // It's okay to ignore errors here because Python doesn't call `__bool__`
                                 // for different union variants. Instead, this is just for us to
                                 // evaluate a possibly truthy value to `false` or `true`.
-                                ty => match ty.bool(db) {
+                                ty => match ty.bool(db, program) {
                                     Truthiness::AlwaysTrue => any_eq = true,
                                     Truthiness::AlwaysFalse => (),
                                     Truthiness::Ambiguous => any_ambiguous = true,
@@ -655,7 +660,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         } else if !any_ambiguous {
                             Ok(Type::bool_literal(op.is_not_in()))
                         } else {
-                            Ok(KnownClass::Bool.to_instance(db))
+                            Ok(KnownClass::Bool.to_instance(db, program))
                         }
                     }
                     ast::CmpOp::Is | ast::CmpOp::IsNot => {
@@ -671,9 +676,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
                             // It's okay to ignore errors here because Python doesn't call `__bool__`
                             // for `is` and `is not` comparisons. This is an implementation detail
                             // for how we determine the truthiness of a type.
-                            ty => match ty.bool(db) {
+                            ty => match ty.bool(db, program) {
                                 Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
-                                _ => KnownClass::Bool.to_instance(db),
+                                _ => KnownClass::Bool.to_instance(db, program),
                             },
                         })
                     }
@@ -710,9 +715,10 @@ fn infer_binary_intersection_type_comparison<'db>(
         Supported,
     }
 
+    let program = context.program();
     let db = context.db();
 
-    if let Some(alternatives) = intersection.finite_alternative_union(db) {
+    if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
         return match intersection_on {
             IntersectionOn::Left => {
                 infer_binary_type_comparison(context, alternatives, op, other, range, visitor)
@@ -807,9 +813,9 @@ fn infer_binary_intersection_type_comparison<'db>(
     //
     // we would get a result type `Literal[True]` which is too narrow.
     //
-    let mut builder = IntersectionBuilder::new(db);
+    let mut builder = IntersectionBuilder::new(db, program);
 
-    builder = builder.add_positive(KnownClass::Bool.to_instance(db));
+    builder = builder.add_positive(KnownClass::Bool.to_instance(db, program));
 
     let mut state = State::NoPositiveElements;
 
@@ -872,6 +878,7 @@ fn infer_binary_intersection_type_comparison<'db>(
 /// see `<https://docs.python.org/3/reference/datamodel.html#object.__lt__>`
 fn infer_rich_comparison<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
     op: RichCompareOperator,
@@ -882,17 +889,18 @@ fn infer_rich_comparison<'db>(
     let call_dunder = |op: RichCompareOperator, left: Type<'db>, right: Type<'db>| {
         left.try_call_dunder_with_policy(
             db,
+            program,
             op.dunder(),
             &mut CallArguments::positional([right]),
             TypeContext::default(),
             policy,
         )
-        .map(|outcome| outcome.return_type(db))
+        .map(|outcome| outcome.return_type(db, program))
         .ok()
     };
 
     // The reflected dunder has priority if the right-hand side is a strict subclass of the left-hand side.
-    if left != right && right.is_subtype_of(db, left) {
+    if left != right && right.is_subtype_of(db, program, left) {
         call_dunder(op.reflect(), right, left).or_else(|| call_dunder(op, left, right))
     } else {
         call_dunder(op, left, right).or_else(|| call_dunder(op.reflect(), right, left))
@@ -906,7 +914,7 @@ fn infer_rich_comparison<'db>(
             // on `object`, so it does not apply if we skip looking up attributes on `object`.
             && !policy.mro_no_object_fallback()
         {
-            Some(KnownClass::Bool.to_instance(db))
+            Some(KnownClass::Bool.to_instance(db, program))
         } else {
             None
         }
@@ -930,19 +938,21 @@ fn infer_membership_test_comparison<'db>(
     range: TextRange,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
+    let program = context.program();
     let compare_result_opt = match right.try_call_dunder(
         db,
+        program,
         "__contains__",
         CallArguments::positional([left]),
         TypeContext::default(),
     ) {
         // If `__contains__` is available, it is used directly for the membership test.
-        Ok(bindings) => Some(bindings.return_type(db)),
+        Ok(bindings) => Some(bindings.return_type(db, program)),
         // If `__contains__` is not available or possibly unbound,
         // fall back to iteration-based membership test.
         Err(CallDunderError::MethodNotAvailable | CallDunderError::PossiblyUnbound { .. }) => right
-            .try_iterate(db)
-            .map(|_| KnownClass::Bool.to_instance(db))
+            .try_iterate(db, program)
+            .map(|_| KnownClass::Bool.to_instance(db, program))
             .ok(),
         // `__contains__` exists but can't be called with the given arguments.
         Err(CallDunderError::CallError(..)) => None,
@@ -954,15 +964,15 @@ fn infer_membership_test_comparison<'db>(
                 return ty;
             }
 
-            let truthiness = ty.try_bool(db).unwrap_or_else(|err| {
+            let truthiness = ty.try_bool(db, program).unwrap_or_else(|err| {
                 err.report_diagnostic(context, range);
                 err.fallback_truthiness()
             });
 
             match op {
-                MembershipTestCompareOperator::In => Type::from_truthiness(db, truthiness),
+                MembershipTestCompareOperator::In => Type::from_truthiness(db, program, truthiness),
                 MembershipTestCompareOperator::NotIn => {
-                    Type::from_truthiness(db, truthiness.negate())
+                    Type::from_truthiness(db, program, truthiness.negate())
                 }
             }
         })
@@ -987,13 +997,14 @@ fn infer_tuple_rich_comparison<'db>(
     visitor: &BinaryComparisonVisitor<'db>,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
+    let program = context.program();
     match (left, right) {
         // Both fixed-length: perform full lexicographic comparison.
         (TupleSpec::Fixed(left), TupleSpec::Fixed(right)) => {
             let left_iter = left.iter_all_elements();
             let right_iter = right.iter_all_elements();
 
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
 
             for (l_ty, r_ty) in left_iter.zip(right_iter) {
                 let pairwise_eq_result = infer_binary_type_comparison(
@@ -1006,12 +1017,14 @@ fn infer_tuple_rich_comparison<'db>(
                 )
                 .expect("infer_binary_type_comparison should never return None for `CmpOp::Eq`");
 
-                match pairwise_eq_result.try_bool(db).unwrap_or_else(|err| {
-                    // TODO: We should, whenever possible, pass the range of the left and right elements
-                    //   instead of the range of the whole tuple.
-                    err.report_diagnostic(context, range);
-                    err.fallback_truthiness()
-                }) {
+                match pairwise_eq_result
+                    .try_bool(db, program)
+                    .unwrap_or_else(|err| {
+                        // TODO: We should, whenever possible, pass the range of the left and right elements
+                        //   instead of the range of the whole tuple.
+                        err.report_diagnostic(context, range);
+                        err.fallback_truthiness()
+                    }) {
                     // - AlwaysTrue : Continue to the next pair for lexicographic comparison
                     Truthiness::AlwaysTrue => continue,
                     // - AlwaysFalse:
@@ -1077,7 +1090,7 @@ fn infer_tuple_rich_comparison<'db>(
         (TupleSpec::Variable(_), _) | (_, TupleSpec::Variable(_))
             if matches!(op, RichCompareOperator::Eq | RichCompareOperator::Ne) =>
         {
-            Ok(KnownClass::Bool.to_instance(db))
+            Ok(KnownClass::Bool.to_instance(db, program))
         }
 
         // At least one variable-length: check all elements that could potentially be compared.
@@ -1096,12 +1109,12 @@ fn infer_tuple_rich_comparison<'db>(
                 Ok::<_, UnsupportedComparisonError<'db>>(())
             })?;
 
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
             for result in results {
                 builder = builder.add(result);
             }
             // Length comparison (when all elements are equal) returns bool.
-            builder = builder.add(KnownClass::Bool.to_instance(db));
+            builder = builder.add(KnownClass::Bool.to_instance(db, program));
 
             Ok(builder.build())
         }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -1,17 +1,45 @@
 use super::builder::TypeInferenceBuilder;
 use crate::db::tests::{TestDb, setup_db};
 use crate::place::symbol;
-use crate::place::{ConsideredDefinitions, Place, global_symbol};
-use crate::types::{KnownClass, KnownInstanceType, check_types};
+use crate::place::{ConsideredDefinitions, Place, PlaceAndQualifiers};
+use crate::types::{KnownClass, KnownInstanceType};
+use ruff_db::Db as _;
 use ruff_db::diagnostic::{Diagnostic, DiagnosticId};
 use ruff_db::files::{File, system_path_to_file};
 use ruff_db::system::DbWithWritableSystem as _;
+use ruff_db::system::SystemPathBuf;
 use ruff_db::testing::{assert_function_query_was_not_run, assert_function_query_was_run};
+use ruff_python_ast::PythonVersion;
+use ty_module_resolver::SearchPathSettings;
 use ty_python_core::definition::Definition;
-use ty_python_core::scope::FileScopeId;
-use ty_python_core::{global_scope, place_table, semantic_index, use_def_map};
+use ty_python_core::environment::{InferenceSettings, ProgramFile};
+use ty_python_core::platform::PythonPlatform;
+use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
+use ty_python_core::scope::{FileScopeId, ScopeId};
+use ty_python_core::{SemanticIndex, place_table, use_def_map};
+use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
 use super::*;
+
+fn program_file(db: &TestDb, file: File) -> ProgramFile<'_> {
+    ProgramFile::new(db, db.program(), file)
+}
+
+fn semantic_index(db: &TestDb, file: File) -> &SemanticIndex<'_> {
+    ty_python_core::semantic_index(db, program_file(db, file))
+}
+
+fn global_scope(db: &TestDb, file: File) -> ScopeId<'_> {
+    ty_python_core::global_scope(db, program_file(db, file))
+}
+
+fn global_symbol<'db>(db: &'db TestDb, file: File, name: &str) -> PlaceAndQualifiers<'db> {
+    crate::place::global_symbol(db, program_file(db, file), name)
+}
+
+fn check_types(db: &TestDb, file: File) -> Vec<Diagnostic> {
+    crate::types::check_types(db, program_file(db, file))
+}
 
 #[track_caller]
 fn get_symbol<'db>(
@@ -21,17 +49,18 @@ fn get_symbol<'db>(
     symbol_name: &str,
 ) -> Place<'db> {
     let file = system_path_to_file(db, file_name).expect("file to exist");
-    let module = parsed_module(db, file).load(db);
+    let program_file = program_file(db, file);
+    let module = program_file.parsed(db).load(db);
     let index = semantic_index(db, file);
     let mut file_scope_id = FileScopeId::global();
-    let mut scope = file_scope_id.to_scope_id(db, file);
+    let mut scope = file_scope_id.to_scope_id(db, program_file);
     for expected_scope_name in scopes {
         file_scope_id = index
             .child_scopes(file_scope_id)
             .next()
             .unwrap_or_else(|| panic!("scope of {expected_scope_name}"))
             .0;
-        scope = file_scope_id.to_scope_id(db, file);
+        scope = file_scope_id.to_scope_id(db, program_file);
         assert_eq!(scope.name(db, &module), *expected_scope_name);
     }
 
@@ -73,6 +102,212 @@ fn assert_revealed_type(db: &TestDb, filename: &str, expected: &str) {
 }
 
 #[test]
+fn one_file_can_be_analyzed_for_multiple_platforms() -> anyhow::Result<()> {
+    let db = crate::db::tests::TestDbBuilder::new()
+        .with_file(
+            "/src/main.py",
+            "import os\nimport sys\nreveal_type(sys.platform)\nreveal_type(os.name)\n",
+        )
+        .build()?;
+    let file = system_path_to_file(&db, "/src/main.py")?;
+    let default = db.program();
+
+    let program = |platform: &str| {
+        Program::create(
+            &db,
+            &ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: default.python_version(&db),
+                    source: PythonVersionSource::Default,
+                },
+                python_platform: PythonPlatform::Identifier(platform.to_string()),
+                search_paths: default.search_paths(&db).clone(),
+            },
+        )
+    };
+    let diagnostics =
+        |platform| crate::types::check_types(&db, ProgramFile::new(&db, program(platform), file));
+
+    let linux = diagnostics("linux");
+    let windows = diagnostics("win32");
+    let messages = |diagnostics: &[Diagnostic]| {
+        diagnostics
+            .iter()
+            .filter_map(|diagnostic| {
+                diagnostic
+                    .primary_annotation()?
+                    .get_message()
+                    .map(str::to_owned)
+            })
+            .collect::<Vec<_>>()
+    };
+
+    assert_eq!(
+        messages(&linux),
+        ["`Literal[\"linux\"]`", "`Literal[\"posix\"]`"]
+    );
+    assert_eq!(
+        messages(&windows),
+        ["`Literal[\"win32\"]`", "`Literal[\"nt\"]`"]
+    );
+    Ok(())
+}
+
+#[test]
+fn one_file_can_be_analyzed_for_multiple_python_versions() -> anyhow::Result<()> {
+    let db = crate::db::tests::TestDbBuilder::new()
+        .with_file(
+            "/src/main.py",
+            "import sys\nif sys.version_info >= (3, 12):\n    value = 1\nelse:\n    value = 'old'\nreveal_type(value)\n",
+        )
+        .build()?;
+    let file = system_path_to_file(&db, "/src/main.py")?;
+    let default = db.program();
+    let revealed = |version| {
+        let program = Program::create(
+            &db,
+            &ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version,
+                    source: PythonVersionSource::Default,
+                },
+                python_platform: default.python_platform(&db).clone(),
+                search_paths: default.search_paths(&db).clone(),
+            },
+        );
+        let diagnostics = crate::types::check_types(&db, ProgramFile::new(&db, program, file));
+        diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.id() == DiagnosticId::RevealedType)
+            .unwrap_or_else(|| panic!("missing reveal diagnostic: {diagnostics:#?}"))
+            .primary_annotation()
+            .and_then(|annotation| annotation.get_message())
+            .unwrap()
+            .to_owned()
+    };
+
+    assert_eq!(revealed(PythonVersion::PY311), "`Literal[\"old\"]`");
+    assert_eq!(revealed(PythonVersion::PY312), "`Literal[1]`");
+    Ok(())
+}
+
+#[test]
+fn known_classes_are_looked_up_in_the_selected_python_version() {
+    let db = setup_db();
+    let default = db.program();
+    let class_name = |version| {
+        let program = Program::create(
+            &db,
+            &ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version,
+                    source: PythonVersionSource::Default,
+                },
+                python_platform: default.python_platform(&db).clone(),
+                search_paths: default.search_paths(&db).clone(),
+            },
+        );
+        let class = KnownClass::EnumType
+            .try_to_class_literal(&db, program)
+            .unwrap();
+        assert_eq!(
+            class.definition(&db).program_file(&db).program(&db),
+            program
+        );
+        class.name(&db).to_string()
+    };
+
+    assert_eq!(class_name(PythonVersion::PY310), "EnumMeta");
+    // Typeshed models `EnumType` as an alias to the class still named `EnumMeta`.
+    assert_eq!(class_name(PythonVersion::PY311), "EnumMeta");
+}
+
+#[test]
+fn imported_files_inherit_the_importers_search_paths() -> anyhow::Result<()> {
+    let mut db = crate::db::tests::TestDbBuilder::new()
+        .with_file(
+            "/src/main.py",
+            "from dependency import value\nreveal_type(value)\n",
+        )
+        .build()?;
+    db.write_file("/first/dependency.py", "value = 1\n")?;
+    db.write_file("/second/dependency.py", "value = 'second'\n")?;
+    let file = system_path_to_file(&db, "/src/main.py")?;
+    let default = db.program();
+
+    let revealed = |root: &str| -> anyhow::Result<String> {
+        let search_paths = SearchPathSettings::new(vec![SystemPathBuf::from(root)])
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)?;
+        let program = Program::create(
+            &db,
+            &ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: default.python_version(&db),
+                    source: PythonVersionSource::Default,
+                },
+                python_platform: default.python_platform(&db).clone(),
+                search_paths,
+            },
+        );
+        let diagnostics = crate::types::check_types(&db, ProgramFile::new(&db, program, file));
+        Ok(diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.id() == DiagnosticId::RevealedType)
+            .unwrap_or_else(|| panic!("missing reveal diagnostic: {diagnostics:#?}"))
+            .primary_annotation()
+            .and_then(|annotation| annotation.get_message())
+            .unwrap()
+            .to_owned())
+    };
+
+    assert_eq!(revealed("/first")?, "`Literal[1]`");
+    assert_eq!(revealed("/second")?, "`Literal[\"second\"]`");
+    Ok(())
+}
+
+#[test]
+fn replace_imports_with_any_forks_inference_environments() -> anyhow::Result<()> {
+    let db = crate::db::tests::TestDbBuilder::new()
+        .with_file(
+            "/src/main.py",
+            "from dependency import value\nreveal_type(value)\n",
+        )
+        .with_file("/src/dependency.py", "value = 1\n")
+        .build()?;
+    let file = system_path_to_file(&db, "/src/main.py")?;
+
+    let revealed = |replace_imports_with_any| {
+        let program = db.program().with_inference_settings(
+            &db,
+            InferenceSettings {
+                replace_imports_with_any,
+            },
+        );
+        let diagnostics = crate::types::check_types(&db, ProgramFile::new(&db, program, file));
+        diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.id() == DiagnosticId::RevealedType)
+            .unwrap_or_else(|| panic!("missing reveal diagnostic: {diagnostics:#?}"))
+            .primary_annotation()
+            .and_then(|annotation| annotation.get_message())
+            .unwrap()
+            .to_owned()
+    };
+
+    assert_eq!(
+        revealed(ty_module_resolver::ModuleGlobSet::empty()),
+        "`Literal[1]`"
+    );
+    assert_eq!(
+        revealed(ty_module_resolver::ModuleGlobSet::from_patterns([
+            "dependency"
+        ])?),
+        "`Any`"
+    );
+    Ok(())
+}
+
+#[test]
 fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     assert!(
         std::mem::size_of::<DefinitionTypes>()
@@ -89,7 +324,7 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
     )?;
 
     let file = system_path_to_file(&db, "/src/definitions.py").unwrap();
-    let module = parsed_module(&db, file).load(&db);
+    let module = program_file(&db, file).parsed(&db).load(&db);
     let first_assignment = module.syntax().body[0].as_assign_stmt().unwrap();
     let second_assignment = module.syntax().body[1].as_assign_stmt().unwrap();
     let first = semantic_index(&db, file)
@@ -241,6 +476,7 @@ fn pep695_type_params() {
             ",
     )
     .unwrap();
+    let program = db.program();
 
     let check_typevar = |var: &'static str,
                          display: &'static str,
@@ -248,11 +484,11 @@ fn pep695_type_params() {
                          constraints: Option<&[&'static str]>,
                          default: Option<&'static str>| {
         let var_ty = get_symbol(&db, "src/a.py", &["f"], var).expect_type();
-        assert_eq!(var_ty.display(&db).to_string(), display);
+        assert_eq!(var_ty.display(&db, program).to_string(), display);
 
         let expected_name_ty = format!(r#"Literal["{var}"]"#);
-        let name_ty = var_ty.member(&db, "__name__").place.expect_type();
-        assert_eq!(name_ty.display(&db).to_string(), expected_name_ty);
+        let name_ty = var_ty.member(&db, program, "__name__").place.expect_type();
+        assert_eq!(name_ty.display(&db, program).to_string(), expected_name_ty);
 
         let Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) = var_ty else {
             panic!("expected TypeVar");
@@ -261,13 +497,13 @@ fn pep695_type_params() {
         assert_eq!(
             typevar
                 .upper_bound(&db)
-                .map(|ty| ty.display(&db).to_string()),
+                .map(|ty| ty.display(&db, program).to_string()),
             upper_bound.map(std::borrow::ToOwned::to_owned)
         );
         assert_eq!(
             typevar.constraints(&db).map(|tys| tys
                 .iter()
-                .map(|ty| ty.display(&db).to_string())
+                .map(|ty| ty.display(&db, program).to_string())
                 .collect::<Vec<_>>()),
             constraints.map(|strings| strings
                 .iter()
@@ -277,7 +513,7 @@ fn pep695_type_params() {
         assert_eq!(
             typevar
                 .default_type(&db)
-                .map(|ty| ty.display(&db).to_string()),
+                .map(|ty| ty.display(&db, program).to_string()),
             default.map(std::borrow::ToOwned::to_owned)
         );
     };
@@ -545,20 +781,22 @@ fn dependency_public_symbol_type_change() -> anyhow::Result<()> {
         ("/src/a.py", "from foo import x"),
         ("/src/foo.py", "x: int = 10\ndef foo(): ..."),
     ])?;
+    let program = db.program();
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
     let x_ty = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty.display(&db).to_string(), "int");
+    assert_eq!(x_ty.display(&db, program).to_string(), "int");
 
     // Change `x` to a different value
     db.write_file("/src/foo.py", "x: bool = True\ndef foo(): ...")?;
+    let program = db.program();
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
 
     let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty_2.display(&db).to_string(), "bool");
+    assert_eq!(x_ty_2.display(&db, program).to_string(), "bool");
 
     Ok(())
 }
@@ -571,21 +809,23 @@ fn dependency_internal_symbol_change() -> anyhow::Result<()> {
         ("/src/a.py", "from foo import x"),
         ("/src/foo.py", "x: int = 10\ndef foo(): y = 1"),
     ])?;
+    let program = db.program();
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
     let x_ty = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty.display(&db).to_string(), "int");
+    assert_eq!(x_ty.display(&db, program).to_string(), "int");
 
     db.write_file("/src/foo.py", "x: int = 10\ndef foo(): pass")?;
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
 
     db.clear_salsa_events();
+    let program = db.program();
 
     let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty_2.display(&db).to_string(), "int");
+    assert_eq!(x_ty_2.display(&db, program).to_string(), "int");
 
     let events = db.take_salsa_events();
 
@@ -607,21 +847,23 @@ fn dependency_unrelated_symbol() -> anyhow::Result<()> {
         ("/src/a.py", "from foo import x"),
         ("/src/foo.py", "x: int = 10\ny: bool = True"),
     ])?;
+    let program = db.program();
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
     let x_ty = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty.display(&db).to_string(), "int");
+    assert_eq!(x_ty.display(&db, program).to_string(), "int");
 
     db.write_file("/src/foo.py", "x: int = 10\ny: bool = False")?;
 
     let a = system_path_to_file(&db, "/src/a.py").unwrap();
 
     db.clear_salsa_events();
+    let program = db.program();
 
     let x_ty_2 = global_symbol(&db, a, "x").place.expect_type();
 
-    assert_eq!(x_ty_2.display(&db).to_string(), "int");
+    assert_eq!(x_ty_2.display(&db, program).to_string(), "int");
 
     let events = db.take_salsa_events();
 
@@ -638,7 +880,7 @@ fn dependency_unrelated_symbol() -> anyhow::Result<()> {
 fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, file_main).load(db);
+        let ast = program_file(db, file_main).parsed(db).load(db);
         // Get the second statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
@@ -665,10 +907,11 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
         x = y = C().attr
         "#,
     )?;
+    let program = db.program();
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
     let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-    assert_eq!(attr_ty.display(&db).to_string(), "int | None");
+    assert_eq!(attr_ty.display(&db, program).to_string(), "int | None");
 
     // Change the type of `attr` to `str | None`; this should trigger the type of `x` to be re-inferred
     db.write_dedented(
@@ -682,8 +925,9 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str | None");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str | None");
         db.take_salsa_events()
     };
     assert_function_query_was_run(
@@ -706,8 +950,9 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str | None");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str | None");
         db.take_salsa_events()
     };
 
@@ -727,7 +972,7 @@ fn dependency_implicit_instance_attribute() -> anyhow::Result<()> {
 fn dependency_own_instance_member() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, file_main).load(db);
+        let ast = program_file(db, file_main).parsed(db).load(db);
         // Get the second statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
@@ -756,10 +1001,11 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
         x = y = C().attr
         "#,
     )?;
+    let program = db.program();
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
     let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-    assert_eq!(attr_ty.display(&db).to_string(), "int | None");
+    assert_eq!(attr_ty.display(&db, program).to_string(), "int | None");
 
     // Change the type of `attr` to `str | None`; this should trigger the type of `x` to be re-inferred
     db.write_dedented(
@@ -775,8 +1021,9 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str | None");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str | None");
         db.take_salsa_events()
     };
     assert_function_query_was_run(
@@ -801,8 +1048,9 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str | None");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str | None");
         db.take_salsa_events()
     };
 
@@ -820,7 +1068,7 @@ fn dependency_own_instance_member() -> anyhow::Result<()> {
 fn dependency_implicit_class_member() -> anyhow::Result<()> {
     fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
         let file_main = system_path_to_file(db, "/src/main.py").unwrap();
-        let ast = parsed_module(db, file_main).load(db);
+        let ast = program_file(db, file_main).parsed(db).load(db);
         // Get the third statement in `main.py` (x = …) and extract the expression
         // node on the right-hand side:
         let x_rhs_node = &ast.syntax().body[2].as_assign_stmt().unwrap().value;
@@ -852,10 +1100,11 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
         x = y = C().class_attr
         "#,
     )?;
+    let program = db.program();
 
     let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
     let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-    assert_eq!(attr_ty.display(&db).to_string(), "int");
+    assert_eq!(attr_ty.display(&db, program).to_string(), "int");
 
     // Change the type of `class_attr` to `str`; this should trigger the type of `x` to be re-inferred
     db.write_dedented(
@@ -873,8 +1122,9 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str");
         db.take_salsa_events()
     };
     assert_function_query_was_run(
@@ -901,8 +1151,9 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
 
     let events = {
         db.clear_salsa_events();
+        let program = db.program();
         let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
-        assert_eq!(attr_ty.display(&db).to_string(), "str");
+        assert_eq!(attr_ty.display(&db, program).to_string(), "str");
         db.take_salsa_events()
     };
 
@@ -938,14 +1189,15 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
         a = b = foo()
         "#,
     )?;
+    let program = db.program();
 
     let bar = system_path_to_file(&db, "src/bar.py")?;
     let a = global_symbol(&db, bar, "a").place;
 
-    assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db));
+    assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db, program));
     let events = db.take_salsa_events();
 
-    let module = parsed_module(&db, bar).load(&db);
+    let module = program_file(&db, bar).parsed(&db).load(&db);
     let call = &*module.syntax().body[1].as_assign_stmt().unwrap().value;
     let foo_call = semantic_index(&db, bar).expression(call);
 
@@ -967,13 +1219,14 @@ fn call_type_doesnt_rerun_when_only_callee_changed() -> anyhow::Result<()> {
         "#,
     )?;
     db.clear_salsa_events();
+    let program = db.program();
 
     let a = global_symbol(&db, bar, "a").place;
 
-    assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db));
+    assert_eq!(a.expect_type(), KnownClass::Int.to_instance(&db, program));
     let events = db.take_salsa_events();
 
-    let module = parsed_module(&db, bar).load(&db);
+    let module = program_file(&db, bar).parsed(&db).load(&db);
     let call = &*module.syntax().body[1].as_assign_stmt().unwrap().value;
     let foo_call = semantic_index(&db, bar).expression(call);
 

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
-use ruff_python_ast::name::Name;
+use ruff_python_ast::{PythonVersion, name::Name};
 use ty_module_resolver::{ModuleName, file_to_module};
 
 use super::protocol_class::ProtocolInterface;
@@ -29,7 +29,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, CallableType, ClassBase, ClassLiteral, ErrorContext,
     FindLegacyTypeVarsVisitor, LiteralValueTypeKind, TypeContext, TypeMapping, VarianceInferable,
 };
-use crate::{Db, FxOrderSet};
+use crate::{Db, FxOrderSet, Program};
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
 use ty_python_core::definition::Definition;
 
@@ -119,11 +119,13 @@ impl<'db> Type<'db> {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::ExactTuple(tuple)))
     }
 
-    pub(crate) const fn sys_version_info() -> Self {
+    pub(crate) const fn sys_version_info(version: PythonVersion) -> Self {
         // Keep construction query-free: resolving the backing typeshed class here is on the hot
         // path for projects with many version guards. Resolve it lazily when class behavior is
         // actually needed instead.
-        Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo))
+        Type::NominalInstance(NominalInstanceType(NominalInstanceInner::SysVersionInfo(
+            version,
+        )))
     }
 
     pub(crate) const fn is_nominal_instance(self) -> bool {
@@ -138,9 +140,16 @@ impl<'db> Type<'db> {
     }
 
     /// Return `true` if `self` is a nominal instance of the given known class.
-    pub(crate) fn is_instance_of(self, db: &'db dyn Db, known_class: KnownClass) -> bool {
+    pub(crate) fn is_instance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        known_class: KnownClass,
+    ) -> bool {
         match self {
-            Type::NominalInstance(instance) => instance.class(db).is_known(db, known_class),
+            Type::NominalInstance(instance) => {
+                instance.class(db, program).is_known(db, known_class)
+            }
             _ => false,
         }
     }
@@ -167,7 +176,7 @@ impl<'db> Type<'db> {
 }
 
 /// A type representing the set of runtime objects which are instances of a certain nominal class.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub struct NominalInstanceType<'db>(
     // Keep this field private, so that the only way of constructing `NominalInstanceType` instances
     // is through the `Type::instance` constructor function.
@@ -176,16 +185,19 @@ pub struct NominalInstanceType<'db>(
 
 pub(super) fn walk_nominal_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: Program,
     nominal: NominalInstanceType<'db>,
     visitor: &V,
 ) {
     match nominal.0 {
         NominalInstanceInner::ExactTuple(tuple) => {
-            walk_tuple_type(db, tuple, visitor);
+            walk_tuple_type(db, program, tuple, visitor);
         }
         NominalInstanceInner::Object => {}
-        NominalInstanceInner::NonTuple(class) => visitor.visit_type(db, class.class(db).into()),
-        NominalInstanceInner::SysVersionInfo => {}
+        NominalInstanceInner::NonTuple(class) => {
+            visitor.visit_type(db, program, class.class(db).into());
+        }
+        NominalInstanceInner::SysVersionInfo(_) => {}
     }
 }
 
@@ -211,8 +223,8 @@ impl<'db> NominalInstanceType<'db> {
     /// As of 2026-02-16, this method is not used in any crates in the Ruff
     /// repo, but is exposed as a public API for external users of
     /// `ty_python_semantic`.
-    pub fn class_name(&self, db: &'db dyn Db) -> &'db Name {
-        self.class(db).name(db)
+    pub fn class_name(&self, db: &'db dyn Db, program: crate::Program) -> &'db Name {
+        self.class(db, program).name(db)
     }
 
     /// Returns the fully qualified module name of the module in which the class
@@ -225,25 +237,33 @@ impl<'db> NominalInstanceType<'db> {
     /// As of 2026-02-16, this method is not used in any crates in the Ruff
     /// repo, but is exposed as a public API for external users of
     /// `ty_python_semantic`.
-    pub fn class_module_name(&self, db: &'db dyn Db) -> Option<&'db ModuleName> {
-        let file = self.class(db).class_literal(db).file(db);
-        file_to_module(db, file).map(|module| module.name(db))
+    pub fn class_module_name(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<&'db ModuleName> {
+        let class = self.class(db, program).class_literal(db).as_static()?;
+        file_to_module(db, class.body_scope(db).program_file(db).resolver_file(db))
+            .map(|module| module.name(db))
     }
 
-    pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
+    pub(super) fn class(&self, db: &'db dyn Db, program: crate::Program) -> ClassType<'db> {
         match self.0 {
-            NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db),
+            NominalInstanceInner::ExactTuple(tuple) => tuple.to_class_type(db, program),
             NominalInstanceInner::NonTuple(class) => class.class(db),
-            NominalInstanceInner::SysVersionInfo => {
-                sys_version_info_class(db).unwrap_or_else(|| ClassType::object(db))
-            }
-            NominalInstanceInner::Object => ClassType::object(db),
+            NominalInstanceInner::SysVersionInfo(_) => sys_version_info_class(db, program)
+                .unwrap_or_else(|| ClassType::object(db, program)),
+            NominalInstanceInner::Object => ClassType::object(db, program),
         }
     }
 
     /// Returns the class literal for this instance.
-    pub(super) fn class_literal(&self, db: &'db dyn Db) -> ClassLiteral<'db> {
-        self.class(db).class_literal(db)
+    pub(super) fn class_literal(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> ClassLiteral<'db> {
+        self.class(db, program).class_literal(db)
     }
 
     /// Returns the [`KnownClass`] that this is a nominal instance of, or `None` if it is not an
@@ -252,13 +272,20 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => Some(KnownClass::Tuple),
             NominalInstanceInner::NonTuple(class) => class.class(db).known(db),
-            NominalInstanceInner::SysVersionInfo => Some(KnownClass::VersionInfo),
+            NominalInstanceInner::SysVersionInfo(_) => Some(KnownClass::VersionInfo),
             NominalInstanceInner::Object => Some(KnownClass::Object),
         }
     }
 
     pub(super) const fn is_sys_version_info(self) -> bool {
-        matches!(self.0, NominalInstanceInner::SysVersionInfo)
+        matches!(self.0, NominalInstanceInner::SysVersionInfo(_))
+    }
+
+    pub(super) const fn sys_version_info_version(self) -> Option<PythonVersion> {
+        match self.0 {
+            NominalInstanceInner::SysVersionInfo(version) => Some(version),
+            _ => None,
+        }
     }
 
     /// Returns whether this is a nominal instance of a particular [`KnownClass`].
@@ -270,12 +297,16 @@ impl<'db> NominalInstanceType<'db> {
     ///
     /// I.e., for the type `tuple[int, str]`, this will return the tuple spec `[int, str]`.
     /// For a subclass of `tuple[int, str]`, it will return the same tuple spec.
-    pub(super) fn tuple_spec(&self, db: &'db dyn Db) -> Option<Cow<'db, TupleSpec<'db>>> {
+    pub(super) fn tuple_spec(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Cow<'db, TupleSpec<'db>>> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
-            NominalInstanceInner::SysVersionInfo => {
-                Some(Cow::Owned(TupleSpec::version_info_spec(db)))
-            }
+            NominalInstanceInner::SysVersionInfo(version) => Some(Cow::Owned(
+                TupleSpec::version_info_spec(db, program, version),
+            )),
             NominalInstanceInner::Object => None,
             NominalInstanceInner::NonTuple(class) => {
                 let class = class.class(db);
@@ -314,7 +345,7 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn is_definition_generic(self, db: &'db dyn Db) -> bool {
         match self.0 {
             NominalInstanceInner::ExactTuple(_) => true,
-            NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => false,
+            NominalInstanceInner::SysVersionInfo(_) | NominalInstanceInner::Object => false,
             NominalInstanceInner::NonTuple(class) => class.class(db).is_generic(),
         }
     }
@@ -333,7 +364,7 @@ impl<'db> NominalInstanceType<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => Some(Cow::Borrowed(tuple.tuple(db))),
             NominalInstanceInner::NonTuple(_)
-            | NominalInstanceInner::SysVersionInfo
+            | NominalInstanceInner::SysVersionInfo(_)
             | NominalInstanceInner::Object => None,
         }
     }
@@ -347,7 +378,7 @@ impl<'db> NominalInstanceType<'db> {
         let class = match self.0 {
             NominalInstanceInner::NonTuple(class) => class.class(db),
             NominalInstanceInner::ExactTuple(_)
-            | NominalInstanceInner::SysVersionInfo
+            | NominalInstanceInner::SysVersionInfo(_)
             | NominalInstanceInner::Object => return None,
         };
         let (class_literal, specialization) = class.static_class_literal(db)?;
@@ -382,23 +413,24 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
                 Some(Self(NominalInstanceInner::ExactTuple(
-                    tuple.recursive_type_normalized_impl(db, div, nested)?,
+                    tuple.recursive_type_normalized_impl(db, program, div, nested)?,
                 )))
             }
-            NominalInstanceInner::SysVersionInfo => {
-                Some(Self(NominalInstanceInner::SysVersionInfo))
+            NominalInstanceInner::SysVersionInfo(version) => {
+                Some(Self(NominalInstanceInner::SysVersionInfo(version)))
             }
             NominalInstanceInner::Object => Some(Self(NominalInstanceInner::Object)),
             NominalInstanceInner::NonTuple(class) => {
                 let transformed = class
                     .class(db)
-                    .recursive_type_normalized_impl(db, div, nested)?;
+                    .recursive_type_normalized_impl_with_program(db, program, div, nested)?;
                 Some(Self(NominalInstanceInner::NonTuple(
                     class.with_class(db, transformed),
                 )))
@@ -414,7 +446,7 @@ impl<'db> NominalInstanceType<'db> {
             // See:
             // https://docs.python.org/3/reference/expressions.html#parenthesized-forms
             NominalInstanceInner::ExactTuple(_) | NominalInstanceInner::Object => false,
-            NominalInstanceInner::SysVersionInfo => true,
+            NominalInstanceInner::SysVersionInfo(_) => true,
             NominalInstanceInner::NonTuple(class) => class
                 .class(db)
                 .known(db)
@@ -423,42 +455,46 @@ impl<'db> NominalInstanceType<'db> {
         }
     }
 
-    pub(super) fn is_single_valued(self, db: &'db dyn Db) -> bool {
+    pub(super) fn is_single_valued(self, db: &'db dyn Db, program: crate::Program) -> bool {
         match self.0 {
-            NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db),
+            NominalInstanceInner::ExactTuple(tuple) => tuple.is_single_valued(db, program),
             NominalInstanceInner::Object => false,
-            NominalInstanceInner::SysVersionInfo => true,
+            NominalInstanceInner::SysVersionInfo(_) => true,
             NominalInstanceInner::NonTuple(class) => class
                 .class(db)
                 .known(db)
                 .and_then(KnownClass::is_single_valued)
-                .or_else(|| Some(self.tuple_spec(db)?.is_single_valued(db)))
+                .or_else(|| Some(self.tuple_spec(db, program)?.is_single_valued(db, program)))
                 .unwrap_or_else(|| is_single_member_enum(db, class.class(db).class_literal(db))),
         }
     }
 
-    pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        SubclassOfType::from(db, self.class(db))
+    pub(super) fn to_meta_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        SubclassOfType::from(db, program, self.class(db, program))
     }
 
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
-                Type::tuple(tuple.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Type::tuple(tuple.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
-            NominalInstanceInner::SysVersionInfo => Type::NominalInstance(self),
+            NominalInstanceInner::SysVersionInfo(_) => Type::NominalInstance(self),
             NominalInstanceInner::Object => Type::object(),
             NominalInstanceInner::NonTuple(class) => {
-                let transformed =
-                    class
-                        .class(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                let transformed = class.class(db).apply_type_mapping_impl_with_program(
+                    db,
+                    program,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                );
                 Type::NominalInstance(Self(NominalInstanceInner::NonTuple(
                     class.with_class(db, transformed),
                 )))
@@ -469,15 +505,16 @@ impl<'db> NominalInstanceType<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         match self.0 {
             NominalInstanceInner::ExactTuple(tuple) => {
-                tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                tuple.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
-            NominalInstanceInner::SysVersionInfo | NominalInstanceInner::Object => {}
+            NominalInstanceInner::SysVersionInfo(_) | NominalInstanceInner::Object => {}
             NominalInstanceInner::NonTuple(class) => {
                 class
                     .class(db)
@@ -501,6 +538,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         protocol: ProtocolInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // `ty` might satisfy the protocol nominally, if `protocol` is a class-based protocol and
         // `ty` has the protocol class in its MRO. This is a much cheaper check than the
         // structural check we perform below, so we do it first to avoid the structural check when
@@ -523,7 +561,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             if result
                 .union(db, self.constraints, nominally_satisfied)
-                .is_always_satisfied(db)
+                .is_always_satisfied(db, program)
             {
                 return result;
             }
@@ -547,7 +585,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // missing. When collecting error context, we continue and let the structural check
         // below report per-member errors instead.
         if !self.is_context_collection_enabled()
-            && !has_all_protocol_members_defined(db, ty, protocol)
+            && !has_all_protocol_members_defined(db, program, ty, protocol)
         {
             return result;
         }
@@ -560,23 +598,22 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 protocol.interface(db),
             )
         } else {
-            protocol
-                .inner
-                .interface(db)
-                .members(db)
-                .when_all(db, self.constraints, |member| {
-                    self.type_satisfies_protocol_member(db, ty, &member)
-                })
+            protocol.inner.interface(db).members(db).when_all(
+                db,
+                program,
+                self.constraints,
+                |member| self.type_satisfies_protocol_member(db, ty, &member),
+            )
         };
         if let Some(context) = self.report_context()
-            && structurally_satisfied.is_never_satisfied(db)
+            && structurally_satisfied.is_never_satisfied(db, program)
         {
             context.push(ErrorContext::TypeNotCompatibleWithProtocol {
                 ty,
                 protocol: Type::ProtocolInstance(protocol),
             });
         }
-        result.or(db, self.constraints, || structurally_satisfied)
+        result.or(db, program, self.constraints, || structurally_satisfied)
     }
 
     pub(super) fn check_nominal_instance_pair(
@@ -585,13 +622,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: NominalInstanceType<'db>,
         target: NominalInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         match (source.0, target.0) {
             (_, NominalInstanceInner::Object) => self.always(),
             (
                 NominalInstanceInner::ExactTuple(source_tuple),
                 NominalInstanceInner::ExactTuple(target_tuple),
             ) => self.check_tuple_type_pair(db, source_tuple, target_tuple),
-            _ => self.check_class_pair(db, source.class(db), target.class(db)),
+            _ => self.check_class_pair(db, source.class(db, program), target.class(db, program)),
         }
     }
 }
@@ -616,28 +654,33 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: NominalInstanceType<'db>,
         right: NominalInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let mut result = self.never();
         if left.is_object() || right.is_object() {
             return result;
         }
-        if let Some(left_spec) = left.tuple_spec(db) {
-            if let Some(right_spec) = right.tuple_spec(db) {
+        if let Some(left_spec) = left.tuple_spec(db, program) {
+            if let Some(right_spec) = right.tuple_spec(db, program) {
                 let compatible = self.check_tuple_spec_pair(db, &left_spec, &right_spec);
                 if result
                     .union(db, self.constraints, compatible)
-                    .is_always_satisfied(db)
+                    .is_always_satisfied(db, program)
                 {
                     return result;
                 }
             }
         }
 
-        result.or(db, self.constraints, || {
+        result.or(db, program, self.constraints, || {
             ConstraintSet::from_bool(
                 self.constraints,
                 !left
-                    .class(db)
-                    .could_coexist_in_mro_with_disjointness_checker(db, right.class(db), self),
+                    .class(db, program)
+                    .could_coexist_in_mro_with_disjointness_checker(
+                        db,
+                        right.class(db, program),
+                        self,
+                    ),
             )
         })
     }
@@ -657,7 +700,7 @@ impl get_size2::GetSize for ExplicitAnyInstanceClass<'_> {}
 ///
 /// Interning the uncommon explicit-`Any` case lets this type store the additional semantic bit
 /// without increasing the size of [`Type`].
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 enum NominalInstanceClass<'db> {
     Plain(ClassType<'db>),
     InheritsFromExplicitAny(ExplicitAnyInstanceClass<'db>),
@@ -696,7 +739,7 @@ impl<'db> NominalInstanceClass<'db> {
 /// [`NominalInstanceType`] is split into several variants internally as a pure optimization to
 /// avoid having to materialize the [`ClassType`] for tuple instances where it would be unnecessary
 /// (this is somewhat expensive!).
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 enum NominalInstanceInner<'db> {
     /// An instance of `object`.
     ///
@@ -716,12 +759,12 @@ enum NominalInstanceInner<'db> {
     /// because they represent "all instances of a class that is a tuple subclass".
     NonTuple(NominalInstanceClass<'db>),
     /// The singleton `sys.version_info` value.
-    SysVersionInfo,
+    SysVersionInfo(PythonVersion),
 }
 
-fn sys_version_info_class(db: &dyn Db) -> Option<ClassType<'_>> {
+fn sys_version_info_class(db: &dyn Db, program: crate::Program) -> Option<ClassType<'_>> {
     KnownClass::VersionInfo
-        .try_to_class_literal(db)
+        .try_to_class_literal(db, program)
         .map(|class| class.default_specialization(db))
 }
 
@@ -732,14 +775,19 @@ pub(crate) struct SliceLiteral {
 }
 
 impl<'db> VarianceInferable<'db> for NominalInstanceType<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
-        self.class(db).variance_of(db, typevar)
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.class(db, program).variance_of(db, program, typevar)
     }
 }
 
 /// A `ProtocolInstanceType` represents the set of all possible runtime objects
 /// that conform to the interface described by a certain protocol.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub struct ProtocolInstanceType<'db> {
     pub(super) inner: Protocol<'db>,
 
@@ -751,11 +799,12 @@ pub struct ProtocolInstanceType<'db> {
 
 pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     protocol: ProtocolInstanceType<'db>,
     visitor: &V,
 ) {
     if visitor.should_visit_lazy_type_attributes() {
-        walk_protocol_interface(db, protocol.inner.interface(db), visitor);
+        walk_protocol_interface(db, program, protocol.inner.interface(db), visitor);
     } else {
         match protocol.inner {
             Protocol::FromClass(class) => {
@@ -764,7 +813,7 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
                 }
             }
             Protocol::Synthesized(synthesized) => {
-                walk_protocol_interface(db, synthesized.interface(), visitor);
+                walk_protocol_interface(db, program, synthesized.interface(), visitor);
             }
         }
     }
@@ -772,9 +821,12 @@ pub(super) fn walk_protocol_instance_type<'db, V: super::visitor::TypeVisitor<'d
 
 impl<'db> ProtocolInstanceType<'db> {
     /// Return `true` if this is the standard-library `Hashable` protocol.
-    pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
-        self.to_nominal_instance()
-            .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
+    pub(super) fn is_hashable(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.to_nominal_instance().is_some_and(|instance| {
+            instance
+                .class(db, program)
+                .is_known(db, KnownClass::Hashable)
+        })
     }
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`
@@ -810,9 +862,9 @@ impl<'db> ProtocolInstanceType<'db> {
     }
 
     /// Return the meta-type of this protocol-instance type.
-    pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(super) fn to_meta_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self.inner {
-            Protocol::FromClass(class) => SubclassOfType::from(db, class),
+            Protocol::FromClass(class) => SubclassOfType::from(db, program, class),
 
             // TODO: we can and should do better here.
             //
@@ -827,7 +879,7 @@ impl<'db> ProtocolInstanceType<'db> {
             //     reveal_type(type(x))                 # mypy: "type[def (builtins.int) -> builtins.str]"
             //     reveal_type(type(x).__call__)        # mypy: "def (*args: Any, **kwds: Any) -> Any"
             // ```
-            Protocol::Synthesized(_) => KnownClass::Type.to_instance(db),
+            Protocol::Synthesized(_) => KnownClass::Type.to_instance(db, program),
         }
     }
 
@@ -837,10 +889,11 @@ impl<'db> ProtocolInstanceType<'db> {
     /// as `object` (since `object` is the universal set of *all* possible runtime objects!).
     /// Such a protocol is therefore an equivalent type to `object`, which would in fact be
     /// normalised to `object`.
-    pub(super) fn is_equivalent_to_object(self, db: &'db dyn Db) -> bool {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, ()| true, heap_size=ruff_memory_usage::heap_size)]
+    pub(super) fn is_equivalent_to_object(self, db: &'db dyn Db, program: Program) -> bool {
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, ()| true, heap_size=ruff_memory_usage::heap_size)]
         fn is_equivalent_to_object_inner<'db>(
             db: &'db dyn Db,
+            program: Program,
             protocol: ProtocolInstanceType<'db>,
             _: (),
         ) -> bool {
@@ -850,6 +903,7 @@ impl<'db> ProtocolInstanceType<'db> {
             let signature_relation_visitor = SignatureRelationVisitor::default();
             let materialization_visitor = ApplyTypeMappingVisitor::default();
             let checker = TypeRelationChecker::subtyping(
+                program,
                 &constraints,
                 InferableTypeVars::None,
                 &relation_visitor,
@@ -859,34 +913,45 @@ impl<'db> ProtocolInstanceType<'db> {
             );
             checker
                 .check_type_satisfies_protocol(db, Type::object(), protocol)
-                .is_always_satisfied(db)
+                .is_always_satisfied(db, program)
         }
 
-        is_equivalent_to_object_inner(db, self, ())
+        is_equivalent_to_object_inner(db, program, self, ())
     }
 
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(Self {
-            inner: self.inner.recursive_type_normalized_impl(db, div, nested)?,
+            inner: self
+                .inner
+                .recursive_type_normalized_impl(db, program, div, nested)?,
             _phantom: PhantomData,
         })
     }
 
-    pub(crate) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+    pub(crate) fn instance_member(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        name: &str,
+    ) -> PlaceAndQualifiers<'db> {
         match self.inner {
             Protocol::FromClass(class) => class.instance_member(db, name),
-            Protocol::Synthesized(synthesized) => synthesized.interface().instance_member(db, name),
+            Protocol::Synthesized(synthesized) => {
+                synthesized.interface().instance_member(db, program, name)
+            }
         }
     }
 
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -896,7 +961,7 @@ impl<'db> ProtocolInstanceType<'db> {
                 Self::from_class(class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
             Protocol::Synthesized(synthesized) => Self::synthesized(
-                synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                synthesized.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             ),
         }
     }
@@ -904,6 +969,7 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -913,7 +979,13 @@ impl<'db> ProtocolInstanceType<'db> {
                 class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
             }
             Protocol::Synthesized(synthesized) => {
-                synthesized.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                synthesized.find_legacy_typevars_impl(
+                    db,
+                    program,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
             }
         }
     }
@@ -924,14 +996,19 @@ impl<'db> ProtocolInstanceType<'db> {
 }
 
 impl<'db> VarianceInferable<'db> for ProtocolInstanceType<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
-        self.inner.variance_of(db, typevar)
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.inner.variance_of(db, program, typevar)
     }
 }
 
 /// An enumeration of the two kinds of protocol types: those that originate from a class
 /// definition in source code, and those that are synthesized from a set of members.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) enum Protocol<'db> {
     FromClass(ProtocolClass<'db>),
     Synthesized(SynthesizedProtocolType<'db>),
@@ -949,6 +1026,7 @@ impl<'db> Protocol<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -957,7 +1035,7 @@ impl<'db> Protocol<'db> {
                 class.recursive_type_normalized_impl(db, div, nested)?,
             )),
             Self::Synthesized(synthesized) => Some(Self::Synthesized(
-                synthesized.recursive_type_normalized_impl(db, div, nested)?,
+                synthesized.recursive_type_normalized_impl(db, program, div, nested)?,
             )),
         }
     }
@@ -968,11 +1046,16 @@ impl<'db> Protocol<'db> {
 }
 
 impl<'db> VarianceInferable<'db> for Protocol<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         match self {
-            Protocol::FromClass(class_type) => class_type.variance_of(db, typevar),
+            Protocol::FromClass(class_type) => class_type.variance_of(db, program, typevar),
             Protocol::Synthesized(synthesized_protocol_type) => {
-                synthesized_protocol_type.variance_of(db, typevar)
+                synthesized_protocol_type.variance_of(db, program, typevar)
             }
         }
     }
@@ -989,7 +1072,7 @@ mod synthesized_protocol {
     use ty_python_core::definition::Definition;
 
     /// A "synthesized" protocol type that is dissociated from a class definition in source code.
-    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, salsa::SalsaValue, get_size2::GetSize)]
     pub(in crate::types) struct SynthesizedProtocolType<'db>(ProtocolInterface<'db>);
 
     impl<'db> SynthesizedProtocolType<'db> {
@@ -1000,25 +1083,27 @@ mod synthesized_protocol {
         pub(super) fn apply_type_mapping_impl<'a>(
             self,
             db: &'db dyn Db,
+            program: crate::Program,
             type_mapping: &TypeMapping<'a, 'db>,
             tcx: TypeContext<'db>,
             visitor: &ApplyTypeMappingVisitor<'db>,
         ) -> Self {
             Self(
                 self.0
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             )
         }
 
         pub(super) fn find_legacy_typevars_impl(
             self,
             db: &'db dyn Db,
+            program: crate::Program,
             binding_context: Option<Definition<'db>>,
             typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
             visitor: &FindLegacyTypeVarsVisitor<'db>,
         ) {
             self.0
-                .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                .find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
 
         pub(in crate::types) fn interface(self) -> ProtocolInterface<'db> {
@@ -1028,11 +1113,13 @@ mod synthesized_protocol {
         pub(in crate::types) fn recursive_type_normalized_impl(
             self,
             db: &'db dyn Db,
+            program: crate::Program,
             div: Type<'db>,
             nested: bool,
         ) -> Option<Self> {
             Some(Self(
-                self.0.recursive_type_normalized_impl(db, div, nested)?,
+                self.0
+                    .recursive_type_normalized_impl(db, program, div, nested)?,
             ))
         }
     }
@@ -1041,9 +1128,10 @@ mod synthesized_protocol {
         fn variance_of(
             self,
             db: &'db dyn Db,
+            program: crate::Program,
             typevar: BoundTypeVarIdentity<'db>,
         ) -> TypeVarVariance {
-            self.0.variance_of(db, typevar)
+            self.0.variance_of(db, program, typevar)
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -516,9 +516,13 @@ impl<'db> NominalInstanceType<'db> {
             }
             NominalInstanceInner::SysVersionInfo(_) | NominalInstanceInner::Object => {}
             NominalInstanceInner::NonTuple(class) => {
-                class
-                    .class(db)
-                    .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                class.class(db).find_legacy_typevars_impl(
+                    db,
+                    program,
+                    binding_context,
+                    typevars,
+                    visitor,
+                );
             }
         }
     }
@@ -976,7 +980,7 @@ impl<'db> ProtocolInstanceType<'db> {
     ) {
         match self.inner {
             Protocol::FromClass(class) => {
-                class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                class.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
             Protocol::Synthesized(synthesized) => {
                 synthesized.find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/iteration.rs
+++ b/crates/ty_python_semantic/src/types/iteration.rs
@@ -22,11 +22,13 @@ use ty_python_core::EvaluationMode;
 /// recursively unpacking starred elements whose iterables are also fixed-length.
 pub(crate) fn extract_fixed_length_iterable_element_types<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     iterable: &ast::Expr,
     mut expression_type: impl FnMut(&ast::Expr) -> Type<'db>,
 ) -> Option<Box<[Type<'db>]>> {
     fn extend_fixed_length_iterable<'db>(
         db: &'db dyn Db,
+        program: crate::Program,
         iterable: &ast::Expr,
         expression_type: &mut impl FnMut(&ast::Expr) -> Type<'db>,
         element_types: &mut Vec<Type<'db>>,
@@ -42,6 +44,7 @@ pub(crate) fn extract_fixed_length_iterable_element_types<'db>(
                 if let ast::Expr::Starred(starred) = element {
                     extend_fixed_length_iterable(
                         db,
+                        program,
                         starred.value.as_ref(),
                         expression_type,
                         element_types,
@@ -54,14 +57,20 @@ pub(crate) fn extract_fixed_length_iterable_element_types<'db>(
         }
 
         let iterable_type = expression_type(iterable);
-        let spec = iterable_type.try_iterate(db).ok()?;
+        let spec = iterable_type.try_iterate(db, program).ok()?;
         let tuple = spec.as_fixed_length()?;
         element_types.extend(tuple.all_elements().iter().copied());
         Some(())
     }
 
     let mut element_types = Vec::new();
-    extend_fixed_length_iterable(db, iterable, &mut expression_type, &mut element_types)?;
+    extend_fixed_length_iterable(
+        db,
+        program,
+        iterable,
+        &mut expression_type,
+        &mut element_types,
+    )?;
     Some(element_types.into_boxed_slice())
 }
 
@@ -70,9 +79,16 @@ impl<'db> Type<'db> {
     ///
     /// This method should only be used outside of type checking because it omits any errors.
     /// For type checking, use [`try_iterate`](Self::try_iterate) instead.
-    pub(super) fn iterate(self, db: &'db dyn Db) -> Cow<'db, TupleSpec<'db>> {
-        self.try_iterate(db)
-            .unwrap_or_else(|err| Cow::Owned(TupleSpec::homogeneous(err.fallback_element_type(db))))
+    pub(super) fn iterate(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Cow<'db, TupleSpec<'db>> {
+        self.try_iterate(db, program).unwrap_or_else(|err| {
+            Cow::Owned(TupleSpec::homogeneous(
+                err.fallback_element_type(db, program),
+            ))
+        })
     }
 
     /// Given the type of an object that is iterated over in some way,
@@ -86,17 +102,20 @@ impl<'db> Type<'db> {
     pub(super) fn try_iterate(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
     ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
-        self.try_iterate_with_mode(db, EvaluationMode::Sync)
+        self.try_iterate_with_mode(db, program, EvaluationMode::Sync)
     }
 
     pub(super) fn try_iterate_with_mode(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         mode: EvaluationMode,
     ) -> Result<Cow<'db, TupleSpec<'db>>, IterationError<'db>> {
         fn non_async_special_case<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
         ) -> Option<Cow<'db, TupleSpec<'db>>> {
             // We will not infer precise heterogeneous tuple specs for literals with lengths above this threshold.
@@ -106,8 +125,8 @@ impl<'db> Type<'db> {
             const MAX_TUPLE_LENGTH: usize = 128;
 
             match ty {
-                Type::NominalInstance(nominal) => nominal.tuple_spec(db),
-                Type::NewTypeInstance(newtype) => non_async_special_case(db, newtype.concrete_base_type(db)),
+                Type::NominalInstance(nominal) => nominal.tuple_spec(db, program),
+                Type::NewTypeInstance(newtype) => non_async_special_case(db, program, newtype.concrete_base_type(db)),
                 Type::GenericAlias(alias) if alias.origin(db).is_tuple(db) => {
                     Some(Cow::Owned(TupleSpec::homogeneous(todo_type!(
                         "*tuple[] annotations"
@@ -123,7 +142,7 @@ impl<'db> Type<'db> {
                                     .map(|b| Type::int_literal( i64::from(*b))),
                             )
                         } else {
-                            TupleSpec::homogeneous(KnownClass::Int.to_instance(db))
+                            TupleSpec::homogeneous(KnownClass::Int.to_instance(db, program))
                         };
                         Some(Cow::Owned(spec))
                     },
@@ -155,22 +174,31 @@ impl<'db> Type<'db> {
                     Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())))
                 }
                 Type::TypeAlias(alias) => {
-                    non_async_special_case(db, alias.value_type(db))
+                    non_async_special_case(db, program, alias.value_type(db))
                 }
                 Type::TypeVar(tvar) => match tvar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        non_async_special_case(db, bound)
+                        non_async_special_case(db, program, bound)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => non_async_special_case(db, constraints.as_type(db)),
+                    TypeVarBoundOrConstraints::Constraints(constraints) => non_async_special_case(db, program, constraints.as_type(db, program)),
                 },
                 Type::Union(union) => {
                     let elements = union.elements(db);
                     if elements.len() < MAX_TUPLE_LENGTH {
                         let mut elements_iter = elements.iter();
-                        let first_element_spec = elements_iter.next()?.try_iterate_with_mode(db, EvaluationMode::Sync).ok()?;
+                        let first_element_spec = elements_iter
+                            .next()?
+                            .try_iterate_with_mode(db, program, EvaluationMode::Sync)
+                            .ok()?;
                         let mut builder = TupleSpecBuilder::from(&*first_element_spec);
                         for element in elements_iter {
-                            builder = builder.union(db, &*element.try_iterate_with_mode(db, EvaluationMode::Sync).ok()?);
+                            builder = builder.union(
+                                db,
+                                program,
+                                &*element
+                                    .try_iterate_with_mode(db, program, EvaluationMode::Sync)
+                                    .ok()?,
+                            );
                         }
                         Some(Cow::Owned(builder.build()))
                     } else {
@@ -191,12 +219,16 @@ impl<'db> Type<'db> {
                     // - A simpler type (if it fully simplified).
                     //
                     // We then iterate over the flattened type.
-                    let flattened = ty.flatten_typevars(db);
+                    let flattened = ty.flatten_typevars(db, program);
 
                     // If flattening didn't change anything, iterate the intersection directly.
                     if flattened == ty {
                         let mut specs_iter = intersection.positive_elements_or_object(db).filter_map(
-                            |element| element.try_iterate_with_mode(db, EvaluationMode::Sync).ok(),
+                            |element| {
+                                element
+                                    .try_iterate_with_mode(db, program, EvaluationMode::Sync)
+                                    .ok()
+                            },
                         );
                         let first_spec = specs_iter.next()?;
                         let mut builder = TupleSpecBuilder::from(&*first_spec);
@@ -204,7 +236,7 @@ impl<'db> Type<'db> {
                             // Two tuples cannot have incompatible specs unless the tuples themselves
                             // are disjoint. `IntersectionBuilder` eagerly simplifies such
                             // intersections to `Never`, so this should always return `Some`.
-                            let Some(intersected) = builder.intersect(db, &spec) else {
+                            let Some(intersected) = builder.intersect(db, program, &spec) else {
                                 return Some(Cow::Owned(TupleSpec::homogeneous(Type::unknown())));
                             };
                             builder = intersected;
@@ -213,10 +245,10 @@ impl<'db> Type<'db> {
                     }
 
                     // Flattening changed the type; recursively iterate the flattened result.
-                    flattened.try_iterate(db).ok()
+                    flattened.try_iterate(db, program).ok()
                 }
                 Type::EnumComplement(complement) => {
-                    non_async_special_case(db, complement.remaining_literal_union(db))
+                    non_async_special_case(db, program, complement.remaining_literal_union(db))
                 }
                 // N.B. This special case isn't strictly necessary, it's just an obvious optimization
                 Type::Dynamic(_) => Some(Cow::Owned(TupleSpec::homogeneous(ty))),
@@ -253,9 +285,9 @@ impl<'db> Type<'db> {
 
         if mode.is_async() {
             if let Type::Intersection(_) = self {
-                let flattened = self.flatten_typevars(db);
+                let flattened = self.flatten_typevars(db, program);
                 if flattened != self {
-                    return flattened.try_iterate_with_mode(db, mode);
+                    return flattened.try_iterate_with_mode(db, program, mode);
                 }
             }
 
@@ -266,21 +298,27 @@ impl<'db> Type<'db> {
                 iterator
                     .try_call_dunder(
                         db,
+                        program,
                         "__anext__",
                         CallArguments::none(),
                         TypeContext::default(),
                     )
-                    .map(|dunder_anext_outcome| dunder_anext_outcome.return_type(db).try_await(db))
+                    .map(|dunder_anext_outcome| {
+                        dunder_anext_outcome
+                            .return_type(db, program)
+                            .try_await(db, program)
+                    })
             };
 
             return match self.try_call_dunder(
                 db,
+                program,
                 "__aiter__",
                 CallArguments::none(),
                 TypeContext::default(),
             ) {
                 Ok(dunder_aiter_bindings) => {
-                    let iterator = dunder_aiter_bindings.return_type(db);
+                    let iterator = dunder_aiter_bindings.return_type(db, program);
                     match try_call_dunder_anext_on_iterator(iterator) {
                         Ok(Ok(result)) => Ok(Cow::Owned(TupleSpec::homogeneous(result))),
                         Ok(Err(AwaitError::InvalidReturnType(..))) => {
@@ -299,7 +337,7 @@ impl<'db> Type<'db> {
                     bindings: dunder_aiter_bindings,
                     ..
                 }) => {
-                    let iterator = dunder_aiter_bindings.return_type(db);
+                    let iterator = dunder_aiter_bindings.return_type(db, program);
                     match try_call_dunder_anext_on_iterator(iterator) {
                         Ok(_) => Err(IterationError::IterCallError {
                             kind: CallErrorKind::PossiblyNotCallable,
@@ -326,39 +364,42 @@ impl<'db> Type<'db> {
             };
         }
 
-        if let Some(special_case) = non_async_special_case(db, self) {
+        if let Some(special_case) = non_async_special_case(db, program, self) {
             return Ok(special_case);
         }
 
         let try_call_dunder_getitem = || {
             self.try_call_dunder(
                 db,
+                program,
                 "__getitem__",
-                CallArguments::positional([KnownClass::Int.to_instance(db)]),
+                CallArguments::positional([KnownClass::Int.to_instance(db, program)]),
                 TypeContext::default(),
             )
-            .map(|dunder_getitem_outcome| dunder_getitem_outcome.return_type(db))
+            .map(|dunder_getitem_outcome| dunder_getitem_outcome.return_type(db, program))
         };
 
         let try_call_dunder_next_on_iterator = |iterator: Type<'db>| {
             iterator
                 .try_call_dunder(
                     db,
+                    program,
                     "__next__",
                     CallArguments::none(),
                     TypeContext::default(),
                 )
-                .map(|dunder_next_outcome| dunder_next_outcome.return_type(db))
+                .map(|dunder_next_outcome| dunder_next_outcome.return_type(db, program))
         };
 
         let dunder_iter_result = self
             .try_call_dunder(
                 db,
+                program,
                 "__iter__",
                 CallArguments::none(),
                 TypeContext::default(),
             )
-            .map(|dunder_iter_outcome| dunder_iter_outcome.return_type(db));
+            .map(|dunder_iter_outcome| dunder_iter_outcome.return_type(db, program));
 
         match dunder_iter_result {
             Ok(iterator) => {
@@ -380,7 +421,7 @@ impl<'db> Type<'db> {
                 bindings: dunder_iter_outcome,
                 unbound_on: unbound_on_iter,
             }) => {
-                let iterator = dunder_iter_outcome.return_type(db);
+                let iterator = dunder_iter_outcome.return_type(db, program);
 
                 match try_call_dunder_next_on_iterator(iterator) {
                     Ok(dunder_next_return) => {
@@ -395,6 +436,7 @@ impl<'db> Type<'db> {
                                 // No diagnostic is emitted; iteration will always succeed!
                                 Cow::Owned(TupleSpec::homogeneous(UnionType::from_two_elements(
                                     db,
+                                    program,
                                     dunder_next_return,
                                     dunder_getitem_return_type,
                                 )))
@@ -488,24 +530,28 @@ pub(super) enum IterationError<'db> {
 }
 
 impl<'db> IterationError<'db> {
-    pub(super) fn fallback_element_type(&self, db: &'db dyn Db) -> Type<'db> {
-        self.element_type(db).unwrap_or(Type::unknown())
+    pub(super) fn fallback_element_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        self.element_type(db, program).unwrap_or(Type::unknown())
     }
 
     /// Returns the element type if it is known, or `None` if the type is never iterable.
-    fn element_type(&self, db: &'db dyn Db) -> Option<Type<'db>> {
+    fn element_type(&self, db: &'db dyn Db, program: crate::Program) -> Option<Type<'db>> {
         let return_type = |result: Result<Bindings<'db>, CallDunderError<'db>>| {
             result
-                .map(|outcome| Some(outcome.return_type(db)))
-                .unwrap_or_else(|call_error| call_error.return_type(db))
+                .map(|outcome| Some(outcome.return_type(db, program)))
+                .unwrap_or_else(|call_error| call_error.return_type(db, program))
         };
 
         match self {
             Self::IterReturnsInvalidIterator {
                 dunder_error, mode, ..
-            } => dunder_error.return_type(db).and_then(|ty| {
+            } => dunder_error.return_type(db, program).and_then(|ty| {
                 if mode.is_async() {
-                    ty.try_await(db).ok()
+                    ty.try_await(db, program).ok()
                 } else {
                     Some(ty)
                 }
@@ -517,20 +563,30 @@ impl<'db> IterationError<'db> {
                 mode,
             } => {
                 if mode.is_async() {
-                    return_type(dunder_iter_bindings.return_type(db).try_call_dunder(
-                        db,
-                        "__anext__",
-                        CallArguments::none(),
-                        TypeContext::default(),
-                    ))
-                    .and_then(|ty| ty.try_await(db).ok())
+                    return_type(
+                        dunder_iter_bindings
+                            .return_type(db, program)
+                            .try_call_dunder(
+                                db,
+                                program,
+                                "__anext__",
+                                CallArguments::none(),
+                                TypeContext::default(),
+                            ),
+                    )
+                    .and_then(|ty| ty.try_await(db, program).ok())
                 } else {
-                    return_type(dunder_iter_bindings.return_type(db).try_call_dunder(
-                        db,
-                        "__next__",
-                        CallArguments::none(),
-                        TypeContext::default(),
-                    ))
+                    return_type(
+                        dunder_iter_bindings
+                            .return_type(db, program)
+                            .try_call_dunder(
+                                db,
+                                program,
+                                "__next__",
+                                CallArguments::none(),
+                                TypeContext::default(),
+                            ),
+                    )
                 }
             }
 
@@ -545,16 +601,18 @@ impl<'db> IterationError<'db> {
                     ..
                 } => Some(UnionType::from_two_elements(
                     db,
+                    program,
                     *dunder_next_return,
-                    dunder_getitem_outcome.return_type(db),
+                    dunder_getitem_outcome.return_type(db, program),
                 )),
                 CallDunderError::CallError(CallErrorKind::NotCallable, _, _) => {
                     Some(*dunder_next_return)
                 }
                 CallDunderError::CallError(_, dunder_getitem_bindings, _) => {
-                    let dunder_getitem_return = dunder_getitem_bindings.return_type(db);
+                    let dunder_getitem_return = dunder_getitem_bindings.return_type(db, program);
                     Some(UnionType::from_two_elements(
                         db,
+                        program,
                         *dunder_next_return,
                         dunder_getitem_return,
                     ))
@@ -563,7 +621,7 @@ impl<'db> IterationError<'db> {
 
             Self::UnboundIterAndGetitemError {
                 dunder_getitem_error,
-            } => dunder_getitem_error.return_type(db),
+            } => dunder_getitem_error.return_type(db, program),
 
             Self::UnboundAiterError => None,
         }
@@ -597,6 +655,7 @@ impl<'db> IterationError<'db> {
         /// based on the variant of iteration error.
         struct Reporter<'a> {
             db: &'a dyn Db,
+            program: crate::Program,
             builder: LintDiagnosticGuardBuilder<'a, 'a>,
             iterable_type: Type<'a>,
             mode: EvaluationMode,
@@ -612,22 +671,23 @@ impl<'db> IterationError<'db> {
                 because: impl std::fmt::Display,
                 error_context: ErrorContext,
             ) -> LintDiagnosticGuard<'a, 'a> {
+                let program = self.program;
                 let mut diag = self.builder.into_diagnostic(format_args!(
                     "Object of type `{iterable_type}` is not {maybe_async}iterable",
-                    iterable_type = self.iterable_type.display(self.db),
+                    iterable_type = self.iterable_type.display(self.db, program),
                     maybe_async = if self.mode.is_async() { "async-" } else { "" }
                 ));
                 diag.info(because);
 
                 if let ErrorContext::Enabled = error_context {
                     let target = if self.mode.is_async() {
-                        KnownClass::TyExtensionsAsyncIterable.to_instance_unknown(self.db)
+                        KnownClass::TyExtensionsAsyncIterable.to_instance_unknown(self.db, program)
                     } else {
-                        KnownClass::TyExtensionsIterable.to_instance_unknown(self.db)
+                        KnownClass::TyExtensionsIterable.to_instance_unknown(self.db, program)
                     };
                     self.iterable_type
-                        .assignability_error_context(self.db, target)
-                        .attach_to(self.db, &mut diag);
+                        .assignability_error_context(self.db, program, target)
+                        .attach_to(self.db, program, &mut diag);
                 }
 
                 diag
@@ -641,22 +701,23 @@ impl<'db> IterationError<'db> {
                 because: impl std::fmt::Display,
                 error_context: ErrorContext,
             ) -> LintDiagnosticGuard<'a, 'a> {
+                let program = self.program;
                 let mut diag = self.builder.into_diagnostic(format_args!(
                     "Object of type `{iterable_type}` may not be {maybe_async}iterable",
-                    iterable_type = self.iterable_type.display(self.db),
+                    iterable_type = self.iterable_type.display(self.db, program),
                     maybe_async = if self.mode.is_async() { "async-" } else { "" }
                 ));
                 diag.info(because);
 
                 if let ErrorContext::Enabled = error_context {
                     let target = if self.mode.is_async() {
-                        KnownClass::TyExtensionsAsyncIterable.to_instance_unknown(self.db)
+                        KnownClass::TyExtensionsAsyncIterable.to_instance_unknown(self.db, program)
                     } else {
-                        KnownClass::TyExtensionsIterable.to_instance_unknown(self.db)
+                        KnownClass::TyExtensionsIterable.to_instance_unknown(self.db, program)
                     };
                     self.iterable_type
-                        .assignability_error_context(self.db, target)
-                        .attach_to(self.db, &mut diag);
+                        .assignability_error_context(self.db, program, target)
+                        .attach_to(self.db, program, &mut diag);
                 }
 
                 diag
@@ -667,9 +728,11 @@ impl<'db> IterationError<'db> {
             return;
         };
         let db = context.db();
+        let program = context.program();
         let mode = self.mode();
         let reporter = Reporter {
             db,
+            program,
             builder,
             iterable_type,
             mode,
@@ -694,7 +757,7 @@ impl<'db> IterationError<'db> {
                     CallErrorKind::NotCallable => {
                         reporter.is_not(format_args!(
                         "Its `{method}` attribute has type `{dunder_iter_type}`, which is not callable",
-                        dunder_iter_type = bindings.callable_type().display(db),
+                        dunder_iter_type = bindings.callable_type().display(db, program),
                     ), ErrorContext::Disabled);
                     }
                     CallErrorKind::PossiblyNotCallable => {
@@ -702,7 +765,7 @@ impl<'db> IterationError<'db> {
                             format_args!(
                                 "Its `{method}` attribute (with type `{dunder_iter_type}`) \
                                  may not be callable",
-                                dunder_iter_type = bindings.callable_type().display(db),
+                                dunder_iter_type = bindings.callable_type().display(db, program),
                             ),
                             ErrorContext::Disabled,
                         );
@@ -722,7 +785,7 @@ impl<'db> IterationError<'db> {
                             );
                             diag.info(format_args!(
                                 "Type of `{method}` is `{dunder_iter_type}`",
-                                dunder_iter_type = bindings.callable_type().display(db),
+                                dunder_iter_type = bindings.callable_type().display(db, program),
                             ));
                             diag.info(format_args!(
                                 "Expected signature for `{method}` is `def {method}(self): ...`",
@@ -752,28 +815,28 @@ impl<'db> IterationError<'db> {
                         reporter.is_not(format_args!(
                         "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                          which has no `{dunder_next_name}` method",
-                        iterator_type = iterator.display(db),
+                        iterator_type = iterator.display(db, program),
                     ), ErrorContext::Disabled);
                     }
                     CallDunderError::PossiblyUnbound { .. } => {
                         reporter.may_not(format_args!(
                             "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                             which may not have a `{dunder_next_name}` method",
-                            iterator_type = iterator.display(db),
+                            iterator_type = iterator.display(db, program),
                         ), ErrorContext::Enabled);
                     }
                     CallDunderError::CallError(CallErrorKind::NotCallable, _, _) => {
                         reporter.is_not(format_args!(
                             "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                             which has a `{dunder_next_name}` attribute that is not callable",
-                            iterator_type = iterator.display(db),
+                            iterator_type = iterator.display(db, program),
                         ), ErrorContext::Disabled);
                     }
                     CallDunderError::CallError(CallErrorKind::PossiblyNotCallable, _, _) => {
                         reporter.may_not(format_args!(
                             "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                             which has a `{dunder_next_name}` attribute that may not be callable",
-                            iterator_type = iterator.display(db),
+                            iterator_type = iterator.display(db, program),
                         ), ErrorContext::Enabled);
                     }
                     CallDunderError::CallError(CallErrorKind::BindingError, bindings, _)
@@ -783,7 +846,7 @@ impl<'db> IterationError<'db> {
                             .is_not(format_args!(
                                 "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                                 which has an invalid `{dunder_next_name}` method",
-                                iterator_type = iterator.display(db),
+                                iterator_type = iterator.display(db, program),
                             ), ErrorContext::Enabled)
                             .info(format_args!("Expected signature for `{dunder_next_name}` is `def {dunder_next_name}(self): ...`"));
                     }
@@ -792,7 +855,7 @@ impl<'db> IterationError<'db> {
                             .may_not(format_args!(
                                 "Its `{dunder_iter_name}` method returns an object of type `{iterator_type}`, \
                                 which may have an invalid `{dunder_next_name}` method",
-                                iterator_type = iterator.display(db),
+                                iterator_type = iterator.display(db, program),
                             ), ErrorContext::Enabled)
                             .info(format_args!("Expected signature for `{dunder_next_name}` is `def {dunder_next_name}(self): ...`"));
                     }
@@ -820,7 +883,7 @@ impl<'db> IterationError<'db> {
                                 "It may not have an `__iter__` method \
                                 and its `__getitem__` attribute has type `{dunder_getitem_type}`, \
                                 which is not callable",
-                                dunder_getitem_type = bindings.callable_type().display(db),
+                                dunder_getitem_type = bindings.callable_type().display(db, program),
                             ),
                             ErrorContext::Disabled,
                         ),
@@ -839,7 +902,7 @@ impl<'db> IterationError<'db> {
                                 "It may not have an `__iter__` method \
                              and its `__getitem__` attribute (with type `{dunder_getitem_type}`) \
                              may not be callable",
-                                dunder_getitem_type = bindings.callable_type().display(db),
+                                dunder_getitem_type = bindings.callable_type().display(db, program),
                             ),
                             ErrorContext::Disabled,
                         )
@@ -866,7 +929,7 @@ impl<'db> IterationError<'db> {
                                 "It may not have an `__iter__` method \
                              and its `__getitem__` method (with type `{dunder_getitem_type}`) \
                              may have an incorrect signature for the old-style iteration protocol",
-                                dunder_getitem_type = bindings.callable_type().display(db),
+                                dunder_getitem_type = bindings.callable_type().display(db, program),
                             ),
                             ErrorContext::Disabled,
                         );
@@ -882,7 +945,7 @@ impl<'db> IterationError<'db> {
                     for ty in unbound_on.iter().copied() {
                         diag.info(format_args!(
                             "`{}` does not implement `__iter__`",
-                            ty.display(db)
+                            ty.display(db, program)
                         ));
                     }
                 }
@@ -909,7 +972,7 @@ impl<'db> IterationError<'db> {
                             "It has no `__iter__` method and \
                          its `__getitem__` attribute has type `{dunder_getitem_type}`, \
                          which is not callable",
-                            dunder_getitem_type = bindings.callable_type().display(db),
+                            dunder_getitem_type = bindings.callable_type().display(db, program),
                         ),
                         ErrorContext::Disabled,
                     );
@@ -929,7 +992,7 @@ impl<'db> IterationError<'db> {
                         ErrorContext::Disabled,
                     ).info(format_args!(
                         "`__getitem__` has type `{dunder_getitem_type}`, which is not callable",
-                        dunder_getitem_type = bindings.callable_type().display(db),
+                        dunder_getitem_type = bindings.callable_type().display(db, program),
                     ));
                 }
                 CallDunderError::CallError(CallErrorKind::BindingError, bindings, _)
@@ -955,7 +1018,7 @@ impl<'db> IterationError<'db> {
                                 "It has no `__iter__` method and \
                                 its `__getitem__` method (with type `{dunder_getitem_type}`) \
                                 may have an incorrect signature for the old-style iteration protocol",
-                                dunder_getitem_type = bindings.callable_type().display(db),
+                                dunder_getitem_type = bindings.callable_type().display(db, program),
                             ),
                             ErrorContext::Disabled,
                         )

--- a/crates/ty_python_semantic/src/types/known_instance.rs
+++ b/crates/ty_python_semantic/src/types/known_instance.rs
@@ -2,7 +2,7 @@ use itertools::Either;
 use ruff_python_ast::name::Name;
 
 use crate::{
-    Db, DisplaySettings,
+    Db, DisplaySettings, Program,
     types::{
         ApplyTypeMappingVisitor, BoundTypeVarIdentity, BoundTypeVarInstance, CallableType,
         ClassType, GenericContext, InferenceFlags, InvalidTypeExpressionError, KnownClass,
@@ -71,7 +71,7 @@ impl get_size2::GetSize for FunctoolsPartialInstance<'_> {}
 /// are generally created by operations at runtime in some way, such as a type alias
 /// statement, a typevar definition, or an instance of `Generic[T]` in a class's
 /// bases list.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 pub enum KnownInstanceType<'db> {
     /// The type of `Protocol[T]`, `Protocol[U, S]`, etc -- usually only found in a class's bases list.
     ///
@@ -149,6 +149,7 @@ pub enum KnownInstanceType<'db> {
 
 pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     known_instance: KnownInstanceType<'db>,
     visitor: &V,
 ) {
@@ -158,10 +159,10 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
             walk_generic_context(db, context, visitor);
         }
         KnownInstanceType::TypeVar(typevar) => {
-            visitor.visit_type_var_type(db, typevar);
+            visitor.visit_type_var_type(db, program, typevar);
         }
         KnownInstanceType::TypeAliasType(type_alias) => {
-            visitor.visit_type_alias_type(db, type_alias);
+            visitor.visit_type_alias_type(db, program, type_alias);
         }
         KnownInstanceType::Deprecated(_)
         | KnownInstanceType::Range { .. }
@@ -172,51 +173,56 @@ pub(super) fn walk_known_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Size
         }
         KnownInstanceType::Field(field) => {
             if let Some(default_ty) = field.default_type(db) {
-                visitor.visit_type(db, default_ty);
+                visitor.visit_type(db, program, default_ty);
             }
             if let Some((input_ty, output_ty)) = field.converter(db) {
-                visitor.visit_type(db, input_ty);
-                visitor.visit_type(db, output_ty);
+                visitor.visit_type(db, program, input_ty);
+                visitor.visit_type(db, program, output_ty);
             }
         }
         KnownInstanceType::UnionType(instance) => {
             if let Ok(union_type) = instance.union_type(db) {
-                visitor.visit_type(db, *union_type);
+                visitor.visit_type(db, program, *union_type);
             }
         }
         KnownInstanceType::Literal(ty)
         | KnownInstanceType::Annotated(ty)
         | KnownInstanceType::TypeGenericAlias(ty)
         | KnownInstanceType::LiteralStringAlias(ty) => {
-            visitor.visit_type(db, ty.inner(db));
+            visitor.visit_type(db, program, ty.inner(db));
         }
         KnownInstanceType::Callable(callable) => {
-            visitor.visit_callable_type(db, callable);
+            visitor.visit_callable_type(db, program, callable);
         }
         KnownInstanceType::NewType(newtype) => {
-            visitor.visit_newtype_instance_type(db, newtype);
+            visitor.visit_newtype_instance_type(db, program, newtype);
         }
         KnownInstanceType::Sentinel(_) => {
             // Nothing to visit
         }
         KnownInstanceType::NamedTupleSpec(spec) => {
             for field in spec.fields(db) {
-                visitor.visit_type(db, field.ty);
+                visitor.visit_type(db, program, field.ty);
             }
         }
         KnownInstanceType::FunctoolsPartial(partial)
         | KnownInstanceType::FunctoolsPartialCall(partial) => {
-            visitor.visit_callable_type(db, partial.partial(db));
+            visitor.visit_callable_type(db, program, partial.partial(db));
         }
     }
 }
 
 impl<'db> VarianceInferable<'db> for KnownInstanceType<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         match self {
-            KnownInstanceType::TypeAliasType(type_alias) => {
-                type_alias.raw_value_type(db).variance_of(db, typevar)
-            }
+            KnownInstanceType::TypeAliasType(type_alias) => type_alias
+                .raw_value_type(db)
+                .variance_of(db, program, typevar),
             _ => TypeVarVariance::Bivariant,
         }
     }
@@ -226,6 +232,7 @@ impl<'db> KnownInstanceType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -239,42 +246,42 @@ impl<'db> KnownInstanceType<'db> {
             Self::TypeVar(typevar) => Some(Self::TypeVar(typevar)),
             Self::TypeAliasType(type_alias) => Some(Self::TypeAliasType(type_alias)),
             Self::Field(field) => field
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Self::Field),
             Self::UnionType(union_type) => union_type
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Self::UnionType),
             Self::Literal(ty) => ty
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::Literal),
             Self::Annotated(ty) => ty
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::Annotated),
             Self::TypeGenericAlias(ty) => ty
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::TypeGenericAlias),
             Self::LiteralStringAlias(ty) => ty
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::LiteralStringAlias),
             Self::Callable(callable) => callable
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Self::Callable),
             Self::NewType(newtype) => newtype
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::NewType),
             Self::Sentinel(sentinel) => Some(Self::Sentinel(sentinel)),
             Self::GenericContext(generic) => Some(Self::GenericContext(generic)),
             Self::Specialization(specialization) => specialization
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::Specialization),
             Self::NamedTupleSpec(spec) => spec
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .map(Self::NamedTupleSpec),
             Self::FunctoolsPartial(partial) => partial
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Self::FunctoolsPartial),
             Self::FunctoolsPartialCall(partial) => partial
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(Self::FunctoolsPartialCall),
         }
     }
@@ -305,13 +312,13 @@ impl<'db> KnownInstanceType<'db> {
             Self::Sentinel(_) => KnownClass::Sentinel,
             Self::NamedTupleSpec(_) => KnownClass::Sequence,
             Self::FunctoolsPartial(_) => KnownClass::FunctoolsPartial,
-            Self::Range { .. } => KnownClass::Range,
             Self::FunctoolsPartialCall(_) => KnownClass::MethodWrapperType,
+            Self::Range { .. } => KnownClass::Range,
         }
     }
 
-    pub(super) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        self.class(db).to_class_literal(db)
+    pub(super) fn to_meta_type(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        self.class(db).to_class_literal(db, program)
     }
 
     /// Return the instance type which this type is a subtype of.
@@ -319,22 +326,26 @@ impl<'db> KnownInstanceType<'db> {
     /// For example, an alias created using the `type` statement is an instance of
     /// `typing.TypeAliasType`, so `KnownInstanceType::TypeAliasType(_).instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing.TypeAliasType> })`.
-    pub(super) fn instance_fallback(self, db: &'db dyn Db) -> Type<'db> {
-        self.class(db).to_instance(db)
+    pub(super) fn instance_fallback(self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        self.class(db).to_instance(db, program)
     }
 
     /// Return the type denoted by this retained runtime type-expression object.
     ///
     /// This is the scope-independent subset of `Type::in_type_expression` used when a value
     /// reaches a `TypeForm` position after it has already been inferred in value context.
-    pub(crate) fn type_form_argument(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn type_form_argument(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         match self {
             Self::TypeAliasType(alias) => Some(Type::TypeAlias(alias)),
             Self::UnionType(instance) => instance.union_type(db).as_ref().ok().copied(),
             Self::Literal(ty) | Self::Annotated(ty) | Self::LiteralStringAlias(ty) => {
                 Some(ty.inner(db))
             }
-            Self::TypeGenericAlias(instance) => Some(instance.inner(db).to_meta_type(db)),
+            Self::TypeGenericAlias(instance) => Some(instance.inner(db).to_meta_type(db, program)),
             Self::Callable(callable) => Some(Type::Callable(callable)),
             Self::NewType(newtype) => Some(Type::NewTypeInstance(newtype)),
             Self::Sentinel(sentinel) => {
@@ -361,18 +372,20 @@ impl<'db> KnownInstanceType<'db> {
     }
 
     /// Return `true` if this symbol is an instance of `class`.
-    pub(super) fn is_instance_of(self, db: &dyn Db, class: ClassType) -> bool {
-        self.class(db).is_subclass_of(db, class)
+    pub(super) fn is_instance_of(self, db: &'db dyn Db, class: ClassType<'db>) -> bool {
+        let program = class.program(db);
+        self.class(db).is_subclass_of(db, program, class)
     }
 
     /// Return the repr of the symbol at runtime
-    pub(super) fn repr(self, db: &'db dyn Db) -> impl std::fmt::Display + 'db {
-        self.display_with(db, DisplaySettings::default())
+    pub(super) fn repr(self, db: &'db dyn Db, program: Program) -> impl std::fmt::Display + 'db {
+        self.display_with(db, program, DisplaySettings::default())
     }
 
     pub(super) fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'_, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -401,42 +414,42 @@ impl<'db> KnownInstanceType<'db> {
             },
             KnownInstanceType::UnionType(instance) => {
                 Type::KnownInstance(KnownInstanceType::UnionType(
-                    instance.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    instance.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
             KnownInstanceType::Annotated(ty) => {
                 Type::KnownInstance(KnownInstanceType::Annotated(InternedType::new(
                     db,
                     ty.inner(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 )))
             }
             KnownInstanceType::Callable(callable_type) => {
                 Type::KnownInstance(KnownInstanceType::Callable(
-                    callable_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    callable_type.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
             KnownInstanceType::FunctoolsPartial(partial) => {
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(
-                    partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                    partial.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
+                ))
+            }
+            KnownInstanceType::FunctoolsPartialCall(partial) => {
+                Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(
+                    partial.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 ))
             }
             KnownInstanceType::Range { .. } => match type_mapping {
                 TypeMapping::Promote(PromotionMode::On, PromotionKind::Regular) => {
-                    self.instance_fallback(db)
+                    self.instance_fallback(db, program)
                 }
                 _ => Type::KnownInstance(self),
             },
-            KnownInstanceType::FunctoolsPartialCall(partial) => {
-                Type::KnownInstance(KnownInstanceType::FunctoolsPartialCall(
-                    partial.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-                ))
-            }
             KnownInstanceType::TypeGenericAlias(ty) => {
                 Type::KnownInstance(KnownInstanceType::TypeGenericAlias(InternedType::new(
                     db,
                     ty.inner(db)
-                        .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                 )))
             }
 
@@ -483,7 +496,7 @@ impl<'db> SentinelInstance<'db> {
 }
 
 /// Data regarding a `warnings.deprecated` or `typing_extensions.deprecated` decorator.
-#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 pub struct DeprecatedInstance<'db> {
     /// The message for the deprecation
     pub(crate) message: Option<StringLiteralType<'db>>,
@@ -528,29 +541,32 @@ impl<'db> FieldInstance<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let default_type = match self.default_type(db) {
-            Some(default) if nested => Some(default.recursive_type_normalized_impl(db, div, true)?),
+            Some(default) if nested => {
+                Some(default.recursive_type_normalized_impl(db, program, div, true)?)
+            }
             Some(default) => Some(
                 default
-                    .recursive_type_normalized_impl(db, div, true)
+                    .recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
             ),
             None => None,
         };
         let converter = match self.converter(db) {
             Some((input_ty, output_ty)) if nested => Some((
-                input_ty.recursive_type_normalized_impl(db, div, true)?,
-                output_ty.recursive_type_normalized_impl(db, div, true)?,
+                input_ty.recursive_type_normalized_impl(db, program, div, true)?,
+                output_ty.recursive_type_normalized_impl(db, program, div, true)?,
             )),
             Some((input_ty, output_ty)) => Some((
                 input_ty
-                    .recursive_type_normalized_impl(db, div, true)
+                    .recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
                 output_ty
-                    .recursive_type_normalized_impl(db, div, true)
+                    .recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div),
             )),
             None => None,
@@ -597,14 +613,21 @@ impl get_size2::GetSize for UnionTypeInstance<'_> {}
 impl<'db> UnionTypeInstance<'db> {
     pub(crate) fn from_value_expression_types(
         db: &'db dyn Db,
+        program: crate::Program,
         value_expr_types: [Type<'db>; 2],
         scope_id: ScopeId<'db>,
         typevar_binding_context: Option<Definition<'db>>,
         inference_flags: InferenceFlags,
     ) -> Type<'db> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         for ty in &value_expr_types {
-            match ty.in_type_expression(db, scope_id, typevar_binding_context, inference_flags) {
+            match ty.in_type_expression(
+                db,
+                program,
+                scope_id,
+                typevar_binding_context,
+                inference_flags,
+            ) {
                 Ok(ty) => builder.add_in_place(ty),
                 Err(error) => {
                     return Type::KnownInstance(KnownInstanceType::UnionType(
@@ -638,6 +661,7 @@ impl<'db> UnionTypeInstance<'db> {
     pub(super) fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'_, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -646,7 +670,7 @@ impl<'db> UnionTypeInstance<'db> {
             UnionTypeInstance::new(
                 db,
                 self._value_expr_types(db),
-                Ok(union_type.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+                Ok(union_type.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)),
             )
         } else {
             self
@@ -662,12 +686,13 @@ impl<'db> UnionTypeInstance<'db> {
     pub(crate) fn value_expression_types(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
     ) -> Result<impl Iterator<Item = Type<'db>> + 'db, InvalidTypeExpressionError<'db>> {
-        let to_class_literal = |ty: Type<'db>| {
+        let to_class_literal = move |ty: Type<'db>| {
             ty.as_nominal_instance()
                 .and_then(|instance| {
                     instance
-                        .class(db)
+                        .class(db, program)
                         .static_class_literal(db)
                         .map(|(lit, _)| Type::ClassLiteral(lit.into()))
                 })
@@ -691,6 +716,7 @@ impl<'db> UnionTypeInstance<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -698,23 +724,23 @@ impl<'db> UnionTypeInstance<'db> {
         // See `UnionType::recursive_type_normalized_impl` for details.
         let value_expr_types = match self._value_expr_types(db).as_ref() {
             Some([first, second]) if nested => Some([
-                first.recursive_type_normalized_impl(db, div, nested)?,
-                second.recursive_type_normalized_impl(db, div, nested)?,
+                first.recursive_type_normalized_impl(db, program, div, nested)?,
+                second.recursive_type_normalized_impl(db, program, div, nested)?,
             ]),
             Some([first, second]) => Some([
                 first
-                    .recursive_type_normalized_impl(db, div, nested)
+                    .recursive_type_normalized_impl(db, program, div, nested)
                     .unwrap_or(div),
                 second
-                    .recursive_type_normalized_impl(db, div, nested)
+                    .recursive_type_normalized_impl(db, program, div, nested)
                     .unwrap_or(div),
             ]),
             None => None,
         };
         let union_type = match self.union_type(db).clone() {
-            Ok(ty) if nested => Ok(ty.recursive_type_normalized_impl(db, div, nested)?),
+            Ok(ty) if nested => Ok(ty.recursive_type_normalized_impl(db, program, div, nested)?),
             Ok(ty) => Ok(ty
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .unwrap_or(div)),
             Err(err) => Err(err),
         };
@@ -728,6 +754,7 @@ impl<'db> FunctoolsPartialInstance<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -737,10 +764,10 @@ impl<'db> FunctoolsPartialInstance<'db> {
                 db,
                 self.wrapped(db)
                     .inner(db)
-                    .recursive_type_normalized_impl(db, div, nested)?,
+                    .recursive_type_normalized_impl(db, program, div, nested)?,
             ),
             self.partial(db)
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
         ))
     }
 
@@ -748,6 +775,7 @@ impl<'db> FunctoolsPartialInstance<'db> {
     fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'_, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -756,12 +784,16 @@ impl<'db> FunctoolsPartialInstance<'db> {
             db,
             InternedType::new(
                 db,
-                self.wrapped(db)
-                    .inner(db)
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                self.wrapped(db).inner(db).apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ),
             ),
             self.partial(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
         )
     }
 }
@@ -779,15 +811,16 @@ impl<'db> InternedType<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let inner = if nested {
             self.inner(db)
-                .recursive_type_normalized_impl(db, div, nested)?
+                .recursive_type_normalized_impl(db, program, div, nested)?
         } else {
             self.inner(db)
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .unwrap_or(div)
         };
         Some(InternedType::new(db, inner))

--- a/crates/ty_python_semantic/src/types/list_members.rs
+++ b/crates/ty_python_semantic/src/types/list_members.rs
@@ -13,8 +13,8 @@ use rustc_hash::FxHashSet;
 use crate::{
     Db, NameKind,
     place::{
-        DefinedPlace, Place, PlaceWithDefinition, imported_symbol, place_from_bindings,
-        place_from_declarations,
+        DefinedPlace, ImportedSymbolContext, Place, PlaceWithDefinition, imported_symbol,
+        place_from_bindings, place_from_declarations,
     },
     types::{
         ClassBase, ClassLiteral, KnownClass, KnownInstanceType, StaticClassLiteral,
@@ -32,13 +32,14 @@ pub(crate) fn all_end_of_scope_members<'db>(
     db: &'db dyn Db,
     scope_id: ScopeId<'db>,
 ) -> impl Iterator<Item = MemberWithDefinition<'db>> + 'db {
+    let program = scope_id.program(db);
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
     use_def_map
         .all_end_of_scope_symbol_declarations()
         .filter_map(move |(symbol_id, declarations)| {
-            let place_result = place_from_declarations(db, declarations);
+            let place_result = place_from_declarations(db, program, declarations);
             let first_reachable_definition = place_result.first_declaration?;
             let ty = place_result
                 .ignore_conflicting_declarations()
@@ -59,7 +60,7 @@ pub(crate) fn all_end_of_scope_members<'db>(
                 let PlaceWithDefinition {
                     place,
                     first_definition,
-                } = place_from_bindings(db, bindings);
+                } = place_from_bindings(db, program, bindings);
 
                 let first_reachable_definition = first_definition?;
                 let ty = place.ignore_possibly_undefined()?;
@@ -83,6 +84,7 @@ pub(crate) fn all_reachable_members<'db>(
     db: &'db dyn Db,
     scope_id: ScopeId<'db>,
 ) -> impl Iterator<Item = MemberWithDefinition<'db>> + 'db {
+    let program = scope_id.program(db);
     let use_def_map = use_def_map(db, scope_id);
     let table = place_table(db, scope_id);
 
@@ -91,7 +93,7 @@ pub(crate) fn all_reachable_members<'db>(
         .flat_map(move |(symbol_id, declarations, bindings)| {
             let symbol = table.symbol(symbol_id);
 
-            let declaration_place_result = place_from_declarations(db, declarations);
+            let declaration_place_result = place_from_declarations(db, program, declarations);
             let declaration =
                 declaration_place_result
                     .first_declaration
@@ -110,7 +112,7 @@ pub(crate) fn all_reachable_members<'db>(
                         })
                     });
 
-            let place_with_definition = place_from_bindings(db, bindings);
+            let place_with_definition = place_from_bindings(db, program, bindings);
             let binding =
                 place_with_definition
                     .first_definition
@@ -149,12 +151,14 @@ const SYNTHETIC_DATACLASS_ATTRIBUTES: &[&str] = &[
 ];
 
 struct AllMembers<'db> {
+    program: crate::Program,
     members: FxHashSet<Member<'db>>,
 }
 
 impl<'db> AllMembers<'db> {
-    fn of(db: &'db dyn Db, ty: Type<'db>) -> Self {
+    fn of(db: &'db dyn Db, program: crate::Program, ty: Type<'db>) -> Self {
         let mut all_members = Self {
+            program,
             members: FxHashSet::default(),
         };
         all_members.extend_with_type(db, ty);
@@ -162,6 +166,7 @@ impl<'db> AllMembers<'db> {
     }
 
     fn extend_with_type(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+        let program = self.program;
         match ty {
             Type::Union(union) => {
                 fn is_dynamic(db: &dyn Db, ty: Type<'_>) -> bool {
@@ -185,7 +190,7 @@ impl<'db> AllMembers<'db> {
                     union
                         .elements(db)
                         .iter()
-                        .map(|ty| AllMembers::of(db, *ty).members)
+                        .map(|ty| AllMembers::of(db, program, *ty).members)
                         .reduce(|acc, members| acc.intersection(&members).cloned().collect())
                         .unwrap_or_default(),
                 );
@@ -195,7 +200,7 @@ impl<'db> AllMembers<'db> {
                 intersection
                     .positive(db)
                     .iter()
-                    .map(|ty| AllMembers::of(db, *ty).members)
+                    .map(|ty| AllMembers::of(db, program, *ty).members)
                     .reduce(|acc, members| acc.union(&members).cloned().collect())
                     .unwrap_or_default(),
             ),
@@ -205,7 +210,7 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::NominalInstance(instance) => {
-                let class = instance.class(db);
+                let class = instance.class(db, program);
                 if let Some((class_literal, _)) = class.static_class_literal(db) {
                     self.extend_with_instance_members(db, ty, class_literal);
                     self.extend_with_synthetic_members(db, ty, ClassLiteral::Static(class_literal));
@@ -221,15 +226,24 @@ impl<'db> AllMembers<'db> {
             }
 
             Type::ClassLiteral(class_literal) if class_literal.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db, program),
+                );
             }
 
             Type::GenericAlias(generic_alias) if generic_alias.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db, program),
+                );
             }
 
-            Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db) => {
-                self.extend_with_type(db, KnownClass::TypedDictFallback.to_class_literal(db));
+            Type::SubclassOf(subclass_of_type) if subclass_of_type.is_typed_dict(db, program) => {
+                self.extend_with_type(
+                    db,
+                    KnownClass::TypedDictFallback.to_class_literal(db, program),
+                );
             }
 
             Type::ClassLiteral(class_literal) => {
@@ -247,10 +261,11 @@ impl<'db> AllMembers<'db> {
 
             Type::SubclassOf(subclass_of_type) => match subclass_of_type.subclass_of() {
                 SubclassOfInner::Dynamic(_) => {
-                    self.extend_with_type(db, KnownClass::Type.to_instance(db));
+                    self.extend_with_type(db, KnownClass::Type.to_instance(db, program));
                 }
                 _ => {
-                    if let Some(class_type) = subclass_of_type.subclass_of().into_class(db) {
+                    if let Some(class_type) = subclass_of_type.subclass_of().into_class(db, program)
+                    {
                         if let Some((class_literal, _)) = class_type.static_class_literal(db) {
                             self.extend_with_class_members(
                                 db,
@@ -292,7 +307,7 @@ impl<'db> AllMembers<'db> {
                             constraints
                                 .elements(db)
                                 .iter()
-                                .map(|ty| AllMembers::of(db, *ty).members)
+                                .map(|ty| AllMembers::of(db, program, *ty).members)
                                 .reduce(|acc, members| {
                                     acc.intersection(&members).cloned().collect()
                                 })
@@ -316,12 +331,12 @@ impl<'db> AllMembers<'db> {
             | Type::KnownInstance(_)
             | Type::BoundSuper(_)
             | Type::TypeIs(_)
-            | Type::TypeGuard(_) => match ty.to_meta_type(db) {
+            | Type::TypeGuard(_) => match ty.to_meta_type(db, program) {
                 Type::ClassLiteral(class_literal) => {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
                 Type::SubclassOf(subclass_of) => {
-                    if let Some(class) = subclass_of.subclass_of().into_class(db)
+                    if let Some(class) = subclass_of.subclass_of().into_class(db, program)
                         && let Some((class_literal, _)) = class.static_class_literal(db)
                     {
                         self.extend_with_class_members(db, ty, ClassLiteral::Static(class_literal));
@@ -335,12 +350,12 @@ impl<'db> AllMembers<'db> {
             },
 
             Type::TypedDict(_) => {
-                if let Type::ClassLiteral(class_literal) = ty.to_meta_type(db) {
+                if let Type::ClassLiteral(class_literal) = ty.to_meta_type(db, program) {
                     self.extend_with_class_members(db, ty, class_literal);
                 }
 
                 if let Type::ClassLiteral(ClassLiteral::Static(class)) =
-                    KnownClass::TypedDictFallback.to_class_literal(db)
+                    KnownClass::TypedDictFallback.to_class_literal(db, program)
                 {
                     self.extend_with_instance_members(db, ty, class);
                 }
@@ -351,30 +366,37 @@ impl<'db> AllMembers<'db> {
                 // as we infer in type inference, but it's confusing if autocomplete etc.
                 // shows a different type in the tooltip to the one inferred by the type checker.
                 let dunder_file_type = if literal.module(db).file(db).is_some() {
-                    KnownClass::Str.to_instance(db)
+                    KnownClass::Str.to_instance(db, program)
                 } else {
-                    Type::none(db)
+                    Type::none(db, program)
                 };
                 self.members.insert(Member {
                     name: Name::new_static("__file__"),
                     ty: dunder_file_type,
                 });
 
-                self.extend_with_type(db, KnownClass::ModuleType.to_instance(db));
+                self.extend_with_type(db, KnownClass::ModuleType.to_instance(db, program));
                 let module = literal.module(db);
 
                 let Some(file) = module.file(db) else {
                     return;
                 };
 
-                let module_scope = global_scope(db, file);
+                let program_file =
+                    ty_python_core::environment::ProgramFile::new(db, literal.program(db), file);
+                let module_scope = global_scope(db, program_file);
                 let use_def_map = use_def_map(db, module_scope);
                 let place_table = place_table(db, module_scope);
 
                 for (symbol_id, _) in use_def_map.all_end_of_scope_symbol_declarations() {
                     let symbol_name = place_table.symbol(symbol_id).name();
-                    let Place::Defined(DefinedPlace { ty, .. }) =
-                        imported_symbol(db, Some(file), symbol_name, None).place
+                    let Place::Defined(DefinedPlace { ty, .. }) = imported_symbol(
+                        db,
+                        ImportedSymbolContext::File(program_file),
+                        symbol_name,
+                        None,
+                    )
+                    .place
                     else {
                         continue;
                     };
@@ -457,6 +479,7 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         class_literal: ClassLiteral<'db>,
     ) {
+        let program = self.program;
         for parent in class_literal
             .iter_mro(db)
             .filter_map(ClassBase::into_class)
@@ -464,7 +487,7 @@ impl<'db> AllMembers<'db> {
         {
             let parent_scope = parent.body_scope(db);
             for memberdef in all_end_of_scope_members(db, parent_scope) {
-                let result = ty.member(db, memberdef.member.name.as_str());
+                let result = ty.member(db, program, memberdef.member.name.as_str());
                 let Some(ty) = result.place.ignore_possibly_undefined() else {
                     continue;
                 };
@@ -503,15 +526,15 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         class_literal: StaticClassLiteral<'db>,
     ) {
+        let program = self.program;
         let class_body_scope = class_literal.body_scope(db);
-        let file = class_body_scope.file(db);
-        let index = semantic_index(db, file);
+        let index = semantic_index(db, class_body_scope.program_file(db));
         for function_scope_id in attribute_scopes(db, class_body_scope) {
             for place_expr in index.place_table(function_scope_id).members() {
                 let Some(name) = place_expr.as_instance_attribute() else {
                     continue;
                 };
-                let result = ty.member(db, name);
+                let result = ty.member(db, program, name);
                 let Some(ty) = result.place.ignore_possibly_undefined() else {
                     continue;
                 };
@@ -528,7 +551,7 @@ impl<'db> AllMembers<'db> {
         // member, e.g., `SomeClass.__delattr__` is not a bound
         // method, but `instance_of_SomeClass.__delattr__` is.
         for memberdef in all_end_of_scope_members(db, class_body_scope) {
-            let result = ty.member(db, memberdef.member.name.as_str());
+            let result = ty.member(db, program, memberdef.member.name.as_str());
             let Some(ty) = result.place.ignore_possibly_undefined() else {
                 continue;
             };
@@ -562,12 +585,19 @@ impl<'db> AllMembers<'db> {
         ty: Type<'db>,
         class_literal: ClassLiteral<'db>,
     ) {
+        let program = self.program;
         match CodeGeneratorKind::from_class(db, class_literal) {
             Some(CodeGeneratorKind::NamedTuple) => {
                 if ty.is_nominal_instance() {
-                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_instance(db));
+                    self.extend_with_type(
+                        db,
+                        KnownClass::NamedTupleFallback.to_instance(db, program),
+                    );
                 } else {
-                    self.extend_with_type(db, KnownClass::NamedTupleFallback.to_class_literal(db));
+                    self.extend_with_type(
+                        db,
+                        KnownClass::NamedTupleFallback.to_class_literal(db, program),
+                    );
                 }
             }
             Some(CodeGeneratorKind::TypedDict) => {}
@@ -576,7 +606,7 @@ impl<'db> AllMembers<'db> {
                     if let Place::Defined(DefinedPlace {
                         ty: synthetic_member,
                         ..
-                    }) = ty.member(db, attr).place
+                    }) = ty.member(db, program, attr).place
                     {
                         self.members.insert(Member {
                             name: Name::from(*attr),
@@ -647,6 +677,10 @@ impl<'db> PartialOrd for Member<'db> {
 
 /// List all members of a given type: anything that would be valid when accessed
 /// as an attribute on an object of the given type.
-pub fn all_members<'db>(db: &'db dyn Db, ty: Type<'db>) -> FxHashSet<Member<'db>> {
-    AllMembers::of(db, ty).members
+pub fn all_members<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    ty: Type<'db>,
+) -> FxHashSet<Member<'db>> {
+    AllMembers::of(db, program, ty).members
 }

--- a/crates/ty_python_semantic/src/types/literal.rs
+++ b/crates/ty_python_semantic/src/types/literal.rs
@@ -2,10 +2,10 @@ use bitflags::bitflags;
 use compact_str::CompactString;
 use ruff_python_ast::name::Name;
 
-use crate::Db;
 use crate::types::enums::EnumClassLiteral;
 use crate::types::set_theoretic::RecursivelyDefined;
 use crate::types::{ClassLiteral, KnownClass, Type};
+use crate::{Db, Program};
 use ty_python_core::definition::Definition;
 use ty_python_core::{place_table, use_def_map};
 
@@ -247,14 +247,14 @@ impl<'db> LiteralValueType<'db> {
         matches!(self.kind(), LiteralValueTypeKind::Bytes(..))
     }
 
-    pub(crate) fn fallback_instance(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn fallback_instance(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self.kind() {
             LiteralValueTypeKind::String(_) | LiteralValueTypeKind::LiteralString => {
-                KnownClass::Str.to_instance(db)
+                KnownClass::Str.to_instance(db, program)
             }
-            LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_instance(db),
-            LiteralValueTypeKind::Int(_) => KnownClass::Int.to_instance(db),
-            LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_instance(db),
+            LiteralValueTypeKind::Bool(_) => KnownClass::Bool.to_instance(db, program),
+            LiteralValueTypeKind::Int(_) => KnownClass::Int.to_instance(db, program),
+            LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.to_instance(db, program),
             LiteralValueTypeKind::Enum(literal) => literal.enum_class_instance(db),
         }
     }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -22,22 +22,28 @@ use crate::types::{
     infer_same_file_expression_type,
 };
 
-pub(crate) fn singleton_pattern_type(db: &dyn Db, singleton: ast::Singleton) -> Type<'_> {
+pub(crate) fn singleton_pattern_type(
+    db: &dyn Db,
+    program: crate::Program,
+    singleton: ast::Singleton,
+) -> Type<'_> {
     let ty = match singleton {
-        ast::Singleton::None => Type::none(db),
+        ast::Singleton::None => Type::none(db, program),
         ast::Singleton::True => Type::bool_literal(true),
         ast::Singleton::False => Type::bool_literal(false),
     };
-    debug_assert!(ty.is_singleton(db));
+    debug_assert!(ty.is_singleton(db, program));
     ty
 }
 
-pub(crate) fn mapping_pattern_type(db: &dyn Db) -> Type<'_> {
-    KnownClass::Mapping.to_instance(db).top_materialization(db)
+pub(crate) fn mapping_pattern_type(db: &dyn Db, program: crate::Program) -> Type<'_> {
+    KnownClass::Mapping
+        .to_instance(db, program)
+        .top_materialization(db, program)
 }
 
-pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
-    Type::Callable(CallableType::unknown(db)).top_materialization(db)
+pub(crate) fn callable_pattern_type(db: &dyn Db, program: crate::Program) -> Type<'_> {
+    Type::Callable(CallableType::unknown(db)).top_materialization(db, program)
 }
 
 /// Return whether every runtime value represented by a `TypedDict` satisfies `class`.
@@ -46,11 +52,18 @@ pub(crate) fn callable_pattern_type(db: &dyn Db) -> Type<'_> {
 /// value is a dictionary. A `TypedDict` therefore matches class patterns such as `dict()`,
 /// `Mapping()`, and `MutableMapping()`.
 pub(crate) fn typed_dict_matches_class_pattern(db: &dyn Db, class: ClassLiteral<'_>) -> bool {
-    let Some(dict) = KnownClass::Dict.to_class_literal(db).as_class_literal() else {
+    let program = class.program(db);
+    let Some(dict) = KnownClass::Dict
+        .to_class_literal(db, program)
+        .as_class_literal()
+    else {
         return false;
     };
-    Type::instance(db, dict.top_materialization(db))
-        .is_subtype_of(db, Type::instance(db, class.top_materialization(db)))
+    Type::instance(db, dict.top_materialization(db)).is_subtype_of(
+        db,
+        program,
+        Type::instance(db, class.top_materialization(db)),
+    )
 }
 
 /// Return whether every value in `ty` belongs to a `TypedDict` domain accepted by `predicate`.
@@ -88,18 +101,26 @@ fn is_typed_dict_pattern_domain(db: &dyn Db, ty: Type<'_>) -> bool {
     typed_dict_pattern_domain_satisfies(db, ty, &|_| true)
 }
 
-pub(crate) fn sequence_pattern_type_builder(db: &dyn Db) -> IntersectionBuilder<'_> {
-    IntersectionBuilder::new(db)
-        .add_positive(KnownClass::Sequence.to_instance(db).top_materialization(db))
+pub(crate) fn sequence_pattern_type_builder(
+    db: &dyn Db,
+    program: crate::Program,
+) -> IntersectionBuilder<'_> {
+    IntersectionBuilder::new(db, program)
+        .add_positive(
+            KnownClass::Sequence
+                .to_instance(db, program)
+                .top_materialization(db, program),
+        )
         // `str`, `bytes`, and `bytearray` are sequences, but Python sequence
         // patterns explicitly do not match them or their subclasses.
-        .add_negative(KnownClass::Str.to_instance(db))
-        .add_negative(KnownClass::Bytes.to_instance(db))
-        .add_negative(KnownClass::Bytearray.to_instance(db))
+        .add_negative(KnownClass::Str.to_instance(db, program))
+        .add_negative(KnownClass::Bytes.to_instance(db, program))
+        .add_negative(KnownClass::Bytearray.to_instance(db, program))
 }
 
 fn sequence_pattern_getitem_method<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     indexed_element_types: impl IntoIterator<Item = (i64, Type<'db>)>,
     fallback_return_type: Option<Type<'db>>,
 ) -> CallableType<'db> {
@@ -122,7 +143,7 @@ fn sequence_pattern_getitem_method<'db>(
             Parameters::standard([
                 self_parameter(),
                 Parameter::positional_only(Some(Name::new_static("index")))
-                    .with_annotated_type(KnownClass::Int.to_instance(db)),
+                    .with_annotated_type(KnownClass::Int.to_instance(db, program)),
             ]),
             fallback_return_type,
         )
@@ -151,16 +172,27 @@ fn sequence_pattern_getitem_method<'db>(
 /// and element types.
 pub(crate) fn exact_sequence_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     element_types: impl ExactSizeIterator<Item = Type<'db>>,
 ) -> Type<'db> {
     let Ok(length) = i64::try_from(element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
+        return sequence_pattern_type_builder(db, program).build();
     };
 
     // `False == 0` and `True == 1`, so the protocol must accept both literals.
     let length_type = match length {
-        0 => UnionType::from_two_elements(db, Type::int_literal(0), Type::bool_literal(false)),
-        1 => UnionType::from_two_elements(db, Type::int_literal(1), Type::bool_literal(true)),
+        0 => UnionType::from_two_elements(
+            db,
+            program,
+            Type::int_literal(0),
+            Type::bool_literal(false),
+        ),
+        1 => UnionType::from_two_elements(
+            db,
+            program,
+            Type::int_literal(1),
+            Type::bool_literal(true),
+        ),
         _ => Type::int_literal(length),
     };
 
@@ -172,7 +204,7 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
     let getitem_method = (element_types.len() > 0).then(|| {
         (
             "__getitem__",
-            sequence_pattern_getitem_method(db, (0..length).zip(element_types), None),
+            sequence_pattern_getitem_method(db, program, (0..length).zip(element_types), None),
         )
     });
 
@@ -181,7 +213,7 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
         std::iter::once(("__len__", len_method)).chain(getitem_method),
     );
 
-    sequence_pattern_type_builder(db)
+    sequence_pattern_type_builder(db, program)
         .add_positive(protocol)
         .build()
 }
@@ -192,25 +224,26 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
 /// negative indices. Other integer indices retain the sequence's element type.
 pub(crate) fn starred_sequence_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     prefix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
     suffix_element_types: impl ExactSizeIterator<Item = Type<'db>>,
 ) -> Type<'db> {
     if prefix_element_types.len() == 0 && suffix_element_types.len() == 0 {
-        return sequence_pattern_type_builder(db).build();
+        return sequence_pattern_type_builder(db, program).build();
     }
 
     let Ok(suffix_length) = i64::try_from(suffix_element_types.len()) else {
-        return sequence_pattern_type_builder(db).build();
+        return sequence_pattern_type_builder(db, program).build();
     };
 
     let indexed_element_types = (0_i64..)
         .zip(prefix_element_types)
         .chain((-suffix_length..0).zip(suffix_element_types));
     let getitem_method =
-        sequence_pattern_getitem_method(db, indexed_element_types, Some(Type::object()));
+        sequence_pattern_getitem_method(db, program, indexed_element_types, Some(Type::object()));
     let protocol = Type::protocol_with_methods(db, [("__getitem__", getitem_method)]);
 
-    sequence_pattern_type_builder(db)
+    sequence_pattern_type_builder(db, program)
         .add_positive(protocol)
         .build()
 }
@@ -235,10 +268,11 @@ fn class_pattern_is_exhaustive(
     subject_ty: Type<'_>,
     kind: &ClassPatternPredicateKind<'_>,
 ) -> bool {
+    let program = class.program(db);
     let class_instance_ty = Type::instance(db, class.top_materialization(db));
     let is_typed_dict_match =
         is_typed_dict_pattern_domain(db, subject_ty) && typed_dict_matches_class_pattern(db, class);
-    if !is_typed_dict_match && !subject_ty.is_subtype_of(db, class_instance_ty) {
+    if !is_typed_dict_match && !subject_ty.is_subtype_of(db, program, class_instance_ty) {
         return false;
     }
 
@@ -247,7 +281,13 @@ fn class_pattern_is_exhaustive(
     }
 
     if !kind.keywords.iter().all(|keyword| {
-        member_pattern_is_exhaustive(db, subject_ty, keyword.attr.as_str(), &keyword.pattern)
+        member_pattern_is_exhaustive(
+            db,
+            program,
+            subject_ty,
+            keyword.attr.as_str(),
+            &keyword.pattern,
+        )
     }) {
         return false;
     }
@@ -258,10 +298,10 @@ fn class_pattern_is_exhaustive(
         .zip(positional_sources)
         .all(|(pattern, source)| match source {
             ClassPatternPositionalSource::MatchSelf => {
-                pattern_is_exhaustive_for_subject(db, pattern, subject_ty)
+                pattern_is_exhaustive_for_subject(db, program, pattern, subject_ty)
             }
             ClassPatternPositionalSource::Attribute(name) => {
-                member_pattern_is_exhaustive(db, subject_ty, name.as_str(), pattern)
+                member_pattern_is_exhaustive(db, program, subject_ty, name.as_str(), pattern)
             }
             ClassPatternPositionalSource::Unknown => false,
         })
@@ -303,7 +343,11 @@ pub(crate) enum ClassPatternPositionalSource {
 /// remains authoritative. `PossiblyUndefined` is distinct from `Undefined` because only a truly
 /// absent `__match_args__` enables match-self behavior.
 fn class_match_args_type<'db>(db: &'db dyn Db, class: ClassLiteral<'db>) -> ClassMatchArgs<'db> {
-    match Type::ClassLiteral(class).member(db, "__match_args__").place {
+    let program = class.program(db);
+    match Type::ClassLiteral(class)
+        .member(db, program, "__match_args__")
+        .place
+    {
         Place::Defined(
             place @ DefinedPlace {
                 ty,
@@ -368,6 +412,7 @@ pub(crate) fn class_pattern_positional_result<'db>(
     db: &'db dyn Db,
     class: ClassLiteral<'db>,
 ) -> Option<ClassPatternPositionalResult<'db>> {
+    let program = class.program(db);
     match class_match_args_type(db, class) {
         ClassMatchArgs::Undefined if class_has_match_self_flag(db, class) => {
             Some(ClassPatternPositionalResult::Limit(1))
@@ -390,7 +435,7 @@ pub(crate) fn class_pattern_positional_result<'db>(
                 Some(ClassPatternPositionalResult::Limit(limit))
             } else {
                 match_args
-                    .is_disjoint_from(db, Type::homogeneous_tuple(db, Type::unknown()))
+                    .is_disjoint_from(db, program, Type::homogeneous_tuple(db, Type::unknown()))
                     .then_some(ClassPatternPositionalResult::InvalidType(match_args))
             }
         }
@@ -461,26 +506,29 @@ pub(crate) fn class_pattern_positional_sources(
 /// Return whether `name` is definitely bound and `pattern` consumes its entire static member type.
 fn member_pattern_is_exhaustive(
     db: &dyn Db,
+    program: crate::Program,
     instance_ty: Type<'_>,
     name: &str,
     pattern: &PatternPredicateKind<'_>,
 ) -> bool {
-    let place = instance_ty.member(db, name).place;
+    let place = instance_ty.member(db, program, name).place;
     place.is_definitely_bound()
-        && place
-            .raw_type()
-            .is_some_and(|member_ty| pattern_is_exhaustive_for_subject(db, pattern, member_ty))
+        && place.raw_type().is_some_and(|member_ty| {
+            pattern_is_exhaustive_for_subject(db, program, pattern, member_ty)
+        })
 }
 
 /// Return whether `pattern` is statically guaranteed to match every value in `subject_ty`.
 fn pattern_is_exhaustive_for_subject(
     db: &dyn Db,
+    program: crate::Program,
     pattern: &PatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
     subject_ty.is_subtype_of(
         db,
-        definite_match_pattern_type_for_subject(db, pattern, subject_ty),
+        program,
+        definite_match_pattern_type_for_subject(db, program, pattern, subject_ty),
     )
 }
 
@@ -491,6 +539,7 @@ fn pattern_is_exhaustive_for_subject(
 /// guarantee that a particular key is present.
 fn mapping_pattern_is_exhaustive(
     db: &dyn Db,
+    program: crate::Program,
     kind: &MappingPatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
@@ -502,7 +551,12 @@ fn mapping_pattern_is_exhaustive(
             };
             typed_dict.item(db, key.value(db)).is_some_and(|field| {
                 field.is_required()
-                    && pattern_is_exhaustive_for_subject(db, &entry.pattern, field.declared_ty)
+                    && pattern_is_exhaustive_for_subject(
+                        db,
+                        program,
+                        &entry.pattern,
+                        field.declared_ty,
+                    )
             })
         })
     })
@@ -514,10 +568,15 @@ fn mapping_pattern_is_exhaustive(
 /// tuple element's actual static type.
 fn sequence_pattern_is_exhaustive_for_subject(
     db: &dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'_>,
     subject_ty: Type<'_>,
 ) -> bool {
-    if !subject_ty.is_subtype_of(db, sequence_pattern_type_builder(db).build()) {
+    if !subject_ty.is_subtype_of(
+        db,
+        program,
+        sequence_pattern_type_builder(db, program).build(),
+    ) {
         return false;
     }
 
@@ -539,7 +598,7 @@ fn sequence_pattern_is_exhaustive_for_subject(
                 .iter()
                 .zip(kind.patterns.iter())
                 .all(|(element, pattern)| {
-                    pattern_is_exhaustive_for_subject(db, pattern, *element)
+                    pattern_is_exhaustive_for_subject(db, program, pattern, *element)
                 });
     };
     if elements.len() < prefix.len() + suffix.len() {
@@ -550,7 +609,7 @@ fn sequence_pattern_is_exhaustive_for_subject(
         .iter()
         .zip(prefix)
         .chain(elements.iter().rev().zip(suffix.iter().rev()))
-        .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, pattern, *element))
+        .all(|(element, pattern)| pattern_is_exhaustive_for_subject(db, program, pattern, *element))
 }
 
 /// Return the values that are statically guaranteed to match `kind`, using `subject_ty` when the
@@ -584,10 +643,12 @@ fn sequence_pattern_is_exhaustive_for_subject(
 /// ```
 pub(crate) fn definite_match_pattern_type_for_subject<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    if let Some(subject_independent_ty) = subject_independent_definite_match_pattern_type(db, kind)
+    if let Some(subject_independent_ty) =
+        subject_independent_definite_match_pattern_type(db, program, kind)
     {
         return subject_independent_ty;
     }
@@ -596,17 +657,19 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
     if let Type::Union(union) = resolved_subject_ty {
         return UnionType::from_elements(
             db,
-            union
-                .elements(db)
-                .iter()
-                .map(|element| definite_match_pattern_type_for_subject(db, kind, *element)),
+            program,
+            union.elements(db).iter().map(|element| {
+                definite_match_pattern_type_for_subject(db, program, kind, *element)
+            }),
         );
     }
 
     match kind {
         PatternPredicateKind::Value(value) => {
             let value_ty = infer_same_file_expression_type(db, *value, TypeContext::default());
-            if equality_truthiness(db, resolved_subject_ty, value_ty) == Truthiness::AlwaysTrue {
+            if equality_truthiness(db, program, resolved_subject_ty, value_ty)
+                == Truthiness::AlwaysTrue
+            {
                 return subject_ty;
             }
         }
@@ -615,7 +678,7 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
             match class_ty {
                 Type::ClassLiteral(class) => {
                     if class_pattern_is_exhaustive(db, class, resolved_subject_ty, kind) {
-                        let top_subject_ty = resolved_subject_ty.top_materialization(db);
+                        let top_subject_ty = resolved_subject_ty.top_materialization(db, program);
                         if !class_pattern_is_exhaustive(db, class, top_subject_ty, kind) {
                             return subject_ty;
                         }
@@ -624,33 +687,38 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable)
                     if kind.is_empty()
-                        && subject_ty.is_subtype_of(db, callable_pattern_type(db)) =>
+                        && subject_ty.is_subtype_of(
+                            db,
+                            program,
+                            callable_pattern_type(db, program),
+                        ) =>
                 {
-                    return callable_pattern_type(db);
+                    return callable_pattern_type(db, program);
                 }
                 _ => {}
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            if !sequence_pattern_is_exhaustive_for_subject(db, kind, resolved_subject_ty) {
+            if !sequence_pattern_is_exhaustive_for_subject(db, program, kind, resolved_subject_ty) {
                 // A nested subject-dependent pattern rejected the context-free approximation.
                 // Reusing that approximation for the surrounding sequence would reintroduce the
                 // values that the recursive analysis deliberately excluded.
                 return Type::Never;
             }
-            let top_subject_ty = resolved_subject_ty.top_materialization(db);
-            return if sequence_pattern_is_exhaustive_for_subject(db, kind, top_subject_ty) {
+            let top_subject_ty = resolved_subject_ty.top_materialization(db, program);
+            return if sequence_pattern_is_exhaustive_for_subject(db, program, kind, top_subject_ty)
+            {
                 top_subject_ty
             } else {
                 subject_ty
             };
         }
         PatternPredicateKind::Mapping(kind) => {
-            if !mapping_pattern_is_exhaustive(db, kind, resolved_subject_ty) {
+            if !mapping_pattern_is_exhaustive(db, program, kind, resolved_subject_ty) {
                 return Type::Never;
             }
-            let top_subject_ty = resolved_subject_ty.top_materialization(db);
-            return if mapping_pattern_is_exhaustive(db, kind, top_subject_ty) {
+            let top_subject_ty = resolved_subject_ty.top_materialization(db, program);
+            return if mapping_pattern_is_exhaustive(db, program, kind, top_subject_ty) {
                 top_subject_ty
             } else {
                 subject_ty
@@ -659,20 +727,21 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
         PatternPredicateKind::Or(patterns) => {
             return UnionType::from_elements(
                 db,
+                program,
                 patterns.iter().map(|pattern| {
-                    definite_match_pattern_type_for_subject(db, pattern, subject_ty)
+                    definite_match_pattern_type_for_subject(db, program, pattern, subject_ty)
                 }),
             );
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            return definite_match_pattern_type_for_subject(db, pattern, subject_ty);
+            return definite_match_pattern_type_for_subject(db, program, pattern, subject_ty);
         }
         _ => return Type::Never,
     }
 
-    IntersectionBuilder::new(db)
+    IntersectionBuilder::new(db, program)
         .add_positive(subject_ty)
-        .add_positive(definite_match_pattern_type(db, kind))
+        .add_positive(definite_match_pattern_type(db, program, kind))
         .build()
 }
 
@@ -693,6 +762,7 @@ pub(crate) fn definite_match_pattern_type_for_subject<'db>(
 /// ```
 pub(crate) fn pattern_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
@@ -703,16 +773,17 @@ pub(crate) fn pattern_fallthrough_type<'db>(
         // matches. This includes narrowed intersections containing `Self` or another type variable
         // whose upper bound is that enum.
         if let Some(enum_literal) = value_ty.as_enum_literal()
-            && is_same_enum_pattern_domain(db, subject_ty, enum_literal)
-            && equality_truthiness(db, value_ty, value_ty) == Truthiness::AlwaysTrue
+            && is_same_enum_pattern_domain(db, program, subject_ty, enum_literal)
+            && equality_truthiness(db, program, value_ty, value_ty) == Truthiness::AlwaysTrue
         {
-            return IntersectionBuilder::new(db)
+            return IntersectionBuilder::new(db, program)
                 .add_positive(subject_ty)
                 .add_negative(value_ty)
                 .build();
         }
         if let Some(constraint) = evaluate_type_equality(
             db,
+            program,
             subject_ty,
             value_ty,
             false,
@@ -721,17 +792,17 @@ pub(crate) fn pattern_fallthrough_type<'db>(
                     .strict_literal_narrowing,
             ),
         ) {
-            return IntersectionBuilder::new(db)
+            return IntersectionBuilder::new(db, program)
                 .add_positive(subject_ty)
                 .add_positive(constraint)
                 .build();
         }
     }
 
-    IntersectionBuilder::new(db)
+    IntersectionBuilder::new(db, program)
         .add_positive(subject_ty)
         .add_negative(definite_match_pattern_type_for_subject(
-            db, kind, subject_ty,
+            db, program, kind, subject_ty,
         ))
         .build()
 }
@@ -757,12 +828,14 @@ pub(crate) fn pattern_fallthrough_type<'db>(
 /// ```
 pub(crate) fn pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
     let mut budget = ExactTuplePatternExpansionBudget::default();
-    try_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget)
-        .unwrap_or_else(|()| conservative_pattern_binding_fallthrough_type(db, kind, subject_ty))
+    try_pattern_binding_fallthrough_type(db, program, kind, subject_ty, &mut budget).unwrap_or_else(
+        |()| conservative_pattern_binding_fallthrough_type(db, program, kind, subject_ty),
+    )
 }
 
 /// Compute binding fallthrough while charging every nested exact-tuple expansion to `budget`.
@@ -771,23 +844,24 @@ pub(crate) fn pattern_binding_fallthrough_type<'db>(
 /// complete pattern conservatively.
 fn try_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
     budget: &mut ExactTuplePatternExpansionBudget,
 ) -> Result<Type<'db>, ()> {
     match kind {
         PatternPredicateKind::Sequence(sequence) => {
-            try_sequence_pattern_binding_fallthrough_type(db, sequence, subject_ty, budget)
+            try_sequence_pattern_binding_fallthrough_type(db, program, sequence, subject_ty, budget)
         }
         PatternPredicateKind::Or(patterns) => {
             patterns.iter().try_fold(subject_ty, |remaining, pattern| {
-                try_pattern_binding_fallthrough_type(db, pattern, remaining, budget)
+                try_pattern_binding_fallthrough_type(db, program, pattern, remaining, budget)
             })
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            try_pattern_binding_fallthrough_type(db, pattern, subject_ty, budget)
+            try_pattern_binding_fallthrough_type(db, program, pattern, subject_ty, budget)
         }
-        _ => Ok(pattern_fallthrough_type(db, kind, subject_ty)),
+        _ => Ok(pattern_fallthrough_type(db, program, kind, subject_ty)),
     }
 }
 
@@ -797,19 +871,20 @@ fn try_pattern_binding_fallthrough_type<'db>(
 /// used when the precise traversal exceeds its expansion budget.
 fn conservative_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
     match kind {
         PatternPredicateKind::Or(patterns) => {
             patterns.iter().fold(subject_ty, |remaining, pattern| {
-                conservative_pattern_binding_fallthrough_type(db, pattern, remaining)
+                conservative_pattern_binding_fallthrough_type(db, program, pattern, remaining)
             })
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            conservative_pattern_binding_fallthrough_type(db, pattern, subject_ty)
+            conservative_pattern_binding_fallthrough_type(db, program, pattern, subject_ty)
         }
-        _ => pattern_fallthrough_type(db, kind, subject_ty),
+        _ => pattern_fallthrough_type(db, program, kind, subject_ty),
     }
 }
 
@@ -819,6 +894,7 @@ fn conservative_pattern_binding_fallthrough_type<'db>(
 /// expansion cannot exceed the configured limits.
 fn try_sequence_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'db>,
     subject_ty: Type<'db>,
     budget: &mut ExactTuplePatternExpansionBudget,
@@ -826,14 +902,15 @@ fn try_sequence_pattern_binding_fallthrough_type<'db>(
     let resolved = subject_ty.resolve_type_alias(db);
     let narrowed = match resolved {
         Type::Union(union) => union
-            .try_map(db, |element| {
-                try_sequence_pattern_binding_fallthrough_type(db, kind, *element, budget).ok()
+            .try_map(db, program, |element| {
+                try_sequence_pattern_binding_fallthrough_type(db, program, kind, *element, budget)
+                    .ok()
             })
             .ok_or(())?,
         Type::Intersection(intersection) => {
             let mut failed = false;
-            let narrowed = intersection.map_positive(db, |element| {
-                try_sequence_pattern_binding_fallthrough_type(db, kind, *element, budget)
+            let narrowed = intersection.map_positive(db, program, |element| {
+                try_sequence_pattern_binding_fallthrough_type(db, program, kind, *element, budget)
                     .unwrap_or_else(|()| {
                         failed = true;
                         *element
@@ -846,17 +923,23 @@ fn try_sequence_pattern_binding_fallthrough_type<'db>(
         }
         Type::TypeVar(typevar)
             if typevar.typevar(db).upper_bound(db).is_some_and(|bound| {
-                pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), bound)
-                    .is_never()
+                pattern_fallthrough_type(
+                    db,
+                    program,
+                    &PatternPredicateKind::Sequence(kind.clone()),
+                    bound,
+                )
+                .is_never()
             }) =>
         {
             Type::Never
         }
         _ if resolved.exact_tuple_instance_spec(db).is_some() => {
-            exact_tuple_sequence_pattern_fallthrough_type(db, kind, resolved, budget)?
+            exact_tuple_sequence_pattern_fallthrough_type(db, program, kind, resolved, budget)?
                 .unwrap_or_else(|| {
                     pattern_fallthrough_type(
                         db,
+                        program,
                         &PatternPredicateKind::Sequence(kind.clone()),
                         resolved,
                     )
@@ -864,9 +947,9 @@ fn try_sequence_pattern_binding_fallthrough_type<'db>(
         }
         // An irrefutable sequence pattern can only fail if the subject is not eligible for sequence
         // matching. Unlike length and indexed-element facts, eligibility is unaffected by mutation.
-        _ if kind.is_irrefutable() => IntersectionBuilder::new(db)
+        _ if kind.is_irrefutable() => IntersectionBuilder::new(db, program)
             .add_positive(resolved)
-            .add_negative(sequence_pattern_type_builder(db).build())
+            .add_negative(sequence_pattern_type_builder(db, program).build())
             .build(),
         _ => resolved,
     };
@@ -909,6 +992,7 @@ impl ExactTuplePatternExpansionBudget {
 /// representation used by the general fallthrough path.
 fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'db>,
     subject_ty: Type<'db>,
     budget: &mut ExactTuplePatternExpansionBudget,
@@ -926,7 +1010,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
     if tuple
         .all_elements()
         .iter()
-        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
+        .any(|element| any_over_type(db, program, *element, true, |ty| ty.is_dynamic()))
     {
         return Ok(None);
     }
@@ -939,7 +1023,8 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
         .zip(kind.patterns.iter())
         .enumerate()
     {
-        let remaining = try_pattern_binding_fallthrough_type(db, pattern, element, budget)?;
+        let remaining =
+            try_pattern_binding_fallthrough_type(db, program, pattern, element, budget)?;
         if remaining == element {
             return Ok(Some(subject_ty));
         }
@@ -953,17 +1038,18 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
         alternatives.push(Type::heterogeneous_tuple(db, elements));
     }
 
-    Ok(Some(UnionType::from_elements(db, alternatives)))
+    Ok(Some(UnionType::from_elements(db, program, alternatives)))
 }
 
 /// Return whether every possible value of `ty` belongs to the same enum as `right`, including
 /// bounded type variables nested inside unions or intersections.
 fn is_same_enum_pattern_domain<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     right: EnumLiteralType<'db>,
 ) -> bool {
-    if is_same_enum_domain(db, ty, right) {
+    if is_same_enum_domain(db, program, ty, right) {
         return true;
     }
 
@@ -971,15 +1057,15 @@ fn is_same_enum_pattern_domain<'db>(
         Type::TypeVar(typevar) => typevar
             .typevar(db)
             .upper_bound(db)
-            .is_some_and(|bound| is_same_enum_domain(db, bound, right)),
+            .is_some_and(|bound| is_same_enum_domain(db, program, bound, right)),
         Type::Union(union) => union
             .elements(db)
             .iter()
-            .all(|element| is_same_enum_pattern_domain(db, *element, right)),
+            .all(|element| is_same_enum_pattern_domain(db, program, *element, right)),
         Type::Intersection(intersection) => intersection
             .positive(db)
             .iter()
-            .any(|element| is_same_enum_pattern_domain(db, *element, right)),
+            .any(|element| is_same_enum_pattern_domain(db, program, *element, right)),
         _ => false,
     }
 }
@@ -991,6 +1077,7 @@ fn is_same_enum_pattern_domain<'db>(
 /// the static subject type.
 fn subject_independent_definite_match_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
 ) -> Option<Type<'db>> {
     match kind {
@@ -1000,38 +1087,38 @@ fn subject_independent_definite_match_pattern_type<'db>(
                     let class_instance_ty = Type::instance(db, class.top_materialization(db));
                     let typed_dict_adds_runtime_matches =
                         typed_dict_matches_class_pattern(db, class)
-                            && !Type::object().is_subtype_of(db, class_instance_ty);
+                            && !Type::object().is_subtype_of(db, program, class_instance_ty);
                     (!typed_dict_adds_runtime_matches).then_some(class_instance_ty)
                 }
                 Type::ClassLiteral(_) => None,
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) if kind.is_empty() => {
-                    Some(callable_pattern_type(db))
+                    Some(callable_pattern_type(db, program))
                 }
                 _ => Some(Type::Never),
             }
         }
         PatternPredicateKind::Sequence(kind) => {
-            build_definite_sequence_pattern_type(db, kind, |pattern| {
-                subject_independent_definite_match_pattern_type(db, pattern)
+            build_definite_sequence_pattern_type(db, program, kind, |pattern| {
+                subject_independent_definite_match_pattern_type(db, program, pattern)
             })
         }
         PatternPredicateKind::Mapping(kind) => {
             if kind.is_irrefutable() {
-                Some(mapping_pattern_type(db))
+                Some(mapping_pattern_type(db, program))
             } else {
                 None
             }
         }
         PatternPredicateKind::Or(patterns) => patterns
             .iter()
-            .map(|pattern| subject_independent_definite_match_pattern_type(db, pattern))
+            .map(|pattern| subject_independent_definite_match_pattern_type(db, program, pattern))
             .collect::<Option<Vec<_>>>()
-            .map(|types| UnionType::from_elements(db, types)),
+            .map(|types| UnionType::from_elements(db, program, types)),
         PatternPredicateKind::As(Some(pattern), _) => {
-            subject_independent_definite_match_pattern_type(db, pattern)
+            subject_independent_definite_match_pattern_type(db, program, pattern)
         }
         PatternPredicateKind::Value(_) => None,
-        _ => Some(definite_match_pattern_type(db, kind)),
+        _ => Some(definite_match_pattern_type(db, program, kind)),
     }
 }
 
@@ -1040,15 +1127,19 @@ fn subject_independent_definite_match_pattern_type<'db>(
 /// Reachability and negative narrowing can only subtract this under-approximation.
 pub(crate) fn definite_match_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &PatternPredicateKind<'db>,
 ) -> Type<'db> {
     match kind {
-        PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
+        PatternPredicateKind::Singleton(singleton) => {
+            singleton_pattern_type(db, program, *singleton)
+        }
         PatternPredicateKind::Value(value) => {
             let ty = infer_same_file_expression_type(db, *value, TypeContext::default());
             // Only return the type if it's single-valued and guaranteed to match itself.
             // Otherwise, we can't definitively exclude it from subsequent patterns.
-            if ty.is_single_valued(db) && equality_truthiness(db, ty, ty) == Truthiness::AlwaysTrue
+            if ty.is_single_valued(db, program)
+                && equality_truthiness(db, program, ty, ty) == Truthiness::AlwaysTrue
             {
                 ty
             } else {
@@ -1061,28 +1152,29 @@ pub(crate) fn definite_match_pattern_type<'db>(
                     Type::instance(db, class.top_materialization(db))
                 }
                 Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) if kind.is_empty() => {
-                    callable_pattern_type(db)
+                    callable_pattern_type(db, program)
                 }
                 _ => Type::Never,
             }
         }
         PatternPredicateKind::Mapping(kind) => {
             if kind.is_irrefutable() {
-                mapping_pattern_type(db)
+                mapping_pattern_type(db, program)
             } else {
                 Type::Never
             }
         }
-        PatternPredicateKind::Sequence(kind) => definite_sequence_pattern_type(db, kind),
+        PatternPredicateKind::Sequence(kind) => definite_sequence_pattern_type(db, program, kind),
         PatternPredicateKind::Or(predicates) => UnionType::from_elements(
             db,
+            program,
             predicates
                 .iter()
-                .map(|p| definite_match_pattern_type(db, p)),
+                .map(|p| definite_match_pattern_type(db, program, p)),
         ),
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|p| definite_match_pattern_type(db, p))
+            .map(|p| definite_match_pattern_type(db, program, p))
             .unwrap_or_else(Type::object),
         PatternPredicateKind::Star(_) => Type::object(),
     }
@@ -1091,21 +1183,23 @@ pub(crate) fn definite_match_pattern_type<'db>(
 /// Return the values that are guaranteed to match a sequence pattern.
 fn definite_sequence_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'db>,
 ) -> Type<'db> {
-    build_definite_sequence_pattern_type(db, kind, |pattern| {
-        Some(definite_match_pattern_type(db, pattern))
+    build_definite_sequence_pattern_type(db, program, kind, |pattern| {
+        Some(definite_match_pattern_type(db, program, pattern))
     })
     .unwrap_or(Type::Never)
 }
 
 fn build_definite_sequence_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'db>,
     mut element_type: impl FnMut(&PatternPredicateKind<'db>) -> Option<Type<'db>>,
 ) -> Option<Type<'db>> {
     if kind.is_irrefutable() {
-        return Some(sequence_pattern_type_builder(db).build());
+        return Some(sequence_pattern_type_builder(db, program).build());
     }
 
     if let Some((prefix, suffix)) = kind.split_around_star() {
@@ -1134,6 +1228,10 @@ fn build_definite_sequence_pattern_type<'db>(
     if element_types.iter().any(Type::is_never) {
         Some(Type::Never)
     } else {
-        Some(exact_sequence_pattern_type(db, element_types.into_iter()))
+        Some(exact_sequence_pattern_type(
+            db,
+            program,
+            element_types.into_iter(),
+        ))
     }
 }

--- a/crates/ty_python_semantic/src/types/member.rs
+++ b/crates/ty_python_semantic/src/types/member.rs
@@ -57,6 +57,7 @@ pub(super) fn class_member<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str
     place_table(db, scope)
         .symbol_id(name)
         .map(|symbol_id| {
+            let program = scope.program(db);
             let place_and_quals = place_by_id(
                 db,
                 scope,
@@ -85,7 +86,7 @@ pub(super) fn class_member<'db>(db: &'db dyn Db, scope: ScopeId<'db>, name: &str
                 // Otherwise, we need to check if the symbol has bindings
                 let use_def = use_def_map(db, scope);
                 let bindings = use_def.end_of_scope_symbol_bindings(symbol_id);
-                let inferred = place_from_bindings(db, bindings).place;
+                let inferred = place_from_bindings(db, program, bindings).place;
 
                 // TODO: we should not need to calculate inferred type second time. This is a temporary
                 // solution until the notion of Boundness and Declaredness is split. See #16036, #16264

--- a/crates/ty_python_semantic/src/types/method.rs
+++ b/crates/ty_python_semantic/src/types/method.rs
@@ -2,7 +2,7 @@ use itertools::Either;
 use ruff_python_ast::name::Name;
 
 use crate::{
-    Db,
+    Db, Program,
     types::{
         CallableType, KnownClass, LiteralValueType, LiteralValueTypeKind, Parameter, Parameters,
         PropertyInstanceType, Signature, StringLiteralType, Type, TypeFormType, UnionType,
@@ -40,8 +40,9 @@ pub(super) fn walk_bound_method_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>
     method: BoundMethodType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_function_type(db, method.function(db));
-    visitor.visit_type(db, method.self_instance(db));
+    let program = method.function(db).program(db);
+    visitor.visit_function_type(db, program, method.function(db));
+    visitor.visit_type(db, program, method.self_instance(db));
 }
 
 #[salsa::tracked]
@@ -50,9 +51,12 @@ impl<'db> BoundMethodType<'db> {
     /// This is normally the bound-instance type (the type of `self` or `cls`), but if the bound method is
     /// a `@classmethod`, then it should be an instance of that bound-instance type.
     pub(crate) fn typing_self_type(self, db: &'db dyn Db) -> Type<'db> {
+        let program = self.function(db).program(db);
         let mut self_instance = self.self_instance(db);
         if self.function(db).is_classmethod(db) {
-            self_instance = self_instance.to_instance(db).unwrap_or_else(Type::unknown);
+            self_instance = self_instance
+                .to_instance(db, program)
+                .unwrap_or_else(Type::unknown);
         }
         self_instance
     }
@@ -85,6 +89,7 @@ impl<'db> BoundMethodType<'db> {
 
     #[salsa::tracked(returns(ref), cycle_initial=|_, _, _| CallableSignature::bottom(), heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn bound_signatures(self, db: &'db dyn Db) -> CallableSignature<'db> {
+        let program = self.function(db).program(db);
         let function_signature = self.function(db).signature(db);
         let typing_self_type = self.typing_self_type(db);
 
@@ -98,7 +103,7 @@ impl<'db> BoundMethodType<'db> {
                     function_signature
                         .overloads
                         .iter()
-                        .map(|signature| signature.bind_self(db, Some(typing_self_type))),
+                        .map(|signature| signature.bind_self(db, program, Some(typing_self_type))),
                 );
             }
 
@@ -107,12 +112,12 @@ impl<'db> BoundMethodType<'db> {
                 function_signature
                     .overloads
                     .iter()
-                    .filter(|signature| signature.can_bind_self_to(db, self_instance))
-                    .map(|signature| signature.bind_self(db, Some(typing_self_type))),
+                    .filter(|signature| signature.can_bind_self_to(db, program, self_instance))
+                    .map(|signature| signature.bind_self(db, program, Some(typing_self_type))),
             );
         };
 
-        CallableSignature::single(signature.bind_self(db, Some(typing_self_type)))
+        CallableSignature::single(signature.bind_self(db, program, Some(typing_self_type)))
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -121,12 +126,13 @@ impl<'db> BoundMethodType<'db> {
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
+        let program = self.function(db).program(db);
         Some(Self::new(
             db,
             self.function(db)
                 .recursive_type_normalized_impl(db, div, nested)?,
             self.self_instance(db)
-                .recursive_type_normalized_impl(db, div, true)?,
+                .recursive_type_normalized_impl(db, program, div, true)?,
         ))
     }
 }
@@ -138,12 +144,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: BoundMethodType<'db>,
         target: BoundMethodType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // A bound method is a typically a subtype of itself. However, we must explicitly verify
         // the subtyping of the underlying function signatures (since they might be specialized
         // differently), and of the bound self parameter (taking care that parameters, including a
         // bound self parameter, are contravariant.)
         self.check_function_pair(db, source.function(db), target.function(db))
-            .and(db, self.constraints, || {
+            .and(db, program, self.constraints, || {
                 self.check_type_pair(db, target.self_instance(db), source.self_instance(db))
             })
     }
@@ -184,28 +191,30 @@ pub enum KnownBoundMethodType<'db> {
 
 pub(super) fn walk_method_wrapper_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     method_wrapper: KnownBoundMethodType<'db>,
     visitor: &V,
 ) {
     match method_wrapper {
         KnownBoundMethodType::FunctionTypeDunderGet(function) => {
-            visitor.visit_function_type(db, function);
+            visitor.visit_function_type(db, program, function);
         }
         KnownBoundMethodType::FunctionTypeDunderCall(function) => {
-            visitor.visit_function_type(db, function);
+            visitor.visit_function_type(db, program, function);
         }
         KnownBoundMethodType::PropertyDunderGet(property) => {
-            visitor.visit_property_instance_type(db, property);
+            visitor.visit_property_instance_type(db, program, property);
         }
         KnownBoundMethodType::PropertyDunderSet(property) => {
-            visitor.visit_property_instance_type(db, property);
+            visitor.visit_property_instance_type(db, program, property);
         }
         KnownBoundMethodType::PropertyDunderDelete(property) => {
-            visitor.visit_property_instance_type(db, property);
+            visitor.visit_property_instance_type(db, program, property);
         }
         KnownBoundMethodType::StrStartswith(string_literal) => {
             visitor.visit_type(
                 db,
+                program,
                 LiteralValueType::promotable(LiteralValueTypeKind::String(string_literal)).into(),
             );
         }
@@ -223,6 +232,7 @@ impl<'db> KnownBoundMethodType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -239,17 +249,17 @@ impl<'db> KnownBoundMethodType<'db> {
             }
             KnownBoundMethodType::PropertyDunderGet(property) => {
                 Some(KnownBoundMethodType::PropertyDunderGet(
-                    property.recursive_type_normalized_impl(db, div, nested)?,
+                    property.recursive_type_normalized_impl(db, program, div, nested)?,
                 ))
             }
             KnownBoundMethodType::PropertyDunderSet(property) => {
                 Some(KnownBoundMethodType::PropertyDunderSet(
-                    property.recursive_type_normalized_impl(db, div, nested)?,
+                    property.recursive_type_normalized_impl(db, program, div, nested)?,
                 ))
             }
             KnownBoundMethodType::PropertyDunderDelete(property) => {
                 Some(KnownBoundMethodType::PropertyDunderDelete(
-                    property.recursive_type_normalized_impl(db, div, nested)?,
+                    property.recursive_type_normalized_impl(db, program, div, nested)?,
                 ))
             }
             KnownBoundMethodType::StrStartswith(_)
@@ -287,7 +297,11 @@ impl<'db> KnownBoundMethodType<'db> {
     /// Return the signatures of this bound method type.
     ///
     /// If the bound method type is overloaded, it may have multiple signatures.
-    pub(super) fn signatures(self, db: &'db dyn Db) -> impl Iterator<Item = Signature<'db>> {
+    pub(super) fn signatures(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> impl Iterator<Item = Signature<'db>> {
         let object_type_form = || TypeFormType::from_type_expression(db, Type::object());
 
         match self {
@@ -316,9 +330,9 @@ impl<'db> KnownBoundMethodType<'db> {
                     Signature::new(
                         Parameters::standard([
                             Parameter::positional_only(Some(Name::new_static("instance")))
-                                .with_annotated_type(Type::none(db)),
+                                .with_annotated_type(Type::none(db, program)),
                             Parameter::positional_only(Some(Name::new_static("owner")))
-                                .with_annotated_type(KnownClass::Type.to_instance(db)),
+                                .with_annotated_type(KnownClass::Type.to_instance(db, program)),
                         ]),
                         Type::unknown(),
                     ),
@@ -329,10 +343,11 @@ impl<'db> KnownBoundMethodType<'db> {
                             Parameter::positional_only(Some(Name::new_static("owner")))
                                 .with_annotated_type(UnionType::from_two_elements(
                                     db,
-                                    KnownClass::Type.to_instance(db),
-                                    Type::none(db),
+                                    program,
+                                    KnownClass::Type.to_instance(db, program),
+                                    Type::none(db, program),
                                 ))
-                                .with_default_type(Type::none(db)),
+                                .with_default_type(Type::none(db, program)),
                         ]),
                         Type::unknown(),
                     ),
@@ -368,25 +383,31 @@ impl<'db> KnownBoundMethodType<'db> {
                         Parameter::positional_only(Some(Name::new_static("prefix")))
                             .with_annotated_type(UnionType::from_two_elements(
                                 db,
-                                KnownClass::Str.to_instance(db),
-                                Type::homogeneous_tuple(db, KnownClass::Str.to_instance(db)),
+                                program,
+                                KnownClass::Str.to_instance(db, program),
+                                Type::homogeneous_tuple(
+                                    db,
+                                    KnownClass::Str.to_instance(db, program),
+                                ),
                             )),
                         Parameter::positional_only(Some(Name::new_static("start")))
                             .with_annotated_type(UnionType::from_two_elements(
                                 db,
-                                KnownClass::SupportsIndex.to_instance(db),
-                                Type::none(db),
+                                program,
+                                KnownClass::SupportsIndex.to_instance(db, program),
+                                Type::none(db, program),
                             ))
-                            .with_default_type(Type::none(db)),
+                            .with_default_type(Type::none(db, program)),
                         Parameter::positional_only(Some(Name::new_static("end")))
                             .with_annotated_type(UnionType::from_two_elements(
                                 db,
-                                KnownClass::SupportsIndex.to_instance(db),
-                                Type::none(db),
+                                program,
+                                KnownClass::SupportsIndex.to_instance(db, program),
+                                Type::none(db, program),
                             ))
-                            .with_default_type(Type::none(db)),
+                            .with_default_type(Type::none(db, program)),
                     ]),
-                    KnownClass::Bool.to_instance(db),
+                    KnownClass::Bool.to_instance(db, program),
                 )))
             }
 
@@ -400,7 +421,7 @@ impl<'db> KnownBoundMethodType<'db> {
                         Parameter::positional_only(Some(Name::new_static("upper_bound")))
                             .with_annotated_type(object_type_form()),
                     ]),
-                    KnownClass::ConstraintSet.to_instance(db),
+                    KnownClass::ConstraintSet.to_instance(db, program),
                 )))
             }
 
@@ -408,7 +429,7 @@ impl<'db> KnownBoundMethodType<'db> {
             | KnownBoundMethodType::ConstraintSetNever => {
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::empty(),
-                    KnownClass::ConstraintSet.to_instance(db),
+                    KnownClass::ConstraintSet.to_instance(db, program),
                 )))
             }
 
@@ -420,7 +441,7 @@ impl<'db> KnownBoundMethodType<'db> {
                         Parameter::positional_only(Some(Name::new_static("of")))
                             .with_annotated_type(object_type_form()),
                     ]),
-                    KnownClass::ConstraintSet.to_instance(db),
+                    KnownClass::ConstraintSet.to_instance(db, program),
                 )))
             }
 
@@ -429,8 +450,8 @@ impl<'db> KnownBoundMethodType<'db> {
                     Parameters::standard([Parameter::positional_only(Some(Name::new_static(
                         "other",
                     )))
-                    .with_annotated_type(KnownClass::ConstraintSet.to_instance(db))]),
-                    KnownClass::ConstraintSet.to_instance(db),
+                    .with_annotated_type(KnownClass::ConstraintSet.to_instance(db, program))]),
+                    KnownClass::ConstraintSet.to_instance(db, program),
                 )))
             }
 
@@ -439,21 +460,22 @@ impl<'db> KnownBoundMethodType<'db> {
                     Parameters::standard([Parameter::keyword_only(Name::new_static("inferable"))
                         .with_annotated_type(UnionType::from_two_elements(
                             db,
+                            program,
                             TypeFormType::from_type_expression(
                                 db,
                                 Type::homogeneous_tuple(db, Type::object()),
                             ),
-                            Type::none(db),
+                            Type::none(db, program),
                         ))
-                        .with_default_type(Type::none(db))]),
-                    KnownClass::Bool.to_instance(db),
+                        .with_default_type(Type::none(db, program))]),
+                    KnownClass::Bool.to_instance(db, program),
                 )))
             }
 
             KnownBoundMethodType::ConstraintSetWithDetailedDisplay(_) => {
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::empty(),
-                    KnownClass::ConstraintSet.to_instance(db),
+                    KnownClass::ConstraintSet.to_instance(db, program),
                 )))
             }
         }
@@ -570,7 +592,11 @@ pub enum WrapperDescriptorKind {
 }
 
 impl WrapperDescriptorKind {
-    pub(super) fn signatures(self, db: &dyn Db) -> impl Iterator<Item = Signature<'_>> {
+    pub(super) fn signatures(
+        self,
+        db: &dyn Db,
+        program: Program,
+    ) -> impl Iterator<Item = Signature<'_>> {
         /// Similar to what we do in [`KnownBoundMethod::signatures`],
         /// here we also model `types.FunctionType.__get__` (or builtins.property.__get__),
         /// but now we consider a call to this as a function, i.e. we also expect the `self`
@@ -579,10 +605,14 @@ impl WrapperDescriptorKind {
         /// TODO: Consider merging these synthesized signatures with the ones in
         /// [`KnownBoundMethod::signatures`], since that one is just this signature
         /// with the `self` parameters removed.
-        fn dunder_get_signatures(db: &dyn Db, class: KnownClass) -> [Signature<'_>; 2] {
-            let type_instance = KnownClass::Type.to_instance(db);
-            let none = Type::none(db);
-            let descriptor = class.to_instance(db);
+        fn dunder_get_signatures(
+            db: &dyn Db,
+            program: Program,
+            class: KnownClass,
+        ) -> [Signature<'_>; 2] {
+            let type_instance = KnownClass::Type.to_instance(db, program);
+            let none = Type::none(db, program);
+            let descriptor = class.to_instance(db, program);
             [
                 Signature::new(
                     Parameters::standard([
@@ -604,6 +634,7 @@ impl WrapperDescriptorKind {
                         Parameter::positional_only(Some(Name::new_static("owner")))
                             .with_annotated_type(UnionType::from_two_elements(
                                 db,
+                                program,
                                 type_instance,
                                 none,
                             ))
@@ -615,18 +646,18 @@ impl WrapperDescriptorKind {
         }
 
         match self {
-            WrapperDescriptorKind::FunctionTypeDunderGet => {
-                Either::Left(dunder_get_signatures(db, KnownClass::FunctionType).into_iter())
-            }
+            WrapperDescriptorKind::FunctionTypeDunderGet => Either::Left(
+                dunder_get_signatures(db, program, KnownClass::FunctionType).into_iter(),
+            ),
             WrapperDescriptorKind::PropertyDunderGet => {
-                Either::Left(dunder_get_signatures(db, KnownClass::Property).into_iter())
+                Either::Left(dunder_get_signatures(db, program, KnownClass::Property).into_iter())
             }
             WrapperDescriptorKind::PropertyDunderSet => {
                 let object = Type::object();
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::standard([
                         Parameter::positional_only(Some(Name::new_static("self")))
-                            .with_annotated_type(KnownClass::Property.to_instance(db)),
+                            .with_annotated_type(KnownClass::Property.to_instance(db, program)),
                         Parameter::positional_only(Some(Name::new_static("instance")))
                             .with_annotated_type(object),
                         Parameter::positional_only(Some(Name::new_static("value")))
@@ -639,7 +670,7 @@ impl WrapperDescriptorKind {
                 Either::Right(std::iter::once(Signature::new(
                     Parameters::standard([
                         Parameter::positional_only(Some(Name::new_static("self")))
-                            .with_annotated_type(KnownClass::Property.to_instance(db)),
+                            .with_annotated_type(KnownClass::Property.to_instance(db, program)),
                         Parameter::positional_only(Some(Name::new_static("instance")))
                             .with_annotated_type(Type::object()),
                     ]),

--- a/crates/ty_python_semantic/src/types/mro.rs
+++ b/crates/ty_python_semantic/src/types/mro.rs
@@ -87,6 +87,7 @@ impl<'db> Mro<'db> {
             resolved_bases.push(ClassBase::Generic);
         }
 
+        let program = class_literal.program(db);
         let class = class_literal.apply_optional_specialization(db, specialization);
 
         let original_bases = class_literal.explicit_bases(db);
@@ -118,10 +119,13 @@ impl<'db> Mro<'db> {
                     Ok(Self::from([
                         ClassBase::Class(class),
                         ClassBase::Generic,
-                        ClassBase::object(db),
+                        ClassBase::object(db, program),
                     ]))
                 } else {
-                    Ok(Self::from([ClassBase::Class(class), ClassBase::object(db)]))
+                    Ok(Self::from([
+                        ClassBase::Class(class),
+                        ClassBase::object(db, program),
+                    ]))
                 }
             }
 
@@ -143,6 +147,7 @@ impl<'db> Mro<'db> {
             {
                 ClassBase::try_from_explicit_base(
                     db,
+                    program,
                     *single_base,
                     Some(ClassLiteral::Static(class_literal)),
                 )
@@ -158,7 +163,7 @@ impl<'db> Mro<'db> {
                             Err(StaticMroErrorKind::InheritanceCycle)
                         } else {
                             Ok(std::iter::once(ClassBase::Class(class))
-                                .chain(single_base.mro(db, specialization))
+                                .chain(single_base.mro(db, program, specialization))
                                 .collect())
                         }
                     },
@@ -189,6 +194,7 @@ impl<'db> Mro<'db> {
                     } else {
                         match ClassBase::try_from_explicit_base(
                             db,
+                            program,
                             *base,
                             Some(ClassLiteral::Static(class_literal)),
                         ) {
@@ -216,7 +222,7 @@ impl<'db> Mro<'db> {
                     if base.has_cyclic_mro(db) {
                         return Err(StaticMroErrorKind::InheritanceCycle.into_mro_error(db, class));
                     }
-                    seqs.push(base.mro(db, specialization).collect());
+                    seqs.push(base.mro(db, program, specialization).collect());
                 }
                 seqs.push(
                     resolved_bases
@@ -264,6 +270,7 @@ impl<'db> Mro<'db> {
                     for (index, base) in original_bases.iter().enumerate() {
                         let Some(base) = ClassBase::try_from_explicit_base(
                             db,
+                            program,
                             *base,
                             Some(ClassLiteral::Static(class_literal)),
                         ) else {
@@ -312,6 +319,7 @@ impl<'db> Mro<'db> {
                             bases_list: original_bases.iter().copied().collect(),
                             generic_index: check_generic_reorder_fixes_mro(
                                 db,
+                                program,
                                 resolved_bases.as_slice(),
                                 original_bases,
                             ),
@@ -329,10 +337,11 @@ impl<'db> Mro<'db> {
     }
 
     pub(super) fn from_error(db: &'db dyn Db, class: ClassType<'db>) -> Self {
+        let program = class.program(db);
         Self::from([
             ClassBase::Class(class),
             ClassBase::unknown(),
-            ClassBase::object(db),
+            ClassBase::object(db, program),
         ])
     }
 
@@ -343,6 +352,7 @@ impl<'db> Mro<'db> {
         db: &'db dyn Db,
         dynamic: DynamicClassLiteral<'db>,
     ) -> Result<Self, DynamicMroError<'db>> {
+        let program = dynamic.scope(db).program(db);
         let original_bases = dynamic.explicit_bases(db);
 
         // Convert Types to ClassBases, tracking any that fail conversion.
@@ -350,7 +360,7 @@ impl<'db> Mro<'db> {
         let mut invalid_bases = Vec::new();
 
         for (i, base_type) in original_bases.iter().enumerate() {
-            match ClassBase::try_from_explicit_base(db, *base_type, None) {
+            match ClassBase::try_from_explicit_base(db, program, *base_type, None) {
                 Some(class_base) => resolved_bases.push(class_base),
                 None => invalid_bases.push((i, *base_type)),
             }
@@ -373,7 +383,7 @@ impl<'db> Mro<'db> {
 
         // Handle empty bases case: MRO is just [self, object].
         if resolved_bases.is_empty() {
-            return Ok(Self::from([self_base, ClassBase::object(db)]));
+            return Ok(Self::from([self_base, ClassBase::object(db, program)]));
         }
 
         // Build MRO sequences and check for inheritance cycles.
@@ -382,7 +392,7 @@ impl<'db> Mro<'db> {
             if base.has_cyclic_mro(db) {
                 return Err(DynamicMroErrorKind::InheritanceCycle.into_error(db, dynamic));
             }
-            seqs.push(base.mro(db, None).collect());
+            seqs.push(base.mro(db, program, None).collect());
         }
         seqs.push(resolved_bases.iter().copied().collect());
 
@@ -434,6 +444,7 @@ impl<'db> Mro<'db> {
         db: &'db dyn Db,
         dynamic_enum: DynamicEnumLiteral<'db>,
     ) -> Result<Self, DynamicMroError<'db>> {
+        let program = dynamic_enum.scope(db).program(db);
         let self_base = ClassBase::Class(ClassType::NonGeneric(dynamic_enum.into()));
 
         // Convert the functional enum bases (`type=` mixin first, enum base second)
@@ -442,7 +453,7 @@ impl<'db> Mro<'db> {
         let original_bases = dynamic_enum.explicit_bases(db);
         let mut resolved_bases: Vec<ClassBase<'db>> = Vec::with_capacity(original_bases.len());
         for base_type in original_bases.iter().copied() {
-            if let Some(base) = ClassBase::try_from_explicit_base(db, base_type, None) {
+            if let Some(base) = ClassBase::try_from_explicit_base(db, program, base_type, None) {
                 resolved_bases.push(base);
             }
         }
@@ -464,7 +475,7 @@ impl<'db> Mro<'db> {
             let mut seen = FxHashSet::default();
             seen.insert(self_base);
             for base in &resolved_bases {
-                for item in base.mro(db, None) {
+                for item in base.mro(db, program, None) {
                     if seen.insert(item) {
                         result.push(item);
                     }
@@ -484,7 +495,7 @@ impl<'db> Mro<'db> {
                     fallback_mro: fallback_mro(),
                 });
             }
-            seqs.push(base.mro(db, None).collect());
+            seqs.push(base.mro(db, program, None).collect());
         }
         seqs.push(resolved_bases.iter().copied().collect());
 
@@ -498,6 +509,7 @@ impl<'db> Mro<'db> {
     ///
     /// Iterates over base MROs sequentially with deduplication.
     pub(super) fn dynamic_fallback(db: &'db dyn Db, dynamic: DynamicClassLiteral<'db>) -> Self {
+        let program = dynamic.scope(db).program(db);
         let self_base = ClassBase::Class(ClassType::NonGeneric(dynamic.into()));
         let mut result = vec![self_base];
         let mut seen = FxHashSet::default();
@@ -505,10 +517,10 @@ impl<'db> Mro<'db> {
 
         for base_type in dynamic.explicit_bases(db) {
             // Convert `Type` to `ClassBase`, falling back to `Unknown` if conversion fails.
-            let base = ClassBase::try_from_explicit_base(db, *base_type, None)
+            let base = ClassBase::try_from_explicit_base(db, program, *base_type, None)
                 .unwrap_or_else(ClassBase::unknown);
 
-            for item in base.mro(db, None) {
+            for item in base.mro(db, program, None) {
                 if seen.insert(item) {
                     result.push(item);
                 }
@@ -835,6 +847,7 @@ fn c3_merge(mut sequences: Vec<VecDeque<ClassBase>>) -> Option<Mro> {
 /// the `Generic[]` base. If not, this function will return `None`.
 fn check_generic_reorder_fixes_mro<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     resolved_bases: &[ClassBase<'db>],
     original_bases: &[Type<'db>],
 ) -> Option<usize> {
@@ -866,7 +879,7 @@ fn check_generic_reorder_fixes_mro<'db>(
         if base.has_cyclic_mro(db) {
             return None;
         }
-        seqs.push(base.mro(db, None).collect());
+        seqs.push(base.mro(db, program, None).collect());
     }
     seqs.push(reordered);
     c3_merge(seqs)?;

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, btree_map::Entry as BTreeEntry, hash_map::Entry
 
 use crate::Db;
 use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
-use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
@@ -121,7 +120,7 @@ fn all_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let module = parsed_module(db, pattern.file(db)).load(db);
+    let module = parsed_module(db, pattern.program_file(db).versioned_file(db)).load(db);
     NarrowingConstraintsBuilder::new(db, &module, PredicateNode::Pattern(pattern), true).finish()
 }
 
@@ -134,7 +133,7 @@ fn all_narrowing_constraints_for_expression<'db>(
     db: &'db dyn Db,
     expression: Expression<'db>,
 ) -> ExpressionNarrowingConstraints<'db> {
-    let module = parsed_module(db, expression.file(db)).load(db);
+    let module = parsed_module(db, expression.program_file(db).versioned_file(db)).load(db);
     let predicate = PredicateNode::Expression(expression);
     ExpressionNarrowingConstraints {
         positive: NarrowingConstraintsBuilder::new(db, &module, predicate, true).finish(),
@@ -147,7 +146,7 @@ fn all_negative_narrowing_constraints_for_pattern<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let module = parsed_module(db, pattern.file(db)).load(db);
+    let module = parsed_module(db, pattern.program_file(db).versioned_file(db)).load(db);
     NarrowingConstraintsBuilder::new(db, &module, PredicateNode::Pattern(pattern), false).finish()
 }
 
@@ -157,7 +156,7 @@ fn all_narrowing_constraints_for_subject_element_pattern<'db>(
     pattern: PatternPredicate<'db>,
     target: ExpressionNodeKey,
 ) -> Option<FrozenNarrowingConstraints<'db>> {
-    let module = parsed_module(db, pattern.file(db)).load(db);
+    let module = parsed_module(db, pattern.program_file(db).versioned_file(db)).load(db);
     NarrowingConstraintsBuilder::new(
         db,
         &module,
@@ -172,7 +171,7 @@ fn all_narrowing_constraints_for_subject_element_pattern<'db>(
 /// This positive structural analysis infers the type of each supported name bound by a successful
 /// pattern. Definite-match analysis, which is used for negative narrowing and exhaustiveness,
 /// intentionally remains separate.
-#[derive(Debug, Eq, PartialEq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Eq, PartialEq, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct PatternSuccessTypes<'db> {
     bindings: FrozenMap<ScopedPlaceId, Type<'db>>,
     missing_binding_ty: Type<'db>,
@@ -200,13 +199,22 @@ impl<'db> PatternSuccessTypes<'db> {
         }
     }
 
-    fn cycle_normalized(mut self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: &Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         for (place, ty) in &mut self.bindings {
-            *ty = ty.cycle_normalized(db, previous.binding_type(*place), cycle);
+            *ty = ty.cycle_normalized(db, program, previous.binding_type(*place), cycle);
         }
-        self.missing_binding_ty =
-            self.missing_binding_ty
-                .cycle_normalized(db, previous.missing_binding_ty, cycle);
+        self.missing_binding_ty = self.missing_binding_ty.cycle_normalized(
+            db,
+            program,
+            previous.missing_binding_ty,
+            cycle,
+        );
         self
     }
 }
@@ -296,8 +304,12 @@ impl<'db> PatternBindingTypes<'db> {
     }
 
     /// Return the union of all contributions to this binding.
-    fn ty(&self, db: &'db dyn Db) -> Type<'db> {
-        UnionType::from_elements(db, self.contributions.iter().map(|binding| binding.ty))
+    fn ty(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        UnionType::from_elements(
+            db,
+            program,
+            self.contributions.iter().map(|binding| binding.ty),
+        )
     }
 
     /// Mark every contribution as referring to a value extracted from the current subject.
@@ -313,9 +325,10 @@ impl<'db> PatternBindingTypes<'db> {
     }
 
     /// Return the union of the contributions that alias the current subject.
-    fn subject_ty(&self, db: &'db dyn Db) -> Type<'db> {
+    fn subject_ty(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         UnionType::from_elements(
             db,
+            program,
             self.contributions
                 .iter()
                 .filter(|binding| binding.aliases_subject)
@@ -367,6 +380,7 @@ enum PatternValueSource {
 struct PatternSuccessAnalyzer<'db> {
     db: &'db dyn Db,
     scope: ScopeId<'db>,
+    program: crate::Program,
 }
 
 /// Infer the types of all names bound when `pattern` succeeds.
@@ -385,8 +399,9 @@ struct PatternSuccessAnalyzer<'db> {
 #[salsa::tracked(
     returns(ref),
     cycle_initial=|_, id, _| PatternSuccessTypes::cycle_initial(Type::divergent(id)),
-    cycle_fn=|db, cycle, previous: &PatternSuccessTypes<'db>, result: PatternSuccessTypes<'db>, _| {
-        result.cycle_normalized(db, previous, cycle)
+    cycle_fn=|db, cycle, previous: &PatternSuccessTypes<'db>, result: PatternSuccessTypes<'db>, pattern: PatternPredicate<'db>| {
+        let program = pattern.program_file(db).program(db);
+        result.cycle_normalized(db, program, previous, cycle)
     },
     heap_size=ruff_memory_usage::heap_size
 )]
@@ -394,16 +409,17 @@ pub(crate) fn pattern_success_types<'db>(
     db: &'db dyn Db,
     pattern: PatternPredicate<'db>,
 ) -> PatternSuccessTypes<'db> {
+    let program = pattern.program_file(db).program(db);
     let subject = pattern.subject(db);
     let incoming_subject_ty = infer_same_file_expression_type(db, subject, TypeContext::default());
     let incoming_subject_ty = type_narrowed_by_previous_patterns(db, pattern, incoming_subject_ty);
-    let analyzer = PatternSuccessAnalyzer::new(db, pattern.scope(db));
+    let analyzer = PatternSuccessAnalyzer::new(db, pattern.scope(db), program);
     let result = analyzer.analyze_successful_pattern(pattern.kind(db), incoming_subject_ty);
     PatternSuccessTypes {
         bindings: result
             .bindings
             .into_iter()
-            .map(|(place, binding)| (place, binding.ty(db)))
+            .map(|(place, binding)| (place, binding.ty(db, program)))
             .collect(),
         missing_binding_ty: if result.matched_subject_ty.is_never() {
             Type::Never
@@ -433,6 +449,7 @@ impl ClassInfoConstraintFunction {
     fn generate_constraint<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         classinfo: Type<'db>,
         is_positive: bool,
     ) -> Option<Type<'db>> {
@@ -441,13 +458,13 @@ impl ClassInfoConstraintFunction {
                 Type::instance(db, class.top_materialization(db))
             }
             ClassInfoConstraintFunction::IsSubclass => {
-                SubclassOfType::from(db, class.top_materialization(db))
+                SubclassOfType::from(db, program, class.top_materialization(db))
             }
         };
 
         match classinfo {
             Type::TypeAlias(alias) => {
-                self.generate_constraint(db, alias.value_type(db), is_positive)
+                self.generate_constraint(db, program, alias.value_type(db), is_positive)
             }
             Type::ClassLiteral(class_literal) => Some(constraint_from_class_literal(class_literal)),
             Type::SubclassOf(subclass_of_ty) => {
@@ -477,7 +494,7 @@ impl ClassInfoConstraintFunction {
             Type::Dynamic(_) | Type::Divergent(_) => Some(classinfo),
             Type::Intersection(intersection) => {
                 if intersection.negative(db).is_empty() {
-                    let mut builder = IntersectionBuilder::new(db);
+                    let mut builder = IntersectionBuilder::new(db, program);
                     let mut any_member = false;
                     for element in intersection.positive(db) {
                         // A member that yields no constraint (e.g. a parametrized
@@ -485,7 +502,9 @@ impl ClassInfoConstraintFunction {
                         // target) should be SKIPPED, not abort narrowing on the
                         // whole intersection. Narrowing on the remaining members
                         // is still sound.
-                        if let Some(c) = self.generate_constraint(db, *element, is_positive) {
+                        if let Some(c) =
+                            self.generate_constraint(db, program, *element, is_positive)
+                        {
                             builder = builder.add_positive(c);
                             any_member = true;
                         }
@@ -500,17 +519,21 @@ impl ClassInfoConstraintFunction {
                     None
                 }
             }
-            Type::Union(union) => union.try_map(db, |element| {
-                self.generate_constraint(db, *element, is_positive)
+            Type::Union(union) => union.try_map(db, program, |element| {
+                self.generate_constraint(db, program, *element, is_positive)
             }),
             Type::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db)? {
                     TypeVarBoundOrConstraints::UpperBound(bound) => {
-                        self.generate_constraint(db, bound, is_positive)
+                        self.generate_constraint(db, program, bound, is_positive)
                     }
-                    TypeVarBoundOrConstraints::Constraints(constraints) => {
-                        self.generate_constraint(db, constraints.as_type(db), is_positive)
-                    }
+                    TypeVarBoundOrConstraints::Constraints(constraints) => self
+                        .generate_constraint(
+                            db,
+                            program,
+                            constraints.as_type(db, program),
+                            is_positive,
+                        ),
                 }
             }
 
@@ -518,56 +541,69 @@ impl ClassInfoConstraintFunction {
             // e.g. `isinstance(x, list[int])` fails at runtime.
             Type::GenericAlias(_) => None,
 
-            Type::NominalInstance(nominal) => nominal.tuple_spec(db).and_then(|tuple| {
+            Type::NominalInstance(nominal) => nominal.tuple_spec(db, program).and_then(|tuple| {
                 UnionType::try_from_elements(
                     db,
+                    program,
                     tuple
                         .iter_all_elements()
-                        .map(|element| self.generate_constraint(db, element, is_positive)),
+                        .map(|element| self.generate_constraint(db, program, element, is_positive)),
                 )
             }),
 
             Type::KnownInstance(KnownInstanceType::UnionType(instance)) => {
                 UnionType::try_from_elements(
                     db,
-                    instance.value_expression_types(db).ok()?.map(|element| {
-                        // A special case is made for `None` at runtime
-                        // (it's implicitly converted to `NoneType` in `int | None`)
-                        // which means that `isinstance(x, int | None)` works even though
-                        // `None` is not a class literal.
-                        if element.is_none(db) {
-                            self.generate_constraint(
-                                db,
-                                KnownClass::NoneType.to_class_literal(db),
-                                is_positive,
-                            )
-                        } else {
-                            self.generate_constraint(db, element, is_positive)
-                        }
-                    }),
+                    program,
+                    instance
+                        .value_expression_types(db, program)
+                        .ok()?
+                        .map(|element| {
+                            // A special case is made for `None` at runtime
+                            // (it's implicitly converted to `NoneType` in `int | None`)
+                            // which means that `isinstance(x, int | None)` works even though
+                            // `None` is not a class literal.
+                            if element.is_none(db, program) {
+                                self.generate_constraint(
+                                    db,
+                                    program,
+                                    KnownClass::NoneType.to_class_literal(db, program),
+                                    is_positive,
+                                )
+                            } else {
+                                self.generate_constraint(db, program, element, is_positive)
+                            }
+                        }),
                 )
             }
 
             Type::SpecialForm(form) => match form {
                 SpecialFormType::LegacyStdlibAlias(alias) => self.generate_constraint(
                     db,
-                    alias.aliased_class().to_class_literal(db),
+                    program,
+                    alias.aliased_class().to_class_literal(db, program),
                     is_positive,
                 ),
                 SpecialFormType::Tuple => self.generate_constraint(
                     db,
-                    KnownClass::Tuple.to_class_literal(db),
+                    program,
+                    KnownClass::Tuple.to_class_literal(db, program),
                     is_positive,
                 ),
-                SpecialFormType::Type => {
-                    self.generate_constraint(db, KnownClass::Type.to_class_literal(db), is_positive)
-                }
+                SpecialFormType::Type => self.generate_constraint(
+                    db,
+                    program,
+                    KnownClass::Type.to_class_literal(db, program),
+                    is_positive,
+                ),
 
                 // We don't have a good meta-type for `Callable`s right now,
                 // so only apply `isinstance()` narrowing, not `issubclass()`
-                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => (self
-                    == ClassInfoConstraintFunction::IsInstance)
-                    .then(|| Type::Callable(CallableType::unknown(db)).top_materialization(db)),
+                SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
+                    (self == ClassInfoConstraintFunction::IsInstance).then(|| {
+                        Type::Callable(CallableType::unknown(db)).top_materialization(db, program)
+                    })
+                }
 
                 // `InitVar` is a class at runtime, so can be used in `isinstance()`,
                 // but we can't represent internally the type that we should narrow to after an `isinstance()` check,
@@ -603,7 +639,7 @@ impl ClassInfoConstraintFunction {
     }
 }
 
-#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::SalsaValue, get_size2::GetSize)]
 struct Conjunctions<'db> {
     conjuncts: SmallVec<[Type<'db>; 2]>,
 }
@@ -628,12 +664,12 @@ impl<'db> Conjunctions<'db> {
         self
     }
 
-    fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
+    fn evaluate_constraint_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         if self.conjuncts.len() == 1 {
             return self.conjuncts[0];
         }
 
-        let mut intersection = IntersectionBuilder::new(db);
+        let mut intersection = IntersectionBuilder::new(db, program);
         for conjunct in self.conjuncts {
             intersection = intersection.add_positive(conjunct);
         }
@@ -661,7 +697,7 @@ impl<'db> Conjunctions<'db> {
 ///   ===> `NarrowingConstraint { intersection_disjuncts: [], replacement_disjuncts: [B] }`
 ///   => `NarrowingConstraint { intersection_disjuncts: [A], replacement_disjuncts: [B] }`
 ///   => evaluates to `(P & A) | B`, where `P` is our previously-known type
-#[derive(Hash, PartialEq, Debug, Eq, Clone, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Hash, PartialEq, Debug, Eq, Clone, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct NarrowingConstraint<'db> {
     /// Intersection constraint (from `isinstance()` narrowing comparisons, `TypeIs`, and
     /// similar). We keep these as a disjunction of conjunctions to avoid constructing
@@ -759,14 +795,18 @@ impl<'db> NarrowingConstraint<'db> {
     /// Evaluate the type this effectively constrains to
     ///
     /// Forgets whether each constraint originated from a `replacement` disjunct or not
-    pub(crate) fn evaluate_constraint_type(self, db: &'db dyn Db) -> Type<'db> {
-        let mut union = UnionBuilder::new(db);
+    pub(crate) fn evaluate_constraint_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        let mut union = UnionBuilder::new(db, program);
         for conjunctions in self
             .replacement_disjuncts
             .into_iter()
             .chain(self.intersection_disjuncts)
         {
-            union = union.add(conjunctions.evaluate_constraint_type(db));
+            union = union.add(conjunctions.evaluate_constraint_type(db, program));
         }
         union.build()
     }
@@ -817,7 +857,7 @@ impl<'db> PatternNarrowingResult<'db> {
     }
 }
 
-#[derive(Default, PartialEq, Eq, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Default, PartialEq, Eq, salsa::SalsaValue, get_size2::GetSize)]
 struct ExpressionNarrowingConstraints<'db> {
     positive: Option<FrozenNarrowingConstraints<'db>>,
     negative: Option<FrozenNarrowingConstraints<'db>>,
@@ -915,15 +955,22 @@ fn merge_constraints_or<'db>(
 /// value of `PatternClass` may be a subclass of `A`.
 fn positive_class_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     class_expression_ty: Type<'db>,
 ) -> Option<Type<'db>> {
     match class_expression_ty {
         Type::SpecialForm(SpecialFormType::CollectionsAbcCallable) => {
-            Some(callable_pattern_type(db))
+            Some(callable_pattern_type(db, program))
         }
-        _ if class_expression_ty.is_assignable_to(db, KnownClass::Type.to_instance(db)) => {
+        _ if class_expression_ty.is_assignable_to(
+            db,
+            program,
+            KnownClass::Type.to_instance(db, program),
+        ) =>
+        {
             ClassInfoConstraintFunction::IsInstance.generate_constraint(
                 db,
+                program,
                 class_expression_ty,
                 true,
             )
@@ -952,6 +999,7 @@ fn positive_class_pattern_type<'db>(
 /// ```
 fn refine_exact_tuple_for_sequence_pattern<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     subject_ty: Type<'db>,
     pattern_element_types: &[Type<'db>],
 ) -> Option<Type<'db>> {
@@ -959,7 +1007,7 @@ fn refine_exact_tuple_for_sequence_pattern<'db>(
     let pattern_tuple = TupleSpec::heterogeneous(pattern_element_types.iter().copied());
     Some(
         TupleSpecBuilder::from(tuple.as_ref())
-            .intersect(db, &pattern_tuple)
+            .intersect(db, program, &pattern_tuple)
             .map_or(Type::Never, |refined| {
                 Type::tuple(TupleType::new(db, &refined.build()))
             }),
@@ -985,26 +1033,31 @@ fn refine_exact_tuple_for_sequence_pattern<'db>(
 /// every value that does.
 fn necessary_match_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     pattern: &PatternPredicateKind<'db>,
 ) -> Type<'db> {
     match pattern {
-        PatternPredicateKind::Singleton(singleton) => singleton_pattern_type(db, *singleton),
+        PatternPredicateKind::Singleton(singleton) => {
+            singleton_pattern_type(db, program, *singleton)
+        }
         PatternPredicateKind::Class(kind) => positive_class_pattern_type(
             db,
+            program,
             infer_same_file_expression_type(db, kind.class, TypeContext::default()),
         )
         .unwrap_or_else(Type::object),
-        PatternPredicateKind::Mapping(_) => mapping_pattern_type(db),
-        PatternPredicateKind::Sequence(kind) => necessary_sequence_pattern_type(db, kind),
+        PatternPredicateKind::Mapping(_) => mapping_pattern_type(db, program),
+        PatternPredicateKind::Sequence(kind) => necessary_sequence_pattern_type(db, program, kind),
         PatternPredicateKind::Or(predicates) => UnionType::from_elements(
             db,
+            program,
             predicates
                 .iter()
-                .map(|predicate| necessary_match_pattern_type(db, predicate)),
+                .map(|predicate| necessary_match_pattern_type(db, program, predicate)),
         ),
         PatternPredicateKind::As(pattern, _) => pattern
             .as_deref()
-            .map(|pattern| necessary_match_pattern_type(db, pattern))
+            .map(|pattern| necessary_match_pattern_type(db, program, pattern))
             .unwrap_or_else(Type::object),
         PatternPredicateKind::Value(_) | PatternPredicateKind::Star(_) => Type::object(),
     }
@@ -1013,23 +1066,24 @@ fn necessary_match_pattern_type<'db>(
 /// Preserve the sequence element constraints that can be addressed at fixed indices.
 fn necessary_sequence_pattern_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     kind: &SequencePatternPredicateKind<'db>,
 ) -> Type<'db> {
     if let Some((prefix_patterns, suffix_patterns)) = kind.split_around_star() {
         let prefix_element_types = prefix_patterns
             .iter()
-            .map(|pattern| necessary_match_pattern_type(db, pattern));
+            .map(|pattern| necessary_match_pattern_type(db, program, pattern));
         let suffix_element_types = suffix_patterns
             .iter()
-            .map(|pattern| necessary_match_pattern_type(db, pattern));
+            .map(|pattern| necessary_match_pattern_type(db, program, pattern));
 
-        starred_sequence_pattern_type(db, prefix_element_types, suffix_element_types)
+        starred_sequence_pattern_type(db, program, prefix_element_types, suffix_element_types)
     } else {
         let element_types = kind
             .patterns
             .iter()
-            .map(|pattern| necessary_match_pattern_type(db, pattern));
-        exact_sequence_pattern_type(db, element_types)
+            .map(|pattern| necessary_match_pattern_type(db, program, pattern));
+        exact_sequence_pattern_type(db, program, element_types)
     }
 }
 
@@ -1037,6 +1091,8 @@ struct NarrowingConstraintsBuilder<'db, 'ast> {
     db: &'db dyn Db,
     module: &'ast ParsedModuleRef,
     predicate: PredicateNode<'db>,
+    scope: ScopeId<'db>,
+    program: crate::Program,
     is_positive: bool,
 }
 
@@ -1047,10 +1103,25 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
         predicate: PredicateNode<'db>,
         is_positive: bool,
     ) -> Self {
+        let scope = match predicate {
+            PredicateNode::Expression(expression) => expression.scope(db),
+            PredicateNode::Pattern(pattern) => pattern.scope(db),
+            PredicateNode::SubjectElementPattern(subject_element) => {
+                subject_element.pattern.scope(db)
+            }
+            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
+                callable.scope(db)
+            }
+            PredicateNode::IsNonEmptyIterable(expression) => expression.scope(db),
+            PredicateNode::StarImportPlaceholder(definition) => definition.scope(db),
+        };
+
         Self {
             db,
             module,
             predicate,
+            scope,
+            program: scope.program(db),
             is_positive,
         }
     }
@@ -1091,8 +1162,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         match expression_node {
             ast::Expr::Name(_) => {
-                let file = expression.file(self.db);
-                let index = semantic_index(self.db, file);
+                let index =
+                    semantic_index(self.db, expression.scope(self.db).program_file(self.db));
                 let constraints = self.evaluate_simple_expr(expression_node, is_positive);
                 if let Some(alias_predicate) = index.narrowing_alias_predicate(expression_node) {
                     let aliased_constraints =
@@ -1161,7 +1232,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
     ) -> Option<NarrowingConstraints<'db>> {
         let test_truthiness = infer_expression_types(self.db, expression, TypeContext::default())
             .expression_type(&expr_if.test)
-            .bool(self.db);
+            .bool(self.db, self.program());
 
         match test_truthiness {
             Truthiness::AlwaysTrue => {
@@ -1317,7 +1388,7 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                     .map(NarrowingConstraint::intersection)
             }
             PatternPredicateKind::Singleton(singleton) => Some(NarrowingConstraint::intersection(
-                singleton_pattern_type(self.db, *singleton),
+                singleton_pattern_type(self.db, self.program(), *singleton),
             )),
             PatternPredicateKind::As(Some(pattern), _) => {
                 self.positive_subject_constraint(pattern, subject_ty)
@@ -1335,9 +1406,10 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
                 Some(constraint)
             }
             _ => {
-                let matched_subject_ty = PatternSuccessAnalyzer::new(self.db, self.scope())
-                    .matched_subject_type(pattern, subject_ty);
-                (!matched_subject_ty.is_equivalent_to(self.db, subject_ty))
+                let matched_subject_ty =
+                    PatternSuccessAnalyzer::new(self.db, self.scope, self.program)
+                        .matched_subject_type(pattern, subject_ty);
+                (!matched_subject_ty.is_equivalent_to(self.db, self.program(), subject_ty))
                     .then(|| NarrowingConstraint::intersection(matched_subject_ty))
             }
         }
@@ -1345,8 +1417,8 @@ impl<'db, 'ast> NarrowingConstraintsBuilder<'db, 'ast> {
 }
 
 impl<'db> PatternSuccessAnalyzer<'db> {
-    fn new(db: &'db dyn Db, scope: ScopeId<'db>) -> Self {
-        Self { db, scope }
+    fn new(db: &'db dyn Db, scope: ScopeId<'db>, program: crate::Program) -> Self {
+        Self { db, scope, program }
     }
 
     fn comparison_soundness_policy(&self) -> ComparisonSoundnessPolicy {
@@ -1355,6 +1427,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .analysis_settings(self.scope.file(self.db))
                 .strict_literal_narrowing,
         )
+    }
+
+    fn program(&self) -> crate::Program {
+        self.program
     }
 
     fn merge_binding(
@@ -1465,8 +1541,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 }
             }
             PatternPredicateKind::Singleton(_) => {
-                let matched_subject_ty = self
-                    .intersect_types(subject_ty, necessary_match_pattern_type(self.db, pattern));
+                let matched_subject_ty = self.intersect_types(
+                    subject_ty,
+                    necessary_match_pattern_type(self.db, self.program(), pattern),
+                );
                 PatternSuccessResult {
                     matched_subject_ty,
                     binding_subject_ty: matched_subject_ty,
@@ -1506,9 +1584,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             PatternPredicateKind::Value(value) => {
                 self.match_value_pattern_subject_type(*value, subject_ty)
             }
-            PatternPredicateKind::Singleton(_) => {
-                self.intersect_types(subject_ty, necessary_match_pattern_type(self.db, pattern))
-            }
+            PatternPredicateKind::Singleton(_) => self.intersect_types(
+                subject_ty,
+                necessary_match_pattern_type(self.db, self.program(), pattern),
+            ),
         }
     }
 
@@ -1523,6 +1602,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             |analyzer, _, subject_ty| {
                 Some(UnionType::from_elements(
                     analyzer.db,
+                    analyzer.program(),
                     patterns
                         .iter()
                         .map(|pattern| analyzer.matched_subject_type(pattern, subject_ty)),
@@ -1552,6 +1632,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let value_ty = infer_same_file_expression_type(self.db, value, TypeContext::default());
         evaluate_type_equality(
             self.db,
+            self.program(),
             subject_ty,
             value_ty,
             true,
@@ -1589,9 +1670,9 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             };
         };
         let first = self.analyze_successful_pattern(first_pattern, subject_ty);
-        let mut matched_subject_types = UnionBuilder::new(self.db);
+        let mut matched_subject_types = UnionBuilder::new(self.db, self.program());
         matched_subject_types.add_in_place(first.matched_subject_ty);
-        let mut binding_subject_types = UnionBuilder::new(self.db);
+        let mut binding_subject_types = UnionBuilder::new(self.db, self.program());
         binding_subject_types.add_in_place(first.binding_subject_ty);
         // All alternatives bind the same names. Merge by logical place so the case body sees the
         // union even though the semantic walk visits the definitions in order.
@@ -1600,8 +1681,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let mut previous_pattern = first_pattern;
 
         for pattern in patterns {
-            remaining_subject_ty =
-                pattern_binding_fallthrough_type(self.db, previous_pattern, remaining_subject_ty);
+            remaining_subject_ty = pattern_binding_fallthrough_type(
+                self.db,
+                self.program(),
+                previous_pattern,
+                remaining_subject_ty,
+            );
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             binding_subject_types.add_in_place(alternative.binding_subject_ty);
             Self::merge_bindings(&mut bindings, alternative.bindings);
@@ -1641,23 +1726,25 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             Type::TypeAlias(alias) => {
                 self.filter_class_pattern_subject_type(class, class_ty, alias.value_type(self.db))
             }
-            Type::Union(union) => union.map(self.db, |element| {
+            Type::Union(union) => union.map(self.db, self.program(), |element| {
                 self.filter_class_pattern_subject_type(class, class_ty, *element)
             }),
             Type::Intersection(intersection) if intersection.positive(self.db).is_empty() => {
                 self.intersect_types(subject_ty, class_ty)
             }
-            Type::Intersection(intersection) => intersection.map_positive(self.db, |positive| {
-                self.filter_class_pattern_subject_type(class, class_ty, *positive)
-            }),
+            Type::Intersection(intersection) => {
+                intersection.map_positive(self.db, self.program(), |positive| {
+                    self.filter_class_pattern_subject_type(class, class_ty, *positive)
+                })
+            }
             Type::NominalInstance(instance) => {
                 let Some(class) = class else {
                     return self.intersect_types(subject_ty, class_ty);
                 };
-                let subject_class = instance.class(self.db);
+                let subject_class = instance.class(self.db, self.program());
                 if subject_class.is_subtype_of_class_literal(self.db, class) {
                     subject_ty
-                } else if subject_ty.is_disjoint_from(self.db, class_ty) {
+                } else if subject_ty.is_disjoint_from(self.db, self.program(), class_ty) {
                     Type::Never
                 } else {
                     self.intersect_types(subject_ty, class_ty)
@@ -1668,8 +1755,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             {
                 subject_ty
             }
-            _ if subject_ty.is_subtype_of(self.db, class_ty) => subject_ty,
-            _ if subject_ty.is_disjoint_from(self.db, class_ty) => Type::Never,
+            _ if subject_ty.is_subtype_of(self.db, self.program(), class_ty) => subject_ty,
+            _ if subject_ty.is_disjoint_from(self.db, self.program(), class_ty) => Type::Never,
             _ => self.intersect_types(subject_ty, class_ty),
         }
     }
@@ -1683,7 +1770,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> Option<Vec<ClassPatternArgument<'db>>> {
         let subject_is_final = subject_ty
-            .nominal_class(self.db)
+            .nominal_class(self.db, self.program())
             .is_some_and(|class| class.is_final(self.db));
         let specialized_pattern_class =
             if context.positional_sources.is_empty() && kind.keywords.is_empty() {
@@ -1691,29 +1778,34 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             } else {
                 context
                     .class
-                    .zip(filtering_subject_ty.nominal_class(self.db))
+                    .zip(filtering_subject_ty.nominal_class(self.db, self.program()))
                     .and_then(|(pattern_class, subject_class)| {
                         self.specialize_pattern_class_for_subject(pattern_class, subject_class)
                     })
             };
         let member_type = |name: &Name| {
             let original_member_ty = original_subject_ty
-                .member(self.db, name.as_str())
+                .member(self.db, self.program(), name.as_str())
                 .place
                 .ignore_possibly_undefined();
-            let place = subject_ty.member(self.db, name.as_str()).place;
+            let place = subject_ty
+                .member(self.db, self.program(), name.as_str())
+                .place;
             let mut member_ty = place.ignore_possibly_undefined();
-            if original_subject_ty.nominal_class(self.db).is_some()
+            if original_subject_ty
+                .nominal_class(self.db, self.program())
+                .is_some()
                 && let Type::Intersection(intersection) = subject_ty
             {
                 let overlapping_member_ty = UnionType::from_elements(
                     self.db,
+                    self.program(),
                     intersection
                         .positive(self.db)
                         .iter()
                         .filter_map(|positive| {
                             positive
-                                .member(self.db, name.as_str())
+                                .member(self.db, self.program(), name.as_str())
                                 .place
                                 .ignore_possibly_undefined()
                         }),
@@ -1725,7 +1817,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
             if let Some(specialized_pattern_class) = specialized_pattern_class {
                 member_ty = Type::instance(self.db, specialized_pattern_class)
-                    .member(self.db, name.as_str())
+                    .member(self.db, self.program(), name.as_str())
                     .place
                     .ignore_possibly_undefined();
             } else if let Some(pattern_class) = context.class
@@ -1741,11 +1833,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                             .place
                             .ignore_possibly_undefined()
                     })
-                    .is_some_and(|ty| ty.has_typevar(self.db))
+                    .is_some_and(|ty| ty.has_typevar(self.db, self.program()))
             {
                 let unknown_pattern_class = pattern_class.unknown_specialization(self.db);
                 let unknown_pattern_member_ty = Type::instance(self.db, unknown_pattern_class)
-                    .member(self.db, name.as_str())
+                    .member(self.db, self.program(), name.as_str())
                     .place
                     .ignore_possibly_undefined();
                 // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
@@ -1753,7 +1845,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 // when the subject does not determine one exact specialization of the pattern
                 // subclass.
                 if original_subject_ty
-                    .nominal_class(self.db)
+                    .nominal_class(self.db, self.program())
                     .is_some_and(|original_class| {
                         unknown_pattern_class.is_subtype_of_class_literal(
                             self.db,
@@ -1777,6 +1869,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     // generic pattern class's member as a possible runtime value.
                     member_ty = Some(UnionType::from_elements(
                         self.db,
+                        self.program(),
                         member_ty.into_iter().chain([pattern_member_ty]),
                     ));
                 }
@@ -1846,6 +1939,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let solutions = Type::instance(self.db, pattern_base)
             .assignable_solutions_with_inferable(
                 self.db,
+                self.program(),
                 Type::instance(self.db, subject_class),
                 generic_context.inferable_typevars(self.db),
             )
@@ -1854,11 +1948,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     return Ok(None);
                 };
                 if variance != TypeVarVariance::Invariant
-                    || path_bound.upper.materialize_exact(self.db) != lower
+                    || path_bound.upper.materialize_exact(self.db, self.program()) != lower
                 {
                     return Ok(None);
                 }
-                PathBounds::default_solve(self.db, &constraints, path_bound)
+                PathBounds::default_solve(self.db, self.program(), &constraints, path_bound)
             });
         let Solutions::Constrained(solutions) = solutions else {
             return None;
@@ -1879,7 +1973,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .collect::<Option<Vec<_>>>()?;
         if types.iter().any(|ty| {
             typevars.clone().any(|typevar| {
-                ty.references_typevar(self.db, typevar.typevar(self.db).identity(self.db))
+                ty.references_typevar(
+                    self.db,
+                    self.program(),
+                    typevar.typevar(self.db).identity(self.db),
+                )
             })
         }) {
             return None;
@@ -1901,7 +1999,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             let class = class_expr_ty.as_class_literal();
             ClassPatternContext {
                 class,
-                class_ty: positive_class_pattern_type(self.db, class_expr_ty)
+                class_ty: positive_class_pattern_type(self.db, self.program(), class_expr_ty)
                     .unwrap_or_else(Type::object),
                 positional_sources: class.map_or_else(
                     || vec![ClassPatternPositionalSource::Unknown; kind.positional.len()],
@@ -1949,6 +2047,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Type<'db> {
         UnionType::from_elements(
             self.db,
+            self.program(),
             self.class_pattern_contexts(kind).iter().map(|context| {
                 self.matched_class_pattern_subject_type_for_context(kind, context, subject_ty)
             }),
@@ -1992,8 +2091,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         kind: &ClassPatternPredicateKind<'db>,
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        let mut matched_subject_types = UnionBuilder::new(self.db);
-        let mut binding_subject_types = UnionBuilder::new(self.db);
+        let mut matched_subject_types = UnionBuilder::new(self.db, self.program());
+        let mut binding_subject_types = UnionBuilder::new(self.db, self.program());
         let mut bindings = BTreeMap::new();
         for context in self.class_pattern_contexts(kind) {
             let result =
@@ -2059,9 +2158,9 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     ) -> Option<Type<'db>> {
         if let Type::TypedDict(typed_dict) = subject_ty.resolve_type_alias(self.db) {
             let key_ty = key_ty.resolve_type_alias(self.db);
-            let typed_dict_key_ty = typed_dict.key_type(self.db);
+            let typed_dict_key_ty = typed_dict.key_type(self.db, self.program());
             if typed_dict_key_ty.is_never()
-                || equality_truthiness(self.db, typed_dict_key_ty, key_ty)
+                || equality_truthiness(self.db, self.program(), typed_dict_key_ty, key_ty)
                     == Truthiness::AlwaysFalse
             {
                 return None;
@@ -2077,14 +2176,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                             .then_some(Type::object())
                     });
             }
-            return Some(typed_dict.value_type(self.db));
+            return Some(typed_dict.value_type(self.db, self.program()));
         }
 
-        let Some((_, mapping_value_ty)) = subject_ty.unpack_keys_and_items(self.db) else {
+        let Some((_, mapping_value_ty)) = subject_ty.unpack_keys_and_items(self.db, self.program())
+        else {
             return Some(Type::unknown());
         };
         let Some(get_method) = subject_ty
-            .member(self.db, "get")
+            .member(self.db, self.program(), "get")
             .place
             .ignore_possibly_undefined()
         else {
@@ -2097,14 +2197,18 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         };
         Some(
             get_method
-                .try_call(self.db, &CallArguments::positional([key_ty, default_ty]))
-                .map(|bindings| bindings.return_type(self.db))
-                .unwrap_or_else(|error| error.return_type(self.db)),
+                .try_call(
+                    self.db,
+                    self.program(),
+                    &CallArguments::positional([key_ty, default_ty]),
+                )
+                .map(|bindings| bindings.return_type(self.db, self.program()))
+                .unwrap_or_else(|error| error.return_type(self.db, self.program())),
         )
     }
 
     fn mapping_pattern_uses_standard_get(&self, subject_ty: Type<'db>) -> bool {
-        let Some(class) = subject_ty.nominal_class(self.db) else {
+        let Some(class) = subject_ty.nominal_class(self.db, self.program()) else {
             return false;
         };
         for base in class.iter_mro(self.db) {
@@ -2146,7 +2250,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
         key_types: &[Type<'db>],
     ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
-        let narrowed_subject_ty = self.intersect_types(subject_ty, mapping_pattern_type(self.db));
+        let narrowed_subject_ty =
+            self.intersect_types(subject_ty, mapping_pattern_type(self.db, self.program()));
         if narrowed_subject_ty.is_never() {
             return None;
         }
@@ -2229,12 +2334,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
     fn mapping_pattern_rest_type_for_arm(&self, subject_ty: Type<'db>) -> Type<'db> {
         let (key_ty, value_ty) = match subject_ty.resolve_type_alias(self.db) {
-            Type::TypedDict(_) => (KnownClass::Str.to_instance(self.db), Type::object()),
+            Type::TypedDict(_) => (
+                KnownClass::Str.to_instance(self.db, self.program()),
+                Type::object(),
+            ),
             _ => subject_ty
-                .unpack_keys_and_items(self.db)
+                .unpack_keys_and_items(self.db, self.program())
                 .unwrap_or_else(|| (Type::unknown(), Type::unknown())),
         };
-        KnownClass::Dict.to_specialized_instance(self.db, &[key_ty, value_ty])
+        KnownClass::Dict.to_specialized_instance(self.db, self.program(), &[key_ty, value_ty])
     }
 
     fn matched_sequence_pattern_subject_type(
@@ -2243,7 +2351,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> Type<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
-        let sequence_ty = sequence_pattern_type_builder(self.db).build();
+        let sequence_ty = sequence_pattern_type_builder(self.db, self.program()).build();
         self.analyze_matched_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::TypeVariablesOnly,
@@ -2289,7 +2397,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
         let target_len = Self::sequence_pattern_target_len(kind);
-        let sequence_ty = sequence_pattern_type_builder(self.db).build();
+        let sequence_ty = sequence_pattern_type_builder(self.db, self.program()).build();
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::TypeVariablesOnly,
@@ -2342,8 +2450,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         matched_element_types: &[Type<'db>],
     ) -> Type<'db> {
         if kind.split_around_star().is_none()
-            && let Some(refined) =
-                refine_exact_tuple_for_sequence_pattern(self.db, subject_ty, matched_element_types)
+            && let Some(refined) = refine_exact_tuple_for_sequence_pattern(
+                self.db,
+                self.program(),
+                subject_ty,
+                matched_element_types,
+            )
         {
             return refined;
         }
@@ -2371,8 +2483,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         binding_element_types: &[Type<'db>],
     ) -> Type<'db> {
         if kind.split_around_star().is_none()
-            && let Some(refined) =
-                refine_exact_tuple_for_sequence_pattern(self.db, subject_ty, binding_element_types)
+            && let Some(refined) = refine_exact_tuple_for_sequence_pattern(
+                self.db,
+                self.program(),
+                subject_ty,
+                binding_element_types,
+            )
         {
             return refined;
         }
@@ -2383,7 +2499,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 self.successful_sequence_pattern_type(kind, binding_element_types),
             )
         } else {
-            self.intersect_types(subject_ty, sequence_pattern_type_builder(self.db).build())
+            self.intersect_types(
+                subject_ty,
+                sequence_pattern_type_builder(self.db, self.program()).build(),
+            )
         }
     }
 
@@ -2398,9 +2517,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .iter()
                 .copied()
                 .skip(matched_element_types.len().saturating_sub(suffix.len()));
-            starred_sequence_pattern_type(self.db, prefix_types, suffix_types)
+            starred_sequence_pattern_type(self.db, self.program(), prefix_types, suffix_types)
         } else {
-            exact_sequence_pattern_type(self.db, matched_element_types.iter().copied())
+            exact_sequence_pattern_type(
+                self.db,
+                self.program(),
+                matched_element_types.iter().copied(),
+            )
         }
     }
 
@@ -2420,15 +2543,17 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             return None;
         }
 
-        let tuple = subject_ty.try_iterate(self.db).unwrap_or_else(|error| {
-            let fallback_element_ty = error.fallback_element_type(self.db);
-            Cow::Owned(Tuple::homogeneous(if fallback_element_ty.is_unknown() {
-                Type::object()
-            } else {
-                fallback_element_ty
-            }))
-        });
-        let mut unpacker = TupleUnpacker::new(self.db, target_len);
+        let tuple = subject_ty
+            .try_iterate(self.db, self.program())
+            .unwrap_or_else(|error| {
+                let fallback_element_ty = error.fallback_element_type(self.db, self.program());
+                Cow::Owned(Tuple::homogeneous(if fallback_element_ty.is_unknown() {
+                    Type::object()
+                } else {
+                    fallback_element_ty
+                }))
+            });
+        let mut unpacker = TupleUnpacker::new(self.db, self.program(), target_len);
         unpacker.unpack_tuple(tuple.as_ref()).ok()?;
         Some((narrowed_subject_ty, unpacker.into_types().collect()))
     }
@@ -2443,11 +2568,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let grouped_arms = subject_arms
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
-        let mut matched_subject_types = UnionBuilder::new(self.db);
+        let mut matched_subject_types = UnionBuilder::new(self.db, self.program());
 
         for (original_subject_ty, arms) in &grouped_arms {
             let matched_types = UnionType::from_elements(
                 self.db,
+                self.program(),
                 arms.filter_map(|(_, filtering_subject_ty)| {
                     analyze_arm(self, original_subject_ty, filtering_subject_ty)
                 }),
@@ -2472,13 +2598,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         let grouped_arms = subject_arms
             .into_iter()
             .chunk_by(|(original_subject_ty, _)| *original_subject_ty);
-        let mut matched_subject_types = UnionBuilder::new(self.db);
-        let mut binding_subject_types = UnionBuilder::new(self.db);
+        let mut matched_subject_types = UnionBuilder::new(self.db, self.program());
+        let mut binding_subject_types = UnionBuilder::new(self.db, self.program());
         let mut bindings = BTreeMap::new();
 
         for (original_subject_ty, arms) in &grouped_arms {
-            let mut matched_types = UnionBuilder::new(self.db);
-            let mut binding_types = UnionBuilder::new(self.db);
+            let mut matched_types = UnionBuilder::new(self.db, self.program());
+            let mut binding_types = UnionBuilder::new(self.db, self.program());
             let mut arm_bindings = BTreeMap::new();
 
             for (_, filtering_subject_ty) in arms {
@@ -2490,7 +2616,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             }
 
             for binding in arm_bindings.values_mut() {
-                let subject_ty = binding.subject_ty(self.db);
+                let subject_ty = binding.subject_ty(self.db, self.program());
                 if !subject_ty.is_never() {
                     binding.restore_subject(self.preserve_original_subject_type(
                         original_subject_ty,
@@ -2528,12 +2654,12 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         preservation: OriginalSubjectPreservation,
     ) -> Type<'db> {
         let filtering_ty = self.pattern_filtering_type(original_subject_ty);
-        if filtered_ty.is_equivalent_to(self.db, filtering_ty)
+        if filtered_ty.is_equivalent_to(self.db, self.program(), filtering_ty)
             && (matches!(preservation, OriginalSubjectPreservation::EquivalentTypes)
-                || original_subject_ty.has_typevar(self.db))
+                || original_subject_ty.has_typevar(self.db, self.program()))
         {
             original_subject_ty
-        } else if original_subject_ty.has_typevar(self.db) {
+        } else if original_subject_ty.has_typevar(self.db, self.program()) {
             self.intersect_types(original_subject_ty, filtered_ty)
         } else {
             filtered_ty
@@ -2596,7 +2722,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
     }
 
     fn intersect_types(&self, left: Type<'db>, right: Type<'db>) -> Type<'db> {
-        IntersectionBuilder::new(self.db)
+        IntersectionBuilder::new(self.db, self.program())
             .add_positive(left)
             .add_positive(right)
             .build()
@@ -2608,6 +2734,10 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 }
 
 impl<'db> NarrowingConstraintsBuilder<'db, '_> {
+    fn program(&self) -> crate::Program {
+        self.program
+    }
+
     fn evaluate_subject_element_pattern(
         &mut self,
         subject_element: SubjectElementPatternPredicate<'db>,
@@ -2625,28 +2755,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     }
 
     fn places(&self) -> &'db PlaceTable {
-        place_table(self.db, self.scope())
-    }
-
-    fn scope(&self) -> ScopeId<'db> {
-        match self.predicate {
-            PredicateNode::Expression(expression) => expression.scope(self.db),
-            PredicateNode::Pattern(pattern) => pattern.scope(self.db),
-            PredicateNode::SubjectElementPattern(subject_element) => {
-                subject_element.pattern.scope(self.db)
-            }
-            PredicateNode::IsNonTerminalCall(CallableAndCallExpr { callable, .. }) => {
-                callable.scope(self.db)
-            }
-            PredicateNode::IsNonEmptyIterable(expression) => expression.scope(self.db),
-            PredicateNode::StarImportPlaceholder(definition) => definition.scope(self.db),
-        }
+        place_table(self.db, self.scope)
     }
 
     fn comparison_soundness_policy(&self) -> ComparisonSoundnessPolicy {
         ComparisonSoundnessPolicy::from_strict_literal_narrowing(
             self.db
-                .analysis_settings(self.scope().file(self.db))
+                .analysis_settings(self.scope.file(self.db))
                 .strict_literal_narrowing,
         )
     }
@@ -2670,9 +2785,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     ///   and much of our special-casing for tuples elsewhere depends on this assumption).
     /// - Arbitrary user types that return `Literal` types from both `__len__` and `__bool__`,
     ///   where the returned `Literal` types are mutually consistent in their truthiness.
-    fn is_base_type_narrowable_by_len(db: &'db dyn Db, ty: Type<'db>) -> bool {
+    fn is_base_type_narrowable_by_len(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+    ) -> bool {
         match ty {
-            Type::NominalInstance(instance) if instance.tuple_spec(db).is_some() => true,
+            Type::NominalInstance(instance) if instance.tuple_spec(db, program).is_some() => true,
             Type::LiteralValue(literal)
                 if matches!(
                     literal.kind(),
@@ -2683,9 +2802,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             {
                 true
             }
-            _ => ty.len(db).is_some_and(|len_ty| {
-                let len_ty_bool = len_ty.bool(db);
-                len_ty_bool != Truthiness::Ambiguous && len_ty_bool == ty.bool(db)
+            _ => ty.len(db, program).is_some_and(|len_ty| {
+                let len_ty_bool = len_ty.bool(db, program);
+                len_ty_bool != Truthiness::Ambiguous && len_ty_bool == ty.bool(db, program)
             }),
         }
     }
@@ -2696,7 +2815,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     /// `~AlwaysTruthy` (negative). For non-narrowable types, we return them unchanged.
     ///
     /// Returns `None` if no part of the type is narrowable.
-    fn narrow_type_by_len(db: &'db dyn Db, ty: Type<'db>, is_positive: bool) -> Option<Type<'db>> {
+    fn narrow_type_by_len(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+        is_positive: bool,
+    ) -> Option<Type<'db>> {
         match ty {
             Type::Union(union) => {
                 let mut has_narrowable = false;
@@ -2704,7 +2828,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .elements(db)
                     .iter()
                     .map(|element| {
-                        if let Some(narrowed) = Self::narrow_type_by_len(db, *element, is_positive)
+                        if let Some(narrowed) =
+                            Self::narrow_type_by_len(db, program, *element, is_positive)
                         {
                             has_narrowable = true;
                             narrowed
@@ -2716,7 +2841,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .collect();
 
                 if has_narrowable {
-                    Some(UnionType::from_elements(db, narrowed_elements))
+                    Some(UnionType::from_elements(db, program, narrowed_elements))
                 } else {
                     None
                 }
@@ -2726,11 +2851,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let positive = intersection.positive(db);
                 let has_narrowable = positive
                     .iter()
-                    .any(|element| Self::is_base_type_narrowable_by_len(db, *element));
+                    .any(|element| Self::is_base_type_narrowable_by_len(db, program, *element));
 
                 if has_narrowable {
                     // Apply the narrowing constraint to the whole intersection.
-                    let mut builder = IntersectionBuilder::new(db).add_positive(ty);
+                    let mut builder = IntersectionBuilder::new(db, program).add_positive(ty);
                     if is_positive {
                         builder = builder.add_negative(Type::AlwaysFalsy);
                     } else {
@@ -2741,8 +2866,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     None
                 }
             }
-            _ if Self::is_base_type_narrowable_by_len(db, ty) => {
-                let mut builder = IntersectionBuilder::new(db).add_positive(ty);
+            _ if Self::is_base_type_narrowable_by_len(db, program, ty) => {
+                let mut builder = IntersectionBuilder::new(db, program).add_positive(ty);
                 if is_positive {
                     builder = builder.add_negative(Type::AlwaysFalsy);
                 } else {
@@ -2761,6 +2886,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     /// an observed length would become stale after mutation.
     fn narrow_type_by_exact_len(
         db: &'db dyn Db,
+        program: crate::Program,
         ty: Type<'db>,
         length: usize,
         is_equality: bool,
@@ -2768,22 +2894,22 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let resolved = ty.resolve_type_alias(db);
 
         let narrowed = match resolved {
-            Type::Union(union) => union.map(db, |element| {
-                Self::narrow_type_by_exact_len(db, *element, length, is_equality)
+            Type::Union(union) => union.map(db, program, |element| {
+                Self::narrow_type_by_exact_len(db, program, *element, length, is_equality)
             }),
-            Type::Intersection(intersection) => intersection.map_positive(db, |element| {
-                Self::narrow_type_by_exact_len(db, *element, length, is_equality)
+            Type::Intersection(intersection) => intersection.map_positive(db, program, |element| {
+                Self::narrow_type_by_exact_len(db, program, *element, length, is_equality)
             }),
             _ => {
                 if is_equality && let Some(tuple) = resolved.exact_tuple_instance_spec(db) {
-                    match tuple.resize(db, TupleLength::Fixed(length)) {
+                    match tuple.resize(db, program, TupleLength::Fixed(length)) {
                         Ok(tuple) => Type::tuple(TupleType::new(db, &tuple)),
                         Err(_) => Type::Never,
                     }
                 } else {
                     let tuple_length = resolved
                         .as_nominal_instance()
-                        .and_then(|instance| instance.tuple_spec(db))
+                        .and_then(|instance| instance.tuple_spec(db, program))
                         .map(|spec| spec.len());
                     let satisfies_comparison = |length_type: Type<'db>| {
                         length_type
@@ -2792,7 +2918,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                             .is_some_and(|actual| (actual == length) == is_equality)
                     };
                     let comparison_possible = resolved
-                        .len(db)
+                        .len(db, program)
                         .map(|length_type| match length_type {
                             Type::Union(union) => union
                                 .elements(db)
@@ -2832,9 +2958,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let place = self.expect_place(&target);
 
         let ty = if is_positive {
-            Type::AlwaysFalsy.negate(self.db)
+            Type::AlwaysFalsy.negate(self.db, self.program())
         } else {
-            Type::AlwaysTruthy.negate(self.db)
+            Type::AlwaysTruthy.negate(self.db, self.program())
         };
 
         Some(NarrowingConstraints::from_iter([(
@@ -2867,7 +2993,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         // combined. String membership also accepts multi-character substrings, so evaluate literal
         // haystacks separately, including when they occur in a union.
         if let Some(haystack) = rhs_ty.as_string_literal() {
-            return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), true);
+            return narrow_string_membership(
+                self.db,
+                self.program(),
+                lhs_ty,
+                haystack.value(self.db),
+                true,
+            );
         }
         if let Type::Union(union) = rhs_ty
             && union.elements(self.db).iter().any(|element| {
@@ -2877,15 +3009,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .is_some()
             })
         {
-            let mut builder = UnionBuilder::new(self.db);
+            let mut builder = UnionBuilder::new(self.db, self.program());
             for element in union.elements(self.db) {
                 builder = builder.add(self.evaluate_expr_in(lhs_ty, *element)?);
             }
             let narrowed = builder.build();
             return (narrowed != lhs_ty).then_some(narrowed);
         }
-        let membership_type = elements_of(self.db, rhs_ty)?;
-        let iterable = membership_type.try_iterate(self.db).ok()?;
+        let membership_type = elements_of(self.db, self.program(), rhs_ty)?;
+        let iterable = membership_type.try_iterate(self.db, self.program()).ok()?;
 
         if iterable
             .as_fixed_length()
@@ -2894,11 +3026,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             return Some(Type::Never);
         }
         let rhs_values = iterable
-            .homogeneous_element_type(self.db)
+            .homogeneous_element_type(self.db, self.program())
             .resolve_type_alias(self.db);
 
         if let Type::Union(union) = rhs_values {
-            let mut builder = UnionBuilder::new(self.db);
+            let mut builder = UnionBuilder::new(self.db, self.program());
             for rhs_value in union.elements(self.db) {
                 builder = builder.add(self.evaluate_membership_equality(lhs_ty, *rhs_value)?);
             }
@@ -2908,7 +3040,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
     }
 
-    /// Apply equality compatibility without losing the container's declared element type.
+    /// Apply equality compatibility without losing the container's declared element domain.
     ///
     /// Generic equality retains disjoint single-valued arms when an element subclass could define
     /// custom equality. Membership narrowing instead removes those arms unless the equality
@@ -2930,8 +3062,17 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             && let Some(TypeVarBoundOrConstraints::Constraints(constraints)) =
                 typevar.typevar(self.db).bound_or_constraints(self.db)
             && constraints.elements(self.db).iter().all(|constraint| {
-                evaluate_type_equality(self.db, lhs_ty, *constraint, true, soundness_policy)
-                    .is_some_and(|narrowed| narrowed.is_equivalent_to(self.db, *constraint))
+                evaluate_type_equality(
+                    self.db,
+                    self.program(),
+                    lhs_ty,
+                    *constraint,
+                    true,
+                    soundness_policy,
+                )
+                .is_some_and(|narrowed| {
+                    narrowed.is_equivalent_to(self.db, self.program(), *constraint)
+                })
             })
         {
             return Some(rhs_ty);
@@ -2941,20 +3082,34 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
             Type::Union(union) => union
                 .elements(self.db)
                 .iter()
-                .any(|element| element.is_single_valued(self.db)),
-            _ => lhs_ty.is_single_valued(self.db),
+                .any(|element| element.is_single_valued(self.db, self.program())),
+            _ => lhs_ty.is_single_valued(self.db, self.program()),
         };
         if !has_single_valued_component {
-            return evaluate_type_equality(self.db, lhs_ty, rhs_ty, true, soundness_policy);
+            return evaluate_type_equality(
+                self.db,
+                self.program(),
+                lhs_ty,
+                rhs_ty,
+                true,
+                soundness_policy,
+            );
         }
 
-        let mut builder = UnionBuilder::new(self.db);
+        let mut builder = UnionBuilder::new(self.db, self.program());
         let add_lhs_element = |builder: UnionBuilder<'db>, element: Type<'db>| {
             let element = element.resolve_type_alias(self.db);
-            match evaluate_type_equality(self.db, element, rhs_ty, true, soundness_policy) {
+            match evaluate_type_equality(
+                self.db,
+                self.program(),
+                element,
+                rhs_ty,
+                true,
+                soundness_policy,
+            ) {
                 Some(Type::Never) => builder,
                 Some(constraint) => builder.add(constraint),
-                None if !element.is_single_valued(self.db) => builder.add(element),
+                None if !element.is_single_valued(self.db, self.program()) => builder.add(element),
                 None => builder,
             }
         };
@@ -2974,18 +3129,26 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
     fn evaluate_expr_not_in(&self, lhs_ty: Type<'db>, rhs_ty: Type<'db>) -> Option<Type<'db>> {
         if let Some(haystack) = rhs_ty.resolve_type_alias(self.db).as_string_literal() {
-            return narrow_string_membership(self.db, lhs_ty, haystack.value(self.db), false);
+            return narrow_string_membership(
+                self.db,
+                self.program(),
+                lhs_ty,
+                haystack.value(self.db),
+                false,
+            );
         }
-        let membership_type = elements_of(self.db, rhs_ty)?;
-        let iterable = membership_type.try_iterate(self.db).ok()?;
+        let membership_type = elements_of(self.db, self.program(), rhs_ty)?;
+        let iterable = membership_type.try_iterate(self.db, self.program()).ok()?;
         let fixed_length = iterable.as_fixed_length()?;
-        let mut builder = IntersectionBuilder::new(self.db);
+        let mut builder = IntersectionBuilder::new(self.db, self.program());
         let mut constrained = false;
 
         // `not in` negates equality with every element; it does not use `__ne__`. Only add an
         // exclusion when every value represented by a slot is known to compare equal.
         for element_ty in fixed_length.all_elements().iter().copied() {
-            if let Some(constraint) = equality_exclusion_constraint(self.db, element_ty) {
+            if let Some(constraint) =
+                equality_exclusion_constraint(self.db, self.program(), element_ty)
+            {
                 builder = builder.add_positive(constraint);
                 constrained = true;
             }
@@ -3004,6 +3167,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if op == ast::CmpOp::Eq {
             return evaluate_type_equality(
                 self.db,
+                self.program(),
                 lhs_ty,
                 rhs_ty,
                 is_positive,
@@ -3013,6 +3177,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if op == ast::CmpOp::NotEq {
             return evaluate_type_inequality(
                 self.db,
+                self.program(),
                 lhs_ty,
                 rhs_ty,
                 is_positive,
@@ -3024,8 +3189,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         match op {
             ast::CmpOp::IsNot => {
-                if rhs_ty.is_singleton(self.db) {
-                    Some(rhs_ty.negate(self.db))
+                if rhs_ty.is_singleton(self.db, self.program()) {
+                    Some(rhs_ty.negate(self.db, self.program()))
                 } else {
                     // Non-singletons cannot be safely narrowed using `is not`
                     None
@@ -3072,21 +3237,30 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         /// at runtime). Similarly, we return `None` for `type[Y[int]]`, type variables
         /// bound to `type[Y[int]]`, and type aliases where the underlying value is a
         /// generic class.
-        fn find_underlying_class<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<ClassLiteral<'db>> {
+        fn find_underlying_class<'db>(
+            db: &'db dyn Db,
+            program: crate::Program,
+            ty: Type<'db>,
+        ) -> Option<ClassLiteral<'db>> {
             match ty {
                 Type::ClassLiteral(class) => Some(class),
                 Type::SubclassOf(subclass_of) => {
-                    match subclass_of.subclass_of().with_transposed_type_var(db) {
+                    match subclass_of
+                        .subclass_of()
+                        .with_transposed_type_var(db, program)
+                    {
                         SubclassOfInner::Class(ClassType::NonGeneric(class)) => Some(class),
                         SubclassOfInner::Class(ClassType::Generic(_))
                         | SubclassOfInner::Dynamic(_) => None,
                         SubclassOfInner::TypeVar(tvar) => {
-                            find_underlying_class(db, tvar.typevar(db).upper_bound(db)?)
+                            find_underlying_class(db, program, tvar.typevar(db).upper_bound(db)?)
                         }
                     }
                 }
-                Type::TypeVar(tvar) => find_underlying_class(db, tvar.typevar(db).upper_bound(db)?),
-                Type::TypeAlias(alias) => find_underlying_class(db, alias.value_type(db)),
+                Type::TypeVar(tvar) => {
+                    find_underlying_class(db, program, tvar.typevar(db).upper_bound(db)?)
+                }
+                Type::TypeAlias(alias) => find_underlying_class(db, program, alias.value_type(db)),
                 _ => None,
             }
         }
@@ -3173,20 +3347,20 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 .as_int_literal()
             && let Ok(index) = i32::try_from(index)
             && let rhs_ty = inference.expression_type(&comparators[0])
-            && rhs_ty.is_singleton(self.db)
+            && rhs_ty.is_singleton(self.db, self.program())
         {
             let is_positive_check = is_positive == (ops[0] == ast::CmpOp::Is);
             let filtered = union.filter(self.db, |elem| {
                 elem.as_nominal_instance()
-                    .and_then(|inst| inst.tuple_spec(self.db))
-                    .and_then(|spec| spec.py_index(self.db, index).ok())
+                    .and_then(|inst| inst.tuple_spec(self.db, self.program()))
+                    .and_then(|spec| spec.py_index(self.db, self.program(), index).ok())
                     .is_none_or(|el_ty| {
                         if is_positive_check {
                             // `is X` context: keep tuples where element could be X
-                            !el_ty.is_disjoint_from(self.db, rhs_ty)
+                            !el_ty.is_disjoint_from(self.db, self.program(), rhs_ty)
                         } else {
                             // `is not X` context: keep tuples where element is not always X
-                            !el_ty.is_subtype_of(self.db, rhs_ty)
+                            !el_ty.is_subtype_of(self.db, self.program(), rhs_ty)
                         }
                     })
             });
@@ -3240,8 +3414,13 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 };
 
                 let arg_type = inference.expression_type(arg);
-                let narrowed =
-                    Self::narrow_type_by_exact_len(self.db, arg_type, length, is_equality);
+                let narrowed = Self::narrow_type_by_exact_len(
+                    self.db,
+                    self.program(),
+                    arg_type,
+                    length,
+                    is_equality,
+                );
                 if narrowed != arg_type {
                     insert_narrowing_constraint(
                         &mut constraints,
@@ -3451,7 +3630,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
                 if let Some(is_positive) = is_positive
                     && let Some(target) = PlaceExpr::try_from_expr(target_expr)
-                    && let Some(other_class) = find_underlying_class(self.db, other)
+                    && let Some(other_class) = find_underlying_class(self.db, self.program(), other)
                     // `else`-branch narrowing for `if type(x) is Y` can only be done
                     // if `Y` is a final class
                     && (is_positive || other_class.is_final(self.db))
@@ -3461,7 +3640,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                         place,
                         NarrowingConstraint::intersection(
                             Type::instance(self.db, other_class.top_materialization(self.db))
-                                .negate_if(self.db, !is_positive),
+                                .negate_if(self.db, self.program(), !is_positive),
                         ),
                     );
                 }
@@ -3510,7 +3689,12 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                     .or_insert(constraint);
 
                 // Use the narrowed type for subsequent comparisons in a chain.
-                last_rhs_ty = Some(IntersectionType::from_two_elements(self.db, rhs_ty, ty));
+                last_rhs_ty = Some(IntersectionType::from_two_elements(
+                    self.db,
+                    self.program(),
+                    rhs_ty,
+                    ty,
+                ));
             } else {
                 last_rhs_ty = Some(rhs_ty);
             }
@@ -3548,7 +3732,9 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let arg_ty = inference.expression_type(arg);
 
                 // Narrow only the parts of the type that are safe to narrow based on len().
-                if let Some(narrowed_ty) = Self::narrow_type_by_len(self.db, arg_ty, is_positive) {
+                if let Some(narrowed_ty) =
+                    Self::narrow_type_by_len(self.db, self.program(), arg_ty, is_positive)
+                {
                     let target = PlaceExpr::try_from_expr(arg)?;
                     let place = self.expect_place(&target);
                     Some(NarrowingConstraints::from_iter([(
@@ -3584,9 +3770,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
                     return Some(NarrowingConstraints::from_iter([(
                         place,
-                        NarrowingConstraint::intersection(
-                            constraint.negate_if(self.db, !is_positive),
-                        ),
+                        NarrowingConstraint::intersection(constraint.negate_if(
+                            self.db,
+                            self.program(),
+                            !is_positive,
+                        )),
                     )]));
                 }
 
@@ -3595,13 +3783,15 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 let class_info_ty = inference.expression_type(second_arg);
 
                 function
-                    .generate_constraint(self.db, class_info_ty, is_positive)
+                    .generate_constraint(self.db, self.program(), class_info_ty, is_positive)
                     .map(|constraint| {
                         NarrowingConstraints::from_iter([(
                             place,
-                            NarrowingConstraint::intersection(
-                                constraint.negate_if(self.db, !is_positive),
-                            ),
+                            NarrowingConstraint::intersection(constraint.negate_if(
+                                self.db,
+                                self.program(),
+                                !is_positive,
+                            )),
                         )])
                     })
             }
@@ -3637,9 +3827,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 Some((
                     place,
                     NarrowingConstraint::intersection(
-                        type_is
-                            .return_type(self.db)
-                            .negate_if(self.db, !is_positive),
+                        type_is.return_type(self.db, self.program()).negate_if(
+                            self.db,
+                            self.program(),
+                            !is_positive,
+                        ),
                     ),
                 ))
             }
@@ -3665,7 +3857,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let subject = PlaceExpr::try_from_expr(subject.node_ref(self.db).node(self.module))?;
         let place = self.expect_place(&subject);
 
-        let ty = singleton_pattern_type(self.db, singleton).negate(self.db);
+        let ty = singleton_pattern_type(self.db, self.program(), singleton)
+            .negate(self.db, self.program());
         Some(NarrowingConstraints::from_iter([(
             place,
             NarrowingConstraint::intersection(ty),
@@ -3681,14 +3874,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let place = self.expect_place(&subject_place);
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
         let definitely_matched =
-            definite_match_pattern_type_for_subject(self.db, pattern, subject_ty);
+            definite_match_pattern_type_for_subject(self.db, self.program(), pattern, subject_ty);
         if definitely_matched.is_never() {
             return None;
         }
 
         Some(NarrowingConstraints::from_iter([(
             place,
-            NarrowingConstraint::intersection(definitely_matched.negate(self.db)),
+            NarrowingConstraint::intersection(definitely_matched.negate(self.db, self.program())),
         )]))
     }
 
@@ -3717,7 +3910,8 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
 
         let subject_ty = infer_same_file_expression_type(self.db, subject, TypeContext::default());
-        let narrowed_ty = pattern_binding_fallthrough_type(self.db, pattern, subject_ty);
+        let narrowed_ty =
+            pattern_binding_fallthrough_type(self.db, self.program(), pattern, subject_ty);
         if narrowed_ty == subject_ty {
             return PatternNarrowingResult::Possible(None);
         }
@@ -3843,7 +4037,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
         if NarrowingConstraint::intersection(subject_ty)
             .merge_constraint_and(constraint.clone())
-            .evaluate_constraint_type(self.db)
+            .evaluate_constraint_type(self.db, self.program())
             .is_never()
         {
             return PatternNarrowingResult::Impossible;
@@ -3935,13 +4129,14 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         expression: Expression<'db>,
         is_positive: bool,
     ) -> Option<NarrowingConstraints<'db>> {
+        let program = self.program();
         let inference = infer_expression_types(self.db, expression, TypeContext::default());
         let sub_constraints = expr_bool_op
             .values
             .iter()
             // filter our arms with statically known truthiness
             .filter(|expr| {
-                inference.expression_type(*expr).bool(self.db)
+                inference.expression_type(*expr).bool(self.db, program)
                     != match expr_bool_op.op {
                         BoolOp::And => Truthiness::AlwaysTrue,
                         BoolOp::Or => Truthiness::AlwaysFalse,
@@ -4018,6 +4213,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if is_equality
             && !all_matching_typeddict_fields_have_literal_types(
                 self.db,
+                self.program(),
                 subscript_value_type,
                 key_literal.value(self.db),
             )
@@ -4031,7 +4227,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         // `is_equality` is true, the whole constraint is going to be a double
         // negative, i.e. "you're *not* a `TypedDict` *without* this literal field". As the
         // first step of building that, we negate the right hand side.
-        let field_type = rhs_type.negate_if(self.db, is_equality);
+        let field_type = rhs_type.negate_if(self.db, self.program(), is_equality);
         // Create the synthesized `TypedDict` with that (possibly negated) field. We don't
         // want to constrain the mutability or required-ness of the field, so the most
         // compatible form is not-required and read-only.
@@ -4042,7 +4238,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         let schema = TypedDictSchema::from_iter([(field_name, field)]);
         let synthesized_typeddict = TypedDictType::from_schema_items(self.db, schema);
         // As mentioned above, the synthesized `TypedDict` is always negated.
-        let intersection = Type::TypedDict(synthesized_typeddict).negate(self.db);
+        let intersection = Type::TypedDict(synthesized_typeddict).negate(self.db, self.program());
         let place = self.expect_place(&subscript_place_expr);
         Some((place, NarrowingConstraint::intersection(intersection)))
     }
@@ -4053,11 +4249,11 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
     fn narrow_with_present_key(&self, ty: Type<'db>, key: &str) -> Type<'db> {
         let db = self.db;
         let constrain = |ty, key_presence_constraint| {
-            IntersectionType::from_two_elements(db, ty, key_presence_constraint)
+            IntersectionType::from_two_elements(db, self.program(), ty, key_presence_constraint)
         };
 
         match ty.resolve_type_alias(self.db) {
-            Type::Union(union) => union.map(self.db, |element| {
+            Type::Union(union) => union.map(self.db, self.program(), |element| {
                 self.narrow_with_present_key(*element, key)
             }),
             resolved if typeddict_declares_key(self.db, resolved, key) => resolved,
@@ -4111,28 +4307,35 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
 
         // Skip narrowing if any tuple in the union has an out-of-bounds index.
         // A diagnostic will be emitted elsewhere for the out-of-bounds access.
-        if any_tuple_has_out_of_bounds_index(self.db, union, index) {
+        if any_tuple_has_out_of_bounds_index(self.db, self.program(), union, index) {
             return None;
         }
 
         // For equality constraints, all matching elements must have literal types to safely narrow.
         // For inequality constraints, we can narrow even with non-literal element types.
-        if is_equality && !all_matching_tuple_elements_have_literal_types(self.db, union, index) {
+        if is_equality
+            && !all_matching_tuple_elements_have_literal_types(
+                self.db,
+                self.program(),
+                union,
+                index,
+            )
+        {
             return None;
         }
 
         // Filter the union based on whether each tuple element at the index could match the rhs.
         let filtered = union.filter(self.db, |elem| {
             elem.as_nominal_instance()
-                .and_then(|inst| inst.tuple_spec(self.db))
-                .and_then(|spec| spec.py_index(self.db, index).ok())
+                .and_then(|inst| inst.tuple_spec(self.db, self.program()))
+                .and_then(|spec| spec.py_index(self.db, self.program(), index).ok())
                 .is_none_or(|el_ty| {
                     if is_equality {
                         // Keep tuples where element could be equal to rhs.
-                        !el_ty.is_disjoint_from(self.db, rhs_type)
+                        !el_ty.is_disjoint_from(self.db, self.program(), rhs_type)
                     } else {
                         // Keep tuples where element is not always equal to rhs.
-                        !el_ty.is_subtype_of(self.db, rhs_type)
+                        !el_ty.is_subtype_of(self.db, self.program(), rhs_type)
                     }
                 })
         });
@@ -4162,14 +4365,16 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         }
 
         let narrowed = union.filter(self.db, |element| {
-            nominal_attribute_type(self.db, *element, attribute_name).is_none_or(|attribute_type| {
-                if is_equality {
-                    !is_supported_tag_literal(attribute_type)
-                        || !attribute_type.is_disjoint_from(self.db, rhs_type)
-                } else {
-                    !attribute_type.is_subtype_of(self.db, rhs_type)
-                }
-            })
+            nominal_attribute_type(self.db, self.program(), *element, attribute_name).is_none_or(
+                |attribute_type| {
+                    if is_equality {
+                        !is_supported_tag_literal(attribute_type)
+                            || !attribute_type.is_disjoint_from(self.db, self.program(), rhs_type)
+                    } else {
+                        !attribute_type.is_subtype_of(self.db, self.program(), rhs_type)
+                    }
+                },
+            )
         });
 
         if narrowed == Type::Union(union) {
@@ -4320,13 +4525,14 @@ fn is_supported_tag_literal(ty: Type) -> bool {
 
 fn nominal_attribute_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     attribute_name: &str,
 ) -> Option<Type<'db>> {
     let resolved_ty = ty.resolve_type_alias(db);
     if resolved_ty.is_nominal_instance() {
         resolved_ty
-            .member(db, attribute_name)
+            .member(db, program, attribute_name)
             .place
             .ignore_possibly_undefined()
     } else {
@@ -4340,6 +4546,7 @@ fn nominal_attribute_type<'db>(
 // supported tag literal type for that field, or a type alias to such a type.
 fn all_matching_typeddict_fields_have_literal_types<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     field_name: &str,
 ) -> bool {
@@ -4357,13 +4564,17 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
             !is_or_contains_typeddict(db, *union_member_ty)
                 || all_matching_typeddict_fields_have_literal_types(
                     db,
+                    program,
                     *union_member_ty,
                     field_name,
                 )
         }),
-        Type::TypeAlias(alias) => {
-            all_matching_typeddict_fields_have_literal_types(db, alias.value_type(db), field_name)
-        }
+        Type::TypeAlias(alias) => all_matching_typeddict_fields_have_literal_types(
+            db,
+            program,
+            alias.value_type(db),
+            field_name,
+        ),
         Type::Intersection(intersection) => {
             intersection
                 .positive(db)
@@ -4372,6 +4583,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
                     !is_or_contains_typeddict(db, *intersection_member_ty)
                         || all_matching_typeddict_fields_have_literal_types(
                             db,
+                            program,
                             *intersection_member_ty,
                             field_name,
                         )
@@ -4411,7 +4623,7 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
         | Type::NewTypeInstance(_) => {
             unreachable!(
                 "invalid type {} in all_matching_typeddict_fields_have_literal_types",
-                ty.display(db)
+                ty.display(db, program)
             )
         }
     }
@@ -4423,13 +4635,14 @@ fn all_matching_typeddict_fields_have_literal_types<'db>(
 /// since a diagnostic will be emitted elsewhere for the out-of-bounds access.
 fn any_tuple_has_out_of_bounds_index<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     union: UnionType<'db>,
     index: i32,
 ) -> bool {
     union.elements(db).iter().any(|elem| {
         elem.as_nominal_instance()
-            .and_then(|inst| inst.tuple_spec(db))
-            .is_some_and(|spec| spec.py_index(db, index).is_err())
+            .and_then(|inst| inst.tuple_spec(db, program))
+            .is_some_and(|spec| spec.py_index(db, program, index).is_err())
     })
 }
 
@@ -4441,25 +4654,39 @@ fn any_tuple_has_out_of_bounds_index<'db>(
 /// `__eq__` in unexpected ways.
 fn all_matching_tuple_elements_have_literal_types<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     union: UnionType<'db>,
     index: i32,
 ) -> bool {
     union.elements(db).iter().all(|elem| {
         elem.as_nominal_instance()
-            .and_then(|inst| inst.tuple_spec(db))
-            .and_then(|spec| spec.py_index(db, index).ok())
+            .and_then(|inst| inst.tuple_spec(db, program))
+            .and_then(|spec| spec.py_index(db, program, index).ok())
             .is_none_or(is_supported_tag_literal)
     })
 }
 
 pub(crate) trait NarrowingEvaluatorExtension<'db> {
-    fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db>;
+    fn narrow(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+    ) -> Type<'db>;
 }
 
 impl<'db> NarrowingEvaluatorExtension<'db> for NarrowingEvaluator<'_, 'db> {
-    fn narrow(&self, db: &'db dyn Db, base_type: Type<'db>, place: ScopedPlaceId) -> Type<'db> {
+    fn narrow(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        base_type: Type<'db>,
+        place: ScopedPlaceId,
+    ) -> Type<'db> {
         narrow_type_by_constraint(
             db,
+            program,
             self.narrowing_constraints(),
             self.predicates(),
             self.constraint(),

--- a/crates/ty_python_semantic/src/types/narrow/containment.rs
+++ b/crates/ty_python_semantic/src/types/narrow/containment.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Db,
+    Db, Program,
     types::{ClassBase, IntersectionBuilder, KnownClass, Type, UnionBuilder},
 };
 
@@ -14,7 +14,11 @@ enum ContainmentBehavior<'db> {
 }
 
 /// Return the containment behavior known for this type.
-fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehavior<'db> {
+fn containment_behavior<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    ty: Type<'db>,
+) -> ContainmentBehavior<'db> {
     let ty = ty.resolve_type_alias(db);
 
     match ty {
@@ -23,10 +27,10 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
             // through wrappers such as type variables. Positive unions that contain string
             // literals are distributed in `evaluate_expr_in` instead because substring semantics
             // depend on the value of each literal haystack.
-            let mut builder = UnionBuilder::new(db);
+            let mut builder = UnionBuilder::new(db, program);
             let mut has_unknown_behavior = false;
             for element in union.elements(db) {
-                match containment_behavior(db, *element) {
+                match containment_behavior(db, program, *element) {
                     ContainmentBehavior::ElementsOf(elements_of) => {
                         builder = builder.add(elements_of);
                     }
@@ -40,13 +44,15 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
                 ContainmentBehavior::ElementsOf(builder.build())
             }
         }
-        Type::TypeVar(type_var) => type_var
-            .typevar(db)
-            .bound_or_constraints(db)
-            .map_or(ContainmentBehavior::Unknown, |bound_or_constraints| {
-                containment_behavior(db, bound_or_constraints.as_type(db))
-            }),
-        Type::NewTypeInstance(newtype) => containment_behavior(db, newtype.concrete_base_type(db)),
+        Type::TypeVar(type_var) => type_var.typevar(db).bound_or_constraints(db).map_or(
+            ContainmentBehavior::Unknown,
+            |bound_or_constraints| {
+                containment_behavior(db, program, bound_or_constraints.as_type(db, program))
+            },
+        ),
+        Type::NewTypeInstance(newtype) => {
+            containment_behavior(db, program, newtype.concrete_base_type(db))
+        }
         Type::Intersection(intersection) => {
             // Preserve the narrowing already supported on main for unsimplified intersections
             // such as `Iterable[T] & tuple[object, ...]`. Replacing the component that establishes
@@ -59,8 +65,8 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
             // https://github.com/astral-sh/ruff/pull/26365
             let mut has_elements_of = false;
             let mut has_custom_behavior = false;
-            let elements_of =
-                intersection.map_positive(db, |element| match containment_behavior(db, *element) {
+            let elements_of = intersection.map_positive(db, program, |element| {
+                match containment_behavior(db, program, *element) {
                     ContainmentBehavior::ElementsOf(elements_of) => {
                         has_elements_of = true;
                         elements_of
@@ -70,7 +76,8 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
                         *element
                     }
                     ContainmentBehavior::Unknown => *element,
-                });
+                }
+            });
             if has_custom_behavior {
                 ContainmentBehavior::Custom
             } else if has_elements_of {
@@ -83,7 +90,7 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
         Type::NominalInstance(instance) => {
             // Walk the MRO until we find either a visible override or a supported built-in
             // implementation.
-            for base in instance.class(db).iter_mro(db) {
+            for base in instance.class(db, program).iter_mro(db) {
                 let class = match base {
                     ClassBase::Class(class) => class,
                     ClassBase::Generic | ClassBase::Protocol => continue,
@@ -122,7 +129,7 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
                     return ContainmentBehavior::Custom;
                 }
             }
-            if instance.class(db).is_final(db) {
+            if instance.class(db, program).is_final(db) {
                 ContainmentBehavior::ElementsOf(ty)
             } else {
                 ContainmentBehavior::Unknown
@@ -133,8 +140,12 @@ fn containment_behavior<'db>(db: &'db dyn Db, ty: Type<'db>) -> ContainmentBehav
 }
 
 /// Return the type whose iterated elements may satisfy membership for `ty`.
-pub(super) fn elements_of<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
-    match containment_behavior(db, ty) {
+pub(super) fn elements_of<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    ty: Type<'db>,
+) -> Option<Type<'db>> {
+    match containment_behavior(db, program, ty) {
         ContainmentBehavior::ElementsOf(elements_of) => Some(elements_of),
         ContainmentBehavior::Custom | ContainmentBehavior::Unknown => None,
     }
@@ -146,18 +157,20 @@ const MAX_STRING_MEMBERSHIP_EXCLUSIONS: usize = 128;
 /// Narrow membership in a known string literal using substring semantics.
 pub(super) fn narrow_string_membership<'db>(
     db: &'db dyn Db,
+    program: Program,
     lhs_ty: Type<'db>,
     haystack: &str,
     is_contained: bool,
 ) -> Option<Type<'db>> {
     let lhs_ty = lhs_ty.resolve_type_alias(db);
-    let flattened_lhs_ty = lhs_ty.flatten_typevars(db);
+    let flattened_lhs_ty = lhs_ty.flatten_typevars(db, program);
     let keep = |element: &Type<'db>| {
         let element = element.resolve_type_alias(db);
         if let Some(needle) = element.as_string_literal() {
             haystack.contains(needle.value(db)) == is_contained
         } else {
-            !(is_contained && element.is_disjoint_from(db, KnownClass::Str.to_instance(db)))
+            !(is_contained
+                && element.is_disjoint_from(db, program, KnownClass::Str.to_instance(db, program)))
         }
     };
 
@@ -173,7 +186,7 @@ pub(super) fn narrow_string_membership<'db>(
             .nth(MAX_STRING_MEMBERSHIP_EXCLUSIONS)
             .is_none()
     {
-        let mut builder = IntersectionBuilder::new(db).add_positive(narrowed);
+        let mut builder = IntersectionBuilder::new(db, program).add_positive(narrowed);
         for character in haystack.chars() {
             builder = builder.add_negative(Type::single_char_string_literal(db, character));
         }

--- a/crates/ty_python_semantic/src/types/newtype.rs
+++ b/crates/ty_python_semantic/src/types/newtype.rs
@@ -2,7 +2,6 @@ use crate::Db;
 use crate::types::constraints::ConstraintSet;
 use crate::types::relation::{DisjointnessChecker, TypeRelation, TypeRelationChecker};
 use crate::types::{ClassType, KnownUnion, Type, definition_expression_type, visitor};
-use ruff_db::parsed::parsed_module;
 use ruff_python_ast as ast;
 use rustc_hash::FxHashSet;
 use ty_python_core::definition::{Definition, DefinitionKind};
@@ -38,6 +37,7 @@ pub struct NewType<'db> {
     // `.normalize()`. Callers should use the `base` method instead of accessing this field
     // directly.
     #[returns(copy)]
+    #[returns(copy)]
     eager_base: Option<NewTypeBase<'db>>,
 }
 
@@ -54,16 +54,21 @@ impl<'db> NewType<'db> {
 
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|db, _, _| NewTypeBase::ClassType(ClassType::object(db)),
+        cycle_initial=|db: &'db dyn Db, _, newtype: NewType<'db>| {
+            let program = newtype.definition(db).program_file(db).program(db);
+            NewTypeBase::ClassType(ClassType::object(db, program))
+        },
         heap_size=ruff_memory_usage::heap_size
     )]
     fn lazy_base(self, db: &'db dyn Db) -> NewTypeBase<'db> {
         // `TypeInferenceBuilder` emits diagnostics for invalid `NewType` definitions that show up
         // in assignments, but invalid definitions still get here, and also `NewType` might show up
         // in places that aren't definitions at all. Fall back to `object` in all error cases.
-        let object_fallback = NewTypeBase::ClassType(ClassType::object(db));
         let definition = self.definition(db);
-        let module = parsed_module(db, definition.file(db)).load(db);
+        let program_file = definition.program_file(db);
+        let program = program_file.program(db);
+        let object_fallback = NewTypeBase::ClassType(ClassType::object(db, program));
+        let module = program_file.parsed(db).load(db);
         let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
             return object_fallback;
         };
@@ -75,7 +80,7 @@ impl<'db> NewType<'db> {
         };
         match definition_expression_type(db, definition, second_arg) {
             Type::NominalInstance(nominal_instance_type) => {
-                NewTypeBase::ClassType(nominal_instance_type.class(db))
+                NewTypeBase::ClassType(nominal_instance_type.class(db, program))
             }
             Type::NewTypeInstance(newtype) => NewTypeBase::NewType(newtype),
             // There are exactly two union types allowed as bases for NewType: `int | float` and
@@ -102,10 +107,11 @@ impl<'db> NewType<'db> {
     // Walk the `NewTypeBase` chain to find the underlying non-newtype `Type`. There might not be
     // one if this `NewType` is cyclical, and we fall back to `object` in that case.
     pub fn concrete_base_type(self, db: &'db dyn Db) -> Type<'db> {
+        let program = self.definition(db).program_file(db).program(db);
         for base in self.iter_bases(db) {
             match base {
                 NewTypeBase::NewType(_) => continue,
-                concrete => return concrete.instance_type(db),
+                concrete => return concrete.instance_type(db, program),
             }
         }
         Type::object()
@@ -182,11 +188,12 @@ impl<'db> NewType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let eager_base = match self.eager_base(db) {
-            Some(base) => Some(base.recursive_type_normalized_impl(db, div, nested)?),
+            Some(base) => Some(base.recursive_type_normalized_impl(db, program, div, nested)?),
             None => None,
         };
 
@@ -230,13 +237,14 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: NewType<'db>,
         right: NewType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // Two NewTypes are disjoint if they're not equal and neither inherits from the other.
         // NewTypes have single inheritance, and a regular class can't inherit from a NewType, so
         // it's not possible for some third type to multiply-inherit from both.
         let relation_checker = self.as_relation_checker(TypeRelation::Subtyping);
         relation_checker
             .check_newtype_pair(db, left, right)
-            .or(db, self.constraints, || {
+            .or(db, program, self.constraints, || {
                 relation_checker.check_newtype_pair(db, right, left)
             })
             .negate(db, self.constraints)
@@ -245,6 +253,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 
 pub(crate) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     newtype: NewType<'db>,
     visitor: &V,
 ) {
@@ -254,7 +263,7 @@ pub(crate) fn walk_newtype_instance_type<'db, V: visitor::TypeVisitor<'db> + ?Si
         newtype.eager_base(db)
     };
     if let Some(base) = base {
-        visitor.visit_type(db, base.instance_type(db));
+        visitor.visit_type(db, program, base.instance_type(db, program));
     }
 }
 
@@ -272,18 +281,19 @@ pub enum NewTypeBase<'db> {
 }
 
 impl<'db> NewTypeBase<'db> {
-    pub fn instance_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub fn instance_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self {
             NewTypeBase::ClassType(class_type) => Type::instance(db, class_type),
             NewTypeBase::NewType(newtype) => Type::NewTypeInstance(newtype),
-            NewTypeBase::Float => KnownUnion::Float.to_type(db),
-            NewTypeBase::Complex => KnownUnion::Complex.to_type(db),
+            NewTypeBase::Float => KnownUnion::Float.to_type(db, program),
+            NewTypeBase::Complex => KnownUnion::Complex.to_type(db, program),
         }
     }
 
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -292,7 +302,7 @@ impl<'db> NewTypeBase<'db> {
                 .recursive_type_normalized_impl(db, div, nested)
                 .map(NewTypeBase::ClassType),
             NewTypeBase::NewType(newtype) => newtype
-                .recursive_type_normalized_impl(db, div, nested)
+                .recursive_type_normalized_impl(db, program, div, nested)
                 .map(NewTypeBase::NewType),
             NewTypeBase::Float | NewTypeBase::Complex => Some(self),
         }

--- a/crates/ty_python_semantic/src/types/overrides.rs
+++ b/crates/ty_python_semantic/src/types/overrides.rs
@@ -151,7 +151,7 @@ fn check_class_declaration<'db>(
 
     let instance_of_class = Type::instance(db, class);
 
-    let subclass_instance_member = instance_of_class.member(db, &member.name);
+    let subclass_instance_member = instance_of_class.member(db, context.program(), &member.name);
     let Place::Defined(DefinedPlace {
         ty: type_on_subclass_instance,
         ..
@@ -293,7 +293,7 @@ fn check_class_declaration<'db>(
                     .can_validate_with_value_annotation()
                     && let Some(expected_type) = enum_info.value_annotation_type()
                 {
-                    if !member_value_type.is_assignable_to(db, expected_type) {
+                    if !member_value_type.is_assignable_to(db, context.program(), expected_type) {
                         if let Some(builder) = context.report_lint(
                             &INVALID_ASSIGNMENT,
                             first_reachable_definition.focus_range(db, context.module()),
@@ -304,8 +304,8 @@ fn check_class_declaration<'db>(
                             ));
                             diagnostic.info(format_args!(
                                 "Expected `{}`, got `{}`",
-                                expected_type.display(db),
-                                member_value_type.display(db)
+                                expected_type.display(db, context.program()),
+                                member_value_type.display(db, context.program())
                             ));
                         }
                     }
@@ -379,7 +379,7 @@ fn check_class_declaration<'db>(
             }
 
             let superclass_instance_member =
-                Type::instance(db, superclass).member(db, &member.name);
+                Type::instance(db, superclass).member(db, context.program(), &member.name);
             let Place::Defined(DefinedPlace {
                 ty: superclass_type,
                 ..
@@ -490,6 +490,7 @@ fn check_class_declaration<'db>(
                     let subclass_kind = *subclass_variable_kind.get_or_insert_with(|| {
                         variable_kind(
                             db,
+                            context.program(),
                             class.own_class_member(db, None, &member.name).inner,
                             subclass_instance_member,
                         )
@@ -559,14 +560,20 @@ fn check_class_declaration<'db>(
                 continue;
             }
 
-            let Some(superclass_type_as_callable) = superclass_type.try_upcast_to_callable(db)
+            let Some(superclass_type_as_callable) =
+                superclass_type.try_upcast_to_callable(db, context.program())
             else {
                 continue;
             };
 
-            let superclass_type_as_type = superclass_type_as_callable.into_type(db);
+            let superclass_type_as_type =
+                superclass_type_as_callable.into_type(db, context.program());
 
-            if type_on_subclass_instance.is_assignable_to(db, superclass_type_as_type) {
+            if type_on_subclass_instance.is_assignable_to(
+                db,
+                context.program(),
+                superclass_type_as_type,
+            ) {
                 continue;
             }
 
@@ -580,7 +587,11 @@ fn check_class_declaration<'db>(
                     // The immediate parent already defines this method and is different from the
                     // current ancestor we're checking. Check if the immediate parent's method
                     // is also incompatible with this ancestor.
-                    if !immediate_parent_type.is_assignable_to(db, superclass_type_as_type) {
+                    if !immediate_parent_type.is_assignable_to(
+                        db,
+                        context.program(),
+                        superclass_type_as_type,
+                    ) {
                         // The immediate parent already has an LSP violation with this ancestor.
                         // Don't report the same violation for the child.
                         continue;
@@ -598,8 +609,11 @@ fn check_class_declaration<'db>(
                 superclass_type,
                 method_kind,
                 || {
-                    type_on_subclass_instance
-                        .assignability_error_context(db, superclass_type_as_type)
+                    type_on_subclass_instance.assignability_error_context(
+                        db,
+                        context.program(),
+                        superclass_type_as_type,
+                    )
                 },
             );
 
@@ -610,8 +624,8 @@ fn check_class_declaration<'db>(
     if !subclass_overrides_superclass_declaration && !has_dynamic_superclass {
         if has_typeddict_in_mro {
             if !KnownClass::TypedDictFallback
-                .to_instance(db)
-                .member(db, &member.name)
+                .to_instance(db, context.program())
+                .member(db, context.program(), &member.name)
                 .place
                 .is_undefined()
             {
@@ -619,8 +633,8 @@ fn check_class_declaration<'db>(
             }
         } else if class_kind == Some(CodeGeneratorKind::NamedTuple) {
             if !KnownClass::NamedTupleFallback
-                .to_instance(db)
-                .member(db, &member.name)
+                .to_instance(db, context.program())
+                .member(db, context.program(), &member.name)
                 .place
                 .is_undefined()
             {
@@ -695,6 +709,7 @@ fn superclass_variable_kind<'db>(
     class_member: PlaceAndQualifiers<'db>,
     instance_member: PlaceAndQualifiers<'db>,
 ) -> Option<VariableKind> {
+    let program = superclass_scope.program(db);
     // Method definitions and properties are not instance-variable declarations. Check the symbol
     // definition before class/instance member lookup can erase that distinction. For example,
     // resolving an abstract `@property def f(self) -> int` through instance-member lookup would
@@ -711,7 +726,7 @@ fn superclass_variable_kind<'db>(
         return None;
     }
 
-    variable_kind(db, class_member, instance_member)
+    variable_kind(db, program, class_member, instance_member)
 }
 
 /// Returns the variable kind for a superclass member, preserving inherited `ClassVar` declarations
@@ -739,6 +754,7 @@ fn effective_superclass_variable_kind<'db>(
     superclass: ClassType<'db>,
     name: Name,
 ) -> Option<VariableKind> {
+    let program = superclass.class_literal(db).program(db);
     let inherited_variable_kind = || {
         superclass
             .iter_mro(db)
@@ -767,7 +783,7 @@ fn effective_superclass_variable_kind<'db>(
             superclass_scope,
             superclass_symbol_id,
             superclass.own_class_member(db, None, &name).inner,
-            Type::instance(db, superclass).member(db, &name),
+            Type::instance(db, superclass).member(db, program, &name),
         );
 
         if superclass_variable_kind == Some(VariableKind::Instance)
@@ -830,6 +846,7 @@ fn is_function_definition<'db>(
 /// Returns the variable kind for an attribute if it should participate in `ClassVar` override checks.
 fn variable_kind<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     class_member: PlaceAndQualifiers<'db>,
     instance_member: PlaceAndQualifiers<'db>,
 ) -> Option<VariableKind> {
@@ -877,7 +894,7 @@ fn variable_kind<'db>(
         ..
     }) = class_member.place
         && class_member_ty
-            .class_member(db, "__get__".into())
+            .class_member(db, program, "__get__".into())
             .place
             .ignore_possibly_undefined()
             .is_some()
@@ -1451,7 +1468,7 @@ fn check_post_init_signature<'db>(
 
     if member
         .ty
-        .is_assignable_to(db, Type::Callable(expected_signature))
+        .is_assignable_to(db, context.program(), Type::Callable(expected_signature))
     {
         return;
     }
@@ -1509,7 +1526,7 @@ fn check_enum_member_against_constructor_method<'db>(
     //   MEMBER = (a, b, c)  →  __new__(cls, a, b, c) / __init__(self, a, b, c)
     //   MEMBER = x          →  __new__(cls, x) / __init__(self, x)
     let args: Vec<Type<'db>> = if let Type::NominalInstance(instance) = member_value_type {
-        if let Some(spec) = instance.tuple_spec(db) {
+        if let Some(spec) = instance.tuple_spec(db, context.program()) {
             if let Tuple::Fixed(fixed) = &*spec {
                 fixed.all_elements().to_vec()
             } else {
@@ -1528,9 +1545,16 @@ fn check_enum_member_against_constructor_method<'db>(
 
     let constraints = ConstraintSetBuilder::new();
     let result = Type::FunctionLiteral(function)
-        .bindings(db)
-        .match_parameters(db, &call_args)
-        .check_types(db, &constraints, &call_args, TypeContext::default(), &[]);
+        .bindings(db, context.program())
+        .match_parameters(db, context.program(), &call_args)
+        .check_types(
+            db,
+            context.program(),
+            &constraints,
+            &call_args,
+            TypeContext::default(),
+            &[],
+        );
 
     if result.is_err() {
         if let Some(builder) = context.report_lint(
@@ -1543,7 +1567,7 @@ fn check_enum_member_against_constructor_method<'db>(
             ));
             diagnostic.info(format_args!(
                 "Expected compatible arguments for `{}`",
-                Type::FunctionLiteral(function).display(db),
+                Type::FunctionLiteral(function).display(db, context.program()),
             ));
         }
     }

--- a/crates/ty_python_semantic/src/types/property_tests.rs
+++ b/crates/ty_python_semantic/src/types/property_tests.rs
@@ -39,34 +39,36 @@ use type_generation::{intersection, union};
 /// where `t1`, `t2`, ..., `tn` are identifiers that represent arbitrary types, and `<property>`
 /// is an expression using these identifiers.
 macro_rules! type_property_test {
-    ($test_name:ident, $db:ident, forall types $($types:ident),+ . $property:expr) => {
+    ($test_name:ident, $db:ident, $program:ident, forall types $($types:ident),+ . $property:expr) => {
         #[quickcheck_macros::quickcheck]
         #[ignore]
         fn $test_name($($types: crate::types::property_tests::type_generation::Ty),+) -> bool {
             let $db = &crate::types::property_tests::setup::get_cached_db();
+            let $program = $db.program();
             $(let $types = $types.into_type($db);)+
             let result = $property;
 
             if !result {
                 println!("\nFailing types were:");
-                $(println!("{}", $types.display($db));)+
+                $(println!("{}", $types.display($db, $program));)+
             }
 
             result
         }
     };
 
-    ($test_name:ident, $db:ident, forall fully_static_types $($types:ident),+ . $property:expr) => {
+    ($test_name:ident, $db:ident, $program:ident, forall fully_static_types $($types:ident),+ . $property:expr) => {
         #[quickcheck_macros::quickcheck]
         #[ignore]
         fn $test_name($($types: crate::types::property_tests::type_generation::FullyStaticTy),+) -> bool {
             let $db = &crate::types::property_tests::setup::get_cached_db();
+            let $program = $db.program();
             $(let $types = $types.into_type($db);)+
             let result = $property;
 
             if !result {
                 println!("\nFailing types were:");
-                $(println!("{}", $types.display($db));)+
+                $(println!("{}", $types.display($db, $program));)+
             }
 
             result
@@ -74,8 +76,8 @@ macro_rules! type_property_test {
     };
 
     // A property test with a logical implication.
-    ($name:ident, $db:ident, forall $typekind:ident $($types:ident),+ . $premise:expr => $conclusion:expr) => {
-        type_property_test!($name, $db, forall $typekind $($types),+ . !($premise) || ($conclusion));
+    ($name:ident, $db:ident, $program:ident, forall $typekind:ident $($types:ident),+ . $premise:expr => $conclusion:expr) => {
+        type_property_test!($name, $db, $program, forall $typekind $($types),+ . !($premise) || ($conclusion));
     };
 }
 
@@ -85,146 +87,146 @@ mod stable {
 
     // Reflexivity: `T` is equivalent to itself.
     type_property_test!(
-        equivalent_to_is_reflexive, db,
-        forall types t. t.is_equivalent_to(db, t)
+        equivalent_to_is_reflexive, db, program,
+        forall types t. t.is_equivalent_to(db, program, t)
     );
 
     // Symmetry: If `S` is equivalent to `T`, then `T` must be equivalent to `S`.
     type_property_test!(
-        equivalent_to_is_symmetric, db,
-        forall types s, t. s.is_equivalent_to(db, t) => t.is_equivalent_to(db, s)
+        equivalent_to_is_symmetric, db, program,
+        forall types s, t. s.is_equivalent_to(db, program, t) => t.is_equivalent_to(db, program, s)
     );
 
     // Transitivity: If `S` is equivalent to `T` and `T` is equivalent to `U`, then `S` must be equivalent to `U`.
     type_property_test!(
-        equivalent_to_is_transitive, db,
-        forall types s, t, u. s.is_equivalent_to(db, t) && t.is_equivalent_to(db, u) => s.is_equivalent_to(db, u)
+        equivalent_to_is_transitive, db, program,
+        forall types s, t, u. s.is_equivalent_to(db, program, t) && t.is_equivalent_to(db, program, u) => s.is_equivalent_to(db, program, u)
     );
 
     // `S <: T` and `T <: U` implies that `S <: U`.
     type_property_test!(
-        subtype_of_is_transitive, db,
-        forall types s, t, u. s.is_subtype_of(db, t) && t.is_subtype_of(db, u) => s.is_subtype_of(db, u)
+        subtype_of_is_transitive, db, program,
+        forall types s, t, u. s.is_subtype_of(db, program, t) && t.is_subtype_of(db, program, u) => s.is_subtype_of(db, program, u)
     );
 
     // `S <: T` and `T <: S` implies that `S` is equivalent to `T`.
     type_property_test!(
-        subtype_of_is_antisymmetric, db,
-        forall types s, t. s.is_subtype_of(db, t) && t.is_subtype_of(db, s) => s.is_equivalent_to(db, t)
+        subtype_of_is_antisymmetric, db, program,
+        forall types s, t. s.is_subtype_of(db, program, t) && t.is_subtype_of(db, program, s) => s.is_equivalent_to(db, program, t)
     );
 
     type_property_test!(
-        structural_negation_subtyping_matches_materialized_negation, db,
+        structural_negation_subtyping_matches_materialized_negation, db, program,
         forall types s, t. {
             let mut cache = None;
-            s.negation_is_subtype_of_cached(db, t, &mut cache) == s.negate(db).is_subtype_of(db, t)
+            s.negation_is_subtype_of_cached(db, program, t, &mut cache) == s.negate(db, program).is_subtype_of(db, program, t)
         }
     );
 
     // `T` is not disjoint from itself, unless `T` is `Never`.
     type_property_test!(
-        disjoint_from_is_irreflexive, db,
-        forall types t. t.is_disjoint_from(db, t) => t.is_never()
+        disjoint_from_is_irreflexive, db, program,
+        forall types t. t.is_disjoint_from(db, program, t) => t.is_never()
     );
 
     // `S` is disjoint from `T` implies that `T` is disjoint from `S`.
     type_property_test!(
-        disjoint_from_is_symmetric, db,
-        forall types s, t. s.is_disjoint_from(db, t) == t.is_disjoint_from(db, s)
+        disjoint_from_is_symmetric, db, program,
+        forall types s, t. s.is_disjoint_from(db, program, t) == t.is_disjoint_from(db, program, s)
     );
 
     // `S <: T` implies that `S` is not disjoint from `T`, unless `S` is `Never`.
     type_property_test!(
-        subtype_of_implies_not_disjoint_from, db,
-        forall types s, t. s.is_subtype_of(db, t) => !s.is_disjoint_from(db, t) || s.is_never()
+        subtype_of_implies_not_disjoint_from, db, program,
+        forall types s, t. s.is_subtype_of(db, program, t) => !s.is_disjoint_from(db, program, t) || s.is_never()
     );
 
     // `S <: T` implies that `S` can be assigned to `T`.
     type_property_test!(
-        subtype_of_implies_assignable_to, db,
-        forall types s, t. s.is_subtype_of(db, t) => s.is_assignable_to(db, t)
+        subtype_of_implies_assignable_to, db, program,
+        forall types s, t. s.is_subtype_of(db, program, t) => s.is_assignable_to(db, program, t)
     );
 
     // If `T` is a singleton, it is also single-valued.
     type_property_test!(
-        singleton_implies_single_valued, db,
-        forall types t. t.is_singleton(db) => t.is_single_valued(db)
+        singleton_implies_single_valued, db, program,
+        forall types t. t.is_singleton(db, program) => t.is_single_valued(db, program)
     );
 
     // All types should be assignable to `object`
     type_property_test!(
-        all_types_assignable_to_object, db,
-        forall types t. t.is_assignable_to(db, Type::object())
+        all_types_assignable_to_object, db, program,
+        forall types t. t.is_assignable_to(db, program, Type::object())
     );
 
     // And all types should be subtypes of `object`
     type_property_test!(
-        all_types_subtype_of_object, db,
-        forall types t. t.is_subtype_of(db, Type::object())
+        all_types_subtype_of_object, db, program,
+        forall types t. t.is_subtype_of(db, program, Type::object())
     );
 
     // Never should be assignable to every type
     type_property_test!(
-        never_assignable_to_every_type, db,
-        forall types t. Type::Never.is_assignable_to(db, t)
+        never_assignable_to_every_type, db, program,
+        forall types t. Type::Never.is_assignable_to(db, program, t)
     );
 
     // And it should be a subtype of all types
     type_property_test!(
-        never_subtype_of_every_type, db,
-        forall types t. Type::Never.is_subtype_of(db, t)
+        never_subtype_of_every_type, db, program,
+        forall types t. Type::Never.is_subtype_of(db, program, t)
     );
 
     // Similar to `Never`, a "bottom" callable type should be a subtype of all callable types
     type_property_test!(
-        bottom_callable_is_subtype_of_all_callable, db,
+        bottom_callable_is_subtype_of_all_callable, db, program,
         forall types t. t.is_callable_type()
-            => Type::Callable(CallableType::bottom(db)).is_subtype_of(db, t)
+            => Type::Callable(CallableType::bottom(db)).is_subtype_of(db, program, t)
     );
 
     // `T` can be assigned to itself.
     type_property_test!(
-        assignable_to_is_reflexive, db,
-        forall types t. t.is_assignable_to(db, t)
+        assignable_to_is_reflexive, db, program,
+        forall types t. t.is_assignable_to(db, program, t)
     );
 
     // For *any* pair of types, each of the pair should be assignable to the union of the two.
     type_property_test!(
-        all_type_pairs_are_assignable_to_their_union, db,
-        forall types s, t. s.is_assignable_to(db, union(db, [s, t])) && t.is_assignable_to(db, union(db, [s, t]))
+        all_type_pairs_are_assignable_to_their_union, db, program,
+        forall types s, t. s.is_assignable_to(db, program, union(db, [s, t])) && t.is_assignable_to(db, program, union(db, [s, t]))
     );
 
     // Only `Never` is a subtype of `Any`.
     type_property_test!(
-        only_never_is_subtype_of_any, db,
-        forall types s. !s.is_equivalent_to(db, Type::Never) => !s.is_subtype_of(db, Type::any())
+        only_never_is_subtype_of_any, db, program,
+        forall types s. !s.is_equivalent_to(db, program, Type::Never) => !s.is_subtype_of(db, program, Type::any())
     );
 
     // Only `object` is a supertype of `Any`.
     type_property_test!(
-        only_object_is_supertype_of_any, db,
-        forall types t. !t.is_equivalent_to(db, Type::object()) => !Type::any().is_subtype_of(db, t)
+        only_object_is_supertype_of_any, db, program,
+        forall types t. !t.is_equivalent_to(db, program, Type::object()) => !Type::any().is_subtype_of(db, program, t)
     );
 
     // Equivalence is commutative.
     type_property_test!(
-        equivalent_to_is_commutative, db,
-        forall types s, t. s.is_equivalent_to(db, t) == t.is_equivalent_to(db, s)
+        equivalent_to_is_commutative, db, program,
+        forall types s, t. s.is_equivalent_to(db, program, t) == t.is_equivalent_to(db, program, s)
     );
 
     // A fully static type `T` is a subtype of itself. (This is not true for non-fully-static
     // types; `Any` is not a subtype of `Any`, only `Never` is.)
     type_property_test!(
-        subtype_of_is_reflexive_for_fully_static_types, db,
-        forall fully_static_types t. t.is_subtype_of(db, t)
+        subtype_of_is_reflexive_for_fully_static_types, db, program,
+        forall fully_static_types t. t.is_subtype_of(db, program, t)
     );
 
     // For any two fully static types, each type in the pair must be a subtype of their union.
     // (This is clearly not true for non-fully-static types, since their subtyping is not
     // reflexive.)
     type_property_test!(
-        all_fully_static_type_pairs_are_subtype_of_their_union, db,
-        forall fully_static_types s, t. s.is_subtype_of(db, union(db, [s, t])) && t.is_subtype_of(db, union(db, [s, t]))
+        all_fully_static_type_pairs_are_subtype_of_their_union, db, program,
+        forall fully_static_types s, t. s.is_subtype_of(db, program, union(db, [s, t])) && t.is_subtype_of(db, program, union(db, [s, t]))
     );
 
     // Any type assignable to `Iterable[object]` should be considered iterable.
@@ -242,15 +244,15 @@ mod stable {
     // the Liskov violation). All you need to do is to create a class that subclasses
     // `Iterable` but assigns `__iter__ = None` in the class body (or similar).
     type_property_test!(
-        all_types_assignable_to_iterable_are_iterable, db,
-        forall types t. t.is_assignable_to(db, KnownClass::Iterable.to_specialized_instance(db, &[Type::object()])) => t.try_iterate(db).is_ok()
+        all_types_assignable_to_iterable_are_iterable, db, program,
+        forall types t. t.is_assignable_to(db, program, KnownClass::Iterable.to_specialized_instance(db, program, &[Type::object()])) => t.try_iterate(db, program).is_ok()
     );
 
     // Our optimized `Type::negate()` function should always produce the exact same type
     // as going "the long way" via the `IntersectionBuilder`.
     type_property_test!(
-        all_negated_types_identical_to_intersection_with_single_negated_element, db,
-        forall types t. t.negate(db) == IntersectionBuilder::new(db).add_negative(t).build()
+        all_negated_types_identical_to_intersection_with_single_negated_element, db, program,
+        forall types t. t.negate(db, program) == IntersectionBuilder::new(db, program).add_negative(t).build()
     );
 }
 
@@ -268,64 +270,64 @@ mod flaky {
 
     // Negating `T` twice is equivalent to `T`.
     type_property_test!(
-        double_negation_is_identity, db,
-        forall types t. t.negate(db).negate(db).is_equivalent_to(db, t)
+        double_negation_is_identity, db, program,
+        forall types t. t.negate(db, program).negate(db, program).is_equivalent_to(db, program, t)
     );
 
     // For any fully static type `T`, `T` should be disjoint from `~T`.
     // https://github.com/astral-sh/ty/issues/216
     type_property_test!(
-        negation_of_fully_static_types_is_disjoint, db,
-        forall fully_static_types t. t.negate(db).is_disjoint_from(db, t)
+        negation_of_fully_static_types_is_disjoint, db, program,
+        forall fully_static_types t. t.negate(db, program).is_disjoint_from(db, program, t)
     );
 
     // For two types, their intersection must be a subtype of each type in the pair.
     type_property_test!(
-        all_type_pairs_are_supertypes_of_their_intersection, db,
+        all_type_pairs_are_supertypes_of_their_intersection, db, program,
         forall types s, t.
-            intersection(db, [s, t]).is_subtype_of(db, s) && intersection(db, [s, t]).is_subtype_of(db, t)
+            intersection(db, [s, t]).is_subtype_of(db, program, s) && intersection(db, [s, t]).is_subtype_of(db, program, t)
     );
 
     // And the intersection of a pair of types
     // should be assignable to both types of the pair.
     // Currently fails due to https://github.com/astral-sh/ruff/issues/14899
     type_property_test!(
-        all_type_pairs_can_be_assigned_from_their_intersection, db,
-        forall types s, t. intersection(db, [s, t]).is_assignable_to(db, s) && intersection(db, [s, t]).is_assignable_to(db, t)
+        all_type_pairs_can_be_assigned_from_their_intersection, db, program,
+        forall types s, t. intersection(db, [s, t]).is_assignable_to(db, program, s) && intersection(db, [s, t]).is_assignable_to(db, program, t)
     );
 
     // Equal element sets of intersections implies equivalence
     // flaky at least in part because of https://github.com/astral-sh/ruff/issues/15513
     type_property_test!(
-        intersection_equivalence_not_order_dependent, db,
+        intersection_equivalence_not_order_dependent, db, program,
         forall types s, t, u.
             [s, t, u]
                 .into_iter()
                 .permutations(3)
                 .map(|trio_of_types| intersection(db, trio_of_types))
                 .permutations(2)
-                .all(|vec_of_intersections| vec_of_intersections[0].is_equivalent_to(db, vec_of_intersections[1]))
+                .all(|vec_of_intersections| vec_of_intersections[0].is_equivalent_to(db, program, vec_of_intersections[1]))
     );
 
     // Equal element sets of unions implies equivalence
     // flaky at least in part because of https://github.com/astral-sh/ruff/issues/15513
     type_property_test!(
-        union_equivalence_not_order_dependent, db,
+        union_equivalence_not_order_dependent, db, program,
         forall types s, t, u.
             [s, t, u]
                 .into_iter()
                 .permutations(3)
                 .map(|trio_of_types| union(db, trio_of_types))
                 .permutations(2)
-                .all(|vec_of_unions| vec_of_unions[0].is_equivalent_to(db, vec_of_unions[1]))
+                .all(|vec_of_unions| vec_of_unions[0].is_equivalent_to(db, program, vec_of_unions[1]))
     );
 
     // `S | T` is always a supertype of `S`.
     // Thus, `S` is never disjoint from `S | T`.
     type_property_test!(
-        constituent_members_of_union_is_not_disjoint_from_that_union, db,
+        constituent_members_of_union_is_not_disjoint_from_that_union, db, program,
         forall types s, t.
-            !s.is_disjoint_from(db, union(db, [s, t])) && !t.is_disjoint_from(db, union(db, [s, t]))
+            !s.is_disjoint_from(db, program, union(db, [s, t])) && !t.is_disjoint_from(db, program, union(db, [s, t]))
     );
 
     // If `S <: T`, then `~T <: ~S`.
@@ -339,8 +341,8 @@ mod flaky {
     // occur very rarely (even running the test with several million seeds does
     // not always reliably reproduce the flake).
     type_property_test!(
-        negation_reverses_subtype_order, db,
-        forall types s, t. s.is_subtype_of(db, t) => t.negate(db).is_subtype_of(db, s.negate(db))
+        negation_reverses_subtype_order, db, program,
+        forall types s, t. s.is_subtype_of(db, program, t) => t.negate(db, program).is_subtype_of(db, program, s.negate(db, program))
     );
 
     // Both the top and bottom materialization tests are flaky in part due to various failures that
@@ -349,13 +351,13 @@ mod flaky {
 
     // `T'`, the top materialization of `T`, should be assignable to `T`.
     type_property_test!(
-        top_materialization_of_type_is_assignable_to_type, db,
-        forall types t. t.top_materialization(db).is_assignable_to(db, t)
+        top_materialization_of_type_is_assignable_to_type, db, program,
+        forall types t. t.top_materialization(db, program).is_assignable_to(db, program, t)
     );
 
     // Similarly, `T'`, the bottom materialization of `T`, should also be assignable to `T`.
     type_property_test!(
-        bottom_materialization_of_type_is_assignable_to_type, db,
-        forall types t. t.bottom_materialization(db).is_assignable_to(db, t)
+        bottom_materialization_of_type_is_assignable_to_type, db, program,
+        forall types t. t.bottom_materialization(db, program).is_assignable_to(db, program, t)
     );
 }

--- a/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
+++ b/crates/ty_python_semantic/src/types/property_tests/type_generation.rs
@@ -1,4 +1,3 @@
-use crate::Db;
 use crate::db::tests::TestDb;
 use crate::place::{DefinedPlace, Place, builtins_symbol, global_symbol, known_module_symbol};
 use crate::types::enums::is_single_member_enum;
@@ -9,6 +8,7 @@ use crate::types::{
     IntersectionType, KnownClass, MaterializationKind, Parameter, Parameters, Signature,
     SpecialFormType, SubclassOfType, Type, UnionType,
 };
+use crate::{Db, Program};
 use quickcheck::{Arbitrary, Gen};
 use ruff_db::files::system_path_to_file;
 use ruff_python_ast::name::Name;
@@ -139,22 +139,25 @@ fn create_bound_method<'db>(
     function: Type<'db>,
     builtins_class: Type<'db>,
 ) -> Type<'db> {
+    let function = function.expect_function_literal();
+    let program = function.program(db);
     Type::BoundMethod(BoundMethodType::new(
         db,
-        function.expect_function_literal(),
-        builtins_class.to_instance(db).unwrap(),
+        function,
+        builtins_class.to_instance(db, program).unwrap(),
     ))
 }
 
 impl Ty {
     pub(crate) fn into_type(self, db: &TestDb) -> Type<'_> {
+        let program = db.program();
         match self {
             Ty::Never => Type::Never,
             Ty::Unknown => Type::unknown(),
             Ty::Divergent => divergent(db, 1, None),
             Ty::TopDivergent => divergent(db, 2, Some(MaterializationKind::Top)),
             Ty::BottomDivergent => divergent(db, 3, Some(MaterializationKind::Bottom)),
-            Ty::None => Type::none(db),
+            Ty::None => Type::none(db, program),
             Ty::Any => Type::any(),
             Ty::IntLiteral(n) => Type::int_literal(n),
             Ty::StringLiteral(s) => Type::string_literal(db, s),
@@ -162,7 +165,7 @@ impl Ty {
             Ty::LiteralString => Type::literal_string(),
             Ty::BytesLiteral(s) => Type::bytes_literal(db, s.as_bytes()),
             Ty::EnumLiteral(name) => {
-                let enum_class = known_module_symbol(db, KnownModule::Uuid, "SafeUUID")
+                let enum_class = known_module_symbol(db, program, KnownModule::Uuid, "SafeUUID")
                     .place
                     .expect_type()
                     .expect_class_literal()
@@ -171,42 +174,44 @@ impl Ty {
                 Type::enum_literal(EnumLiteralType::new(db, enum_class, Name::new(name)))
             }
             Ty::SingleMemberEnumLiteral => {
-                let ty = known_module_symbol(db, KnownModule::Dataclasses, "MISSING")
+                let ty = known_module_symbol(db, program, KnownModule::Dataclasses, "MISSING")
                     .place
                     .expect_type();
                 debug_assert!(
-                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class_literal(db)))
+                    matches!(ty, Type::NominalInstance(instance) if is_single_member_enum(db, instance.class_literal(db, program)))
                 );
                 ty
             }
-            Ty::BuiltinInstance(s) => builtins_symbol(db, s)
+            Ty::BuiltinInstance(s) => builtins_symbol(db, program, s)
                 .place
                 .expect_type()
-                .to_instance(db)
+                .to_instance(db, program)
                 .unwrap(),
-            Ty::AbcInstance(s) => known_module_symbol(db, KnownModule::Abc, s)
+            Ty::AbcInstance(s) => known_module_symbol(db, program, KnownModule::Abc, s)
                 .place
                 .expect_type()
-                .to_instance(db)
+                .to_instance(db, program)
                 .unwrap(),
-            Ty::AbcClassLiteral(s) => known_module_symbol(db, KnownModule::Abc, s)
+            Ty::AbcClassLiteral(s) => known_module_symbol(db, program, KnownModule::Abc, s)
                 .place
                 .expect_type(),
-            Ty::UnittestMockLiteral => known_module_symbol(db, KnownModule::UnittestMock, "Mock")
-                .place
-                .expect_type(),
+            Ty::UnittestMockLiteral => {
+                known_module_symbol(db, program, KnownModule::UnittestMock, "Mock")
+                    .place
+                    .expect_type()
+            }
             Ty::UnittestMockInstance => Ty::UnittestMockLiteral
                 .into_type(db)
-                .to_instance(db)
+                .to_instance(db, program)
                 .unwrap(),
             Ty::TypingLiteral => Type::SpecialForm(SpecialFormType::Literal),
-            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, s).place.expect_type(),
-            Ty::KnownClassInstance(known_class) => known_class.to_instance(db),
+            Ty::BuiltinClassLiteral(s) => builtins_symbol(db, program, s).place.expect_type(),
+            Ty::KnownClassInstance(known_class) => known_class.to_instance(db, program),
             Ty::Union(tys) => {
-                UnionType::from_elements(db, tys.into_iter().map(|ty| ty.into_type(db)))
+                UnionType::from_elements(db, program, tys.into_iter().map(|ty| ty.into_type(db)))
             }
             Ty::Intersection { pos, neg } => {
-                let mut builder = IntersectionBuilder::new(db);
+                let mut builder = IntersectionBuilder::new(db, program);
                 for p in pos {
                     builder = builder.add_positive(p.into_type(db));
                 }
@@ -228,7 +233,8 @@ impl Ty {
             Ty::SubclassOfAny => SubclassOfType::subclass_of_any(),
             Ty::SubclassOfBuiltinClass(s) => SubclassOfType::from(
                 db,
-                builtins_symbol(db, s)
+                program,
+                builtins_symbol(db, program, s)
                     .place
                     .expect_type()
                     .expect_class_literal()
@@ -236,7 +242,8 @@ impl Ty {
             ),
             Ty::SubclassOfAbcClass(s) => SubclassOfType::from(
                 db,
-                known_module_symbol(db, KnownModule::Abc, s)
+                program,
+                known_module_symbol(db, program, KnownModule::Abc, s)
                     .place
                     .expect_type()
                     .expect_class_literal()
@@ -244,10 +251,13 @@ impl Ty {
             ),
             Ty::AlwaysTruthy => Type::AlwaysTruthy,
             Ty::AlwaysFalsy => Type::AlwaysFalsy,
-            Ty::BuiltinsFunction(name) => builtins_symbol(db, name).place.expect_type(),
+            Ty::BuiltinsFunction(name) => builtins_symbol(db, program, name).place.expect_type(),
             Ty::BuiltinsBoundMethod { class, method } => {
-                let builtins_class = builtins_symbol(db, class).place.expect_type();
-                let function = builtins_class.member(db, method).place.expect_type();
+                let builtins_class = builtins_symbol(db, program, class).place.expect_type();
+                let function = builtins_class
+                    .member(db, program, method)
+                    .place
+                    .expect_type();
 
                 create_bound_method(db, function, builtins_class)
             }
@@ -255,23 +265,25 @@ impl Ty {
                 db,
                 Signature::new(params.into_parameters(db), returns.into_type(db)),
             ),
-            Ty::FloatNewtypeInstance => newtype_instance(db, "NewTypeOfFloat"),
-            Ty::IntNewtypeInstance => newtype_instance(db, "NewTypeOfInt"),
-            Ty::StrNewtypeInstance => newtype_instance(db, "NewTypeOfStr"),
-            Ty::ComplexNewtypeInstance => newtype_instance(db, "NewTypeOfComplex"),
-            Ty::SubNewTypeOfIntInstance => newtype_instance(db, "SubNewTypeOfInt"),
-            Ty::SubSubNewTypeOfIntInstance => newtype_instance(db, "SubSubNewTypeOfInt"),
-            Ty::SubNewTypeOfFloatInstance => newtype_instance(db, "SubNewTypeOfFloat"),
+            Ty::FloatNewtypeInstance => newtype_instance(db, program, "NewTypeOfFloat"),
+            Ty::IntNewtypeInstance => newtype_instance(db, program, "NewTypeOfInt"),
+            Ty::StrNewtypeInstance => newtype_instance(db, program, "NewTypeOfStr"),
+            Ty::ComplexNewtypeInstance => newtype_instance(db, program, "NewTypeOfComplex"),
+            Ty::SubNewTypeOfIntInstance => newtype_instance(db, program, "SubNewTypeOfInt"),
+            Ty::SubSubNewTypeOfIntInstance => newtype_instance(db, program, "SubSubNewTypeOfInt"),
+            Ty::SubNewTypeOfFloatInstance => newtype_instance(db, program, "SubNewTypeOfFloat"),
         }
     }
 }
 
 fn divergent(db: &TestDb, id_bits: u64, materialization: Option<MaterializationKind>) -> Type<'_> {
+    let program = db.program();
     let divergent = Type::divergent(salsa::plumbing::Id::from_bits(id_bits));
 
     match materialization {
         Some(materialization_kind) => divergent.materialize(
             db,
+            program,
             materialization_kind,
             &ApplyTypeMappingVisitor::default(),
         ),
@@ -279,10 +291,12 @@ fn divergent(db: &TestDb, id_bits: u64, materialization: Option<MaterializationK
     }
 }
 
-fn newtype_instance<'db>(db: &'db dyn Db, name: &str) -> Type<'db> {
+fn newtype_instance<'db>(db: &'db TestDb, program: Program, name: &str) -> Type<'db> {
     let file = system_path_to_file(db, super::setup::PROPERTY_TEST_MODULE_PATH)
         .expect("Property-test module must exist");
-    let Place::Defined(DefinedPlace { ty, .. }) = global_symbol(db, file, name).place else {
+    let Place::Defined(DefinedPlace { ty, .. }) =
+        global_symbol(db, crate::ProgramFile::new(db, program, file), name).place
+    else {
         panic!(
             "Expected a global symbol for `{name}` in the property test module, but it was not found"
         );
@@ -629,9 +643,9 @@ pub(crate) fn intersection<'db>(
     db: &'db TestDb,
     tys: impl IntoIterator<Item = Type<'db>>,
 ) -> Type<'db> {
-    IntersectionType::from_elements(db, tys)
+    IntersectionType::from_elements(db, db.program(), tys)
 }
 
 pub(crate) fn union<'db>(db: &'db TestDb, tys: impl IntoIterator<Item = Type<'db>>) -> Type<'db> {
-    UnionType::from_elements(db, tys)
+    UnionType::from_elements(db, db.program(), tys)
 }

--- a/crates/ty_python_semantic/src/types/protocol_class.rs
+++ b/crates/ty_python_semantic/src/types/protocol_class.rs
@@ -49,7 +49,7 @@ impl<'db> ClassType<'db> {
 }
 
 /// Representation of a single `Protocol` class definition.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) struct ProtocolClass<'db>(ClassType<'db>);
 
 impl<'db> ProtocolClass<'db> {
@@ -90,7 +90,12 @@ impl<'db> ProtocolClass<'db> {
     /// class P(Protocol):
     ///     __doc__: str
     /// ```
-    pub(super) fn has_member_declaration(self, db: &'db dyn Db, name: &str) -> bool {
+    pub(super) fn has_member_declaration(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        name: &str,
+    ) -> bool {
         self.iter_mro(db)
             .filter_map(ClassBase::into_class)
             .any(|superclass| {
@@ -104,6 +109,7 @@ impl<'db> ProtocolClass<'db> {
                 };
                 !place_from_declarations(
                     db,
+                    program,
                     use_def_map(db, superclass_scope)
                         .end_of_scope_declarations(ScopedPlaceId::Symbol(scoped_symbol_id)),
                 )
@@ -134,7 +140,7 @@ impl<'db> ProtocolClass<'db> {
                 continue;
             }
 
-            if self.has_member_declaration(db, symbol_name) {
+            if self.has_member_declaration(db, context.program(), symbol_name) {
                 continue;
             }
 
@@ -198,11 +204,12 @@ impl get_size2::GetSize for ProtocolInterface<'_> {}
 
 pub(super) fn walk_protocol_interface<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     interface: ProtocolInterface<'db>,
     visitor: &V,
 ) {
     for member in interface.members(db) {
-        walk_protocol_member(db, &member, visitor);
+        walk_protocol_member(db, program, &member, visitor);
     }
 }
 
@@ -243,7 +250,13 @@ impl<'db> ProtocolInterface<'db> {
         Self::new(db, BTreeMap::default())
     }
 
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         let prev_inner = previous.inner(db);
         let curr_inner = self.inner(db);
 
@@ -251,7 +264,7 @@ impl<'db> ProtocolInterface<'db> {
             .iter()
             .map(|(name, curr_data)| {
                 let normalized = if let Some(prev_data) = prev_inner.get(name) {
-                    curr_data.cycle_normalized(db, prev_data, cycle)
+                    curr_data.cycle_normalized(db, program, prev_data, cycle)
                 } else {
                     curr_data.clone()
                 };
@@ -301,32 +314,37 @@ impl<'db> ProtocolInterface<'db> {
     pub(super) fn instance_write_requirement(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         receiver_ty: Type<'db>,
         name: &str,
     ) -> Option<(Option<Type<'db>>, TypeQualifiers)> {
         self.member_by_name(db, name).map(|member| {
-            let capabilities = member.capabilities(db);
+            let capabilities = member.capabilities(db, program);
             (
                 capabilities
                     .instance
                     .write
-                    .and_then(|write| write.bind_self(db, receiver_ty)),
+                    .and_then(|write| write.bind_self(db, program, receiver_ty)),
                 member.qualifiers(),
             )
         })
     }
 
     /// Returns the `__call__` method's callable type if this protocol has a `__call__` method member.
-    pub(super) fn call_method(self, db: &'db dyn Db) -> Option<CallableType<'db>> {
+    pub(super) fn call_method(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<CallableType<'db>> {
         self.member_by_name(db, "__call__").and_then(|member| {
             if !member.is_method() {
                 return None;
             }
             match member
-                .capabilities(db)
+                .capabilities(db, program)
                 .class
                 .read
-                .and_then(|read| read.resolve(db))
+                .and_then(|read| read.resolve(db, program))
                 .map(ProtocolMemberType::ty)
             {
                 Some(Type::Callable(callable)) => Some(callable),
@@ -335,27 +353,33 @@ impl<'db> ProtocolInterface<'db> {
         })
     }
 
-    pub(super) fn instance_member(self, db: &'db dyn Db, name: &str) -> PlaceAndQualifiers<'db> {
+    pub(super) fn instance_member(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        name: &str,
+    ) -> PlaceAndQualifiers<'db> {
         self.member_by_name(db, name)
             .map(|member| {
-                let capabilities = member.capabilities(db);
+                let capabilities = member.capabilities(db, program);
                 PlaceAndQualifiers {
                     place: capabilities
                         .instance
                         .read
-                        .and_then(|read| read.resolve(db))
+                        .and_then(|read| read.resolve(db, program))
                         .map(|read| Place::bound(read.ty()))
                         .unwrap_or(Place::Undefined)
                         .with_provenance(Provenance::from_definition(member.definition())),
                     qualifiers: member.qualifiers(),
                 }
             })
-            .unwrap_or_else(|| Type::object().member(db, name))
+            .unwrap_or_else(|| Type::object().member(db, program, name))
     }
 
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -366,7 +390,7 @@ impl<'db> ProtocolInterface<'db> {
                 .map(|(name, data)| {
                     Some((
                         name.clone(),
-                        data.recursive_type_normalized_impl(db, div, nested)?,
+                        data.recursive_type_normalized_impl(db, program, div, nested)?,
                     ))
                 })
                 .collect::<Option<BTreeMap<_, _>>>()?,
@@ -376,6 +400,7 @@ impl<'db> ProtocolInterface<'db> {
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -387,7 +412,7 @@ impl<'db> ProtocolInterface<'db> {
                 .map(|(name, data)| {
                     (
                         name.clone(),
-                        data.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                        data.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
                     )
                 })
                 .collect::<BTreeMap<_, _>>(),
@@ -397,18 +422,24 @@ impl<'db> ProtocolInterface<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         for data in self.inner(db).values() {
-            data.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            data.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 
-    pub(super) fn display(self, db: &'db dyn Db) -> impl std::fmt::Display {
+    pub(super) fn display(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> impl std::fmt::Display {
         struct ProtocolInterfaceDisplay<'db> {
             db: &'db dyn Db,
+            program: crate::Program,
             interface: ProtocolInterface<'db>,
         }
 
@@ -416,7 +447,11 @@ impl<'db> ProtocolInterface<'db> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_char('{')?;
                 for (i, (name, data)) in self.interface.inner(self.db).iter().enumerate() {
-                    write!(f, "\"{name}\": {data}", data = data.display(self.db))?;
+                    write!(
+                        f,
+                        "\"{name}\": {data}",
+                        data = data.display(self.db, self.program)
+                    )?;
                     if i < self.interface.inner(self.db).len() - 1 {
                         f.write_str(", ")?;
                     }
@@ -427,21 +462,27 @@ impl<'db> ProtocolInterface<'db> {
 
         ProtocolInterfaceDisplay {
             db,
+            program,
             interface: self,
         }
     }
 }
 
 impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         self.members(db)
             .flat_map(|member| {
-                let capabilities = member.capabilities(db);
+                let capabilities = member.capabilities(db, program);
                 [capabilities.instance, capabilities.class]
                     .into_iter()
-                    .flat_map(|access| access.variances(db))
+                    .flat_map(|access| access.variances(db, program))
             })
-            .map(|(ty, variance)| ty.with_polarity(variance).variance_of(db, typevar))
+            .map(|(ty, variance)| ty.with_polarity(variance).variance_of(db, program, typevar))
             .collect()
     }
 }
@@ -451,7 +492,7 @@ impl<'db> VarianceInferable<'db> for ProtocolInterface<'db> {
 /// Property accessors remain as callables until a relation needs their read or write type. Once
 /// resolved, `Value` retains the accessor's binding context so that only its own `Self` type is
 /// rebound during protocol checks.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 enum ProtocolMemberType<'db> {
     Value {
         ty: Type<'db>,
@@ -511,50 +552,71 @@ impl<'db> ProtocolMemberType<'db> {
     }
 
     /// Resolves a stored property accessor to the value type exposed by that access.
-    fn resolve(self, db: &'db dyn Db) -> Option<Self> {
+    fn resolve(self, db: &'db dyn Db, program: crate::Program) -> Option<Self> {
         match self {
             Self::Value { .. } => Some(self),
-            Self::PropertyGetter(getter) => property_get_member_type(db, getter),
-            Self::PropertySetter(setter) => property_set_member_type(db, setter),
+            Self::PropertyGetter(getter) => property_get_member_type(db, program, getter),
+            Self::PropertySetter(setter) => property_set_member_type(db, program, setter),
         }
     }
 
     /// Resolves this member type and binds member-local `Self` occurrences to `self_type`.
-    fn bind_self(self, db: &'db dyn Db, self_type: Type<'db>) -> Option<Type<'db>> {
+    fn bind_self(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> Option<Type<'db>> {
         let Self::Value {
             ty,
             self_binding_context,
-        } = self.resolve(db)?
+        } = self.resolve(db, program)?
         else {
             return None;
         };
-        if !ty.contains_self(db) {
+        if !ty.contains_self(db, program) {
             return Some(ty);
         }
 
         Some(ty.apply_type_mapping(
             db,
-            &TypeMapping::BindSelf(SelfBinding::new(db, self_type, self_binding_context)),
+            program,
+            &TypeMapping::BindSelf(SelfBinding::new(
+                db,
+                program,
+                self_type,
+                self_binding_context,
+            )),
             TypeContext::default(),
         ))
     }
 
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
-        let ty = self.ty().cycle_normalized(db, previous.ty(), cycle);
+    fn cycle_normalized(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
+        let ty = self
+            .ty()
+            .cycle_normalized(db, program, previous.ty(), cycle);
         self.with_ty(ty)
     }
 
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let ty = if nested {
-            self.ty().recursive_type_normalized_impl(db, div, true)?
+            self.ty()
+                .recursive_type_normalized_impl(db, program, div, true)?
         } else {
             self.ty()
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .unwrap_or(div)
         };
         Some(self.with_ty(ty))
@@ -563,18 +625,19 @@ impl<'db> ProtocolMemberType<'db> {
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         let ty = self
             .ty()
-            .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+            .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor);
         self.with_ty(ty)
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 /// The types supported by one way of accessing a protocol member.
 ///
 /// `read` is covariant and `write` is contravariant. Either operation can be absent: for example,
@@ -597,14 +660,18 @@ impl<'db> ProtocolMemberAccess<'db> {
         Self { read, write }
     }
 
-    fn variances(self, db: &'db dyn Db) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> {
+    fn variances(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> impl Iterator<Item = (Type<'db>, TypeVarVariance)> {
         self.read
-            .and_then(|member| member.resolve(db))
+            .and_then(|member| member.resolve(db, program))
             .map(|member| (member.ty(), TypeVarVariance::Covariant))
             .into_iter()
             .chain(
                 self.write
-                    .and_then(|member| member.resolve(db))
+                    .and_then(|member| member.resolve(db, program))
                     .map(|member| (member.ty(), TypeVarVariance::Contravariant)),
             )
     }
@@ -629,20 +696,23 @@ enum ProtocolMemberAccessMode {
 
 fn cycle_normalized_optional_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     current: Option<ProtocolMemberType<'db>>,
     previous: Option<ProtocolMemberType<'db>>,
     cycle: &salsa::Cycle,
 ) -> Option<ProtocolMemberType<'db>> {
     match (current, previous) {
-        (Some(current), Some(previous)) => Some(current.cycle_normalized(db, previous, cycle)),
+        (Some(current), Some(previous)) => {
+            Some(current.cycle_normalized(db, program, previous, cycle))
+        }
         (Some(current), None) => {
-            Some(current.with_ty(current.ty().recursive_type_normalized(db, cycle)))
+            Some(current.with_ty(current.ty().recursive_type_normalized(db, program, cycle)))
         }
         (None, _) => None,
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(super) struct ProtocolMemberData<'db> {
     kind: ProtocolMemberKind<'db>,
     qualifiers: TypeQualifiers,
@@ -688,13 +758,17 @@ impl<'db> ProtocolMemberData<'db> {
     ///
     /// These are views of the canonical method, property, or attribute representation below;
     /// keeping them derived prevents the stored member kind and its capabilities from diverging.
-    fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
+    fn capabilities(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> ProtocolMemberCapabilities<'db> {
         match self.kind {
             ProtocolMemberKind::Method(method) => {
                 let instance_method = match method.ty() {
-                    Type::Callable(callable) => {
-                        method.with_ty(Type::Callable(protocol_bind_self(db, callable, None)))
-                    }
+                    Type::Callable(callable) => method.with_ty(Type::Callable(protocol_bind_self(
+                        db, program, callable, None,
+                    ))),
                     _ => method,
                 };
                 ProtocolMemberCapabilities {
@@ -731,9 +805,17 @@ impl<'db> ProtocolMemberData<'db> {
         }
     }
 
-    fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: &Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         Self {
-            kind: self.kind.cycle_normalized(db, previous.kind, cycle),
+            kind: self
+                .kind
+                .cycle_normalized(db, program, previous.kind, cycle),
             qualifiers: self.qualifiers,
             definition: self.definition,
         }
@@ -742,11 +824,14 @@ impl<'db> ProtocolMemberData<'db> {
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(Self {
-            kind: self.kind.recursive_type_normalized_impl(db, div, nested)?,
+            kind: self
+                .kind
+                .recursive_type_normalized_impl(db, program, div, nested)?,
             qualifiers: self.qualifiers,
             definition: self.definition,
         })
@@ -755,6 +840,7 @@ impl<'db> ProtocolMemberData<'db> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -762,7 +848,7 @@ impl<'db> ProtocolMemberData<'db> {
         Self {
             kind: self
                 .kind
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             qualifiers: self.qualifiers,
             definition: self.definition,
         }
@@ -771,6 +857,7 @@ impl<'db> ProtocolMemberData<'db> {
     fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         _visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -778,13 +865,14 @@ impl<'db> ProtocolMemberData<'db> {
         for member_type in self.kind.member_types() {
             member_type
                 .ty()
-                .find_legacy_typevars(db, binding_context, typevars);
+                .find_legacy_typevars(db, program, binding_context, typevars);
         }
     }
 
-    fn display(&self, db: &'db dyn Db) -> impl std::fmt::Display {
+    fn display(&self, db: &'db dyn Db, program: crate::Program) -> impl std::fmt::Display {
         struct ProtocolMemberDataDisplay<'db> {
             db: &'db dyn Db,
+            program: crate::Program,
             kind: ProtocolMemberKind<'db>,
             qualifiers: TypeQualifiers,
         }
@@ -793,21 +881,35 @@ impl<'db> ProtocolMemberData<'db> {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self.kind {
                     ProtocolMemberKind::Method(method) => {
-                        write!(f, "MethodMember(`{}`)", method.ty().display(self.db))
+                        write!(
+                            f,
+                            "MethodMember(`{}`)",
+                            method.ty().display(self.db, self.program)
+                        )
                     }
                     ProtocolMemberKind::Property { read, write } => {
                         let mut d = f.debug_struct("PropertyMember");
-                        if let Some(read) = read.and_then(|read| read.resolve(self.db)) {
-                            d.field("read", &format_args!("`{}`", &read.ty().display(self.db)));
+                        if let Some(read) =
+                            read.and_then(|read| read.resolve(self.db, self.program))
+                        {
+                            d.field(
+                                "read",
+                                &format_args!("`{}`", &read.ty().display(self.db, self.program)),
+                            );
                         }
-                        if let Some(write) = write.and_then(|write| write.resolve(self.db)) {
-                            d.field("write", &format_args!("`{}`", &write.ty().display(self.db)));
+                        if let Some(write) =
+                            write.and_then(|write| write.resolve(self.db, self.program))
+                        {
+                            d.field(
+                                "write",
+                                &format_args!("`{}`", &write.ty().display(self.db, self.program)),
+                            );
                         }
                         d.finish()
                     }
                     ProtocolMemberKind::Attribute(attribute) => {
                         f.write_str("AttributeMember(")?;
-                        write!(f, "`{}`", attribute.ty().display(self.db))?;
+                        write!(f, "`{}`", attribute.ty().display(self.db, self.program))?;
                         if self.qualifiers.contains(TypeQualifiers::CLASS_VAR) {
                             f.write_str("; ClassVar")?;
                         }
@@ -819,13 +921,14 @@ impl<'db> ProtocolMemberData<'db> {
 
         ProtocolMemberDataDisplay {
             db,
+            program,
             kind: self.kind,
             qualifiers: self.qualifiers,
         }
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 enum ProtocolMemberKind<'db> {
     Method(ProtocolMemberType<'db>),
     Property {
@@ -846,17 +949,24 @@ impl<'db> ProtocolMemberKind<'db> {
         .flatten()
     }
 
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         match (self, previous) {
             (Self::Method(current), Self::Method(previous)) => {
                 let (Type::Callable(current_callable), Type::Callable(previous_callable)) =
                     (current.ty(), previous.ty())
                 else {
-                    return Self::Method(current.cycle_normalized(db, previous, cycle));
+                    return Self::Method(current.cycle_normalized(db, program, previous, cycle));
                 };
                 debug_assert_eq!(current_callable.kind(db), previous_callable.kind(db));
                 let signatures = current_callable.signatures(db).cycle_normalized(
                     db,
+                    program,
                     previous_callable.signatures(db),
                     cycle,
                 );
@@ -877,11 +987,23 @@ impl<'db> ProtocolMemberKind<'db> {
                     write: previous_write,
                 },
             ) => Self::Property {
-                read: cycle_normalized_optional_type(db, current_read, previous_read, cycle),
-                write: cycle_normalized_optional_type(db, current_write, previous_write, cycle),
+                read: cycle_normalized_optional_type(
+                    db,
+                    program,
+                    current_read,
+                    previous_read,
+                    cycle,
+                ),
+                write: cycle_normalized_optional_type(
+                    db,
+                    program,
+                    current_write,
+                    previous_write,
+                    cycle,
+                ),
             },
             (Self::Attribute(current), Self::Attribute(previous)) => {
-                Self::Attribute(current.cycle_normalized(db, previous, cycle))
+                Self::Attribute(current.cycle_normalized(db, program, previous, cycle))
             }
             (current, _) => current,
         }
@@ -890,25 +1012,30 @@ impl<'db> ProtocolMemberKind<'db> {
     fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(match self {
             Self::Method(method) => {
-                Self::Method(method.recursive_type_normalized_impl(db, div, nested)?)
+                Self::Method(method.recursive_type_normalized_impl(db, program, div, nested)?)
             }
             Self::Property { read, write } => Self::Property {
                 read: match read {
-                    Some(read) => Some(read.recursive_type_normalized_impl(db, div, nested)?),
+                    Some(read) => {
+                        Some(read.recursive_type_normalized_impl(db, program, div, nested)?)
+                    }
                     None => None,
                 },
                 write: match write {
-                    Some(write) => Some(write.recursive_type_normalized_impl(db, div, nested)?),
+                    Some(write) => {
+                        Some(write.recursive_type_normalized_impl(db, program, div, nested)?)
+                    }
                     None => None,
                 },
             },
             Self::Attribute(attribute) => {
-                Self::Attribute(attribute.recursive_type_normalized_impl(db, div, nested)?)
+                Self::Attribute(attribute.recursive_type_normalized_impl(db, program, div, nested)?)
             }
         })
     }
@@ -916,22 +1043,34 @@ impl<'db> ProtocolMemberKind<'db> {
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
-            Self::Method(method) => {
-                Self::Method(method.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Self::Method(method) => Self::Method(method.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            )),
             Self::Property { read, write } => Self::Property {
-                read: read.map(|read| read.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
-                write: write
-                    .map(|write| write.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+                read: read.map(|read| {
+                    read.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+                }),
+                write: write.map(|write| {
+                    write.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+                }),
             },
-            Self::Attribute(attribute) => {
-                Self::Attribute(attribute.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
-            }
+            Self::Attribute(attribute) => Self::Attribute(attribute.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            )),
         }
     }
 }
@@ -945,11 +1084,12 @@ pub(super) struct ProtocolMember<'a, 'db> {
 
 fn walk_protocol_member<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     member: &ProtocolMember<'_, 'db>,
     visitor: &V,
 ) {
     for member_type in member.data.kind.member_types() {
-        visitor.visit_type(db, member_type.ty());
+        visitor.visit_type(db, program, member_type.ty());
     }
 }
 
@@ -974,8 +1114,12 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
         self.data.definition
     }
 
-    fn capabilities(&self, db: &'db dyn Db) -> ProtocolMemberCapabilities<'db> {
-        self.data.capabilities(db)
+    fn capabilities(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> ProtocolMemberCapabilities<'db> {
+        self.data.capabilities(db, program)
     }
 
     fn has_todo_type(&self) -> bool {
@@ -988,36 +1132,38 @@ impl<'a, 'db> ProtocolMember<'a, 'db> {
 
 fn property_get_member_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     getter: Type<'db>,
 ) -> Option<ProtocolMemberType<'db>> {
     let mut get_types = Vec::new();
     let mut definition = None;
-    for callable in &getter.try_upcast_to_callable(db)? {
+    for callable in &getter.try_upcast_to_callable(db, program)? {
         for signature in callable.signatures(db) {
             get_types.push(signature.return_ty);
             definition = definition.or(signature.definition());
         }
     }
     Some(ProtocolMemberType::with_definition(
-        UnionType::from_elements(db, get_types),
+        UnionType::from_elements(db, program, get_types),
         definition,
     ))
 }
 
 fn property_set_member_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     setter: Type<'db>,
 ) -> Option<ProtocolMemberType<'db>> {
     let mut set_types = Vec::new();
     let mut definition = None;
-    for callable in &setter.try_upcast_to_callable(db)? {
+    for callable in &setter.try_upcast_to_callable(db, program)? {
         for signature in callable.signatures(db) {
             set_types.push(signature.parameters().get_positional(1)?.annotated_type());
             definition = definition.or(signature.definition());
         }
     }
     Some(ProtocolMemberType::with_definition(
-        UnionType::from_elements(db, set_types),
+        UnionType::from_elements(db, program, set_types),
         definition,
     ))
 }
@@ -1025,15 +1171,12 @@ fn property_set_member_type<'db>(
 /// Derive the observable instance capabilities of a descriptor-decorated protocol member.
 fn descriptor_decorated_protocol_member<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     descriptor_ty: Type<'db>,
     protocol: ClassType<'db>,
     definition: Option<Definition<'db>>,
 ) -> Option<ProtocolMemberData<'db>> {
-    // Applying a generic descriptor decorator to a method that refers to an enclosing type
-    // variable can currently materialize that variable as `Unknown`. Reducing the descriptor to
-    // its `__get__` result would then erase the remaining descriptor structure and weaken the
-    // protocol member to a bare `Unknown`.
-    if super::visitor::any_over_type(db, descriptor_ty, false, |ty| ty.is_unknown()) {
+    if super::visitor::any_over_type(db, program, descriptor_ty, false, |ty| ty.is_unknown()) {
         return None;
     }
 
@@ -1041,15 +1184,24 @@ fn descriptor_decorated_protocol_member<'db>(
         definedness: Definedness::AlwaysDefined,
         ..
     }) = descriptor_ty
-        .class_member_with_policy(db, "__get__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .class_member_with_policy(
+            db,
+            program,
+            "__get__".into(),
+            MemberLookupPolicy::REQUIRE_CONCRETE,
+        )
         .place
     else {
         return None;
     };
 
     let receiver_ty = Type::instance(db, protocol);
-    let (read_ty, _) =
-        descriptor_ty.try_call_dunder_get(db, Some(receiver_ty), receiver_ty.to_meta_type(db))?;
+    let (read_ty, _) = descriptor_ty.try_call_dunder_get(
+        db,
+        program,
+        Some(receiver_ty),
+        receiver_ty.to_meta_type(db, program),
+    )?;
     let read = Some(ProtocolMemberType::with_definition(read_ty, definition));
 
     let write = if let Place::Defined(DefinedPlace {
@@ -1057,11 +1209,16 @@ fn descriptor_decorated_protocol_member<'db>(
         definedness: Definedness::AlwaysDefined,
         ..
     }) = descriptor_ty
-        .class_member_with_policy(db, "__set__".into(), MemberLookupPolicy::REQUIRE_CONCRETE)
+        .class_member_with_policy(
+            db,
+            program,
+            "__set__".into(),
+            MemberLookupPolicy::REQUIRE_CONCRETE,
+        )
         .place
     {
         Some(ProtocolMemberType::with_definition(
-            descriptor_setter_write_type(db, setter_ty, descriptor_ty, receiver_ty)
+            descriptor_setter_write_type(db, program, setter_ty, descriptor_ty, receiver_ty)
                 .unwrap_or_else(Type::unknown),
             definition,
         ))
@@ -1075,18 +1232,19 @@ fn descriptor_decorated_protocol_member<'db>(
 /// Derive a write type from a single ordinary setter signature.
 fn descriptor_setter_write_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     setter_ty: Type<'db>,
     descriptor_ty: Type<'db>,
     receiver_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    let callable = setter_ty.try_upcast_to_callable(db)?.exactly_one()?;
+    let callable = setter_ty
+        .try_upcast_to_callable(db, program)?
+        .exactly_one()?;
     let signatures = callable.signatures(db);
     let [signature] = signatures.overloads.as_ref() else {
         return None;
     };
 
-    // A method type variable cannot be used as the write type directly: it is inferred separately
-    // for each call. Deriving its accepted values requires generic call analysis.
     if signature.generic_context.is_some_and(|generic_context| {
         generic_context.variables(db).any(|typevar| {
             !typevar.typevar(db).is_self(db)
@@ -1106,13 +1264,13 @@ fn descriptor_setter_write_type<'db>(
     let descriptor_parameter = parameters
         .get_positional(0)?
         .annotated_type()
-        .bind_self_typevars(db, descriptor_ty);
+        .bind_self_typevars(db, program, descriptor_ty);
     let receiver_parameter = parameters
         .get_positional(1)?
         .annotated_type()
-        .bind_self_typevars(db, descriptor_ty);
-    if !descriptor_ty.is_assignable_to(db, descriptor_parameter)
-        || !receiver_ty.is_assignable_to(db, receiver_parameter)
+        .bind_self_typevars(db, program, descriptor_ty);
+    if !descriptor_ty.is_assignable_to(db, program, descriptor_parameter)
+        || !receiver_ty.is_assignable_to(db, program, receiver_parameter)
     {
         return None;
     }
@@ -1121,20 +1279,22 @@ fn descriptor_setter_write_type<'db>(
         parameters
             .get_positional(2)?
             .annotated_type()
-            .bind_self_typevars(db, descriptor_ty),
+            .bind_self_typevars(db, program, descriptor_ty),
     )
 }
 
 fn property_set_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     property: PropertyInstanceType<'db>,
     receiver_ty: Type<'db>,
 ) -> Option<Type<'db>> {
-    property_set_member_type(db, property.setter(db)?)?.bind_self(db, receiver_ty)
+    property_set_member_type(db, program, property.setter(db)?)?.bind_self(db, program, receiver_ty)
 }
 
 fn protocol_member_read_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     receiver_ty: Type<'db>,
     member: &ProtocolMember<'_, 'db>,
@@ -1150,17 +1310,16 @@ fn protocol_member_read_type<'db>(
     let place = if access == ProtocolMemberAccessMode::Instance && member.is_method() {
         ty.invoke_descriptor_protocol(
             db,
+            program,
             ty,
             member.name,
             Place::Undefined.into(),
             InstanceFallbackShadowsNonDataDescriptor::No,
-            // The undefined fallback excludes instance members. Keep the class
-            // member lookup from reintroducing dynamic instance fallbacks.
             MemberLookupPolicy::NO_INSTANCE_FALLBACK,
         )
         .place
     } else {
-        receiver_ty.member(db, member.name).place
+        receiver_ty.member(db, program, member.name).place
     };
 
     match place {
@@ -1186,7 +1345,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         member_name: &str,
         value_ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let requirement = attribute_write_requirement(db, ty, member_name);
+        let requirement = attribute_write_requirement(db, self.program, ty, member_name);
         self.check_property_write_requirement(db, &requirement, member_name, value_ty)
     }
 
@@ -1201,15 +1360,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             AttributeWriteRequirement::All { element_tys, .. } => {
                 let mut result = self.always();
                 for element_ty in *element_tys {
-                    let requirement = attribute_write_requirement(db, *element_ty, member_name);
+                    let requirement =
+                        attribute_write_requirement(db, self.program, *element_ty, member_name);
                     let element_result = self.check_property_write_requirement(
                         db,
                         &requirement,
                         member_name,
                         value_ty,
                     );
-                    result = result.and(db, self.constraints, || element_result);
-                    if result.is_never_satisfied(db) {
+                    result = result.and(db, self.program, self.constraints, || element_result);
+                    if result.is_never_satisfied(db, self.program) {
                         break;
                     }
                 }
@@ -1218,15 +1378,16 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             AttributeWriteRequirement::Any { intersection, .. } => {
                 let mut result = self.never();
                 for element_ty in intersection.positive(db) {
-                    let requirement = attribute_write_requirement(db, *element_ty, member_name);
+                    let requirement =
+                        attribute_write_requirement(db, self.program, *element_ty, member_name);
                     let element_result = self.check_property_write_requirement(
                         db,
                         &requirement,
                         member_name,
                         value_ty,
                     );
-                    result = result.or(db, self.constraints, || element_result);
-                    if result.is_always_satisfied(db) {
+                    result = result.or(db, self.program, self.constraints, || element_result);
+                    if result.is_always_satisfied(db, self.program) {
                         break;
                     }
                 }
@@ -1260,14 +1421,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
     ) -> ConstraintSet<'db, 'c> {
         let setattr_result = object_ty.try_call_dunder_with_policy(
             db,
+            self.program,
             "__setattr__",
             &mut CallArguments::positional([Type::string_literal(db, member_name), value_ty]),
             TypeContext::default(),
             MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK,
         );
         if match &setattr_result {
-            Ok(bindings) => bindings.return_type(db).is_never(),
-            Err(error) => error.return_type(db).is_some_and(|ty| ty.is_never()),
+            Ok(bindings) => bindings.return_type(db, self.program).is_never(),
+            Err(error) => error
+                .return_type(db, self.program)
+                .is_some_and(|ty| ty.is_never()),
         } {
             return self.never();
         }
@@ -1280,7 +1444,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 if let Some(fallback) = fallback {
                     let fallback_result =
                         self.check_fallback_property_write(db, fallback, value_ty);
-                    member_result.and(db, self.constraints, || fallback_result)
+                    member_result.and(db, self.program, self.constraints, || fallback_result)
                 } else {
                     member_result
                 }
@@ -1311,13 +1475,13 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             ClassAttributeWriteMember::Explicit { member, fallback } => {
                 let member_result =
                     self.check_explicit_property_write(db, object_ty, member, value_ty);
-                if member_result.is_never_satisfied(db) {
+                if member_result.is_never_satisfied(db, self.program) {
                     return member_result;
                 }
                 if let Some(fallback) = fallback {
                     let fallback_result =
                         self.check_fallback_property_write(db, fallback, value_ty);
-                    member_result.and(db, self.constraints, || fallback_result)
+                    member_result.and(db, self.program, self.constraints, || fallback_result)
                 } else {
                     member_result
                 }
@@ -1346,7 +1510,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 ..
             } => {
                 if let Some(property) = descriptor_ty.as_property_instance()
-                    && let Some(set_type) = property_set_type(db, property, object_ty)
+                    && let Some(set_type) = property_set_type(db, self.program, property, object_ty)
                 {
                     return self.check_type_pair(db, value_ty, set_type);
                 }
@@ -1375,6 +1539,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         if setter_ty
             .try_call(
                 db,
+                self.program,
                 &CallArguments::positional([descriptor_ty, object_ty, Type::unknown()]),
             )
             .is_err()
@@ -1394,6 +1559,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let Place::Defined(DefinedPlace { ty: setattr_ty, .. }) = object_ty
             .member_lookup_with_policy(
                 db,
+                self.program,
                 "__setattr__".into(),
                 MemberLookupPolicy::MRO_NO_OBJECT_FALLBACK
                     | MemberLookupPolicy::NO_INSTANCE_FALLBACK,
@@ -1415,10 +1581,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         value_ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
         if let Type::Union(union) = value_ty {
-            return union
-                .elements(db)
-                .iter()
-                .when_all(db, self.constraints, |value_ty| {
+            return union.elements(db).iter().when_all(
+                db,
+                self.program,
+                self.constraints,
+                |value_ty| {
                     self.check_callable_write_parameter(
                         db,
                         callable_ty,
@@ -1426,34 +1593,42 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         self_ty,
                         *value_ty,
                     )
-                });
+                },
+            );
         }
 
         callable_ty
-            .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
+            .try_upcast_to_callable_with_policy(db, self.program, UpcastPolicy::from(self.relation))
             .when_some_and(db, self.constraints, |callables| {
-                callables.iter().when_all(db, self.constraints, |callable| {
-                    callable.signatures(db).into_iter().when_any(
-                        db,
-                        self.constraints,
-                        |signature| {
-                            let parameters = signature.parameters();
-                            parameters
-                                .get_positional(parameter_index)
-                                .or_else(|| {
-                                    parameters.variadic().and_then(|(index, parameter)| {
-                                        (index <= parameter_index).then_some(parameter)
+                callables
+                    .iter()
+                    .when_all(db, self.program, self.constraints, |callable| {
+                        callable.signatures(db).into_iter().when_any(
+                            db,
+                            self.program,
+                            self.constraints,
+                            |signature| {
+                                let parameters = signature.parameters();
+                                parameters
+                                    .get_positional(parameter_index)
+                                    .or_else(|| {
+                                        parameters.variadic().and_then(|(index, parameter)| {
+                                            (index <= parameter_index).then_some(parameter)
+                                        })
                                     })
-                                })
-                                .map(|parameter| {
-                                    parameter.annotated_type().bind_self_typevars(db, self_ty)
-                                })
-                                .when_some_and(db, self.constraints, |write_ty| {
-                                    self.check_type_pair(db, value_ty, write_ty)
-                                })
-                        },
-                    )
-                })
+                                    .map(|parameter| {
+                                        parameter.annotated_type().bind_self_typevars(
+                                            db,
+                                            self.program,
+                                            self_ty,
+                                        )
+                                    })
+                                    .when_some_and(db, self.constraints, |write_ty| {
+                                        self.check_type_pair(db, value_ty, write_ty)
+                                    })
+                            },
+                        )
+                    })
             })
     }
 
@@ -1484,8 +1659,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         required_ty: ProtocolMemberType<'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        let fallback_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
-        let Some(attribute_type) = protocol_member_read_type(db, ty, receiver_ty, member, access)
+        let fallback_ty = ty.literal_fallback_instance(db, self.program).unwrap_or(ty);
+        let Some(attribute_type) =
+            protocol_member_read_type(db, self.program, ty, receiver_ty, member, access)
         else {
             return self.never();
         };
@@ -1500,51 +1676,66 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         }
 
         if member.is_method() && access == ProtocolMemberAccessMode::Instance {
-            let Some(required_ty) = required_ty.resolve(db) else {
+            let Some(required_ty) = required_ty.resolve(db, self.program) else {
                 return self.never();
             };
             let Type::Callable(required_callable) = required_ty.ty() else {
                 return self.never();
             };
             attribute_type
-                .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
+                .try_upcast_to_callable_with_policy(
+                    db,
+                    self.program,
+                    UpcastPolicy::from(self.relation),
+                )
                 .when_some_and(db, self.constraints, |callables| {
                     self.check_callables_vs_callable(
                         db,
-                        &callables.map(|callable| callable.apply_self(db, fallback_ty)),
-                        required_callable.apply_self(db, fallback_ty),
+                        &callables
+                            .map(|callable| callable.apply_self(db, self.program, fallback_ty)),
+                        required_callable.apply_self(db, self.program, fallback_ty),
                     )
                 })
         } else if member.is_method() {
-            let Some(required_ty) = required_ty.resolve(db) else {
+            let Some(required_ty) = required_ty.resolve(db, self.program) else {
                 return self.never();
             };
             let Type::Callable(required_callable) = required_ty.ty() else {
                 return self.never();
             };
             attribute_type
-                .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
+                .try_upcast_to_callable_with_policy(
+                    db,
+                    self.program,
+                    UpcastPolicy::from(self.relation),
+                )
                 .when_some_and(db, self.constraints, |callables| {
-                    callables.iter().when_all(db, self.constraints, |callable| {
-                        if callable.is_function_like(db) {
-                            self.check_callable_pair(
-                                db,
-                                callable.bind_self(db, Some(fallback_ty)),
-                                protocol_bind_self(db, required_callable, Some(fallback_ty)),
-                            )
-                        } else {
-                            self.check_callable_pair(db, *callable, required_callable)
-                        }
-                    })
+                    callables
+                        .iter()
+                        .when_all(db, self.program, self.constraints, |callable| {
+                            if callable.is_function_like(db) {
+                                self.check_callable_pair(
+                                    db,
+                                    callable.bind_self(db, self.program, Some(fallback_ty)),
+                                    protocol_bind_self(
+                                        db,
+                                        self.program,
+                                        required_callable,
+                                        Some(fallback_ty),
+                                    ),
+                                )
+                            } else {
+                                self.check_callable_pair(db, *callable, required_callable)
+                            }
+                        })
                 })
         } else {
-            required_ty.bind_self(db, fallback_ty).when_some_and(
-                db,
-                self.constraints,
-                |required_ty| {
+            required_ty
+                .bind_self(db, self.program, fallback_ty)
+                .when_some_and(db, self.constraints, |required_ty| {
                     let result = self.check_type_pair(db, attribute_type, required_ty);
                     if let Some(context) = self.report_context()
-                        && result.is_never_satisfied(db)
+                        && result.is_never_satisfied(db, self.program)
                     {
                         context.push(ErrorContext::ProtocolMemberReadTypeIncompatible {
                             source: attribute_type,
@@ -1552,8 +1743,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         });
                     }
                     result
-                },
-            )
+                })
         }
     }
 
@@ -1580,6 +1770,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 member.name == "__call__"
                     || protocol_member_read_type(
                         db,
+                        self.program,
                         ty,
                         receiver_ty,
                         member,
@@ -1596,11 +1787,11 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             },
         );
 
-        read_result.and(db, self.constraints, || {
+        read_result.and(db, self.program, self.constraints, || {
             required.write.map_or_else(
                 || self.always(),
                 |write_ty| {
-                    let fallback_ty = ty.literal_fallback_instance(db).unwrap_or(ty);
+                    let fallback_ty = ty.literal_fallback_instance(db, self.program).unwrap_or(ty);
                     let receiver_ty = if access == ProtocolMemberAccessMode::Instance
                         && matches!(ty, Type::LiteralValue(_))
                     {
@@ -1608,22 +1799,20 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     } else {
                         receiver_ty
                     };
-                    write_ty.bind_self(db, fallback_ty).when_some_and(
-                        db,
-                        self.constraints,
-                        |write_ty| {
+                    write_ty
+                        .bind_self(db, self.program, fallback_ty)
+                        .when_some_and(db, self.constraints, |write_ty| {
                             let result =
                                 self.check_property_write(db, receiver_ty, member.name, write_ty);
                             if let Some(context) = self.report_context()
-                                && result.is_never_satisfied(db)
+                                && result.is_never_satisfied(db, self.program)
                             {
                                 context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible {
                                     target: write_ty,
                                 });
                             }
                             result
-                        },
-                    )
+                        })
                 },
             )
         })
@@ -1636,11 +1825,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         ty: Type<'db>,
         member: &ProtocolMember<'_, 'db>,
     ) -> ConstraintSet<'db, 'c> {
-        let capabilities = member.capabilities(db);
+        let capabilities = member.capabilities(db, self.program);
         if let Some(context) = self.report_context() {
             let instance_read_missing = capabilities.instance.read.is_some()
                 && protocol_member_read_type(
                     db,
+                    self.program,
                     ty,
                     ty,
                     member,
@@ -1651,8 +1841,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 && !(member.is_method() && member.name == "__call__")
                 && protocol_member_read_type(
                     db,
+                    self.program,
                     ty,
-                    ty.to_meta_type(db),
+                    ty.to_meta_type(db, self.program),
                     member,
                     ProtocolMemberAccessMode::Class,
                 )
@@ -1675,18 +1866,18 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 capabilities.instance,
                 ProtocolMemberAccessMode::Instance,
             )
-            .and(db, self.constraints, || {
+            .and(db, self.program, self.constraints, || {
                 self.type_satisfies_protocol_member_access(
                     db,
                     ty,
-                    ty.to_meta_type(db),
+                    ty.to_meta_type(db, self.program),
                     member,
                     capabilities.class,
                     ProtocolMemberAccessMode::Class,
                 )
             });
         if let Some(context) = self.report_context()
-            && result.is_never_satisfied(db)
+            && result.is_never_satisfied(db, self.program)
         {
             context.push(ErrorContext::ProtocolMemberIncompatible {
                 member_name: member.name.into(),
@@ -1707,8 +1898,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         target_member: &ProtocolMember<'_, 'db>,
         access: ProtocolMemberAccessMode,
     ) -> ConstraintSet<'db, 'c> {
-        let source_capabilities = source_member.capabilities(db);
-        let target_capabilities = target_member.capabilities(db);
+        let source_capabilities = source_member.capabilities(db, self.program);
+        let target_capabilities = target_member.capabilities(db, self.program);
         let (source, target) = match access {
             ProtocolMemberAccessMode::Instance => {
                 (source_capabilities.instance, target_capabilities.instance)
@@ -1732,13 +1923,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             (Some(source), Some(target)) => {
                 let bind_read = |member_type: ProtocolMemberType<'db>,
                                  member: &ProtocolMember<'_, 'db>| {
-                    let member_type = member_type.resolve(db)?;
+                    let member_type = member_type.resolve(db, self.program)?;
                     if member.is_method()
                         && let Type::Callable(callable) = member_type.ty()
                     {
-                        Some(Type::Callable(callable.apply_self(db, source_type)))
+                        Some(Type::Callable(callable.apply_self(
+                            db,
+                            self.program,
+                            source_type,
+                        )))
                     } else {
-                        member_type.bind_self(db, source_type)
+                        member_type.bind_self(db, self.program, source_type)
                     }
                 };
                 let (Some(source), Some(target)) = (
@@ -1750,7 +1945,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 let result = self.check_type_pair(db, source, target);
                 if let Some(context) = self.report_context()
                     && !target_member.is_method()
-                    && result.is_never_satisfied(db)
+                    && result.is_never_satisfied(db, self.program)
                 {
                     context
                         .push(ErrorContext::ProtocolMemberReadTypeIncompatible { source, target });
@@ -1759,7 +1954,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
         };
 
-        read_result.and(db, self.constraints, || {
+        read_result.and(db, self.program, self.constraints, || {
             match (source.write, target.write) {
                 (_, None) => self.always(),
                 (None, Some(_)) => {
@@ -1770,14 +1965,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
                 (Some(source), Some(target)) => {
                     let (Some(target), Some(source)) = (
-                        target.bind_self(db, source_type),
-                        source.bind_self(db, source_type),
+                        target.bind_self(db, self.program, source_type),
+                        source.bind_self(db, self.program, source_type),
                     ) else {
                         return self.never();
                     };
                     let result = self.check_type_pair(db, target, source);
                     if let Some(context) = self.report_context()
-                        && result.is_never_satisfied(db)
+                        && result.is_never_satisfied(db, self.program)
                     {
                         context.push(ErrorContext::ProtocolMemberWriteTypeIncompatible { target });
                     }
@@ -1794,6 +1989,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: ProtocolInterface<'db>,
         target: ProtocolInterface<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         if source.member_count(db) < target.member_count(db)
             && !self.is_context_collection_enabled()
         {
@@ -1802,7 +1998,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         target
             .members(db)
-            .when_all(db, self.constraints, |target_member| {
+            .when_all(db, self.program, self.constraints, |target_member| {
                 let source_member = source.member_by_name(db, target_member.name);
 
                 if let Some(context) = self.report_context()
@@ -1823,7 +2019,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         &target_member,
                         ProtocolMemberAccessMode::Instance,
                     )
-                    .and(db, self.constraints, || {
+                    .and(db, self.program, self.constraints, || {
                         self.check_protocol_member_access_pair(
                             db,
                             source_type,
@@ -1834,7 +2030,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     })
                 });
                 if let Some(context) = self.report_context()
-                    && result.is_never_satisfied(db)
+                    && result.is_never_satisfied(db, program)
                 {
                     context.push(ErrorContext::ProtocolMemberIncompatible {
                         member_name: target_member.name.into(),
@@ -1856,7 +2052,12 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         member: &ProtocolMember<'_, 'db>,
         ty: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        if member.capabilities(db).instance.write.is_none() {
+        if member
+            .capabilities(db, self.program)
+            .instance
+            .write
+            .is_none()
+        {
             return self.never();
         }
 
@@ -1864,7 +2065,9 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             ty: Type::PropertyInstance(actual_property),
             definedness: Definedness::AlwaysDefined,
             ..
-        }) = ty.class_member(db, member.name().into()).place
+        }) = ty
+            .class_member(db, self.program, member.name().into())
+            .place
         else {
             return self.never();
         };
@@ -1887,40 +2090,42 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         if member.is_property() && matches!(ty, Type::PropertyInstance(_)) {
             return self.never();
         }
-        let capabilities = member.capabilities(db);
+        let capabilities = member.capabilities(db, self.program);
         if !member.is_method() {
             capabilities
                 .instance
                 .read
                 .when_some_and(db, self.constraints, |read_ty| {
-                    read_ty
-                        .resolve(db)
-                        .when_some_and(db, self.constraints, |read_ty| {
-                            self.check_type_pair(db, ty, read_ty.ty())
-                        })
+                    read_ty.resolve(db, self.program).when_some_and(
+                        db,
+                        self.constraints,
+                        |read_ty| self.check_type_pair(db, ty, read_ty.ty()),
+                    )
                 })
         } else {
             let Some(Type::Callable(method)) = capabilities
                 .instance
                 .read
-                .and_then(|read| read.resolve(db))
+                .and_then(|read| read.resolve(db, self.program))
                 .map(ProtocolMemberType::ty)
             else {
                 return self.never();
             };
-            let Some(method_return_type) = non_never_callable_return_type(db, method) else {
+            let Some(method_return_type) = non_never_callable_return_type(db, self.program, method)
+            else {
                 return self.never();
             };
 
-            ty.try_upcast_to_callable_with_policy(db, UpcastPolicy::Sound)
+            ty.try_upcast_to_callable_with_policy(db, self.program, UpcastPolicy::Sound)
                 .when_some_and(db, self.constraints, |callables| {
-                    callables.iter().when_all(db, self.constraints, |callable| {
-                        non_never_callable_return_type(db, *callable).when_some_and(
-                            db,
-                            self.constraints,
-                            |return_type| self.check_type_pair(db, method_return_type, return_type),
-                        )
-                    })
+                    callables
+                        .iter()
+                        .when_all(db, self.program, self.constraints, |callable| {
+                            non_never_callable_return_type(db, self.program, *callable)
+                                .when_some_and(db, self.constraints, |return_type| {
+                                    self.check_type_pair(db, method_return_type, return_type)
+                                })
+                        })
                 })
         }
     }
@@ -1988,6 +2193,7 @@ fn cached_protocol_interface<'db>(
     db: &'db dyn Db,
     class: ClassType<'db>,
 ) -> ProtocolInterface<'db> {
+    let program = class.class_literal(db).program(db);
     let mut members = BTreeMap::default();
 
     for (parent_scope, specialization) in class
@@ -2013,7 +2219,7 @@ fn cached_protocol_interface<'db>(
         // type narrowing that uses `isinstance()` or `issubclass()` with
         // runtime-checkable protocols.
         for (symbol_id, bindings) in use_def_map.all_end_of_scope_symbol_bindings() {
-            let place_and_definition = place_from_bindings(db, bindings);
+            let place_and_definition = place_from_bindings(db, program, bindings);
             let Some(ty) = place_and_definition.place.ignore_possibly_undefined() else {
                 continue;
             };
@@ -2029,7 +2235,7 @@ fn cached_protocol_interface<'db>(
         }
 
         for (symbol_id, declarations) in use_def_map.all_end_of_scope_symbol_declarations() {
-            let place_result = place_from_declarations(db, declarations);
+            let place_result = place_from_declarations(db, program, declarations);
             let first_declaration = place_result.first_declaration;
             let place = place_result.ignore_conflicting_declarations();
             if let Some(new_type) = place.place.ignore_possibly_undefined() {
@@ -2091,7 +2297,7 @@ fn cached_protocol_interface<'db>(
                         .is_some_and(|definition| definition.kind(db).is_function_def()) =>
                 {
                     if let Some(descriptor) =
-                        descriptor_decorated_protocol_member(db, ty, class, definition)
+                        descriptor_decorated_protocol_member(db, program, ty, class, definition)
                     {
                         descriptor
                     } else {
@@ -2114,9 +2320,10 @@ fn proto_interface_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous: &ProtocolInterface<'db>,
     value: ProtocolInterface<'db>,
-    _class: ClassType<'db>,
+    class: ClassType<'db>,
 ) -> ProtocolInterface<'db> {
-    value.cycle_normalized(db, *previous, cycle)
+    let program = class.class_literal(db).program(db);
+    value.cycle_normalized(db, program, *previous, cycle)
 }
 
 /// Bind `self` unless this is a `Callable[P, R]` dunder, and *also* discard the functionlike-ness
@@ -2127,10 +2334,11 @@ fn proto_interface_cycle_recover<'db>(
 /// of the `__call__` method will be function-like but a `Callable` type is not.
 fn protocol_bind_self<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     callable: CallableType<'db>,
     self_type: Option<Type<'db>>,
 ) -> CallableType<'db> {
-    callable.bind_self(db, self_type).into_regular(db)
+    callable.bind_self(db, program, self_type).into_regular(db)
 }
 
 /// Return the possible output type of a callable unless any overload returns `Never`.
@@ -2139,13 +2347,18 @@ fn protocol_bind_self<'db>(
 /// `Never` could satisfy otherwise-incompatible signatures, so it must not establish disjointness.
 fn non_never_callable_return_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     callable: CallableType<'db>,
 ) -> Option<Type<'db>> {
     callable
         .signatures(db)
         .iter()
         .all(|signature| !signature.return_ty.resolve_type_alias(db).is_never())
-        .then(|| callable.signatures(db).overload_return_type_or_unknown(db))
+        .then(|| {
+            callable
+                .signatures(db)
+                .overload_return_type_or_unknown(db, program)
+        })
 }
 
 /// Protocol compatibility can only succeed if every required member is present.
@@ -2154,6 +2367,7 @@ fn non_never_callable_return_type<'db>(
 /// comparisons and generic protocol solving when the actual type is plainly missing a member.
 pub(super) fn has_all_protocol_members_defined<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
     protocol: ProtocolInstanceType<'db>,
 ) -> bool {
@@ -2170,7 +2384,7 @@ pub(super) fn has_all_protocol_members_defined<'db>(
         }
         _ => target_interface.members(db).all(|member| {
             matches!(
-                ty.member(db, member.name()).place,
+                ty.member(db, program, member.name()).place,
                 Place::Defined(DefinedPlace {
                     definedness: Definedness::AlwaysDefined,
                     ..

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -22,7 +22,7 @@ use crate::types::{
     SubclassOfType, TypeVarBoundOrConstraints, UnionType, UpcastPolicy,
 };
 use crate::{
-    Db,
+    Db, Program,
     types::{
         ErrorContext, ErrorContextTree, Type, constraints::ConstraintSet,
         generics::InferableTypeVars,
@@ -308,20 +308,33 @@ impl<'db> Type<'db> {
     /// Return true if this type is a subtype of type `target`.
     ///
     /// See [`TypeRelation::Subtyping`] for more details.
-    pub(crate) fn is_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+    pub(crate) fn is_subtype_of(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        target: Type<'db>,
+    ) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        self.when_subtype_of(db, target, &constraints, InferableTypeVars::None)
-            .is_always_satisfied(db)
+        self.when_subtype_of(db, program, target, &constraints, InferableTypeVars::None)
+            .is_always_satisfied(db, program)
     }
 
     pub(super) fn when_subtype_of<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
-        self.has_relation_to(db, target, constraints, inferable, TypeRelation::Subtyping)
+        self.has_relation_to(
+            db,
+            program,
+            target,
+            constraints,
+            inferable,
+            TypeRelation::Subtyping,
+        )
     }
 
     /// Return the constraints under which this type is a subtype of type `target`, assuming that
@@ -331,6 +344,7 @@ impl<'db> Type<'db> {
     pub(super) fn when_subtype_of_assuming<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         assuming: ConstraintSet<'db, 'c>,
         constraints: &'c ConstraintSetBuilder<'db>,
@@ -341,6 +355,7 @@ impl<'db> Type<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
+            program,
             constraints,
             inferable,
             relation: TypeRelation::SubtypingAssuming,
@@ -358,10 +373,10 @@ impl<'db> Type<'db> {
     /// Return true if this type is assignable to type `target`.
     ///
     /// See `TypeRelation::Assignability` for more details.
-    pub fn is_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+    pub fn is_assignable_to(self, db: &'db dyn Db, program: Program, target: Type<'db>) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        self.when_assignable_to(db, target, &constraints, InferableTypeVars::None)
-            .is_always_satisfied(db)
+        self.when_assignable_to(db, program, target, &constraints, InferableTypeVars::None)
+            .is_always_satisfied(db, program)
     }
 
     /// Re-run the assignability check with error context collection enabled.
@@ -374,10 +389,12 @@ impl<'db> Type<'db> {
     pub(crate) fn assignability_error_context(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
     ) -> ErrorContextTree<'db> {
         let builder = ConstraintSetBuilder::new();
         let checker = TypeRelationChecker {
+            program,
             constraints: &builder,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
@@ -394,28 +411,40 @@ impl<'db> Type<'db> {
     }
 
     /// Return true if this type is assignable to type `target` using constraint-set typevar rules.
-    pub fn is_constraint_set_assignable_to(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+    pub fn is_constraint_set_assignable_to(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        target: Type<'db>,
+    ) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        self.when_constraint_set_assignable_to(db, target, &constraints)
-            .is_always_satisfied(db)
+        self.when_constraint_set_assignable_to(db, program, target, &constraints)
+            .is_always_satisfied(db, program)
     }
 
     /// Return true if this type is a subtype of `target` using constraint-set typevar rules.
-    pub(super) fn is_constraint_set_subtype_of(self, db: &'db dyn Db, target: Type<'db>) -> bool {
+    pub(super) fn is_constraint_set_subtype_of(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        target: Type<'db>,
+    ) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        self.when_constraint_set_subtype_of(db, target, &constraints)
-            .is_always_satisfied(db)
+        self.when_constraint_set_subtype_of(db, program, target, &constraints)
+            .is_always_satisfied(db, program)
     }
 
     pub(super) fn when_assignable_to<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
     ) -> ConstraintSet<'db, 'c> {
         self.has_relation_to(
             db,
+            program,
             target,
             constraints,
             inferable,
@@ -456,22 +485,25 @@ impl<'db> Type<'db> {
     pub(super) fn when_constraint_set_assignable_to_owned(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
     ) -> Cow<'db, OwnedConstraintSet<'db>> {
         #[salsa::tracked(
             returns(ref),
-            cycle_initial=|_, _, _, _| OwnedConstraintSet::default(),
+            cycle_initial=|_, _, _, _, _| OwnedConstraintSet::default(),
             heap_size=ruff_memory_usage::heap_size,
         )]
         fn when_constraint_set_assignable_to_owned_impl<'db>(
             db: &'db dyn Db,
             source: Type<'db>,
+            program: Program,
             target: Type<'db>,
         ) -> OwnedConstraintSet<'db> {
             let constraints = ConstraintSetBuilder::new();
             constraints.into_owned(|constraints| {
                 source.has_relation_to_with_typevar_evaluation(
                     db,
+                    program,
                     target,
                     constraints,
                     InferableTypeVars::None,
@@ -486,18 +518,20 @@ impl<'db> Type<'db> {
         }
 
         Cow::Borrowed(when_constraint_set_assignable_to_owned_impl(
-            db, self, target,
+            db, self, program, target,
         ))
     }
 
     pub(super) fn when_constraint_set_assignable_to<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
         self.has_relation_to_with_typevar_evaluation(
             db,
+            program,
             target,
             constraints,
             InferableTypeVars::None,
@@ -509,11 +543,13 @@ impl<'db> Type<'db> {
     pub(super) fn when_constraint_set_subtype_of<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
         self.has_relation_to_with_typevar_evaluation(
             db,
+            program,
             target,
             constraints,
             InferableTypeVars::None,
@@ -525,34 +561,42 @@ impl<'db> Type<'db> {
     /// Return `true` if it would be redundant to add `self` to a union that already contains `other`.
     ///
     /// See [`TypeRelation::Redundancy`] for more details.
-    pub(super) fn is_redundant_with(self, db: &'db dyn Db, other: Type<'db>) -> bool {
-        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _| true, heap_size=ruff_memory_usage::heap_size)]
+    pub(super) fn is_redundant_with(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        other: Type<'db>,
+    ) -> bool {
+        #[salsa::tracked(returns(copy), cycle_initial=|_, _, _, _, _| true, heap_size=ruff_memory_usage::heap_size)]
         fn is_redundant_with_impl<'db>(
             db: &'db dyn Db,
             self_ty: Type<'db>,
+            program: Program,
             other: Type<'db>,
         ) -> bool {
             self_ty
                 .has_relation_to(
                     db,
+                    program,
                     other,
                     &ConstraintSetBuilder::new(),
                     InferableTypeVars::None,
                     TypeRelation::Redundancy { pure: false },
                 )
-                .is_always_satisfied(db)
+                .is_always_satisfied(db, program)
         }
 
         if self == other {
             return true;
         }
 
-        is_redundant_with_impl(db, self, other)
+        is_redundant_with_impl(db, self, program, other)
     }
 
     pub(super) fn has_relation_to<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
@@ -560,6 +604,7 @@ impl<'db> Type<'db> {
     ) -> ConstraintSet<'db, 'c> {
         self.has_relation_to_with_typevar_evaluation(
             db,
+            program,
             target,
             constraints,
             inferable,
@@ -568,9 +613,11 @@ impl<'db> Type<'db> {
         )
     }
 
+    #[expect(clippy::too_many_arguments)]
     fn has_relation_to_with_typevar_evaluation<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         target: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
@@ -582,6 +629,7 @@ impl<'db> Type<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker {
+            program,
             constraints,
             inferable,
             relation,
@@ -608,35 +656,44 @@ impl<'db> Type<'db> {
     /// > &mdash; [Summary of type relations]
     ///
     /// [equivalent to]: https://typing.python.org/en/latest/spec/glossary.html#term-equivalent
-    pub(crate) fn is_equivalent_to(self, db: &'db dyn Db, other: Type<'db>) -> bool {
-        self.when_equivalent_to(db, other, &ConstraintSetBuilder::new())
-            .is_always_satisfied(db)
+    pub(crate) fn is_equivalent_to(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        other: Type<'db>,
+    ) -> bool {
+        self.when_equivalent_to(db, program, other, &ConstraintSetBuilder::new())
+            .is_always_satisfied(db, program)
     }
 
     pub(crate) fn is_equivalent_to_with_materialization_visitor(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: Type<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> bool {
         self.when_equivalent_to_with_materialization_visitor(
             db,
+            program,
             other,
             &ConstraintSetBuilder::new(),
             materialization_visitor,
         )
-        .is_always_satisfied(db)
+        .is_always_satisfied(db, program)
     }
 
     pub(crate) fn when_equivalent_to<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         self.when_equivalent_to_with_materialization_visitor(
             db,
+            program,
             other,
             constraints,
             &materialization_visitor,
@@ -646,6 +703,7 @@ impl<'db> Type<'db> {
     pub(crate) fn when_equivalent_to_with_materialization_visitor<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         materialization_visitor: &ApplyTypeMappingVisitor<'db>,
@@ -654,6 +712,7 @@ impl<'db> Type<'db> {
         let disjointness_visitor = IsDisjointVisitor::default(constraints);
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let checker = EquivalenceChecker {
+            program,
             constraints,
             given: ConstraintSet::from_bool(constraints, false),
             relation_visitor: &relation_visitor,
@@ -679,15 +738,21 @@ impl<'db> Type<'db> {
     ///
     /// This function aims to have no false positives, but might return wrong
     /// `false` answers in some cases.
-    pub(crate) fn is_disjoint_from(self, db: &'db dyn Db, other: Type<'db>) -> bool {
+    pub(crate) fn is_disjoint_from(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+        other: Type<'db>,
+    ) -> bool {
         let constraints = ConstraintSetBuilder::new();
-        self.when_disjoint_from(db, other, &constraints, InferableTypeVars::None)
-            .is_always_satisfied(db)
+        self.when_disjoint_from(db, program, other, &constraints, InferableTypeVars::None)
+            .is_always_satisfied(db, program)
     }
 
     pub(crate) fn when_disjoint_from<'c>(
         self,
         db: &'db dyn Db,
+        program: Program,
         other: Type<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
@@ -697,6 +762,7 @@ impl<'db> Type<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = DisjointnessChecker {
+            program,
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
@@ -737,6 +803,7 @@ impl<'db, 'c> IsDisjointVisitor<'db, 'c> {
 
 #[derive(Clone)]
 pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
+    pub(super) program: Program,
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
     pub(super) relation: TypeRelation,
@@ -758,6 +825,7 @@ pub(super) struct TypeRelationChecker<'a, 'c, 'db> {
 
 impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     pub(super) fn subtyping(
+        program: Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
@@ -766,6 +834,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
+            program,
             constraints,
             inferable,
             relation: TypeRelation::Subtyping,
@@ -780,6 +849,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     }
 
     pub(super) fn constraint_set_assignability(
+        program: Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
@@ -787,6 +857,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
+            program,
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
@@ -801,6 +872,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     }
 
     pub(super) fn constraint_set_assignability_with_context(
+        program: Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
@@ -808,6 +880,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
+            program,
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
@@ -822,6 +895,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     }
 
     pub(super) fn assignability_with_context(
+        program: Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
         disjointness_visitor: &'a IsDisjointVisitor<'db, 'c>,
@@ -829,6 +903,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
+            program,
             constraints,
             inferable: InferableTypeVars::None,
             relation: TypeRelation::Assignability,
@@ -883,10 +958,6 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         self.report_context().is_some()
     }
 
-    /// If error context collection is enabled, returns the current error context tree. You will
-    /// typically use [`push`][ErrorContextTree::push] to add additional information to the error
-    /// context. Returns `None` if error context collection is disabled, allowing you to skip
-    /// expensive checks.
     pub(super) fn report_context(&self) -> Option<&ErrorContextTree<'db>> {
         self.context_tree
             .as_ref()
@@ -949,13 +1020,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// that are unrelated to each other in the regular-class domain (they do not inherit each
     /// other or any other common base), but they are all constrained to have a metaclass that
     /// inherits from `ABCMeta`.
-    fn is_metaclass_instance(db: &'db dyn Db, target: Type<'db>) -> bool {
+    fn is_metaclass_instance(&self, db: &'db dyn Db, target: Type<'db>) -> bool {
+        let program = self.program;
         target.as_nominal_instance().is_some_and(|instance| {
             KnownClass::Type
-                .try_to_class_literal(db)
+                .try_to_class_literal(db, program)
                 .is_some_and(|type_class| {
                     instance
-                        .class(db)
+                        .class(db, program)
                         .is_subclass_of(db, ClassType::NonGeneric(ClassLiteral::Static(type_class)))
                 })
         })
@@ -973,14 +1045,17 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
     /// That can only happen for a final class, so the exact object is the only valid
     /// specialization of the type variable.
     fn can_check_typevar_subclass_relation_to_target(
+        &self,
         db: &'db dyn Db,
         source_subclass: SubclassOfType<'db>,
         target: Type<'db>,
     ) -> bool {
-        let is_exact_upper_bound = source_subclass.exact_typevar_upper_bound(db) == Some(target);
+        let program = self.program;
+        let is_exact_upper_bound =
+            source_subclass.exact_typevar_upper_bound(db, program) == Some(target);
 
         (!matches!(target, Type::ClassLiteral(_) | Type::GenericAlias(_)) || is_exact_upper_bound)
-            && (Self::is_metaclass_instance(db, target) || target.to_instance(db).is_some())
+            && (self.is_metaclass_instance(db, target) || target.to_instance(db, program).is_some())
     }
 
     /// Check the relation between a `type[T]` and a target type `A` when `A` can either be
@@ -1011,14 +1086,18 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source_subclass
             .into_type_var()
             .when_some_and(db, self.constraints, |source_i| {
-                if Self::is_metaclass_instance(db, target) {
-                    self.check_type_pair(db, source_subclass.to_metaclass_instance(db), target)
+                if self.is_metaclass_instance(db, target) {
+                    self.check_type_pair(
+                        db,
+                        source_subclass.to_metaclass_instance(db, self.program),
+                        target,
+                    )
                 } else {
-                    target
-                        .to_instance(db)
-                        .when_some_and(db, self.constraints, |target_i| {
-                            self.check_type_pair(db, Type::TypeVar(source_i), target_i)
-                        })
+                    target.to_instance(db, self.program).when_some_and(
+                        db,
+                        self.constraints,
+                        |target_i| self.check_type_pair(db, Type::TypeVar(source_i), target_i),
+                    )
                 }
             })
     }
@@ -1030,6 +1109,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: Type<'db>,
         target: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         if let Some(source) = source.materialized_divergent_fallback() {
             return self.check_type_pair(db, source, target);
         }
@@ -1054,7 +1134,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         {
             return self
                 .given
-                .implies_subtype_of(db, self.constraints, source, target);
+                .implies_subtype_of(db, program, self.constraints, source, target);
         }
 
         // With lazy evaluation, comparisons with a type variable are translated directly into a
@@ -1067,24 +1147,26 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // satisfies the upper bound/constraints).
             if let Type::TypeVar(bound_typevar) = source {
                 let upper = if self.relation.is_subtyping() {
-                    target.bottom_materialization(db)
+                    target.bottom_materialization(db, self.program)
                 } else {
                     target
                 };
                 return ConstraintSet::constrain_typevar_upper_bound(
                     db,
+                    program,
                     self.constraints,
                     bound_typevar,
                     upper,
                 );
             } else if let Type::TypeVar(bound_typevar) = target {
                 let lower = if self.relation.is_subtyping() {
-                    source.top_materialization(db)
+                    source.top_materialization(db, self.program)
                 } else {
                     source
                 };
                 return ConstraintSet::constrain_typevar_lower_bound(
                     db,
+                    program,
                     self.constraints,
                     bound_typevar,
                     lower,
@@ -1106,7 +1188,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         match (source, target) {
             // Everything is a subtype of `object`.
             (_, Type::NominalInstance(target)) if target.is_object() => self.always(),
-            (_, Type::ProtocolInstance(target)) if target.is_equivalent_to_object(db) => {
+            (_, Type::ProtocolInstance(target))
+                if target.is_equivalent_to_object(db, self.program) =>
+            {
                 self.always()
             }
 
@@ -1148,7 +1232,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // that depend on multiple elements, such as all members of an enum, are visible.
             (_, Type::Union(union)) if union.has_aliases(db) => {
                 self.with_recursion_guard(source, target, || {
-                    self.check_type_pair(db, source, union.expand_aliases(db))
+                    self.check_type_pair(db, source, union.expand_aliases(db, self.program))
                 })
             }
 
@@ -1191,17 +1275,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::KnownInstance(source_instance), Type::TypeForm(target_typeform))
                 if source_instance.is_type_form_value() =>
             {
-                source_instance.type_form_argument(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |source_argument| {
+                source_instance
+                    .type_form_argument(db, self.program)
+                    .when_some_and(db, self.constraints, |source_argument| {
                         self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
-                    },
-                )
+                    })
             }
 
             (Type::SpecialForm(source_form), Type::TypeForm(target_typeform)) => source_form
-                .type_form_argument(db)
+                .type_form_argument(db, self.program)
                 .when_some_and(db, self.constraints, |source_argument| {
                     self.check_type_pair(db, source_argument, target_typeform.type_argument(db))
                 }),
@@ -1253,7 +1335,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     .when_none_or(db, self.constraints, |default_type| {
                         self.check_type_pair(db, default_type, target)
                     })
-                    .and(db, self.constraints, || {
+                    .and(db, program, self.constraints, || {
                         field
                             .converter(db)
                             .map(|(_, output_ty)| output_ty)
@@ -1288,10 +1370,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 Type::KnownInstance(KnownInstanceType::FunctoolsPartial(partial)),
                 Type::NominalInstance(target_instance),
             ) if target_instance
-                .class(db)
+                .class(db, self.program)
                 .is_known(db, KnownClass::FunctoolsPartial) =>
             {
-                let specialized = partial.partial(db).into_functools_partial_instance(db);
+                let specialized = partial
+                    .partial(db)
+                    .into_functools_partial_instance(db, self.program);
                 self.check_type_pair(db, specialized, target)
             }
 
@@ -1377,7 +1461,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // precise representation for "all instances of any classes with a given metaclass").
             (Type::SubclassOf(subclass_of), _)
                 if subclass_of.is_type_var()
-                    && Self::can_check_typevar_subclass_relation_to_target(
+                    && self.can_check_typevar_subclass_relation_to_target(
                         db,
                         subclass_of,
                         target,
@@ -1389,11 +1473,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // And vice versa. (No special metaclass handling is needed in this direction, since
             // "collapse to 'object'" in this case is a sound over-approximation.)
             (_, Type::SubclassOf(subclass_of))
-                if subclass_of.is_type_var() && source.to_instance(db).is_some() =>
+                if subclass_of.is_type_var() && source.to_instance(db, self.program).is_some() =>
             {
                 subclass_of
                     .into_type_var()
-                    .zip(source.to_instance(db))
+                    .zip(source.to_instance(db, self.program))
                     .when_some_and(db, self.constraints, |(target_i, source_i)| {
                         self.check_type_pair(db, source_i, Type::TypeVar(target_i))
                     })
@@ -1438,6 +1522,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(typevar_constraints)) => {
                         typevar_constraints.elements(db).iter().when_all(
                             db,
+                            program,
                             self.constraints,
                             |constraint| self.check_type_pair(db, *constraint, target),
                         )
@@ -1454,11 +1539,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         .typevar(db)
                         .constraints(db)
                         .when_some_and(db, self.constraints, |constraints| {
-                            constraints.iter().when_all(db, self.constraints, |c| {
-                                self.check_type_pair(db, source, *c)
-                            })
+                            constraints
+                                .iter()
+                                .when_all(db, self.program, self.constraints, |c| {
+                                    self.check_type_pair(db, source, *c)
+                                })
                         })
-                        .is_never_satisfied(db) =>
+                        .is_never_satisfied(db, program) =>
             {
                 // TODO: The repetition here isn't great, but we really need the fallthrough logic,
                 // where this arm only engages if it returns true (or in the world of constraints,
@@ -1468,9 +1555,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     db,
                     self.constraints,
                     |constraints| {
-                        constraints.iter().when_all(db, self.constraints, |c| {
-                            self.check_type_pair(db, source, *c)
-                        })
+                        constraints
+                            .iter()
+                            .when_all(db, self.program, self.constraints, |c| {
+                                self.check_type_pair(db, source, *c)
+                            })
                     },
                 )
             }
@@ -1508,13 +1597,13 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             }
 
             (Type::Union(union), _) => {
-                if let Some(supertype) = union.common_literal_supertype(db) {
+                if let Some(supertype) = union.common_literal_supertype(db, self.program) {
                     // Use the broader supertype only as a positive proof. If it has the requested
                     // relation to the target, then every literal in the union does too. Otherwise,
                     // check each literal individually.
                     let supertype_result = self
                         .without_context_collection(|| self.check_type_pair(db, supertype, target));
-                    if supertype_result.is_always_satisfied(db) {
+                    if supertype_result.is_always_satisfied(db, program) {
                         return supertype_result;
                     }
                 }
@@ -1522,10 +1611,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 union
                     .elements(db)
                     .iter()
-                    .when_all(db, self.constraints, |&elem_ty| {
+                    .when_all(db, self.program, self.constraints, |&elem_ty| {
                         let constraint_set = self.check_type_pair(db, elem_ty, target);
                         if let Some(context) = self.report_context()
-                            && constraint_set.is_never_satisfied(db)
+                            && constraint_set.is_never_satisfied(db, program)
                         {
                             context.push(ErrorContext::NotAllUnionElementsAssignable {
                                 element: elem_ty,
@@ -1539,7 +1628,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (_, Type::Union(union)) => {
                 if let Type::Intersection(intersection) = source
-                    && let Some(alternatives) = intersection.finite_alternative_union(db)
+                    && let Some(alternatives) = intersection.finite_alternative_union(db, program)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1556,7 +1645,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         {
                             self.check_type_pair(
                                 db,
-                                intersection.with_expanded_typevars_and_newtypes(db),
+                                intersection.with_expanded_typevars_and_newtypes(db, self.program),
                                 target,
                             )
                         }
@@ -1578,7 +1667,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 let elements = union.elements(db);
                 let result = elements
                     .iter()
-                    .when_any(db, self.constraints, |&elem_ty| {
+                    .when_any(db, self.program, self.constraints, |&elem_ty| {
                         let result = self.check_type_pair(db, source, elem_ty);
                         if let Some(context_tree) = context_tree {
                             let ctx = context_tree.take();
@@ -1588,11 +1677,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         }
                         result
                     })
-                    .or(db, self.constraints, is_new_type_of_union);
+                    .or(db, program, self.constraints, is_new_type_of_union);
 
                 if context_tree.is_some()
                     && !elements_context.is_empty()
-                    && result.is_never_satisfied(db)
+                    && result.is_never_satisfied(db, program)
                 {
                     let elements_without_context = elements.len() - elements_context.len();
                     if elements_without_context > 0 && elements_without_context < elements.len() {
@@ -1621,10 +1710,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (_, Type::Intersection(intersection)) => intersection
                 .positive(db)
                 .iter()
-                .when_all(db, self.constraints, |&pos_ty| {
+                .when_all(db, self.program, self.constraints, |&pos_ty| {
                     let constraint_set = self.check_type_pair(db, source, pos_ty);
                     if let Some(context) = self.report_context()
-                        && constraint_set.is_never_satisfied(db)
+                        && constraint_set.is_never_satisfied(db, program)
                     {
                         context.push(ErrorContext::NotAssignableToIntersectionElement {
                             source,
@@ -1634,7 +1723,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                     }
                     constraint_set
                 })
-                .and(db, self.constraints, || {
+                .and(db, program, self.constraints, || {
                     // For subtyping, we would want to check whether the *top materialization* of `source`
                     // is disjoint from the *top materialization* of `neg_ty`. As an optimization, however,
                     // we can avoid this explicit transformation here, since our `Type::is_disjoint_from`
@@ -1652,26 +1741,32 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         TypeRelation::Subtyping
                         | TypeRelation::Redundancy { .. }
                         | TypeRelation::SubtypingAssuming => source,
-                        TypeRelation::Assignability => source.bottom_materialization(db),
+                        TypeRelation::Assignability => {
+                            source.bottom_materialization(db, self.program)
+                        }
                     };
-                    intersection
-                        .negative(db)
-                        .iter()
-                        .when_all(db, self.constraints, |&neg_ty| {
+                    intersection.negative(db).iter().when_all(
+                        db,
+                        self.program,
+                        self.constraints,
+                        |&neg_ty| {
                             let neg_ty = match self.relation {
                                 TypeRelation::Subtyping
                                 | TypeRelation::Redundancy { .. }
                                 | TypeRelation::SubtypingAssuming => neg_ty,
-                                TypeRelation::Assignability => neg_ty.bottom_materialization(db),
+                                TypeRelation::Assignability => {
+                                    neg_ty.bottom_materialization(db, self.program)
+                                }
                             };
                             self.as_disjointness_checker()
                                 .check_type_pair(db, source_ty, neg_ty)
-                        })
+                        },
+                    )
                 }),
 
             (Type::Intersection(intersection), _) => {
                 if matches!(target, Type::LiteralValue(_))
-                    && let Some(alternatives) = intersection.finite_alternative_union(db)
+                    && let Some(alternatives) = intersection.finite_alternative_union(db, program)
                 {
                     return self.check_type_pair(db, alternatives, target);
                 }
@@ -1686,7 +1781,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
                 let result = intersection
                     .positive_elements_or_object(db)
-                    .when_any(db, self.constraints, |elem_ty| {
+                    .when_any(db, self.program, self.constraints, |elem_ty| {
                         let result = self.check_type_pair(db, elem_ty, target);
                         if let Some(context_tree) = context_tree {
                             let ctx = context_tree.take();
@@ -1696,11 +1791,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                         }
                         result
                     })
-                    .or(db, self.constraints, || {
+                    .or(db, program, self.constraints, || {
                         if should_expand_intersection(intersection) {
                             self.check_type_pair(
                                 db,
-                                intersection.with_expanded_typevars_and_newtypes(db),
+                                intersection.with_expanded_typevars_and_newtypes(db, self.program),
                                 target,
                             )
                         } else {
@@ -1710,7 +1805,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
                 if context_tree.is_some()
                     && !elements_context.is_empty()
-                    && result.is_never_satisfied(db)
+                    && result.is_never_satisfied(db, program)
                 {
                     self.set_context(
                         ErrorContext::NoIntersectionElementAssignableToTarget {
@@ -1767,12 +1862,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // Note that the definition of `Type::AlwaysFalsy` depends on the return value of `__bool__`.
             // If `__bool__` always returns True or False, it can be treated as a subtype of `AlwaysTruthy` or `AlwaysFalsy`, respectively.
-            (_, Type::AlwaysFalsy) => {
-                ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_false())
-            }
-            (_, Type::AlwaysTruthy) => {
-                ConstraintSet::from_bool(self.constraints, source.bool(db).is_always_true())
-            }
+            (_, Type::AlwaysFalsy) => ConstraintSet::from_bool(
+                self.constraints,
+                source.bool(db, self.program).is_always_false(),
+            ),
+            (_, Type::AlwaysTruthy) => ConstraintSet::from_bool(
+                self.constraints,
+                source.bool(db, self.program).is_always_true(),
+            ),
             // Currently, the only supertype of `AlwaysFalsy` and `AlwaysTruthy` is the universal set (object instance).
             (Type::AlwaysFalsy | Type::AlwaysTruthy, _) => {
                 self.with_recursion_guard(source, target, || {
@@ -1863,9 +1960,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (_, Type::Callable(target_callable)) => {
                 self.with_recursion_guard(source, target, || {
-                    let Some(callables) = source
-                        .try_upcast_to_callable_with_policy(db, UpcastPolicy::from(self.relation))
-                    else {
+                    let Some(callables) = source.try_upcast_to_callable_with_policy(
+                        db,
+                        self.program,
+                        UpcastPolicy::from(self.relation),
+                    ) else {
                         return self.never();
                     };
 
@@ -1873,11 +1972,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
                     if let Some(context) = self.report_context()
                         && self.should_provide_callable_upcast_context(source)
-                        && result.is_never_satisfied(db)
+                        && result.is_never_satisfied(db, program)
                     {
                         context.push(ErrorContext::InferredCallableType {
                             source,
-                            callable: callables.into_type(db),
+                            callable: callables.into_type(db, self.program),
                         });
                     }
 
@@ -1895,7 +1994,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 if (source_subclass_ty.is_dynamic() || source_subclass_ty.is_type_var())
                     && !self.is_eager_assignability() =>
             {
-                self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
+                self.check_type_pair(db, KnownClass::Type.to_instance(db, self.program), target)
             }
 
             (_, Type::ProtocolInstance(target_proto)) => {
@@ -1915,24 +2014,33 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             (Type::TypedDict(typed_dict), _) => self.with_recursion_guard(source, target, || {
                 let dict_value_type = if self.relation.is_assignability() {
-                    typed_dict.assignable_dict_value_type(db)
+                    typed_dict.assignable_dict_value_type(db, self.program)
                 } else {
-                    typed_dict.dict_value_type(db)
+                    typed_dict.dict_value_type(db, self.program)
                 };
                 let fallback = if let Some(value_ty) = dict_value_type {
-                    KnownClass::Dict
-                        .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), value_ty])
+                    KnownClass::Dict.to_specialized_instance(
+                        db,
+                        self.program,
+                        &[KnownClass::Str.to_instance(db, self.program), value_ty],
+                    )
                 } else {
                     KnownClass::Mapping.to_specialized_instance(
                         db,
-                        &[KnownClass::Str.to_instance(db), typed_dict.value_type(db)],
+                        self.program,
+                        &[
+                            KnownClass::Str.to_instance(db, self.program),
+                            typed_dict.value_type(db, self.program),
+                        ],
                     )
                 };
                 let result = self.check_type_pair(db, fallback, target);
                 if let Some(context) = self.report_context()
-                    && result.is_never_satisfied(db)
+                    && result.is_never_satisfied(db, program)
                     && let Type::NominalInstance(instance) = target
-                    && instance.class(db).is_known(db, KnownClass::Dict)
+                    && instance
+                        .class(db, self.program)
+                        .is_known(db, KnownClass::Dict)
                 {
                     context.push(ErrorContext::TypedDictNotAssignableToDict(typed_dict));
                 }
@@ -1948,13 +2056,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 if literal.is_string() =>
             {
                 let value = literal.as_string().unwrap();
-                let target_class = instance.class(db);
+                let target_class = instance.class(db, self.program);
 
                 if target_class.is_known(db, KnownClass::Str) {
                     return self.always();
                 }
 
-                if let Some(sequence_class) = KnownClass::Sequence.try_to_class_literal(db)
+                if let Some(sequence_class) =
+                    KnownClass::Sequence.try_to_class_literal(db, self.program)
                     && !sequence_class
                         .iter_mro(db, None)
                         .filter_map(ClassBase::into_class)
@@ -1982,7 +2091,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 };
 
                 KnownClass::Sequence
-                    .to_specialized_class_type(db, &[spec])
+                    .to_specialized_class_type(db, self.program, &[spec])
                     .when_some_and(db, self.constraints, |sequence| {
                         self.check_class_pair(db, sequence, target_class)
                     })
@@ -1996,13 +2105,14 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 if literal.is_bytes() =>
             {
                 let value = literal.as_bytes().unwrap();
-                let target_class = instance.class(db);
+                let target_class = instance.class(db, self.program);
 
                 if target_class.is_known(db, KnownClass::Bytes) {
                     return self.always();
                 }
 
-                if let Some(sequence_class) = KnownClass::Sequence.try_to_class_literal(db)
+                if let Some(sequence_class) =
+                    KnownClass::Sequence.try_to_class_literal(db, self.program)
                     && !sequence_class
                         .iter_mro(db, None)
                         .filter_map(ClassBase::into_class)
@@ -2029,7 +2139,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 };
 
                 KnownClass::Sequence
-                    .to_specialized_class_type(db, &[spec])
+                    .to_specialized_class_type(db, self.program, &[spec])
                     .when_some_and(db, self.constraints, |sequence| {
                         self.check_class_pair(db, sequence, target_class)
                     })
@@ -2055,23 +2165,25 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // most `Literal` types delegate to their instance fallbacks
             // unless `source` is exactly equivalent to `target` (handled above)
             (Type::ModuleLiteral(_) | Type::LiteralValue(_) | Type::FunctionLiteral(_), _) => {
-                source.literal_fallback_instance(db).when_some_and(
-                    db,
-                    self.constraints,
-                    |source_instance| self.check_type_pair(db, source_instance, target),
-                )
+                source
+                    .literal_fallback_instance(db, self.program)
+                    .when_some_and(db, self.constraints, |source_instance| {
+                        self.check_type_pair(db, source_instance, target)
+                    })
             }
 
             // The same reasoning applies for these special callable types:
-            (Type::BoundMethod(_), _) => {
-                self.check_type_pair(db, KnownClass::MethodType.to_instance(db), target)
-            }
+            (Type::BoundMethod(_), _) => self.check_type_pair(
+                db,
+                KnownClass::MethodType.to_instance(db, self.program),
+                target,
+            ),
             (Type::KnownBoundMethod(method), _) => {
-                self.check_type_pair(db, method.class().to_instance(db), target)
+                self.check_type_pair(db, method.class().to_instance(db, self.program), target)
             }
             (Type::WrapperDescriptor(_), _) => self.check_type_pair(
                 db,
-                KnownClass::WrapperDescriptorType.to_instance(db),
+                KnownClass::WrapperDescriptorType.to_instance(db, self.program),
                 target,
             ),
 
@@ -2084,10 +2196,12 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::TypeIs(source), Type::TypeIs(target)) => {
                 let source_type = source.type_argument(db);
                 let target_type = target.type_argument(db);
-                self.check_type_pair(db, source_type, target_type)
-                    .and(db, self.constraints, || {
-                        self.check_type_pair(db, target_type, source_type)
-                    })
+                self.check_type_pair(db, source_type, target_type).and(
+                    db,
+                    program,
+                    self.constraints,
+                    || self.check_type_pair(db, target_type, source_type),
+                )
             }
 
             // `TypeGuard` is covariant.
@@ -2097,13 +2211,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `TypeIs[T]` and `TypeGuard[T]` are subtypes of `bool`.
             (Type::TypeIs(_) | Type::TypeGuard(_), _) => {
-                self.check_type_pair(db, KnownClass::Bool.to_instance(db), target)
+                self.check_type_pair(db, KnownClass::Bool.to_instance(db, self.program), target)
             }
 
             // Function-like callables are subtypes of `FunctionType`
-            (Type::Callable(callable), _) if callable.is_function_like(db) => {
-                self.check_type_pair(db, KnownClass::FunctionType.to_instance(db), target)
-            }
+            (Type::Callable(callable), _) if callable.is_function_like(db) => self.check_type_pair(
+                db,
+                KnownClass::FunctionType.to_instance(db, self.program),
+                target,
+            ),
 
             (Type::Callable(_), _) => self.never(),
 
@@ -2112,7 +2228,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 .check_bound_super_pair(db, source, target),
 
             (Type::BoundSuper(_), _) => {
-                self.check_type_pair(db, KnownClass::Super.to_instance(db), target)
+                self.check_type_pair(db, KnownClass::Super.to_instance(db, self.program), target)
             }
 
             (Type::SubclassOf(subclass_of), _) | (_, Type::SubclassOf(subclass_of))
@@ -2126,7 +2242,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::ClassLiteral(source_cls), Type::SubclassOf(target_subclass_ty)) => {
                 target_subclass_ty
                     .subclass_of()
-                    .into_class(db)
+                    .into_class(db, self.program)
                     .map(|target_cls| {
                         self.check_class_pair(db, source_cls.default_specialization(db), target_cls)
                     })
@@ -2157,7 +2273,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (Type::GenericAlias(source_alias), Type::SubclassOf(target_subclass_ty)) => {
                 target_subclass_ty
                     .subclass_of()
-                    .into_class(db)
+                    .into_class(db, self.program)
                     .map(|target_cls| {
                         self.check_class_pair(db, ClassType::Generic(source_alias), target_cls)
                     })
@@ -2185,11 +2301,15 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
             // `type[Any]` is a subtype of `type[object]`, and is assignable to any `type[...]`
             (Type::SubclassOf(subclass_of_ty), _) if subclass_of_ty.is_dynamic() => {
-                self.check_type_pair(db, KnownClass::Type.to_instance(db), target)
-                    .or(db, self.constraints, || {
+                self.check_type_pair(db, KnownClass::Type.to_instance(db, self.program), target)
+                    .or(db, program, self.constraints, || {
                         ConstraintSet::from_bool(self.constraints, self.is_eager_assignability())
-                            .and(db, self.constraints, || {
-                                self.check_type_pair(db, target, KnownClass::Type.to_instance(db))
+                            .and(db, program, self.constraints, || {
+                                self.check_type_pair(
+                                    db,
+                                    target,
+                                    KnownClass::Type.to_instance(db, self.program),
+                                )
                             })
                     })
             }
@@ -2198,7 +2318,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             (_, Type::SubclassOf(subclass_of_ty))
                 if subclass_of_ty.is_dynamic() && self.is_eager_assignability() =>
             {
-                self.check_type_pair(db, source, KnownClass::Type.to_instance(db))
+                self.check_type_pair(db, source, KnownClass::Type.to_instance(db, self.program))
             }
 
             // `type[str]` (== `SubclassOf("str")` in ty) describes all possible runtime subclasses
@@ -2212,9 +2332,9 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 db,
                 subclass_of_ty
                     .subclass_of()
-                    .into_class(db)
+                    .into_class(db, self.program)
                     .map(|source_class| source_class.metaclass_instance_type(db))
-                    .unwrap_or_else(|| KnownClass::Type.to_instance(db)),
+                    .unwrap_or_else(|| KnownClass::Type.to_instance(db, self.program)),
                 target,
             ),
 
@@ -2224,11 +2344,11 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
             // because `Type::SpecialForm(SpecialFormType::Type)` is a set with exactly one runtime value in it
             // (the symbol `typing.Type`), and that symbol is known to be an instance of `typing._SpecialForm` at runtime.
             (Type::SpecialForm(source_form), _) => {
-                self.check_type_pair(db, source_form.instance_fallback(db), target)
+                self.check_type_pair(db, source_form.instance_fallback(db, self.program), target)
             }
 
             (Type::KnownInstance(source), _) => {
-                self.check_type_pair(db, source.instance_fallback(db), target)
+                self.check_type_pair(db, source.instance_fallback(db, self.program), target)
             }
 
             // `bool` is a subtype of `int`, because `bool` subclasses `int`,
@@ -2244,10 +2364,10 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
                 }),
 
             (Type::PropertyInstance(property), _) => {
-                self.check_type_pair(db, property.instance_fallback(db), target)
+                self.check_type_pair(db, property.instance_fallback(db, self.program), target)
             }
             (_, Type::PropertyInstance(property)) => {
-                self.check_type_pair(db, source, property.instance_fallback(db))
+                self.check_type_pair(db, source, property.instance_fallback(db, self.program))
             }
             // Other than the special cases enumerated above, nominal-instance types are never
             // subtypes of any other variants
@@ -2261,6 +2381,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
         source: PropertyInstanceType<'db>,
         target: PropertyInstanceType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let check_optional_methods = |source, target| match (source, target) {
             (None, None) => self.always(),
             (Some(source), Some(target)) => self.check_type_pair(db, source, target),
@@ -2269,16 +2390,18 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
         self.check_type_pair(
             db,
-            source.instance_fallback(db),
-            target.instance_fallback(db),
+            source.instance_fallback(db, self.program),
+            target.instance_fallback(db, self.program),
         )
-        .and(db, self.constraints, || {
+        .and(db, program, self.constraints, || {
             check_optional_methods(source.getter(db), target.getter(db)).and(
                 db,
+                program,
                 self.constraints,
                 || {
                     check_optional_methods(source.setter(db), target.setter(db)).and(
                         db,
+                        program,
                         self.constraints,
                         || check_optional_methods(source.deleter(db), target.deleter(db)),
                     )
@@ -2289,6 +2412,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     pub(super) fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
         EquivalenceChecker {
+            program: self.program,
             constraints: self.constraints,
             given: self.given,
             relation_visitor: self.relation_visitor,
@@ -2300,6 +2424,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 
     pub(super) fn as_disjointness_checker(&self) -> DisjointnessChecker<'_, 'c, 'db> {
         DisjointnessChecker {
+            program: self.program,
             constraints: self.constraints,
             inferable: self.inferable,
             given: self.given,
@@ -2339,6 +2464,7 @@ impl<'a, 'c, 'db> TypeRelationChecker<'a, 'c, 'db> {
 }
 
 pub(super) struct EquivalenceChecker<'a, 'c, 'db> {
+    pub(super) program: Program,
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     given: ConstraintSet<'db, 'c>,
 
@@ -2360,6 +2486,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> TypeRelationChecker<'a, 'c, 'db> {
         TypeRelationChecker {
+            program: self.program,
             relation: TypeRelation::Redundancy { pure: true },
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
@@ -2387,6 +2514,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
         left: Type<'db>,
         right: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // Recursive materialization fallbacks depend on the comparison root, so each directional
         // pass needs fresh materialization caches. Nested equivalence checks still share the
         // materialization-equivalence recursion guard to avoid re-entering the same comparison.
@@ -2394,7 +2522,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
             self.materialization_visitor.for_new_materialization_root();
         self.as_relation_checker(&left_to_right_materialization_visitor)
             .check_type_pair(db, left, right)
-            .and(db, self.constraints, || {
+            .and(db, program, self.constraints, || {
                 let right_to_left_materialization_visitor =
                     self.materialization_visitor.for_new_materialization_root();
                 self.as_relation_checker(&right_to_left_materialization_visitor)
@@ -2404,6 +2532,7 @@ impl<'c, 'db> EquivalenceChecker<'_, 'c, 'db> {
 }
 
 pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
+    pub(super) program: Program,
     pub(super) constraints: &'c ConstraintSetBuilder<'db>,
     pub(super) inferable: InferableTypeVars<'db>,
     given: ConstraintSet<'db, 'c>,
@@ -2422,6 +2551,7 @@ pub(super) struct DisjointnessChecker<'a, 'c, 'db> {
 
 impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
     pub(super) fn new(
+        program: Program,
         constraints: &'c ConstraintSetBuilder<'db>,
         inferable: InferableTypeVars<'db>,
         relation_visitor: &'a HasRelationToVisitor<'db, 'c>,
@@ -2430,6 +2560,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         materialization_visitor: &'a ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
+            program,
             constraints,
             inferable,
             given: ConstraintSet::from_bool(constraints, false),
@@ -2445,6 +2576,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         relation: TypeRelation,
     ) -> TypeRelationChecker<'_, 'c, 'db> {
         TypeRelationChecker {
+            program: self.program,
             relation,
             typevar_evaluation: TypeVarEvaluation::Eager,
             constraints: self.constraints,
@@ -2460,6 +2592,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
     pub(super) fn as_equivalence_checker(&self) -> EquivalenceChecker<'_, 'c, 'db> {
         EquivalenceChecker {
+            program: self.program,
             constraints: self.constraints,
             given: self.given,
             relation_visitor: self.relation_visitor,
@@ -2487,14 +2620,14 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         protocol
             .interface(db)
             .members(db)
-            .when_any(db, self.constraints, |member| {
+            .when_any(db, self.program, self.constraints, |member| {
                 other
-                    .member(db, member.name())
+                    .member(db, self.program, member.name())
                     .place
                     .ignore_possibly_undefined()
                     .when_none_or(db, self.constraints, |attribute_type| {
                         self.protocol_member_has_disjoint_type_from_ty(db, &member, attribute_type)
-                            .or(db, self.constraints, || {
+                            .or(db, self.program, self.constraints, || {
                                 self.protocol_member_write_is_definitely_missing_from_ty(
                                     db, &member, other,
                                 )
@@ -2523,22 +2656,25 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         intersection: IntersectionType<'db>,
         other: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         self.with_recursion_guard(left, right, || {
             intersection
                 .positive(db)
                 .iter()
-                .when_any(db, self.constraints, |&pos_ty| {
+                .when_any(db, self.program, self.constraints, |&pos_ty| {
                     self.check_type_pair(db, pos_ty, other)
                 })
                 // A & B & Not[C] is disjoint from C
-                .or(db, self.constraints, || {
-                    intersection
-                        .negative(db)
-                        .iter()
-                        .when_any(db, self.constraints, |&neg_ty| {
+                .or(db, program, self.constraints, || {
+                    intersection.negative(db).iter().when_any(
+                        db,
+                        self.program,
+                        self.constraints,
+                        |&neg_ty| {
                             self.as_relation_checker(TypeRelation::Subtyping)
                                 .check_type_pair(db, other, neg_ty)
-                        })
+                        },
+                    )
                 })
         })
     }
@@ -2549,6 +2685,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
         left: Type<'db>,
         right: Type<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         if let Some(left) = left.materialized_divergent_fallback() {
             return self.check_type_pair(db, left, right);
         }
@@ -2596,7 +2733,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             ) if subclass_of.is_type_var() => {
                 let type_var = subclass_of
                     .subclass_of()
-                    .with_transposed_type_var(db)
+                    .with_transposed_type_var(db, self.program)
                     .into_type_var()
                     .unwrap();
 
@@ -2605,11 +2742,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
             // `type[T]` is disjoint from a class object `A` if every instance of `T` is disjoint from an instance of `A`.
             (Type::SubclassOf(subclass_of), other) | (other, Type::SubclassOf(subclass_of))
-                if subclass_of.is_type_var() && other.to_instance(db).is_some() =>
+                if subclass_of.is_type_var() && other.to_instance(db, self.program).is_some() =>
             {
                 subclass_of
                     .into_type_var()
-                    .zip(other.to_instance(db))
+                    .zip(other.to_instance(db, self.program))
                     .when_none_or(db, self.constraints, |(this_instance, other_instance)| {
                         self.check_type_pair(db, Type::TypeVar(this_instance), other_instance)
                     })
@@ -2649,6 +2786,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     Some(TypeVarBoundOrConstraints::Constraints(typevar_constraints)) => {
                         typevar_constraints.elements(db).iter().when_all(
                             db,
+                            program,
                             self.constraints,
                             |constraint| self.check_type_pair(db, *constraint, other),
                         )
@@ -2662,7 +2800,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::Union(union), other) | (other, Type::Union(union)) => union
                 .elements(db)
                 .iter()
-                .when_all(db, self.constraints, |e| {
+                .when_all(db, program, self.constraints, |e| {
                     self.check_type_pair(db, *e, other)
                 }),
 
@@ -2670,21 +2808,25 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // Negative elements need a positive element on the other side in order to be disjoint.
             // This is similar to what would happen if we tried to build a new intersection that combines the two
             (Type::Intersection(left_intersection), Type::Intersection(right_intersection)) => {
-                if let Some(alternatives) = left_intersection.finite_alternative_union(db) {
+                if let Some(alternatives) = left_intersection.finite_alternative_union(db, program)
+                {
                     self.check_type_pair(db, alternatives, right)
-                } else if let Some(alternatives) = right_intersection.finite_alternative_union(db) {
+                } else if let Some(alternatives) =
+                    right_intersection.finite_alternative_union(db, program)
+                {
                     self.check_type_pair(db, left, alternatives)
                 } else {
                     self.with_recursion_guard(left, right, || {
                         left_intersection
                             .positive(db)
                             .iter()
-                            .when_any(db, self.constraints, |&pos_ty| {
+                            .when_any(db, program, self.constraints, |&pos_ty| {
                                 self.check_type_pair(db, pos_ty, right)
                             })
-                            .or(db, self.constraints, || {
+                            .or(db, program, self.constraints, || {
                                 right_intersection.positive(db).iter().when_any(
                                     db,
+                                    program,
                                     self.constraints,
                                     |&pos_ty| self.check_type_pair(db, pos_ty, left),
                                 )
@@ -2694,7 +2836,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (Type::Intersection(intersection), other) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db) {
+                if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
                     self.check_type_pair(db, alternatives, other)
                 } else {
                     self.check_intersection_pair_via_elements(db, left, right, intersection, other)
@@ -2702,7 +2844,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             }
 
             (other, Type::Intersection(intersection)) => {
-                if let Some(alternatives) = intersection.finite_alternative_union(db) {
+                if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
                     self.check_type_pair(db, other, alternatives)
                 } else {
                     self.check_intersection_pair_via_elements(db, left, right, intersection, other)
@@ -2795,11 +2937,17 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::AlwaysTruthy, ty) | (ty, Type::AlwaysTruthy) => {
                 // `Truthiness::Ambiguous` may include `AlwaysTrue` as a subset, so it's not guaranteed to be disjoint.
                 // Thus, they are only disjoint if `ty.bool() == AlwaysFalse`.
-                ConstraintSet::from_bool(self.constraints, ty.bool(db).is_always_false())
+                ConstraintSet::from_bool(
+                    self.constraints,
+                    ty.bool(db, self.program).is_always_false(),
+                )
             }
             (Type::AlwaysFalsy, ty) | (ty, Type::AlwaysFalsy) => {
                 // Similarly, they are only disjoint if `ty.bool() == AlwaysTrue`.
-                ConstraintSet::from_bool(self.constraints, ty.bool(db).is_always_true())
+                ConstraintSet::from_bool(
+                    self.constraints,
+                    ty.bool(db, self.program).is_always_true(),
+                )
             }
 
             (Type::ProtocolInstance(left_proto), Type::ProtocolInstance(right_proto)) => self
@@ -2813,7 +2961,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     self.any_protocol_members_absent_or_disjoint(
                         db,
                         protocol,
-                        special_form.instance_fallback(db),
+                        special_form.instance_fallback(db, self.program),
                     )
                 }),
 
@@ -2823,7 +2971,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     self.any_protocol_members_absent_or_disjoint(
                         db,
                         protocol,
-                        known_instance.instance_fallback(db),
+                        known_instance.instance_fallback(db, self.program),
                     )
                 }),
 
@@ -2878,7 +3026,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // (<https://github.com/rust-lang/rust/issues/129967>)
             (Type::ProtocolInstance(protocol), Type::NominalInstance(nominal))
             | (Type::NominalInstance(nominal), Type::ProtocolInstance(protocol))
-                if nominal.class(db).is_final(db) =>
+                if nominal.class(db, self.program).is_final(db) =>
             {
                 self.with_recursion_guard(left, right, || {
                     self.any_protocol_members_absent_or_disjoint(
@@ -2892,21 +3040,21 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::ProtocolInstance(protocol), other)
             | (other, Type::ProtocolInstance(protocol)) => {
                 self.with_recursion_guard(left, right, || {
-                    protocol
-                        .interface(db)
-                        .members(db)
-                        .when_any(db, self.constraints, |member| {
-                            match other.member(db, member.name()).place {
-                                Place::Defined(DefinedPlace {
-                                    ty: attribute_type, ..
-                                }) => self.protocol_member_has_disjoint_type_from_ty(
-                                    db,
-                                    &member,
-                                    attribute_type,
-                                ),
-                                Place::Undefined => self.never(),
-                            }
-                        })
+                    protocol.interface(db).members(db).when_any(
+                        db,
+                        program,
+                        self.constraints,
+                        |member| match other.member(db, self.program, member.name()).place {
+                            Place::Defined(DefinedPlace {
+                                ty: attribute_type, ..
+                            }) => self.protocol_member_has_disjoint_type_from_ty(
+                                db,
+                                &member,
+                                attribute_type,
+                            ),
+                            Place::Undefined => self.never(),
+                        },
+                    )
                 })
             }
 
@@ -2921,7 +3069,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                     self.constraints,
                     left_alias.origin(db) != right_alias.origin(db),
                 )
-                .or(db, self.constraints, || {
+                .or(db, program, self.constraints, || {
                     self.check_specialization_pair(
                         db,
                         left_alias.specialization(db),
@@ -2979,7 +3127,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (Type::SubclassOf(subclass_of_ty), other)
             | (other, Type::SubclassOf(subclass_of_ty)) => match subclass_of_ty.subclass_of() {
                 SubclassOfInner::Dynamic(_) => {
-                    self.check_type_pair(db, KnownClass::Type.to_instance(db), other)
+                    self.check_type_pair(db, KnownClass::Type.to_instance(db, self.program), other)
                 }
                 SubclassOfInner::Class(class) => {
                     self.check_type_pair(db, class.metaclass_instance_type(db), other)
@@ -2991,7 +3139,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (Type::NominalInstance(instance), Type::SpecialForm(special_form)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    !special_form.is_instance_of(db, instance.class(db)),
+                    !special_form.is_instance_of(db, instance.class(db, self.program)),
                 )
             }
 
@@ -2999,25 +3147,39 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (Type::NominalInstance(instance), Type::KnownInstance(known_instance)) => {
                 ConstraintSet::from_bool(
                     self.constraints,
-                    !known_instance.is_instance_of(db, instance.class(db)),
+                    !known_instance.is_instance_of(db, instance.class(db, self.program)),
                 )
             }
 
             (Type::LiteralValue(literal), Type::NominalInstance(instance))
             | (Type::NominalInstance(instance), Type::LiteralValue(literal)) => {
                 let positive_relation_holds = match literal.kind() {
-                    LiteralValueTypeKind::Int(_) => {
-                        KnownClass::Int.when_subclass_of(db, instance.class(db), self.constraints)
-                    }
-                    LiteralValueTypeKind::Bool(_) => {
-                        KnownClass::Bool.when_subclass_of(db, instance.class(db), self.constraints)
-                    }
+                    LiteralValueTypeKind::Int(_) => KnownClass::Int.when_subclass_of(
+                        db,
+                        self.program,
+                        instance.class(db, self.program),
+                        self.constraints,
+                    ),
+                    LiteralValueTypeKind::Bool(_) => KnownClass::Bool.when_subclass_of(
+                        db,
+                        self.program,
+                        instance.class(db, self.program),
+                        self.constraints,
+                    ),
                     LiteralValueTypeKind::LiteralString | LiteralValueTypeKind::String(_) => {
-                        KnownClass::Str.when_subclass_of(db, instance.class(db), self.constraints)
+                        KnownClass::Str.when_subclass_of(
+                            db,
+                            self.program,
+                            instance.class(db, self.program),
+                            self.constraints,
+                        )
                     }
-                    LiteralValueTypeKind::Bytes(_) => {
-                        KnownClass::Bytes.when_subclass_of(db, instance.class(db), self.constraints)
-                    }
+                    LiteralValueTypeKind::Bytes(_) => KnownClass::Bytes.when_subclass_of(
+                        db,
+                        self.program,
+                        instance.class(db, self.program),
+                        self.constraints,
+                    ),
                     LiteralValueTypeKind::Enum(enum_literal) => self
                         .as_relation_checker(TypeRelation::Subtyping)
                         .check_type_pair(
@@ -3034,7 +3196,12 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 // A boolean literal must be an instance of exactly `bool`
                 // (it cannot be an instance of a `bool` subclass)
                 KnownClass::Bool
-                    .when_subclass_of(db, instance.class(db), self.constraints)
+                    .when_subclass_of(
+                        db,
+                        self.program,
+                        instance.class(db, self.program),
+                        self.constraints,
+                    )
                     .negate(db, self.constraints)
             }
 
@@ -3051,6 +3218,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 .metaclass_instance_type(db)
                 .when_subtype_of(
                     db,
+                    self.program,
                     Type::NominalInstance(instance),
                     self.constraints,
                     self.inferable,
@@ -3072,7 +3240,12 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 // A `Type::FunctionLiteral()` must be an instance of exactly `types.FunctionType`
                 // (it cannot be an instance of a `types.FunctionType` subclass)
                 KnownClass::FunctionType
-                    .when_subclass_of(db, instance.class(db), self.constraints)
+                    .when_subclass_of(
+                        db,
+                        self.program,
+                        instance.class(db, self.program),
+                        self.constraints,
+                    )
                     .negate(db, self.constraints)
             }
 
@@ -3128,17 +3301,22 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 }
             }
 
-            (Type::BoundMethod(_), other) | (other, Type::BoundMethod(_)) => {
-                self.check_type_pair(db, KnownClass::MethodType.to_instance(db), other)
-            }
+            (Type::BoundMethod(_), other) | (other, Type::BoundMethod(_)) => self.check_type_pair(
+                db,
+                KnownClass::MethodType.to_instance(db, self.program),
+                other,
+            ),
 
             (Type::KnownBoundMethod(method), other) | (other, Type::KnownBoundMethod(method)) => {
-                self.check_type_pair(db, method.class().to_instance(db), other)
+                self.check_type_pair(db, method.class().to_instance(db, self.program), other)
             }
 
-            (Type::WrapperDescriptor(_), other) | (other, Type::WrapperDescriptor(_)) => {
-                self.check_type_pair(db, KnownClass::WrapperDescriptorType.to_instance(db), other)
-            }
+            (Type::WrapperDescriptor(_), other) | (other, Type::WrapperDescriptor(_)) => self
+                .check_type_pair(
+                    db,
+                    KnownClass::WrapperDescriptorType.to_instance(db, self.program),
+                    other,
+                ),
 
             (Type::Callable(_) | Type::FunctionLiteral(_), Type::Callable(_))
             | (Type::Callable(_), Type::FunctionLiteral(_)) => {
@@ -3164,9 +3342,10 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             | (
                 Type::NominalInstance(nominal),
                 Type::Callable(_) | Type::DataclassDecorator(_) | Type::DataclassTransformer(_),
-            ) if nominal.class(db).is_final(db) => Type::NominalInstance(nominal)
+            ) if nominal.class(db, self.program).is_final(db) => Type::NominalInstance(nominal)
                 .member_lookup_with_policy(
                     db,
+                    self.program,
                     Name::new_static("__call__"),
                     MemberLookupPolicy::NO_INSTANCE_FALLBACK,
                 )
@@ -3196,7 +3375,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 self.check_type_pair(
                     db,
                     Type::NominalInstance(instance),
-                    KnownClass::ModuleType.to_instance(db),
+                    KnownClass::ModuleType.to_instance(db, self.program),
                 )
             }
 
@@ -3214,7 +3393,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
 
             (Type::PropertyInstance(property), other)
             | (other, Type::PropertyInstance(property)) => {
-                self.check_type_pair(db, property.instance_fallback(db), other)
+                self.check_type_pair(db, property.instance_fallback(db, self.program), other)
             }
 
             (Type::BoundSuper(left), Type::BoundSuper(right)) => self
@@ -3223,7 +3402,7 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
                 .negate(db, self.constraints),
 
             (Type::BoundSuper(_), other) | (other, Type::BoundSuper(_)) => {
-                self.check_type_pair(db, KnownClass::Super.to_instance(db), other)
+                self.check_type_pair(db, KnownClass::Super.to_instance(db, self.program), other)
             }
 
             (Type::TypeForm(_), _) | (_, Type::TypeForm(_)) => self.never(),
@@ -3241,9 +3420,11 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // `dict` *itself* is almost always disjoint from `TypedDict` -- but it's a good
             // approximation, and some false negatives are acceptable.
             (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
-                let dict_str_any = KnownClass::Dict
-                    .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()]);
-
+                let dict_str_any = KnownClass::Dict.to_specialized_instance(
+                    db,
+                    self.program,
+                    &[KnownClass::Str.to_instance(db, self.program), Type::any()],
+                );
                 self.as_relation_checker(TypeRelation::Assignability)
                     .check_type_pair(db, dict_str_any, other)
                     .negate(db, self.constraints)
@@ -3263,12 +3444,18 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             (None | Some(_), None | Some(_)) => self.always(),
         };
 
-        check_optional_methods(left.getter(db), right.getter(db)).or(db, self.constraints, || {
-            check_optional_methods(left.setter(db), right.setter(db)).or(
-                db,
-                self.constraints,
-                || check_optional_methods(left.deleter(db), right.deleter(db)),
-            )
-        })
+        check_optional_methods(left.getter(db), right.getter(db)).or(
+            db,
+            self.program,
+            self.constraints,
+            || {
+                check_optional_methods(left.setter(db), right.setter(db)).or(
+                    db,
+                    self.program,
+                    self.constraints,
+                    || check_optional_methods(left.deleter(db), right.deleter(db)),
+                )
+            },
+        )
     }
 }

--- a/crates/ty_python_semantic/src/types/relation_error.rs
+++ b/crates/ty_python_semantic/src/types/relation_error.rs
@@ -153,11 +153,14 @@ impl<'db> ErrorContext<'db> {
     fn render(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         help_messages: &mut FxOrderSet<HelpMessages>,
     ) -> Option<String> {
         let typed_dict_name = |typed_dict: &TypedDictType<'db>| match typed_dict {
             TypedDictType::Class(class) => format!("TypedDict `{}`", class.name(db)),
-            TypedDictType::Synthesized(_) => Type::TypedDict(*typed_dict).display(db).to_string(),
+            TypedDictType::Synthesized(_) => Type::TypedDict(*typed_dict)
+                .display(db, program)
+                .to_string(),
         };
 
         Some(match self {
@@ -170,14 +173,14 @@ impl<'db> ErrorContext<'db> {
                 target,
             } => format!(
                 "element `{}` of union `{}` is not assignable to `{}`",
-                element.display(db),
-                union.display(db),
-                target.display(db),
+                element.display(db, program),
+                union.display(db, program),
+                target.display(db, program),
             ),
             Self::NotAssignableToAnyUnionElement { source, union } => format!(
                 "type `{}` is not assignable to any element of the union `{}`",
-                source.display(db),
-                union.display(db),
+                source.display(db, program),
+                union.display(db, program),
             ),
             Self::NotAssignableToNOtherUnionElements { n } => format!(
                 "... omitted {n} union element{} without additional context",
@@ -189,17 +192,17 @@ impl<'db> ErrorContext<'db> {
                 intersection,
             } => format!(
                 "type `{}` is not assignable to element `{}` of intersection `{}`",
-                source.display(db),
-                element.display(db),
-                intersection.display(db),
+                source.display(db, program),
+                element.display(db, program),
+                intersection.display(db, program),
             ),
             Self::NoIntersectionElementAssignableToTarget {
                 intersection,
                 target,
             } => format!(
                 "no element of intersection `{}` is assignable to `{}`",
-                intersection.display(db),
-                target.display(db),
+                intersection.display(db, program),
+                target.display(db, program),
             ),
             Self::TypedDictFieldMissing { field_name, source } => {
                 format!(
@@ -251,8 +254,8 @@ impl<'db> ErrorContext<'db> {
                 "field \"{field_name}\" on {source} has type `{source_field}` which is not assignable to type `{target_field}` expected by {target}",
                 source = typed_dict_name(source),
                 target = typed_dict_name(target),
-                source_field = source_field.display(db),
-                target_field = target_field.display(db),
+                source_field = source_field.display(db, program),
+                target_field = target_field.display(db, program),
             ),
             Self::TypedDictNotAssignableToDict(typed_dict) => {
                 help_messages.insert(HelpMessages::TypedDictNotAssignableToDict);
@@ -265,8 +268,8 @@ impl<'db> ErrorContext<'db> {
             }
             Self::IncompatibleReturnTypes { source, target } => format!(
                 "incompatible return types: `{source}` is not assignable to `{target}`",
-                source = source.display(db),
-                target = target.display(db),
+                source = source.display(db, program),
+                target = target.display(db, program),
             ),
             Self::IncompatibleParameterTypes {
                 source,
@@ -276,14 +279,14 @@ impl<'db> ErrorContext<'db> {
                 // reversed order due to contravariance of parameter types
                 format!(
                     "{parameter} has an incompatible type: `{target}` is not assignable to `{source}`",
-                    source = source.display(db),
-                    target = target.display(db),
+                    source = source.display(db, program),
+                    target = target.display(db, program),
                 )
             }
             Self::InferredCallableType { source, callable } => format!(
                 "type `{}` has inferred callable type `{}`",
-                source.display(db),
-                callable.display(db),
+                source.display(db, program),
+                callable.display(db, program),
             ),
             Self::ExtraRequiredParameter { parameter } => match parameter {
                 ParameterDescription::Named(name) => format!("unexpected extra parameter `{name}`"),
@@ -332,41 +335,41 @@ impl<'db> ErrorContext<'db> {
                 };
                 format!(
                     "{which} is not compatible: `{source}` is not assignable to `{target}`",
-                    source = source.display(db),
-                    target = target.display(db)
+                    source = source.display(db, program),
+                    target = target.display(db, program)
                 )
             }
             Self::TypeNotCompatibleWithProtocol { ty, protocol } => {
                 if let Type::ProtocolInstance(_) = ty {
                     format!(
                         "protocol `{}` is not assignable to protocol `{}`",
-                        ty.display(db),
-                        protocol.display(db),
+                        ty.display(db, program),
+                        protocol.display(db, program),
                     )
                 } else {
                     format!(
                         "type `{}` is not assignable to protocol `{}`",
-                        ty.display(db),
-                        protocol.display(db),
+                        ty.display(db, program),
+                        protocol.display(db, program),
                     )
                 }
             }
             Self::ProtocolMemberNotDefined { member_name, ty } => format!(
                 "protocol member `{member_name}` is not defined on type `{}`",
-                ty.display(db),
+                ty.display(db, program),
             ),
             Self::ProtocolMemberIncompatible { member_name } => {
                 format!("protocol member `{member_name}` is incompatible")
             }
             Self::ProtocolMemberReadTypeIncompatible { source, target } => format!(
                 "read type `{source}` is not assignable to `{target}`",
-                source = source.display(db),
-                target = target.display(db),
+                source = source.display(db, program),
+                target = target.display(db, program),
             ),
             Self::ProtocolMemberNotWritable => "the member is not writable".to_string(),
             Self::ProtocolMemberWriteTypeIncompatible { target } => format!(
                 "the member does not accept writes of type `{}`",
-                target.display(db),
+                target.display(db, program),
             ),
         })
     }
@@ -419,12 +422,13 @@ impl<'db> ErrorContextNode<'db> {
     fn render_tree(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         output_lines: &mut Vec<String>,
         help_messages: &mut FxOrderSet<HelpMessages>,
         prefix: &str,
         continuation: &str,
     ) {
-        if let Some(line) = self.context.render(db, help_messages) {
+        if let Some(line) = self.context.render(db, program, help_messages) {
             output_lines.push(format!("{prefix}{line}"));
         }
 
@@ -438,6 +442,7 @@ impl<'db> ErrorContextNode<'db> {
             };
             child.render_tree(
                 db,
+                program,
                 output_lines,
                 help_messages,
                 &child_prefix,
@@ -536,13 +541,14 @@ impl<'db> ErrorContextTree<'db> {
     pub(in crate::types) fn attach_to(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         diag: &mut LintDiagnosticGuard<'_, '_>,
     ) {
         let mut output_lines = Vec::new();
         let mut help_messages = FxOrderSet::default();
         self.root
             .borrow()
-            .render_tree(db, &mut output_lines, &mut help_messages, "", "");
+            .render_tree(db, program, &mut output_lines, &mut help_messages, "", "");
         for line in output_lines {
             diag.info(line);
         }

--- a/crates/ty_python_semantic/src/types/set_theoretic.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic.rs
@@ -9,7 +9,7 @@ use crate::types::class::KnownClass;
 use crate::types::enums::EnumComplement;
 use crate::types::{Type, TypeQualifiers};
 use crate::types::{TypeVarBoundOrConstraints, visitor};
-use crate::{Db, FxOrderSet};
+use crate::{Db, FxOrderSet, Program};
 
 pub(crate) mod builder;
 
@@ -28,11 +28,12 @@ pub struct UnionType<'db> {
 
 pub(crate) fn walk_union<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     union: UnionType<'db>,
     visitor: &V,
 ) {
     for element in union.elements(db) {
-        visitor.visit_type(db, *element);
+        visitor.visit_type(db, program, *element);
     }
 }
 
@@ -46,7 +47,7 @@ impl<'db> UnionType<'db> {
     ///
     /// For performance reasons, consider using [`UnionType::from_two_elements`] if
     /// the union is constructed from exactly two elements.
-    pub fn from_elements<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
+    pub fn from_elements<I, T>(db: &'db dyn Db, program: Program, elements: I) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
@@ -55,7 +56,9 @@ impl<'db> UnionType<'db> {
 
         if let Some(first) = iter_elements.next() {
             if let Some(second) = iter_elements.next() {
-                let builder = UnionBuilder::new(db).add(first.into()).add(second.into());
+                let builder = UnionBuilder::new(db, program)
+                    .add(first.into())
+                    .add(second.into());
                 iter_elements
                     .fold(builder, |builder, element| builder.add(element.into()))
                     .build()
@@ -70,18 +73,27 @@ impl<'db> UnionType<'db> {
     /// Create a union type `A | B` from two elements `A` and `B`.
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
-            result.cycle_normalized(db, *previous, cycle)
+        cycle_initial=|_, id, _, _, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, program, _, _| {
+            result.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub fn from_two_elements(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
-        UnionBuilder::new(db).add(a).add(b).build()
+    pub fn from_two_elements(
+        db: &'db dyn Db,
+        program: Program,
+        a: Type<'db>,
+        b: Type<'db>,
+    ) -> Type<'db> {
+        UnionBuilder::new(db, program).add(a).add(b).build()
     }
 
     /// Create a union from a list of elements without unpacking type aliases.
-    pub(crate) fn from_elements_leave_aliases<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
+    pub(crate) fn from_elements_leave_aliases<I, T>(
+        db: &'db dyn Db,
+        program: Program,
+        elements: I,
+    ) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
@@ -89,7 +101,7 @@ impl<'db> UnionType<'db> {
         elements
             .into_iter()
             .fold(
-                UnionBuilder::new(db).unpack_aliases(false),
+                UnionBuilder::new(db, program).unpack_aliases(false),
                 |builder, element| builder.add(element.into()),
             )
             .build()
@@ -105,12 +117,16 @@ impl<'db> UnionType<'db> {
     /// Recursively expands aliases that expose top-level union elements.
     ///
     /// Aliases nested inside non-union elements remain part of those elements.
-    pub(crate) fn expand_aliases(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn expand_aliases(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         // Rebuild the union so that `UnionBuilder` simplifies any redundancies exposed.
-        Self::from_elements(db, self.elements(db).iter().copied())
+        Self::from_elements(db, program, self.elements(db).iter().copied())
     }
 
-    pub(crate) fn from_elements_cycle_recovery<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
+    pub(crate) fn from_elements_cycle_recovery<I, T>(
+        db: &'db dyn Db,
+        program: Program,
+        elements: I,
+    ) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
@@ -118,7 +134,7 @@ impl<'db> UnionType<'db> {
         elements
             .into_iter()
             .fold(
-                UnionBuilder::new(db).cycle_recovery(true),
+                UnionBuilder::new(db, program).cycle_recovery(true),
                 |builder, element| builder.add(element.into()),
             )
             .build()
@@ -129,12 +145,16 @@ impl<'db> UnionType<'db> {
     /// If all items in `elements` are `Some()`, the result of unioning all elements is returned.
     /// As soon as a `None` element in the iterable is encountered,
     /// the function short-circuits and returns `None`.
-    pub(crate) fn try_from_elements<I, T>(db: &'db dyn Db, elements: I) -> Option<Type<'db>>
+    pub(crate) fn try_from_elements<I, T>(
+        db: &'db dyn Db,
+        program: Program,
+        elements: I,
+    ) -> Option<Type<'db>>
     where
         I: IntoIterator<Item = Option<T>>,
         T: Into<Type<'db>>,
     {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         for element in elements {
             builder = builder.add(element?.into());
         }
@@ -146,10 +166,12 @@ impl<'db> UnionType<'db> {
     pub(crate) fn map(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        let Ok(mapped) =
-            self.try_map_impl(db, |element| Ok::<_, Infallible>(transform_fn(element)));
+        let Ok(mapped) = self.try_map_impl(db, program, |element| {
+            Ok::<_, Infallible>(transform_fn(element))
+        });
         mapped
     }
 
@@ -157,6 +179,7 @@ impl<'db> UnionType<'db> {
     pub(crate) fn map_leave_aliases(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
         let elements = self.elements(db);
@@ -164,7 +187,7 @@ impl<'db> UnionType<'db> {
         while let Some((i, ty)) = iter.next() {
             let new_ty = transform_fn(ty);
             if &new_ty != ty {
-                let mut builder = UnionBuilder::new(db).unpack_aliases(false);
+                let mut builder = UnionBuilder::new(db, program).unpack_aliases(false);
                 for prev in &elements[..i] {
                     builder = builder.add(*prev);
                 }
@@ -191,15 +214,17 @@ impl<'db> UnionType<'db> {
     pub(crate) fn try_map(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Option<Type<'db>>,
     ) -> Option<Type<'db>> {
-        self.try_map_impl(db, |element| transform_fn(element).ok_or(()))
+        self.try_map_impl(db, program, |element| transform_fn(element).ok_or(()))
             .ok()
     }
 
     fn try_map_impl<E>(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Result<Type<'db>, E>,
     ) -> Result<Type<'db>, E> {
         let elements = self.elements(db);
@@ -210,7 +235,7 @@ impl<'db> UnionType<'db> {
                 let mut builder = elements[..i]
                     .iter()
                     .copied()
-                    .fold(UnionBuilder::new(db), UnionBuilder::add);
+                    .fold(UnionBuilder::new(db, program), UnionBuilder::add);
                 builder = builder.add(new_ty);
                 for (_, element) in iter {
                     builder = builder.add(transform_fn(element)?);
@@ -224,15 +249,19 @@ impl<'db> UnionType<'db> {
         Ok(Type::Union(self))
     }
 
-    pub(crate) fn to_instance(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.try_map(db, |element| element.to_instance(db))
+    pub(crate) fn to_instance(self, db: &'db dyn Db, program: Program) -> Option<Type<'db>> {
+        self.try_map(db, program, |element| element.to_instance(db, program))
     }
 
     /// Returns a shared fully static supertype for a union of literal-value types.
     ///
     /// The returned type is broader than the literal types themselves. For example, the
     /// supertype for `Literal["a"] | Literal["b"]` is `LiteralString`.
-    pub(crate) fn common_literal_supertype(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn common_literal_supertype(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Option<Type<'db>> {
         // Do not use `Type::literal_fallback_instance` here: it also falls back from function
         // literals to `FunctionType`. Since `FunctionType.__call__` is gradual, it can be
         // assignable to a callable that the function literal's precise signature is not.
@@ -240,7 +269,7 @@ impl<'db> UnionType<'db> {
         // supertype proves the relation for every literal in the union.
         let supertype = |element: &Type<'db>| match element {
             Type::LiteralValue(literal) if literal.is_string() => Some(Type::literal_string()),
-            Type::LiteralValue(literal) => Some(literal.fallback_instance(db)),
+            Type::LiteralValue(literal) => Some(literal.fallback_instance(db, program)),
             _ => None,
         };
 
@@ -266,9 +295,10 @@ impl<'db> UnionType<'db> {
     pub(crate) fn map_with_boundness(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Place<'db>,
     ) -> Place<'db> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
 
         let mut all_unbound = true;
         let mut possibly_unbound = false;
@@ -321,9 +351,10 @@ impl<'db> UnionType<'db> {
     pub(crate) fn map_with_boundness_and_qualifiers(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> PlaceAndQualifiers<'db>,
     ) -> PlaceAndQualifiers<'db> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         let mut qualifiers = TypeQualifiers::empty();
 
         let mut all_unbound = true;
@@ -383,10 +414,11 @@ impl<'db> UnionType<'db> {
     pub(crate) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Type<'db>> {
-        let mut builder = UnionBuilder::new(db)
+        let mut builder = UnionBuilder::new(db, program)
             .unpack_aliases(false)
             .cycle_recovery(true)
             .recursively_defined(self.recursively_defined(db));
@@ -394,7 +426,7 @@ impl<'db> UnionType<'db> {
         for ty in self.elements(db) {
             if nested {
                 // list[T | Divergent] => list[Divergent]
-                let ty = ty.recursive_type_normalized_impl(db, div, nested)?;
+                let ty = ty.recursive_type_normalized_impl(db, program, div, nested)?;
                 if ty.same_divergent_marker(div) {
                     return Some(ty);
                 }
@@ -408,7 +440,7 @@ impl<'db> UnionType<'db> {
                     continue;
                 }
                 builder = builder.add(
-                    ty.recursive_type_normalized_impl(db, div, nested)
+                    ty.recursive_type_normalized_impl(db, program, div, nested)
                         .unwrap_or(div),
                 );
                 empty = false;
@@ -449,19 +481,21 @@ pub(crate) enum KnownUnion {
 }
 
 impl KnownUnion {
-    pub(crate) fn to_type(self, db: &dyn Db) -> Type<'_> {
+    pub(crate) fn to_type(self, db: &dyn Db, program: Program) -> Type<'_> {
         match self {
             KnownUnion::Float => UnionType::from_two_elements(
                 db,
-                KnownClass::Int.to_instance(db),
-                KnownClass::Float.to_instance(db),
+                program,
+                KnownClass::Int.to_instance(db, program),
+                KnownClass::Float.to_instance(db, program),
             ),
             KnownUnion::Complex => UnionType::from_elements(
                 db,
+                program,
                 [
-                    KnownClass::Int.to_instance(db),
-                    KnownClass::Float.to_instance(db),
-                    KnownClass::Complex.to_instance(db),
+                    KnownClass::Int.to_instance(db, program),
+                    KnownClass::Float.to_instance(db, program),
+                    KnownClass::Complex.to_instance(db, program),
                 ],
             ),
         }
@@ -498,7 +532,7 @@ pub struct IntersectionType<'db> {
 /// and `Self::Single` would add overhead to methods like `Self::swap_remove`,
 /// and would have little value. At the point when you're calling that method, a
 /// heap allocation has already taken place.
-#[derive(Debug, Clone, get_size2::GetSize, Default, salsa::SalsaValue)]
+#[derive(Debug, Clone, get_size2::GetSize, salsa::SalsaValue, Default)]
 pub enum NegativeIntersectionElements<'db> {
     #[default]
     Empty,
@@ -703,42 +737,59 @@ const MAX_INTERSECTION_DNF_TERMS: usize = 4;
 
 pub(crate) fn walk_intersection_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     intersection: IntersectionType<'db>,
     visitor: &V,
 ) {
     for element in intersection.positive(db) {
-        visitor.visit_type(db, *element);
+        visitor.visit_type(db, program, *element);
     }
     for element in intersection.negative(db) {
-        visitor.visit_type(db, *element);
+        visitor.visit_type(db, program, *element);
     }
 }
 
 #[salsa::tracked]
 impl<'db> IntersectionType<'db> {
     /// Return the compact enum-complement view of this intersection, if it has one.
-    pub(crate) fn enum_complement(self, db: &'db dyn Db) -> Option<EnumComplement<'db>> {
-        EnumComplement::from_intersection_parts(db, self.positive(db), self.negative(db))
+    pub(crate) fn enum_complement(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<EnumComplement<'db>> {
+        EnumComplement::from_intersection_parts(db, program, self.positive(db), self.negative(db))
     }
 
     /// Return the exact finite alternatives represented by this intersection, if available.
-    pub fn finite_alternatives(self, db: &'db dyn Db) -> Option<Vec<Type<'db>>> {
-        self.enum_complement(db)
+    pub fn finite_alternatives(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Vec<Type<'db>>> {
+        self.enum_complement(db, program)
             .map(|complement| complement.remaining_literal_types(db))
     }
 
     /// Return the exact finite alternative union represented by this intersection, if available.
-    pub(crate) fn finite_alternative_union(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        Some(self.enum_complement(db)?.remaining_literal_union(db))
+    pub(crate) fn finite_alternative_union(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
+        Some(
+            self.enum_complement(db, program)?
+                .remaining_literal_union(db),
+        )
     }
 
     /// Return the finite alternatives only if they remain concise enough for display.
     pub(crate) fn finite_alternatives_for_display(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         max_literals: usize,
     ) -> Option<Vec<Type<'db>>> {
-        self.enum_complement(db)?
+        self.enum_complement(db, program)?
             .remaining_literal_types_for_display(db, max_literals)
     }
 
@@ -746,7 +797,7 @@ impl<'db> IntersectionType<'db> {
     ///
     /// For performance reasons, consider using [`IntersectionType::from_two_elements`] if
     /// the intersection is constructed from exactly two elements.
-    pub(crate) fn from_elements<I, T>(db: &'db dyn Db, elements: I) -> Type<'db>
+    pub(crate) fn from_elements<I, T>(db: &'db dyn Db, program: Program, elements: I) -> Type<'db>
     where
         I: IntoIterator<Item = T>,
         T: Into<Type<'db>>,
@@ -755,8 +806,8 @@ impl<'db> IntersectionType<'db> {
 
         if let Some(first) = elements_iter.next() {
             if let Some(second) = elements_iter.next() {
-                let builder =
-                    IntersectionBuilder::new(db).positive_elements([first.into(), second.into()]);
+                let builder = IntersectionBuilder::new(db, program)
+                    .positive_elements([first.into(), second.into()]);
                 elements_iter
                     .fold(builder, |builder, element| {
                         builder.add_positive(element.into())
@@ -779,7 +830,11 @@ impl<'db> IntersectionType<'db> {
     /// work, and if so, returns `None`. (Redundant terms do not count toward the budget.)
     ///
     /// Like [`from_elements`][Self::from_elements], a successful result is exact.
-    pub(crate) fn bounded_from_elements<I, T>(db: &'db dyn Db, elements: I) -> Option<Type<'db>>
+    pub(crate) fn bounded_from_elements<I, T>(
+        db: &'db dyn Db,
+        program: Program,
+        elements: I,
+    ) -> Option<Type<'db>>
     where
         I: IntoIterator<Item = T>,
         I::IntoIter: Clone,
@@ -795,21 +850,21 @@ impl<'db> IntersectionType<'db> {
             // there is a single union, the product of all union counts should be reasonable, even
             // if it exceeds the budget below. In both cases, just return the precise answer
             // without considering the budget.
-            return Some(Self::from_elements(db, elements));
+            return Some(Self::from_elements(db, program, elements));
         }
 
         let non_union_elements = elements.clone().filter(|element| !element.is_union());
-        let initial = Self::from_elements(db, non_union_elements);
+        let initial = Self::from_elements(db, program, non_union_elements);
         let insert_candidate = |candidates: &mut Vec<Type<'db>>, new_ty: Type<'db>| -> Option<()> {
             if new_ty.is_never()
                 || candidates
                     .iter()
-                    .any(|old| new_ty.is_redundant_with(db, *old))
+                    .any(|old| new_ty.is_redundant_with(db, program, *old))
             {
                 return Some(());
             }
 
-            candidates.retain(|old| !old.is_redundant_with(db, new_ty));
+            candidates.retain(|old| !old.is_redundant_with(db, program, new_ty));
             if candidates.len() >= MAX_INTERSECTION_DNF_TERMS {
                 return None;
             }
@@ -832,7 +887,7 @@ impl<'db> IntersectionType<'db> {
             next.clear();
             for candidate in &frontier {
                 for alternative in clause.elements(db) {
-                    let refined = Self::from_two_elements(db, *candidate, *alternative);
+                    let refined = Self::from_two_elements(db, program, *candidate, *alternative);
                     insert_candidate(&mut next, refined).or(skip_budget_check)?;
                 }
             }
@@ -844,20 +899,25 @@ impl<'db> IntersectionType<'db> {
             std::mem::swap(&mut frontier, &mut next);
         }
 
-        Some(UnionType::from_elements(db, frontier))
+        Some(UnionType::from_elements(db, program, frontier))
     }
 
     /// Create an intersection type `A & B` from two elements `A` and `B`.
     #[salsa::tracked(
         returns(copy),
-        cycle_initial=|_, id, _, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, _, _| {
-            result.cycle_normalized(db, *previous, cycle)
+        cycle_initial=|_, id, _, _, _| Type::divergent(id),
+        cycle_fn=|db, cycle, previous: &Type<'db>, result: Type<'db>, program, _, _| {
+            result.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
-    pub(crate) fn from_two_elements(db: &'db dyn Db, a: Type<'db>, b: Type<'db>) -> Type<'db> {
-        IntersectionBuilder::new(db)
+    pub(crate) fn from_two_elements(
+        db: &'db dyn Db,
+        program: Program,
+        a: Type<'db>,
+        b: Type<'db>,
+    ) -> Type<'db> {
+        IntersectionBuilder::new(db, program)
             .positive_elements([a, b])
             .build()
     }
@@ -865,19 +925,20 @@ impl<'db> IntersectionType<'db> {
     pub(crate) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let positive = if nested {
             self.positive(db)
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, nested))
+                .map(|ty| ty.recursive_type_normalized_impl(db, program, div, nested))
                 .collect::<Option<FxOrderSet<Type<'db>>>>()?
         } else {
             self.positive(db)
                 .iter()
                 .map(|ty| {
-                    ty.recursive_type_normalized_impl(db, div, nested)
+                    ty.recursive_type_normalized_impl(db, program, div, nested)
                         .unwrap_or(div)
                 })
                 .collect()
@@ -885,10 +946,10 @@ impl<'db> IntersectionType<'db> {
 
         let negative = if nested {
             self.negative(db)
-                .try_map(|ty| ty.recursive_type_normalized_impl(db, div, nested))?
+                .try_map(|ty| ty.recursive_type_normalized_impl(db, program, div, nested))?
         } else {
             self.negative(db).map(|ty| {
-                ty.recursive_type_normalized_impl(db, div, nested)
+                ty.recursive_type_normalized_impl(db, program, div, nested)
                     .unwrap_or(div)
             })
         };
@@ -914,9 +975,10 @@ impl<'db> IntersectionType<'db> {
     pub(crate) fn map_positive(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Type<'db>,
     ) -> Type<'db> {
-        let mut builder = IntersectionBuilder::new(db);
+        let mut builder = IntersectionBuilder::new(db, program);
         for ty in self.positive(db) {
             builder = builder.add_positive(transform_fn(ty));
         }
@@ -929,9 +991,10 @@ impl<'db> IntersectionType<'db> {
     pub(crate) fn map_with_boundness(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> Place<'db>,
     ) -> Place<'db> {
-        let mut builder = IntersectionBuilder::new(db);
+        let mut builder = IntersectionBuilder::new(db, program);
 
         let mut all_unbound = true;
         let mut any_definitely_bound = false;
@@ -980,9 +1043,10 @@ impl<'db> IntersectionType<'db> {
     pub(crate) fn map_with_boundness_and_qualifiers(
         self,
         db: &'db dyn Db,
+        program: Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> PlaceAndQualifiers<'db>,
     ) -> PlaceAndQualifiers<'db> {
-        let mut builder = IntersectionBuilder::new(db);
+        let mut builder = IntersectionBuilder::new(db, program);
         let mut qualifiers = TypeQualifiers::empty();
 
         let mut all_unbound = true;
@@ -1039,8 +1103,12 @@ impl<'db> IntersectionType<'db> {
     /// Return a version of this intersection type where any type variables in the positive elements
     /// have been replaced by their bounds or constraints, and where any newtypes in the positive elements
     /// have been replaced by their concrete base types.
-    pub(crate) fn with_expanded_typevars_and_newtypes(self, db: &'db dyn Db) -> Type<'db> {
-        expand_intersection_typevars_and_newtypes(db, self.positive(db), self.negative(db))
+    pub(crate) fn with_expanded_typevars_and_newtypes(
+        self,
+        db: &'db dyn Db,
+        program: Program,
+    ) -> Type<'db> {
+        expand_intersection_typevars_and_newtypes(db, program, self.positive(db), self.negative(db))
     }
 
     pub fn iter_positive(self, db: &'db dyn Db) -> impl Iterator<Item = Type<'db>> {
@@ -1062,10 +1130,11 @@ impl<'db> IntersectionType<'db> {
 
 fn expand_intersection_typevars_and_newtypes<'db>(
     db: &'db dyn Db,
+    program: Program,
     positive: &FxOrderSet<Type<'db>>,
     negative: &NegativeIntersectionElements<'db>,
 ) -> Type<'db> {
-    let mut builder = IntersectionBuilder::new(db);
+    let mut builder = IntersectionBuilder::new(db, program);
     for &element in positive {
         match element {
             Type::TypeVar(tvar) => {
@@ -1074,7 +1143,7 @@ fn expand_intersection_typevars_and_newtypes<'db>(
                         builder = builder.add_positive(bound);
                     }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        builder = builder.add_positive(constraints.as_type(db));
+                        builder = builder.add_positive(constraints.as_type(db, program));
                     }
                     // Type variables without bounds or constraints implicitly have `object`
                     // as their upper bound, and adding `object` to an intersection is always a no-op

--- a/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
+++ b/crates/ty_python_semantic/src/types/set_theoretic/builder.rs
@@ -44,7 +44,7 @@ use crate::types::{
     KnownInstanceType, LiteralValueType, LiteralValueTypeKind, NegativeIntersectionElements,
     StringLiteralType, SubclassOfType, Type, TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
 };
-use crate::{Db, FxOrderMap, FxOrderSet};
+use crate::{Db, FxOrderMap, FxOrderSet, Program};
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 
@@ -59,13 +59,14 @@ use smallvec::SmallVec;
 /// This only recognizes the "single truthiness guard" forms used by truthiness narrowing.
 fn split_truthiness_guarded_intersection<'db>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
 ) -> Option<(Type<'db>, Type<'db>)> {
     let Type::Intersection(intersection) = ty else {
         return None;
     };
-    let falsy = Type::AlwaysTruthy.negate(db);
-    let truthy = Type::AlwaysFalsy.negate(db);
+    let falsy = Type::AlwaysTruthy.negate(db, program);
+    let truthy = Type::AlwaysFalsy.negate(db, program);
 
     let has_not_truthy = intersection.negative(db).contains(&Type::AlwaysTruthy);
     let has_not_falsy = intersection.negative(db).contains(&Type::AlwaysFalsy);
@@ -75,7 +76,7 @@ fn split_truthiness_guarded_intersection<'db>(
         _ => return None,
     };
 
-    let mut core = IntersectionBuilder::new(db);
+    let mut core = IntersectionBuilder::new(db, program);
     for positive in intersection.positive(db) {
         core = core.add_positive(*positive);
     }
@@ -95,11 +96,12 @@ fn split_truthiness_guarded_intersection<'db>(
 /// `list[Any]` is an invariant-dynamic generalization of `list[int]`.
 fn is_invariant_dynamic_generalization_of<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     general: Type<'db>,
     specific: Type<'db>,
 ) -> bool {
     // Fast path to avoid performance regressions.
-    if !general.has_dynamic(db) {
+    if !general.has_dynamic(db, program) {
         return false;
     }
 
@@ -111,8 +113,8 @@ fn is_invariant_dynamic_generalization_of<'db>(
         Some((general_class, general_specialization)),
         Some((specific_class, specific_specialization)),
     ) = (
-        general.class_specialization(db),
-        specific.class_specialization(db),
+        general.class_specialization(db, program),
+        specific.class_specialization(db, program),
     )
     else {
         return false;
@@ -137,7 +139,7 @@ fn is_invariant_dynamic_generalization_of<'db>(
             continue;
         }
         if general_type.is_non_divergent_dynamic()
-            && typevar.variance(db) == TypeVarVariance::Invariant
+            && typevar.variance(db, program) == TypeVarVariance::Invariant
         {
             has_dynamic_replacement = true;
             continue;
@@ -163,22 +165,25 @@ fn is_invariant_dynamic_generalization_of<'db>(
 /// Discussion: <https://github.com/astral-sh/ty/issues/224>
 fn merge_truthiness_guarded_pair<'db>(
     db: &'db dyn Db,
+    program: Program,
     left: Type<'db>,
     right: Type<'db>,
 ) -> Option<Type<'db>> {
-    let (left_core, left_guard) = split_truthiness_guarded_intersection(db, left)?;
-    let (right_core, right_guard) = split_truthiness_guarded_intersection(db, right)?;
+    let (left_core, left_guard) = split_truthiness_guarded_intersection(db, program, left)?;
+    let (right_core, right_guard) = split_truthiness_guarded_intersection(db, program, right)?;
     if left_guard == right_guard {
         return None;
     }
 
-    if left_core.is_equivalent_to(db, right_core) {
+    if left_core.is_equivalent_to(db, program, right_core) {
         return Some(left_core);
     }
 
-    let candidate = UnionType::from_elements(db, [left_core, right_core]);
-    let left_reconstructed = IntersectionType::from_two_elements(db, candidate, left_guard);
-    let right_reconstructed = IntersectionType::from_two_elements(db, candidate, right_guard);
+    let candidate = UnionType::from_elements(db, program, [left_core, right_core]);
+    let left_reconstructed =
+        IntersectionType::from_two_elements(db, program, candidate, left_guard);
+    let right_reconstructed =
+        IntersectionType::from_two_elements(db, program, candidate, right_guard);
     if left_reconstructed == left && right_reconstructed == right {
         Some(candidate)
     } else {
@@ -191,11 +196,15 @@ fn merge_truthiness_guarded_pair<'db>(
 ///
 /// Hashability does not obey normal inheritance rules: subclasses of hashable classes can be
 /// unhashable. Keeping the non-final type allows downstream checks to consider it independently.
-fn should_preserve_hashable_union(db: &dyn Db, left: Type, right: Type) -> bool {
+fn should_preserve_hashable_union(
+    db: &dyn Db,
+    program: crate::Program,
+    left: Type,
+    right: Type,
+) -> bool {
     let is_hashable =
-        |ty| matches!(ty, Type::ProtocolInstance(protocol) if protocol.is_hashable(db));
-    let is_non_final_nominal_instance =
-        |ty| matches!(ty, Type::NominalInstance(instance) if !instance.class(db).is_final(db));
+        |ty| matches!(ty, Type::ProtocolInstance(protocol) if protocol.is_hashable(db, program));
+    let is_non_final_nominal_instance = |ty| matches!(ty, Type::NominalInstance(instance) if !instance.class(db, program).is_final(db));
 
     (is_hashable(left) && is_non_final_nominal_instance(right))
         || (is_hashable(right) && is_non_final_nominal_instance(left))
@@ -216,7 +225,11 @@ fn should_preserve_hashable_union(db: &dyn Db, left: Type, right: Type) -> bool 
 ///
 /// # (Color excluding RED) | Literal[Color.RED] simplifies to Color.
 /// ```
-fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'db>>) -> bool {
+fn normalize_enum_complement_unions<'db>(
+    db: &'db dyn Db,
+    program: Program,
+    types: &mut Vec<Type<'db>>,
+) -> bool {
     for complement_index in 0..types.len() {
         let Type::EnumComplement(complement) = types[complement_index] else {
             continue;
@@ -263,8 +276,8 @@ fn normalize_enum_complement_unions<'db>(db: &'db dyn Db, types: &mut Vec<Type<'
         }
 
         if !remove_indices.is_empty() {
-            let mut builder =
-                IntersectionBuilder::new(db).add_positive(enum_class.to_non_generic_instance(db));
+            let mut builder = IntersectionBuilder::new(db, program)
+                .add_positive(enum_class.to_non_generic_instance(db));
             for rest in complement.rest(db) {
                 builder = builder.add_positive(*rest);
             }
@@ -377,6 +390,7 @@ impl<'db> UnionElement<'db> {
     fn try_reduce(
         &mut self,
         db: &'db dyn Db,
+        program: Program,
         other_type: Type<'db>,
         cycle_recovery: bool,
     ) -> ReduceResult<'db> {
@@ -386,18 +400,18 @@ impl<'db> UnionElement<'db> {
             return match self {
                 UnionElement::Type(existing) => ReduceResult::Type(*existing),
                 UnionElement::IntLiterals(_) => {
-                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Int))
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, program, KnownClass::Int))
                 }
                 UnionElement::StringLiterals(_) => {
-                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Str))
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, program, KnownClass::Str))
                 }
                 UnionElement::BytesLiterals(_) => {
-                    ReduceResult::KeepIf(!other_type.is_instance_of(db, KnownClass::Bytes))
+                    ReduceResult::KeepIf(!other_type.is_instance_of(db, program, KnownClass::Bytes))
                 }
                 UnionElement::EnumLiterals { enum_class, .. } => ReduceResult::KeepIf(
                     other_type
                         .as_nominal_instance()
-                        .is_none_or(|instance| instance.class_literal(db) != *enum_class),
+                        .is_none_or(|instance| instance.class_literal(db, program) != *enum_class),
                 ),
             };
         }
@@ -426,17 +440,22 @@ impl<'db> UnionElement<'db> {
         // both `ignore` and `collapse` are `false`. If either is `true`,
         // we skip the expensive redundancy check and return `true`.
         let mut should_retain_type = |ty| {
-            if ignore || other_type.is_redundant_with(db, ty) {
+            if ignore || other_type.is_redundant_with(db, program, ty) {
                 ignore = true;
                 return true;
             }
             if collapse
-                || other_type.negation_is_subtype_of_cached(db, ty, &mut other_type_negated_cache)
+                || other_type.negation_is_subtype_of_cached(
+                    db,
+                    program,
+                    ty,
+                    &mut other_type_negated_cache,
+                )
             {
                 collapse = true;
                 return true;
             }
-            !ty.is_redundant_with(db, other_type)
+            !ty.is_redundant_with(db, program, other_type)
         };
 
         let should_keep = match self {
@@ -449,7 +468,7 @@ impl<'db> UnionElement<'db> {
                 } else {
                     let (literal, promotable) = literals.first().unwrap();
                     !Type::from(LiteralValueType::new(*literal, *promotable))
-                        .is_redundant_with(db, other_type)
+                        .is_redundant_with(db, program, other_type)
                 }
             }
             UnionElement::StringLiterals(literals) => {
@@ -461,7 +480,7 @@ impl<'db> UnionElement<'db> {
                 } else {
                     let (literal, promotable) = literals.first().unwrap();
                     !Type::from(LiteralValueType::new(*literal, *promotable))
-                        .is_redundant_with(db, other_type)
+                        .is_redundant_with(db, program, other_type)
                 }
             }
             UnionElement::BytesLiterals(literals) => {
@@ -473,7 +492,7 @@ impl<'db> UnionElement<'db> {
                 } else {
                     let (literal, promotable) = literals.first().unwrap();
                     !Type::from(LiteralValueType::new(*literal, *promotable))
-                        .is_redundant_with(db, other_type)
+                        .is_redundant_with(db, program, other_type)
                 }
             }
             UnionElement::EnumLiterals {
@@ -491,7 +510,7 @@ impl<'db> UnionElement<'db> {
                 } else {
                     let (literal, promotable) = literals.first().unwrap();
                     !Type::from(LiteralValueType::new(*literal, *promotable))
-                        .is_redundant_with(db, other_type)
+                        .is_redundant_with(db, program, other_type)
                 }
             }
             UnionElement::Type(existing) => return ReduceResult::Type(*existing),
@@ -532,6 +551,7 @@ const MAX_NON_RECURSIVE_UNION_LITERALS: usize = 8192;
 pub(crate) struct UnionBuilder<'db> {
     elements: Vec<UnionElement<'db>>,
     db: &'db dyn Db,
+    program: Program,
     unpack_aliases: bool,
     /// This is enabled when joining types in a `cycle_recovery` function. Because recovery cannot
     /// introduce a new cycle, relation-based union simplifications are skipped in this mode.
@@ -554,13 +574,13 @@ impl<'db> UnionAccumulator<'db> {
         UnionAccumulator::One(ty)
     }
 
-    pub(crate) fn add(&mut self, db: &'db dyn Db, ty: Type<'db>) {
+    pub(crate) fn add(&mut self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
         match self {
             UnionAccumulator::One(existing) => {
                 *self = UnionAccumulator::Two(*existing, ty);
             }
             UnionAccumulator::Two(first, second) => {
-                let mut builder = UnionBuilder::new(db);
+                let mut builder = UnionBuilder::new(db, program);
                 builder.add_in_place(*first);
                 builder.add_in_place(*second);
                 builder.add_in_place(ty);
@@ -570,35 +590,39 @@ impl<'db> UnionAccumulator<'db> {
         }
     }
 
-    pub(crate) fn get_or_build(&mut self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn get_or_build(&mut self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             UnionAccumulator::One(ty) => *ty,
             UnionAccumulator::Two(first, second) => {
-                let ty = UnionType::from_two_elements(db, *first, *second);
+                let ty = UnionType::from_two_elements(db, program, *first, *second);
                 *self = UnionAccumulator::One(ty);
                 ty
             }
             UnionAccumulator::Deferred(_) => {
-                let ty = std::mem::replace(self, UnionAccumulator::new(Type::Never)).into_type(db);
+                let ty = std::mem::replace(self, UnionAccumulator::new(Type::Never))
+                    .into_type(db, program);
                 *self = UnionAccumulator::new(ty);
                 ty
             }
         }
     }
 
-    pub(crate) fn into_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn into_type(self, db: &'db dyn Db, program: Program) -> Type<'db> {
         match self {
             UnionAccumulator::One(ty) => ty,
-            UnionAccumulator::Two(first, second) => UnionType::from_two_elements(db, first, second),
+            UnionAccumulator::Two(first, second) => {
+                UnionType::from_two_elements(db, program, first, second)
+            }
             UnionAccumulator::Deferred(builder) => builder.build(),
         }
     }
 }
 
 impl<'db> UnionBuilder<'db> {
-    pub(crate) fn new(db: &'db dyn Db) -> Self {
+    pub(crate) fn new(db: &'db dyn Db, program: Program) -> Self {
         Self {
             db,
+            program,
             elements: vec![],
             unpack_aliases: true,
             cycle_recovery: false,
@@ -628,6 +652,10 @@ impl<'db> UnionBuilder<'db> {
         self.elements.is_empty()
     }
 
+    pub(crate) fn program(&self) -> Program {
+        self.program
+    }
+
     /// Collapse the union to a single type: `object`.
     fn collapse_to_object(&mut self) {
         self.elements.clear();
@@ -639,13 +667,13 @@ impl<'db> UnionBuilder<'db> {
         for elem in &self.elements {
             match elem {
                 UnionElement::IntLiterals(_) => {
-                    replace_with.push(KnownClass::Int.to_instance(self.db));
+                    replace_with.push(KnownClass::Int.to_instance(self.db, self.program));
                 }
                 UnionElement::StringLiterals(_) => {
-                    replace_with.push(KnownClass::Str.to_instance(self.db));
+                    replace_with.push(KnownClass::Str.to_instance(self.db, self.program));
                 }
                 UnionElement::BytesLiterals(_) => {
-                    replace_with.push(KnownClass::Bytes.to_instance(self.db));
+                    replace_with.push(KnownClass::Bytes.to_instance(self.db, self.program));
                 }
                 UnionElement::EnumLiterals { literals, .. } => {
                     let (enum_literal, _) = literals.first().unwrap();
@@ -681,7 +709,8 @@ impl<'db> UnionBuilder<'db> {
         };
 
         let mut ty_negated_cache = None;
-        let mut ty_negated = || *ty_negated_cache.get_or_insert_with(|| ty.negate(self.db));
+        let mut ty_negated =
+            || *ty_negated_cache.get_or_insert_with(|| ty.negate(self.db, self.program));
 
         match ty {
             Type::Union(union) => {
@@ -732,7 +761,8 @@ impl<'db> UnionBuilder<'db> {
                             match element {
                                 UnionElement::StringLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
-                                        let replace_with = KnownClass::Str.to_instance(self.db);
+                                        let replace_with =
+                                            KnownClass::Str.to_instance(self.db, self.program);
                                         self.add_in_place_impl(replace_with, seen_aliases);
                                         return;
                                     }
@@ -741,21 +771,23 @@ impl<'db> UnionBuilder<'db> {
                                 }
                                 UnionElement::Type(existing)
                                     if cycle_recovery
-                                        && literal.fallback_instance(self.db) == *existing =>
+                                        && literal.fallback_instance(self.db, self.program)
+                                            == *existing =>
                                 {
                                     return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
                                     // e.g. `existing` could be `Literal[""] & Any`,
                                     // and `ty` could be `Literal[""]`
-                                    if ty.is_redundant_with(self.db, *existing) {
+                                    if ty.is_redundant_with(self.db, self.program, *existing) {
                                         return;
                                     }
-                                    if existing.is_redundant_with(self.db, ty) {
+                                    if existing.is_redundant_with(self.db, self.program, ty) {
                                         to_remove = Some(index);
                                         continue;
                                     }
-                                    if ty_negated().is_subtype_of(self.db, *existing) {
+                                    if ty_negated().is_subtype_of(self.db, self.program, *existing)
+                                    {
                                         // The type that includes both this new element, and its negation
                                         // (or a supertype of its negation), must be simply `object`.
                                         self.collapse_to_object();
@@ -785,7 +817,8 @@ impl<'db> UnionBuilder<'db> {
                             match element {
                                 UnionElement::BytesLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
-                                        let replace_with = KnownClass::Bytes.to_instance(self.db);
+                                        let replace_with =
+                                            KnownClass::Bytes.to_instance(self.db, self.program);
                                         self.add_in_place_impl(replace_with, seen_aliases);
                                         return;
                                     }
@@ -794,21 +827,23 @@ impl<'db> UnionBuilder<'db> {
                                 }
                                 UnionElement::Type(existing)
                                     if cycle_recovery
-                                        && literal.fallback_instance(self.db) == *existing =>
+                                        && literal.fallback_instance(self.db, self.program)
+                                            == *existing =>
                                 {
                                     return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
-                                    if ty.is_redundant_with(self.db, *existing) {
+                                    if ty.is_redundant_with(self.db, self.program, *existing) {
                                         return;
                                     }
                                     // e.g. `existing` could be `Literal[b""] & Any`,
                                     // and `ty` could be `Literal[b""]`
-                                    if existing.is_redundant_with(self.db, ty) {
+                                    if existing.is_redundant_with(self.db, self.program, ty) {
                                         to_remove = Some(index);
                                         continue;
                                     }
-                                    if ty_negated().is_subtype_of(self.db, *existing) {
+                                    if ty_negated().is_subtype_of(self.db, self.program, *existing)
+                                    {
                                         // The type that includes both this new element, and its negation
                                         // (or a supertype of its negation), must be simply `object`.
                                         self.collapse_to_object();
@@ -840,7 +875,8 @@ impl<'db> UnionBuilder<'db> {
                             match element {
                                 UnionElement::IntLiterals(literals) => {
                                     if should_widen(literals.len(), self.recursively_defined) {
-                                        let replace_with = KnownClass::Int.to_instance(self.db);
+                                        let replace_with =
+                                            KnownClass::Int.to_instance(self.db, self.program);
                                         self.add_in_place_impl(replace_with, seen_aliases);
                                         return;
                                     }
@@ -849,21 +885,23 @@ impl<'db> UnionBuilder<'db> {
                                 }
                                 UnionElement::Type(existing)
                                     if cycle_recovery
-                                        && literal.fallback_instance(self.db) == *existing =>
+                                        && literal.fallback_instance(self.db, self.program)
+                                            == *existing =>
                                 {
                                     return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
-                                    if ty.is_redundant_with(self.db, *existing) {
+                                    if ty.is_redundant_with(self.db, self.program, *existing) {
                                         return;
                                     }
                                     // e.g. `existing` could be `Literal[1] & Any`,
                                     // and `ty` could be `Literal[1]`
-                                    if existing.is_redundant_with(self.db, ty) {
+                                    if existing.is_redundant_with(self.db, self.program, ty) {
                                         to_remove = Some(index);
                                         continue;
                                     }
-                                    if ty_negated().is_subtype_of(self.db, *existing) {
+                                    if ty_negated().is_subtype_of(self.db, self.program, *existing)
+                                    {
                                         // The type that includes both this new element, and its negation
                                         // (or a supertype of its negation), must be simply `object`.
                                         self.collapse_to_object();
@@ -925,21 +963,23 @@ impl<'db> UnionBuilder<'db> {
                                 }
                                 UnionElement::Type(existing)
                                     if cycle_recovery
-                                        && literal.fallback_instance(self.db) == *existing =>
+                                        && literal.fallback_instance(self.db, self.program)
+                                            == *existing =>
                                 {
                                     return;
                                 }
                                 UnionElement::Type(existing) if !cycle_recovery => {
-                                    if ty.is_redundant_with(self.db, *existing) {
+                                    if ty.is_redundant_with(self.db, self.program, *existing) {
                                         return;
                                     }
                                     // e.g. `existing` could be `Literal[Foo.X] & Any`,
                                     // and `ty` could be `Literal[Foo.X]`
-                                    if existing.is_redundant_with(self.db, ty) {
+                                    if existing.is_redundant_with(self.db, self.program, ty) {
                                         to_remove = Some(index);
                                         continue;
                                     }
-                                    if ty_negated().is_subtype_of(self.db, *existing) {
+                                    if ty_negated().is_subtype_of(self.db, self.program, *existing)
+                                    {
                                         // The type that includes both this new element, and its negation
                                         // (or a supertype of its negation), must be simply `object`.
                                         self.collapse_to_object();
@@ -1007,22 +1047,23 @@ impl<'db> UnionBuilder<'db> {
         let mut to_remove = SmallVec::<[usize; 2]>::new();
 
         for (i, element) in self.elements.iter_mut().enumerate() {
-            let element_type = match element.try_reduce(self.db, ty, self.cycle_recovery) {
-                ReduceResult::KeepIf(keep) => {
-                    if !keep {
-                        to_remove.push(i);
+            let element_type =
+                match element.try_reduce(self.db, self.program, ty, self.cycle_recovery) {
+                    ReduceResult::KeepIf(keep) => {
+                        if !keep {
+                            to_remove.push(i);
+                        }
+                        continue;
                     }
-                    continue;
-                }
-                ReduceResult::Type(ty) => ty,
-                ReduceResult::CollapseToObject => {
-                    self.collapse_to_object();
-                    return;
-                }
-                ReduceResult::Ignore => {
-                    return;
-                }
-            };
+                    ReduceResult::Type(ty) => ty,
+                    ReduceResult::CollapseToObject => {
+                        self.collapse_to_object();
+                        return;
+                    }
+                    ReduceResult::Ignore => {
+                        return;
+                    }
+                };
 
             if ty == element_type {
                 return;
@@ -1033,7 +1074,9 @@ impl<'db> UnionBuilder<'db> {
                 return;
             }
 
-            if !self.cycle_recovery && should_preserve_hashable_union(self.db, ty, element_type) {
+            if !self.cycle_recovery
+                && should_preserve_hashable_union(self.db, self.program, ty, element_type)
+            {
                 continue;
             }
 
@@ -1048,13 +1091,14 @@ impl<'db> UnionBuilder<'db> {
                 && left != right
             {
                 to_remove.push(i);
-                ty = KnownClass::Range.to_instance(self.db);
+                ty = KnownClass::Range.to_instance(self.db, self.program);
                 continue;
             }
 
             // Fold `(T & ~AlwaysTruthy) | (T & ~AlwaysFalsy)` to `T`.
             if !self.cycle_recovery
-                && let Some(merged_type) = merge_truthiness_guarded_pair(self.db, ty, element_type)
+                && let Some(merged_type) =
+                    merge_truthiness_guarded_pair(self.db, self.program, ty, element_type)
             {
                 to_remove.push(i);
                 ty = merged_type;
@@ -1067,7 +1111,10 @@ impl<'db> UnionBuilder<'db> {
                     .zip(bool_pair(ty))
                     .is_some_and(|(element, pair)| element == pair)
             {
-                self.add_in_place_impl(KnownClass::Bool.to_instance(self.db), seen_aliases);
+                self.add_in_place_impl(
+                    KnownClass::Bool.to_instance(self.db, self.program),
+                    seen_aliases,
+                );
                 return;
             }
 
@@ -1080,16 +1127,21 @@ impl<'db> UnionBuilder<'db> {
             }
 
             if should_simplify_full && !matches!(element_type, Type::TypeAlias(_)) {
-                if ty.is_redundant_with(self.db, element_type) {
+                if ty.is_redundant_with(self.db, self.program, element_type) {
                     return;
                 }
 
-                if element_type.is_redundant_with(self.db, ty) {
+                if element_type.is_redundant_with(self.db, self.program, ty) {
                     to_remove.push(i);
                     continue;
                 }
 
-                if ty.negation_is_subtype_of_cached(self.db, element_type, &mut ty_negated) {
+                if ty.negation_is_subtype_of_cached(
+                    self.db,
+                    self.program,
+                    element_type,
+                    &mut ty_negated,
+                ) {
                     // We add `ty` to the union. We just checked that `~ty` is a subtype of an
                     // existing `element`. This also means that `~ty | ty` is a subtype of
                     // `element | ty`, because both elements in the first union are subtypes of
@@ -1123,6 +1175,7 @@ impl<'db> UnionBuilder<'db> {
 
     pub(crate) fn try_build(self) -> Option<Type<'db>> {
         let db = self.db;
+        let program = self.program;
         let unpack_aliases = self.unpack_aliases;
         let cycle_recovery = self.cycle_recovery;
         let recursively_defined = self.recursively_defined;
@@ -1167,8 +1220,8 @@ impl<'db> UnionBuilder<'db> {
             }
         }
 
-        if normalize_enum_complement_unions(db, &mut types) {
-            let builder = UnionBuilder::new(db)
+        if normalize_enum_complement_unions(db, program, &mut types) {
+            let builder = UnionBuilder::new(db, program)
                 .unpack_aliases(unpack_aliases)
                 .cycle_recovery(cycle_recovery)
                 .recursively_defined(recursively_defined);
@@ -1199,19 +1252,22 @@ pub(crate) struct IntersectionBuilder<'db> {
     // create a union of intersections.
     intersections: Vec<InnerIntersectionBuilder<'db>>,
     db: &'db dyn Db,
+    program: Program,
 }
 
 impl<'db> IntersectionBuilder<'db> {
-    pub(crate) fn new(db: &'db dyn Db) -> Self {
+    pub(crate) fn new(db: &'db dyn Db, program: Program) -> Self {
         Self {
             db,
+            program,
             intersections: vec![InnerIntersectionBuilder::default()],
         }
     }
 
-    fn empty(db: &'db dyn Db) -> Self {
+    fn empty(db: &'db dyn Db, program: Program) -> Self {
         Self {
             db,
+            program,
             intersections: vec![],
         }
     }
@@ -1262,10 +1318,13 @@ impl<'db> IntersectionBuilder<'db> {
                     .elements(self.db)
                     .iter()
                     .map(|elem| self.clone().add_positive_impl(*elem, seen_aliases))
-                    .fold(IntersectionBuilder::empty(self.db), |mut builder, sub| {
-                        builder.extend(sub);
-                        builder
-                    })
+                    .fold(
+                        IntersectionBuilder::empty(self.db, self.program),
+                        |mut builder, sub| {
+                            builder.extend(sub);
+                            builder
+                        },
+                    )
             }
             // `(A & B & ~C) & (D & E & ~F)` -> `A & B & D & E & ~C & ~F`
             Type::Intersection(other) => {
@@ -1286,7 +1345,7 @@ impl<'db> IntersectionBuilder<'db> {
                 // If we are already a union-of-intersections, distribute the new intersected element
                 // across all of those intersections.
                 for inner in &mut self.intersections {
-                    inner.add_positive(self.db, ty);
+                    inner.add_positive(self.db, self.program, ty);
                 }
                 self
             }
@@ -1349,7 +1408,7 @@ impl<'db> IntersectionBuilder<'db> {
                     });
 
                 positive_side.chain(negative_side).fold(
-                    IntersectionBuilder::empty(self.db),
+                    IntersectionBuilder::empty(self.db, self.program),
                     |mut builder, sub| {
                         builder.extend(sub);
                         builder
@@ -1362,7 +1421,7 @@ impl<'db> IntersectionBuilder<'db> {
             }
             _ => {
                 for inner in &mut self.intersections {
-                    inner.add_negative(self.db, ty);
+                    inner.add_negative(self.db, self.program, ty);
                 }
                 self
             }
@@ -1383,9 +1442,10 @@ impl<'db> IntersectionBuilder<'db> {
     pub(crate) fn build(self) -> Type<'db> {
         UnionType::from_elements(
             self.db,
+            self.program,
             self.intersections
                 .into_iter()
-                .map(|inner| inner.build(self.db)),
+                .map(|inner| inner.build(self.db, self.program)),
         )
     }
 }
@@ -1417,13 +1477,14 @@ impl<'db> InnerIntersectionBuilder<'db> {
     ///     if color is not Color.RED and color is not Color.BLUE:
     ///         reveal_type(color)  # Never
     /// ```
-    fn has_empty_enum_complement(&self, db: &'db dyn Db) -> bool {
+    fn has_empty_enum_complement(&self, db: &'db dyn Db, program: Program) -> bool {
         for positive in &self.positive {
             let Type::NominalInstance(instance) = positive else {
                 continue;
             };
 
-            let Some(enum_class_literal) = instance.class_literal(db).into_enum_class(db) else {
+            let Some(enum_class_literal) = instance.class_literal(db, program).into_enum_class(db)
+            else {
                 continue;
             };
             if !enum_class_literal.members_are_exhaustive(db) {
@@ -1462,7 +1523,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
     }
 
     /// Adds a positive type to this intersection.
-    fn add_positive(&mut self, db: &'db dyn Db, mut new_positive: Type<'db>) {
+    fn add_positive(&mut self, db: &'db dyn Db, program: Program, mut new_positive: Type<'db>) {
         // `Never & T` -> `Never`
         if self.positive.contains(&Type::Never) {
             return;
@@ -1494,8 +1555,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
             Type::TypeForm(typeform) => {
                 if let Some(narrowed) = SubclassOfType::try_from_instance(
                     db,
+                    program,
                     typeform.type_argument(db).resolve_type_alias(db),
-                ) && self.positive.swap_remove(&KnownClass::Type.to_instance(db))
+                ) && self
+                    .positive
+                    .swap_remove(&KnownClass::Type.to_instance(db, program))
                 {
                     new_positive = narrowed;
                 }
@@ -1508,6 +1572,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         .find_map(|(index, positive)| match positive {
                             Type::TypeForm(typeform) => SubclassOfType::try_from_instance(
                                 db,
+                                program,
                                 typeform.type_argument(db).resolve_type_alias(db),
                             )
                             .map(|narrowed| (index, narrowed)),
@@ -1524,39 +1589,39 @@ impl<'db> InnerIntersectionBuilder<'db> {
         match new_positive {
             // `LiteralString & AlwaysTruthy` -> `LiteralString & ~Literal[""]`
             Type::AlwaysTruthy if self.positive.contains(&Type::literal_string()) => {
-                self.add_negative(db, Type::string_literal(db, ""));
+                self.add_negative(db, program, Type::string_literal(db, ""));
             }
             // `LiteralString & AlwaysFalsy` -> `Literal[""]`
             Type::AlwaysFalsy if self.positive.swap_remove(&Type::literal_string()) => {
-                self.add_positive(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::string_literal(db, ""));
             }
             // `AlwaysTruthy & LiteralString` -> `LiteralString & ~Literal[""]`
             Type::LiteralValue(literal)
                 if literal.is_literal_string()
                     && self.positive.swap_remove(&Type::AlwaysTruthy) =>
             {
-                self.add_positive(db, Type::literal_string());
-                self.add_negative(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::literal_string());
+                self.add_negative(db, program, Type::string_literal(db, ""));
             }
             // `AlwaysFalsy & LiteralString` -> `Literal[""]`
             Type::LiteralValue(literal)
                 if literal.is_literal_string() && self.positive.swap_remove(&Type::AlwaysFalsy) =>
             {
-                self.add_positive(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysTruthy` -> `LiteralString & AlwaysFalsy` -> `Literal[""]`
             Type::LiteralValue(literal)
                 if literal.is_literal_string()
                     && self.negative.swap_remove(&Type::AlwaysTruthy) =>
             {
-                self.add_positive(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::string_literal(db, ""));
             }
             // `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
             Type::LiteralValue(literal)
                 if literal.is_literal_string() && self.negative.swap_remove(&Type::AlwaysFalsy) =>
             {
-                self.add_positive(db, Type::literal_string());
-                self.add_negative(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::literal_string());
+                self.add_negative(db, program, Type::string_literal(db, ""));
             }
 
             _ => {
@@ -1632,9 +1697,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_positive) in self.positive.iter().enumerate() {
                     // S & T = S if S <: T or T is an invariant-dynamic generalization of S.
-                    if existing_positive.is_redundant_with(db, new_positive)
+                    if existing_positive.is_redundant_with(db, program, new_positive)
                         || is_invariant_dynamic_generalization_of(
                             db,
+                            program,
                             new_positive,
                             *existing_positive,
                         )
@@ -1642,9 +1708,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         return;
                     }
                     // same rule, reverse order
-                    if new_positive.is_redundant_with(db, *existing_positive)
+                    if new_positive.is_redundant_with(db, program, *existing_positive)
                         || is_invariant_dynamic_generalization_of(
                             db,
+                            program,
                             *existing_positive,
                             new_positive,
                         )
@@ -1652,7 +1719,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         to_remove.push(index);
                     }
                     // A & B = Never    if A and B are disjoint
-                    if new_positive.is_disjoint_from(db, *existing_positive) {
+                    if new_positive.is_disjoint_from(db, program, *existing_positive) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
@@ -1665,13 +1732,13 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let mut to_remove = SmallVec::<[usize; 1]>::new();
                 for (index, existing_negative) in self.negative.iter().enumerate() {
                     // S & ~T = Never    if S <: T
-                    if new_positive.is_subtype_of(db, *existing_negative) {
+                    if new_positive.is_subtype_of(db, program, *existing_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
                     }
                     // A & ~B = A    if A and B are disjoint
-                    if existing_negative.is_disjoint_from(db, new_positive) {
+                    if existing_negative.is_disjoint_from(db, program, new_positive) {
                         to_remove.push(index);
                     }
                 }
@@ -1685,7 +1752,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
     }
 
     /// Adds a negative type to this intersection.
-    fn add_negative(&mut self, db: &'db dyn Db, new_negative: Type<'db>) {
+    fn add_negative(&mut self, db: &'db dyn Db, program: Program, new_negative: Type<'db>) {
         // `Never & ~T` -> `Never`.
         if self.positive.contains(&Type::Never) {
             return;
@@ -1714,10 +1781,10 @@ impl<'db> InnerIntersectionBuilder<'db> {
         match new_negative {
             Type::Intersection(inter) => {
                 for pos in inter.positive(db) {
-                    self.add_negative(db, *pos);
+                    self.add_negative(db, program, *pos);
                 }
                 for neg in inter.negative(db) {
-                    self.add_positive(db, *neg);
+                    self.add_positive(db, program, *neg);
                 }
             }
             Type::Never => {
@@ -1732,31 +1799,31 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 // Adding any of these types to the negative side of an intersection
                 // is equivalent to adding it to the positive side. We do this to
                 // simplify the representation.
-                self.add_positive(db, ty);
+                self.add_positive(db, program, ty);
             }
             // `bool & ~AlwaysTruthy` -> `bool & Literal[False]`
             Type::AlwaysTruthy if contains_bool() => {
-                self.add_positive(db, Type::bool_literal(false));
+                self.add_positive(db, program, Type::bool_literal(false));
             }
             // `bool & ~Literal[True]` -> `bool & Literal[False]`
             Type::LiteralValue(literal) if literal.as_bool() == Some(true) && contains_bool() => {
-                self.add_positive(db, Type::bool_literal(false));
+                self.add_positive(db, program, Type::bool_literal(false));
             }
             // `LiteralString & ~AlwaysTruthy` -> `LiteralString & Literal[""]`
             Type::AlwaysTruthy if self.positive.contains(&Type::literal_string()) => {
-                self.add_positive(db, Type::string_literal(db, ""));
+                self.add_positive(db, program, Type::string_literal(db, ""));
             }
             // `bool & ~AlwaysFalsy` -> `bool & Literal[True]`
             Type::AlwaysFalsy if contains_bool() => {
-                self.add_positive(db, Type::bool_literal(true));
+                self.add_positive(db, program, Type::bool_literal(true));
             }
             // `bool & ~Literal[False]` -> `bool & Literal[True]`
             Type::LiteralValue(literal) if literal.as_bool() == Some(false) && contains_bool() => {
-                self.add_positive(db, Type::bool_literal(true));
+                self.add_positive(db, program, Type::bool_literal(true));
             }
             // `LiteralString & ~AlwaysFalsy` -> `LiteralString & ~Literal[""]`
             Type::AlwaysFalsy if self.positive.contains(&Type::literal_string()) => {
-                self.add_negative(db, Type::string_literal(db, ""));
+                self.add_negative(db, program, Type::string_literal(db, ""));
             }
             _ => {
                 let new_negative_enum = new_negative.as_enum_literal();
@@ -1776,11 +1843,11 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     }
 
                     // ~S & ~T = ~T    if S <: T
-                    if existing_negative.is_redundant_with(db, new_negative) {
+                    if existing_negative.is_redundant_with(db, program, new_negative) {
                         to_remove.push(index);
                     }
                     // same rule, reverse order
-                    if new_negative.is_subtype_of(db, *existing_negative) {
+                    if new_negative.is_subtype_of(db, program, *existing_negative) {
                         return;
                     }
                 }
@@ -1803,7 +1870,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                         if existing_positive
                             .as_nominal_instance()
                             .is_some_and(|instance| {
-                                instance.class_literal(db) == new_enum.enum_class(db)
+                                instance.class_literal(db, program) == new_enum.enum_class(db)
                             })
                         {
                             continue;
@@ -1811,13 +1878,13 @@ impl<'db> InnerIntersectionBuilder<'db> {
                     }
 
                     // S & ~T = Never    if S <: T
-                    if existing_positive.is_subtype_of(db, new_negative) {
+                    if existing_positive.is_subtype_of(db, program, new_negative) {
                         *self = Self::default();
                         self.positive.insert(Type::Never);
                         return;
                     }
                     // A & ~B = A    if A and B are disjoint
-                    if existing_positive.is_disjoint_from(db, new_negative) {
+                    if existing_positive.is_disjoint_from(db, program, new_negative) {
                         return;
                     }
                 }
@@ -1838,7 +1905,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
     ///
     /// - If the intersection contains negative entries for all of the constraints, the overall
     ///   intersection is `Never`.
-    fn simplify_constrained_typevars(&mut self, db: &'db dyn Db) {
+    fn simplify_constrained_typevars(&mut self, db: &'db dyn Db, program: Program) {
         let mut to_add = SmallVec::<[Type<'db>; 1]>::new();
 
         for ty in &self.positive {
@@ -1860,7 +1927,7 @@ impl<'db> InnerIntersectionBuilder<'db> {
                 let matching_constraints = constraints
                     .iter()
                     .enumerate()
-                    .filter(|(_, c)| c.is_subtype_of(db, *negative));
+                    .filter(|(_, c)| c.is_subtype_of(db, program, *negative));
                 for (constraint_index, _) in matching_constraints {
                     remaining_constraints[constraint_index] = None;
                 }
@@ -1888,16 +1955,16 @@ impl<'db> InnerIntersectionBuilder<'db> {
         }
 
         for remaining_constraint in to_add {
-            self.add_positive(db, remaining_constraint);
+            self.add_positive(db, program, remaining_constraint);
         }
     }
 
-    fn build(mut self, db: &'db dyn Db) -> Type<'db> {
-        if self.has_empty_enum_complement(db) {
+    fn build(mut self, db: &'db dyn Db, program: Program) -> Type<'db> {
+        if self.has_empty_enum_complement(db, program) {
             return Type::Never;
         }
 
-        self.simplify_constrained_typevars(db);
+        self.simplify_constrained_typevars(db, program);
 
         // If any typevars are in `self.positive`, speculatively solve all bounded type variables
         // to their upper bound and all constrained type variables to the union of their constraints.
@@ -1908,15 +1975,19 @@ impl<'db> InnerIntersectionBuilder<'db> {
             .iter()
             .any(|ty| matches!(ty, Type::TypeVar(_) | Type::NewTypeInstance(_)))
         {
-            let speculative =
-                expand_intersection_typevars_and_newtypes(db, &self.positive, &self.negative);
+            let speculative = expand_intersection_typevars_and_newtypes(
+                db,
+                program,
+                &self.positive,
+                &self.negative,
+            );
             if speculative.is_never() {
                 return Type::Never;
             }
         }
 
         if let Some(complement) =
-            EnumComplement::from_intersection_parts(db, &self.positive, &self.negative)
+            EnumComplement::from_intersection_parts(db, program, &self.positive, &self.negative)
         {
             return Type::EnumComplement(complement);
         }
@@ -1952,27 +2023,30 @@ mod tests {
     #[test]
     fn build_union_no_elements() {
         let db = setup_db();
+        let program = db.program();
 
-        let empty_union = UnionBuilder::new(&db).build();
+        let empty_union = UnionBuilder::new(&db, program).build();
         assert_eq!(empty_union, Type::Never);
     }
 
     #[test]
     fn build_union_single_element() {
         let db = setup_db();
+        let program = db.program();
 
         let t0 = Type::int_literal(0);
-        let union = UnionType::from_elements(&db, [t0]);
+        let union = UnionType::from_elements(&db, program, [t0]);
         assert_eq!(union, t0);
     }
 
     #[test]
     fn build_union_two_elements() {
         let db = setup_db();
+        let program = db.program();
 
         let t0 = Type::int_literal(0);
         let t1 = Type::int_literal(1);
-        let union = UnionType::from_elements(&db, [t0, t1]).expect_union();
+        let union = UnionType::from_elements(&db, program, [t0, t1]).expect_union();
 
         assert_eq!(union.elements(&db), &[t0, t1]);
     }
@@ -1980,21 +2054,22 @@ mod tests {
     #[test]
     fn cycle_recovery_widens_recursive_literal_union() {
         let db = setup_db();
+        let program = db.program();
         let literal_limit =
             i64::try_from(MAX_RECURSIVE_UNION_LITERALS).expect("literal limit fits in i64");
 
         let union = (0..=literal_limit).map(Type::int_literal).fold(
-            UnionBuilder::new(&db)
+            UnionBuilder::new(&db, program)
                 .cycle_recovery(true)
                 .recursively_defined(RecursivelyDefined::Yes),
             UnionBuilder::add,
         );
 
-        assert_eq!(union.build(), KnownClass::Int.to_instance(&db));
+        assert_eq!(union.build(), KnownClass::Int.to_instance(&db, program));
 
         let assert_widens = |literal, instance| {
             for (first, second) in [(literal, instance), (instance, literal)] {
-                let union = UnionBuilder::new(&db)
+                let union = UnionBuilder::new(&db, program)
                     .cycle_recovery(true)
                     .add(first)
                     .add(second)
@@ -2003,17 +2078,20 @@ mod tests {
             }
         };
 
-        assert_widens(Type::int_literal(1), KnownClass::Int.to_instance(&db));
+        assert_widens(
+            Type::int_literal(1),
+            KnownClass::Int.to_instance(&db, program),
+        );
         assert_widens(
             Type::string_literal(&db, "literal"),
-            KnownClass::Str.to_instance(&db),
+            KnownClass::Str.to_instance(&db, program),
         );
         assert_widens(
             Type::bytes_literal(&db, b"literal"),
-            KnownClass::Bytes.to_instance(&db),
+            KnownClass::Bytes.to_instance(&db, program),
         );
 
-        let safe_uuid_class = known_module_symbol(&db, KnownModule::Uuid, "SafeUUID")
+        let safe_uuid_class = known_module_symbol(&db, program, KnownModule::Uuid, "SafeUUID")
             .place
             .expect_type()
             .expect_class_literal();
@@ -2030,15 +2108,19 @@ mod tests {
     #[test]
     fn cycle_recovery_skips_other_redundancy_simplification() {
         let db = setup_db();
+        let program = db.program();
 
         for (left, right) in [
             (Type::string_literal(&db, "literal"), Type::literal_string()),
-            (Type::bool_literal(true), KnownClass::Bool.to_instance(&db)),
+            (
+                Type::bool_literal(true),
+                KnownClass::Bool.to_instance(&db, program),
+            ),
             (Type::int_literal(1), Type::object()),
             (Type::bool_literal(true), Type::bool_literal(false)),
         ] {
             for (first, second) in [(left, right), (right, left)] {
-                let union = UnionBuilder::new(&db)
+                let union = UnionBuilder::new(&db, program)
                     .cycle_recovery(true)
                     .add(first)
                     .add(second)
@@ -2053,9 +2135,11 @@ mod tests {
     #[test]
     fn union_common_literal_supertype() {
         let db = setup_db();
+        let program = db.program();
 
         let str_union = UnionType::from_elements(
             &db,
+            program,
             [
                 Type::string_literal(&db, "a"),
                 Type::string_literal(&db, "b"),
@@ -2063,21 +2147,25 @@ mod tests {
         )
         .expect_union();
         assert_eq!(
-            str_union.common_literal_supertype(&db),
+            str_union.common_literal_supertype(&db, program),
             Some(Type::literal_string())
         );
 
-        let int_union = UnionType::from_elements(&db, [Type::int_literal(1), Type::int_literal(2)])
-            .expect_union();
+        let int_union =
+            UnionType::from_elements(&db, program, [Type::int_literal(1), Type::int_literal(2)])
+                .expect_union();
         assert_eq!(
-            int_union.common_literal_supertype(&db),
-            Some(KnownClass::Int.to_instance(&db))
+            int_union.common_literal_supertype(&db, program),
+            Some(KnownClass::Int.to_instance(&db, program))
         );
 
-        let mixed_union =
-            UnionType::from_elements(&db, [Type::string_literal(&db, "a"), Type::int_literal(1)])
-                .expect_union();
-        assert_eq!(mixed_union.common_literal_supertype(&db), None);
+        let mixed_union = UnionType::from_elements(
+            &db,
+            program,
+            [Type::string_literal(&db, "a"), Type::int_literal(1)],
+        )
+        .expect_union();
+        assert_eq!(mixed_union.common_literal_supertype(&db, program), None);
     }
 
     fn map_marker<'db>(ty: &Type<'db>, marker: Type<'db>, replacement: Type<'db>) -> Type<'db> {
@@ -2087,26 +2175,31 @@ mod tests {
     #[test]
     fn map_rebuilds_prefix_for_literal_widening() {
         let db = setup_db();
+        let program = db.program();
 
-        let marker = KnownClass::Str.to_instance(&db);
+        let marker = KnownClass::Str.to_instance(&db, program);
         let literal_limit =
             i64::try_from(MAX_NON_RECURSIVE_UNION_LITERALS).expect("literal limit fits in i64");
         let widening_literal = Type::int_literal(literal_limit);
-        let expected = KnownClass::Int.to_instance(&db);
+        let expected = KnownClass::Int.to_instance(&db, program);
 
         let elements = (0..literal_limit).map(Type::int_literal).chain([marker]);
-        let union = UnionType::from_elements(&db, elements).expect_union();
+        let union = UnionType::from_elements(&db, program, elements).expect_union();
 
         assert_eq!(
-            union.map(&db, |ty| map_marker(ty, marker, widening_literal)),
+            union.map(&db, program, |ty| map_marker(ty, marker, widening_literal)),
             expected
         );
         assert_eq!(
-            union.map_leave_aliases(&db, |ty| map_marker(ty, marker, widening_literal)),
+            union.map_leave_aliases(&db, program, |ty| map_marker(ty, marker, widening_literal)),
             expected
         );
         assert_eq!(
-            union.try_map(&db, |ty| Some(map_marker(ty, marker, widening_literal))),
+            union.try_map(&db, program, |ty| Some(map_marker(
+                ty,
+                marker,
+                widening_literal
+            ))),
             Some(expected)
         );
     }
@@ -2115,9 +2208,12 @@ mod tests {
     fn map_preserves_alias_unpacking_behavior() {
         let mut db = setup_db();
         db.write_dedented("/src/a.py", "type Alias = int").unwrap();
+        let program = db.program();
 
         let module = ruff_db::files::system_path_to_file(&db, "/src/a.py").unwrap();
-        let alias_ty = global_symbol(&db, module, "Alias").place.expect_type();
+        let alias_ty = global_symbol(&db, crate::ProgramFile::new(&db, program, module), "Alias")
+            .place
+            .expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(alias))) =
             alias_ty
         else {
@@ -2125,35 +2221,40 @@ mod tests {
         };
 
         let alias = Type::TypeAlias(TypeAliasType::PEP695(alias));
-        let str_instance = KnownClass::Str.to_instance(&db);
-        let union_ty = UnionType::from_elements_leave_aliases(&db, [alias, str_instance]);
+        let str_instance = KnownClass::Str.to_instance(&db, program);
+        let union_ty = UnionType::from_elements_leave_aliases(&db, program, [alias, str_instance]);
         let union = union_ty.expect_union();
-        let unpacked =
-            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), str_instance]);
+        let unpacked = UnionType::from_elements(
+            &db,
+            program,
+            [KnownClass::Int.to_instance(&db, program), str_instance],
+        );
 
-        assert_eq!(union.map(&db, |ty| *ty), unpacked);
-        assert_eq!(union.try_map(&db, |ty| Some(*ty)), Some(unpacked));
-        assert_eq!(union.map_leave_aliases(&db, |ty| *ty), union_ty);
+        assert_eq!(union.map(&db, program, |ty| *ty), unpacked);
+        assert_eq!(union.try_map(&db, program, |ty| Some(*ty)), Some(unpacked));
+        assert_eq!(union.map_leave_aliases(&db, program, |ty| *ty), union_ty);
     }
 
     #[test]
     fn build_intersection_empty_intersection_equals_object() {
         let db = setup_db();
+        let program = db.program();
 
-        let intersection = IntersectionBuilder::new(&db).build();
+        let intersection = IntersectionBuilder::new(&db, program).build();
         assert_eq!(intersection, Type::object());
     }
 
     #[test]
     fn build_intersection_discards_never_dnf_branches() {
         let db = setup_db();
-        let int = KnownClass::Int.to_instance(&db);
-        let str = KnownClass::Str.to_instance(&db);
-        let bytes = KnownClass::Bytes.to_instance(&db);
+        let program = db.program();
+        let int = KnownClass::Int.to_instance(&db, program);
+        let str = KnownClass::Str.to_instance(&db, program);
+        let bytes = KnownClass::Bytes.to_instance(&db, program);
 
-        let int_or_str = UnionType::from_elements(&db, [int, str]);
-        let int_or_bytes = UnionType::from_elements(&db, [int, bytes]);
-        let intersection = IntersectionBuilder::new(&db)
+        let int_or_str = UnionType::from_elements(&db, program, [int, str]);
+        let int_or_bytes = UnionType::from_elements(&db, program, [int, bytes]);
+        let intersection = IntersectionBuilder::new(&db, program)
             .add_positive(int_or_str)
             .add_positive(int_or_bytes);
 
@@ -2172,36 +2273,37 @@ mod tests {
     }
 
     fn build_intersection_simplify_split_bool_impl(db: &TestDb, t_splitter: Type) {
-        let bool_value = t_splitter.bool(db) == Truthiness::AlwaysTrue;
+        let program = db.program();
+        let bool_value = t_splitter.bool(db, program) == Truthiness::AlwaysTrue;
 
         // We add t_object in various orders (in first or second position) in
         // the tests below to ensure that the boolean simplification eliminates
         // everything from the intersection, not just `bool`.
         let t_object = Type::object();
-        let t_bool = KnownClass::Bool.to_instance(db);
+        let t_bool = KnownClass::Bool.to_instance(db, program);
 
-        let ty = IntersectionBuilder::new(db)
+        let ty = IntersectionBuilder::new(db, program)
             .add_positive(t_object)
             .add_positive(t_bool)
             .add_negative(t_splitter)
             .build();
         assert_eq!(ty, Type::bool_literal(!bool_value));
 
-        let ty = IntersectionBuilder::new(db)
+        let ty = IntersectionBuilder::new(db, program)
             .add_positive(t_bool)
             .add_positive(t_object)
             .add_negative(t_splitter)
             .build();
         assert_eq!(ty, Type::bool_literal(!bool_value));
 
-        let ty = IntersectionBuilder::new(db)
+        let ty = IntersectionBuilder::new(db, program)
             .add_positive(t_object)
             .add_negative(t_splitter)
             .add_positive(t_bool)
             .build();
         assert_eq!(ty, Type::bool_literal(!bool_value));
 
-        let ty = IntersectionBuilder::new(db)
+        let ty = IntersectionBuilder::new(db, program)
             .add_negative(t_splitter)
             .add_positive(t_object)
             .add_positive(t_bool)
@@ -2212,8 +2314,9 @@ mod tests {
     #[test]
     fn build_intersection_enums() {
         let db = setup_db();
+        let program = db.program();
 
-        let safe_uuid_class = known_module_symbol(&db, KnownModule::Uuid, "SafeUUID")
+        let safe_uuid_class = known_module_symbol(&db, program, KnownModule::Uuid, "SafeUUID")
             .place
             .ignore_possibly_undefined()
             .unwrap();
@@ -2237,48 +2340,55 @@ mod tests {
         let safe_uuid = l_safe.expect_enum_literal().enum_class_instance(&db);
 
         {
-            let actual = IntersectionBuilder::new(&db)
+            let actual = IntersectionBuilder::new(&db, program)
                 .add_positive(safe_uuid)
                 .add_negative(l_safe)
                 .build();
 
             assert_eq!(
-                actual.display(&db).to_string(),
+                actual.display(&db, program).to_string(),
                 "Literal[SafeUUID.unsafe, SafeUUID.unknown]"
             );
         }
         {
             // Same as above, but with the order reversed
-            let actual = IntersectionBuilder::new(&db)
+            let actual = IntersectionBuilder::new(&db, program)
                 .add_negative(l_safe)
                 .add_positive(safe_uuid)
                 .build();
 
             assert_eq!(
-                actual.display(&db).to_string(),
+                actual.display(&db, program).to_string(),
                 "Literal[SafeUUID.unsafe, SafeUUID.unknown]"
             );
         }
         {
             // Also the same, but now with a nested intersection
-            let actual = IntersectionBuilder::new(&db)
+            let actual = IntersectionBuilder::new(&db, program)
                 .add_positive(safe_uuid)
-                .add_positive(IntersectionBuilder::new(&db).add_negative(l_safe).build())
+                .add_positive(
+                    IntersectionBuilder::new(&db, program)
+                        .add_negative(l_safe)
+                        .build(),
+                )
                 .build();
 
             assert_eq!(
-                actual.display(&db).to_string(),
+                actual.display(&db, program).to_string(),
                 "Literal[SafeUUID.unsafe, SafeUUID.unknown]"
             );
         }
         {
-            let actual = IntersectionBuilder::new(&db)
+            let actual = IntersectionBuilder::new(&db, program)
                 .add_negative(l_safe)
                 .add_positive(safe_uuid)
                 .add_negative(l_unsafe)
                 .build();
 
-            assert_eq!(actual.display(&db).to_string(), "Literal[SafeUUID.unknown]");
+            assert_eq!(
+                actual.display(&db, program).to_string(),
+                "Literal[SafeUUID.unknown]"
+            );
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -10,7 +10,6 @@
 //! argument types and return types. For each callable type in the union, the call expression's
 //! arguments must match _at least one_ overload.
 
-use std::fmt;
 use std::slice::Iter;
 use std::sync::Arc;
 
@@ -18,7 +17,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::{SmallVec, smallvec_inline};
 
-use super::{DynamicType, Type, TypeVarVariance, UnionType, semantic_index};
+use super::{DynamicType, Type, TypeVarVariance, UnionType};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::constraints::{
     ConstraintSet, ConstraintSetBuilder, IteratorConstraintsExtension,
@@ -44,6 +43,7 @@ use crate::types::{
 use crate::{Db, FxOrderSet};
 use ruff_python_ast::{self as ast, name::Name};
 use ty_python_core::definition::Definition;
+use ty_python_core::semantic_index;
 
 /// Selects which binding context to use for type variables that only appear in a return-position
 /// `Callable`.
@@ -68,10 +68,10 @@ fn function_signature_expression_type<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> Type<'db> {
-    let file = definition.file(db);
-    let index = semantic_index(db, file);
+    let program_file = definition.program_file(db);
+    let index = ty_python_core::semantic_index(db, program_file);
     let file_scope = index.expression_scope_id(expression);
-    let scope = file_scope.to_scope_id(db, file);
+    let scope = file_scope.to_scope_id(db, program_file);
     if scope == definition.scope(db) {
         // expression is in the function definition scope, but always deferred
         infer_deferred_types(db, definition).expression_type(expression)
@@ -86,10 +86,10 @@ fn function_signature_type_expression_flags<'db>(
     definition: Definition<'db>,
     expression: &ast::Expr,
 ) -> TypeExpressionFlags {
-    let file = definition.file(db);
-    let index = semantic_index(db, file);
+    let program_file = definition.program_file(db);
+    let index = ty_python_core::semantic_index(db, program_file);
     let file_scope = index.expression_scope_id(expression);
-    let scope = file_scope.to_scope_id(db, file);
+    let scope = file_scope.to_scope_id(db, program_file);
     if scope == definition.scope(db) {
         // expression is in the function definition scope, but always deferred
         infer_deferred_types(db, definition).type_expression_flags(expression)
@@ -101,7 +101,7 @@ fn function_signature_type_expression_flags<'db>(
 
 /// The signature of a single callable. If the callable is overloaded, there is a separate
 /// [`Signature`] for each overload.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub struct CallableSignature<'db> {
     /// The signatures of each overload of this callable. Will be empty if the type is not
     /// callable.
@@ -146,10 +146,10 @@ impl<'db> CallableSignature<'db> {
         Self::single(Signature::bottom())
     }
 
-    pub(crate) fn cycle_initial(db: &'db dyn Db, id: salsa::Id) -> Self {
+    pub(crate) fn cycle_initial(db: &'db dyn Db, program: crate::Program, id: salsa::Id) -> Self {
         Self::single(Signature::new(
             Parameters::bottom(),
-            Type::divergent(id).bottom_materialization(db),
+            Type::divergent(id).bottom_materialization(db, program),
         ))
     }
 
@@ -180,11 +180,17 @@ impl<'db> CallableSignature<'db> {
     }
 
     /// Returns the union of all overload return types, or `Unknown` if there are no overloads.
-    pub(crate) fn overload_return_type_or_unknown(&self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn overload_return_type_or_unknown(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
         match self.overloads.as_slice() {
             [] => Type::unknown(),
             [signature] => signature.return_ty,
-            overloads => UnionType::from_elements(db, overloads.iter().map(|sig| sig.return_ty)),
+            overloads => {
+                UnionType::from_elements(db, program, overloads.iter().map(|sig| sig.return_ty))
+            }
         }
     }
 
@@ -203,6 +209,7 @@ impl<'db> CallableSignature<'db> {
     /// Returns the reduced overloaded signature exposed by a `functools.partial(...)` object.
     pub(crate) fn partially_apply(
         db: &'db dyn Db,
+        program: crate::Program,
         overloads: impl IntoIterator<Item = PartialSignatureApplication<'db>>,
     ) -> Option<Self> {
         let mut new_overloads = Vec::new();
@@ -211,6 +218,7 @@ impl<'db> CallableSignature<'db> {
         for overload in overloads {
             let signature = overload.signature.partially_apply(
                 db,
+                program,
                 &overload.partial_application,
                 overload.inference,
                 overload.unspecialized_return_ty,
@@ -227,6 +235,7 @@ impl<'db> CallableSignature<'db> {
     pub(crate) fn cycle_normalized(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous: &Self,
         cycle: &salsa::Cycle,
     ) -> Self {
@@ -236,7 +245,7 @@ impl<'db> CallableSignature<'db> {
                     .overloads
                     .iter()
                     .zip(previous.overloads.iter())
-                    .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle))
+                    .map(|(curr, prev)| curr.cycle_normalized(db, program, prev, cycle))
                     .collect(),
             }
         } else {
@@ -248,6 +257,7 @@ impl<'db> CallableSignature<'db> {
     pub(super) fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -255,7 +265,7 @@ impl<'db> CallableSignature<'db> {
             overloads: self
                 .overloads
                 .iter()
-                .map(|signature| signature.recursive_type_normalized_impl(db, div, nested))
+                .map(|signature| signature.recursive_type_normalized_impl(db, program, div, nested))
                 .collect::<Option<SmallVec<_>>>()?,
         })
     }
@@ -263,12 +273,15 @@ impl<'db> CallableSignature<'db> {
     pub(crate) fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
+        #[expect(clippy::too_many_arguments)]
         fn try_apply_type_mapping_for_paramspec<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             self_signature: &Signature<'db>,
             prefix_parameters: &[Parameter<'db>],
             paramspec_value: Type<'db>,
@@ -280,13 +293,16 @@ impl<'db> CallableSignature<'db> {
                 Type::TypeVar(typevar) if typevar.is_paramspec(db) => {
                     let prefix_parameters = prefix_parameters
                         .iter()
-                        .map(|param| param.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                        .map(|param| {
+                            param.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+                        })
                         .collect::<Vec<_>>();
                     let parameters = if prefix_parameters.is_empty() {
-                        Parameters::paramspec(db, typevar)
+                        Parameters::paramspec(db, program, typevar)
                     } else {
                         Parameters::concatenate(
                             db,
+                            program,
                             prefix_parameters,
                             ConcatenateTail::ParamSpec(typevar),
                         )
@@ -294,12 +310,13 @@ impl<'db> CallableSignature<'db> {
 
                     Some(CallableSignature::single(Signature {
                         generic_context: self_signature.generic_context.map(|context| {
-                            type_mapping.update_signature_generic_context(db, context)
+                            type_mapping.update_signature_generic_context(db, program, context)
                         }),
                         definition: self_signature.definition,
                         parameters,
                         return_ty: self_signature.return_ty.apply_type_mapping_impl(
                             db,
+                            program,
                             type_mapping,
                             tcx,
                             visitor,
@@ -315,17 +332,25 @@ impl<'db> CallableSignature<'db> {
                                 db,
                                 signature.generic_context,
                                 self_signature.generic_context.map(|context| {
-                                    type_mapping.update_signature_generic_context(db, context)
+                                    type_mapping
+                                        .update_signature_generic_context(db, program, context)
                                 }),
                             ),
                             definition: signature.definition,
                             parameters: signature.parameters().with_prefix(
                                 prefix_parameters.iter().map(|param| {
-                                    param.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
+                                    param.apply_type_mapping_impl(
+                                        db,
+                                        program,
+                                        type_mapping,
+                                        tcx,
+                                        visitor,
+                                    )
                                 }),
                             ),
                             return_ty: self_signature.return_ty.apply_type_mapping_impl(
                                 db,
+                                program,
                                 type_mapping,
                                 tcx,
                                 visitor,
@@ -346,6 +371,7 @@ impl<'db> CallableSignature<'db> {
                     && let Some(value) = specialization.get(db, paramspec)
                     && let Some(result) = try_apply_type_mapping_for_paramspec(
                         db,
+                        program,
                         signature,
                         prefix,
                         value,
@@ -358,42 +384,65 @@ impl<'db> CallableSignature<'db> {
                 } else {
                     smallvec_inline![signature.apply_type_mapping_impl(
                         db,
+                        program,
                         type_mapping,
                         tcx,
-                        visitor
+                        visitor,
                     )]
                 }
             }))
         } else {
-            Self::from_overloads(
-                self.overloads.iter().map(|signature| {
-                    signature.apply_type_mapping_impl(db, type_mapping, tcx, visitor)
-                }),
-            )
+            Self::from_overloads(self.overloads.iter().map(|signature| {
+                signature.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+            }))
         }
     }
 
     pub(crate) fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         for signature in &self.overloads {
-            signature.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            signature.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 
     /// Binds the first (presumably `self`) parameter of this signature. If a `self_type` is
     /// provided, we will replace any occurrences of `typing.Self` in the parameter and return
     /// annotations with that type.
-    pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
+    pub(crate) fn bind_self(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Option<Type<'db>>,
+    ) -> Self {
         Self {
             overloads: self
                 .overloads
                 .iter()
-                .map(|signature| signature.bind_self(db, self_type))
+                .map(|signature| signature.bind_self(db, program, self_type))
+                .collect(),
+        }
+    }
+
+    /// Replaces any occurrences of `typing.Self` in the parameter and return annotations with the
+    /// given type. (Does not bind the `self` parameter; to do that, use
+    /// [`bind_self`][Self::bind_self].)
+    pub(crate) fn apply_self(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> Self {
+        Self {
+            overloads: self
+                .overloads
+                .iter()
+                .map(|signature| signature.apply_self(db, program, self_type))
                 .collect(),
         }
     }
@@ -402,19 +451,6 @@ impl<'db> CallableSignature<'db> {
         self.overloads
             .iter()
             .any(|signature| !signature.parameters().as_slice().is_empty())
-    }
-
-    /// Replaces any occurrences of `typing.Self` in the parameter and return annotations with the
-    /// given type. (Does not bind the `self` parameter; to do that, use
-    /// [`bind_self`][Self::bind_self].)
-    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
-        Self {
-            overloads: self
-                .overloads
-                .iter()
-                .map(|signature| signature.apply_self(db, self_type))
-                .collect(),
-        }
     }
 
     pub(crate) fn is_single_paramspec(&self) -> Option<(BoundTypeVarInstance<'db>, Type<'db>)> {
@@ -440,6 +476,7 @@ impl<'db> CallableSignature<'db> {
     pub(crate) fn when_constraint_set_assignable_to<'c>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
@@ -448,6 +485,7 @@ impl<'db> CallableSignature<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability(
+            program,
             constraints,
             &relation_visitor,
             &disjointness_visitor,
@@ -469,16 +507,21 @@ impl<'a, 'db> IntoIterator for &'a CallableSignature<'db> {
 
 impl<'db> VarianceInferable<'db> for &CallableSignature<'db> {
     // TODO: possibly need to replace self
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         self.overloads
             .iter()
-            .map(|signature| signature.variance_of(db, typevar))
+            .map(|signature| signature.variance_of(db, program, typevar))
             .collect()
     }
 }
 
 /// The signature of one of the overloads of a callable.
-#[derive(Clone, Debug, get_size2::GetSize, PartialEq, Eq, Hash, salsa::SalsaValue)]
+#[derive(Clone, Debug, salsa::SalsaValue, get_size2::GetSize, PartialEq, Eq, Hash)]
 pub struct Signature<'db> {
     /// The generic context for this overload, if it is generic.
     pub(crate) generic_context: Option<GenericContext<'db>>,
@@ -549,6 +592,7 @@ pub(crate) type SignatureRelationVisitor<'db> = ActiveRecursionDetector<Signatur
 
 pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     signature: &Signature<'db>,
     visitor: &V,
 ) {
@@ -558,9 +602,9 @@ pub(super) fn walk_signature<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     // By default we usually don't visit the type of the default value,
     // as it isn't relevant to most things
     for parameter in &signature.parameters {
-        visitor.visit_type(db, parameter.annotated_type());
+        visitor.visit_type(db, program, parameter.annotated_type());
     }
-    visitor.visit_type(db, signature.return_ty);
+    visitor.visit_type(db, program, signature.return_ty);
 }
 
 /// Describes how a `functools.partial(...)` call binds one overload's parameters.
@@ -701,9 +745,16 @@ impl<'db> Signature<'db> {
         }
     }
 
-    pub(super) fn wrap_coroutine_return_type(self, db: &'db dyn Db) -> Self {
-        let return_ty = KnownClass::CoroutineType
-            .to_specialized_instance(db, &[Type::any(), Type::any(), self.return_ty]);
+    pub(super) fn wrap_coroutine_return_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Self {
+        let return_ty = KnownClass::CoroutineType.to_specialized_instance(
+            db,
+            program,
+            &[Type::any(), Type::any(), self.return_ty],
+        );
         Self { return_ty, ..self }
     }
 
@@ -722,12 +773,15 @@ impl<'db> Signature<'db> {
     /// `Self` is hidden if it does not appear in:
     /// 1. The return type
     /// 2. Any explicitly annotated parameter (not inferred)
-    pub(crate) fn should_hide_self_from_display(&self, db: &'db dyn Db) -> bool {
-        !self.return_ty.contains_self(db)
-            && !self
-                .parameters()
-                .iter()
-                .any(|p| p.should_annotation_be_displayed() && p.annotated_type().contains_self(db))
+    pub(crate) fn should_hide_self_from_display(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> bool {
+        !self.return_ty.contains_self(db, program)
+            && !self.parameters().iter().any(|p| {
+                p.should_annotation_be_displayed() && p.annotated_type().contains_self(db, program)
+            })
     }
 
     pub(crate) fn with_inherited_generic_context(
@@ -746,17 +800,23 @@ impl<'db> Signature<'db> {
         self
     }
 
-    fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: &Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         let return_ty = self
             .return_ty
-            .cycle_normalized(db, previous.return_ty, cycle);
+            .cycle_normalized(db, program, previous.return_ty, cycle);
 
         let parameters = if self.parameters.len() == previous.parameters.len() {
             Parameters::new(
                 self.parameters
                     .iter()
                     .zip(previous.parameters.iter())
-                    .map(|(curr, prev)| curr.cycle_normalized(db, prev, cycle))
+                    .map(|(curr, prev)| curr.cycle_normalized(db, program, prev, cycle))
                     .collect::<Box<[_]>>(),
                 self.parameters.kind(),
             )
@@ -776,21 +836,22 @@ impl<'db> Signature<'db> {
     pub(super) fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         let return_ty = if nested {
             self.return_ty
-                .recursive_type_normalized_impl(db, div, true)?
+                .recursive_type_normalized_impl(db, program, div, true)?
         } else {
             self.return_ty
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .unwrap_or(div)
         };
         let parameters = {
             let mut parameters = Vec::with_capacity(self.parameters.len());
             for param in &self.parameters {
-                parameters.push(param.recursive_type_normalized_impl(db, div, nested)?);
+                parameters.push(param.recursive_type_normalized_impl(db, program, div, nested)?);
             }
             Parameters::new(parameters, self.parameters.kind())
         };
@@ -805,6 +866,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -812,24 +874,38 @@ impl<'db> Signature<'db> {
         Self {
             generic_context: self
                 .generic_context
-                .map(|context| type_mapping.update_signature_generic_context(db, context)),
+                .map(|context| type_mapping.update_signature_generic_context(db, program, context)),
             definition: self.definition,
-            parameters: self
-                .parameters
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
-            return_ty: self
-                .return_ty
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            parameters: self.parameters.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            ),
+            return_ty: self.return_ty.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            ),
         }
     }
 
-    pub(crate) fn freshen_bound_typevars(&self, db: &'db dyn Db, delta: u32) -> Self {
+    pub(crate) fn freshen_bound_typevars(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        delta: u32,
+    ) -> Self {
         let Some(generic_context) = self.generic_context else {
             return self.clone();
         };
 
         self.apply_type_mapping_impl(
             db,
+            program,
             &TypeMapping::FreshenBoundTypeVars {
                 generic_context,
                 delta,
@@ -842,6 +918,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn max_typevar_freshness_matching_generic_context(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         generic_context: GenericContext<'db>,
     ) -> Option<TypeVarNonce> {
         let typevars = self
@@ -856,12 +933,13 @@ impl<'db> Signature<'db> {
             .chain(parameters)
             .chain(std::iter::once(self.return_ty));
 
-        max_typevar_freshness_matching_generic_context(db, types, generic_context)
+        max_typevar_freshness_matching_generic_context(db, program, types, generic_context)
     }
 
     pub(crate) fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -869,16 +947,17 @@ impl<'db> Signature<'db> {
         for param in &self.parameters {
             param.annotated_type().find_legacy_typevars_impl(
                 db,
+                program,
                 binding_context,
                 typevars,
                 visitor,
             );
             if let Some(ty) = param.default_type() {
-                ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
         }
         self.return_ty
-            .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            .find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
     }
 
     /// Return the parameters in this signature.
@@ -917,6 +996,7 @@ impl<'db> Signature<'db> {
             };
 
             if let Some(self_typevar) = self_typevar {
+                let program = self_typevar.program(db);
                 match self.generic_context.as_mut() {
                     Some(generic_context)
                         if generic_context
@@ -925,12 +1005,14 @@ impl<'db> Signature<'db> {
                     Some(generic_context) => {
                         *generic_context = GenericContext::from_typevar_instances(
                             db,
+                            program,
                             std::iter::once(self_typevar).chain(generic_context.variables(db)),
                         );
                     }
                     None => {
                         self.generic_context = Some(GenericContext::from_typevar_instances(
                             db,
+                            program,
                             std::iter::once(self_typevar),
                         ));
                     }
@@ -944,7 +1026,12 @@ impl<'db> Signature<'db> {
         self.definition
     }
 
-    pub(crate) fn bind_self(&self, db: &'db dyn Db, self_type: Option<Type<'db>>) -> Self {
+    pub(crate) fn bind_self(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Option<Type<'db>>,
+    ) -> Self {
         let removed_receiver = self.parameters.get(0).is_some_and(Parameter::is_positional);
 
         // TODO: Theoretically, for a signature like `f(*args: *tuple[MyClass, int, *tuple[str, ...]])` with
@@ -957,17 +1044,19 @@ impl<'db> Signature<'db> {
         let mut return_ty = self.return_ty;
         let binding_context = self.definition.map(BindingContext::Definition);
         if let Some(self_type) = self_type
-            && self.needs_self_mapping(db, removed_receiver)
+            && self.needs_self_mapping(db, program, removed_receiver)
         {
             let self_mapping =
-                TypeMapping::BindSelf(SelfBinding::new(db, self_type, binding_context));
+                TypeMapping::BindSelf(SelfBinding::new(db, program, self_type, binding_context));
             parameters = parameters.apply_type_mapping_impl(
                 db,
+                program,
                 &self_mapping,
                 TypeContext::default(),
                 &ApplyTypeMappingVisitor::default(),
             );
-            return_ty = return_ty.apply_type_mapping(db, &self_mapping, TypeContext::default());
+            return_ty =
+                return_ty.apply_type_mapping(db, program, &self_mapping, TypeContext::default());
         }
         Self {
             generic_context: self
@@ -983,7 +1072,12 @@ impl<'db> Signature<'db> {
     ///
     /// This is used to prune impossible overloads when a method is bound to a concrete receiver.
     /// If a signature has no positional first parameter, we conservatively keep it.
-    pub(crate) fn can_bind_self_to(&self, db: &'db dyn Db, self_type: Type<'db>) -> bool {
+    pub(crate) fn can_bind_self_to(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> bool {
         // A dynamic receiver might be compatible with any explicit receiver annotation.
         if self_type.is_dynamic() {
             return true;
@@ -1017,7 +1111,7 @@ impl<'db> Signature<'db> {
 
         // TODO: Expand type aliases here so `type Alias = Self` in a class body
         // participates in receiver-specific overload pruning.
-        expected_self_ty = expected_self_ty.bind_self_typevars(db, self_type);
+        expected_self_ty = expected_self_ty.bind_self_typevars(db, program, self_type);
 
         // `Self` binding can make the receiver annotation trivially compatible.
         if accepts_any_or_exact_self(expected_self_ty) {
@@ -1025,7 +1119,7 @@ impl<'db> Signature<'db> {
         }
 
         // A specialized receiver can make generic receiver annotations concrete enough to compare.
-        if let Some((_, self_specialization)) = self_type.class_specialization(db) {
+        if let Some((_, self_specialization)) = self_type.class_specialization(db, program) {
             expected_self_ty =
                 expected_self_ty.apply_optional_specialization(db, Some(self_specialization));
 
@@ -1039,11 +1133,12 @@ impl<'db> Signature<'db> {
         self_type
             .when_assignable_to(
                 db,
+                program,
                 expected_self_ty,
                 &constraints,
                 self.inferable_typevars(db),
             )
-            .is_always_satisfied(db)
+            .is_always_satisfied(db, program)
     }
 
     pub(crate) fn has_explicit_positional_receiver_annotation(&self) -> bool {
@@ -1058,25 +1153,32 @@ impl<'db> Signature<'db> {
             .is_some_and(|parameter| parameter.is_positional() && parameter.inferred_annotation)
     }
 
-    pub(crate) fn apply_self(&self, db: &'db dyn Db, self_type: Type<'db>) -> Self {
-        if !self.needs_self_mapping(db, false) {
+    pub(crate) fn apply_self(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        self_type: Type<'db>,
+    ) -> Self {
+        if !self.needs_self_mapping(db, program, false) {
             return self.clone();
         }
 
         let self_mapping = TypeMapping::BindSelf(SelfBinding::new(
             db,
+            program,
             self_type,
             self.definition.map(BindingContext::Definition),
         ));
         let parameters = self.parameters.apply_type_mapping_impl(
             db,
+            program,
             &self_mapping,
             TypeContext::default(),
             &ApplyTypeMappingVisitor::default(),
         );
         let return_ty =
             self.return_ty
-                .apply_type_mapping(db, &self_mapping, TypeContext::default());
+                .apply_type_mapping(db, program, &self_mapping, TypeContext::default());
         Self {
             generic_context: self.generic_context,
             definition: self.definition,
@@ -1089,12 +1191,14 @@ impl<'db> Signature<'db> {
     pub(crate) fn apply_specialization(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         specialization: Specialization<'db>,
     ) -> Self {
         let type_mapping =
             TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(specialization));
         self.apply_type_mapping_impl(
             db,
+            program,
             &type_mapping,
             TypeContext::default(),
             &ApplyTypeMappingVisitor::default(),
@@ -1105,21 +1209,25 @@ impl<'db> Signature<'db> {
     pub(crate) fn partially_apply(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         partial_application: &PartialApplication<'db>,
         inference: Option<TypeVarInference<'db>>,
         unspecialized_return_ty: Type<'db>,
     ) -> Self {
         let signature_specialization =
-            self.partial_application_specialization(db, partial_application, inference);
+            self.partial_application_specialization(db, program, partial_application, inference);
         let signature = signature_specialization.map_or_else(
             || self.clone(),
-            |specialization| self.apply_specialization(db, specialization),
+            |specialization| self.apply_specialization(db, program, specialization),
         );
 
         let parameters = signature.parameters().as_slice();
         let return_ty = signature_specialization.map_or_else(
             || unspecialized_return_ty,
-            |specialization| unspecialized_return_ty.apply_specialization(db, specialization),
+            |specialization| {
+                unspecialized_return_ty
+                    .apply_specialization(db, signature_specialization.unwrap_or(specialization))
+            },
         );
 
         let mut remaining = Vec::with_capacity(parameters.len());
@@ -1190,6 +1298,7 @@ impl<'db> Signature<'db> {
     fn partial_application_specialization(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         partial_application: &PartialApplication<'db>,
         inference: Option<TypeVarInference<'db>>,
     ) -> Option<Specialization<'db>> {
@@ -1206,9 +1315,11 @@ impl<'db> Signature<'db> {
                     .enumerate()
                     .filter(|(index, _)| !partial_application.is_positionally_bound(*index))
                     .any(|(_, parameter)| {
-                        parameter
-                            .annotated_type()
-                            .references_typevar(db, typevar.typevar(db).identity(db))
+                        parameter.annotated_type().references_typevar(
+                            db,
+                            program,
+                            typevar.typevar(db).identity(db),
+                        )
                     })
             })
             .map(|typevar| typevar.identity(db))
@@ -1221,20 +1332,25 @@ impl<'db> Signature<'db> {
         Some(inference.specialization_with(db, |typevar, inferred| {
             promoted_typevars
                 .contains(&typevar.identity(db))
-                .then(|| inferred.map_or(Type::TypeVar(typevar), |ty| ty.promote(db)))
+                .then(|| inferred.map_or(Type::TypeVar(typevar), |ty| ty.promote(db, program)))
         }))
     }
 
-    fn needs_self_mapping(&self, db: &'db dyn Db, receiver_is_removed: bool) -> bool {
+    fn needs_self_mapping(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        receiver_is_removed: bool,
+    ) -> bool {
         // TODO: Expand type aliases here so `type Alias = Self` in parameters or returns
         // triggers binding when a method is accessed on a concrete receiver.
-        self.return_ty.contains_self(db)
+        self.return_ty.contains_self(db, program)
             || self
                 .parameters
                 .iter()
                 .enumerate()
                 .skip(usize::from(receiver_is_removed))
-                .any(|(_, parameter)| parameter.annotated_type().contains_self(db))
+                .any(|(_, parameter)| parameter.annotated_type().contains_self(db, program))
     }
 
     fn inferable_typevars(&self, db: &'db dyn Db) -> InferableTypeVars<'db> {
@@ -1257,6 +1373,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn non_generic_implementation_parameters_consistency_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         overload: &Self,
     ) -> ParameterConsistency<'db> {
         debug_assert!(self.is_non_generic());
@@ -1270,6 +1387,7 @@ impl<'db> Signature<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability_with_context(
+            program,
             &constraints,
             &relation_visitor,
             &disjointness_visitor,
@@ -1279,7 +1397,7 @@ impl<'db> Signature<'db> {
 
         let is_consistent = checker
             .check_signature_pair(db, &implementation, &overload)
-            .is_always_satisfied(db);
+            .is_always_satisfied(db, program);
 
         if is_consistent {
             ParameterConsistency::Consistent
@@ -1293,6 +1411,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn non_generic_implementation_return_type_consistency_with(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         overload: &Self,
     ) -> ReturnTypeConsistency<'db> {
         debug_assert!(self.is_non_generic());
@@ -1304,6 +1423,7 @@ impl<'db> Signature<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::assignability_with_context(
+            program,
             &constraints,
             &relation_visitor,
             &disjointness_visitor,
@@ -1313,7 +1433,7 @@ impl<'db> Signature<'db> {
 
         let is_consistent = checker
             .check_type_pair(db, overload.return_ty, self.return_ty)
-            .is_always_satisfied(db);
+            .is_always_satisfied(db, program);
 
         if is_consistent {
             ReturnTypeConsistency::Consistent
@@ -1325,6 +1445,7 @@ impl<'db> Signature<'db> {
     pub(crate) fn when_constraint_set_assignable_to_signatures<'c>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         other: &CallableSignature<'db>,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
@@ -1346,6 +1467,7 @@ impl<'db> Signature<'db> {
             ));
             let param_spec_matches = ConstraintSet::constrain_typevar_upper_bound(
                 db,
+                program,
                 constraints,
                 self_bound_typevar,
                 upper,
@@ -1354,27 +1476,29 @@ impl<'db> Signature<'db> {
                 .overloads
                 .iter()
                 .map(|signature| signature.return_ty)
-                .when_any(db, constraints, |other_return_type| {
+                .when_any(db, program, constraints, |other_return_type| {
                     self.return_ty.when_constraint_set_assignable_to(
                         db,
+                        program,
                         other_return_type,
                         constraints,
                     )
                 });
-            return param_spec_matches.and(db, constraints, || return_types_match);
+            return param_spec_matches.and(db, program, constraints, || return_types_match);
         }
 
         other
             .overloads
             .iter()
-            .when_all(db, constraints, |other_signature| {
-                self.when_constraint_set_assignable_to(db, other_signature, constraints)
+            .when_all(db, program, constraints, |other_signature| {
+                self.when_constraint_set_assignable_to(db, program, other_signature, constraints)
             })
     }
 
     fn when_constraint_set_assignable_to<'c>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         other: &Self,
         constraints: &'c ConstraintSetBuilder<'db>,
     ) -> ConstraintSet<'db, 'c> {
@@ -1383,6 +1507,7 @@ impl<'db> Signature<'db> {
         let signature_relation_visitor = SignatureRelationVisitor::default();
         let materialization_visitor = ApplyTypeMappingVisitor::default();
         let checker = TypeRelationChecker::constraint_set_assignability(
+            program,
             constraints,
             &relation_visitor,
             &disjointness_visitor,
@@ -1409,7 +1534,12 @@ impl<'db> Signature<'db> {
 }
 
 impl<'db> VarianceInferable<'db> for &Signature<'db> {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         tracing::trace!(
             "Checking variance of `{tvar}` in `{self:?}`",
             tvar = typevar.identity.name(db)
@@ -1419,7 +1549,7 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
             parameter
                 .annotated_type()
                 .with_polarity(TypeVarVariance::Contravariant)
-                .variance_of(db, typevar)
+                .variance_of(db, program, typevar)
         };
 
         let parameter_variances = if let Some((prefix_parameters, paramspec)) =
@@ -1432,7 +1562,7 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
                     .chain(std::iter::once(
                         Type::TypeVar(paramspec)
                             .with_polarity(TypeVarVariance::Contravariant)
-                            .variance_of(db, typevar),
+                            .variance_of(db, program, typevar),
                     )),
             )
         } else {
@@ -1441,7 +1571,7 @@ impl<'db> VarianceInferable<'db> for &Signature<'db> {
 
         itertools::chain(
             parameter_variances,
-            Some(self.return_ty.variance_of(db, typevar)),
+            Some(self.return_ty.variance_of(db, program, typevar)),
         )
         .collect()
     }
@@ -1459,6 +1589,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_signatures: &[Signature<'db>],
         target_signature: &Signature<'db>,
     ) -> Option<ConstraintSet<'db, 'c>> {
+        let program = self.program;
         let single_required_positional_parameter_type = |signature: &Signature<'db>| {
             if signature.parameters().len() != 1 {
                 return None;
@@ -1479,7 +1610,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let is_unary_overload_aggregate_candidate_type = |ty: Type<'db>| {
             // Keep aggregate probing away from inference-sensitive shapes and defer them to the
             // legacy path, which already handles dynamic/typevar interactions.
-            !ty.has_dynamic(db) && !ty.has_typevar_or_typevar_instance(db)
+            !ty.has_dynamic(db, program) && !ty.has_typevar_or_typevar_instance(db, program)
         };
 
         let other_parameter_type = single_required_positional_parameter_type(target_signature)?;
@@ -1495,8 +1626,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             return None;
         }
 
-        let mut parameter_type_union = UnionBuilder::new(db);
-        let mut return_type_union = UnionBuilder::new(db);
+        let mut parameter_type_union = UnionBuilder::new(db, program);
+        let mut return_type_union = UnionBuilder::new(db, program);
         let mut has_overlapping_domain = false;
 
         for self_signature in source_signatures {
@@ -1509,7 +1640,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             let signatures_are_disjoint = self
                 .as_disjointness_checker()
                 .check_type_pair(db, self_parameter_type, other_parameter_type)
-                .is_always_satisfied(db);
+                .is_always_satisfied(db, program);
 
             if signatures_are_disjoint {
                 continue;
@@ -1530,9 +1661,9 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let returns_match_target =
             || self.check_type_pair(db, return_type_union.build(), target_signature.return_ty);
         let aggregate_relation =
-            parameters_cover_target.and(db, self.constraints, returns_match_target);
+            parameters_cover_target.and(db, program, self.constraints, returns_match_target);
         aggregate_relation
-            .is_always_satisfied(db)
+            .is_always_satisfied(db, program)
             .then_some(aggregate_relation)
     }
 
@@ -1553,6 +1684,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_overloads: &[Signature<'db>],
         target_overloads: &[Signature<'db>],
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
             // TODO: Oof, maybe ParamSpec needs to live at CallableSignature, not Signature?
             let source_is_single_paramspec =
@@ -1585,6 +1717,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar_upper_bound(
                         db,
+                        program,
                         self.constraints,
                         source_tvar,
                         upper,
@@ -1596,12 +1729,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             target_overloads
                                 .iter()
                                 .map(|signature| signature.return_ty)
-                                .when_any(db, self.constraints, |target_return| {
+                                .when_any(db, self.program, self.constraints, |target_return| {
                                     self.check_type_pair(db, source_return, target_return)
                                 })
                         })
                     };
-                    return param_spec_matches.and(db, self.constraints, return_types_match);
+                    return param_spec_matches.and(
+                        db,
+                        program,
+                        self.constraints,
+                        return_types_match,
+                    );
                 }
 
                 (None, Some((target_tvar, target_return))) if source_overloads.len() > 1 => {
@@ -1622,7 +1760,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                                 target_return,
                                             )
                                         })
-                                        .is_never_satisfied(db)
+                                        .is_never_satisfied(db, program)
                                 })
                                 .map(|signature| {
                                     Signature::new_generic(
@@ -1637,6 +1775,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar_lower_bound(
                         db,
+                        program,
                         self.constraints,
                         target_tvar,
                         lower,
@@ -1648,12 +1787,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             source_overloads
                                 .iter()
                                 .map(|signature| signature.return_ty)
-                                .when_any(db, self.constraints, |source_return| {
+                                .when_any(db, self.program, self.constraints, |source_return| {
                                     self.check_type_pair(db, source_return, target_return)
                                 })
                         })
                     };
-                    return param_spec_matches.and(db, self.constraints, return_types_match);
+                    return param_spec_matches.and(
+                        db,
+                        program,
+                        self.constraints,
+                        return_types_match,
+                    );
                 }
 
                 _ => {}
@@ -1692,41 +1836,48 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // TODO: Similar to how we do this for unions, we should collect error
                 // context for all elements and report it if *all* checks fail.
                 self.without_context_collection(|| {
-                    source_overloads
-                        .iter()
-                        .when_any(db, self.constraints, |self_signature| {
+                    source_overloads.iter().when_any(
+                        db,
+                        self.program,
+                        self.constraints,
+                        |self_signature| {
                             self.check_callable_signature_pair_inner(
                                 db,
                                 std::slice::from_ref(self_signature),
                                 target_overloads,
                             )
-                        })
+                        },
+                    )
                 })
             }
 
             // source is definitely not overloaded while target is possibly overloaded.
-            ([_], _) => {
-                target_overloads
-                    .iter()
-                    .when_all(db, self.constraints, |target_signature| {
-                        self.check_callable_signature_pair_inner(
-                            db,
-                            source_overloads,
-                            std::slice::from_ref(target_signature),
-                        )
-                    })
-            }
-
-            // source is definitely overloaded while target is possibly overloaded.
-            (_, _) => target_overloads
-                .iter()
-                .when_all(db, self.constraints, |target_signature| {
+            ([_], _) => target_overloads.iter().when_all(
+                db,
+                self.program,
+                self.constraints,
+                |target_signature| {
                     self.check_callable_signature_pair_inner(
                         db,
                         source_overloads,
                         std::slice::from_ref(target_signature),
                     )
-                }),
+                },
+            ),
+
+            // source is definitely overloaded while target is possibly overloaded.
+            (_, _) => target_overloads.iter().when_all(
+                db,
+                self.program,
+                self.constraints,
+                |target_signature| {
+                    self.check_callable_signature_pair_inner(
+                        db,
+                        source_overloads,
+                        std::slice::from_ref(target_signature),
+                    )
+                },
+            ),
         }
     }
 
@@ -1737,6 +1888,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &Signature<'db>,
         target: &Signature<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // If either signature is generic, freshen that signature's typevars before considering
         // them inferable for this relation. The relation only needs to find one specialization of
         // each generic callable that causes the check to succeed, but those callable-local
@@ -1745,10 +1897,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let source = if source.generic_context != target.generic_context
             && let Some(generic_context) = source.generic_context
             && let Some(delta) = target
-                .max_typevar_freshness_matching_generic_context(db, generic_context)
+                .max_typevar_freshness_matching_generic_context(db, program, generic_context)
                 .map(|freshness| freshness.increment().value())
         {
-            freshened_source = source.freshen_bound_typevars(db, delta);
+            freshened_source = source.freshen_bound_typevars(db, program, delta);
             &freshened_source
         } else {
             source
@@ -1757,10 +1909,10 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let freshened_target;
         let target = if let Some(generic_context) = target.generic_context
             && let Some(delta) = source
-                .max_typevar_freshness_matching_generic_context(db, generic_context)
+                .max_typevar_freshness_matching_generic_context(db, program, generic_context)
                 .map(|freshness| freshness.increment().value())
         {
-            freshened_target = target.freshen_bound_typevars(db, delta);
+            freshened_target = target.freshen_bound_typevars(db, program, delta);
             &freshened_target
         } else {
             target
@@ -1768,8 +1920,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
         let source_inferable = source.inferable_typevars(db);
         let target_inferable = target.inferable_typevars(db);
-        let signature_inferable = source_inferable.merge(db, target_inferable);
-        let inferable = self.inferable.merge(db, signature_inferable);
+        let signature_inferable = *source_inferable.merge(db, target_inferable);
+        let inferable = *self.inferable.merge(db, signature_inferable);
 
         // `inner` will create a constraint set that references these newly inferable typevars.
         let checker = self.with_inferable_typevars(inferable);
@@ -1781,7 +1933,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         // we produce, we reduce it back down to the inferable set that the caller asked about.
         // If we introduced new inferable typevars, those will be existentially quantified away
         // before returning.
-        when.reduce_inferable(db, self.constraints, signature_inferable)
+        when.reduce_inferable(db, program, self.constraints, signature_inferable)
     }
 
     fn with_signature_recursion_guard(
@@ -1915,7 +2067,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         let return_type_constraints = self.check_type_pair(db, source.return_ty, target.return_ty);
         let return_type_checks = !result
             .intersect(db, self.constraints, return_type_constraints)
-            .is_never_satisfied(db);
+            .is_never_satisfied(db, self.program);
         if let Some(context) = self.report_context()
             && !return_type_checks
         {
@@ -1953,7 +2105,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
             let constraint_set = self.check_type_pair(db, target_ty, source_ty);
             if let Some(context) = self.report_context()
-                && constraint_set.is_never_satisfied(db)
+                && constraint_set.is_never_satisfied(db, self.program)
             {
                 let parameter = ParameterDescription::new(target_index, target_name);
                 context.push(ErrorContext::IncompatibleParameterTypes {
@@ -1964,7 +2116,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
             }
             !result
                 .intersect(db, self.constraints, constraint_set)
-                .is_never_satisfied(db)
+                .is_never_satisfied(db, self.program)
         };
 
         if self.typevar_evaluation == TypeVarEvaluation::Lazy {
@@ -1981,6 +2133,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 (Some(([], source_bound_typevar)), Some(([], target_bound_typevar))) => {
                     let param_spec_matches = ConstraintSet::constrain_typevar(
                         db,
+                        self.program,
                         self.constraints,
                         source_bound_typevar,
                         Type::TypeVar(target_bound_typevar),
@@ -2002,6 +2155,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             source.generic_context,
                             Parameters::concatenate(
                                 db,
+                                self.program,
                                 source_prefix_params.to_vec(),
                                 ConcatenateTail::ParamSpec(source_bound_typevar),
                             ),
@@ -2012,6 +2166,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar_lower_bound(
                         db,
+                        self.program,
                         self.constraints,
                         target_bound_typevar,
                         lower,
@@ -2032,6 +2187,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             target.generic_context,
                             Parameters::concatenate(
                                 db,
+                                self.program,
                                 target_prefix_params.to_vec(),
                                 ConcatenateTail::ParamSpec(target_bound_typevar),
                             ),
@@ -2042,6 +2198,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar_upper_bound(
                         db,
+                        self.program,
                         self.constraints,
                         source_bound_typevar,
                         upper,
@@ -2154,6 +2311,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 source.generic_context,
                                 Parameters::concatenate(
                                     db,
+                                    self.program,
                                     std::iter::once(source_param.clone())
                                         .chain(source_params.cloned())
                                         .collect(),
@@ -2167,6 +2325,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         let param_spec_prefix_matches =
                             ConstraintSet::constrain_typevar_lower_bound(
                                 db,
+                                self.program,
                                 self.constraints,
                                 target_bound_typevar,
                                 lower,
@@ -2179,6 +2338,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 target.generic_context,
                                 Parameters::concatenate(
                                     db,
+                                    self.program,
                                     std::iter::once(target_param.clone())
                                         .chain(target_params.cloned())
                                         .collect(),
@@ -2192,6 +2352,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         let param_spec_prefix_matches =
                             ConstraintSet::constrain_typevar_upper_bound(
                                 db,
+                                self.program,
                                 self.constraints,
                                 source_bound_typevar,
                                 upper,
@@ -2201,6 +2362,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         // When the prefixes match exactly, we just relate the remaining tails.
                         let param_spec_matches = ConstraintSet::constrain_typevar(
                             db,
+                            self.program,
                             self.constraints,
                             source_bound_typevar,
                             Type::TypeVar(target_bound_typevar),
@@ -2226,6 +2388,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar_lower_bound(
                         db,
+                        self.program,
                         self.constraints,
                         target_bound_typevar,
                         lower,
@@ -2366,6 +2529,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar_lower_bound(
                         db,
+                        self.program,
                         self.constraints,
                         target_bound_typevar,
                         lower,
@@ -2390,6 +2554,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_matches = ConstraintSet::constrain_typevar_upper_bound(
                         db,
+                        self.program,
                         self.constraints,
                         source_bound_typevar,
                         upper,
@@ -2502,6 +2667,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     ));
                     let param_spec_prefix_matches = ConstraintSet::constrain_typevar_upper_bound(
                         db,
+                        self.program,
                         self.constraints,
                         source_bound_typevar,
                         upper,
@@ -3102,7 +3268,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 }
 
 /// The tail of a `Concatenate[T1, T2, Tn, tail]` form.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) enum ConcatenateTail<'db> {
     /// Represents the `Concatenate[T1, T2, Tn, ...]` form where the prefix parameters are followed
     /// by a gradual `*args: Any, **kwargs: Any`.
@@ -3119,7 +3285,7 @@ pub(crate) enum ConcatenateTail<'db> {
 /// and must be preserved when its parameter types are transformed. In particular, specializing a
 /// standard `(*args: T, **kwargs: T)` parameter list with `T = Any` does not make it gradual.
 #[derive(
-    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue,
+    Copy, Clone, Debug, Default, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize,
 )]
 pub(crate) enum ParametersKind<'db> {
     /// A standard parameter list.
@@ -3176,14 +3342,14 @@ pub(crate) enum ParametersKind<'db> {
 // TODO: Given how the current structure is laid out which needs to follow certain invariants
 // between the `value` and `kind` field, it would be better to structure it such that these
 // invariants are followed at the type level instead.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 struct ParametersData<'db> {
     // TODO: use SmallVec here once invariance bug is fixed
     value: Box<[Parameter<'db>]>,
     kind: ParametersKind<'db>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct Parameters<'db> {
     data: Arc<ParametersData<'db>>,
 }
@@ -3554,14 +3720,22 @@ impl<'db> Parameters<'db> {
         )
     }
 
-    pub(crate) fn paramspec(db: &'db dyn Db, typevar: BoundTypeVarInstance<'db>) -> Self {
+    pub(crate) fn paramspec(
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarInstance<'db>,
+    ) -> Self {
         Self::new(
             [
                 Parameter::variadic(Name::new_static("args")).with_annotated_type(Type::TypeVar(
-                    typevar.with_paramspec_attr(db, ParamSpecAttrKind::Args),
+                    typevar.with_paramspec_attr(db, program, ParamSpecAttrKind::Args),
                 )),
                 Parameter::keyword_variadic(Name::new_static("kwargs")).with_annotated_type(
-                    Type::TypeVar(typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs)),
+                    Type::TypeVar(typevar.with_paramspec_attr(
+                        db,
+                        program,
+                        ParamSpecAttrKind::Kwargs,
+                    )),
                 ),
             ],
             ParametersKind::ParamSpec(typevar),
@@ -3576,14 +3750,15 @@ impl<'db> Parameters<'db> {
     /// - `(<prefix_params>, /, *args: P.args, **kwargs: P.kwargs)` for the `ParamSpec` form.
     pub(crate) fn concatenate(
         db: &'db dyn Db,
+        program: crate::Program,
         mut prefix_params: Vec<Parameter<'db>>,
         concatenate_tail: ConcatenateTail<'db>,
     ) -> Self {
         let (args_type, kwargs_type) = match concatenate_tail {
             ConcatenateTail::Gradual => (Type::any(), Type::any()),
             ConcatenateTail::ParamSpec(typevar) => (
-                Type::TypeVar(typevar.with_paramspec_attr(db, ParamSpecAttrKind::Args)),
-                Type::TypeVar(typevar.with_paramspec_attr(db, ParamSpecAttrKind::Kwargs)),
+                Type::TypeVar(typevar.with_paramspec_attr(db, program, ParamSpecAttrKind::Args)),
+                Type::TypeVar(typevar.with_paramspec_attr(db, program, ParamSpecAttrKind::Kwargs)),
             ),
         };
         prefix_params.extend([
@@ -3650,6 +3825,7 @@ impl<'db> Parameters<'db> {
         parameters: &ast::Parameters,
         has_implicitly_positional_first_parameter: bool,
     ) -> Self {
+        let program = definition.program_file(db).program(db);
         let ast::Parameters {
             posonlyargs,
             args,
@@ -3667,7 +3843,7 @@ impl<'db> Parameters<'db> {
                 // directly to infer_deferred_types without first checking infer_definition_types.
                 infer_deferred_types(db, definition)
                     .expression_type(default)
-                    .replace_parameter_defaults(db)
+                    .replace_parameter_defaults(db, program)
             })
         };
 
@@ -3763,6 +3939,7 @@ impl<'db> Parameters<'db> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -3792,7 +3969,7 @@ impl<'db> Parameters<'db> {
             .data
             .value
             .iter()
-            .map(|param| param.apply_type_mapping_impl(db, &type_mapping, tcx, visitor))
+            .map(|param| param.apply_type_mapping_impl(db, program, &type_mapping, tcx, visitor))
             .collect();
 
         Self::new(value, self.data.kind)
@@ -3945,46 +4122,7 @@ impl<'db> std::ops::Index<usize> for Parameters<'db> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ParameterDisplayName<N> {
-    name: N,
-    prefix: ParameterNamePrefix,
-}
-
-impl ParameterDisplayName<&Name> {
-    pub(crate) fn into_owned(self) -> ParameterDisplayName<Name> {
-        ParameterDisplayName {
-            name: (*self.name).clone(),
-            prefix: self.prefix,
-        }
-    }
-}
-
-impl<N: AsRef<str>> fmt::Display for ParameterDisplayName<N> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.prefix.as_str())?;
-        f.write_str(self.name.as_ref())
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ParameterNamePrefix {
-    None,
-    Variadic,
-    KeywordVariadic,
-}
-
-impl ParameterNamePrefix {
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::None => "",
-            Self::Variadic => "*",
-            Self::KeywordVariadic => "**",
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub(crate) struct Parameter<'db> {
     /// Annotated type of the parameter. If no annotation was provided, this is `Unknown`.
     annotated_type: Type<'db>,
@@ -4010,7 +4148,7 @@ pub(crate) struct Parameter<'db> {
     kind: ParameterKind<'db>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 enum ParameterAnnotationKind {
     Normal,
 
@@ -4124,6 +4262,7 @@ impl<'db> Parameter<'db> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -4131,6 +4270,7 @@ impl<'db> Parameter<'db> {
         Self {
             annotated_type: self.annotated_type.apply_type_mapping_impl(
                 db,
+                program,
                 type_mapping,
                 tcx,
                 visitor,
@@ -4138,18 +4278,26 @@ impl<'db> Parameter<'db> {
             definition: self.definition,
             kind: self
                 .kind
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             inferred_annotation: self.inferred_annotation,
             annotation_kind: self.annotation_kind,
         }
     }
 
-    fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: &Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         let annotated_type =
             self.annotated_type
-                .cycle_normalized(db, previous.annotated_type, cycle);
+                .cycle_normalized(db, program, previous.annotated_type, cycle);
 
-        let kind = self.kind.cycle_normalized(db, &previous.kind, cycle);
+        let kind = self
+            .kind
+            .cycle_normalized(db, program, &previous.kind, cycle);
 
         Self {
             annotated_type,
@@ -4163,6 +4311,7 @@ impl<'db> Parameter<'db> {
     pub(super) fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -4175,10 +4324,10 @@ impl<'db> Parameter<'db> {
         } = self;
 
         let annotated_type = if nested {
-            annotated_type.recursive_type_normalized_impl(db, div, true)?
+            annotated_type.recursive_type_normalized_impl(db, program, div, true)?
         } else {
             annotated_type
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .unwrap_or(div)
         };
 
@@ -4186,9 +4335,11 @@ impl<'db> Parameter<'db> {
             ParameterKind::PositionalOnly { name, default_type } => ParameterKind::PositionalOnly {
                 name: name.clone(),
                 default_type: match default_type {
-                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+                    Some(ty) if nested => {
+                        Some(ty.recursive_type_normalized_impl(db, program, div, true)?)
+                    }
                     Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true)
+                        ty.recursive_type_normalized_impl(db, program, div, true)
                             .unwrap_or(div),
                     ),
                     None => None,
@@ -4199,10 +4350,10 @@ impl<'db> Parameter<'db> {
                     name: name.clone(),
                     default_type: match default_type {
                         Some(ty) if nested => {
-                            Some(ty.recursive_type_normalized_impl(db, div, true)?)
+                            Some(ty.recursive_type_normalized_impl(db, program, div, true)?)
                         }
                         Some(ty) => Some(
-                            ty.recursive_type_normalized_impl(db, div, true)
+                            ty.recursive_type_normalized_impl(db, program, div, true)
                                 .unwrap_or(div),
                         ),
                         None => None,
@@ -4212,9 +4363,11 @@ impl<'db> Parameter<'db> {
             ParameterKind::KeywordOnly { name, default_type } => ParameterKind::KeywordOnly {
                 name: name.clone(),
                 default_type: match default_type {
-                    Some(ty) if nested => Some(ty.recursive_type_normalized_impl(db, div, true)?),
+                    Some(ty) if nested => {
+                        Some(ty.recursive_type_normalized_impl(db, program, div, true)?)
+                    }
                     Some(ty) => Some(
-                        ty.recursive_type_normalized_impl(db, div, true)
+                        ty.recursive_type_normalized_impl(db, program, div, true)
                             .unwrap_or(div),
                     ),
                     None => None,
@@ -4241,7 +4394,7 @@ impl<'db> Parameter<'db> {
         parameter: &ast::Parameter,
         kind: ParameterKind<'db>,
     ) -> Self {
-        let index = semantic_index(db, function_definition.file(db));
+        let index = semantic_index(db, function_definition.program_file(db));
         let definition = Some(index.expect_single_definition(parameter));
 
         let (annotated_type, inferred_annotation, has_starred_annotation) =
@@ -4377,14 +4530,12 @@ impl<'db> Parameter<'db> {
     }
 
     /// Display name of the parameter, if it has one.
-    pub(crate) fn display_name(&self) -> Option<ParameterDisplayName<&Name>> {
-        let prefix = match self.kind {
-            ParameterKind::Variadic { .. } => ParameterNamePrefix::Variadic,
-            ParameterKind::KeywordVariadic { .. } => ParameterNamePrefix::KeywordVariadic,
-            _ => ParameterNamePrefix::None,
-        };
-        self.name()
-            .map(|name| ParameterDisplayName { name, prefix })
+    pub(crate) fn display_name(&self) -> Option<ast::name::Name> {
+        self.name().map(|name| match self.kind {
+            ParameterKind::Variadic { .. } => ast::name::Name::new(format!("*{name}")),
+            ParameterKind::KeywordVariadic { .. } => ast::name::Name::new(format!("**{name}")),
+            _ => name.clone(),
+        })
     }
 
     /// Default-value type of the parameter, if any.
@@ -4410,7 +4561,7 @@ impl<'db> Parameter<'db> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub enum ParameterKind<'db> {
     /// Positional-only parameter, e.g. `def f(x, /): ...`
     PositionalOnly {
@@ -4453,18 +4604,25 @@ impl<'db> ParameterKind<'db> {
     #[expect(clippy::ref_option)]
     fn cycle_normalized_default(
         db: &'db dyn Db,
+        program: crate::Program,
         current: &Option<Type<'db>>,
         previous: &Option<Type<'db>>,
         cycle: &salsa::Cycle,
     ) -> Option<Type<'db>> {
         match (current, previous) {
-            (Some(curr), Some(prev)) => Some(curr.cycle_normalized(db, *prev, cycle)),
-            (Some(curr), None) => Some(curr.recursive_type_normalized(db, cycle)),
+            (Some(curr), Some(prev)) => Some(curr.cycle_normalized(db, program, *prev, cycle)),
+            (Some(curr), None) => Some(curr.recursive_type_normalized(db, program, cycle)),
             (None, _) => *current,
         }
     }
 
-    fn cycle_normalized(&self, db: &'db dyn Db, previous: &Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: &Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         match (self, previous) {
             (
                 ParameterKind::PositionalOnly { name, default_type },
@@ -4474,7 +4632,13 @@ impl<'db> ParameterKind<'db> {
                 },
             ) => ParameterKind::PositionalOnly {
                 name: name.clone(),
-                default_type: Self::cycle_normalized_default(db, default_type, prev_default, cycle),
+                default_type: Self::cycle_normalized_default(
+                    db,
+                    program,
+                    default_type,
+                    prev_default,
+                    cycle,
+                ),
             },
             (
                 ParameterKind::PositionalOrKeyword { name, default_type },
@@ -4484,7 +4648,13 @@ impl<'db> ParameterKind<'db> {
                 },
             ) => ParameterKind::PositionalOrKeyword {
                 name: name.clone(),
-                default_type: Self::cycle_normalized_default(db, default_type, prev_default, cycle),
+                default_type: Self::cycle_normalized_default(
+                    db,
+                    program,
+                    default_type,
+                    prev_default,
+                    cycle,
+                ),
             },
             (
                 ParameterKind::KeywordOnly { name, default_type },
@@ -4494,7 +4664,13 @@ impl<'db> ParameterKind<'db> {
                 },
             ) => ParameterKind::KeywordOnly {
                 name: name.clone(),
-                default_type: Self::cycle_normalized_default(db, default_type, prev_default, cycle),
+                default_type: Self::cycle_normalized_default(
+                    db,
+                    program,
+                    default_type,
+                    prev_default,
+                    cycle,
+                ),
             },
             // Variadic / KeywordVariadic have no types to normalize.
             // Also, if the current `ParameterKind` is different from `previous`, it means that `previous` is the cycle initial value,
@@ -4506,6 +4682,7 @@ impl<'db> ParameterKind<'db> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -4516,7 +4693,7 @@ impl<'db> ParameterKind<'db> {
             } else {
                 default_type
                     .as_ref()
-                    .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                    .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
         };
 
@@ -4549,7 +4726,7 @@ mod tests {
     #[track_caller]
     fn get_function_f<'db>(db: &'db TestDb, file: &'static str) -> FunctionType<'db> {
         let module = ruff_db::files::system_path_to_file(db, file).unwrap();
-        global_symbol(db, module, "f")
+        global_symbol(db, crate::ProgramFile::new(db, db.program(), module), "f")
             .place
             .expect_type()
             .expect_function_literal()
@@ -4636,24 +4813,25 @@ mod tests {
             ",
         )
         .unwrap();
+        let program = db.program();
         let func = get_function_f(&db, "/src/a.py")
             .literal(&db)
             .last_definition;
 
         let sig = func.signature(&db);
 
-        assert_eq!(sig.return_ty.display(&db).to_string(), "bytes");
+        assert_eq!(sig.return_ty.display(&db, program).to_string(), "bytes");
         assert_params_have_definitions(&sig);
         assert_params(
             &sig,
             &[
                 Parameter::positional_only(Some(Name::new_static("a"))),
                 Parameter::positional_only(Some(Name::new_static("b")))
-                    .with_annotated_type(KnownClass::Int.to_instance(&db)),
+                    .with_annotated_type(KnownClass::Int.to_instance(&db, program)),
                 Parameter::positional_only(Some(Name::new_static("c")))
                     .with_default_type(Type::int_literal(1)),
                 Parameter::positional_only(Some(Name::new_static("d")))
-                    .with_annotated_type(KnownClass::Int.to_instance(&db))
+                    .with_annotated_type(KnownClass::Int.to_instance(&db, program))
                     .with_default_type(Type::int_literal(2)),
                 Parameter::positional_or_keyword(Name::new_static("e"))
                     .with_default_type(Type::int_literal(3)),
@@ -4667,7 +4845,7 @@ mod tests {
                     .with_annotated_type(LiteralValueType::unpromotable(6).into())
                     .with_default_type(LiteralValueType::unpromotable(6).into()),
                 Parameter::keyword_variadic(Name::new_static("kwargs"))
-                    .with_annotated_type(KnownClass::Str.to_instance(&db)),
+                    .with_annotated_type(KnownClass::Str.to_instance(&db, program)),
             ],
         );
     }
@@ -4689,6 +4867,7 @@ mod tests {
             ",
         )
         .unwrap();
+        let program = db.program();
         let func = get_function_f(&db, "/src/a.py")
             .literal(&db)
             .last_definition;
@@ -4707,7 +4886,7 @@ mod tests {
         };
         assert_eq!(name, "a");
         // Parameter resolution not deferred; we should see A not B
-        assert_eq!(annotated_type.display(&db).to_string(), "A");
+        assert_eq!(annotated_type.display(&db, program).to_string(), "A");
     }
 
     #[test]
@@ -4727,6 +4906,7 @@ mod tests {
             ",
         )
         .unwrap();
+        let program = db.program();
         let func = get_function_f(&db, "/src/a.pyi")
             .literal(&db)
             .last_definition;
@@ -4745,7 +4925,7 @@ mod tests {
         };
         assert_eq!(name, "a");
         // Parameter resolution deferred:
-        assert_eq!(annotated_type.display(&db).to_string(), "A | B");
+        assert_eq!(annotated_type.display(&db, program).to_string(), "A | B");
     }
 
     #[test]
@@ -4765,6 +4945,7 @@ mod tests {
             ",
         )
         .unwrap();
+        let program = db.program();
         let func = get_function_f(&db, "/src/a.py")
             .literal(&db)
             .last_definition;
@@ -4788,8 +4969,8 @@ mod tests {
         };
         assert_eq!(a_name, "a");
         assert_eq!(b_name, "b");
-        assert_eq!(a_annotated_ty.display(&db).to_string(), "A");
-        assert_eq!(b_annotated_ty.display(&db).to_string(), "T@f");
+        assert_eq!(a_annotated_ty.display(&db, program).to_string(), "A");
+        assert_eq!(b_annotated_ty.display(&db, program).to_string(), "T@f");
     }
 
     #[test]
@@ -4809,6 +4990,7 @@ mod tests {
             ",
         )
         .unwrap();
+        let program = db.program();
         let func = get_function_f(&db, "/src/a.pyi")
             .literal(&db)
             .last_definition;
@@ -4833,8 +5015,8 @@ mod tests {
         assert_eq!(a_name, "a");
         assert_eq!(b_name, "b");
         // Parameter resolution deferred:
-        assert_eq!(a_annotated_ty.display(&db).to_string(), "A | B");
-        assert_eq!(b_annotated_ty.display(&db).to_string(), "T@f");
+        assert_eq!(a_annotated_ty.display(&db, program).to_string(), "A | B");
+        assert_eq!(b_annotated_ty.display(&db, program).to_string(), "T@f");
     }
 
     #[test]

--- a/crates/ty_python_semantic/src/types/signatures.rs
+++ b/crates/ty_python_semantic/src/types/signatures.rs
@@ -696,6 +696,7 @@ impl<'db> Signature<'db> {
     /// Return a typed signature from a function definition.
     pub(super) fn from_function(
         db: &'db dyn Db,
+        program: crate::Program,
         pep695_generic_context: Option<GenericContext<'db>>,
         definition: Definition<'db>,
         function_node: &ast::StmtFunctionDef,
@@ -704,6 +705,7 @@ impl<'db> Signature<'db> {
     ) -> Self {
         let parameters = Parameters::from_parameters(
             db,
+            program,
             definition,
             function_node.parameters.as_ref(),
             has_implicitly_positional_first_parameter,
@@ -714,7 +716,7 @@ impl<'db> Signature<'db> {
             .map(|returns| function_signature_expression_type(db, definition, returns.as_ref()))
             .unwrap_or_else(Type::unknown);
         let legacy_generic_context =
-            GenericContext::from_function_params(db, definition, &parameters, return_ty);
+            GenericContext::from_function_params(db, program, definition, &parameters, return_ty);
         let full_generic_context = GenericContext::merge_pep695_and_legacy(
             db,
             pep695_generic_context,
@@ -729,6 +731,7 @@ impl<'db> Signature<'db> {
                 // because we need to apply this heuristic to PEP-695 typevars as well.)
                 GenericContext::remove_callable_only_typevars(
                     db,
+                    program,
                     full_generic_context,
                     &parameters,
                     return_ty,
@@ -3821,11 +3824,11 @@ impl<'db> Parameters<'db> {
 
     fn from_parameters(
         db: &'db dyn Db,
+        program: crate::Program,
         definition: Definition<'db>,
         parameters: &ast::Parameters,
         has_implicitly_positional_first_parameter: bool,
     ) -> Self {
-        let program = definition.program_file(db).program(db);
         let ast::Parameters {
             posonlyargs,
             args,

--- a/crates/ty_python_semantic/src/types/special_form.rs
+++ b/crates/ty_python_semantic/src/types/special_form.rs
@@ -10,12 +10,12 @@ use crate::types::{
     generics::typing_self,
     infer::{function_known_decorator_flags, nearest_enclosing_class},
 };
-use ruff_db::files::File;
 use strum_macros::EnumString;
 use ty_module_resolver::{KnownModule, file_to_module, resolve_module_confident};
 use ty_python_core::{
     FileScopeId,
     definition::{Definition, DefinitionKind},
+    environment::ProgramFile,
     place::ScopedPlaceId,
     place_table,
     scope::ScopeId,
@@ -230,13 +230,17 @@ impl SpecialFormType {
     /// For example, the symbol `typing.Literal` is an instance of `typing._SpecialForm`,
     /// so `SpecialFormType::Literal.instance_fallback(db)`
     /// returns `Type::NominalInstance(NominalInstanceType { class: <typing._SpecialForm> })`.
-    pub(super) fn instance_fallback(self, db: &dyn Db) -> Type<'_> {
-        self.class().to_instance(db)
+    pub(super) fn instance_fallback(self, db: &dyn Db, program: crate::Program) -> Type<'_> {
+        self.class().to_instance(db, program)
     }
 
     /// Return the type denoted by this retained special-form value when it is valid without
     /// parameters or a surrounding inference scope.
-    pub(crate) fn type_form_argument(self, db: &dyn Db) -> Option<Type<'_>> {
+    pub(crate) fn type_form_argument(
+        self,
+        db: &dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'_>> {
         match self {
             Self::Never | Self::NoReturn => Some(Type::Never),
             Self::LiteralString => Some(Type::literal_string()),
@@ -246,37 +250,41 @@ impl SpecialFormType {
             Self::AlwaysFalsy => Some(Type::AlwaysFalsy),
             Self::NamedTuple => Some(IntersectionType::from_two_elements(
                 db,
+                program,
                 Type::homogeneous_tuple(db, Type::object()),
-                KnownClass::NamedTupleLike.to_instance(db),
+                KnownClass::NamedTupleLike.to_instance(db, program),
             )),
-            Self::Type => Some(KnownClass::Type.to_instance(db)),
+            Self::Type => Some(KnownClass::Type.to_instance(db, program)),
             Self::TypeForm => Some(TypeFormType::from_type_expression(db, Type::any())),
             Self::Tuple => Some(Type::homogeneous_tuple(db, Type::unknown())),
             Self::TypingCallable | Self::CollectionsAbcCallable => {
                 Some(Type::Callable(CallableType::unknown(db)))
             }
-            Self::LegacyStdlibAlias(alias) => Some(alias.aliased_class().to_instance(db)),
+            Self::LegacyStdlibAlias(alias) => Some(alias.aliased_class().to_instance(db, program)),
             _ => None,
         }
     }
 
     /// Return `true` if this symbol is an instance of `class`.
     pub(super) fn is_instance_of(self, db: &dyn Db, class: ClassType) -> bool {
-        self.class().is_subclass_of(db, class)
+        let program = class.program(db);
+        self.class().is_subclass_of(db, program, class)
     }
 
-    pub(super) fn try_from_file_and_name(
+    pub(super) fn try_from_program_file_and_name(
         db: &dyn Db,
-        file: File,
+        program_file: ProgramFile<'_>,
         symbol_name: &str,
     ) -> Option<Self> {
-        Self::candidates_from_name(symbol_name)
+        let candidates = Self::candidates_from_name(symbol_name);
+        if candidates.is_empty() {
+            return None;
+        }
+
+        let known_module = file_to_module(db, program_file.resolver_file(db))?.known(db)?;
+        candidates
             .iter()
-            .find(|candidate| {
-                file_to_module(db, file)
-                    .and_then(|module| module.known(db))
-                    .is_some_and(|known_module| candidate.check_module(known_module))
-            })
+            .find(|candidate| candidate.check_module(known_module))
             .copied()
     }
 
@@ -570,8 +578,8 @@ impl SpecialFormType {
         }
     }
 
-    pub(super) fn to_meta_type(self, db: &dyn Db) -> Type<'_> {
-        self.class().to_class_literal(db)
+    pub(super) fn to_meta_type(self, db: &dyn Db, program: crate::Program) -> Type<'_> {
+        self.class().to_class_literal(db, program)
     }
 
     /// Return true if this special form is callable at runtime.
@@ -790,12 +798,18 @@ impl SpecialFormType {
         }
     }
 
-    pub(super) fn definition(self, db: &dyn Db) -> Option<TypeDefinition<'_>> {
+    pub(super) fn definition(
+        self,
+        db: &dyn Db,
+        program: crate::Program,
+    ) -> Option<TypeDefinition<'_>> {
         self.definition_modules()
             .iter()
             .find_map(|module| {
-                let file = resolve_module_confident(db, &module.name())?.file(db)?;
-                let scope = FileScopeId::global().to_scope_id(db, file);
+                let file =
+                    resolve_module_confident(db, program.resolver(db), &module.name())?.file(db)?;
+                let scope =
+                    FileScopeId::global().to_scope_id(db, ProgramFile::new(db, program, file));
                 let symbol_id = place_table(db, scope).symbol_id(self.name())?;
 
                 use_def_map(db, scope)
@@ -814,6 +828,7 @@ impl SpecialFormType {
     pub(super) fn in_type_expression<'db>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         scope_id: ScopeId<'db>,
         typevar_binding_context: Option<Definition<'db>>,
         inference_flags: InferenceFlags,
@@ -838,8 +853,9 @@ impl SpecialFormType {
             // See conversation in https://github.com/astral-sh/ruff/pull/19915.
             Self::NamedTuple => Ok(IntersectionType::from_two_elements(
                 db,
+                program,
                 Type::homogeneous_tuple(db, Type::object()),
-                KnownClass::NamedTupleLike.to_instance(db),
+                KnownClass::NamedTupleLike.to_instance(db, program),
             )),
 
             Self::TypingSelf => {
@@ -847,7 +863,7 @@ impl SpecialFormType {
                     return Err(InvalidTypeExpression::TypingSelfInTypeAlias);
                 }
 
-                let index = semantic_index(db, scope_id.file(db));
+                let index = semantic_index(db, scope_id.program_file(db));
                 let Some(class) = nearest_enclosing_class(db, index, scope_id) else {
                     return Err(InvalidTypeExpression::InvalidType(
                         Type::SpecialForm(self),
@@ -876,7 +892,7 @@ impl SpecialFormType {
                 }
 
                 let is_in_metaclass = KnownClass::Type
-                    .to_class_literal(db)
+                    .to_class_literal(db, program)
                     .to_class_type(db)
                     .is_some_and(|type_class| {
                         class
@@ -927,13 +943,15 @@ impl SpecialFormType {
             | Self::RegularCallableTypeOf => Err(InvalidTypeExpression::RequiresOneArgument(self)),
 
             // We treat `typing.Type` exactly the same as `builtins.type`:
-            SpecialFormType::Type => Ok(KnownClass::Type.to_instance(db)),
+            SpecialFormType::Type => Ok(KnownClass::Type.to_instance(db, program)),
             SpecialFormType::TypeForm => Ok(TypeFormType::from_type_expression(db, Type::any())),
             SpecialFormType::Tuple => Ok(Type::homogeneous_tuple(db, Type::unknown())),
             SpecialFormType::TypingCallable | SpecialFormType::CollectionsAbcCallable => {
                 Ok(Type::Callable(CallableType::unknown(db)))
             }
-            SpecialFormType::LegacyStdlibAlias(alias) => Ok(alias.aliased_class().to_instance(db)),
+            SpecialFormType::LegacyStdlibAlias(alias) => {
+                Ok(alias.aliased_class().to_instance(db, program))
+            }
             SpecialFormType::TypeQualifier(qualifier) => {
                 Err(InvalidTypeExpression::TypeQualifier(qualifier))
             }

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -207,7 +207,7 @@ impl<'db> SubclassOfType<'db> {
         match self.subclass_of {
             SubclassOfInner::Dynamic(_) => {}
             SubclassOfInner::Class(class) => {
-                class.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                class.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
             SubclassOfInner::TypeVar(typevar) => {
                 Type::TypeVar(typevar).find_legacy_typevars_impl(

--- a/crates/ty_python_semantic/src/types/subclass_of.rs
+++ b/crates/ty_python_semantic/src/types/subclass_of.rs
@@ -22,10 +22,11 @@ pub struct SubclassOfType<'db> {
 
 pub(super) fn walk_subclass_of_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     subclass_of: SubclassOfType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, Type::from(subclass_of));
+    visitor.visit_type(db, program, Type::from(subclass_of));
 }
 
 impl<'db> SubclassOfType<'db> {
@@ -40,14 +41,18 @@ impl<'db> SubclassOfType<'db> {
     ///
     /// The eager normalization here means that we do not need to worry elsewhere about distinguishing
     /// between `@final` classes and other classes when dealing with [`Type::SubclassOf`] variants.
-    pub(crate) fn from(db: &'db dyn Db, subclass_of: impl Into<SubclassOfInner<'db>>) -> Type<'db> {
+    pub(crate) fn from(
+        db: &'db dyn Db,
+        program: crate::Program,
+        subclass_of: impl Into<SubclassOfInner<'db>>,
+    ) -> Type<'db> {
         let subclass_of = subclass_of.into();
         match subclass_of {
             SubclassOfInner::Class(class) => {
                 if class.is_final(db) {
                     Type::from(class)
                 } else if class.is_object(db) {
-                    Self::subclass_of_object(db)
+                    Self::subclass_of_object(db, program)
                 } else {
                     Type::SubclassOf(Self { subclass_of })
                 }
@@ -59,7 +64,11 @@ impl<'db> SubclassOfType<'db> {
     }
 
     /// Given the class object `T`, returns a [`Type`] instance representing `type[T]`.
-    pub(crate) fn try_from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    pub(crate) fn try_from_type(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+    ) -> Option<Type<'db>> {
         let subclass_of = match ty {
             Type::Dynamic(dynamic) => SubclassOfInner::Dynamic(dynamic),
             Type::ClassLiteral(literal) => {
@@ -73,24 +82,29 @@ impl<'db> SubclassOfType<'db> {
             _ => return None,
         };
 
-        Some(Self::from(db, subclass_of))
+        Some(Self::from(db, program, subclass_of))
     }
 
     /// Given an instance of the class or type variable `T`, returns a [`Type`] instance representing `type[T]`.
-    pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Type<'db>> {
+    pub(crate) fn try_from_instance(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+    ) -> Option<Type<'db>> {
         // Handle unions by distributing `type[]` over each element:
         // `type[A | B]` -> `type[A] | type[B]`
         match ty {
             Type::Union(union) => UnionType::try_from_elements(
                 db,
+                program,
                 union
                     .elements(db)
                     .iter()
-                    .map(|element| Self::try_from_instance(db, *element)),
+                    .map(|element| Self::try_from_instance(db, program, *element)),
             ),
-            Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db)),
-            _ => SubclassOfInner::try_from_instance(db, ty)
-                .map(|subclass_of| Self::from(db, subclass_of)),
+            Type::ProtocolInstance(protocol) => Some(protocol.to_meta_type(db, program)),
+            _ => SubclassOfInner::try_from_instance(db, program, ty)
+                .map(|subclass_of| Self::from(db, program, subclass_of)),
         }
     }
 
@@ -110,9 +124,9 @@ impl<'db> SubclassOfType<'db> {
     }
 
     /// Return a [`Type`] instance representing the type `type[object]`.
-    pub(crate) fn subclass_of_object(db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn subclass_of_object(db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         // See the documentation of `SubclassOfType::from` for details.
-        KnownClass::Type.to_instance(db)
+        KnownClass::Type.to_instance(db, program)
     }
 
     /// Return the inner [`SubclassOfInner`] value wrapped by this `SubclassOfType`.
@@ -138,11 +152,15 @@ impl<'db> SubclassOfType<'db> {
     /// Return the exact class-object type of this `type[T]` `TypeVar`'s upper bound, if it has one.
     ///
     /// This can only succeed when the upper bound normalizes to a final class.
-    pub(crate) fn exact_typevar_upper_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn exact_typevar_upper_bound(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         self.into_type_var()
             .and_then(|typevar| typevar.typevar(db).upper_bound(db))
             .and_then(|bound| {
-                let bound = Self::try_from_instance(db, bound.resolve_type_alias(db))?;
+                let bound = Self::try_from_instance(db, program, bound.resolve_type_alias(db))?;
                 matches!(bound, Type::ClassLiteral(_) | Type::GenericAlias(_)).then_some(bound)
             })
     }
@@ -150,6 +168,7 @@ impl<'db> SubclassOfType<'db> {
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -165,14 +184,14 @@ impl<'db> SubclassOfType<'db> {
             }),
             SubclassOfInner::Dynamic(_) => match type_mapping {
                 TypeMapping::Materialize(materialization_kind) => match materialization_kind {
-                    MaterializationKind::Top => KnownClass::Type.to_instance(db),
+                    MaterializationKind::Top => KnownClass::Type.to_instance(db, program),
                     MaterializationKind::Bottom => Type::Never,
                 },
                 _ => Type::SubclassOf(self),
             },
             SubclassOfInner::TypeVar(typevar) => {
-                let mapped = typevar.apply_type_mapping_impl(db, type_mapping, visitor);
-                mapped.to_meta_type(db)
+                let mapped = typevar.apply_type_mapping_impl(db, program, type_mapping, visitor);
+                mapped.to_meta_type(db, program)
             }
         }
     }
@@ -180,6 +199,7 @@ impl<'db> SubclassOfType<'db> {
     pub(super) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
@@ -192,6 +212,7 @@ impl<'db> SubclassOfType<'db> {
             SubclassOfInner::TypeVar(typevar) => {
                 Type::TypeVar(typevar).find_legacy_typevars_impl(
                     db,
+                    program,
                     binding_context,
                     typevars,
                     visitor,
@@ -203,10 +224,11 @@ impl<'db> SubclassOfType<'db> {
     pub(crate) fn find_name_in_mro_with_policy(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         name: &str,
         policy: MemberLookupPolicy,
     ) -> Option<PlaceAndQualifiers<'db>> {
-        let class_like = match self.subclass_of.with_transposed_type_var(db) {
+        let class_like = match self.subclass_of.with_transposed_type_var(db, program) {
             SubclassOfInner::Class(class) => Type::from(class),
             SubclassOfInner::Dynamic(dynamic) => Type::Dynamic(dynamic),
             SubclassOfInner::TypeVar(bound_typevar) => {
@@ -214,13 +236,13 @@ impl<'db> SubclassOfType<'db> {
                     None => unreachable!(),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound,
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        constraints.as_type(db)
+                        constraints.as_type(db, program)
                     }
                 }
             }
         };
 
-        class_like.find_name_in_mro_with_policy(db, name, policy)
+        class_like.find_name_in_mro_with_policy(db, program, name, policy)
     }
 
     pub(super) fn recursive_type_normalized_impl(
@@ -245,14 +267,18 @@ impl<'db> SubclassOfType<'db> {
     }
 
     /// Return a type representing "the set of all instances of the metaclass of this type".
-    pub(crate) fn to_metaclass_instance(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn to_metaclass_instance(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
         // This kind of looks like a no-op, but it's not. For `type[C]` where `C` has metaclass
         // `M`, `to_meta_type` transforms `type[C]` to `type[M]`, and then `to_instance` makes it
         // just `M`. And `to_meta_type` will transpose `type[T: C]` into `T: type[C]`, collapse to
         // the upper bound `type[C]`, and transform that to the meta-type `type[M]`, which
         // `to_instance` then resolves to `M`.
-        self.to_meta_type(db)
-            .to_instance(db)
+        self.to_meta_type(db, program)
+            .to_instance(db, program)
             .expect("the meta-type of a SubclassOf type should always be instantiable")
     }
 
@@ -261,13 +287,15 @@ impl<'db> SubclassOfType<'db> {
     /// For `type[C]` where `C` is a concrete class, this returns `type[metaclass(C)]`.
     /// For `type[T]` where `T` is a `TypeVar`, this computes the metatype based on the
     /// `TypeVar`'s bounds or constraints.
-    pub(crate) fn to_meta_type(self, db: &'db dyn Db) -> Type<'db> {
-        match self.subclass_of.with_transposed_type_var(db) {
+    pub(crate) fn to_meta_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        match self.subclass_of.with_transposed_type_var(db, program) {
             SubclassOfInner::Dynamic(dynamic) => {
-                SubclassOfType::from(db, SubclassOfInner::Dynamic(dynamic))
+                SubclassOfType::from(db, program, SubclassOfInner::Dynamic(dynamic))
             }
-            SubclassOfInner::Class(class) => SubclassOfType::try_from_type(db, class.metaclass(db))
-                .unwrap_or(SubclassOfType::subclass_of_unknown()),
+            SubclassOfInner::Class(class) => {
+                SubclassOfType::try_from_type(db, program, class.metaclass(db))
+                    .unwrap_or(SubclassOfType::subclass_of_unknown())
+            }
             // For `type[T]` where `T` is a TypeVar, `with_transposed_type_var` transforms
             // the bounds from instance types to `type[]` types. For example, `type[T]` where
             // `T: A | B` becomes a TypeVar with bound `type[A] | type[B]`. The metatype is
@@ -276,26 +304,33 @@ impl<'db> SubclassOfType<'db> {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
                     // `with_transposed_type_var` always adds a bound for unbounded TypeVars
                     None => unreachable!(),
-                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => bound.to_meta_type(db),
+                    Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
+                        bound.to_meta_type(db, program)
+                    }
                     Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                        constraints.as_type(db).to_meta_type(db)
+                        constraints.as_type(db, program).to_meta_type(db, program)
                     }
                 }
             }
         }
     }
 
-    pub(crate) fn is_typed_dict(self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_typed_dict(self, db: &'db dyn Db, program: crate::Program) -> bool {
         self.subclass_of
-            .into_class(db)
+            .into_class(db, program)
             .is_some_and(|class| class.class_literal(db).is_typed_dict(db))
     }
 }
 
 impl<'db> VarianceInferable<'db> for SubclassOfType<'db> {
-    fn variance_of(self, db: &dyn Db, typevar: BoundTypeVarIdentity<'_>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         match self.subclass_of {
-            SubclassOfInner::Class(class) => class.variance_of(db, typevar),
+            SubclassOfInner::Class(class) => class.variance_of(db, program, typevar),
             SubclassOfInner::Dynamic(_) | SubclassOfInner::TypeVar(_) => TypeVarVariance::Bivariant,
         }
     }
@@ -399,19 +434,25 @@ impl<'db> SubclassOfInner<'db> {
         matches!(self, Self::TypeVar(_))
     }
 
-    pub(crate) fn into_class(self, db: &'db dyn Db) -> Option<ClassType<'db>> {
+    pub(crate) fn into_class(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<ClassType<'db>> {
         match self {
             Self::Dynamic(_) => None,
             Self::Class(class) => Some(class),
             Self::TypeVar(bound_typevar) => {
                 match bound_typevar.typevar(db).bound_or_constraints(db) {
-                    None => Some(ClassType::object(db)),
+                    None => Some(ClassType::object(db, program)),
                     Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                        Self::try_from_instance(db, bound)
-                            .and_then(|subclass_of| subclass_of.into_class(db))
+                        Self::try_from_instance(db, program, bound)
+                            .and_then(|subclass_of| subclass_of.into_class(db, program))
                     }
                     // TODO this is quite imprecise
-                    Some(TypeVarBoundOrConstraints::Constraints(_)) => Some(ClassType::object(db)),
+                    Some(TypeVarBoundOrConstraints::Constraints(_)) => {
+                        Some(ClassType::object(db, program))
+                    }
                 }
             }
         }
@@ -431,9 +472,13 @@ impl<'db> SubclassOfInner<'db> {
         }
     }
 
-    pub(crate) fn try_from_instance(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    pub(crate) fn try_from_instance(
+        db: &'db dyn Db,
+        program: crate::Program,
+        ty: Type<'db>,
+    ) -> Option<Self> {
         Some(match ty {
-            Type::NominalInstance(instance) => SubclassOfInner::Class(instance.class(db)),
+            Type::NominalInstance(instance) => SubclassOfInner::Class(instance.class(db, program)),
             Type::TypedDict(typed_dict) => match typed_dict {
                 TypedDictType::Class(class) => SubclassOfInner::Class(class),
                 TypedDictType::Synthesized(_) => SubclassOfInner::Dynamic(
@@ -463,7 +508,7 @@ impl<'db> SubclassOfInner<'db> {
     /// - Otherwise, for an unbounded type variable, this returns `type[object]`.
     ///
     /// If this is type of a concrete type `C`, returns the type unchanged.
-    pub(crate) fn with_transposed_type_var(self, db: &'db dyn Db) -> Self {
+    pub(crate) fn with_transposed_type_var(self, db: &'db dyn Db, program: crate::Program) -> Self {
         let Some(bound_typevar) = self.into_type_var() else {
             return self;
         };
@@ -471,15 +516,15 @@ impl<'db> SubclassOfInner<'db> {
         let bound_typevar = bound_typevar.map_bound_or_constraints(db, |bound_or_constraints| {
             Some(match bound_or_constraints {
                 None => TypeVarBoundOrConstraints::UpperBound(
-                    SubclassOfType::try_from_instance(db, Type::object())
+                    SubclassOfType::try_from_instance(db, program, Type::object())
                         .unwrap_or(SubclassOfType::subclass_of_unknown()),
                 ),
                 Some(TypeVarBoundOrConstraints::UpperBound(bound)) => {
-                    TypeVarBoundOrConstraints::UpperBound(bound.to_meta_type(db))
+                    TypeVarBoundOrConstraints::UpperBound(bound.to_meta_type(db, program))
                 }
                 Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
                     TypeVarBoundOrConstraints::Constraints(
-                        constraints.map(db, |constraint| constraint.to_meta_type(db)),
+                        constraints.map(db, |constraint| constraint.to_meta_type(db, program)),
                     )
                 }
             })

--- a/crates/ty_python_semantic/src/types/subscript.rs
+++ b/crates/ty_python_semantic/src/types/subscript.rs
@@ -208,6 +208,7 @@ impl<'db> SubscriptErrorKind<'db> {
         slice_node: &ast::Expr,
     ) {
         let db = context.db();
+        let program = context.program();
         match self {
             Self::IndexOutOfBounds {
                 kind,
@@ -238,7 +239,7 @@ impl<'db> SubscriptErrorKind<'db> {
                         diagnostic.annotate(context.secondary(&*subscript.value).message(
                             format_args!(
                                 "Alias to `{}`, which is already specialized",
-                                value_type.display(db)
+                                value_type.display(db, program)
                             ),
                         ));
                     }
@@ -250,7 +251,7 @@ impl<'db> SubscriptErrorKind<'db> {
                 {
                     builder.into_diagnostic(format_args!(
                         "Method `{method}` of type `{}` may be missing",
-                        value_ty.display(db),
+                        value_ty.display(db, program),
                     ));
                 }
             }
@@ -265,8 +266,8 @@ impl<'db> SubscriptErrorKind<'db> {
                     if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, value_node) {
                         builder.into_diagnostic(format_args!(
                             "Method `{method}` of type `{}` is not callable on object of type `{}`",
-                            bindings.callable_type().display(db),
-                            value_ty.display(db),
+                            bindings.callable_type().display(db, program),
+                            value_ty.display(db, program),
                         ));
                     }
                 }
@@ -286,9 +287,9 @@ impl<'db> SubscriptErrorKind<'db> {
                     {
                         builder.into_diagnostic(format_args!(
                             "Method `{method}` of type `{}` cannot be called with key of type `{}` on object of type `{}`",
-                            bindings.callable_type().display(db),
-                            slice_ty.display(db),
-                            value_ty.display(db),
+                            bindings.callable_type().display(db, program),
+                            slice_ty.display(db, program),
+                            value_ty.display(db, program),
                         ));
                     }
                 }
@@ -296,8 +297,8 @@ impl<'db> SubscriptErrorKind<'db> {
                     if let Some(builder) = context.report_lint(&CALL_NON_CALLABLE, value_node) {
                         builder.into_diagnostic(format_args!(
                             "Method `{method}` of type `{}` may not be callable on object of type `{}`",
-                            bindings.callable_type().display(db),
-                            value_ty.display(db),
+                            bindings.callable_type().display(db, program),
+                            value_ty.display(db, program),
                         ));
                     }
                 }
@@ -328,7 +329,7 @@ impl<'db> SubscriptErrorKind<'db> {
                 if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, value_node) {
                     builder.into_diagnostic(format_args!(
                         "`{}` is not a valid argument to `{origin}`",
-                        argument_ty.display(db),
+                        argument_ty.display(db, program),
                     ));
                 }
             }
@@ -363,13 +364,14 @@ impl<'db> SubscriptErrorKind<'db> {
 
 fn map_union_subscript<'db, F>(
     db: &'db dyn Db,
+    program: crate::Program,
     union: UnionType<'db>,
     mut map_fn: F,
 ) -> Result<Type<'db>, SubscriptError<'db>>
 where
     F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
 {
-    let mut builder = UnionBuilder::new(db);
+    let mut builder = UnionBuilder::new(db, program);
     let mut errors = Vec::new();
 
     for element in union.elements(db) {
@@ -401,13 +403,14 @@ where
 
 fn map_intersection_subscript<'db, F>(
     db: &'db dyn Db,
+    program: crate::Program,
     intersection: IntersectionType<'db>,
     mut map_fn: F,
 ) -> Result<Type<'db>, SubscriptError<'db>>
 where
     F: FnMut(Type<'db>) -> Result<Type<'db>, SubscriptError<'db>>,
 {
-    if let Some(alternatives) = intersection.finite_alternative_union(db) {
+    if let Some(alternatives) = intersection.finite_alternative_union(db, program) {
         return map_fn(alternatives);
     }
 
@@ -426,7 +429,7 @@ where
 
     // If any element succeeded, return the intersection of successful results.
     if !results.is_empty() {
-        let mut builder = IntersectionBuilder::new(db);
+        let mut builder = IntersectionBuilder::new(db, program);
         for result in results {
             builder = builder.add_positive(result);
         }
@@ -438,7 +441,7 @@ where
     // for elements that lack the method.
     let any_has_method = errors.iter().any(SubscriptError::any_method_available);
 
-    let mut builder = IntersectionBuilder::new(db);
+    let mut builder = IntersectionBuilder::new(db, program);
     let mut collected_errors = Vec::new();
     let full_object_ty = Type::Intersection(intersection);
 
@@ -470,11 +473,12 @@ where
 // `Unknown` otherwise. This is not naturally representable via synthesized `__getitem__` overloads.
 fn typed_dict_subscript<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     typed_dict: TypedDictType<'db>,
     slice_ty: Type<'db>,
 ) -> Result<Type<'db>, SubscriptError<'db>> {
     if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
-        return typed_dict_subscript(db, typed_dict, fallback);
+        return typed_dict_subscript(db, program, typed_dict, fallback);
     }
 
     if slice_ty.is_dynamic() {
@@ -486,14 +490,14 @@ fn typed_dict_subscript<'db>(
         .map(|literal| literal.value(db))
     else {
         if typed_dict.explicit_extra_items(db).is_some()
-            && slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            && slice_ty.is_assignable_to(db, program, KnownClass::Str.to_instance(db, program))
         {
-            return Ok(typed_dict.value_type(db));
+            return Ok(typed_dict.value_type(db, program));
         }
         let result_ty = if typed_dict.openness(db).is_closed()
-            && slice_ty.is_assignable_to(db, KnownClass::Str.to_instance(db))
+            && slice_ty.is_assignable_to(db, program, KnownClass::Str.to_instance(db, program))
         {
-            typed_dict.value_type(db)
+            typed_dict.value_type(db, program)
         } else {
             Type::unknown()
         };
@@ -526,15 +530,16 @@ impl<'db> Type<'db> {
     pub(super) fn subscript(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         slice_ty: Type<'db>,
         expr_context: ast::ExprContext,
     ) -> Result<Type<'db>, SubscriptError<'db>> {
         if let Some(fallback) = self.materialized_divergent_fallback() {
-            return fallback.subscript(db, slice_ty, expr_context);
+            return fallback.subscript(db, program, slice_ty, expr_context);
         }
 
         if let Some(fallback) = slice_ty.materialized_divergent_fallback() {
-            return self.subscript(db, fallback, expr_context);
+            return self.subscript(db, program, fallback, expr_context);
         }
 
         let value_ty = self;
@@ -543,44 +548,44 @@ impl<'db> Type<'db> {
             (Type::Dynamic(_) | Type::Divergent(_) | Type::Never, _) => Some(Ok(value_ty)),
 
             (Type::TypeAlias(alias), _) => {
-                Some(alias.value_type(db).subscript(db, slice_ty, expr_context))
+                Some(alias.value_type(db).subscript(db, program, slice_ty, expr_context))
             }
 
             (_, Type::TypeAlias(alias)) => {
-                Some(value_ty.subscript(db, alias.value_type(db), expr_context))
+                Some(value_ty.subscript(db, program, alias.value_type(db), expr_context))
             }
 
-            (Type::Union(union), _) => Some(map_union_subscript(db, union, |element| {
-                element.subscript(db, slice_ty, expr_context)
+            (Type::Union(union), _) => Some(map_union_subscript(db, program, union, |element| {
+                element.subscript(db, program, slice_ty, expr_context)
             })),
 
-            (_, Type::Union(union)) => Some(map_union_subscript(db, union, |element| {
-                value_ty.subscript(db, element, expr_context)
+            (_, Type::Union(union)) => Some(map_union_subscript(db, program, union, |element| {
+                value_ty.subscript(db, program, element, expr_context)
             })),
 
             (Type::EnumComplement(complement), _) => {
-                Some(complement.remaining_literal_union(db).subscript(db, slice_ty, expr_context))
+                Some(complement.remaining_literal_union(db).subscript(db, program, slice_ty, expr_context))
             }
 
             (_, Type::EnumComplement(complement)) => {
-                Some(value_ty.subscript(db, complement.remaining_literal_union(db), expr_context))
+                Some(value_ty.subscript(db, program, complement.remaining_literal_union(db), expr_context))
             }
 
             (Type::Intersection(intersection), _) => {
-                Some(map_intersection_subscript(db, intersection, |element| {
-                    element.subscript(db, slice_ty, expr_context)
+                Some(map_intersection_subscript(db, program, intersection, |element| {
+                    element.subscript(db, program, slice_ty, expr_context)
                 }))
             }
 
             (_, Type::Intersection(intersection)) => {
-                Some(map_intersection_subscript(db, intersection, |element| {
-                    value_ty.subscript(db, element, expr_context)
+                Some(map_intersection_subscript(db, program, intersection, |element| {
+                    value_ty.subscript(db, program, element, expr_context)
                 }))
             }
 
             // Ex) Given `person["name"]`, return `str`
             (Type::TypedDict(typed_dict), _) if expr_context != ast::ExprContext::Store => {
-                Some(typed_dict_subscript(db, typed_dict, slice_ty))
+                Some(typed_dict_subscript(db, program, typed_dict, slice_ty))
             }
 
             (
@@ -612,9 +617,9 @@ impl<'db> Type<'db> {
             (Type::NominalInstance(nominal), Type::LiteralValue(literal)) if literal.is_int() => {
                 let i64_int = literal.as_int().unwrap();
                 nominal
-                    .tuple_spec(db)
+                    .tuple_spec(db, program)
                     .and_then(|tuple| Some((tuple, i32::try_from(i64_int).ok()?)))
-                    .map(|(tuple, i32_int)| match tuple.py_index(db, i32_int) {
+                    .map(|(tuple, i32_int)| match tuple.py_index(db, program, i32_int) {
                         Ok(result) => Ok(result),
                         Err(_) => Err(SubscriptError::new(
                             Type::unknown(),
@@ -633,11 +638,11 @@ impl<'db> Type<'db> {
                 Type::NominalInstance(maybe_tuple_nominal),
                 Type::NominalInstance(maybe_slice_nominal),
             ) => maybe_tuple_nominal
-                .tuple_spec(db)
+                .tuple_spec(db, program)
                 .as_deref()
                 .and_then(|tuple_spec| Some((tuple_spec, maybe_slice_nominal.slice_literal(db)?)))
                 .map(|(tuple, SliceLiteral { start, stop, step })| {
-                    tuple.py_slice_type(db, start, stop, step).map_err(|_| {
+                    tuple.py_slice_type(db, program, start, stop, step).map_err(|_| {
                         SubscriptError::new(Type::unknown(), SubscriptErrorKind::SliceStepSizeZero)
                     })
                 }),
@@ -741,14 +746,14 @@ impl<'db> Type<'db> {
             // Ex) Given `"value"[True]`, return `"a"`
             (Type::LiteralValue(lhs_literal), Type::LiteralValue(rhs_literal)) if (lhs_literal.is_string() || lhs_literal.is_bytes()) && rhs_literal.is_bool() => {
                 let bool = rhs_literal.as_bool().unwrap();
-                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
+                Some(value_ty.subscript(db, program, Type::int_literal(i64::from(bool)), expr_context))
             }
 
             (Type::NominalInstance(nominal), Type::LiteralValue(literal))
-                if literal.is_bool() && nominal.tuple_spec(db).is_some() =>
+                if literal.is_bool() && nominal.tuple_spec(db, program).is_some() =>
             {
                 let bool = literal.as_bool().unwrap();
-                Some(value_ty.subscript(db, Type::int_literal(i64::from(bool)), expr_context))
+                Some(value_ty.subscript(db, program, Type::int_literal(i64::from(bool)), expr_context))
             }
 
             (Type::KnownInstance(KnownInstanceType::SubscriptedProtocol(_)), _) => {
@@ -833,16 +838,17 @@ impl<'db> Type<'db> {
         // See: https://docs.python.org/3/reference/datamodel.html#class-getitem-versus-getitem
         match value_ty.try_call_dunder(
             db,
+            program,
             "__getitem__",
             CallArguments::positional([slice_ty]),
             TypeContext::default(),
         ) {
             Ok(outcome) => {
-                return Ok(outcome.return_type(db));
+                return Ok(outcome.return_type(db, program));
             }
             Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
                 return Err(SubscriptError::new(
-                    bindings.return_type(db),
+                    bindings.return_type(db, program),
                     SubscriptErrorKind::DunderPossiblyUnbound {
                         method: DunderMethod::GetItem,
                         value_ty,
@@ -851,7 +857,7 @@ impl<'db> Type<'db> {
             }
             Err(CallDunderError::CallError(call_error_kind, bindings, _)) => {
                 return Err(SubscriptError::new(
-                    bindings.return_type(db),
+                    bindings.return_type(db, program),
                     SubscriptErrorKind::DunderCallError {
                         method: DunderMethod::GetItem,
                         value_ty,
@@ -875,20 +881,21 @@ impl<'db> Type<'db> {
         // even if the target version is Python 3.8 or lower,
         // despite the fact that there will be no corresponding `__class_getitem__`
         // method in these `sys.version_info` branches.
-        if value_ty.is_subtype_of(db, KnownClass::Type.to_instance(db)) {
+        if value_ty.is_subtype_of(db, program, KnownClass::Type.to_instance(db, program)) {
             let call_arguments = CallArguments::positional([slice_ty]);
             match value_ty.try_call_dunder_on_class(
                 db,
+                program,
                 "__class_getitem__",
                 &call_arguments,
                 TypeContext::default(),
             ) {
                 Ok(bindings) => {
-                    return Ok(bindings.return_type(db));
+                    return Ok(bindings.return_type(db, program));
                 }
                 Err(CallDunderError::PossiblyUnbound { bindings, .. }) => {
                     return Err(SubscriptError::new(
-                        bindings.return_type(db),
+                        bindings.return_type(db, program),
                         SubscriptErrorKind::DunderPossiblyUnbound {
                             method: DunderMethod::ClassGetItem,
                             value_ty,
@@ -897,7 +904,7 @@ impl<'db> Type<'db> {
                 }
                 Err(CallDunderError::CallError(call_error_kind, bindings, _)) => {
                     return Err(SubscriptError::new(
-                        bindings.return_type(db),
+                        bindings.return_type(db, program),
                         SubscriptErrorKind::DunderCallError {
                             method: DunderMethod::ClassGetItem,
                             value_ty,
@@ -914,7 +921,7 @@ impl<'db> Type<'db> {
 
             if let Type::ClassLiteral(class) = value_ty {
                 if class.is_known(db, KnownClass::Type) {
-                    return Ok(KnownClass::GenericAlias.to_instance(db));
+                    return Ok(KnownClass::GenericAlias.to_instance(db, program));
                 }
 
                 if class.generic_context(db).is_some() {

--- a/crates/ty_python_semantic/src/types/tests.rs
+++ b/crates/ty_python_semantic/src/types/tests.rs
@@ -17,10 +17,11 @@ fn no_default_type_is_singleton(python_version: PythonVersion) {
         .with_python_version(python_version)
         .build()
         .unwrap();
+    let program = db.program();
 
-    let no_default = KnownClass::NoDefaultType.to_instance(&db);
+    let no_default = KnownClass::NoDefaultType.to_instance(&db, program);
 
-    assert!(no_default.is_singleton(&db));
+    assert!(no_default.is_singleton(&db, program));
 }
 
 #[test]
@@ -29,22 +30,28 @@ fn typing_vs_typeshed_no_default() {
         .with_python_version(PythonVersion::PY313)
         .build()
         .unwrap();
+    let program = db.program();
 
-    let typing_no_default = typing_symbol(&db, "NoDefault").place.expect_type();
-    let typing_extensions_no_default = typing_extensions_symbol(&db, "NoDefault")
+    let typing_no_default = typing_symbol(&db, program, "NoDefault").place.expect_type();
+    let typing_extensions_no_default = typing_extensions_symbol(&db, program, "NoDefault")
         .place
         .expect_type();
 
-    assert_eq!(typing_no_default.display(&db).to_string(), "NoDefault");
     assert_eq!(
-        typing_extensions_no_default.display(&db).to_string(),
+        typing_no_default.display(&db, program).to_string(),
+        "NoDefault"
+    );
+    assert_eq!(
+        typing_extensions_no_default
+            .display(&db, program)
+            .to_string(),
         "NoDefault"
     );
 }
 
-fn list_alias<'db>(db: &'db dyn Db, argument: Type<'db>) -> GenericAlias<'db> {
+fn list_alias<'db>(db: &'db dyn Db, program: Program, argument: Type<'db>) -> GenericAlias<'db> {
     KnownClass::List
-        .to_specialized_class_type(db, &[argument])
+        .to_specialized_class_type(db, program, &[argument])
         .expect("`list` should accept one type argument")
         .into_generic_alias()
         .expect("a specialized `list` should be a generic alias")
@@ -55,32 +62,33 @@ fn oscillating_generic_alias_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous: &Type<'db>,
     current: Type<'db>,
+    program: Program,
 ) -> Type<'db> {
-    current.cycle_normalized(db, *previous, cycle)
+    current.cycle_normalized(db, program, *previous, cycle)
 }
 
 #[salsa::tracked(
-    returns(copy),
-    cycle_initial=|_, id| Type::divergent(id),
+    cycle_initial=|_, id, _| Type::divergent(id),
     cycle_fn=oscillating_generic_alias_cycle_recover,
 )]
-fn oscillating_generic_alias(db: &dyn Db) -> Type<'_> {
-    let previous = oscillating_generic_alias(db);
+fn oscillating_generic_alias(db: &dyn Db, program: Program) -> Type<'_> {
+    let previous = oscillating_generic_alias(db, program);
     let argument = if let Type::GenericAlias(alias) = previous
         && alias.specialization(db).types(db) == [Type::unknown()]
     {
-        KnownClass::Int.to_instance(db)
+        KnownClass::Int.to_instance(db, program)
     } else {
         Type::unknown()
     };
 
-    list_alias(db, argument).into()
+    list_alias(db, program, argument).into()
 }
 
 #[test]
 fn generic_alias_cycle_recovery_normalizes_same_origin_unknown_oscillation() {
     let db = setup_db();
-    let Type::GenericAlias(alias) = oscillating_generic_alias(&db) else {
+    let program = db.program();
+    let Type::GenericAlias(alias) = oscillating_generic_alias(&db, program) else {
         panic!("cycle recovery should preserve the generic alias");
     };
 
@@ -90,14 +98,15 @@ fn generic_alias_cycle_recovery_normalizes_same_origin_unknown_oscillation() {
 #[test]
 fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
     let db = setup_db();
-    let int = list_alias(&db, KnownClass::Int.to_instance(&db));
-    let str = list_alias(&db, KnownClass::Str.to_instance(&db));
+    let program = db.program();
+    let int = list_alias(&db, program, KnownClass::Int.to_instance(&db, program));
+    let str = list_alias(&db, program, KnownClass::Str.to_instance(&db, program));
     assert!(str.merge_cycle_recovery(&db, int).is_none());
 
     let generic_context = int.specialization(&db).generic_context(&db);
     let unknown_generic = Type::Dynamic(DynamicType::UnknownGeneric(generic_context));
     assert!(
-        int.merge_cycle_recovery(&db, list_alias(&db, unknown_generic))
+        int.merge_cycle_recovery(&db, list_alias(&db, program, unknown_generic))
             .is_none()
     );
 }
@@ -108,15 +117,16 @@ fn generic_alias_cycle_recovery_rejects_unsafe_merges() {
 #[test]
 fn todo_types() {
     let db = setup_db();
+    let program = db.program();
 
     let todo1 = todo_type!("1");
     let todo2 = todo_type!("2");
 
-    let int = KnownClass::Int.to_instance(&db);
+    let int = KnownClass::Int.to_instance(&db, program);
 
-    assert!(int.is_assignable_to(&db, todo1));
+    assert!(int.is_assignable_to(&db, program, todo1));
 
-    assert!(todo1.is_assignable_to(&db, int));
+    assert!(todo1.is_assignable_to(&db, program, int));
 
     // We lose information when combining several `Todo` types. This is an
     // acknowledged limitation of the current implementation. We cannot
@@ -128,12 +138,12 @@ fn todo_types() {
     // salsa, but that would mean we would have to pass in `db` everywhere.
 
     // A union of several `Todo` types collapses to a single `Todo` type:
-    assert!(UnionType::from_elements(&db, [todo1, todo2]).is_todo());
+    assert!(UnionType::from_elements(&db, program, [todo1, todo2]).is_todo());
 
     // And similar for intersection types:
-    assert!(IntersectionType::from_elements(&db, [todo1, todo2]).is_todo());
+    assert!(IntersectionType::from_elements(&db, program, [todo1, todo2]).is_todo());
     assert!(
-        IntersectionBuilder::new(&db)
+        IntersectionBuilder::new(&db, program)
             .add_positive(todo1)
             .add_negative(todo2)
             .build()
@@ -144,105 +154,131 @@ fn todo_types() {
 #[test]
 fn divergent_type() {
     let db = setup_db();
+    let program = db.program();
     let div = Type::divergent(salsa::plumbing::Id::from_bits(1));
     assert!(div.is_dynamic());
-    assert!(div.has_dynamic(&db));
+    assert!(div.has_dynamic(&db, program));
     let visitor = ApplyTypeMappingVisitor::default();
-    let top_div = div.materialize(&db, MaterializationKind::Top, &visitor);
-    let bottom_div = div.materialize(&db, MaterializationKind::Bottom, &visitor);
+    let top_div = div.materialize(&db, program, MaterializationKind::Top, &visitor);
+    let bottom_div = div.materialize(&db, program, MaterializationKind::Bottom, &visitor);
 
     assert!(top_div.is_divergent());
     assert!(bottom_div.is_divergent());
     assert!(!top_div.is_dynamic());
     assert!(!bottom_div.is_dynamic());
-    assert!(!top_div.has_dynamic(&db));
-    assert!(!bottom_div.has_dynamic(&db));
+    assert!(!top_div.has_dynamic(&db, program));
+    assert!(!bottom_div.has_dynamic(&db, program));
     assert!(top_div.is_object());
     assert!(!top_div.is_never());
     assert!(!bottom_div.is_object());
     assert!(bottom_div.is_never());
-    assert_eq!(top_div.negate(&db), bottom_div);
-    assert_eq!(bottom_div.negate(&db), top_div);
-    assert_eq!(IntersectionBuilder::new(&db).add_negative(div).build(), div);
+    assert_eq!(top_div.negate(&db, program), bottom_div);
+    assert_eq!(bottom_div.negate(&db, program), top_div);
     assert_eq!(
-        IntersectionBuilder::new(&db).add_negative(top_div).build(),
+        IntersectionBuilder::new(&db, program)
+            .add_negative(div)
+            .build(),
+        div
+    );
+    assert_eq!(
+        IntersectionBuilder::new(&db, program)
+            .add_negative(top_div)
+            .build(),
         bottom_div
     );
     assert_eq!(
-        IntersectionBuilder::new(&db)
+        IntersectionBuilder::new(&db, program)
             .add_negative(bottom_div)
             .build(),
         top_div
     );
     assert!(
         KnownClass::Int
-            .to_instance(&db)
-            .is_assignable_to(&db, top_div)
+            .to_instance(&db, program)
+            .is_assignable_to(&db, program, top_div)
     );
-    assert!(!top_div.is_assignable_to(&db, KnownClass::Int.to_instance(&db)));
-    assert!(bottom_div.is_assignable_to(&db, KnownClass::Int.to_instance(&db)));
+    assert!(!top_div.is_assignable_to(&db, program, KnownClass::Int.to_instance(&db, program)));
+    assert!(bottom_div.is_assignable_to(&db, program, KnownClass::Int.to_instance(&db, program)));
     assert!(
         !KnownClass::Int
-            .to_instance(&db)
-            .is_assignable_to(&db, bottom_div)
+            .to_instance(&db, program)
+            .is_assignable_to(&db, program, bottom_div)
     );
     assert_eq!(
-        top_div.member(&db, "__str__").place.expect_type(),
-        Type::object().member(&db, "__str__").place.expect_type()
+        top_div.member(&db, program, "__str__").place.expect_type(),
+        Type::object()
+            .member(&db, program, "__str__")
+            .place
+            .expect_type()
     );
     assert_eq!(
-        top_div.member(&db, "__class__").place.expect_type(),
-        Type::object().dunder_class(&db)
+        top_div
+            .member(&db, program, "__class__")
+            .place
+            .expect_type(),
+        Type::object().dunder_class(&db, program)
     );
-    assert!(top_div.try_upcast_to_callable(&db).is_none());
+    assert!(top_div.try_upcast_to_callable(&db, program).is_none());
     assert!(
         top_div
-            .subscript(&db, Type::int_literal(0), ast::ExprContext::Load)
+            .subscript(&db, program, Type::int_literal(0), ast::ExprContext::Load)
             .is_err()
     );
-    assert_eq!(top_div.recursive_type_normalized_impl(&db, div, true), None);
     assert_eq!(
-        bottom_div.recursive_type_normalized_impl(&db, div, true),
+        top_div.recursive_type_normalized_impl(&db, program, div, true),
+        None
+    );
+    assert_eq!(
+        bottom_div.recursive_type_normalized_impl(&db, program, div, true),
         None
     );
 
     // The `Divergent` type must not be eliminated in union with other dynamic types,
     // as this would prevent detection of divergent type inference using `Divergent`.
-    let union = UnionType::from_elements(&db, [Type::unknown(), div]);
-    assert_eq!(union.display(&db).to_string(), "Unknown | Divergent");
+    let union = UnionType::from_elements(&db, program, [Type::unknown(), div]);
+    assert_eq!(
+        union.display(&db, program).to_string(),
+        "Unknown | Divergent"
+    );
 
-    let union = UnionType::from_elements(&db, [div, Type::unknown()]);
-    assert_eq!(union.display(&db).to_string(), "Divergent | Unknown");
+    let union = UnionType::from_elements(&db, program, [div, Type::unknown()]);
+    assert_eq!(
+        union.display(&db, program).to_string(),
+        "Divergent | Unknown"
+    );
 
-    let union = UnionType::from_elements(&db, [div, Type::unknown(), todo_type!("1")]);
-    assert_eq!(union.display(&db).to_string(), "Divergent | Unknown");
+    let union = UnionType::from_elements(&db, program, [div, Type::unknown(), todo_type!("1")]);
+    assert_eq!(
+        union.display(&db, program).to_string(),
+        "Divergent | Unknown"
+    );
 
-    assert!(div.is_equivalent_to(&db, div));
-    assert!(!div.is_equivalent_to(&db, Type::unknown()));
-    assert!(!Type::unknown().is_equivalent_to(&db, div));
-    assert!(!div.is_redundant_with(&db, Type::unknown()));
-    assert!(!Type::unknown().is_redundant_with(&db, div));
+    assert!(div.is_equivalent_to(&db, program, div));
+    assert!(!div.is_equivalent_to(&db, program, Type::unknown()));
+    assert!(!Type::unknown().is_equivalent_to(&db, program, div));
+    assert!(!div.is_redundant_with(&db, program, Type::unknown()));
+    assert!(!Type::unknown().is_redundant_with(&db, program, div));
 
     // `Divergent & T` and `Divergent & ~T` both simplify to `Divergent`, except for the
     // specific case of `Divergent & Never`, which simplifies to `Never`.
-    let divergent_intersection = IntersectionBuilder::new(&db)
+    let divergent_intersection = IntersectionBuilder::new(&db, program)
         .add_positive(div)
         .add_positive(todo_type!("2"))
         .add_negative(todo_type!("3"))
         .build();
     assert_eq!(divergent_intersection, div);
-    let divergent_intersection = IntersectionBuilder::new(&db)
+    let divergent_intersection = IntersectionBuilder::new(&db, program)
         .add_positive(todo_type!("2"))
         .add_negative(todo_type!("3"))
         .add_positive(div)
         .build();
     assert_eq!(divergent_intersection, div);
-    let divergent_never_intersection = IntersectionBuilder::new(&db)
+    let divergent_never_intersection = IntersectionBuilder::new(&db, program)
         .add_positive(div)
         .add_positive(Type::Never)
         .build();
     assert_eq!(divergent_never_intersection, Type::Never);
-    let divergent_never_intersection = IntersectionBuilder::new(&db)
+    let divergent_never_intersection = IntersectionBuilder::new(&db, program)
         .add_positive(Type::Never)
         .add_positive(div)
         .build();
@@ -251,66 +287,93 @@ fn divergent_type() {
     // The `object` type has a good convergence property, that is, its union with all other types is `object`.
     // (e.g. `object | tuple[Divergent] == object`, `object | tuple[object] == object`)
     // So we can safely eliminate `Divergent`.
-    let union = UnionType::from_elements(&db, [div, KnownClass::Object.to_instance(&db)]);
-    assert_eq!(union.display(&db).to_string(), "object");
+    let union = UnionType::from_elements(
+        &db,
+        program,
+        [div, KnownClass::Object.to_instance(&db, program)],
+    );
+    assert_eq!(union.display(&db, program).to_string(), "object");
 
-    let union = UnionType::from_elements(&db, [KnownClass::Object.to_instance(&db), div]);
-    assert_eq!(union.display(&db).to_string(), "object");
+    let union = UnionType::from_elements(
+        &db,
+        program,
+        [KnownClass::Object.to_instance(&db, program), div],
+    );
+    assert_eq!(union.display(&db, program).to_string(), "object");
 
     let recursive = UnionType::from_elements(
         &db,
+        program,
         [
-            KnownClass::List.to_specialized_instance(&db, &[div]),
-            Type::none(&db),
+            KnownClass::List.to_specialized_instance(&db, program, &[div]),
+            Type::none(&db, program),
         ],
     );
-    let nested_rec = KnownClass::List.to_specialized_instance(&db, &[recursive]);
+    let nested_rec = KnownClass::List.to_specialized_instance(&db, program, &[recursive]);
     assert_eq!(
-        nested_rec.display(&db).to_string(),
+        nested_rec.display(&db, program).to_string(),
         "list[list[Divergent] | None]"
     );
     let normalized = nested_rec
-        .recursive_type_normalized_impl(&db, div, false)
+        .recursive_type_normalized_impl(&db, program, div, false)
         .unwrap();
-    assert_eq!(normalized.display(&db).to_string(), "list[Divergent]");
+    assert_eq!(
+        normalized.display(&db, program).to_string(),
+        "list[Divergent]"
+    );
 
     let recursive_tuple = Type::heterogeneous_tuple(
         &db,
         [
             UnionType::from_elements(
                 &db,
+                program,
                 [
-                    KnownClass::Int.to_instance(&db),
+                    KnownClass::Int.to_instance(&db, program),
                     Type::heterogeneous_tuple(
                         &db,
                         [
-                            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), div]),
-                            KnownClass::Str.to_instance(&db),
+                            UnionType::from_elements(
+                                &db,
+                                program,
+                                [KnownClass::Int.to_instance(&db, program), div],
+                            ),
+                            KnownClass::Str.to_instance(&db, program),
                         ],
                     ),
                 ],
             ),
-            KnownClass::Str.to_instance(&db),
+            KnownClass::Str.to_instance(&db, program),
         ],
     );
     let normalized = recursive_tuple
-        .recursive_type_normalized_impl(&db, div, false)
+        .recursive_type_normalized_impl(&db, program, div, false)
         .unwrap();
-    assert_eq!(normalized.display(&db).to_string(), "tuple[Divergent, str]");
+    assert_eq!(
+        normalized.display(&db, program).to_string(),
+        "tuple[Divergent, str]"
+    );
 
     let recursive_dict = KnownClass::Dict.to_specialized_instance(
         &db,
+        program,
         &[
-            KnownClass::Str.to_instance(&db),
+            KnownClass::Str.to_instance(&db, program),
             UnionType::from_elements(
                 &db,
+                program,
                 [
-                    KnownClass::Int.to_instance(&db),
+                    KnownClass::Int.to_instance(&db, program),
                     KnownClass::Dict.to_specialized_instance(
                         &db,
+                        program,
                         &[
-                            KnownClass::Str.to_instance(&db),
-                            UnionType::from_elements(&db, [KnownClass::Int.to_instance(&db), div]),
+                            KnownClass::Str.to_instance(&db, program),
+                            UnionType::from_elements(
+                                &db,
+                                program,
+                                [KnownClass::Int.to_instance(&db, program), div],
+                            ),
                         ],
                     ),
                 ],
@@ -318,27 +381,34 @@ fn divergent_type() {
         ],
     );
     let normalized = recursive_dict
-        .recursive_type_normalized_impl(&db, div, false)
+        .recursive_type_normalized_impl(&db, program, div, false)
         .unwrap();
-    assert_eq!(normalized.display(&db).to_string(), "dict[str, Divergent]");
+    assert_eq!(
+        normalized.display(&db, program).to_string(),
+        "dict[str, Divergent]"
+    );
 
-    let union = UnionType::from_elements(&db, [div, KnownClass::Int.to_instance(&db)]);
-    assert_eq!(union.display(&db).to_string(), "Divergent | int");
+    let union = UnionType::from_elements(
+        &db,
+        program,
+        [div, KnownClass::Int.to_instance(&db, program)],
+    );
+    assert_eq!(union.display(&db, program).to_string(), "Divergent | int");
     for (source, target) in [(div, union), (div, Type::unknown()), (Type::unknown(), div)] {
-        let when = source.when_constraint_set_assignable_to_owned(&db, target);
-        assert!(when.query(|_builder, when| when.is_always_satisfied(&db)));
+        let when = source.when_constraint_set_assignable_to_owned(&db, program, target);
+        assert!(when.query(|_builder, when| when.is_always_satisfied(&db, program)));
     }
     let normalized = union
-        .recursive_type_normalized_impl(&db, div, false)
+        .recursive_type_normalized_impl(&db, program, div, false)
         .unwrap();
-    assert_eq!(normalized.display(&db).to_string(), "int");
+    assert_eq!(normalized.display(&db, program).to_string(), "int");
 
     // The same can be said about intersections for the `Never` type.
-    let intersection = IntersectionType::from_elements(&db, [Type::Never, div]);
-    assert_eq!(intersection.display(&db).to_string(), "Never");
+    let intersection = IntersectionType::from_elements(&db, program, [Type::Never, div]);
+    assert_eq!(intersection.display(&db, program).to_string(), "Never");
 
-    let intersection = IntersectionType::from_elements(&db, [div, Type::Never]);
-    assert_eq!(intersection.display(&db).to_string(), "Never");
+    let intersection = IntersectionType::from_elements(&db, program, [div, Type::Never]);
+    assert_eq!(intersection.display(&db, program).to_string(), "Never");
 }
 
 #[test]
@@ -348,7 +418,8 @@ fn type_alias_variance() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> PEP695TypeAliasType<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let ty = global_symbol(db, module, name).place.expect_type();
+        let program_file = ty_python_core::environment::ProgramFile::new(db, db.program(), module);
+        let ty = global_symbol(db, program_file, name).place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,
         ))) = ty
@@ -405,94 +476,135 @@ type RecursiveAlias2[T] = None | list[T] | list[RecursiveAlias2[T]]
 "#,
     )
     .unwrap();
+    let program = db.program();
     let covariant = get_type_alias(&db, "CovariantAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(covariant))
-            .variance_of(&db, get_bound_typevar(&db, covariant)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(covariant)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, covariant)
+        ),
         TypeVarVariance::Covariant
     );
 
     let contravariant = get_type_alias(&db, "ContravariantAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(contravariant))
-            .variance_of(&db, get_bound_typevar(&db, contravariant)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(contravariant)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, contravariant)
+        ),
         TypeVarVariance::Contravariant
     );
 
     let invariant = get_type_alias(&db, "InvariantAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(invariant))
-            .variance_of(&db, get_bound_typevar(&db, invariant)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(invariant)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, invariant)
+        ),
         TypeVarVariance::Invariant
     );
 
     let bivariant = get_type_alias(&db, "BivariantAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant))
-            .variance_of(&db, get_bound_typevar(&db, bivariant)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, bivariant)
+        ),
         TypeVarVariance::Bivariant
     );
 
     let covariant_alias = get_type_alias(&db, "CovariantAliasAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(covariant_alias))
-            .variance_of(&db, get_bound_typevar(&db, covariant_alias)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(covariant_alias)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, covariant_alias)
+        ),
         TypeVarVariance::Covariant
     );
 
     let contravariant_alias = get_type_alias(&db, "ContravariantAliasAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(contravariant_alias))
-            .variance_of(&db, get_bound_typevar(&db, contravariant_alias)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(contravariant_alias)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, contravariant_alias)
+        ),
         TypeVarVariance::Contravariant
     );
 
     let invariant_alias = get_type_alias(&db, "InvariantAliasAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(invariant_alias))
-            .variance_of(&db, get_bound_typevar(&db, invariant_alias)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(invariant_alias)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, invariant_alias)
+        ),
         TypeVarVariance::Invariant
     );
 
     let bivariant_alias = get_type_alias(&db, "BivariantAliasAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant_alias))
-            .variance_of(&db, get_bound_typevar(&db, bivariant_alias)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(bivariant_alias)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, bivariant_alias)
+        ),
         TypeVarVariance::Bivariant
     );
 
     let paramspec_contravariant = get_type_alias(&db, "ParamSpecContravariantAlias");
     assert_eq!(
         KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_contravariant))
-            .variance_of(&db, get_bound_typevar(&db, paramspec_contravariant)),
+            .variance_of(
+                &db,
+                program,
+                get_bound_typevar(&db, paramspec_contravariant)
+            ),
         TypeVarVariance::Contravariant
     );
 
     let paramspec_concatenate = get_type_alias(&db, "ParamSpecConcatenateAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_concatenate))
-            .variance_of(&db, get_bound_typevar(&db, paramspec_concatenate)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_concatenate)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, paramspec_concatenate)
+        ),
         TypeVarVariance::Contravariant
     );
 
     let paramspec_bivariant = get_type_alias(&db, "ParamSpecBivariantAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_bivariant))
-            .variance_of(&db, get_bound_typevar(&db, paramspec_bivariant)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(paramspec_bivariant)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, paramspec_bivariant)
+        ),
         TypeVarVariance::Bivariant
     );
 
     let recursive = get_type_alias(&db, "RecursiveAlias");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive))
-            .variance_of(&db, get_bound_typevar(&db, recursive)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, recursive)
+        ),
         TypeVarVariance::Bivariant
     );
 
     let recursive2 = get_type_alias(&db, "RecursiveAlias2");
     assert_eq!(
-        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive2))
-            .variance_of(&db, get_bound_typevar(&db, recursive2)),
+        KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(recursive2)).variance_of(
+            &db,
+            program,
+            get_bound_typevar(&db, recursive2)
+        ),
         TypeVarVariance::Invariant
     );
 }
@@ -504,7 +616,8 @@ fn eager_expansion() {
 
     fn get_type_alias<'db>(db: &'db TestDb, name: &str) -> Type<'db> {
         let module = ruff_db::files::system_path_to_file(db, "/src/a.py").unwrap();
-        let ty = global_symbol(db, module, name).place.expect_type();
+        let program_file = ty_python_core::environment::ProgramFile::new(db, db.program(), module);
+        let ty = global_symbol(db, program_file, name).place.expect_type();
         let Type::KnownInstance(KnownInstanceType::TypeAliasType(TypeAliasType::PEP695(
             type_alias,
         ))) = ty
@@ -531,46 +644,82 @@ type H[T] = G[T]
 "#,
     )
     .unwrap();
+    let program = db.program();
 
     let int_str = get_type_alias(&db, "IntStr");
     assert_eq!(
-        int_str.expand_eagerly(&db).display(&db).to_string(),
+        int_str
+            .expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
         "int | str",
     );
 
     let list_int_str = get_type_alias(&db, "ListIntStr");
     assert_eq!(
-        list_int_str.expand_eagerly(&db).display(&db).to_string(),
+        list_int_str
+            .expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
         "list[int | str]",
     );
 
     let rec_list = get_type_alias(&db, "RecursiveList");
     assert_eq!(
-        rec_list.expand_eagerly(&db).display(&db).to_string(),
+        rec_list
+            .expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
         "list[Divergent]",
     );
 
     let rec_int_list = get_type_alias(&db, "RecursiveIntList");
     assert_eq!(
-        rec_int_list.expand_eagerly(&db).display(&db).to_string(),
+        rec_int_list
+            .expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
         "list[Divergent]",
     );
 
     let itself = get_type_alias(&db, "Itself");
     assert_eq!(
-        itself.expand_eagerly(&db).display(&db).to_string(),
+        itself
+            .expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
         "Divergent",
     );
 
     let a = get_type_alias(&db, "A");
-    assert_eq!(a.expand_eagerly(&db).display(&db).to_string(), "Divergent",);
+    assert_eq!(
+        a.expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
+        "Divergent",
+    );
 
     let b = get_type_alias(&db, "B");
-    assert_eq!(b.expand_eagerly(&db).display(&db).to_string(), "Divergent",);
+    assert_eq!(
+        b.expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
+        "Divergent",
+    );
 
     let g = get_type_alias(&db, "G");
-    assert_eq!(g.expand_eagerly(&db).display(&db).to_string(), "Divergent",);
+    assert_eq!(
+        g.expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
+        "Divergent",
+    );
 
     let h = get_type_alias(&db, "H");
-    assert_eq!(h.expand_eagerly(&db).display(&db).to_string(), "Divergent",);
+    assert_eq!(
+        h.expand_eagerly(&db, program)
+            .display(&db, program)
+            .to_string(),
+        "Divergent",
+    );
 }

--- a/crates/ty_python_semantic/src/types/tuple.rs
+++ b/crates/ty_python_semantic/src/types/tuple.rs
@@ -21,6 +21,7 @@ use std::hash::Hash;
 use std::num::{NonZeroI32, NonZeroUsize};
 
 use itertools::{Either, EitherOrBoth, Itertools};
+use ruff_python_ast::PythonVersion;
 use smallvec::{SmallVec, smallvec_inline};
 
 use crate::subscript::{
@@ -34,7 +35,7 @@ use crate::types::{
     ApplyTypeMappingVisitor, BoundTypeVarInstance, ErrorContext, FindLegacyTypeVarsVisitor,
     IntersectionType, Type, TypeContext, TypeMapping, UnionBuilder, UnionType,
 };
-use crate::{Db, FxOrderSet, Program};
+use crate::{Db, FxOrderSet};
 use ty_python_core::Truthiness;
 use ty_python_core::definition::Definition;
 
@@ -138,11 +139,12 @@ pub struct TupleType<'db> {
 
 pub(super) fn walk_tuple_type<'db, V: super::visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     tuple: TupleType<'db>,
     visitor: &V,
 ) {
     for element in tuple.tuple(db).iter_all_elements() {
-        visitor.visit_type(db, element);
+        visitor.visit_type(db, program, element);
     }
 }
 
@@ -205,14 +207,14 @@ impl<'db> TupleType<'db> {
     // `static-frame` as part of the ecosystem analysis. This is because it's called
     // from `NominalInstanceType::class()`, which is a very hot method.
     #[salsa::tracked(returns(copy), cycle_initial=to_class_type_cycle_initial, heap_size=ruff_memory_usage::heap_size)]
-    pub(crate) fn to_class_type(self, db: &'db dyn Db) -> ClassType<'db> {
+    pub(crate) fn to_class_type(self, db: &'db dyn Db, program: crate::Program) -> ClassType<'db> {
         let tuple_class = KnownClass::Tuple
-            .try_to_class_literal(db)
+            .try_to_class_literal(db, program)
             .expect("Typeshed should always have a `tuple` class in `builtins.pyi`");
 
         tuple_class.apply_specialization(db, |generic_context| {
             if generic_context.variables(db).len() == 1 {
-                let element_type = self.tuple(db).homogeneous_element_type(db);
+                let element_type = self.tuple(db).homogeneous_element_type(db, program);
                 generic_context.specialize_tuple(db, element_type, self)
             } else {
                 generic_context.default_specialization(db, Some(KnownClass::Tuple))
@@ -223,19 +225,21 @@ impl<'db> TupleType<'db> {
     pub(super) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         Some(Self::new_internal(
             db,
             self.tuple(db)
-                .recursive_type_normalized_impl(db, div, nested)?,
+                .recursive_type_normalized_impl(db, program, div, nested)?,
         ))
     }
 
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -244,23 +248,24 @@ impl<'db> TupleType<'db> {
             db,
             &self
                 .tuple(db)
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
         )
     }
 
     pub(crate) fn find_legacy_typevars_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         self.tuple(db)
-            .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            .find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
     }
 
-    pub(crate) fn is_single_valued(self, db: &'db dyn Db) -> bool {
-        self.tuple(db).is_single_valued(db)
+    pub(crate) fn is_single_valued(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.tuple(db).is_single_valued(db, program)
     }
 }
 
@@ -292,6 +297,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source_tuple: &FixedLengthTuple<Type<'db>>,
         target_tuple: &TupleSpec<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         match target_tuple {
             Tuple::Fixed(target) => {
                 let equal_length = source_tuple.0.len() == target.0.len();
@@ -309,15 +315,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 let mut n = 1;
                 ConstraintSet::from_bool(self.constraints, equal_length).and(
                     db,
+                    program,
                     self.constraints,
                     || {
                         (source_tuple.0.iter().zip(&target.0)).when_all(
                             db,
+                            program,
                             self.constraints,
                             |(&source, &target)| {
                                 let constraint_set = self.check_type_pair(db, source, target);
                                 if let Some(context) = self.report_context()
-                                    && constraint_set.is_never_satisfied(db)
+                                    && constraint_set.is_never_satisfied(db, program)
                                 {
                                     context.push(ErrorContext::TupleElementNotCompatible {
                                         source,
@@ -348,7 +356,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
@@ -360,7 +368,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
@@ -368,8 +376,8 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
 
                 // In addition, any remaining elements in this tuple must satisfy the
                 // variable-length portion of the other tuple.
-                result.and(db, self.constraints, || {
-                    source_iter.when_all(db, self.constraints, |&source_ty| {
+                result.and(db, program, self.constraints, || {
+                    source_iter.when_all(db, self.program, self.constraints, |&source_ty| {
                         self.check_type_pair(db, source_ty, target.variable())
                     })
                 })
@@ -383,6 +391,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: &VariableLengthTuple<Type<'db>>,
         target: &TupleSpec<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         match target {
             Tuple::Fixed(target) => {
                 // The `...` length specifier of a variable-length tuple type is interpreted
@@ -404,19 +413,21 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // relation.
                 let mut result = self.always();
                 let mut target_iter = target.iter_all_elements();
-                for source_ty in source.prenormalized_prefix_elements(db, None) {
+                for source_ty in source.prenormalized_prefix_elements(db, program, None) {
                     let Some(target_ty) = target_iter.next() else {
                         return self.never();
                     };
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
                 }
-                let suffix: Vec<_> = source.prenormalized_suffix_elements(db, None).collect();
+                let suffix: Vec<_> = source
+                    .prenormalized_suffix_elements(db, program, None)
+                    .collect();
                 for &source_ty in suffix.iter().rev() {
                     let Some(target_ty) = target_iter.next_back() else {
                         return self.never();
@@ -424,7 +435,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     let element_constraints = self.check_type_pair(db, source_ty, target_ty);
                     if result
                         .intersect(db, self.constraints, element_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
@@ -450,10 +461,12 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 // variable-length part.
                 let mut result = self.always();
                 let pairwise = source
-                    .prenormalized_prefix_elements(db, source_prenormalize_variable)
-                    .zip_longest(
-                        target.prenormalized_prefix_elements(db, target_prenormalize_variable),
-                    );
+                    .prenormalized_prefix_elements(db, program, source_prenormalize_variable)
+                    .zip_longest(target.prenormalized_prefix_elements(
+                        db,
+                        program,
+                        target_prenormalize_variable,
+                    ));
                 for pair in pairwise {
                     let pair_constraints = match pair {
                         EitherOrBoth::Both(self_ty, other_ty) => {
@@ -475,17 +488,17 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     };
                     if result
                         .intersect(db, self.constraints, pair_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
                 }
 
                 let source_suffix: Vec<_> = source
-                    .prenormalized_suffix_elements(db, source_prenormalize_variable)
+                    .prenormalized_suffix_elements(db, program, source_prenormalize_variable)
                     .collect();
                 let target_suffix: Vec<_> = target
-                    .prenormalized_suffix_elements(db, target_prenormalize_variable)
+                    .prenormalized_suffix_elements(db, program, target_prenormalize_variable)
                     .collect();
                 let pairwise = source_suffix
                     .iter()
@@ -512,14 +525,14 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     };
                     if result
                         .intersect(db, self.constraints, pair_constraints)
-                        .is_never_satisfied(db)
+                        .is_never_satisfied(db, program)
                     {
                         return result;
                     }
                 }
 
                 // And lastly, the variable-length portions must satisfy the relation.
-                result.and(db, self.constraints, || {
+                result.and(db, program, self.constraints, || {
                     self.check_type_pair(db, source.variable(), target.variable())
                 })
             }
@@ -543,6 +556,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: &TupleSpec<'db>,
         right: &TupleSpec<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         // Two tuples with an incompatible number of required elements must always be disjoint.
         let (self_min, self_max) = left.len().size_hint();
         let (other_min, other_max) = right.len().size_hint();
@@ -558,13 +572,17 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             if rev {
                 std::iter::zip(a.iter().rev(), b.iter().rev()).when_any(
                     db,
+                    program,
                     self.constraints,
                     |(&left_elem, &right_elem)| self.check_type_pair(db, left_elem, right_elem),
                 )
             } else {
-                std::iter::zip(a, b).when_any(db, self.constraints, |(&left_elem, &right_elem)| {
-                    self.check_type_pair(db, left_elem, right_elem)
-                })
+                std::iter::zip(a, b).when_any(
+                    db,
+                    program,
+                    self.constraints,
+                    |(&left_elem, &right_elem)| self.check_type_pair(db, left_elem, right_elem),
+                )
             }
         };
 
@@ -579,6 +597,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             (Tuple::Variable(left), Tuple::Variable(right)) => {
                 any_disjoint(left.prefix_elements(), right.prefix_elements(), false).or(
                     db,
+                    program,
                     self.constraints,
                     || any_disjoint(left.suffix_elements(), right.suffix_elements(), true),
                 )
@@ -588,6 +607,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
             | (Tuple::Variable(variable), Tuple::Fixed(fixed)) => {
                 any_disjoint(fixed.all_elements(), variable.prefix_elements(), false).or(
                     db,
+                    program,
                     self.constraints,
                     || any_disjoint(fixed.all_elements(), variable.suffix_elements(), true),
                 )
@@ -600,9 +620,10 @@ fn to_class_type_cycle_initial<'db>(
     db: &'db dyn Db,
     id: salsa::Id,
     self_: TupleType<'db>,
+    program: crate::Program,
 ) -> ClassType<'db> {
     let tuple_class = KnownClass::Tuple
-        .try_to_class_literal(db)
+        .try_to_class_literal(db, program)
         .expect("Typeshed should always have a `tuple` class in `builtins.pyi`");
 
     tuple_class.apply_specialization(db, |generic_context| {
@@ -670,6 +691,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     fn resize(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         new_length: TupleLength,
     ) -> Result<Tuple<Type<'db>>, ResizeTupleError> {
         match new_length {
@@ -689,8 +711,11 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 // suffix.
                 let mut elements = self.iter_all_elements();
                 let prefix: Vec<_> = elements.by_ref().take(prefix).collect();
-                let variable =
-                    UnionType::from_elements_leave_aliases(db, elements.by_ref().take(variable));
+                let variable = UnionType::from_elements_leave_aliases(
+                    db,
+                    program,
+                    elements.by_ref().take(variable),
+                );
                 let suffix = elements.by_ref().take(suffix);
                 Ok(VariableLengthTuple::mixed(prefix, variable, suffix))
             }
@@ -700,6 +725,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -707,7 +733,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
             Some(Self::from_elements(
                 self.0
                     .iter()
-                    .map(|ty| ty.recursive_type_normalized_impl(db, div, true))
+                    .map(|ty| ty.recursive_type_normalized_impl(db, program, div, true))
                     .collect::<Option<Box<[_]>>>()?,
             ))
         } else {
@@ -715,7 +741,7 @@ impl<'db> FixedLengthTuple<Type<'db>> {
                 self.0
                     .iter()
                     .map(|ty| {
-                        ty.recursive_type_normalized_impl(db, div, true)
+                        ty.recursive_type_normalized_impl(db, program, div, true)
                             .unwrap_or(div)
                     })
                     .collect::<Box<[_]>>(),
@@ -726,18 +752,19 @@ impl<'db> FixedLengthTuple<Type<'db>> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         let tcx_tuple = tcx
             .annotation
-            .and_then(|annotation| annotation.known_specialization(db, KnownClass::Tuple))
+            .and_then(|annotation| annotation.known_specialization(db, program, KnownClass::Tuple))
             .and_then(|specialization| {
                 specialization
                     .tuple(db)
                     .expect("the specialization of `KnownClass::Tuple` must have a tuple spec")
-                    .resize(db, TupleLength::Fixed(self.0.len()))
+                    .resize(db, program, TupleLength::Fixed(self.0.len()))
                     .ok()
             });
 
@@ -751,27 +778,27 @@ impl<'db> FixedLengthTuple<Type<'db>> {
         };
 
         Self::from_elements(
-            self.0
-                .iter()
-                .zip(tcx_elements)
-                .map(|(ty, tcx)| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+            self.0.iter().zip(tcx_elements).map(|(ty, tcx)| {
+                ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+            }),
         )
     }
 
     fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         for ty in &self.0 {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 
-    fn is_single_valued(&self, db: &'db dyn Db) -> bool {
-        self.0.iter().all(|ty| ty.is_single_valued(db))
+    fn is_single_valued(&self, db: &'db dyn Db, program: crate::Program) -> bool {
+        self.0.iter().all(|ty| ty.is_single_valued(db, program))
     }
 }
 
@@ -1128,9 +1155,15 @@ impl VariableSlice {
         })
     }
 
-    fn ty<'db>(self, db: &'db dyn Db, tuple: &VariableLengthTuple<Type<'db>>) -> Type<'db> {
+    fn ty<'db>(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        tuple: &VariableLengthTuple<Type<'db>>,
+    ) -> Type<'db> {
         UnionType::from_elements_leave_aliases(
             db,
+            program,
             self.include_variable
                 .then_some(tuple.variable())
                 .into_iter()
@@ -1145,14 +1178,19 @@ impl VariableSlice {
 }
 
 impl VariableTupleSlicePlan {
-    fn into_type<'db>(self, db: &'db dyn Db, tuple: &VariableLengthTuple<Type<'db>>) -> Type<'db> {
+    fn into_type<'db>(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        tuple: &VariableLengthTuple<Type<'db>>,
+    ) -> Type<'db> {
         match self {
             VariableTupleSlicePlan::Empty => {
                 Type::heterogeneous_tuple(db, std::iter::empty::<Type<'db>>())
             }
 
             VariableTupleSlicePlan::Fixed(fixed) => {
-                Type::heterogeneous_tuple(db, tuple.slice_fixed_position(db, fixed))
+                Type::heterogeneous_tuple(db, tuple.slice_fixed_position(db, program, fixed))
             }
 
             VariableTupleSlicePlan::Mixed {
@@ -1162,11 +1200,11 @@ impl VariableTupleSlicePlan {
             } => Type::tuple(TupleType::mixed(
                 db,
                 VariableLengthTuple::optional_fixed_slice(tuple.prefix_elements(), fixed_prefix),
-                variable.ty(db, tuple),
+                variable.ty(db, program, tuple),
                 VariableLengthTuple::optional_fixed_slice(tuple.suffix_elements(), fixed_suffix),
             )),
 
-            VariableTupleSlicePlan::Homogeneous => tuple.homogeneous_type(db),
+            VariableTupleSlicePlan::Homogeneous => tuple.homogeneous_type(db, program),
         }
     }
 }
@@ -1245,6 +1283,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn slice_fixed_position<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         slice: FixedPositionSlice,
     ) -> impl Iterator<Item = Type<'db>> + 'a
     where
@@ -1258,10 +1297,10 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         } = slice;
         match origin {
             FixedPositionOrigin::Front => {
-                Either::Left(self.slice_front_forward(db, start, exclusive_stop, step))
+                Either::Left(self.slice_front_forward(db, program, start, exclusive_stop, step))
             }
             FixedPositionOrigin::Back => {
-                Either::Right(self.slice_back(db, start, exclusive_stop, step))
+                Either::Right(self.slice_back(db, program, start, exclusive_stop, step))
             }
         }
     }
@@ -1269,6 +1308,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn slice_front_forward<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         start: usize,
         exclusive_stop: usize,
         step: NonZeroUsize,
@@ -1279,17 +1319,19 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         (start..exclusive_stop)
             .step_by(step.get())
             .map(move |index| {
-                self.type_at_nonnegative_index(db, index).unwrap_or_else(|| {
+                self.type_at_nonnegative_index(db, program, index)
+                    .unwrap_or_else(|| {
                     unreachable!(
                         "front-origin fixed slice positions are validated during plan construction"
                     )
-                })
+                    })
             })
     }
 
     fn slice_back<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         start: usize,
         exclusive_stop: usize,
         step: NonZeroUsize,
@@ -1306,7 +1348,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
             }
 
             let element = self
-                .type_at_negative_distance(db, distance)
+                .type_at_negative_distance(db, program, distance)
                 .unwrap_or_else(|| {
                     unreachable!(
                         "back-origin fixed slice positions are validated during plan construction"
@@ -1340,6 +1382,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn py_slice_type(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         start: Option<i32>,
         stop: Option<i32>,
         step: Option<i32>,
@@ -1355,7 +1398,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         Ok(match direction {
             TupleSliceDirection::Forward => self
                 .forward_slice_plan(start, stop, step)
-                .into_type(db, self),
+                .into_type(db, program, self),
             TupleSliceDirection::Backward => {
                 let reversed = self.reversed();
                 reversed
@@ -1364,7 +1407,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                         TupleSliceDirection::reverse_bound(stop),
                         step,
                     )
-                    .into_type(db, &reversed)
+                    .into_type(db, program, &reversed)
             }
         })
     }
@@ -1672,20 +1715,36 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         start + ((stop - start - 1) / step) * step
     }
 
-    fn type_at_nonnegative_index(&self, db: &'db dyn Db, index: usize) -> Option<Type<'db>> {
-        (index < self.len().minimum()).then(|| self.type_at_nonnegative_index_unbounded(db, index))
+    fn type_at_nonnegative_index(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        index: usize,
+    ) -> Option<Type<'db>> {
+        (index < self.len().minimum())
+            .then(|| self.type_at_nonnegative_index_unbounded(db, program, index))
     }
 
-    fn type_at_nonnegative_index_unbounded(&self, db: &'db dyn Db, index: usize) -> Type<'db> {
+    fn type_at_nonnegative_index_unbounded(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        index: usize,
+    ) -> Type<'db> {
         if let Some(element) = self.prefix_elements().get(index) {
             *element
         } else {
             let suffix_stop = index - self.prefix_len() + 1;
-            self.variable_and_suffix_type(db, Some(suffix_stop))
+            self.variable_and_suffix_type(db, program, Some(suffix_stop))
         }
     }
 
-    fn type_at_negative_distance(&self, db: &'db dyn Db, distance: usize) -> Option<Type<'db>> {
+    fn type_at_negative_distance(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        distance: usize,
+    ) -> Option<Type<'db>> {
         if distance == 0 || distance > self.len().minimum() {
             return None;
         }
@@ -1700,20 +1759,27 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         let prefix_and_variable_len = distance - self.suffix_len();
         Some(UnionType::from_elements_leave_aliases(
             db,
+            program,
             self.iter_prefix_elements()
                 .skip(self.prefix_len() - prefix_and_variable_len)
                 .chain(std::iter::once(self.variable())),
         ))
     }
 
-    fn homogeneous_type(&self, db: &'db dyn Db) -> Type<'db> {
-        let element = UnionType::from_elements_leave_aliases(db, self.all_elements());
+    fn homogeneous_type(&self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        let element = UnionType::from_elements_leave_aliases(db, program, self.all_elements());
         Type::homogeneous_tuple(db, element)
     }
 
-    fn variable_and_suffix_type(&self, db: &'db dyn Db, suffix_stop: Option<usize>) -> Type<'db> {
+    fn variable_and_suffix_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        suffix_stop: Option<usize>,
+    ) -> Type<'db> {
         UnionType::from_elements_leave_aliases(
             db,
+            program,
             std::iter::once(self.variable()).chain(
                 self.iter_suffix_elements()
                     .take(suffix_stop.unwrap_or_else(|| self.suffix_len())),
@@ -1743,12 +1809,13 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn prenormalized_prefix_elements<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         variable: Option<Type<'db>>,
     ) -> impl Iterator<Item = Type<'db>> + 'a {
         let variable = variable.unwrap_or(self.variable());
         self.iter_prefix_elements().chain(
             self.iter_suffix_elements()
-                .take_while(move |element| element.is_equivalent_to(db, variable)),
+                .take_while(move |element| element.is_equivalent_to(db, program, variable)),
         )
     }
 
@@ -1774,16 +1841,18 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn prenormalized_suffix_elements<'a>(
         &'a self,
         db: &'db dyn Db,
+        program: crate::Program,
         variable: Option<Type<'db>>,
     ) -> impl Iterator<Item = Type<'db>> + 'a {
         let variable = variable.unwrap_or(self.variable());
         self.iter_suffix_elements()
-            .skip_while(move |element| element.is_equivalent_to(db, variable))
+            .skip_while(move |element| element.is_equivalent_to(db, program, variable))
     }
 
     fn resize(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         new_length: TupleLength,
     ) -> Result<Tuple<Type<'db>>, ResizeTupleError> {
         match new_length {
@@ -1816,6 +1885,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
                 // `I2` (variable empty, suffix shifts left), so it should be `I1 | I2`.
                 let variable = UnionType::from_elements_leave_aliases(
                     db,
+                    program,
                     self.iter_prefix_elements()
                         .skip(prefix_length)
                         .chain(std::iter::once(self.variable()))
@@ -1833,6 +1903,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -1840,31 +1911,31 @@ impl<'db> VariableLengthTuple<Type<'db>> {
             let prefix = self
                 .prefix_elements()
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true));
+                .map(|ty| ty.recursive_type_normalized_impl(db, program, div, true));
 
             let variable = self
                 .variable()
-                .recursive_type_normalized_impl(db, div, true)?;
+                .recursive_type_normalized_impl(db, program, div, true)?;
 
             let suffix = self
                 .suffix_elements()
                 .iter()
-                .map(|ty| ty.recursive_type_normalized_impl(db, div, true));
+                .map(|ty| ty.recursive_type_normalized_impl(db, program, div, true));
 
             Self::try_new(prefix, variable, suffix)
         } else {
             let prefix = self.prefix_elements().iter().map(|ty| {
-                ty.recursive_type_normalized_impl(db, div, true)
+                ty.recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div)
             });
 
             let variable = self
                 .variable()
-                .recursive_type_normalized_impl(db, div, true)
+                .recursive_type_normalized_impl(db, program, div, true)
                 .unwrap_or(div);
 
             let suffix = self.suffix_elements().iter().map(|ty| {
-                ty.recursive_type_normalized_impl(db, div, true)
+                ty.recursive_type_normalized_impl(db, program, div, true)
                     .unwrap_or(div)
             });
 
@@ -1875,6 +1946,7 @@ impl<'db> VariableLengthTuple<Type<'db>> {
     fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -1882,39 +1954,46 @@ impl<'db> VariableLengthTuple<Type<'db>> {
         Self::mixed(
             self.prefix_elements()
                 .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+                .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)),
             self.variable()
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             self.suffix_elements()
                 .iter()
-                .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, tcx, visitor)),
+                .map(|ty| ty.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)),
         )
     }
 
     fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         for ty in self.prefix_elements() {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
         self.variable()
-            .find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            .find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         for ty in self.suffix_elements() {
-            ty.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+            ty.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
         }
     }
 }
 
-impl<'db> PyIndex<'db> for &VariableLengthTuple<Type<'db>> {
-    type Item = Type<'db>;
-
-    fn py_index(self, db: &'db dyn Db, index: i32) -> Result<Self::Item, OutOfBoundsError> {
+impl<'db> VariableLengthTuple<Type<'db>> {
+    #[expect(clippy::unnecessary_wraps)]
+    pub(crate) fn py_index(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        index: i32,
+    ) -> Result<Type<'db>, OutOfBoundsError> {
         match Nth::from_index(index) {
-            Nth::FromStart(index) => Ok(self.type_at_nonnegative_index_unbounded(db, index)),
+            Nth::FromStart(index) => {
+                Ok(self.type_at_nonnegative_index_unbounded(db, program, index))
+            }
 
             Nth::FromEnd(index_from_end) => {
                 if index_from_end < self.suffix_elements().len() {
@@ -1930,6 +2009,7 @@ impl<'db> PyIndex<'db> for &VariableLengthTuple<Type<'db>> {
                 let index_past_suffix = index_from_end - self.suffix_elements().len() + 1;
                 Ok(UnionType::from_elements_leave_aliases(
                     db,
+                    program,
                     (self.prefix_elements().iter().rev().copied())
                         .take(index_past_suffix)
                         .rev()
@@ -2034,8 +2114,12 @@ impl<T> Tuple<T> {
 }
 
 impl<'db> Tuple<Type<'db>> {
-    pub(crate) fn homogeneous_element_type(&self, db: &'db dyn Db) -> Type<'db> {
-        UnionType::from_elements_leave_aliases(db, self.all_elements())
+    pub(crate) fn homogeneous_element_type(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
+        UnionType::from_elements_leave_aliases(db, program, self.all_elements())
     }
 
     /// Returns the type of a static slice into this tuple.
@@ -2045,6 +2129,7 @@ impl<'db> Tuple<Type<'db>> {
     pub(crate) fn py_slice_type(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         start: Option<i32>,
         stop: Option<i32>,
         step: Option<i32>,
@@ -2054,7 +2139,7 @@ impl<'db> Tuple<Type<'db>> {
                 db,
                 tuple.py_slice(db, start, stop, step)?,
             )),
-            Tuple::Variable(tuple) => tuple.py_slice_type(db, start, stop, step),
+            Tuple::Variable(tuple) => tuple.py_slice_type(db, program, start, stop, step),
         }
     }
 
@@ -2064,26 +2149,28 @@ impl<'db> Tuple<Type<'db>> {
     pub(crate) fn resize(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         new_length: TupleLength,
     ) -> Result<Self, ResizeTupleError> {
         match self {
-            Tuple::Fixed(tuple) => tuple.resize(db, new_length),
-            Tuple::Variable(tuple) => tuple.resize(db, new_length),
+            Tuple::Fixed(tuple) => tuple.resize(db, program, new_length),
+            Tuple::Variable(tuple) => tuple.resize(db, program, new_length),
         }
     }
 
     pub(super) fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
         match self {
             Tuple::Fixed(tuple) => Some(Tuple::Fixed(
-                tuple.recursive_type_normalized_impl(db, div, nested)?,
+                tuple.recursive_type_normalized_impl(db, program, div, nested)?,
             )),
             Tuple::Variable(tuple) => Some(Tuple::Variable(
-                tuple.recursive_type_normalized_impl(db, div, nested)?,
+                tuple.recursive_type_normalized_impl(db, program, div, nested)?,
             )),
         }
     }
@@ -2091,38 +2178,42 @@ impl<'db> Tuple<Type<'db>> {
     pub(crate) fn apply_type_mapping_impl<'a>(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
             Tuple::Fixed(tuple) => {
-                Tuple::Fixed(tuple.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
+                Tuple::Fixed(tuple.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor))
             }
-            Tuple::Variable(tuple) => tuple.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            Tuple::Variable(tuple) => {
+                tuple.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor)
+            }
         }
     }
 
     fn find_legacy_typevars_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         binding_context: Option<Definition<'db>>,
         typevars: &mut FxOrderSet<BoundTypeVarInstance<'db>>,
         visitor: &FindLegacyTypeVarsVisitor<'db>,
     ) {
         match self {
             Tuple::Fixed(tuple) => {
-                tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                tuple.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
             Tuple::Variable(tuple) => {
-                tuple.find_legacy_typevars_impl(db, binding_context, typevars, visitor);
+                tuple.find_legacy_typevars_impl(db, program, binding_context, typevars, visitor);
             }
         }
     }
 
-    pub(crate) fn is_single_valued(&self, db: &'db dyn Db) -> bool {
+    pub(crate) fn is_single_valued(&self, db: &'db dyn Db, program: crate::Program) -> bool {
         match self {
-            Tuple::Fixed(tuple) => tuple.is_single_valued(db),
+            Tuple::Fixed(tuple) => tuple.is_single_valued(db, program),
             Tuple::Variable(_) => false,
         }
     }
@@ -2270,9 +2361,12 @@ impl<'db> Tuple<Type<'db>> {
     }
 
     /// Return the `TupleSpec` for the singleton `sys.version_info`
-    pub(crate) fn version_info_spec(db: &'db dyn Db) -> TupleSpec<'db> {
-        let python_version = Program::get(db).python_version(db);
-        let int_instance_ty = KnownClass::Int.to_instance(db);
+    pub(crate) fn version_info_spec(
+        db: &'db dyn Db,
+        program: crate::Program,
+        python_version: PythonVersion,
+    ) -> TupleSpec<'db> {
+        let int_instance_ty = KnownClass::Int.to_instance(db, program);
 
         // TODO: just grab this type from typeshed (it's a `sys._ReleaseLevel` type alias there)
         let release_level_ty = {
@@ -2310,13 +2404,16 @@ impl<T> From<VariableLengthTuple<T>> for Tuple<T> {
     }
 }
 
-impl<'db> PyIndex<'db> for &Tuple<Type<'db>> {
-    type Item = Type<'db>;
-
-    fn py_index(self, db: &'db dyn Db, index: i32) -> Result<Self::Item, OutOfBoundsError> {
+impl<'db> Tuple<Type<'db>> {
+    pub(crate) fn py_index(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        index: i32,
+    ) -> Result<Type<'db>, OutOfBoundsError> {
         match self {
             Tuple::Fixed(tuple) => tuple.py_index(db, index),
-            Tuple::Variable(tuple) => tuple.py_index(db, index),
+            Tuple::Variable(tuple) => tuple.py_index(db, program, index),
         }
     }
 }
@@ -2337,23 +2434,29 @@ pub(crate) enum TupleElement<T> {
 /// assigned to the starred target in `list`.
 pub(crate) struct TupleUnpacker<'db> {
     db: &'db dyn Db,
+    program: crate::Program,
     targets: Tuple<UnionBuilder<'db>>,
 }
 
 impl<'db> TupleUnpacker<'db> {
-    pub(crate) fn new(db: &'db dyn Db, len: TupleLength) -> Self {
-        let new_builders = |len: usize| std::iter::repeat_with(|| UnionBuilder::new(db)).take(len);
+    pub(crate) fn new(db: &'db dyn Db, program: crate::Program, len: TupleLength) -> Self {
+        let new_builders =
+            |len: usize| std::iter::repeat_with(|| UnionBuilder::new(db, program)).take(len);
         let targets = match len {
             TupleLength::Fixed(len) => {
                 Tuple::Fixed(FixedLengthTuple::from_elements(new_builders(len)))
             }
             TupleLength::Variable(prefix, suffix) => VariableLengthTuple::mixed(
                 new_builders(prefix),
-                UnionBuilder::new(db),
+                UnionBuilder::new(db, program),
                 new_builders(suffix),
             ),
         };
-        Self { db, targets }
+        Self {
+            db,
+            program,
+            targets,
+        }
     }
 
     /// Unpacks a single rhs tuple into the target tuple that we are building. If you want to
@@ -2367,13 +2470,13 @@ impl<'db> TupleUnpacker<'db> {
         &mut self,
         values: &Tuple<Type<'db>>,
     ) -> Result<(), ResizeTupleError> {
-        let values = values.resize(self.db, self.targets.len())?;
+        let values = values.resize(self.db, self.program, self.targets.len())?;
         match (&mut self.targets, &values) {
             (Tuple::Fixed(targets), Tuple::Fixed(values)) => {
                 targets.unpack_tuple(values);
             }
             (Tuple::Variable(targets), Tuple::Variable(values)) => {
-                targets.unpack_tuple(self.db, values);
+                targets.unpack_tuple(self.db, self.program, values);
             }
             _ => panic!("should have ensured that tuples are the same length"),
         }
@@ -2387,9 +2490,13 @@ impl<'db> TupleUnpacker<'db> {
     pub(crate) fn into_types(self) -> impl Iterator<Item = Type<'db>> {
         self.targets
             .into_all_elements_with_kind()
-            .map(|builder| match builder {
+            .map(move |builder| match builder {
                 TupleElement::Variable(builder) => builder.try_build().unwrap_or_else(|| {
-                    KnownClass::List.to_specialized_instance(self.db, &[Type::unknown()])
+                    KnownClass::List.to_specialized_instance(
+                        self.db,
+                        self.program,
+                        &[Type::unknown()],
+                    )
                 }),
                 TupleElement::Fixed(builder)
                 | TupleElement::Prefix(builder)
@@ -2410,7 +2517,12 @@ impl<'db> FixedLengthTuple<UnionBuilder<'db>> {
 }
 
 impl<'db> VariableLengthTuple<UnionBuilder<'db>> {
-    fn unpack_tuple(&mut self, db: &'db dyn Db, values: &VariableLengthTuple<Type<'db>>) {
+    fn unpack_tuple(
+        &mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        values: &VariableLengthTuple<Type<'db>>,
+    ) {
         // We have already verified above that the two tuples have the same length.
         for (target, value) in
             (self.prefix_elements_mut().iter_mut()).zip(values.iter_prefix_elements())
@@ -2418,7 +2530,11 @@ impl<'db> VariableLengthTuple<UnionBuilder<'db>> {
             target.add_in_place(value);
         }
         self.variable_element_mut()
-            .add_in_place(KnownClass::List.to_specialized_instance(db, &[values.variable()]));
+            .add_in_place(KnownClass::List.to_specialized_instance(
+                db,
+                program,
+                &[values.variable()],
+            ));
         for (target, value) in
             (self.suffix_elements_mut().iter_mut()).zip(values.iter_suffix_elements())
         {
@@ -2457,7 +2573,12 @@ impl<'db> TupleSpecBuilder<'db> {
     }
 
     /// Concatenates another tuple to the end of this tuple, returning a new tuple.
-    pub(crate) fn concat(mut self, db: &'db dyn Db, other: &TupleSpec<'db>) -> Self {
+    pub(crate) fn concat(
+        mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        other: &TupleSpec<'db>,
+    ) -> Self {
         match (&mut self, other) {
             (TupleSpecBuilder::Fixed(left_tuple), TupleSpec::Fixed(right_tuple)) => {
                 left_tuple.extend_from_slice(&right_tuple.0);
@@ -2495,6 +2616,7 @@ impl<'db> TupleSpecBuilder<'db> {
             ) => {
                 let variable = UnionType::from_elements_leave_aliases(
                     db,
+                    program,
                     left_suffix
                         .iter()
                         .chain([left_variable, &right.variable()])
@@ -2532,13 +2654,19 @@ impl<'db> TupleSpecBuilder<'db> {
     /// `tuple[int, str, bytes]`, the result will be a tuple-spec builder for
     /// `tuple[int | str | bytes, ...]`. We could consider improving this in the future if real-world
     /// use cases arise.
-    pub(crate) fn union(mut self, db: &'db dyn Db, other: &TupleSpec<'db>) -> Self {
+    pub(crate) fn union(
+        mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        other: &TupleSpec<'db>,
+    ) -> Self {
         match (&mut self, other) {
             (TupleSpecBuilder::Fixed(our_elements), TupleSpec::Fixed(new_elements))
                 if our_elements.len() == new_elements.len() =>
             {
                 for (existing, new) in our_elements.iter_mut().zip(new_elements.all_elements()) {
-                    *existing = UnionType::from_elements_leave_aliases(db, [*existing, *new]);
+                    *existing =
+                        UnionType::from_elements_leave_aliases(db, program, [*existing, *new]);
                 }
                 self
             }
@@ -2553,6 +2681,7 @@ impl<'db> TupleSpecBuilder<'db> {
             _ => {
                 let unioned = UnionType::from_elements_leave_aliases(
                     db,
+                    program,
                     self.all_elements().chain(other.all_elements()),
                 );
                 TupleSpecBuilder::Variable {
@@ -2571,14 +2700,19 @@ impl<'db> TupleSpecBuilder<'db> {
     /// For example, if `self` is a tuple-spec builder for `tuple[int, str]` and `other` is a
     /// tuple-spec for `tuple[object, object]`, the result will be a tuple-spec builder for
     /// `tuple[int, str]` (since `int & object` simplifies to `int`, and `str & object` to `str`).
-    pub(crate) fn intersect(mut self, db: &'db dyn Db, other: &TupleSpec<'db>) -> Option<Self> {
+    pub(crate) fn intersect(
+        mut self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        other: &TupleSpec<'db>,
+    ) -> Option<Self> {
         match (&mut self, other) {
             // Both fixed-length with the same length: element-wise intersection.
             (TupleSpecBuilder::Fixed(our_elements), TupleSpec::Fixed(new_elements))
                 if our_elements.len() == new_elements.len() =>
             {
                 for (existing, new) in our_elements.iter_mut().zip(new_elements.all_elements()) {
-                    *existing = IntersectionType::from_elements(db, [*existing, *new]);
+                    *existing = IntersectionType::from_elements(db, program, [*existing, *new]);
                 }
                 Some(self)
             }
@@ -2587,16 +2721,16 @@ impl<'db> TupleSpecBuilder<'db> {
             (TupleSpecBuilder::Fixed(_), TupleSpec::Fixed(_)) => None,
 
             (TupleSpecBuilder::Fixed(our_elements), TupleSpec::Variable(var)) => var
-                .resize(db, TupleLength::Fixed(our_elements.len()))
+                .resize(db, program, TupleLength::Fixed(our_elements.len()))
                 .ok()
-                .and_then(|tuple| self.intersect(db, &tuple)),
+                .and_then(|tuple| self.intersect(db, program, &tuple)),
 
             (TupleSpecBuilder::Variable { .. }, TupleSpec::Fixed(fixed)) => self
                 .clone()
                 .build()
-                .resize(db, TupleLength::Fixed(fixed.len()))
+                .resize(db, program, TupleLength::Fixed(fixed.len()))
                 .ok()
-                .and_then(|tuple| TupleSpecBuilder::from(&tuple).intersect(db, other)),
+                .and_then(|tuple| TupleSpecBuilder::from(&tuple).intersect(db, program, other)),
 
             (
                 TupleSpecBuilder::Variable {
@@ -2610,24 +2744,30 @@ impl<'db> TupleSpecBuilder<'db> {
                     && suffix.len() == var.suffix_elements().len()
                 {
                     for (existing, new) in prefix.iter_mut().zip(var.prefix_elements()) {
-                        *existing = IntersectionType::from_two_elements(db, *existing, *new);
+                        *existing =
+                            IntersectionType::from_two_elements(db, program, *existing, *new);
                     }
-                    *variable = IntersectionType::from_two_elements(db, *variable, var.variable());
+                    *variable =
+                        IntersectionType::from_two_elements(db, program, *variable, var.variable());
                     for (existing, new) in suffix.iter_mut().zip(var.suffix_elements()) {
-                        *existing = IntersectionType::from_two_elements(db, *existing, *new);
+                        *existing =
+                            IntersectionType::from_two_elements(db, program, *existing, *new);
                     }
                     return Some(self);
                 }
 
                 let self_built = self.clone().build();
                 let self_len = self_built.len();
-                var.resize(db, self_len)
+                var.resize(db, program, self_len)
                     .ok()
-                    .and_then(|resized| self.intersect(db, &resized))
+                    .and_then(|resized| self.intersect(db, program, &resized))
                     .or_else(|| {
-                        self_built.resize(db, var.len()).ok().and_then(|resized| {
-                            TupleSpecBuilder::from(&resized).intersect(db, other)
-                        })
+                        self_built
+                            .resize(db, program, var.len())
+                            .ok()
+                            .and_then(|resized| {
+                                TupleSpecBuilder::from(&resized).intersect(db, program, other)
+                            })
                     })
             }
         }

--- a/crates/ty_python_semantic/src/types/tuple/promotion.rs
+++ b/crates/ty_python_semantic/src/types/tuple/promotion.rs
@@ -24,12 +24,13 @@ impl<'db> TupleSizePromotionConstraints<'db> {
     pub(crate) fn record_inferred_expression_type(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         typevar_identity: BoundTypeVarIdentity<'db>,
         expression: &ast::Expr,
         ty: Type<'db>,
     ) {
-        if !Self::is_promotable_tuple_literal(db, expression, ty) {
-            self.record_unpromotable_type(db, typevar_identity, ty);
+        if !Self::is_promotable_tuple_literal(db, program, expression, ty) {
+            self.record_unpromotable_type(db, program, typevar_identity, ty);
         }
     }
 
@@ -38,10 +39,13 @@ impl<'db> TupleSizePromotionConstraints<'db> {
     pub(crate) fn record_unpromotable_type(
         &mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         typevar_identity: BoundTypeVarIdentity<'db>,
         ty: Type<'db>,
     ) {
-        if any_over_type(db, ty, true, |ty| ty.tuple_instance_spec(db).is_some()) {
+        if any_over_type(db, program, ty, true, |ty| {
+            ty.tuple_instance_spec(db, program).is_some()
+        }) {
             self.blocked_typevars.insert(typevar_identity);
         }
     }
@@ -54,9 +58,14 @@ impl<'db> TupleSizePromotionConstraints<'db> {
 
     /// Returns true if the given expression is either a non-starred homogeneous tuple literal or the
     /// empty tuple (and hence is eligible for tuple size promotion).
-    fn is_promotable_tuple_literal(db: &'db dyn Db, expression: &ast::Expr, ty: Type<'db>) -> bool {
+    fn is_promotable_tuple_literal(
+        db: &'db dyn Db,
+        program: crate::Program,
+        expression: &ast::Expr,
+        ty: Type<'db>,
+    ) -> bool {
         matches!(expression, ast::Expr::Tuple(tuple) if !tuple.iter().any(ast::Expr::is_starred_expr))
-            && TupleSizePromotionCandidate::from_type(db, ty).is_some()
+            && TupleSizePromotionCandidate::from_type(db, program, ty).is_some()
     }
 }
 
@@ -72,7 +81,7 @@ enum TupleSizePromotionCandidate<'db> {
 impl<'db> TupleSizePromotionCandidate<'db> {
     /// Returns an eligible candidate if the given type represents one (i.e., it is a
     /// fixed-length homogeneous tuple or the empty tuple).
-    fn from_type(db: &'db dyn Db, ty: Type<'db>) -> Option<Self> {
+    fn from_type(db: &'db dyn Db, program: crate::Program, ty: Type<'db>) -> Option<Self> {
         let tuple_spec = ty.exact_tuple_instance_spec(db)?;
         let TupleSpec::Fixed(tuple) = tuple_spec.as_ref() else {
             return None;
@@ -84,7 +93,7 @@ impl<'db> TupleSizePromotionCandidate<'db> {
         };
 
         elements
-            .all(|element| element.is_equivalent_to(db, element_type))
+            .all(|element| element.is_equivalent_to(db, program, element_type))
             .then_some(Self::Homogeneous {
                 element_type,
                 length: tuple.len(),
@@ -122,21 +131,23 @@ impl<'db> HomogeneousTupleUnionGroup<'db> {
 /// candidates for tuple size promotion, and another for groups of homogeneous tuple elements that are.
 fn partition_tuple_union_elements<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     elements: impl IntoIterator<Item = Type<'db>>,
 ) -> (Vec<Type<'db>>, Vec<HomogeneousTupleUnionGroup<'db>>) {
     let mut other_union_elements = Vec::new();
     let mut tuple_groups: Vec<HomogeneousTupleUnionGroup<'db>> = Vec::new();
 
     for element in elements {
-        match TupleSizePromotionCandidate::from_type(db, element) {
+        match TupleSizePromotionCandidate::from_type(db, program, element) {
             Some(TupleSizePromotionCandidate::Homogeneous {
                 element_type,
                 length,
             }) => {
-                if let Some(group) = tuple_groups
-                    .iter_mut()
-                    .find(|group| group.element_type.is_equivalent_to(db, element_type))
-                {
+                if let Some(group) = tuple_groups.iter_mut().find(|group| {
+                    group
+                        .element_type
+                        .is_equivalent_to(db, program, element_type)
+                }) {
                     group.add(element, length);
                 } else {
                     tuple_groups.push(HomogeneousTupleUnionGroup::new(
@@ -175,19 +186,23 @@ impl<'db> Type<'db> {
     /// reveal_type(languages)  # revealed: dict[str, tuple[str, ...]]
     /// ```
     ///
-    pub(crate) fn promote_tuple_size_in_union(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn promote_tuple_size_in_union(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Type<'db> {
         let Type::Union(union) = self else {
             return self;
         };
 
         let (other_union_elements, tuple_groups) =
-            partition_tuple_union_elements(db, union.elements(db).iter().copied());
+            partition_tuple_union_elements(db, program, union.elements(db).iter().copied());
 
         if !tuple_groups.iter().any(|group| group.has_multiple_lengths) {
             return self;
         }
 
-        let mut builder = UnionBuilder::new(db)
+        let mut builder = UnionBuilder::new(db, program)
             .unpack_aliases(false)
             .recursively_defined(union.recursively_defined(db));
 

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -38,10 +38,11 @@ impl get_size2::GetSize for PEP695TypeAliasType<'_> {}
 
 pub(super) fn walk_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     type_alias: PEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    visitor.visit_type(db, program, type_alias.value_type(db));
 }
 
 #[salsa::tracked]
@@ -49,7 +50,7 @@ impl<'db> PEP695TypeAliasType<'db> {
     pub(crate) fn definition(self, db: &'db dyn Db) -> Definition<'db> {
         let scope = self.rhs_scope(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
-        semantic_index(db, scope.file(db)).expect_single_definition(type_alias_stmt_node)
+        semantic_index(db, scope.program_file(db)).expect_single_definition(type_alias_stmt_node)
     }
 
     /// The RHS type of a PEP-695 style type alias with specialization applied.
@@ -62,14 +63,15 @@ impl<'db> PEP695TypeAliasType<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_initial=|_, id, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _| {
-            value.cycle_normalized(db, *previous, cycle)
+        cycle_fn=|db: &'db dyn Db, cycle, previous: &Type<'db>, value: Type<'db>, alias: PEP695TypeAliasType<'db>| {
+            let program = alias.rhs_scope(db).program(db);
+            value.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
     pub(super) fn raw_value_type(self, db: &'db dyn Db) -> Type<'db> {
         let scope = self.rhs_scope(db);
-        let module = parsed_module(db, scope.file(db)).load(db);
+        let module = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
         let definition = self.definition(db);
 
@@ -77,6 +79,7 @@ impl<'db> PEP695TypeAliasType<'db> {
     }
 
     fn apply_function_specialization(self, db: &'db dyn Db, ty: Type<'db>) -> Type<'db> {
+        let program = self.rhs_scope(db).program(db);
         if let Some(generic_context) = self.generic_context(db) {
             let specialization = self
                 .specialization(db)
@@ -93,6 +96,7 @@ impl<'db> PEP695TypeAliasType<'db> {
 
             ty.apply_type_mapping_impl(
                 db,
+                program,
                 &type_mapping,
                 TypeContext::default(),
                 &ApplyTypeMappingVisitor::default(),
@@ -134,8 +138,7 @@ impl<'db> PEP695TypeAliasType<'db> {
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let scope = self.rhs_scope(db);
-        let file = scope.file(db);
-        let parsed = parsed_module(db, file).load(db);
+        let parsed = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
 
         type_alias_stmt_node
@@ -143,7 +146,7 @@ impl<'db> PEP695TypeAliasType<'db> {
             .type_params
             .as_ref()
             .map(|type_params| {
-                let index = semantic_index(db, scope.file(db));
+                let index = semantic_index(db, scope.program_file(db));
                 let definition = index.expect_single_definition(type_alias_stmt_node);
                 GenericContext::from_type_params(db, index, definition, type_params)
             })
@@ -167,10 +170,11 @@ impl get_size2::GetSize for ManualPEP695TypeAliasType<'_> {}
 
 pub(super) fn walk_manual_pep_695_type_alias<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     type_alias: ManualPEP695TypeAliasType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, type_alias.value_type(db));
+    visitor.visit_type(db, program, type_alias.value_type(db));
 }
 
 #[salsa::tracked]
@@ -182,15 +186,16 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
     #[salsa::tracked(
         returns(copy),
         cycle_initial=|_, id, _| Type::divergent(id),
-        cycle_fn=|db, cycle, previous: &Type<'db>, value: Type<'db>, _| {
-            value.cycle_normalized(db, *previous, cycle)
+        cycle_fn=|db: &'db dyn Db, cycle, previous: &Type<'db>, value: Type<'db>, alias: ManualPEP695TypeAliasType<'db>| {
+            let definition = alias.definition(db);
+            let program = definition.program_file(db).program(db);
+            value.cycle_normalized(db, program, *previous, cycle)
         },
         heap_size=ruff_memory_usage::heap_size
     )]
     pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
         let definition = self.definition(db);
-        let file = definition.file(db);
-        let module = parsed_module(db, file).load(db);
+        let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
         let DefinitionKind::Assignment(assignment) = definition.kind(db) else {
             return Type::unknown();
         };
@@ -206,7 +211,7 @@ impl<'db> ManualPEP695TypeAliasType<'db> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue, get_size2::GetSize)]
 pub enum TypeAliasType<'db> {
     /// A type alias defined using the PEP 695 `type` statement.
     PEP695(PEP695TypeAliasType<'db>),
@@ -216,6 +221,7 @@ pub enum TypeAliasType<'db> {
 
 pub(super) fn walk_type_alias_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     type_alias: TypeAliasType<'db>,
     visitor: &V,
 ) {
@@ -224,15 +230,24 @@ pub(super) fn walk_type_alias_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     }
     match type_alias {
         TypeAliasType::PEP695(type_alias) => {
-            walk_pep_695_type_alias(db, type_alias, visitor);
+            walk_pep_695_type_alias(db, program, type_alias, visitor);
         }
         TypeAliasType::ManualPEP695(type_alias) => {
-            walk_manual_pep_695_type_alias(db, type_alias, visitor);
+            walk_manual_pep_695_type_alias(db, program, type_alias, visitor);
         }
     }
 }
 
 impl<'db> TypeAliasType<'db> {
+    pub(crate) fn program(self, db: &'db dyn Db) -> crate::Program {
+        match self {
+            TypeAliasType::PEP695(type_alias) => type_alias.rhs_scope(db).program(db),
+            TypeAliasType::ManualPEP695(type_alias) => {
+                type_alias.definition(db).program_file(db).program(db)
+            }
+        }
+    }
+
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db str {
         match self {
             TypeAliasType::PEP695(type_alias) => type_alias.name(db),
@@ -309,15 +324,28 @@ impl<'db> TypeAliasType<'db> {
     }
 }
 
-#[salsa::tracked]
+#[salsa::tracked(
+    returns(copy),
+    cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
+    heap_size=ruff_memory_usage::heap_size
+)]
+fn type_alias_variance_of<'db>(
+    db: &'db dyn Db,
+    type_alias: TypeAliasType<'db>,
+    typevar: BoundTypeVarIdentity<'db>,
+) -> TypeVarVariance {
+    let program = type_alias.program(db);
+    type_alias.value_type(db).variance_of(db, program, typevar)
+}
+
 impl<'db> VarianceInferable<'db> for TypeAliasType<'db> {
-    #[salsa::tracked(
-        returns(copy),
-        cycle_initial=|_, _, _, _| TypeVarVariance::Bivariant,
-        heap_size=ruff_memory_usage::heap_size
-    )]
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
-        self.value_type(db).variance_of(db, typevar)
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        _program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        type_alias_variance_of(db, self, typevar)
     }
 }
 
@@ -342,7 +370,7 @@ impl<'db> QualifiedTypeAliasName<'db> {
     /// would return `["a", "b", "C"]`.
     pub(crate) fn components_excluding_self(&self) -> Vec<String> {
         let definition = self.type_alias.definition(self.db);
-        let file = definition.file(self.db);
+        let file = definition.program_file(self.db);
         let file_scope_id = definition.file_scope(self.db);
 
         // Type aliases are defined directly in their enclosing scope (no body scope like classes),

--- a/crates/ty_python_semantic/src/types/type_alias.rs
+++ b/crates/ty_python_semantic/src/types/type_alias.rs
@@ -138,7 +138,8 @@ impl<'db> PEP695TypeAliasType<'db> {
     #[salsa::tracked(returns(copy), cycle_initial=|_, _, _| None, heap_size=ruff_memory_usage::heap_size)]
     pub(crate) fn generic_context(self, db: &'db dyn Db) -> Option<GenericContext<'db>> {
         let scope = self.rhs_scope(db);
-        let parsed = parsed_module(db, scope.program_file(db).versioned_file(db)).load(db);
+        let program_file = scope.program_file(db);
+        let parsed = parsed_module(db, program_file.versioned_file(db)).load(db);
         let type_alias_stmt_node = scope.node(db).expect_type_alias();
 
         type_alias_stmt_node
@@ -146,7 +147,7 @@ impl<'db> PEP695TypeAliasType<'db> {
             .type_params
             .as_ref()
             .map(|type_params| {
-                let index = semantic_index(db, scope.program_file(db));
+                let index = semantic_index(db, program_file);
                 let definition = index.expect_single_definition(type_alias_stmt_node);
                 GenericContext::from_type_params(db, index, definition, type_params)
             })

--- a/crates/ty_python_semantic/src/types/type_expansion.rs
+++ b/crates/ty_python_semantic/src/types/type_expansion.rs
@@ -16,19 +16,23 @@ const MAX_TUPLE_EXPANSION: usize = 64;
 /// Expands a type into its possible subtypes, if applicable.
 ///
 /// Returns [`None`] if the type cannot be expanded.
-pub(crate) fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Type<'db>>> {
+pub(crate) fn expand_type<'db>(
+    db: &'db dyn Db,
+    program: crate::Program,
+    ty: Type<'db>,
+) -> Option<Vec<Type<'db>>> {
     match ty {
         Type::EnumComplement(complement) => Some(complement.remaining_literal_types(db)),
-        Type::Intersection(intersection) => intersection.finite_alternatives(db),
+        Type::Intersection(intersection) => intersection.finite_alternatives(db, program),
         Type::NominalInstance(instance) => {
-            let class = instance.class(db);
+            let class = instance.class(db, program);
 
             if class.is_known(db, KnownClass::Bool) {
                 return Some(vec![Type::bool_literal(true), Type::bool_literal(false)]);
             }
 
             // If the class is a fixed-length tuple subtype, we expand it to its elements.
-            if let Some(spec) = instance.tuple_spec(db) {
+            if let Some(spec) = instance.tuple_spec(db, program) {
                 return match &*spec {
                     Tuple::Fixed(fixed_length_tuple) => {
                         // Pre-expand each element and compute the total Cartesian product size.
@@ -38,7 +42,7 @@ pub(crate) fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Typ
                         let per_element: Vec<_> = fixed_length_tuple
                             .iter_all_elements()
                             .map(|element| {
-                                expand_type(db, element).unwrap_or_else(|| vec![element])
+                                expand_type(db, program, element).unwrap_or_else(|| vec![element])
                             })
                             .collect();
 
@@ -75,14 +79,14 @@ pub(crate) fn expand_type<'db>(db: &'db dyn Db, ty: Type<'db>) -> Option<Vec<Typ
                 .flat_map(|element| match element {
                     Type::EnumComplement(complement) => complement.remaining_literal_types(db),
                     Type::Intersection(intersection) => intersection
-                        .finite_alternatives(db)
+                        .finite_alternatives(db, program)
                         .unwrap_or_else(|| vec![*element]),
                     _ => vec![*element],
                 })
                 .collect(),
         ),
         // For type aliases, expand the underlying value type.
-        Type::TypeAlias(alias) => expand_type(db, alias.value_type(db)),
+        Type::TypeAlias(alias) => expand_type(db, program, alias.value_type(db)),
         // We don't handle `type[A | B]` here because it's already stored in the expanded form
         // i.e., `type[A] | type[B]` which is handled by the `Type::Union` case.
         _ => None,
@@ -100,13 +104,14 @@ mod tests {
     #[test]
     fn expand_union_type() {
         let db = setup_db();
+        let program = db.program();
         let types = [
-            KnownClass::Int.to_instance(&db),
-            KnownClass::Str.to_instance(&db),
-            KnownClass::Bytes.to_instance(&db),
+            KnownClass::Int.to_instance(&db, program),
+            KnownClass::Str.to_instance(&db, program),
+            KnownClass::Bytes.to_instance(&db, program),
         ];
-        let union_type = UnionType::from_elements(&db, types);
-        let expanded = expand_type(&db, union_type).unwrap();
+        let union_type = UnionType::from_elements(&db, program, types);
+        let expanded = expand_type(&db, program, union_type).unwrap();
         assert_eq!(expanded.len(), types.len());
         assert_eq!(expanded, types);
     }
@@ -114,8 +119,9 @@ mod tests {
     #[test]
     fn expand_bool_type() {
         let db = setup_db();
-        let bool_instance = KnownClass::Bool.to_instance(&db);
-        let expanded = expand_type(&db, bool_instance).unwrap();
+        let program = db.program();
+        let bool_instance = KnownClass::Bool.to_instance(&db, program);
+        let expanded = expand_type(&db, program, bool_instance).unwrap();
         let expected_types = [Type::bool_literal(true), Type::bool_literal(false)];
         assert_eq!(expanded.len(), expected_types.len());
         assert_eq!(expanded, expected_types);
@@ -124,22 +130,23 @@ mod tests {
     #[test]
     fn expand_tuple_type() {
         let db = setup_db();
+        let program = db.program();
 
-        let int_ty = KnownClass::Int.to_instance(&db);
-        let str_ty = KnownClass::Str.to_instance(&db);
-        let bytes_ty = KnownClass::Bytes.to_instance(&db);
-        let bool_ty = KnownClass::Bool.to_instance(&db);
+        let int_ty = KnownClass::Int.to_instance(&db, program);
+        let str_ty = KnownClass::Str.to_instance(&db, program);
+        let bytes_ty = KnownClass::Bytes.to_instance(&db, program);
+        let bool_ty = KnownClass::Bool.to_instance(&db, program);
         let true_ty = Type::bool_literal(true);
         let false_ty = Type::bool_literal(false);
 
         // Empty tuple
         let empty_tuple = Type::empty_tuple(&db);
-        let expanded = expand_type(&db, empty_tuple);
+        let expanded = expand_type(&db, program, empty_tuple);
         assert!(expanded.is_none());
 
         // None of the elements can be expanded.
         let tuple_type1 = Type::heterogeneous_tuple(&db, [int_ty, str_ty]);
-        let expanded = expand_type(&db, tuple_type1);
+        let expanded = expand_type(&db, program, tuple_type1);
         assert!(expanded.is_none());
 
         // All elements can be expanded.
@@ -147,7 +154,7 @@ mod tests {
             &db,
             [
                 bool_ty,
-                UnionType::from_elements(&db, [int_ty, str_ty, bytes_ty]),
+                UnionType::from_elements(&db, program, [int_ty, str_ty, bytes_ty]),
             ],
         );
         let expected_types = [
@@ -158,7 +165,7 @@ mod tests {
             Type::heterogeneous_tuple(&db, [false_ty, str_ty]),
             Type::heterogeneous_tuple(&db, [false_ty, bytes_ty]),
         ];
-        let expanded = expand_type(&db, tuple_type2).unwrap();
+        let expanded = expand_type(&db, program, tuple_type2).unwrap();
         assert_eq!(expanded, expected_types);
 
         // Mixed set of elements where some can be expanded while others cannot be.
@@ -167,7 +174,7 @@ mod tests {
             [
                 bool_ty,
                 int_ty,
-                UnionType::from_elements(&db, [str_ty, bytes_ty]),
+                UnionType::from_elements(&db, program, [str_ty, bytes_ty]),
                 str_ty,
             ],
         );
@@ -177,7 +184,7 @@ mod tests {
             Type::heterogeneous_tuple(&db, [false_ty, int_ty, str_ty, str_ty]),
             Type::heterogeneous_tuple(&db, [false_ty, int_ty, bytes_ty, str_ty]),
         ];
-        let expanded = expand_type(&db, tuple_type3).unwrap();
+        let expanded = expand_type(&db, program, tuple_type3).unwrap();
         assert_eq!(expanded, expected_types);
 
         // Variable-length tuples are not expanded.
@@ -185,9 +192,12 @@ mod tests {
             &db,
             [bool_ty],
             int_ty,
-            [UnionType::from_elements(&db, [str_ty, bytes_ty]), str_ty],
+            [
+                UnionType::from_elements(&db, program, [str_ty, bytes_ty]),
+                str_ty,
+            ],
         ));
-        let expanded = expand_type(&db, variable_length_tuple);
+        let expanded = expand_type(&db, program, variable_length_tuple);
         assert!(expanded.is_none());
     }
 }

--- a/crates/ty_python_semantic/src/types/type_form.rs
+++ b/crates/ty_python_semantic/src/types/type_form.rs
@@ -13,10 +13,11 @@ pub struct TypeFormType<'db> {
 
 pub(super) fn walk_typeform_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     typeform_type: TypeFormType<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type(db, typeform_type.type_argument(db));
+    visitor.visit_type(db, program, typeform_type.type_argument(db));
 }
 
 // The Salsa heap is tracked separately.
@@ -36,64 +37,75 @@ impl<'db> Type<'db> {
     /// bounds or constraints, using cycle detection for recursive types. Union and intersection
     /// elements that do not represent type forms are ignored, as are negative intersection
     /// elements. If no type-form component can be projected, this returns the original type.
-    pub(crate) fn project_type_form(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn project_type_form(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         struct TypeFormArgument;
         type TypeFormArgumentVisitor<'db> =
             CycleDetector<TypeFormArgument, Type<'db>, Option<Type<'db>>, 3>;
 
         fn project<'db>(
             db: &'db dyn Db,
+            program: crate::Program,
             ty: Type<'db>,
             visitor: &TypeFormArgumentVisitor<'db>,
         ) -> Option<Type<'db>> {
             match ty {
                 Type::TypeForm(type_form) => Some(type_form.type_argument(db)),
                 Type::TypeAlias(alias) => {
-                    visitor.visit(ty, || project(db, alias.value_type(db), visitor))
+                    visitor.visit(ty, || project(db, program, alias.value_type(db), visitor))
                 }
                 Type::Union(union) => {
                     let mut elements = union
                         .elements(db)
                         .iter()
-                        .filter_map(|element| project(db, *element, visitor))
+                        .filter_map(|element| project(db, program, *element, visitor))
                         .peekable();
                     elements.peek()?;
-                    Some(UnionType::from_elements(db, elements))
+                    Some(UnionType::from_elements(db, program, elements))
                 }
                 Type::Intersection(intersection) => {
                     let mut elements = intersection
                         .iter_positive(db)
-                        .filter_map(|element| project(db, element, visitor))
+                        .filter_map(|element| project(db, program, element, visitor))
                         .peekable();
                     elements.peek()?;
-                    Some(IntersectionType::from_elements(db, elements))
+                    Some(IntersectionType::from_elements(db, program, elements))
                 }
                 Type::TypeVar(typevar) => visitor.visit(ty, || {
                     typevar
                         .typevar(db)
                         .bound_or_constraints(db)
                         .and_then(|bound_or_constraints| {
-                            project(db, bound_or_constraints.as_type(db), visitor)
+                            project(
+                                db,
+                                program,
+                                bound_or_constraints.as_type(db, program),
+                                visitor,
+                            )
                         })
                 }),
-                Type::SpecialForm(special_form) => special_form.type_form_argument(db),
+                Type::SpecialForm(special_form) => special_form.type_form_argument(db, program),
                 Type::KnownInstance(instance) if instance.is_type_form_value() => {
-                    instance.type_form_argument(db)
+                    instance.type_form_argument(db, program)
                 }
                 Type::ClassLiteral(_) | Type::GenericAlias(_) | Type::SubclassOf(_) => {
-                    ty.to_instance(db)
+                    ty.to_instance(db, program)
                 }
                 _ => None,
             }
         }
 
-        project(db, self, &TypeFormArgumentVisitor::default()).unwrap_or(self)
+        project(db, program, self, &TypeFormArgumentVisitor::default()).unwrap_or(self)
     }
 }
 
 impl<'db> VarianceInferable<'db> for TypeFormType<'db> {
     // `TypeForm` is covariant in its type argument.
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
-        self.type_argument(db).variance_of(db, typevar)
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
+        self.type_argument(db).variance_of(db, program, typevar)
     }
 }

--- a/crates/ty_python_semantic/src/types/typed_dict.rs
+++ b/crates/ty_python_semantic/src/types/typed_dict.rs
@@ -125,6 +125,7 @@ impl<'db> TypedDictOpenness<'db> {
     fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -133,9 +134,13 @@ impl<'db> TypedDictOpenness<'db> {
             Self::ImplicitlyOpen | Self::Closed => self,
             Self::Extra(extra_items) => Self::extra(
                 db,
-                extra_items
-                    .declared_ty
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                extra_items.declared_ty.apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    tcx,
+                    visitor,
+                ),
                 extra_items.is_read_only,
             ),
         }
@@ -144,6 +149,7 @@ impl<'db> TypedDictOpenness<'db> {
     pub(crate) fn recursive_type_normalized_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -152,7 +158,7 @@ impl<'db> TypedDictOpenness<'db> {
             Self::Extra(extra_items) => {
                 let declared_ty = extra_items
                     .declared_ty
-                    .recursive_type_normalized_impl(db, div, true);
+                    .recursive_type_normalized_impl(db, program, div, true);
                 let declared_ty = if nested {
                     declared_ty?
                 } else {
@@ -202,7 +208,7 @@ pub(super) fn functional_typed_dict_field(
 
 /// Type that represents the set of all inhabitants (`dict` instances) that conform to
 /// a given `TypedDict` schema.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, salsa::SalsaValue, Hash, get_size2::GetSize)]
 pub enum TypedDictType<'db> {
     /// A reference to the class (inheriting from `typing.TypedDict`) that specifies the
     /// schema of this `TypedDict`.
@@ -212,7 +218,7 @@ pub enum TypedDictType<'db> {
     Synthesized(SynthesizedTypedDictType<'db>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, get_size2::GetSize, salsa::SalsaValue)]
 pub enum SynthesizedTypedDictKind {
     Schema,
     Patch,
@@ -244,6 +250,7 @@ impl<'db> TypedDictType<'db> {
             db: &'db dyn Db,
             class: ClassType<'db>,
         ) -> TypedDictOpenness<'db> {
+            let program = class.class_literal(db).program(db);
             let (class_literal, specialization) = class.class_literal_and_specialization(db);
             let static_class = match class_literal {
                 ClassLiteral::Static(static_class) => static_class,
@@ -256,8 +263,9 @@ impl<'db> TypedDictType<'db> {
                 }
             };
 
-            let module = parsed_module(db, static_class.file(db)).load(db);
             let class_definition = static_class.definition(db);
+            let module =
+                parsed_module(db, class_definition.program_file(db).versioned_file(db)).load(db);
             let class_stmt = class_definition
                 .kind(db)
                 .as_class()
@@ -278,7 +286,7 @@ impl<'db> TypedDictType<'db> {
 
                 if let Some(closed) = arguments.find_keyword("closed") {
                     let closed_ty = definition_expression_type(db, class_definition, &closed.value);
-                    return if closed_ty.bool(db).is_always_true() {
+                    return if closed_ty.bool(db, program).is_always_true() {
                         TypedDictOpenness::Closed
                     } else {
                         TypedDictOpenness::ImplicitlyOpen
@@ -307,7 +315,7 @@ impl<'db> TypedDictType<'db> {
 
         match self {
             Self::Class(defining_class) => class_based_openness(db, defining_class),
-            Self::Synthesized(synthesized) => synthesized.openness(db),
+            Self::Synthesized(synthesized) => *synthesized.openness(db),
         }
     }
 
@@ -320,13 +328,13 @@ impl<'db> TypedDictType<'db> {
     ///
     /// An implicitly open `TypedDict` immediately returns `object` because hidden items may have
     /// any value type. This also avoids unnecessarily materializing its declared items.
-    pub(crate) fn value_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn value_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         let openness = self.openness(db);
         if openness.is_implicitly_open() {
             return Type::object();
         }
 
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         for field in self.items(db).values() {
             builder = builder.add(field.declared_ty);
         }
@@ -340,15 +348,15 @@ impl<'db> TypedDictType<'db> {
     ///
     /// A closed `TypedDict` has a finite set of literal keys. Open and extra-items `TypedDict`s may
     /// contain arbitrary string keys.
-    pub(crate) fn key_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn key_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         if !self.openness(db).is_closed() {
-            return KnownClass::Str.to_instance(db);
+            return KnownClass::Str.to_instance(db, program);
         }
 
         self.items(db)
             .iter()
             .filter(|(_, field)| field.may_be_present(db))
-            .fold(UnionBuilder::new(db), |builder, (name, _)| {
+            .fold(UnionBuilder::new(db, program), |builder, (name, _)| {
                 builder.add(Type::string_literal(db, name))
             })
             .build()
@@ -375,8 +383,12 @@ impl<'db> TypedDictType<'db> {
     /// The runtime key may name either an extra item or any declared item, so the result is the
     /// intersection of all possible destination item types. Returns `None` unless extra items are
     /// explicit.
-    pub(crate) fn arbitrary_key_initialization_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        self.arbitrary_key_initialization_type_excluding(db, &OrderSet::new())
+    pub(crate) fn arbitrary_key_initialization_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
+        self.arbitrary_key_initialization_type_excluding(db, program, &OrderSet::new())
     }
 
     /// Returns the arbitrary-key initialization type after excluding keys that are known to be
@@ -387,12 +399,14 @@ impl<'db> TypedDictType<'db> {
     fn arbitrary_key_initialization_type_excluding(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         excluded_keys: &OrderSet<Name>,
     ) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
 
         Some(IntersectionType::from_elements(
             db,
+            program,
             std::iter::once(extra_items.declared_ty).chain(
                 self.items(db)
                     .iter()
@@ -406,7 +420,11 @@ impl<'db> TypedDictType<'db> {
     ///
     /// A mutation may target any declared or extra item, so no such mutation is allowed if any
     /// possible destination is read-only.
-    pub(crate) fn arbitrary_key_mutation_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn arbitrary_key_mutation_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         if self
             .explicit_extra_items(db)
             .is_some_and(TypedDictExtraItems::is_read_only)
@@ -415,7 +433,7 @@ impl<'db> TypedDictType<'db> {
             return None;
         }
 
-        self.arbitrary_key_initialization_type(db)
+        self.arbitrary_key_initialization_type(db, program)
     }
 
     /// Returns whether operations that delete an arbitrary key are safe.
@@ -440,7 +458,11 @@ impl<'db> TypedDictType<'db> {
     ///
     /// This requires mutable explicit extra items and optional, mutable declared items whose value
     /// types are equivalent to the extra-items type.
-    pub(crate) fn dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn dict_value_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
         if extra_items.is_read_only()
             || self.items(db).values().any(|field| {
@@ -448,7 +470,7 @@ impl<'db> TypedDictType<'db> {
                     || field.is_read_only()
                     || !field
                         .declared_ty
-                        .is_equivalent_to(db, extra_items.declared_ty)
+                        .is_equivalent_to(db, program, extra_items.declared_ty)
             })
         {
             return None;
@@ -460,7 +482,11 @@ impl<'db> TypedDictType<'db> {
     ///
     /// This uses mutual assignability rather than equivalence so gradual value types can satisfy
     /// the mutable `dict` contract.
-    pub(crate) fn assignable_dict_value_type(self, db: &'db dyn Db) -> Option<Type<'db>> {
+    pub(crate) fn assignable_dict_value_type(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<Type<'db>> {
         let extra_items = self.explicit_extra_items(db)?;
         if extra_items.is_read_only()
             || self.items(db).values().any(|field| {
@@ -468,10 +494,10 @@ impl<'db> TypedDictType<'db> {
                     || field.is_read_only()
                     || !field
                         .declared_ty
-                        .is_assignable_to(db, extra_items.declared_ty)
+                        .is_assignable_to(db, program, extra_items.declared_ty)
                     || !extra_items
                         .declared_ty
-                        .is_assignable_to(db, field.declared_ty)
+                        .is_assignable_to(db, program, field.declared_ty)
             })
         {
             return None;
@@ -531,6 +557,7 @@ impl<'db> TypedDictType<'db> {
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -541,7 +568,7 @@ impl<'db> TypedDictType<'db> {
                 Self::Class(defining_class.apply_type_mapping_impl(db, type_mapping, tcx, visitor))
             }
             Self::Synthesized(synthesized) => Self::Synthesized(
-                synthesized.apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+                synthesized.apply_type_mapping_impl(db, program, type_mapping, tcx, visitor),
             ),
         }
     }
@@ -635,6 +662,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
         source: TypedDictType<'db>,
         target: TypedDictType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         if let TypedDictType::Synthesized(synthesized_target) = target
             && synthesized_target.is_patch(db)
         {
@@ -661,7 +689,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                     self.check_type_pair(db, source_item_field.declared_ty, target_ty),
                 );
 
-                if result.is_never_satisfied(db) {
+                if result.is_never_satisfied(db, program) {
                     return result;
                 }
             }
@@ -685,7 +713,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             target_item_field.declared_ty,
                         ),
                     );
-                    if result.is_never_satisfied(db) {
+                    if result.is_never_satisfied(db, program) {
                         return result;
                     }
                 }
@@ -783,7 +811,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         source_item_field.declared_ty,
                         target_item_field.declared_ty,
                     )
-                    .and(db, self.constraints, || {
+                    .and(db, program, self.constraints, || {
                         self.check_type_pair(
                             db,
                             target_item_field.declared_ty,
@@ -849,7 +877,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             source_item_field.declared_ty,
                             target_item_field.declared_ty,
                         )
-                        .and(db, self.constraints, || {
+                        .and(db, program, self.constraints, || {
                             self.check_type_pair(
                                 db,
                                 target_item_field.declared_ty,
@@ -869,7 +897,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                             source_extra_items.declared_ty,
                             target_item_field.declared_ty,
                         )
-                        .and(db, self.constraints, || {
+                        .and(db, program, self.constraints, || {
                             self.check_type_pair(
                                 db,
                                 target_item_field.declared_ty,
@@ -880,7 +908,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                 }
             };
             result.intersect(db, self.constraints, field_constraints);
-            if result.is_never_satisfied(db) {
+            if result.is_never_satisfied(db, program) {
                 if let Some(context) = self.report_context()
                     && let Some(source_item_field) = source_items.get(target_item_name)
                 {
@@ -921,7 +949,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                         source_extra_items.declared_ty,
                         target_extra_items.declared_ty,
                     )
-                    .and(db, self.constraints, || {
+                    .and(db, program, self.constraints, || {
                         self.check_type_pair(
                             db,
                             target_extra_items.declared_ty,
@@ -942,7 +970,7 @@ impl<'c, 'db> TypeRelationChecker<'_, 'c, 'db> {
                                 source_item_field.declared_ty,
                                 target_extra_items.declared_ty,
                             )
-                            .and(db, self.constraints, || {
+                            .and(db, program, self.constraints, || {
                                 self.check_type_pair(
                                     db,
                                     target_extra_items.declared_ty,
@@ -1056,11 +1084,15 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         left: TypedDictType<'db>,
         right: TypedDictType<'db>,
     ) -> ConstraintSet<'db, 'c> {
+        let program = self.program;
         let left_items = left.items(db);
         let right_items = right.items(db);
         let fields_in_common = btreemap_values_with_same_key(left_items, right_items);
-        let common_fields_disjoint =
-            fields_in_common.when_any(db, self.constraints, |(left_field, right_field)| {
+        let common_fields_disjoint = fields_in_common.when_any(
+            db,
+            program,
+            self.constraints,
+            |(left_field, right_field)| {
                 // Condition 1 above.
                 if left_field.is_required() || right_field.is_required() {
                     if (!left_field.is_required() && !left_field.is_read_only())
@@ -1077,7 +1109,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                     let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
                     relation_checker
                         .check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
-                        .and(db, self.constraints, || {
+                        .and(db, program, self.constraints, || {
                             relation_checker.check_type_pair(
                                 db,
                                 right_field.declared_ty,
@@ -1099,101 +1131,122 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                     // Condition 4 above.
                     self.check_type_pair(db, left_field.declared_ty, right_field.declared_ty)
                 }
+            },
+        );
+
+        let required_fields_disjoint =
+            common_fields_disjoint.or(db, program, self.constraints, || {
+                left_items
+                    .iter()
+                    .filter(|(name, field)| field.is_required() && !right_items.contains_key(*name))
+                    .map(|(_, field)| (field, right.openness(db)))
+                    .chain(
+                        right_items
+                            .iter()
+                            .filter(|(name, field)| {
+                                field.is_required() && !left_items.contains_key(*name)
+                            })
+                            .map(|(_, field)| (field, left.openness(db))),
+                    )
+                    .when_any(
+                        db,
+                        program,
+                        self.constraints,
+                        |(required_field, other_openness)| {
+                            let check_read_only_extra_items = |extra_items_ty| {
+                                if required_field.is_read_only() {
+                                    self.check_type_pair(
+                                        db,
+                                        required_field.declared_ty,
+                                        extra_items_ty,
+                                    )
+                                } else {
+                                    self.as_relation_checker(TypeRelation::Assignability)
+                                        .check_type_pair(
+                                            db,
+                                            required_field.declared_ty,
+                                            extra_items_ty,
+                                        )
+                                        .negate(db, self.constraints)
+                                }
+                            };
+
+                            match other_openness {
+                                TypedDictOpenness::Closed => self.always(),
+                                TypedDictOpenness::Extra(extra_items)
+                                    if !extra_items.is_read_only() =>
+                                {
+                                    self.always()
+                                }
+                                TypedDictOpenness::ImplicitlyOpen => {
+                                    check_read_only_extra_items(Type::object())
+                                }
+                                TypedDictOpenness::Extra(extra_items) => {
+                                    check_read_only_extra_items(extra_items.declared_ty)
+                                }
+                            }
+                        },
+                    )
             });
 
-        let required_fields_disjoint = common_fields_disjoint.or(db, self.constraints, || {
-            left_items
-                .iter()
-                .filter(|(name, field)| field.is_required() && !right_items.contains_key(*name))
-                .map(|(_, field)| (field, right.openness(db)))
-                .chain(
-                    right_items
-                        .iter()
-                        .filter(|(name, field)| {
-                            field.is_required() && !left_items.contains_key(*name)
-                        })
-                        .map(|(_, field)| (field, left.openness(db))),
-                )
-                .when_any(db, self.constraints, |(required_field, other_openness)| {
-                    let check_read_only_extra_items = |extra_items_ty| {
-                        if required_field.is_read_only() {
-                            self.check_type_pair(db, required_field.declared_ty, extra_items_ty)
+        let unshared_fields_disjoint =
+            required_fields_disjoint.or(db, program, self.constraints, || {
+                left_items
+                    .iter()
+                    .map(|(name, field)| (name, field, right_items, right.openness(db)))
+                    .chain(
+                        right_items
+                            .iter()
+                            .map(|(name, field)| (name, field, left_items, left.openness(db))),
+                    )
+                    .filter_map(|(name, field, other_items, other_openness)| {
+                        if field.is_required() || other_items.contains_key(name) {
+                            return None;
+                        }
+                        match other_openness {
+                            TypedDictOpenness::Closed if !field.is_read_only() => {
+                                Some((field, None))
+                            }
+                            TypedDictOpenness::Extra(extra_items)
+                                if !field.is_read_only() || !extra_items.is_read_only() =>
+                            {
+                                Some((field, Some(extra_items)))
+                            }
+                            TypedDictOpenness::ImplicitlyOpen
+                            | TypedDictOpenness::Closed
+                            | TypedDictOpenness::Extra(_) => None,
+                        }
+                    })
+                    .when_any(db, program, self.constraints, |(field, extra_items)| {
+                        let Some(extra_items) = extra_items else {
+                            return self.always();
+                        };
+                        let relation_checker =
+                            self.as_relation_checker(TypeRelation::Assignability);
+                        if field.is_read_only() {
+                            relation_checker
+                                .check_type_pair(db, extra_items.declared_ty, field.declared_ty)
+                                .negate(db, self.constraints)
+                        } else if extra_items.is_read_only() {
+                            relation_checker
+                                .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
+                                .negate(db, self.constraints)
                         } else {
-                            self.as_relation_checker(TypeRelation::Assignability)
-                                .check_type_pair(db, required_field.declared_ty, extra_items_ty)
+                            relation_checker
+                                .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
+                                .and(db, program, self.constraints, || {
+                                    relation_checker.check_type_pair(
+                                        db,
+                                        extra_items.declared_ty,
+                                        field.declared_ty,
+                                    )
+                                })
                                 .negate(db, self.constraints)
                         }
-                    };
+                    })
+            });
 
-                    match other_openness {
-                        TypedDictOpenness::Closed => self.always(),
-                        TypedDictOpenness::Extra(extra_items) if !extra_items.is_read_only() => {
-                            self.always()
-                        }
-                        TypedDictOpenness::ImplicitlyOpen => {
-                            check_read_only_extra_items(Type::object())
-                        }
-                        TypedDictOpenness::Extra(extra_items) => {
-                            check_read_only_extra_items(extra_items.declared_ty)
-                        }
-                    }
-                })
-        });
-
-        let unshared_fields_disjoint = required_fields_disjoint.or(db, self.constraints, || {
-            left_items
-                .iter()
-                .map(|(name, field)| (name, field, right_items, right.openness(db)))
-                .chain(
-                    right_items
-                        .iter()
-                        .map(|(name, field)| (name, field, left_items, left.openness(db))),
-                )
-                .filter_map(|(name, field, other_items, other_openness)| {
-                    if field.is_required() || other_items.contains_key(name) {
-                        return None;
-                    }
-                    match other_openness {
-                        TypedDictOpenness::Closed if !field.is_read_only() => Some((field, None)),
-                        TypedDictOpenness::Extra(extra_items)
-                            if !field.is_read_only() || !extra_items.is_read_only() =>
-                        {
-                            Some((field, Some(extra_items)))
-                        }
-                        TypedDictOpenness::ImplicitlyOpen
-                        | TypedDictOpenness::Closed
-                        | TypedDictOpenness::Extra(_) => None,
-                    }
-                })
-                .when_any(db, self.constraints, |(field, extra_items)| {
-                    let Some(extra_items) = extra_items else {
-                        return self.always();
-                    };
-                    let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
-                    if field.is_read_only() {
-                        relation_checker
-                            .check_type_pair(db, extra_items.declared_ty, field.declared_ty)
-                            .negate(db, self.constraints)
-                    } else if extra_items.is_read_only() {
-                        relation_checker
-                            .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
-                            .negate(db, self.constraints)
-                    } else {
-                        relation_checker
-                            .check_type_pair(db, field.declared_ty, extra_items.declared_ty)
-                            .and(db, self.constraints, || {
-                                relation_checker.check_type_pair(
-                                    db,
-                                    extra_items.declared_ty,
-                                    field.declared_ty,
-                                )
-                            })
-                            .negate(db, self.constraints)
-                    }
-                })
-        });
-
-        unshared_fields_disjoint.or(db, self.constraints, || {
+        unshared_fields_disjoint.or(db, program, self.constraints, || {
             let left_openness = left.openness(db);
             let right_openness = right.openness(db);
             let relation_checker = self.as_relation_checker(TypeRelation::Assignability);
@@ -1210,7 +1263,7 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
                 {
                     relation_checker
                         .check_type_pair(db, left_extra.declared_ty, right_extra.declared_ty)
-                        .and(db, self.constraints, || {
+                        .and(db, program, self.constraints, || {
                             relation_checker.check_type_pair(
                                 db,
                                 right_extra.declared_ty,
@@ -1244,19 +1297,20 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 
 pub(crate) fn walk_typed_dict_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     typed_dict: TypedDictType<'db>,
     visitor: &V,
 ) {
     match typed_dict {
         TypedDictType::Class(defining_class) => {
-            visitor.visit_type(db, defining_class.into());
+            visitor.visit_type(db, program, defining_class.into());
         }
         TypedDictType::Synthesized(synthesized) => {
             for field in synthesized.items(db).values() {
-                visitor.visit_type(db, field.declared_ty);
+                visitor.visit_type(db, program, field.declared_ty);
             }
             if let Some(extra_items) = synthesized.openness(db).explicit_extra_items() {
-                visitor.visit_type(db, extra_items.declared_ty);
+                visitor.visit_type(db, program, extra_items.declared_ty);
             }
         }
     }
@@ -1271,7 +1325,9 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> TypedDictSchema<'db> {
-    let module = parsed_module(db, definition.file(db)).load(db);
+    let program_file = definition.program_file(db);
+    let program = program_file.program(db);
+    let module = program_file.parsed(db).load(db);
     let node = definition
         .kind(db)
         .value(&module)
@@ -1283,7 +1339,7 @@ pub(super) fn deferred_functional_typed_dict_schema<'db>(
 
     let total = node.arguments.find_keyword("total").is_none_or(|total_kw| {
         let total_ty = definition_expression_type(db, definition, &total_kw.value);
-        !total_ty.bool(db).is_always_false()
+        !total_ty.bool(db, program).is_always_false()
     });
 
     let mut schema = TypedDictSchema::default();
@@ -1333,7 +1389,9 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
     db: &'db dyn Db,
     definition: Definition<'db>,
 ) -> TypedDictOpenness<'db> {
-    let module = parsed_module(db, definition.file(db)).load(db);
+    let program_file = definition.program_file(db);
+    let program = program_file.program(db);
+    let module = program_file.parsed(db).load(db);
     let node = definition
         .kind(db)
         .value(&module)
@@ -1354,7 +1412,7 @@ pub(super) fn deferred_functional_typed_dict_openness<'db>(
 
     if let Some(closed) = node.arguments.find_keyword("closed") {
         let closed_ty = definition_expression_type(db, definition, &closed.value);
-        if closed_ty.bool(db).is_always_true() {
+        if closed_ty.bool(db, program).is_always_true() {
             return TypedDictOpenness::Closed;
         }
     }
@@ -1429,6 +1487,7 @@ pub(super) struct TypedDictKeyAssignment<'a, 'db, 'ast> {
 impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
     pub(super) fn validate(&self) -> bool {
         let db = self.context.db();
+        let program = self.context.program();
         let items = self.typed_dict.items(db);
 
         // Check if key exists in `TypedDict` or is accepted by explicit extra items.
@@ -1455,7 +1514,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                     .report_lint(self.assignment_kind.diagnostic_type(), self.key_node)
             {
                 let typed_dict_ty = Type::TypedDict(self.typed_dict);
-                let typed_dict_d = typed_dict_ty.display(db);
+                let typed_dict_d = typed_dict_ty.display(db, program);
 
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Cannot assign to key \"{}\" on TypedDict `{typed_dict_d}`",
@@ -1463,7 +1522,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                 ));
 
                 diagnostic.set_primary_message(format_args!("key is marked read-only"));
-                self.add_object_type_annotation(db, &mut diagnostic);
+                self.add_object_type_annotation(db, program, &mut diagnostic);
                 Self::add_item_definition_subdiagnostic(
                     db,
                     &item,
@@ -1476,7 +1535,10 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
         }
 
         // Key exists, check if value type is assignable to declared type
-        if self.value_ty.is_assignable_to(db, item.declared_ty) {
+        if self
+            .value_ty
+            .is_assignable_to(db, self.context.program(), item.declared_ty)
+        {
             return true;
         }
 
@@ -1491,9 +1553,9 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                 .report_lint(self.assignment_kind.diagnostic_type(), self.value_node)
         {
             let typed_dict_ty = Type::TypedDict(self.typed_dict);
-            let typed_dict_d = typed_dict_ty.display(db);
-            let value_d = self.value_ty.display(db);
-            let item_type_d = item.declared_ty.display(db);
+            let typed_dict_d = typed_dict_ty.display(db, program);
+            let value_d = self.value_ty.display(db, program);
+            let item_type_d = item.declared_ty.display(db, program);
 
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Invalid {} to key \"{}\" with declared type `{item_type_d}` \
@@ -1516,19 +1578,24 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
                 &mut diagnostic,
                 "Item declared here",
             );
-            self.add_object_type_annotation(db, &mut diagnostic);
+            self.add_object_type_annotation(db, program, &mut diagnostic);
         }
 
         false
     }
 
-    fn add_object_type_annotation(&self, db: &'db dyn Db, diagnostic: &mut Diagnostic) {
+    fn add_object_type_annotation(
+        &self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        diagnostic: &mut Diagnostic,
+    ) {
         if let Some(full_object_ty) = self.full_object_ty {
             diagnostic.annotate(self.context.secondary(self.typed_dict_node).message(
                 format_args!(
                     "TypedDict `{}` in {kind} type `{}`",
-                    Type::TypedDict(self.typed_dict).display(db),
-                    full_object_ty.display(db),
+                    Type::TypedDict(self.typed_dict).display(db, program),
+                    full_object_ty.display(db, program),
                     kind = if full_object_ty.is_union() {
                         "union"
                     } else {
@@ -1540,7 +1607,7 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
             diagnostic.annotate(self.context.secondary(self.typed_dict_node).message(
                 format_args!(
                     "TypedDict `{}`",
-                    Type::TypedDict(self.typed_dict).display(db)
+                    Type::TypedDict(self.typed_dict).display(db, program)
                 ),
             ));
         }
@@ -1554,7 +1621,8 @@ impl<'db> TypedDictKeyAssignment<'_, 'db, '_> {
     ) {
         if let Some(declaration) = item.first_declaration() {
             let file = declaration.file(db);
-            let module = parsed_module(db, file).load(db);
+            let module =
+                parsed_module(db, declaration.program_file(db).versioned_file(db)).load(db);
 
             let mut sub = SubDiagnostic::new(SubDiagnosticSeverity::Info, "Item declaration");
             sub.annotate(
@@ -1633,6 +1701,7 @@ pub(crate) struct UnpackedTypedDict<'db> {
 /// writes through the synthesized policy.
 fn intersect_unpacked_typed_dict_openness<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
 ) -> TypedDictOpenness<'db> {
     let mut explicit_value_types = Vec::new();
@@ -1652,7 +1721,7 @@ fn intersect_unpacked_typed_dict_openness<'db>(
     } else {
         TypedDictOpenness::extra(
             db,
-            IntersectionType::from_elements(db, explicit_value_types),
+            IntersectionType::from_elements(db, program, explicit_value_types),
             true,
         )
     }
@@ -1671,9 +1740,10 @@ fn intersect_unpacked_typed_dict_openness<'db>(
 /// observes its values.
 fn union_unpacked_typed_dict_openness<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     openness: impl IntoIterator<Item = TypedDictOpenness<'db>>,
 ) -> TypedDictOpenness<'db> {
-    let mut value_types = UnionBuilder::new(db);
+    let mut value_types = UnionBuilder::new(db, program);
     let mut has_implicitly_open = false;
     let mut has_explicit_extra_items = false;
 
@@ -1710,14 +1780,16 @@ fn union_unpacked_typed_dict_openness<'db>(
 /// and a key is only considered required if every arm requires it.
 pub(crate) fn extract_unpacked_typed_dict_keys_from_value_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
 ) -> Option<BTreeMap<Name, UnpackedTypedDictKey<'db>>> {
-    extract_unpacked_typed_dict_from_value_type(db, ty).map(|unpacked| unpacked.keys)
+    extract_unpacked_typed_dict_from_value_type(db, program, ty).map(|unpacked| unpacked.keys)
 }
 
 /// Extracts the declared keys and openness from a `TypedDict`-shaped value.
 pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     ty: Type<'db>,
 ) -> Option<UnpackedTypedDict<'db>> {
     match ty {
@@ -1746,7 +1818,9 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             let unpacked_elements: Vec<_> = intersection
                 .positive(db)
                 .iter()
-                .filter_map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
+                .filter_map(|element| {
+                    extract_unpacked_typed_dict_from_value_type(db, program, *element)
+                })
                 .collect();
 
             if unpacked_elements.is_empty() {
@@ -1763,6 +1837,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                         .and_modify(|existing| {
                             existing.value_ty = IntersectionType::from_two_elements(
                                 db,
+                                program,
                                 existing.value_ty,
                                 unpacked_key.value_ty,
                             );
@@ -1784,6 +1859,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
                     if let Some(extra_items) = unpacked.openness.effective_extra_items() {
                         unpacked_key.value_ty = IntersectionType::from_two_elements(
                             db,
+                            program,
                             unpacked_key.value_ty,
                             extra_items.declared_ty,
                         );
@@ -1794,6 +1870,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
 
             let openness = intersect_unpacked_typed_dict_openness(
                 db,
+                program,
                 unpacked_elements.iter().map(|unpacked| unpacked.openness),
             );
 
@@ -1806,7 +1883,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             let unpacked_elements: Vec<_> = union
                 .elements(db)
                 .iter()
-                .map(|element| extract_unpacked_typed_dict_from_value_type(db, *element))
+                .map(|element| extract_unpacked_typed_dict_from_value_type(db, program, *element))
                 .collect::<Option<_>>()?;
 
             let all_keys: OrderSet<Name> = unpacked_elements
@@ -1816,7 +1893,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             let mut result = BTreeMap::new();
 
             for key in all_keys {
-                let mut value_ty = UnionBuilder::new(db);
+                let mut value_ty = UnionBuilder::new(db, program);
                 let mut is_required = true;
                 let mut definition = None;
                 let mut saw_key = false;
@@ -1856,6 +1933,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
 
             let openness = union_unpacked_typed_dict_openness(
                 db,
+                program,
                 unpacked_elements.iter().map(|unpacked| unpacked.openness),
             );
 
@@ -1865,7 +1943,7 @@ pub(crate) fn extract_unpacked_typed_dict_from_value_type<'db>(
             })
         }
         Type::TypeAlias(alias) => {
-            extract_unpacked_typed_dict_from_value_type(db, alias.value_type(db))
+            extract_unpacked_typed_dict_from_value_type(db, program, alias.value_type(db))
         }
         // All other types cannot contain a TypedDict
         Type::Dynamic(_)
@@ -1977,6 +2055,7 @@ pub(super) fn unpacked_keyword_is_gradual<'db>(db: &'db dyn Db, ty: Type<'db>) -
 /// key diagnostics for the positional mapping.
 pub(super) fn collect_guaranteed_keyword_keys<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     typed_dict: TypedDictType<'db>,
     arguments: &Arguments,
     unpacked_keyword_types: &[Option<Type<'db>>],
@@ -2009,6 +2088,7 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
 
         collect_guaranteed_keys_from_merged_unpacked_keyword(
             db,
+            program,
             typed_dict,
             &keyword.value,
             unpacked_type,
@@ -2023,6 +2103,7 @@ pub(super) fn collect_guaranteed_keyword_keys<'db>(
 /// Collects keys guaranteed by one unpacked constructor argument.
 fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     typed_dict: TypedDictType<'db>,
     expr: &ast::Expr,
     unpacked_type: Type<'db>,
@@ -2040,6 +2121,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
                 let nested_ty = expression_type_fn(&item.value, TypeContext::default());
                 collect_guaranteed_keys_from_merged_unpacked_keyword(
                     db,
+                    program,
                     typed_dict,
                     &item.value,
                     nested_ty,
@@ -2054,7 +2136,7 @@ fn collect_guaranteed_keys_from_merged_unpacked_keyword<'db>(
     if unpacked_keyword_is_gradual(db, unpacked_type) {
         provided_keys.extend(typed_dict.items(db).keys().cloned());
     } else if let Some(unpacked_keys) =
-        extract_unpacked_typed_dict_keys_from_value_type(db, unpacked_type)
+        extract_unpacked_typed_dict_keys_from_value_type(db, program, unpacked_type)
     {
         for (key, unpacked_key) in unpacked_keys {
             if unpacked_key.is_required {
@@ -2198,6 +2280,7 @@ fn validate_extracted_typed_dict_openness<'db, 'ast>(
     ignored_keys: &OrderSet<Name>,
 ) -> bool {
     let db = context.db();
+    let program = context.program();
     let Some(extra_items) = source_openness.effective_extra_items() else {
         return true;
     };
@@ -2215,41 +2298,39 @@ fn validate_extracted_typed_dict_openness<'db, 'ast>(
             typed_dict.items(db).iter().find(|(name, field)| {
                 !source_keys.contains_key(*name)
                     && !ignored_keys.contains(*name)
-                    && !extra_items_ty.is_assignable_to(db, field.declared_ty)
+                    && !extra_items_ty.is_assignable_to(db, context.program(), field.declared_ty)
             })
         {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
                 let mut diagnostic = builder.into_diagnostic(format_args!(
                     "Unpacked argument has extra items of type `{}` that are not assignable to item `{target_name}` with type `{}` on TypedDict `{}`",
-                    extra_items_ty.display(db),
-                    target_field.declared_ty.display(db),
-                    typed_dict_ty.display(db),
+                    extra_items_ty.display(db, program),
+                    target_field.declared_ty.display(db, program),
+                    typed_dict_ty.display(db, program),
                 ));
-                diagnostic.annotate(
-                    context
-                        .secondary(nodes.typed_dict)
-                        .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
-                );
+                diagnostic.annotate(context.secondary(nodes.typed_dict).message(format_args!(
+                    "TypedDict `{}`",
+                    typed_dict_ty.display(db, program)
+                )));
             }
             return false;
         }
 
-        if extra_items_ty.is_assignable_to(db, target_extra_items.declared_ty) {
+        if extra_items_ty.is_assignable_to(db, context.program(), target_extra_items.declared_ty) {
             return true;
         }
 
         if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
             let mut diagnostic = builder.into_diagnostic(format_args!(
                 "Unpacked argument has extra items of type `{}` that are not assignable to extra items type `{}` on TypedDict `{}`",
-                extra_items_ty.display(db),
-                target_extra_items.declared_ty.display(db),
-                typed_dict_ty.display(db),
+                extra_items_ty.display(db, program),
+                target_extra_items.declared_ty.display(db, program),
+                typed_dict_ty.display(db, program),
             ));
-            diagnostic.annotate(
-                context
-                    .secondary(nodes.typed_dict)
-                    .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
-            );
+            diagnostic.annotate(context.secondary(nodes.typed_dict).message(format_args!(
+                "TypedDict `{}`",
+                typed_dict_ty.display(db, program)
+            )));
         }
         return false;
     }
@@ -2257,13 +2338,12 @@ fn validate_extracted_typed_dict_openness<'db, 'ast>(
     if let Some(builder) = context.report_lint(&INVALID_KEY, nodes.key) {
         let mut diagnostic = builder.into_diagnostic(format_args!(
             "Unpacked argument may contain unknown keys for TypedDict `{}`",
-            typed_dict_ty.display(db),
+            typed_dict_ty.display(db, program),
         ));
-        diagnostic.annotate(
-            context
-                .secondary(nodes.typed_dict)
-                .message(format_args!("TypedDict `{}`", typed_dict_ty.display(db))),
-        );
+        diagnostic.annotate(context.secondary(nodes.typed_dict).message(format_args!(
+            "TypedDict `{}`",
+            typed_dict_ty.display(db, program)
+        )));
     }
     false
 }
@@ -2285,7 +2365,7 @@ fn validate_from_typed_dict_argument<'db, 'ast>(
 ) -> Option<OrderSet<Name>> {
     let db = context.db();
     let typed_dict_items = typed_dict.items(db);
-    let unpacked = extract_unpacked_typed_dict_from_value_type(db, arg_ty)?;
+    let unpacked = extract_unpacked_typed_dict_from_value_type(db, context.program(), arg_ty)?;
     let source_openness = unpacked.openness;
     let validate_extra_keys = !typed_dict.openness(db).is_implicitly_open();
     let unpacked_keys = unpacked
@@ -2327,11 +2407,12 @@ fn report_duplicate_typed_dict_constructor_key<'db, 'ast>(
     duplicate_node: AnyNodeRef<'ast>,
     original_node: AnyNodeRef<'ast>,
 ) {
+    let program = context.program();
     let Some(builder) = context.report_lint(&PARAMETER_ALREADY_ASSIGNED, duplicate_node) else {
         return;
     };
 
-    let typed_dict_display = Type::TypedDict(typed_dict).display(context.db());
+    let typed_dict_display = Type::TypedDict(typed_dict).display(context.db(), program);
     let mut diagnostic = builder.into_diagnostic(format_args!(
         "Multiple values provided for key \"{key}\" in TypedDict `{typed_dict_display}` constructor",
     ));
@@ -2384,6 +2465,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
     mut expression_type_fn: impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) {
     let db = context.db();
+    let program = context.program();
     let typed_dict_ty = Type::TypedDict(typed_dict);
 
     if arguments.args.len() > 1 {
@@ -2392,7 +2474,7 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
         {
             builder.into_diagnostic(format_args!(
                 "Too many positional arguments to TypedDict `{}` constructor: expected 1, got {}",
-                typed_dict_ty.display(db),
+                typed_dict_ty.display(db, program),
                 arguments.args.len(),
             ));
         }
@@ -2450,13 +2532,13 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
                 provided_keys
             } else {
                 if !positional_target_is_unconstrained
-                    && !arg_ty.is_assignable_to(db, positional_target_ty)
+                    && !arg_ty.is_assignable_to(db, context.program(), positional_target_ty)
                 {
                     if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
                         builder.into_diagnostic(format_args!(
                             "Argument of type `{}` is not assignable to `{}`",
-                            arg_ty.display(db),
-                            positional_target_ty.display(db),
+                            arg_ty.display(db, program),
+                            positional_target_ty.display(db, program),
                         ));
                     }
                 }
@@ -2491,12 +2573,12 @@ pub(super) fn validate_typed_dict_constructor<'db, 'ast>(
         let arg = &arguments.args[0];
         let arg_ty = expression_type_fn(arg, TypeContext::new(Some(typed_dict_ty)));
 
-        if !arg_ty.is_assignable_to(db, typed_dict_ty) {
+        if !arg_ty.is_assignable_to(db, context.program(), typed_dict_ty) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, arg) {
                 builder.into_diagnostic(format_args!(
                     "Argument of type `{}` is not assignable to `{}`",
-                    arg_ty.display(db),
-                    typed_dict_ty.display(db),
+                    arg_ty.display(db, program),
+                    typed_dict_ty.display(db, program),
                 ));
             }
         }
@@ -2653,28 +2735,37 @@ fn validate_merged_dict_literal<'db, 'ast>(
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> bool {
     let db = context.db();
+    let program = context.program();
     let mut valid = true;
 
     for item in dict_expr.items.iter().rev() {
         if let Some(key_expr) = &item.key {
             let key_ty = expression_type_fn(key_expr, TypeContext::default());
             let Some(key_literal) = key_ty.as_string_literal() else {
-                if key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
-                    if let Some(expected_ty) =
-                        typed_dict.arbitrary_key_initialization_type_excluding(db, shadowed_keys)
+                if key_ty.is_assignable_to(
+                    db,
+                    context.program(),
+                    KnownClass::Str.to_instance(db, context.program()),
+                ) {
+                    if let Some(expected_ty) = typed_dict
+                        .arbitrary_key_initialization_type_excluding(
+                            db,
+                            context.program(),
+                            shadowed_keys,
+                        )
                     {
                         let value_ty =
                             expression_type_fn(&item.value, TypeContext::new(Some(expected_ty)));
-                        if !value_ty.is_assignable_to(db, expected_ty) {
+                        if !value_ty.is_assignable_to(db, context.program(), expected_ty) {
                             valid = false;
                             if let Some(builder) =
                                 context.report_lint(&INVALID_ARGUMENT_TYPE, &item.value)
                             {
                                 builder.into_diagnostic(format_args!(
                                     "Value of type `{}` is not assignable to arbitrary key value type `{}` on TypedDict `{}`",
-                                    value_ty.display(db),
-                                    expected_ty.display(db),
-                                    Type::TypedDict(typed_dict).display(db),
+                                    value_ty.display(db, program),
+                                    expected_ty.display(db, program),
+                                    Type::TypedDict(typed_dict).display(db, program),
                                 ));
                             }
                         }
@@ -2683,7 +2774,7 @@ fn validate_merged_dict_literal<'db, 'ast>(
                         if let Some(builder) = context.report_lint(&INVALID_KEY, key_expr) {
                             builder.into_diagnostic(format_args!(
                                 "Non-literal string key may be unknown for TypedDict `{}`",
-                                Type::TypedDict(typed_dict).display(db),
+                                Type::TypedDict(typed_dict).display(db, program),
                             ));
                         }
                     }
@@ -2692,8 +2783,8 @@ fn validate_merged_dict_literal<'db, 'ast>(
                     if let Some(builder) = context.report_lint(&INVALID_KEY, key_expr) {
                         builder.into_diagnostic(format_args!(
                             "TypedDict `{}` requires string keys, got key of type `{}`",
-                            Type::TypedDict(typed_dict).display(db),
-                            key_ty.display(db),
+                            Type::TypedDict(typed_dict).display(db, program),
+                            key_ty.display(db, program),
                         ));
                     }
                 }
@@ -2763,6 +2854,7 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
     expression_type_fn: &mut impl FnMut(&ast::Expr, TypeContext<'db>) -> Type<'db>,
 ) -> bool {
     let db = context.db();
+    let program = context.program();
     let items = typed_dict.items(db);
 
     if let ast::Expr::Dict(dict_expr) = expr {
@@ -2785,7 +2877,9 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
             guaranteed_keys.entry(key_name.clone()).or_insert(None);
         }
         return true;
-    } else if let Some(unpacked) = extract_unpacked_typed_dict_from_value_type(db, unpacked_type) {
+    } else if let Some(unpacked) =
+        extract_unpacked_typed_dict_from_value_type(db, context.program(), unpacked_type)
+    {
         let ignored_keys = shadowed_keys.clone();
         let (_, mut unpacked_valid) = validate_extracted_typed_dict_keys(
             context,
@@ -2819,12 +2913,18 @@ fn validate_merged_unpacked_keyword_argument<'db, 'ast>(
         }
 
         return unpacked_valid;
-    } else if let Some((key_ty, value_ty)) = unpacked_type.unpack_keys_and_items(db) {
-        if !key_ty.is_assignable_to(db, KnownClass::Str.to_instance(db)) {
+    } else if let Some((key_ty, value_ty)) =
+        unpacked_type.unpack_keys_and_items(db, context.program())
+    {
+        if !key_ty.is_assignable_to(
+            db,
+            context.program(),
+            KnownClass::Str.to_instance(db, context.program()),
+        ) {
             if let Some(builder) = context.report_lint(&INVALID_ARGUMENT_TYPE, nodes.value) {
                 builder.into_diagnostic(format_args!(
                     "Unpacked argument has key type `{}` that is not assignable to `str`",
-                    key_ty.display(db),
+                    key_ty.display(db, program),
                 ));
             }
             return false;
@@ -2890,7 +2990,6 @@ pub struct SynthesizedTypedDictType<'db> {
     #[returns(copy)]
     pub(crate) kind: SynthesizedTypedDictKind,
     /// Whether keys absent from `items` are hidden, forbidden, or explicitly typed.
-    #[returns(copy)]
     pub(crate) openness: TypedDictOpenness<'db>,
 }
 
@@ -2921,6 +3020,7 @@ impl<'db> SynthesizedTypedDictType<'db> {
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -2929,17 +3029,18 @@ impl<'db> SynthesizedTypedDictType<'db> {
             .items(db)
             .iter()
             .map(|(name, field)| {
-                let field = field
-                    .clone()
-                    .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+                let field =
+                    field
+                        .clone()
+                        .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor);
 
                 (name.clone(), field)
             })
             .collect::<TypedDictSchema<'db>>();
 
-        let openness = self
-            .openness(db)
-            .apply_type_mapping_impl(db, type_mapping, tcx, visitor);
+        let openness =
+            self.openness(db)
+                .apply_type_mapping_impl(db, program, type_mapping, tcx, visitor);
 
         match self.kind(db) {
             SynthesizedTypedDictKind::Schema => Self::schema(db, items, openness),
@@ -2955,6 +3056,7 @@ impl<'db> TypedDictSchema<'db> {
     pub(super) fn recursive_type_normalized_impl(
         &self,
         db: &'db dyn Db,
+        program: crate::Program,
         div: Type<'db>,
         nested: bool,
     ) -> Option<Self> {
@@ -2962,7 +3064,7 @@ impl<'db> TypedDictSchema<'db> {
             .map(|(name, field)| {
                 let declared_ty = field
                     .declared_ty
-                    .recursive_type_normalized_impl(db, div, true);
+                    .recursive_type_normalized_impl(db, program, div, true);
                 let declared_ty = if nested {
                     declared_ty?
                 } else {
@@ -3042,14 +3144,19 @@ impl<'db> TypedDictField<'db> {
     pub(crate) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         tcx: TypeContext<'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self {
-            declared_ty: self
-                .declared_ty
-                .apply_type_mapping_impl(db, type_mapping, tcx, visitor),
+            declared_ty: self.declared_ty.apply_type_mapping_impl(
+                db,
+                program,
+                type_mapping,
+                tcx,
+                visitor,
+            ),
             flags: self.flags,
             first_declaration: self.first_declaration,
         }
@@ -3101,7 +3208,7 @@ impl<'db> TypedDictFieldBuilder<'db> {
 }
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, salsa::SalsaValue)]
     struct TypedDictFieldFlags: u8 {
         const REQUIRED = 1 << 0;
         const READ_ONLY = 1 << 1;

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -523,8 +523,8 @@ impl<'db> TypeVarInstance<'db> {
     }
 
     fn lazy_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
-        let program = self.definition(db)?.program_file(db).program(db);
         let bound = self.lazy_bound_unchecked(db)?;
+        let program = self.definition(db)?.program_file(db).program(db);
 
         if bound.has_typevar_or_typevar_instance(db, program) {
             return None;
@@ -582,8 +582,8 @@ impl<'db> TypeVarInstance<'db> {
     }
 
     fn lazy_constraints(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
-        let program = self.definition(db)?.program_file(db).program(db);
         let constraints = self.lazy_constraints_unchecked(db)?;
+        let program = self.definition(db)?.program_file(db).program(db);
 
         if constraints
             .elements(db)

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -39,16 +39,19 @@ impl<'db> Type<'db> {
         }
     }
 
-    pub(crate) fn has_typevar(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, false, |ty| matches!(ty, Type::TypeVar(_)))
+    pub(crate) fn has_typevar(self, db: &'db dyn Db, program: crate::Program) -> bool {
+        any_over_type(db, program, self, false, |ty| {
+            matches!(ty, Type::TypeVar(_))
+        })
     }
 
     pub(crate) fn references_typevar(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         typevar_id: TypeVarIdentity<'db>,
     ) -> bool {
-        any_over_type(db, self, false, |ty| match ty {
+        any_over_type(db, program, self, false, |ty| match ty {
             Type::TypeVar(bound_typevar) => typevar_id == bound_typevar.typevar(db).identity(db),
             Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
                 typevar_id == typevar.identity(db)
@@ -57,17 +60,22 @@ impl<'db> Type<'db> {
         })
     }
 
-    pub(crate) fn has_non_self_typevar(self, db: &'db dyn Db) -> bool {
+    pub(crate) fn has_non_self_typevar(self, db: &'db dyn Db, program: crate::Program) -> bool {
         any_over_type(
             db,
+            program,
             self,
             false,
             |ty| matches!(ty, Type::TypeVar(tv) if !tv.typevar(db).is_self(db)),
         )
     }
 
-    pub(crate) fn has_typevar_or_typevar_instance(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, false, |ty| {
+    pub(crate) fn has_typevar_or_typevar_instance(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> bool {
+        any_over_type(db, program, self, false, |ty| {
             matches!(
                 ty,
                 Type::KnownInstance(KnownInstanceType::TypeVar(_)) | Type::TypeVar(_)
@@ -75,8 +83,12 @@ impl<'db> Type<'db> {
         })
     }
 
-    pub(crate) fn has_unspecialized_type_var(self, db: &'db dyn Db) -> bool {
-        any_over_type(db, self, false, |ty| {
+    pub(crate) fn has_unspecialized_type_var(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> bool {
+        any_over_type(db, program, self, false, |ty| {
             matches!(ty, Type::Dynamic(DynamicType::UnspecializedTypeVar))
         })
     }
@@ -141,6 +153,7 @@ impl get_size2::GetSize for TypeVarInstance<'_> {}
 
 pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     typevar: TypeVarInstance<'db>,
     visitor: &V,
 ) {
@@ -155,7 +168,7 @@ pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
             _ => None,
         }
     } {
-        walk_type_var_bounds(db, bound_or_constraints, visitor);
+        walk_type_var_bounds(db, program, bound_or_constraints, visitor);
     }
     if let Some(default_type) = if visitor.should_visit_lazy_type_attributes() {
         typevar.default_type(db)
@@ -165,7 +178,7 @@ pub(super) fn walk_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
             _ => None,
         }
     } {
-        visitor.visit_type(db, default_type);
+        visitor.visit_type(db, program, default_type);
     }
 }
 
@@ -289,6 +302,7 @@ impl<'db> TypeVarInstance<'db> {
     fn materialize_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
@@ -299,43 +313,45 @@ impl<'db> TypeVarInstance<'db> {
                 .and_then(|bound_or_constraints| match bound_or_constraints {
                     TypeVarBoundOrConstraintsEvaluation::Eager(bound_or_constraints) => Some(
                         bound_or_constraints
-                            .materialize_impl(db, materialization_kind, visitor)
+                            .materialize_impl(db, program, materialization_kind, visitor)
                             .into(),
                     ),
                     TypeVarBoundOrConstraintsEvaluation::LazyUpperBound => {
                         self.lazy_bound(db).map(|bound| {
                             TypeVarBoundOrConstraints::UpperBound(bound)
-                                .materialize_impl(db, materialization_kind, visitor)
+                                .materialize_impl(db, program, materialization_kind, visitor)
                                 .into()
                         })
                     }
                     TypeVarBoundOrConstraintsEvaluation::LazyConstraints => {
                         self.lazy_constraints(db).map(|constraints| {
                             TypeVarBoundOrConstraints::Constraints(constraints)
-                                .materialize_impl(db, materialization_kind, visitor)
+                                .materialize_impl(db, program, materialization_kind, visitor)
                                 .into()
                         })
                     }
                 }),
             self.explicit_variance(db),
             self._default(db).and_then(|default| match default {
-                TypeVarDefaultEvaluation::Eager(ty) => {
-                    Some(ty.materialize(db, materialization_kind, visitor).into())
-                }
-                TypeVarDefaultEvaluation::Lazy => self
-                    .lazy_default(db)
-                    .map(|ty| ty.materialize(db, materialization_kind, visitor).into()),
+                TypeVarDefaultEvaluation::Eager(ty) => Some(
+                    ty.materialize(db, program, materialization_kind, visitor)
+                        .into(),
+                ),
+                TypeVarDefaultEvaluation::Lazy => self.lazy_default(db).map(|ty| {
+                    ty.materialize(db, program, materialization_kind, visitor)
+                        .into()
+                }),
             }),
         )
     }
 
-    fn to_instance(self, db: &'db dyn Db) -> Option<Self> {
+    fn to_instance(self, db: &'db dyn Db, program: crate::Program) -> Option<Self> {
         let bound_or_constraints = match self.bound_or_constraints(db)? {
             TypeVarBoundOrConstraints::UpperBound(upper_bound) => {
-                TypeVarBoundOrConstraints::UpperBound(upper_bound.to_instance(db)?)
+                TypeVarBoundOrConstraints::UpperBound(upper_bound.to_instance(db, program)?)
             }
             TypeVarBoundOrConstraints::Constraints(constraints) => {
-                TypeVarBoundOrConstraints::Constraints(constraints.to_instance(db)?)
+                TypeVarBoundOrConstraints::Constraints(constraints.to_instance(db, program)?)
             }
         };
         let identity = TypeVarIdentity::new(
@@ -364,6 +380,7 @@ impl<'db> TypeVarInstance<'db> {
         #[derive(Copy, Clone)]
         struct State<'db, 'a> {
             db: &'db dyn Db,
+            program: crate::Program,
             visitor: &'a TypeVarDefaultVisitor<'db>,
             seen_typevars: &'a RefCell<FxHashSet<TypeVarInstance<'db>>>,
             seen_type_aliases: &'a RefCell<SeenTypeAliases<'db>>,
@@ -433,30 +450,41 @@ impl<'db> TypeVarInstance<'db> {
             ty: Type<'db>,
             self_identity: TypeVarIdentity<'db>,
         ) -> bool {
-            any_over_type(state.db, ty, false, |inner_ty| match inner_ty {
-                Type::TypeVar(bound_typevar) => typevar_default_is_self_referential(
-                    state,
-                    bound_typevar.typevar(state.db),
-                    self_identity,
-                ),
-                Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
-                    typevar_default_is_self_referential(state, typevar, self_identity)
-                }
-                Type::TypeAlias(alias) => {
-                    type_alias_is_self_referential(state, alias, self_identity)
-                }
-                Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => {
-                    type_alias_is_self_referential(state, alias, self_identity)
-                }
-                _ => false,
-            })
+            any_over_type(
+                state.db,
+                state.program,
+                ty,
+                false,
+                |inner_ty| match inner_ty {
+                    Type::TypeVar(bound_typevar) => typevar_default_is_self_referential(
+                        state,
+                        bound_typevar.typevar(state.db),
+                        self_identity,
+                    ),
+                    Type::KnownInstance(KnownInstanceType::TypeVar(typevar)) => {
+                        typevar_default_is_self_referential(state, typevar, self_identity)
+                    }
+                    Type::TypeAlias(alias) => {
+                        type_alias_is_self_referential(state, alias, self_identity)
+                    }
+                    Type::KnownInstance(KnownInstanceType::TypeAliasType(alias)) => {
+                        type_alias_is_self_referential(state, alias, self_identity)
+                    }
+                    _ => false,
+                },
+            )
         }
 
+        let Some(definition) = self.definition(db) else {
+            return false;
+        };
+        let program = definition.program_file(db).program(db);
         let seen_typevars = RefCell::new(FxHashSet::default());
         let seen_type_aliases = RefCell::new(SeenTypeAliases::new());
 
         let state = State {
             db,
+            program,
             visitor,
             seen_typevars: &seen_typevars,
             seen_type_aliases: &seen_type_aliases,
@@ -475,7 +503,7 @@ impl<'db> TypeVarInstance<'db> {
     )]
     fn lazy_bound_unchecked(self, db: &'db dyn Db) -> Option<Type<'db>> {
         let definition = self.definition(db)?;
-        let module = parsed_module(db, definition.file(db)).load(db);
+        let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
         let ty = match definition.kind(db) {
             // PEP 695 typevar
             DefinitionKind::TypeVar(typevar) => {
@@ -495,9 +523,10 @@ impl<'db> TypeVarInstance<'db> {
     }
 
     fn lazy_bound(self, db: &'db dyn Db) -> Option<Type<'db>> {
+        let program = self.definition(db)?.program_file(db).program(db);
         let bound = self.lazy_bound_unchecked(db)?;
 
-        if bound.has_typevar_or_typevar_instance(db) {
+        if bound.has_typevar_or_typevar_instance(db, program) {
             return None;
         }
 
@@ -514,14 +543,16 @@ impl<'db> TypeVarInstance<'db> {
     )]
     fn lazy_constraints_unchecked(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
         let definition = self.definition(db)?;
-        let module = parsed_module(db, definition.file(db)).load(db);
+        let program_file = definition.program_file(db);
+        let program = program_file.program(db);
+        let module = program_file.parsed(db).load(db);
         let constraints = match definition.kind(db) {
             // PEP 695 typevar
             DefinitionKind::TypeVar(typevar) => {
                 let typevar_node = typevar.node(&module);
                 let bound =
                     definition_expression_type(db, definition, typevar_node.bound.as_ref()?);
-                let constraints = if let Some(tuple) = bound.tuple_instance_spec(db)
+                let constraints = if let Some(tuple) = bound.tuple_instance_spec(db, program)
                     && let Tuple::Fixed(tuple) = tuple.into_owned()
                 {
                     tuple.owned_elements()
@@ -551,12 +582,13 @@ impl<'db> TypeVarInstance<'db> {
     }
 
     fn lazy_constraints(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
+        let program = self.definition(db)?.program_file(db).program(db);
         let constraints = self.lazy_constraints_unchecked(db)?;
 
         if constraints
             .elements(db)
             .iter()
-            .any(|ty| ty.has_typevar_or_typevar_instance(db))
+            .any(|ty| ty.has_typevar_or_typevar_instance(db, program))
         {
             return None;
         }
@@ -611,7 +643,7 @@ impl<'db> TypeVarInstance<'db> {
         }
 
         let definition = self.definition(db)?;
-        let module = parsed_module(db, definition.file(db)).load(db);
+        let module = parsed_module(db, definition.program_file(db).versioned_file(db)).load(db);
         let ty = match definition.kind(db) {
             // PEP 695 typevar
             DefinitionKind::TypeVar(typevar) => {
@@ -678,7 +710,7 @@ impl<'db> TypeVarInstance<'db> {
             return None;
         }
         let typevar_definition = self.definition(db)?;
-        let index = semantic_index(db, typevar_definition.file(db));
+        let index = semantic_index(db, typevar_definition.program_file(db));
         let (_, child) = index
             .child_scopes(typevar_definition.file_scope(db))
             .next()?;
@@ -787,6 +819,7 @@ impl<'db> TypeVarNonceGenerator<'db> {
 
 pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
     db: &'db dyn Db,
+    program: crate::Program,
     types: impl IntoIterator<Item = Type<'db>>,
     generic_context: GenericContext<'db>,
 ) -> Option<TypeVarNonce> {
@@ -822,6 +855,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
         fn visit_bound_type_var_type(
             &self,
             db: &'db dyn Db,
+            _program: crate::Program,
             bound_typevar: BoundTypeVarInstance<'db>,
         ) {
             let mut identity = bound_typevar.identity(db);
@@ -835,14 +869,14 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
             }
         }
 
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
-            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+        fn visit_type(&self, db: &'db dyn Db, program: crate::Program, ty: Type<'db>) {
+            walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
         }
     }
 
     let collector = MatchingFreshnessCollector::new(db, generic_context);
     for ty in types {
-        collector.visit_type(db, ty);
+        collector.visit_type(db, program, ty);
     }
     collector.max_freshness.get()
 }
@@ -896,6 +930,10 @@ impl<'db> BoundTypeVarInstance<'db> {
         self.identity(db).freshness
     }
 
+    pub(crate) fn program(self, db: &'db dyn Db) -> crate::Program {
+        self.binding_context(db).program(db)
+    }
+
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
         Self::new(
             db,
@@ -936,7 +974,12 @@ impl<'db> BoundTypeVarInstance<'db> {
     ///
     /// It's the caller's responsibility to ensure that this method is only called on a `ParamSpec`
     /// type variable.
-    pub(crate) fn with_paramspec_attr(self, db: &'db dyn Db, kind: ParamSpecAttrKind) -> Self {
+    pub(crate) fn with_paramspec_attr(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        kind: ParamSpecAttrKind,
+    ) -> Self {
         debug_assert!(
             self.is_paramspec(db),
             "Expected a ParamSpec, got {:?}",
@@ -946,8 +989,12 @@ impl<'db> BoundTypeVarInstance<'db> {
         let upper_bound = TypeVarBoundOrConstraints::UpperBound(match kind {
             ParamSpecAttrKind::Args => Type::homogeneous_tuple(db, Type::object()),
             ParamSpecAttrKind::Kwargs => KnownClass::Dict
-                .to_specialized_instance(db, &[KnownClass::Str.to_instance(db), Type::any()])
-                .top_materialization(db),
+                .to_specialized_instance(
+                    db,
+                    program,
+                    &[KnownClass::Str.to_instance(db, program), Type::any()],
+                )
+                .top_materialization(db, program),
         });
 
         let typevar = TypeVarInstance::new(
@@ -1004,7 +1051,12 @@ impl<'db> BoundTypeVarInstance<'db> {
 
     /// Create a new PEP 695 type variable that can be used in signatures
     /// of synthetic generic functions.
-    pub(crate) fn synthetic(db: &'db dyn Db, name: Name, variance: TypeVarVariance) -> Self {
+    pub(crate) fn synthetic(
+        db: &'db dyn Db,
+        program: crate::Program,
+        name: Name,
+        variance: TypeVarVariance,
+    ) -> Self {
         let identity = TypeVarIdentity::new(
             db,
             name,
@@ -1021,7 +1073,7 @@ impl<'db> BoundTypeVarInstance<'db> {
         Self::new(
             db,
             typevar,
-            BindingContext::Synthetic,
+            BindingContext::Synthetic(program),
             None,
             TypeVarNonce::NONE,
         )
@@ -1077,6 +1129,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     pub(crate) fn variance_with_polarity(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         polarity: TypeVarVariance,
     ) -> TypeVarVariance {
         let _span = tracing::trace_span!("variance_with_polarity").entered();
@@ -1085,19 +1138,20 @@ impl<'db> BoundTypeVarInstance<'db> {
             None => match self.binding_context(db) {
                 BindingContext::Definition(definition) => binding_type(db, definition)
                     .with_polarity(polarity)
-                    .variance_of(db, self.identity(db)),
-                BindingContext::Synthetic => TypeVarVariance::Invariant,
+                    .variance_of(db, program, self.identity(db)),
+                BindingContext::Synthetic(_) => TypeVarVariance::Invariant,
             },
         }
     }
 
-    pub fn variance(self, db: &'db dyn Db) -> TypeVarVariance {
-        self.variance_with_polarity(db, TypeVarVariance::Covariant)
+    pub fn variance(self, db: &'db dyn Db, program: crate::Program) -> TypeVarVariance {
+        self.variance_with_polarity(db, program, TypeVarVariance::Covariant)
     }
 
     pub(super) fn apply_type_mapping_impl<'a>(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'a, 'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Type<'db> {
@@ -1113,7 +1167,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                         && let Type::TypeVar(typevar) = ty
                         && typevar.is_paramspec(db)
                     {
-                        return Type::TypeVar(typevar.with_paramspec_attr(db, attr));
+                        return Type::TypeVar(typevar.with_paramspec_attr(db, program, attr));
                     }
                     ty
                 })
@@ -1137,12 +1191,17 @@ impl<'db> BoundTypeVarInstance<'db> {
                         // Materialization uses a different mapping mode. Reuse of the outer
                         // visitor can incorrectly hit a cache entry from specialization.
                         let materialization_visitor = ApplyTypeMappingVisitor::default();
-                        mapped.materialize(db, *materialization_kind, &materialization_visitor)
+                        mapped.materialize(
+                            db,
+                            program,
+                            *materialization_kind,
+                            &materialization_visitor,
+                        )
                     }
                 })
                 .unwrap_or(Type::TypeVar(self)),
             TypeMapping::BindSelf(binding) => {
-                if binding.should_bind(db, self) {
+                if binding.should_bind(db, program, self) {
                     binding.self_type()
                 } else {
                     Type::TypeVar(self)
@@ -1166,6 +1225,7 @@ impl<'db> BoundTypeVarInstance<'db> {
                 if generic_context.contains(db, self.identity(db)) && !self.is_paramspec(db) {
                     Type::TypeVar(self.freshen_with_mapping(
                         db,
+                        program,
                         self.freshness(db).add(*delta),
                         type_mapping,
                         visitor,
@@ -1180,7 +1240,7 @@ impl<'db> BoundTypeVarInstance<'db> {
             | TypeMapping::EagerExpansion
             | TypeMapping::RescopeReturnCallables(_) => Type::TypeVar(self),
             TypeMapping::Materialize(materialization_kind) => {
-                Type::TypeVar(self.materialize_impl(db, *materialization_kind, visitor))
+                Type::TypeVar(self.materialize_impl(db, program, *materialization_kind, visitor))
             }
         }
     }
@@ -1188,10 +1248,11 @@ impl<'db> BoundTypeVarInstance<'db> {
 
 pub(super) fn walk_bound_type_var_type<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     bound_typevar: BoundTypeVarInstance<'db>,
     visitor: &V,
 ) {
-    visitor.visit_type_var_type(db, bound_typevar.typevar(db));
+    visitor.visit_type_var_type(db, program, bound_typevar.typevar(db));
 }
 
 impl<'db> BoundTypeVarInstance<'db> {
@@ -1224,13 +1285,14 @@ impl<'db> BoundTypeVarInstance<'db> {
     fn materialize_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         Self::new(
             db,
             self.typevar(db)
-                .materialize_impl(db, materialization_kind, visitor),
+                .materialize_impl(db, program, materialization_kind, visitor),
             self.binding_context(db),
             self.paramspec_attr(db),
             self.freshness(db),
@@ -1240,6 +1302,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     fn freshen_with_mapping(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         nonce: TypeVarNonce,
         type_mapping: &TypeMapping<'_, 'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
@@ -1263,13 +1326,19 @@ impl<'db> BoundTypeVarInstance<'db> {
             typevar.identity(db),
             bound_or_constraints.map(|bound_or_constraints| {
                 bound_or_constraints
-                    .apply_type_mapping_impl(db, type_mapping, visitor)
+                    .apply_type_mapping_impl(db, program, type_mapping, visitor)
                     .into()
             }),
             typevar.explicit_variance(db),
             default.map(|ty| {
-                ty.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor)
-                    .into()
+                ty.apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    TypeContext::default(),
+                    visitor,
+                )
+                .into()
             }),
         );
 
@@ -1282,10 +1351,10 @@ impl<'db> BoundTypeVarInstance<'db> {
         )
     }
 
-    pub(super) fn to_instance(self, db: &'db dyn Db) -> Option<Self> {
+    pub(super) fn to_instance(self, db: &'db dyn Db, program: crate::Program) -> Option<Self> {
         Some(Self::new(
             db,
-            self.typevar(db).to_instance(db)?,
+            self.typevar(db).to_instance(db, program)?,
             self.binding_context(db),
             self.paramspec_attr(db),
             self.freshness(db),
@@ -1352,12 +1421,13 @@ fn lazy_bound_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous: &Option<Type<'db>>,
     current: Option<Type<'db>>,
-    _typevar: TypeVarInstance<'db>,
+    typevar: TypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
+    let program = typevar.definition(db)?.program_file(db).program(db);
     // Normalize the bounds/constraints to ensure cycle convergence.
     match (previous, current) {
-        (Some(prev), Some(current)) => Some(current.cycle_normalized(db, *prev, cycle)),
-        (None, Some(current)) => Some(current.recursive_type_normalized(db, cycle)),
+        (Some(prev), Some(current)) => Some(current.cycle_normalized(db, program, *prev, cycle)),
+        (None, Some(current)) => Some(current.recursive_type_normalized(db, program, cycle)),
         (_, None) => None,
     }
 }
@@ -1369,12 +1439,15 @@ fn lazy_constraints_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous: &Option<TypeVarConstraints<'db>>,
     current: Option<TypeVarConstraints<'db>>,
-    _typevar: TypeVarInstance<'db>,
+    typevar: TypeVarInstance<'db>,
 ) -> Option<TypeVarConstraints<'db>> {
+    let program = typevar.definition(db)?.program_file(db).program(db);
     // Normalize the bounds/constraints to ensure cycle convergence.
     match (previous, current) {
-        (Some(prev), Some(constraints)) => Some(constraints.cycle_normalized(db, *prev, cycle)),
-        (None, Some(current)) => Some(current.recursive_type_normalized(db, cycle)),
+        (Some(prev), Some(constraints)) => {
+            Some(constraints.cycle_normalized(db, program, *prev, cycle))
+        }
+        (None, Some(current)) => Some(current.recursive_type_normalized(db, program, cycle)),
         (_, None) => None,
     }
 }
@@ -1385,12 +1458,13 @@ fn lazy_default_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous_default: &Option<Type<'db>>,
     default: Option<Type<'db>>,
-    _typevar: TypeVarInstance<'db>,
+    typevar: TypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
+    let program = typevar.definition(db)?.program_file(db).program(db);
     // Normalize the default to ensure cycle convergence.
     match (previous_default, default) {
-        (Some(prev), Some(default)) => Some(default.cycle_normalized(db, *prev, cycle)),
-        (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
+        (Some(prev), Some(default)) => Some(default.cycle_normalized(db, program, *prev, cycle)),
+        (None, Some(default)) => Some(default.recursive_type_normalized(db, program, cycle)),
         (_, None) => None,
     }
 }
@@ -1402,7 +1476,7 @@ pub enum BindingContext<'db> {
     Definition(Definition<'db>),
     /// The typevar is synthesized internally, and is not associated with a particular definition
     /// in the source, but is still bound and eligible for specialization inference.
-    Synthetic,
+    Synthetic(crate::Program),
 }
 
 impl<'db> From<Definition<'db>> for BindingContext<'db> {
@@ -1415,7 +1489,14 @@ impl<'db> BindingContext<'db> {
     pub(crate) fn definition(self) -> Option<Definition<'db>> {
         match self {
             BindingContext::Definition(definition) => Some(definition),
-            BindingContext::Synthetic => None,
+            BindingContext::Synthetic(_) => None,
+        }
+    }
+
+    pub(crate) fn program(self, db: &'db dyn Db) -> crate::Program {
+        match self {
+            BindingContext::Definition(definition) => definition.scope(db).program(db),
+            BindingContext::Synthetic(program) => program,
         }
     }
 
@@ -1488,10 +1569,12 @@ fn bound_typevar_default_type<'db>(
     db: &'db dyn Db,
     bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
+    let program = bound_typevar.program(db);
     let binding_context = bound_typevar.binding_context(db);
     bound_typevar.typevar(db).default_type(db).map(|ty| {
         ty.apply_type_mapping(
             db,
+            program,
             &TypeMapping::BindLegacyTypevars(binding_context),
             TypeContext::default(),
         )
@@ -1504,11 +1587,14 @@ fn bound_typevar_default_type_cycle_recover<'db>(
     cycle: &salsa::Cycle,
     previous_default: &Option<Type<'db>>,
     default: Option<Type<'db>>,
-    _bound_typevar: BoundTypeVarInstance<'db>,
+    bound_typevar: BoundTypeVarInstance<'db>,
 ) -> Option<Type<'db>> {
+    let program = bound_typevar.program(db);
     match (previous_default, default) {
-        (Some(previous), Some(default)) => Some(default.cycle_normalized(db, *previous, cycle)),
-        (None, Some(default)) => Some(default.recursive_type_normalized(db, cycle)),
+        (Some(previous), Some(default)) => {
+            Some(default.cycle_normalized(db, program, *previous, cycle))
+        }
+        (None, Some(default)) => Some(default.recursive_type_normalized(db, program, cycle)),
         (_, None) => None,
     }
 }
@@ -1557,23 +1643,28 @@ impl get_size2::GetSize for TypeVarConstraints<'_> {}
 
 fn walk_type_var_constraints<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     constraints: TypeVarConstraints<'db>,
     visitor: &V,
 ) {
     for ty in constraints.elements(db) {
-        visitor.visit_type(db, *ty);
+        visitor.visit_type(db, program, *ty);
     }
 }
 
 impl<'db> TypeVarConstraints<'db> {
-    pub(super) fn as_type(self, db: &'db dyn Db) -> Type<'db> {
-        UnionType::from_elements(db, self.elements(db))
+    pub(super) fn as_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
+        UnionType::from_elements(db, program, self.elements(db))
     }
 
-    fn to_instance(self, db: &'db dyn Db) -> Option<TypeVarConstraints<'db>> {
+    fn to_instance(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+    ) -> Option<TypeVarConstraints<'db>> {
         let mut instance_elements = Vec::new();
         for ty in self.elements(db) {
-            instance_elements.push(ty.to_instance(db)?);
+            instance_elements.push(ty.to_instance(db, program)?);
         }
         Some(TypeVarConstraints::new(
             db,
@@ -1597,9 +1688,10 @@ impl<'db> TypeVarConstraints<'db> {
     pub(crate) fn map_with_boundness_and_qualifiers(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         mut transform_fn: impl FnMut(&Type<'db>) -> PlaceAndQualifiers<'db>,
     ) -> PlaceAndQualifiers<'db> {
-        let mut builder = UnionBuilder::new(db);
+        let mut builder = UnionBuilder::new(db, program);
         let mut qualifiers = TypeQualifiers::empty();
 
         let mut all_unbound = true;
@@ -1654,13 +1746,14 @@ impl<'db> TypeVarConstraints<'db> {
     fn materialize_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         let materialized = self
             .elements(db)
             .iter()
-            .map(|ty| ty.materialize(db, materialization_kind, visitor))
+            .map(|ty| ty.materialize(db, program, materialization_kind, visitor))
             .collect::<Box<_>>();
         TypeVarConstraints::new(db, materialized)
     }
@@ -1668,13 +1761,22 @@ impl<'db> TypeVarConstraints<'db> {
     fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'_, 'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         let mapped = self
             .elements(db)
             .iter()
-            .map(|ty| ty.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor))
+            .map(|ty| {
+                ty.apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    TypeContext::default(),
+                    visitor,
+                )
+            })
             .collect::<Box<_>>();
         TypeVarConstraints::new(db, mapped)
     }
@@ -1683,7 +1785,13 @@ impl<'db> TypeVarConstraints<'db> {
     /// removing divergent types introduced by the cycle.
     ///
     /// See [`Type::cycle_normalized`] for more details on how this works.
-    fn cycle_normalized(self, db: &'db dyn Db, previous: Self, cycle: &salsa::Cycle) -> Self {
+    fn cycle_normalized(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        previous: Self,
+        cycle: &salsa::Cycle,
+    ) -> Self {
         let current_elements = self.elements(db);
         let prev_elements = previous.elements(db);
         TypeVarConstraints::new(
@@ -1691,7 +1799,7 @@ impl<'db> TypeVarConstraints<'db> {
             current_elements
                 .iter()
                 .zip(prev_elements.iter())
-                .map(|(ty, prev_ty)| ty.cycle_normalized(db, *prev_ty, cycle))
+                .map(|(ty, prev_ty)| ty.cycle_normalized(db, program, *prev_ty, cycle))
                 .collect::<Box<_>>(),
         )
     }
@@ -1699,8 +1807,13 @@ impl<'db> TypeVarConstraints<'db> {
     /// Normalize recursive types for cycle recovery when there's no previous value.
     ///
     /// See [`Type::recursive_type_normalized`] for more details.
-    fn recursive_type_normalized(self, db: &'db dyn Db, cycle: &salsa::Cycle) -> Self {
-        self.map(db, |ty| ty.recursive_type_normalized(db, cycle))
+    fn recursive_type_normalized(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        cycle: &salsa::Cycle,
+    ) -> Self {
+        self.map(db, |ty| ty.recursive_type_normalized(db, program, cycle))
     }
 }
 
@@ -1712,13 +1825,14 @@ pub enum TypeVarBoundOrConstraints<'db> {
 
 pub(super) fn walk_type_var_bounds<'db, V: visitor::TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: crate::Program,
     bounds: TypeVarBoundOrConstraints<'db>,
     visitor: &V,
 ) {
     match bounds {
-        TypeVarBoundOrConstraints::UpperBound(bound) => visitor.visit_type(db, bound),
+        TypeVarBoundOrConstraints::UpperBound(bound) => visitor.visit_type(db, program, bound),
         TypeVarBoundOrConstraints::Constraints(constraints) => {
-            walk_type_var_constraints(db, constraints, visitor);
+            walk_type_var_constraints(db, program, constraints, visitor);
         }
     }
 }
@@ -1727,16 +1841,18 @@ impl<'db> TypeVarBoundOrConstraints<'db> {
     fn materialize_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         materialization_kind: MaterializationKind,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
             TypeVarBoundOrConstraints::UpperBound(bound) => TypeVarBoundOrConstraints::UpperBound(
-                bound.materialize(db, materialization_kind, visitor),
+                bound.materialize(db, program, materialization_kind, visitor),
             ),
             TypeVarBoundOrConstraints::Constraints(constraints) => {
                 TypeVarBoundOrConstraints::Constraints(constraints.materialize_impl(
                     db,
+                    program,
                     materialization_kind,
                     visitor,
                 ))
@@ -1747,16 +1863,24 @@ impl<'db> TypeVarBoundOrConstraints<'db> {
     fn apply_type_mapping_impl(
         self,
         db: &'db dyn Db,
+        program: crate::Program,
         type_mapping: &TypeMapping<'_, 'db>,
         visitor: &ApplyTypeMappingVisitor<'db>,
     ) -> Self {
         match self {
-            TypeVarBoundOrConstraints::UpperBound(bound) => TypeVarBoundOrConstraints::UpperBound(
-                bound.apply_type_mapping_impl(db, type_mapping, TypeContext::default(), visitor),
-            ),
+            TypeVarBoundOrConstraints::UpperBound(bound) => {
+                TypeVarBoundOrConstraints::UpperBound(bound.apply_type_mapping_impl(
+                    db,
+                    program,
+                    type_mapping,
+                    TypeContext::default(),
+                    visitor,
+                ))
+            }
             TypeVarBoundOrConstraints::Constraints(constraints) => {
                 TypeVarBoundOrConstraints::Constraints(constraints.apply_type_mapping_impl(
                     db,
+                    program,
                     type_mapping,
                     visitor,
                 ))
@@ -1770,10 +1894,10 @@ impl<'db> TypeVarBoundOrConstraints<'db> {
     /// constraints provides a conservative upper bound, but it loses precision. And for many use
     /// cases, it's more efficient to just map over the constraint types directly, rather than
     /// building a union out of them and mapping over that.
-    pub(crate) fn as_type(self, db: &'db dyn Db) -> Type<'db> {
+    pub(crate) fn as_type(self, db: &'db dyn Db, program: crate::Program) -> Type<'db> {
         match self {
             TypeVarBoundOrConstraints::UpperBound(bound) => bound,
-            TypeVarBoundOrConstraints::Constraints(constraints) => constraints.as_type(db),
+            TypeVarBoundOrConstraints::Constraints(constraints) => constraints.as_type(db, program),
         }
     }
 }

--- a/crates/ty_python_semantic/src/types/unpacker.rs
+++ b/crates/ty_python_semantic/src/types/unpacker.rs
@@ -57,6 +57,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
 
     /// Unpack the value to the target expression.
     pub(crate) fn unpack(&mut self, target: &ast::Expr, value: UnpackValue<'db>) {
+        let program = self.context.program();
         debug_assert!(
             matches!(target, ast::Expr::List(_) | ast::Expr::Tuple(_)),
             "Unpacking target must be a list or tuple expression"
@@ -83,25 +84,25 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 }
             }
             UnpackKind::Iterable { mode } => value_type
-                .try_iterate_with_mode(self.db(), mode)
-                .map(|tuple| tuple.homogeneous_element_type(self.db()))
+                .try_iterate_with_mode(self.db(), program, mode)
+                .map(|tuple| tuple.homogeneous_element_type(self.db(), program))
                 .unwrap_or_else(|err| {
                     err.report_diagnostic(
                         &self.context,
                         value_type,
                         value.as_any_node_ref(self.db(), self.module()),
                     );
-                    err.fallback_element_type(self.db())
+                    err.fallback_element_type(self.db(), program)
                 }),
             UnpackKind::ContextManager { mode } => value_type
-                .try_enter_with_mode(self.db(), mode)
+                .try_enter_with_mode(self.db(), program, mode)
                 .unwrap_or_else(|err| {
                     err.report_diagnostic(
                         &self.context,
                         value_type,
                         value.as_any_node_ref(self.db(), self.module()),
                     );
-                    err.fallback_enter_type(self.db())
+                    err.fallback_enter_type(self.db(), program)
                 }),
         };
 
@@ -187,6 +188,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
         value_expr: AnyNodeRef<'_>,
         value_ty: Type<'db>,
     ) {
+        let program = self.context.program();
         match target {
             ast::Expr::Name(_) | ast::Expr::Attribute(_) | ast::Expr::Subscript(_) => {
                 self.targets.insert(target.into(), value_ty);
@@ -202,7 +204,7 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                     }
                     None => TupleLength::Fixed(elts.len()),
                 };
-                let mut unpacker = TupleUnpacker::new(self.db(), target_len);
+                let mut unpacker = TupleUnpacker::new(self.db(), program, target_len);
 
                 // N.B. `Type::try_iterate` internally handles unions, but in a lossy way.
                 // For our purposes here, we get better error messages and more precise inference
@@ -215,9 +217,11 @@ impl<'db, 'ast> Unpacker<'db, 'ast> {
                 };
 
                 for ty in unpack_types.iter().copied() {
-                    let tuple = ty.try_iterate(self.db()).unwrap_or_else(|err| {
+                    let tuple = ty.try_iterate(self.db(), program).unwrap_or_else(|err| {
                         err.report_diagnostic(&self.context, ty, value_expr);
-                        Cow::Owned(TupleSpec::homogeneous(err.fallback_element_type(self.db())))
+                        Cow::Owned(TupleSpec::homogeneous(
+                            err.fallback_element_type(self.db(), program),
+                        ))
                     });
 
                     if let Err(err) = unpacker.unpack_tuple(tuple.as_ref()) {
@@ -331,12 +335,13 @@ impl<'db> UnpackResult<'db> {
     pub(crate) fn cycle_normalized(
         mut self,
         db: &'db dyn Db,
+        program: crate::Program,
         previous_cycle_result: &UnpackResult<'db>,
         cycle: &salsa::Cycle,
     ) -> Self {
         for (expr, ty) in &mut self.targets {
             let previous_ty = previous_cycle_result.expression_type(*expr);
-            *ty = ty.cycle_normalized(db, previous_ty, cycle);
+            *ty = ty.cycle_normalized(db, program, previous_ty, cycle);
         }
 
         self

--- a/crates/ty_python_semantic/src/types/variance.rs
+++ b/crates/ty_python_semantic/src/types/variance.rs
@@ -141,7 +141,12 @@ pub(crate) trait VarianceInferable<'db>: Sized {
     ///
     /// Sometimes the recursive calls will be in positions where you need to
     /// specify a non-covariant polarity. See `with_polarity` for more details.
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance;
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance;
 
     /// Creates a `VarianceInferable` that applies `polarity` (see
     /// `TypeVarVariance::compose`) to the result of variance inference on the
@@ -173,12 +178,17 @@ impl<'db, T> VarianceInferable<'db> for WithPolarity<T>
 where
     T: VarianceInferable<'db>,
 {
-    fn variance_of(self, db: &'db dyn Db, typevar: BoundTypeVarIdentity<'db>) -> TypeVarVariance {
+    fn variance_of(
+        self,
+        db: &'db dyn Db,
+        program: crate::Program,
+        typevar: BoundTypeVarIdentity<'db>,
+    ) -> TypeVarVariance {
         let WithPolarity {
             variance_inferable,
             polarity,
         } = self;
 
-        polarity.compose_thunk(|| variance_inferable.variance_of(db, typevar))
+        polarity.compose_thunk(|| variance_inferable.variance_of(db, program, typevar))
     }
 }

--- a/crates/ty_python_semantic/src/types/visitor.rs
+++ b/crates/ty_python_semantic/src/types/visitor.rs
@@ -4,7 +4,7 @@ use rustc_hash::{FxBuildHasher, FxHashSet};
 use smallvec::SmallVec;
 
 use crate::{
-    Db,
+    Db, Program,
     types::{
         BoundMethodType, BoundSuperType, BoundTypeVarInstance, CallableType, EnumComplementType,
         GenericAlias, IntersectionType, KnownBoundMethodType, KnownInstanceType,
@@ -38,100 +38,176 @@ pub(crate) trait TypeVisitor<'db> {
     /// Should the visitor trigger inference of and visit lazily-inferred type attributes?
     fn should_visit_lazy_type_attributes(&self) -> bool;
 
-    fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>);
+    fn visit_type(&self, db: &'db dyn Db, program: Program, ty: Type<'db>);
 
-    fn visit_union_type(&self, db: &'db dyn Db, union: UnionType<'db>) {
-        walk_union(db, union, self);
+    fn visit_union_type(&self, db: &'db dyn Db, program: Program, union: UnionType<'db>) {
+        walk_union(db, program, union, self);
     }
 
-    fn visit_intersection_type(&self, db: &'db dyn Db, intersection: IntersectionType<'db>) {
-        walk_intersection_type(db, intersection, self);
+    fn visit_intersection_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        intersection: IntersectionType<'db>,
+    ) {
+        walk_intersection_type(db, program, intersection, self);
     }
 
-    fn visit_enum_complement_type(&self, db: &'db dyn Db, complement: EnumComplementType<'db>) {
+    fn visit_enum_complement_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        complement: EnumComplementType<'db>,
+    ) {
         for rest in complement.rest(db) {
-            self.visit_type(db, *rest);
+            self.visit_type(db, program, *rest);
         }
     }
 
-    fn visit_callable_type(&self, db: &'db dyn Db, callable: CallableType<'db>) {
-        walk_callable_type(db, callable, self);
+    fn visit_callable_type(&self, db: &'db dyn Db, program: Program, callable: CallableType<'db>) {
+        walk_callable_type(db, program, callable, self);
     }
 
-    fn visit_property_instance_type(&self, db: &'db dyn Db, property: PropertyInstanceType<'db>) {
-        walk_property_instance_type(db, property, self);
+    fn visit_property_instance_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        property: PropertyInstanceType<'db>,
+    ) {
+        walk_property_instance_type(db, program, property, self);
     }
 
-    fn visit_typeis_type(&self, db: &'db dyn Db, type_is: TypeIsType<'db>) {
-        walk_typeis_type(db, type_is, self);
+    fn visit_typeis_type(&self, db: &'db dyn Db, program: Program, type_is: TypeIsType<'db>) {
+        walk_typeis_type(db, program, type_is, self);
     }
 
-    fn visit_typeguard_type(&self, db: &'db dyn Db, type_is: TypeGuardType<'db>) {
-        walk_typeguard_type(db, type_is, self);
+    fn visit_typeguard_type(&self, db: &'db dyn Db, program: Program, type_is: TypeGuardType<'db>) {
+        walk_typeguard_type(db, program, type_is, self);
     }
 
-    fn visit_typeform_type(&self, db: &'db dyn Db, typeform: TypeFormType<'db>) {
-        walk_typeform_type(db, typeform, self);
+    fn visit_typeform_type(&self, db: &'db dyn Db, program: Program, typeform: TypeFormType<'db>) {
+        walk_typeform_type(db, program, typeform, self);
     }
 
-    fn visit_subclass_of_type(&self, db: &'db dyn Db, subclass_of: SubclassOfType<'db>) {
-        walk_subclass_of_type(db, subclass_of, self);
+    fn visit_subclass_of_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        subclass_of: SubclassOfType<'db>,
+    ) {
+        walk_subclass_of_type(db, program, subclass_of, self);
     }
 
-    fn visit_generic_alias_type(&self, db: &'db dyn Db, alias: GenericAlias<'db>) {
+    fn visit_generic_alias_type(
+        &self,
+        db: &'db dyn Db,
+        _program: Program,
+        alias: GenericAlias<'db>,
+    ) {
         walk_generic_alias(db, alias, self);
     }
 
-    fn visit_function_type(&self, db: &'db dyn Db, function: FunctionType<'db>) {
-        walk_function_type(db, function, self);
+    fn visit_function_type(&self, db: &'db dyn Db, program: Program, function: FunctionType<'db>) {
+        walk_function_type(db, program, function, self);
     }
 
-    fn visit_bound_method_type(&self, db: &'db dyn Db, method: BoundMethodType<'db>) {
+    fn visit_bound_method_type(
+        &self,
+        db: &'db dyn Db,
+        _program: Program,
+        method: BoundMethodType<'db>,
+    ) {
         walk_bound_method_type(db, method, self);
     }
 
-    fn visit_bound_super_type(&self, db: &'db dyn Db, bound_super: BoundSuperType<'db>) {
-        walk_bound_super_type(db, bound_super, self);
+    fn visit_bound_super_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        bound_super: BoundSuperType<'db>,
+    ) {
+        walk_bound_super_type(db, program, bound_super, self);
     }
 
-    fn visit_nominal_instance_type(&self, db: &'db dyn Db, nominal: NominalInstanceType<'db>) {
-        walk_nominal_instance_type(db, nominal, self);
+    fn visit_nominal_instance_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        nominal: NominalInstanceType<'db>,
+    ) {
+        walk_nominal_instance_type(db, program, nominal, self);
     }
 
-    fn visit_bound_type_var_type(&self, db: &'db dyn Db, bound_typevar: BoundTypeVarInstance<'db>) {
-        walk_bound_type_var_type(db, bound_typevar, self);
+    fn visit_bound_type_var_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        bound_typevar: BoundTypeVarInstance<'db>,
+    ) {
+        walk_bound_type_var_type(db, program, bound_typevar, self);
     }
 
-    fn visit_type_var_type(&self, db: &'db dyn Db, typevar: TypeVarInstance<'db>) {
-        walk_type_var_type(db, typevar, self);
+    fn visit_type_var_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        typevar: TypeVarInstance<'db>,
+    ) {
+        walk_type_var_type(db, program, typevar, self);
     }
 
-    fn visit_protocol_instance_type(&self, db: &'db dyn Db, protocol: ProtocolInstanceType<'db>) {
-        walk_protocol_instance_type(db, protocol, self);
+    fn visit_protocol_instance_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        protocol: ProtocolInstanceType<'db>,
+    ) {
+        walk_protocol_instance_type(db, program, protocol, self);
     }
 
     fn visit_method_wrapper_type(
         &self,
         db: &'db dyn Db,
+        program: Program,
         method_wrapper: KnownBoundMethodType<'db>,
     ) {
-        walk_method_wrapper_type(db, method_wrapper, self);
+        walk_method_wrapper_type(db, program, method_wrapper, self);
     }
 
-    fn visit_known_instance_type(&self, db: &'db dyn Db, known_instance: KnownInstanceType<'db>) {
-        walk_known_instance_type(db, known_instance, self);
+    fn visit_known_instance_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        known_instance: KnownInstanceType<'db>,
+    ) {
+        walk_known_instance_type(db, program, known_instance, self);
     }
 
-    fn visit_type_alias_type(&self, db: &'db dyn Db, type_alias: TypeAliasType<'db>) {
-        walk_type_alias_type(db, type_alias, self);
+    fn visit_type_alias_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        type_alias: TypeAliasType<'db>,
+    ) {
+        walk_type_alias_type(db, program, type_alias, self);
     }
 
-    fn visit_typed_dict_type(&self, db: &'db dyn Db, typed_dict: TypedDictType<'db>) {
-        walk_typed_dict_type(db, typed_dict, self);
+    fn visit_typed_dict_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        typed_dict: TypedDictType<'db>,
+    ) {
+        walk_typed_dict_type(db, program, typed_dict, self);
     }
 
-    fn visit_newtype_instance_type(&self, db: &'db dyn Db, newtype: NewType<'db>) {
-        walk_newtype_instance_type(db, newtype, self);
+    fn visit_newtype_instance_type(
+        &self,
+        db: &'db dyn Db,
+        program: Program,
+        newtype: NewType<'db>,
+    ) {
+        walk_newtype_instance_type(db, program, newtype, self);
     }
 }
 
@@ -238,54 +314,68 @@ impl<'db> From<Type<'db>> for TypeKind<'db> {
 
 pub(super) fn walk_non_atomic_type<'db, V: TypeVisitor<'db> + ?Sized>(
     db: &'db dyn Db,
+    program: Program,
     non_atomic_type: NonAtomicType<'db>,
     visitor: &V,
 ) {
     match non_atomic_type {
-        NonAtomicType::FunctionLiteral(function) => visitor.visit_function_type(db, function),
+        NonAtomicType::FunctionLiteral(function) => {
+            visitor.visit_function_type(db, program, function);
+        }
         NonAtomicType::Intersection(intersection) => {
-            visitor.visit_intersection_type(db, intersection);
+            visitor.visit_intersection_type(db, program, intersection);
         }
         NonAtomicType::EnumComplement(complement) => {
-            visitor.visit_enum_complement_type(db, complement);
+            visitor.visit_enum_complement_type(db, program, complement);
         }
-        NonAtomicType::Union(union) => visitor.visit_union_type(db, union),
-        NonAtomicType::BoundMethod(method) => visitor.visit_bound_method_type(db, method),
-        NonAtomicType::BoundSuper(bound_super) => visitor.visit_bound_super_type(db, bound_super),
+        NonAtomicType::Union(union) => visitor.visit_union_type(db, program, union),
+        NonAtomicType::BoundMethod(method) => visitor.visit_bound_method_type(db, program, method),
+        NonAtomicType::BoundSuper(bound_super) => {
+            visitor.visit_bound_super_type(db, program, bound_super);
+        }
         NonAtomicType::MethodWrapper(method_wrapper) => {
-            visitor.visit_method_wrapper_type(db, method_wrapper);
+            visitor.visit_method_wrapper_type(db, program, method_wrapper);
         }
-        NonAtomicType::Callable(callable) => visitor.visit_callable_type(db, callable),
-        NonAtomicType::GenericAlias(alias) => visitor.visit_generic_alias_type(db, alias),
+        NonAtomicType::Callable(callable) => visitor.visit_callable_type(db, program, callable),
+        NonAtomicType::GenericAlias(alias) => visitor.visit_generic_alias_type(db, program, alias),
         NonAtomicType::KnownInstance(known_instance) => {
-            visitor.visit_known_instance_type(db, known_instance);
+            visitor.visit_known_instance_type(db, program, known_instance);
         }
-        NonAtomicType::SubclassOf(subclass_of) => visitor.visit_subclass_of_type(db, subclass_of),
-        NonAtomicType::NominalInstance(nominal) => visitor.visit_nominal_instance_type(db, nominal),
+        NonAtomicType::SubclassOf(subclass_of) => {
+            visitor.visit_subclass_of_type(db, program, subclass_of);
+        }
+        NonAtomicType::NominalInstance(nominal) => {
+            visitor.visit_nominal_instance_type(db, program, nominal);
+        }
         NonAtomicType::PropertyInstance(property) => {
-            visitor.visit_property_instance_type(db, property);
+            visitor.visit_property_instance_type(db, program, property);
         }
-        NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, type_is),
-        NonAtomicType::TypeGuard(type_guard) => visitor.visit_typeguard_type(db, type_guard),
-        NonAtomicType::TypeForm(typeform) => visitor.visit_typeform_type(db, typeform),
+        NonAtomicType::TypeIs(type_is) => visitor.visit_typeis_type(db, program, type_is),
+        NonAtomicType::TypeGuard(type_guard) => {
+            visitor.visit_typeguard_type(db, program, type_guard);
+        }
+        NonAtomicType::TypeForm(typeform) => visitor.visit_typeform_type(db, program, typeform),
         NonAtomicType::TypeVar(bound_typevar) => {
-            visitor.visit_bound_type_var_type(db, bound_typevar);
+            visitor.visit_bound_type_var_type(db, program, bound_typevar);
         }
         NonAtomicType::ProtocolInstance(protocol) => {
-            visitor.visit_protocol_instance_type(db, protocol);
+            visitor.visit_protocol_instance_type(db, program, protocol);
         }
-        NonAtomicType::TypedDict(typed_dict) => visitor.visit_typed_dict_type(db, typed_dict),
+        NonAtomicType::TypedDict(typed_dict) => {
+            visitor.visit_typed_dict_type(db, program, typed_dict);
+        }
         NonAtomicType::TypeAlias(alias) => {
-            visitor.visit_type_alias_type(db, alias);
+            visitor.visit_type_alias_type(db, program, alias);
         }
         NonAtomicType::NewTypeInstance(newtype) => {
-            visitor.visit_newtype_instance_type(db, newtype);
+            visitor.visit_newtype_instance_type(db, program, newtype);
         }
     }
 }
 
 pub(crate) fn walk_type_with_recursion_guard<'db>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
     visitor: &impl TypeVisitor<'db>,
     recursion_guard: &TypeCollector<'db>,
@@ -297,7 +387,7 @@ pub(crate) fn walk_type_with_recursion_guard<'db>(
                 // If we have already seen this type, we can skip it.
                 return;
             }
-            walk_non_atomic_type(db, non_atomic_type, visitor);
+            walk_non_atomic_type(db, program, non_atomic_type, visitor);
         }
     }
 }
@@ -372,6 +462,7 @@ impl<T, const INLINE_CAPACITY: usize> SmallSet<T, INLINE_CAPACITY> {
 /// Implementation for `any_over_type` and `find_over_type`.
 fn any_over_type_impl<'db, F, T>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
     query: F,
@@ -395,7 +486,7 @@ where
             self.should_visit_lazy_type_attributes
         }
 
-        fn visit_type(&self, db: &'db dyn Db, ty: Type<'db>) {
+        fn visit_type(&self, db: &'db dyn Db, program: Program, ty: Type<'db>) {
             let default_value = U::default();
             let pre_existing = self.found_matching_type.get();
             if pre_existing != default_value {
@@ -406,7 +497,7 @@ where
             if new_value != default_value {
                 return;
             }
-            walk_type_with_recursion_guard(db, ty, self, &self.recursion_guard);
+            walk_type_with_recursion_guard(db, program, ty, self, &self.recursion_guard);
         }
     }
 
@@ -416,7 +507,7 @@ where
         found_matching_type: Cell::default(),
         should_visit_lazy_type_attributes,
     };
-    visitor.visit_type(db, ty);
+    visitor.visit_type(db, program, ty);
     visitor.found_matching_type.get()
 }
 
@@ -430,11 +521,12 @@ where
 /// are visited or not.
 pub(super) fn any_over_type<'db>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> bool,
 ) -> bool {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, program, ty, should_visit_lazy_type_attributes, query)
 }
 
 /// Recurse into a type and calls the passed-in closure on every nested type
@@ -452,6 +544,7 @@ pub(super) fn any_over_type<'db>(
 /// are visited or not.
 pub(super) fn find_over_type<'db, T>(
     db: &'db dyn Db,
+    program: Program,
     ty: Type<'db>,
     should_visit_lazy_type_attributes: bool,
     query: impl Fn(Type<'db>) -> Option<T>,
@@ -459,7 +552,7 @@ pub(super) fn find_over_type<'db, T>(
 where
     T: Copy + PartialEq,
 {
-    any_over_type_impl(db, ty, should_visit_lazy_type_attributes, query)
+    any_over_type_impl(db, program, ty, should_visit_lazy_type_attributes, query)
 }
 
 #[cfg(test)]

--- a/crates/ty_python_semantic/tests/corpus.rs
+++ b/crates/ty_python_semantic/tests/corpus.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{Context, anyhow};
-use ruff_db::Db;
 use ruff_db::files::{File, Files, system_path_to_file};
 use ruff_db::system::{DbWithTestSystem, System, SystemPath, SystemPathBuf, TestSystem};
 use ruff_db::vendored::VendoredFileSystem;
@@ -12,7 +11,7 @@ use ty_python_core::platform::PythonPlatform;
 use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::pull_types::pull_types;
-use ty_python_semantic::{AnalysisSettings, check_file_unwrap, default_lint_registry};
+use ty_python_semantic::{AnalysisSettings, ProgramFile, check_file_unwrap, default_lint_registry};
 use ty_site_packages::{PythonVersionSource, PythonVersionWithSource};
 
 use ruff_db::diagnostic::Diagnostic;
@@ -127,7 +126,8 @@ fn run_corpus_tests(pattern: &str) -> anyhow::Result<()> {
             // (and some non-expressions that clearly define a single type)
             let file = system_path_to_file(&db, path).unwrap();
 
-            let result = std::panic::catch_unwind(|| pull_types(&db, file));
+            let program_file = ProgramFile::new(&db, db.program(), file);
+            let result = std::panic::catch_unwind(|| pull_types(&db, program_file));
 
             let expected_to_fail = if path.extension().map(|e| e == "pyi").unwrap_or(false) {
                 pyi_expected_to_fail
@@ -184,35 +184,39 @@ pub struct CorpusDb {
     system: TestSystem,
     vendored: VendoredFileSystem,
     analysis_settings: Arc<AnalysisSettings>,
+    program: Option<Program>,
 }
 
 impl CorpusDb {
     #[expect(clippy::new_without_default)]
     pub fn new() -> Self {
-        let db = Self {
+        let system = TestSystem::default();
+        let vendored = ty_vendored::file_system().clone();
+        let program_settings = ProgramSettings {
+            python_version: PythonVersionWithSource {
+                version: PythonVersion::latest_ty(),
+                source: PythonVersionSource::default(),
+            },
+            python_platform: PythonPlatform::default(),
+            search_paths: SearchPathSettings::new(vec![])
+                .to_search_paths(&system, &vendored, &FallibleStrategy)
+                .unwrap(),
+        };
+        let mut db = Self {
             storage: salsa::Storage::new(None),
-            system: TestSystem::default(),
-            vendored: ty_vendored::file_system().clone(),
+            system,
+            vendored,
             rule_selection: RuleSelection::from_registry(default_lint_registry()),
             files: Files::default(),
             analysis_settings: Arc::new(AnalysisSettings::default()),
+            program: None,
         };
-
-        Program::from_settings(
-            &db,
-            ProgramSettings {
-                python_version: PythonVersionWithSource {
-                    version: PythonVersion::latest_ty(),
-                    source: PythonVersionSource::default(),
-                },
-                python_platform: PythonPlatform::default(),
-                search_paths: SearchPathSettings::new(vec![])
-                    .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
-                    .unwrap(),
-            },
-        );
-
+        db.program = Some(Program::create(&db, &program_settings));
         db
+    }
+
+    fn program(&self) -> Program {
+        self.program.expect("corpus database has a program")
     }
 }
 
@@ -241,16 +245,12 @@ impl ruff_db::Db for CorpusDb {
     }
 
     fn python_version(&self) -> PythonVersion {
-        Program::get(self).python_version(self)
+        self.program().python_version(self)
     }
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for CorpusDb {
-    fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for CorpusDb {}
 
 #[salsa::db]
 impl ty_python_core::Db for CorpusDb {
@@ -261,9 +261,10 @@ impl ty_python_core::Db for CorpusDb {
 
 #[salsa::db]
 impl ty_python_semantic::Db for CorpusDb {
-    fn check_file(&self, file: File) -> Vec<Diagnostic> {
+    fn check_file(&self, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+        let file = program_file.file(self);
         if self.should_check_file(file) {
-            check_file_unwrap(self, file)
+            check_file_unwrap(self, program_file)
         } else {
             Vec::new()
         }

--- a/crates/ty_server/src/server/api.rs
+++ b/crates/ty_server/src/server/api.rs
@@ -19,7 +19,14 @@ use self::traits::{NotificationHandler, RequestHandler};
 use super::{Result, schedule::BackgroundSchedule};
 use crate::session::client::Client;
 pub(crate) use diagnostics::publish_settings_diagnostics;
+use ruff_db::files::File;
 use ruff_db::panic::PanicError;
+use ty_project::Db as _;
+use ty_python_core::environment::ProgramFile;
+
+pub(crate) fn program_file(db: &ty_project::ProjectDatabase, file: File) -> ProgramFile<'_> {
+    ProgramFile::new(db, db.project().program(db), file)
+}
 
 /// Processes a request from the client to the server.
 ///

--- a/crates/ty_server/src/server/api/diagnostics.rs
+++ b/crates/ty_server/src/server/api/diagnostics.rs
@@ -401,7 +401,7 @@ pub(super) fn compute_diagnostics(
     };
 
     let diagnostics = db.check_file(file);
-    let unnecessary_hints = hints(db, file);
+    let unnecessary_hints = hints(db, crate::server::api::program_file(db, file));
 
     Some(Diagnostics {
         items: diagnostics,

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_incoming_calls.rs
@@ -40,7 +40,9 @@ impl BackgroundRequestHandler for CallHierarchyIncomingCallsRequestHandler {
                 continue;
             };
 
-            for call in ty_ide::incoming_calls(db, file, offset) {
+            for call in
+                ty_ide::incoming_calls(db, crate::server::api::program_file(db, file), offset)
+            {
                 // `from_ranges` are byte offsets into `call.from.file` (the caller),
                 // NOT into `file` (the prepared/queried symbol). Capture the caller
                 // file before moving `call.from` into `convert_to_lsp_item`.

--- a/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
+++ b/crates/ty_server/src/server/api/requests/call_hierarchy_outgoing_calls.rs
@@ -40,7 +40,9 @@ impl BackgroundRequestHandler for CallHierarchyOutgoingCallsRequestHandler {
                 continue;
             };
 
-            for call in ty_ide::outgoing_calls(db, file, offset) {
+            for call in
+                ty_ide::outgoing_calls(db, crate::server::api::program_file(db, file), offset)
+            {
                 let Some(to) = convert_to_lsp_item(db, call.to, encoding) else {
                     continue;
                 };

--- a/crates/ty_server/src/server/api/requests/code_action.rs
+++ b/crates/ty_server/src/server/api/requests/code_action.rs
@@ -99,7 +99,12 @@ impl BackgroundDocumentRequestHandler for CodeActionRequestHandler {
             if let Some(diagnostic_id) = diagnostic_id
                 && let Some(range) = diagnostic.range.to_text_range(db, file, uri, encoding)
             {
-                for action in code_actions(db, file, range, &diagnostic_id) {
+                for action in code_actions(
+                    db,
+                    crate::server::api::program_file(db, file),
+                    range,
+                    &diagnostic_id,
+                ) {
                     actions.push(CodeActionResponse::CodeAction(lsp_types::CodeAction {
                         title: action.title,
                         kind: Some(CodeActionKind::QuickFix),

--- a/crates/ty_server/src/server/api/requests/completion.rs
+++ b/crates/ty_server/src/server/api/requests/completion.rs
@@ -9,7 +9,7 @@ use lsp_types::{
 use ruff_source_file::OneIndexed;
 use ruff_text_size::Ranged;
 use ty_ide::{CompletionCapabilities, CompletionInsertTextFormat, CompletionKind, completion};
-use ty_project::ProjectDatabase;
+use ty_project::{Db as _, ProjectDatabase};
 
 use crate::document::{PositionExt, ToRangeExt};
 use crate::server::api::traits::{
@@ -62,7 +62,7 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             snapshot.workspace_settings().completions(),
             CompletionCapabilities::default()
                 .snippets(client_capabilities.supports_completion_item_snippets()),
-            file,
+            crate::server::api::program_file(db, file),
             offset,
         );
         if completions.is_empty() {
@@ -76,7 +76,8 @@ impl BackgroundDocumentRequestHandler for CompletionRequestHandler {
             .enumerate()
             .map(|(i, comp)| {
                 let kind = comp.kind.map(ty_kind_to_lsp_kind);
-                let type_display = comp.ty.map(|ty| ty.display(db).to_string());
+                let program = db.project().program(db);
+                let type_display = comp.ty.map(|ty| ty.display(db, program).to_string());
                 let import_edit = comp.import.as_ref().and_then(|edit| {
                     let range = edit
                         .range()

--- a/crates/ty_server/src/server/api/requests/doc_highlights.rs
+++ b/crates/ty_server/src/server/api/requests/doc_highlights.rs
@@ -49,7 +49,9 @@ impl BackgroundDocumentRequestHandler for DocumentHighlightRequestHandler {
             return Ok(None);
         };
 
-        let Some(highlights_result) = document_highlights(db, file, offset) else {
+        let Some(highlights_result) =
+            document_highlights(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/document_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/document_symbols.rs
@@ -48,7 +48,7 @@ impl BackgroundDocumentRequestHandler for DocumentSymbolRequestHandler {
             .resolved_client_capabilities()
             .supports_hierarchical_document_symbols();
 
-        let symbols = document_symbols(db, file);
+        let symbols = document_symbols(db, crate::server::api::program_file(db, file));
         if symbols.is_empty() {
             return Ok(None);
         }

--- a/crates/ty_server/src/server/api/requests/execute_command.rs
+++ b/crates/ty_server/src/server/api/requests/execute_command.rs
@@ -12,7 +12,6 @@ use std::fmt::{self, Write};
 use std::str::FromStr;
 use ty_module_resolver::ModuleResolveMode;
 use ty_project::Db as _;
-use ty_python_core::program::Program;
 
 pub(crate) struct ExecuteCommand;
 
@@ -67,13 +66,9 @@ fn debug_information(session: &Session) -> crate::Result<String> {
 
     for db in session.project_dbs() {
         writeln!(buffer, "Project at {}", db.project().root(db))?;
-        let program = Program::get(db);
+        let program = db.project().program(db);
         writeln!(buffer, "Program:")?;
-        writeln!(
-            buffer,
-            "  python-version: {}",
-            program.python_version_with_source(db).version
-        )?;
+        writeln!(buffer, "  python-version: {}", program.python_version(db))?;
         writeln!(buffer, "  python-platform: {}", program.python_platform(db))?;
         let mut writer = IndentingWriter {
             inner: &mut buffer,
@@ -85,7 +80,7 @@ fn debug_information(session: &Session) -> crate::Result<String> {
             "  search-paths: {:#}",
             program
                 .search_paths(db)
-                .display(db, ModuleResolveMode::Typing)
+                .display(db, program.resolver(db), ModuleResolveMode::Typing)
         )?;
 
         writeln!(buffer, "Settings: {:#?}", db.project().settings(db))?;

--- a/crates/ty_server/src/server/api/requests/folding_range.rs
+++ b/crates/ty_server/src/server/api/requests/folding_range.rs
@@ -56,29 +56,31 @@ impl BackgroundDocumentRequestHandler for FoldingRangeRequestHandler {
             cell_range = cell_index.and_then(|index| notebook.cell_range(index));
         }
 
-        let results: Vec<_> = folding_ranges(db, file, cell_range)
-            .into_iter()
-            .filter_map(|folding_range| {
-                let lsp_range = folding_range
-                    .range
-                    .to_lsp_range(db, file, snapshot.encoding())?;
+        let results: Vec<_> =
+            folding_ranges(db, crate::server::api::program_file(db, file), cell_range)
+                .into_iter()
+                .filter_map(|folding_range| {
+                    let lsp_range =
+                        folding_range
+                            .range
+                            .to_lsp_range(db, file, snapshot.encoding())?;
 
-                let kind = folding_range.kind.map(|k| match k {
-                    ty_ide::FoldingRangeKind::Comment => FoldingRangeKind::Comment,
-                    ty_ide::FoldingRangeKind::Imports => FoldingRangeKind::Imports,
-                    ty_ide::FoldingRangeKind::Region => FoldingRangeKind::Region,
-                });
+                    let kind = folding_range.kind.map(|k| match k {
+                        ty_ide::FoldingRangeKind::Comment => FoldingRangeKind::Comment,
+                        ty_ide::FoldingRangeKind::Imports => FoldingRangeKind::Imports,
+                        ty_ide::FoldingRangeKind::Region => FoldingRangeKind::Region,
+                    });
 
-                Some(FoldingRange {
-                    start_line: lsp_range.local_range().start.line,
-                    start_character: Some(lsp_range.local_range().start.character),
-                    end_line: lsp_range.local_range().end.line,
-                    end_character: Some(lsp_range.local_range().end.character),
-                    kind,
-                    collapsed_text: None,
+                    Some(FoldingRange {
+                        start_line: lsp_range.local_range().start.line,
+                        start_character: Some(lsp_range.local_range().start.character),
+                        end_line: lsp_range.local_range().end.line,
+                        end_character: Some(lsp_range.local_range().end.character),
+                        kind,
+                        collapsed_text: None,
+                    })
                 })
-            })
-            .collect();
+                .collect();
 
         if results.is_empty() {
             Ok(None)

--- a/crates/ty_server/src/server/api/requests/goto_declaration.rs
+++ b/crates/ty_server/src/server/api/requests/goto_declaration.rs
@@ -48,7 +48,8 @@ impl BackgroundDocumentRequestHandler for GotoDeclarationRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_declaration(db, file, offset) else {
+        let Some(ranged) = goto_declaration(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_definition.rs
@@ -49,7 +49,8 @@ impl BackgroundDocumentRequestHandler for GotoDefinitionRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_definition(db, file, offset) else {
+        let Some(ranged) = goto_definition(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/goto_type_definition.rs
+++ b/crates/ty_server/src/server/api/requests/goto_type_definition.rs
@@ -49,7 +49,9 @@ impl BackgroundDocumentRequestHandler for GotoTypeDefinitionRequestHandler {
             return Ok(None);
         };
 
-        let Some(ranged) = goto_type_definition(db, file, offset) else {
+        let Some(ranged) =
+            goto_type_definition(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/hover.rs
+++ b/crates/ty_server/src/server/api/requests/hover.rs
@@ -48,7 +48,7 @@ impl BackgroundDocumentRequestHandler for HoverRequestHandler {
             return Ok(None);
         };
 
-        let Some(range_info) = hover(db, file, offset) else {
+        let Some(range_info) = hover(db, crate::server::api::program_file(db, file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/inlay_hints.rs
+++ b/crates/ty_server/src/server/api/requests/inlay_hints.rs
@@ -51,7 +51,12 @@ impl BackgroundDocumentRequestHandler for InlayHintRequestHandler {
             return Ok(None);
         };
 
-        let inlay_hints = inlay_hints(db, file, range, workspace_settings.inlay_hints());
+        let inlay_hints = inlay_hints(
+            db,
+            crate::server::api::program_file(db, file),
+            range,
+            workspace_settings.inlay_hints(),
+        );
 
         let inlay_hints: Vec<lsp_types::InlayHint> = inlay_hints
             .into_iter()

--- a/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_call_hierarchy.rs
@@ -57,7 +57,9 @@ impl BackgroundDocumentRequestHandler for PrepareCallHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(items) = ty_ide::prepare_call_hierarchy(db, file, offset) else {
+        let Some(items) =
+            ty_ide::prepare_call_hierarchy(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_rename.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_rename.rs
@@ -48,7 +48,7 @@ impl BackgroundDocumentRequestHandler for PrepareRenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(range) = can_rename(db, file, offset) else {
+        let Some(range) = can_rename(db, crate::server::api::program_file(db, file), offset) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/requests/prepare_type_hierarchy.rs
@@ -58,7 +58,9 @@ impl BackgroundDocumentRequestHandler for PrepareTypeHierarchyRequestHandler {
             return Ok(None);
         };
 
-        let Some(item) = ty_ide::prepare_type_hierarchy(db, file, offset) else {
+        let Some(item) =
+            ty_ide::prepare_type_hierarchy(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/references.rs
+++ b/crates/ty_server/src/server/api/requests/references.rs
@@ -51,7 +51,12 @@ impl BackgroundDocumentRequestHandler for ReferencesRequestHandler {
 
         let include_declaration = params.context.include_declaration;
 
-        let Some(references_result) = find_references(db, file, offset, include_declaration) else {
+        let Some(references_result) = find_references(
+            db,
+            crate::server::api::program_file(db, file),
+            offset,
+            include_declaration,
+        ) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/rename.rs
+++ b/crates/ty_server/src/server/api/requests/rename.rs
@@ -50,7 +50,12 @@ impl BackgroundDocumentRequestHandler for RenameRequestHandler {
             return Ok(None);
         };
 
-        let Some(rename_results) = rename(db, file, offset, &params.new_name) else {
+        let Some(rename_results) = rename(
+            db,
+            crate::server::api::program_file(db, file),
+            offset,
+            &params.new_name,
+        ) else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/selection_range.rs
+++ b/crates/ty_server/src/server/api/requests/selection_range.rs
@@ -49,7 +49,7 @@ impl BackgroundDocumentRequestHandler for SelectionRangeRequestHandler {
                 continue;
             };
 
-            let ranges = selection_range(db, file, offset);
+            let ranges = selection_range(db, crate::server::api::program_file(db, file), offset);
             if !ranges.is_empty() {
                 // Convert ranges to nested LSP SelectionRange structure
                 let mut lsp_range = None;

--- a/crates/ty_server/src/server/api/requests/signature_help.rs
+++ b/crates/ty_server/src/server/api/requests/signature_help.rs
@@ -54,7 +54,9 @@ impl BackgroundDocumentRequestHandler for SignatureHelpRequestHandler {
         // Extract signature help capabilities from the client
         let resolved_capabilities = snapshot.resolved_client_capabilities();
 
-        let Some(signature_help_info) = signature_help(db, file, offset) else {
+        let Some(signature_help_info) =
+            signature_help(db, crate::server::api::program_file(db, file), offset)
+        else {
             return Ok(None);
         };
 

--- a/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_diagnostic.rs
@@ -240,7 +240,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
     }
 
     fn report_checked_file(&self, db: &ProjectDatabase, file: File, diagnostics: &[Diagnostic]) {
-        let unnecessary_hints = hints(db, file);
+        let unnecessary_hints = hints(db, crate::server::api::program_file(db, file));
 
         // Another thread might have panicked at this point because of a salsa cancellation which
         // poisoned the result. If the response is poisoned, just don't report and wait for our thread
@@ -288,7 +288,7 @@ impl ProgressReporter for WorkspaceDiagnosticsProgressReporter<'_> {
         let response = &mut self.state.get_mut().unwrap().response;
 
         for (file, diagnostics) in by_file {
-            let unnecessary_hints = hints(db, file);
+            let unnecessary_hints = hints(db, crate::server::api::program_file(db, file));
             response.write_diagnostics_for_file(db, file, &diagnostics, &unnecessary_hints);
         }
         response.maybe_flush();

--- a/crates/ty_server/src/server/api/requests/workspace_symbols.rs
+++ b/crates/ty_server/src/server/api/requests/workspace_symbols.rs
@@ -1,6 +1,7 @@
 use lsp_types::WorkspaceSymbolRequest;
 use lsp_types::{WorkspaceSymbolParams, WorkspaceSymbolResponse};
 use ty_ide::{WorkspaceSymbolInfo, workspace_symbols};
+use ty_project::Db as _;
 
 use crate::server::api::symbols::convert_to_lsp_symbol_information;
 use crate::server::api::traits::{
@@ -28,7 +29,7 @@ impl BackgroundRequestHandler for WorkspaceSymbolRequestHandler {
         for db in snapshot.projects() {
             // Get workspace symbols matching the query
             let start = std::time::Instant::now();
-            let workspace_symbol_infos = workspace_symbols(db, query);
+            let workspace_symbol_infos = workspace_symbols(db, db.project().program(db), query);
             tracing::debug!(
                 "Found {len} workspace symbols in {elapsed:?}",
                 len = workspace_symbol_infos.len(),

--- a/crates/ty_server/src/server/api/semantic_tokens.rs
+++ b/crates/ty_server/src/server/api/semantic_tokens.rs
@@ -18,7 +18,8 @@ pub(crate) fn generate_semantic_tokens(
 ) -> Vec<SemanticToken> {
     let source = source_text(db, file);
     let line_index = line_index(db, file);
-    let semantic_token_data = semantic_tokens(db, file, range);
+    let semantic_token_data =
+        semantic_tokens(db, crate::server::api::program_file(db, file), range);
 
     let mut encoder = Encoder {
         tokens: Vec::with_capacity(semantic_token_data.len()),

--- a/crates/ty_server/src/server/api/type_hierarchy.rs
+++ b/crates/ty_server/src/server/api/type_hierarchy.rs
@@ -1,7 +1,7 @@
 use lsp_types::{SymbolKind, TypeHierarchyItem};
-use ruff_db::files::File;
 use ruff_text_size::TextSize;
 use ty_project::ProjectDatabase;
+use ty_python_core::environment::ProgramFile;
 
 use crate::PositionEncoding;
 use crate::document::{ToRangeExt, resolve_file_uri_range};
@@ -15,7 +15,11 @@ use crate::system::file_to_uri;
 pub(crate) fn hierarchy_handler(
     snapshot: &SessionSnapshot,
     requested_item: &TypeHierarchyItem,
-    hierarchy_types: fn(&dyn ty_project::Db, File, TextSize) -> Vec<ty_ide::TypeHierarchyItem>,
+    hierarchy_types: for<'db> fn(
+        &'db dyn ty_project::Db,
+        ProgramFile<'db>,
+        TextSize,
+    ) -> Vec<ty_ide::TypeHierarchyItem>,
 ) -> Option<Vec<TypeHierarchyItem>> {
     let encoding = snapshot.position_encoding();
 
@@ -33,7 +37,7 @@ pub(crate) fn hierarchy_handler(
             continue;
         };
         items.extend(
-            hierarchy_types(db, file, offset)
+            hierarchy_types(db, crate::server::api::program_file(db, file), offset)
                 .into_iter()
                 .filter_map(|item| convert_to_lsp_item(db, item, encoding)),
         );

--- a/crates/ty_server/src/session.rs
+++ b/crates/ty_server/src/session.rs
@@ -1090,7 +1090,11 @@ impl Session {
             let paths = self
                 .project_dbs()
                 .flat_map(|db| {
-                    ty_module_resolver::system_module_search_paths(db).map(move |path| (db, path))
+                    ty_module_resolver::system_module_search_paths(
+                        db,
+                        db.project().program(db).resolver(db),
+                    )
+                    .map(move |path| (db, path))
                 })
                 .filter(|(db, path)| !path.starts_with(db.project().root(*db)))
                 .map(|(_, path)| path)

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -179,8 +179,9 @@ Settings: Settings {
 
 Memory report:
 =======SALSA STRUCTS=======
-`Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`ResolverProgram`                                  metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `Project`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
+`Program`                                          metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `FileRoot`                                         metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 `ModuleResolveModeIngredient`                      metadata=[X.XXMB]   fields=[X.XXMB]   count=1
 =======SALSA QUERIES=======

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -13,9 +13,10 @@ use salsa::Setter as _;
 use std::borrow::Cow;
 use std::sync::Arc;
 use tempfile::TempDir;
-use ty_module_resolver::{ModuleGlobSetBuilder, SearchPaths};
+use ty_module_resolver::ModuleGlobSetBuilder;
 use ty_python_core::Db as _;
-use ty_python_core::program::Program;
+use ty_python_core::environment::InferenceSettings;
+use ty_python_core::program::{Program, ProgramSettings};
 use ty_python_semantic::lint::{LintRegistry, RuleSelection};
 use ty_python_semantic::{
     AnalysisSettings, Db as SemanticDb, check_file_unwrap, default_lint_registry,
@@ -29,10 +30,12 @@ pub(crate) struct Db {
     system: MdtestSystem,
     vendored: VendoredFileSystem,
     settings: Option<Settings>,
+    program: Option<Program>,
 }
 
 impl Db {
     pub(crate) fn setup() -> Self {
+        let vendored = ty_vendored::file_system().clone();
         let mut db = Self {
             system: MdtestSystem::in_memory(),
             storage: salsa::Storage::new(Some(Box::new({
@@ -40,7 +43,8 @@ impl Db {
                     tracing::trace!("event: {:?}", event);
                 }
             }))),
-            vendored: ty_vendored::file_system().clone(),
+            program: None,
+            vendored,
             files: Files::default(),
             settings: None,
         };
@@ -51,6 +55,17 @@ impl Db {
 
     fn settings(&self) -> Settings {
         self.settings.unwrap()
+    }
+
+    pub(crate) fn program(&self) -> Program {
+        self.program.expect("mdtest database has a program")
+    }
+
+    pub(crate) fn set_program_settings(&mut self, settings: ProgramSettings) {
+        self.program = Some(match self.program {
+            Some(program) => program.with_program_settings(self, settings),
+            None => Program::create(self, &settings),
+        });
     }
 
     pub(crate) fn set_verbosity(&mut self, verbose: bool) {
@@ -108,10 +123,17 @@ impl Db {
             AnalysisSettings::default()
         };
 
+        let inference_settings = InferenceSettings {
+            replace_imports_with_any: analysis.replace_imports_with_any.clone(),
+        };
         let settings = self.settings();
         if settings.analysis(self) != &analysis {
             settings.set_analysis(self).to(analysis);
         }
+        self.program = Some(
+            self.program()
+                .with_inference_settings(self, inference_settings),
+        );
     }
 
     pub(crate) fn update_mdtest_rule_selection(
@@ -159,16 +181,12 @@ impl SourceDb for Db {
     }
 
     fn python_version(&self) -> ruff_python_ast::PythonVersion {
-        Program::get(self).python_version(self)
+        self.program().python_version(self)
     }
 }
 
 #[salsa::db]
-impl ty_module_resolver::Db for Db {
-    fn search_paths(&self) -> &SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ty_module_resolver::Db for Db {}
 
 #[salsa::db]
 impl ty_python_core::Db for Db {
@@ -179,12 +197,16 @@ impl ty_python_core::Db for Db {
 
 #[salsa::db]
 impl SemanticDb for Db {
-    fn check_file(&self, file: File) -> Vec<Diagnostic> {
+    fn check_file(
+        &self,
+        program_file: ty_python_core::environment::ProgramFile<'_>,
+    ) -> Vec<Diagnostic> {
+        let file = program_file.file(self);
         if !self.should_check_file(file) {
             return Vec::new();
         }
 
-        check_file_unwrap(self, file)
+        check_file_unwrap(self, program_file)
     }
 
     fn rule_selection(&self, _file: File) -> &RuleSelection {

--- a/crates/ty_test/src/lib.rs
+++ b/crates/ty_test/src/lib.rs
@@ -20,7 +20,7 @@ use ty_module_resolver::{
     Module, SearchPath, SearchPathSettings, list_modules, resolve_module_confident,
 };
 use ty_python_core::platform::PythonPlatform;
-use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
+use ty_python_core::program::{FallibleStrategy, ProgramSettings};
 use ty_python_semantic::pull_types::pull_types;
 use ty_python_semantic::types::UNDEFINED_REVEAL;
 use ty_python_semantic::{
@@ -316,10 +316,11 @@ fn run_test(
         .expect("Failed to resolve search path settings"),
     };
 
-    Program::init_or_update(db, settings);
+    db.set_program_settings(settings);
     db.update_analysis_options(configuration.analysis.as_ref());
     db.update_mdtest_rule_selection(configuration.rules.as_ref(), options.default_error_rule);
     db.set_verbosity(test.configuration().verbose());
+    let program = db.program();
 
     let mut all_diagnostics = vec![];
 
@@ -333,7 +334,12 @@ fn run_test(
         .iter()
         .filter_map(|test_file| {
             let mdtest_result = attempt_test(
-                |file| ty_python_semantic::Db::check_file(db, file),
+                |file| {
+                    ty_python_semantic::Db::check_file(
+                        db,
+                        ty_python_core::environment::ProgramFile::new(db, program, file),
+                    )
+                },
                 test_file,
             );
             let diagnostics = match mdtest_result {
@@ -348,16 +354,23 @@ fn run_test(
                 }
             };
 
-            let failure = match matcher::match_file(db, test_file.file, &diagnostics, options)
-                .and_then(|inline_diagnostics| {
-                    mdtest::validate_inline_snapshot(
-                        db,
-                        "ty",
-                        test_file,
-                        &inline_diagnostics,
-                        &mut markdown_edits,
-                    )
-                }) {
+            let program_file =
+                ty_python_core::environment::ProgramFile::new(db, program, test_file.file);
+            let failure = match matcher::match_file(
+                db,
+                program_file.versioned_file(db),
+                &diagnostics,
+                options,
+            )
+            .and_then(|inline_diagnostics| {
+                mdtest::validate_inline_snapshot(
+                    db,
+                    "ty",
+                    test_file,
+                    &inline_diagnostics,
+                    &mut markdown_edits,
+                )
+            }) {
                 Ok(()) => None,
                 Err(line_failures) => Some(FileFailures {
                     backtick_offsets: test_file.to_code_block_backtick_offsets(),
@@ -367,7 +380,15 @@ fn run_test(
 
             all_diagnostics.extend(diagnostics);
 
-            let pull_types_result = attempt_test(|file| pull_types(db, file), test_file);
+            let pull_types_result = attempt_test(
+                |file| {
+                    pull_types(
+                        db,
+                        ty_python_core::environment::ProgramFile::new(db, program, file),
+                    );
+                },
+                test_file,
+            );
             match pull_types_result {
                 Ok(()) => {}
                 Err(failures) => {
@@ -425,9 +446,11 @@ fn run_test(
     // Test to fix all fixable diagnostics and verify that they don't introduce any syntax errors.
     // But don't try to run fixes for tests that are expected to panic.
     if test.should_expect_panic().is_err() {
+        let program = db.program();
         let token_source = CancellationTokenSource::new();
         let result = fix_all_diagnostics(
             db,
+            program,
             all_diagnostics,
             Applicability::Unsafe,
             &token_source.token(),
@@ -498,22 +521,25 @@ struct ModuleInconsistency<'db> {
 /// `list_module`.
 fn run_module_resolution_consistency_test(db: &db::Db) -> Result<(), Vec<ModuleInconsistency<'_>>> {
     let mut errs = vec![];
-    for from_list in list_modules(db).iter().copied() {
+    let program = db.program().resolver(db);
+    for from_list in list_modules(db, program).iter().copied() {
         // TODO: For now list_modules does not partake in desperate module resolution so
         // only compare against confident module resolution.
-        errs.push(match resolve_module_confident(db, from_list.name(db)) {
-            None => ModuleInconsistency {
-                db,
-                from_list,
-                from_resolve: None,
+        errs.push(
+            match resolve_module_confident(db, program, from_list.name(db)) {
+                None => ModuleInconsistency {
+                    db,
+                    from_list,
+                    from_resolve: None,
+                },
+                Some(from_resolve) if from_list != from_resolve => ModuleInconsistency {
+                    db,
+                    from_list,
+                    from_resolve: Some(from_resolve),
+                },
+                _ => continue,
             },
-            Some(from_resolve) if from_list != from_resolve => ModuleInconsistency {
-                db,
-                from_list,
-                from_resolve: Some(from_resolve),
-            },
-            _ => continue,
-        });
+        );
     }
     if errs.is_empty() { Ok(()) } else { Err(errs) }
 }

--- a/crates/ty_wasm/src/lib.rs
+++ b/crates/ty_wasm/src/lib.rs
@@ -27,7 +27,8 @@ use ty_project::metadata::options::Options;
 use ty_project::watch::{ChangeEvent, ChangedKind, CreatedKind, DeletedKind};
 use ty_project::{CheckMode, ProjectMetadata};
 use ty_project::{Db, ProjectDatabase};
-use ty_python_core::program::{FallibleStrategy, Program};
+use ty_python_core::environment::ProgramFile;
+use ty_python_core::program::FallibleStrategy;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
@@ -112,6 +113,12 @@ pub struct Workspace {
     system: WasmSystem,
 }
 
+impl Workspace {
+    fn program_file(&self, file: File) -> ProgramFile<'_> {
+        ProgramFile::new(&self.db, self.db.project().program(&self.db), file)
+    }
+}
+
 #[wasm_bindgen]
 impl Workspace {
     #[wasm_bindgen(constructor)]
@@ -169,16 +176,15 @@ impl Workspace {
         let (program_settings, program_settings_diagnostics) = merged_options
             .to_program_settings(&self.system, self.db.vendored(), &FallibleStrategy)
             .map_err(into_error)?;
-        Program::get(&self.db).update_from_settings(&mut self.db, program_settings);
 
         let (settings, settings_diagnostics) = merged_options
             .to_settings(&self.db, &FallibleStrategy)
             .map_err(into_error)?;
-
         self.db.project().reload(
             &mut self.db,
             project,
             Some(settings),
+            Some(program_settings),
             settings_diagnostics,
             program_settings_diagnostics,
         );
@@ -275,7 +281,7 @@ impl Workspace {
 
     #[wasm_bindgen(js_name = "hints")]
     pub fn hints(&self, file_id: &FileHandle) -> Result<Vec<Hint>, Error> {
-        Ok(hints(&self.db, file_id.file)
+        Ok(hints(&self.db, self.program_file(file_id.file))
             .into_iter()
             .map(|hint| Hint::from_ide_hint(&self.db, file_id.file, self.position_encoding, &hint))
             .collect())
@@ -290,18 +296,28 @@ impl Workspace {
 
     /// Returns the parsed AST for `path`
     pub fn parsed(&self, file_id: &FileHandle) -> Result<String, Error> {
-        let parsed = ruff_db::parsed::parsed_module(&self.db, file_id.file).load(&self.db);
+        let parsed = self
+            .program_file(file_id.file)
+            .parsed(&self.db)
+            .load(&self.db);
 
         Ok(format!("{:#?}", parsed.syntax()))
     }
 
     pub fn format(&self, file_id: &FileHandle) -> Result<Option<String>, Error> {
-        formatted_file(&self.db, file_id.file).map_err(into_error)
+        formatted_file(
+            &self.db,
+            self.program_file(file_id.file).versioned_file(&self.db),
+        )
+        .map_err(into_error)
     }
 
     /// Returns the token stream for `path` serialized as a string.
     pub fn tokens(&self, file_id: &FileHandle) -> Result<String, Error> {
-        let parsed = ruff_db::parsed::parsed_module(&self.db, file_id.file).load(&self.db);
+        let parsed = self
+            .program_file(file_id.file)
+            .parsed(&self.db)
+            .load(&self.db);
 
         Ok(format!("{:#?}", parsed.tokens()))
     }
@@ -324,7 +340,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_type_definition(&self.db, file_id.file, offset) else {
+        let Some(targets) = goto_type_definition(&self.db, self.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -348,7 +365,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_declaration(&self.db, file_id.file, offset) else {
+        let Some(targets) = goto_declaration(&self.db, self.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -372,7 +390,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = goto_definition(&self.db, file_id.file, offset) else {
+        let Some(targets) = goto_definition(&self.db, self.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 
@@ -396,7 +415,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = find_references(&self.db, file_id.file, offset, true) else {
+        let Some(targets) =
+            find_references(&self.db, self.program_file(file_id.file), offset, true)
+        else {
             return Ok(Vec::new());
         };
 
@@ -435,7 +456,7 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(range) = can_rename(&self.db, file_id.file, offset) else {
+        let Some(range) = can_rename(&self.db, self.program_file(file_id.file), offset) else {
             return Ok(None);
         };
 
@@ -459,11 +480,13 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        if can_rename(&self.db, file_id.file, offset).is_none() {
+        if can_rename(&self.db, self.program_file(file_id.file), offset).is_none() {
             return Ok(Vec::new());
         }
 
-        let Some(rename_results) = rename(&self.db, file_id.file, offset, new_name) else {
+        let Some(rename_results) =
+            rename(&self.db, self.program_file(file_id.file), offset, new_name)
+        else {
             return Ok(Vec::new());
         };
 
@@ -488,7 +511,7 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(range_info) = hover(&self.db, file_id.file, offset) else {
+        let Some(range_info) = hover(&self.db, self.program_file(file_id.file), offset) else {
             return Ok(None);
         };
 
@@ -523,7 +546,7 @@ impl Workspace {
             &self.db,
             &settings,
             CompletionCapabilities::default(),
-            file_id.file,
+            self.program_file(file_id.file),
             offset,
         );
 
@@ -532,7 +555,8 @@ impl Workspace {
             .map(|comp| {
                 let name = comp.label.to_string();
                 let kind = comp.kind.map(CompletionKind::from);
-                let type_display = comp.ty.map(|ty| ty.display(&self.db).to_string());
+                let program = self.db.project().program(&self.db);
+                let type_display = comp.ty.map(|ty| ty.display(&self.db, program).to_string());
                 let import_edit = comp.import.as_ref().map(|edit| {
                     let range = Range::from_text_range(
                         edit.range(),
@@ -567,7 +591,7 @@ impl Workspace {
 
         let result = inlay_hints(
             &self.db,
-            file_id.file,
+            self.program_file(file_id.file),
             range.to_text_range(&index, &source, self.position_encoding)?,
             // TODO: Provide a way to configure this
             &InlayHintSettings {
@@ -624,7 +648,8 @@ impl Workspace {
         let index = line_index(&self.db, file_id.file);
         let source = source_text(&self.db, file_id.file);
 
-        let semantic_token = ty_ide::semantic_tokens(&self.db, file_id.file, None);
+        let semantic_token =
+            ty_ide::semantic_tokens(&self.db, self.program_file(file_id.file), None);
 
         let result = semantic_token
             .iter()
@@ -649,7 +674,7 @@ impl Workspace {
 
         let semantic_token = ty_ide::semantic_tokens(
             &self.db,
-            file_id.file,
+            self.program_file(file_id.file),
             Some(range.to_text_range(&index, &source, self.position_encoding)?),
         );
 
@@ -686,7 +711,7 @@ impl Workspace {
             actions.extend(
                 ty_ide::code_actions(
                     &self.db,
-                    file_id.file,
+                    self.program_file(file_id.file),
                     range,
                     diagnostic.inner.id().as_str(),
                 )
@@ -721,7 +746,9 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(signature_help_info) = signature_help(&self.db, file_id.file, offset) else {
+        let Some(signature_help_info) =
+            signature_help(&self.db, self.program_file(file_id.file), offset)
+        else {
             return Ok(None);
         };
 
@@ -768,7 +795,8 @@ impl Workspace {
 
         let offset = position.to_text_size(&source, &index, self.position_encoding)?;
 
-        let Some(targets) = document_highlights(&self.db, file_id.file, offset) else {
+        let Some(targets) = document_highlights(&self.db, self.program_file(file_id.file), offset)
+        else {
             return Ok(Vec::new());
         };
 

--- a/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
+++ b/fuzz/fuzz_targets/ty_check_invalid_syntax.rs
@@ -23,8 +23,8 @@ use ty_python_core::program::{FallibleStrategy, Program, ProgramSettings};
 use ty_python_semantic::lint::LintRegistry;
 use ty_python_semantic::types::check_types;
 use ty_python_semantic::{
-    AnalysisSettings, Db as SemanticDb, PythonVersionWithSource, default_lint_registry,
-    lint::RuleSelection,
+    AnalysisSettings, Db as SemanticDb, ProgramFile, PythonVersionWithSource,
+    default_lint_registry, lint::RuleSelection,
 };
 
 /// Database that can be used for testing.
@@ -39,10 +39,12 @@ struct TestDb {
     vendored: VendoredFileSystem,
     rule_selection: Arc<RuleSelection>,
     analysis_settings: Arc<AnalysisSettings>,
+    program: Option<Program>,
 }
 
 impl TestDb {
     fn new() -> Self {
+        let vendored = ty_vendored::file_system().clone();
         Self {
             storage: salsa::Storage::new(Some(Box::new({
                 move |event| {
@@ -50,11 +52,16 @@ impl TestDb {
                 }
             }))),
             system: TestSystem::default(),
-            vendored: ty_vendored::file_system().clone(),
+            program: None,
+            vendored,
             files: Files::default(),
             rule_selection: RuleSelection::from_registry(default_lint_registry()).into(),
             analysis_settings: AnalysisSettings::default().into(),
         }
+    }
+
+    fn program(&self) -> Program {
+        self.program.expect("fuzz database has a program")
     }
 }
 
@@ -73,7 +80,7 @@ impl SourceDb for TestDb {
     }
 
     fn python_version(&self) -> PythonVersion {
-        Program::get(self).python_version(self)
+        self.program().python_version(self)
     }
 }
 
@@ -88,11 +95,7 @@ impl DbWithTestSystem for TestDb {
 }
 
 #[salsa::db]
-impl ModuleResolverDb for TestDb {
-    fn search_paths(&self) -> &ty_module_resolver::SearchPaths {
-        Program::get(self).search_paths(self)
-    }
-}
+impl ModuleResolverDb for TestDb {}
 
 #[salsa::db]
 impl ty_python_core::Db for TestDb {
@@ -103,9 +106,10 @@ impl ty_python_core::Db for TestDb {
 
 #[salsa::db]
 impl SemanticDb for TestDb {
-    fn check_file(&self, file: File) -> Vec<Diagnostic> {
+    fn check_file(&self, program_file: ProgramFile<'_>) -> Vec<Diagnostic> {
+        let file = program_file.file(self);
         if self.should_check_file(file) {
-            ty_python_semantic::check_file_unwrap(self, file)
+            ty_python_semantic::check_file_unwrap(self, program_file)
         } else {
             Vec::new()
         }
@@ -136,23 +140,21 @@ impl SemanticDb for TestDb {
 impl salsa::Database for TestDb {}
 
 fn setup_db() -> TestDb {
-    let db = TestDb::new();
+    let mut db = TestDb::new();
 
     let src_root = SystemPathBuf::from("/src");
     db.memory_file_system()
         .create_directory_all(&src_root)
         .unwrap();
 
-    Program::from_settings(
-        &db,
-        ProgramSettings {
-            python_version: PythonVersionWithSource::default(),
-            python_platform: PythonPlatform::default(),
-            search_paths: SearchPathSettings::new(vec![src_root])
-                .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
-                .expect("Valid search path settings"),
-        },
-    );
+    let program_settings = ProgramSettings {
+        python_version: PythonVersionWithSource::default(),
+        python_platform: PythonPlatform::default(),
+        search_paths: SearchPathSettings::new(vec![src_root])
+            .to_search_paths(db.system(), db.vendored(), &FallibleStrategy)
+            .expect("Valid search path settings"),
+    };
+    db.program = Some(Program::create(&db, &program_settings));
 
     db
 }
@@ -177,7 +179,7 @@ fn do_fuzz(case: &[u8]) -> Corpus {
     for path in &["/src/a.py", "/src/a.pyi"] {
         db.write_file(path, code).unwrap();
         let file = system_path_to_file(&*db, path).unwrap();
-        check_types(&*db, file);
+        check_types(&*db, ProgramFile::new(&*db, db.program(), file));
         db.memory_file_system().remove_file(path).unwrap();
         file.sync(&mut *db);
     }


### PR DESCRIPTION
## Summary

Allow one project database to analyze files under multiple Python versions, platforms, search paths, and inference settings while sharing physical source data.
Carry environment identity through parsing, module resolution, and type inference without relying on an ambient singleton.

## Test Plan

Testing: Added multi-environment coverage and ran focused tests, Clippy, repository hooks, and performance benchmarks.
