### PR TITLE
[ty] Split equality from other comparison inference

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -494,10 +494,12 @@ def compare_str_bound(a: V, b: V) -> bool:
 
 ### Constrained TypeVar comparisons
 
-Constrained TypeVars support comparisons if all constraints support the operation:
+Constrained TypeVars support comparisons if all constraints support the operation. Comparisons
+between two occurrences of the same constrained TypeVar preserve the correlation that both
+occurrences have the same specialization:
 
 ```py
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 W = TypeVar("W", int, str)
 
@@ -510,6 +512,12 @@ X = TypeVar("X", int, str)
 def compare_constrained_lt(a: X, b: X) -> bool:
     # Both int and str support <
     return a < b
+
+Y = TypeVar("Y", Literal[1], Literal[2])
+
+def compare_same_constrained_literal(value: Y):
+    reveal_type(value == value)  # revealed: Literal[True]
+    reveal_type(value != value)  # revealed: Literal[False]
 ```
 
 ### TypeVar with `complex` bound

--- a/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/instances/rich_comparison.md
@@ -494,10 +494,11 @@ def compare_str_bound(a: V, b: V) -> bool:
 
 ### Constrained TypeVar comparisons
 
-Constrained TypeVars support comparisons if all constraints support the operation:
+Constrained TypeVars support comparisons if all constraints support the operation. Repeated
+occurrences of the same constrained TypeVar share one specialization.
 
 ```py
-from typing import TypeVar
+from typing import Literal, TypeVar
 
 W = TypeVar("W", int, str)
 
@@ -510,6 +511,12 @@ X = TypeVar("X", int, str)
 def compare_constrained_lt(a: X, b: X) -> bool:
     # Both int and str support <
     return a < b
+
+Values = TypeVar("Values", Literal[1], Literal[2])
+
+def compare_same_constrained_literal(value: Values):
+    reveal_type(value == value)  # revealed: Literal[True]
+    reveal_type(value != value)  # revealed: Literal[False]
 ```
 
 ### TypeVar with `complex` bound

--- a/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
@@ -63,6 +63,33 @@ def _(small: Literal[1, 2], large: Literal[2, 3]):
     reveal_type(small > large)  # revealed: Literal[False]
 ```
 
+Equality inference still preserves custom return types for every union arm:
+
+```py
+class AEq: ...
+class ANe: ...
+class BEq: ...
+class BNe: ...
+
+class A:
+    def __eq__(self, other: object) -> AEq:  # error: [invalid-method-override]
+        return AEq()
+
+    def __ne__(self, other: object) -> ANe:  # error: [invalid-method-override]
+        return ANe()
+
+class B:
+    def __eq__(self, other: object) -> BEq:  # error: [invalid-method-override]
+        return BEq()
+
+    def __ne__(self, other: object) -> BNe:  # error: [invalid-method-override]
+        return BNe()
+
+def _(value: A | B):
+    reveal_type(value == object())  # revealed: AEq | BEq
+    reveal_type(value != object())  # revealed: ANe | BNe
+```
+
 ## Unsupported operations
 
 Make sure we emit a diagnostic if *any* of the possible comparisons is unsupported. For now, we fall

--- a/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
+++ b/crates/ty_python_semantic/resources/mdtest/comparison/unions.md
@@ -63,6 +63,42 @@ def _(small: Literal[1, 2], large: Literal[2, 3]):
     reveal_type(small > large)  # revealed: Literal[False]
 ```
 
+## Custom equality return types
+
+Equality and inequality must preserve the custom return type from each alternative, even when other
+alternatives return a normal boolean.
+
+```py
+from typing import Literal
+
+class AEq: ...
+class ANe: ...
+class BEq: ...
+class BNe: ...
+
+class A:
+    def __eq__(self, other: object) -> AEq:  # error: [invalid-method-override]
+        return AEq()
+
+    def __ne__(self, other: object) -> ANe:  # error: [invalid-method-override]
+        return ANe()
+
+class B:
+    def __eq__(self, other: object) -> BEq:  # error: [invalid-method-override]
+        return BEq()
+
+    def __ne__(self, other: object) -> BNe:  # error: [invalid-method-override]
+        return BNe()
+
+def custom(value: A | B):
+    reveal_type(value == object())  # revealed: AEq | BEq
+    reveal_type(value != object())  # revealed: ANe | BNe
+
+def mixed(value: A | Literal[1, 2]):
+    reveal_type(value == 1)  # revealed: AEq | bool
+    reveal_type(value != 1)  # revealed: ANe | bool
+```
+
 ## Unsupported operations
 
 Make sure we emit a diagnostic if *any* of the possible comparisons is unsupported. For now, we fall

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -127,8 +127,11 @@ impl<'db> ComparisonResult<'db> {
         }
     }
 
-    /// Discard builtin return-type information that may be refined by expression inference.
-    fn discard_boolean_result(self) -> Self {
+    /// Defer ambiguous result-type inference to expression inference.
+    ///
+    /// Definite comparison results are preserved; only the knowledge that an ambiguous result is a
+    /// builtin `bool` is discarded.
+    fn defer(self) -> Self {
         match self {
             ComparisonResult::AmbiguousBoolean => ComparisonResult::Ambiguous,
             result => result,
@@ -479,12 +482,12 @@ fn evaluate_comparison_once<'db>(
             }
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
                 .evaluate(constraints.as_type(db), other, branch, operator)
-                .discard_boolean_result(),
+                .defer(),
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
             Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
                 .evaluate(other, constraints.as_type(db), branch, operator)
-                .discard_boolean_result(),
+                .defer(),
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
@@ -1046,8 +1049,7 @@ fn evaluate_intersection_left<'db>(
             positive
                 .iter()
                 .map(|element| evaluator.evaluate(*element, other, branch, operator)),
-        )
-        .discard_boolean_result();
+        );
     }
 
     let db = evaluator.db;

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -10,10 +10,12 @@ use rustc_hash::FxHashSet;
 use crate::{Db, place::PlaceAndQualifiers};
 
 use super::{
-    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, LiteralValueType,
-    LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeVarBoundOrConstraints,
-    UnionBuilder,
+    EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass, KnownInstanceType,
+    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type,
+    TypeVarBoundOrConstraints, UnionBuilder,
+    constraints::ConstraintSetBuilder,
     enums::{enum_member_literals, enum_metadata},
+    tuple::TupleSpec,
 };
 
 mod enums;
@@ -57,6 +59,12 @@ enum ComparisonResult<'db> {
 
     /// The comparison may evaluate to true or false, depending on runtime values.
     Ambiguous,
+
+    /// The comparison may evaluate to true or false, but its result is known to be a `bool`.
+    ///
+    /// This distinction lets expression inference avoid repeating comparison dispatch merely to
+    /// recover the builtin `bool` return type.
+    AmbiguousBoolean,
 }
 
 /// The branch of a comparison for which a narrowing constraint is being computed.
@@ -102,7 +110,7 @@ impl<'db> ComparisonResult<'db> {
                 (branch == ComparisonBranch::Positive).then_some(Type::Never)
             }
             ComparisonResult::CanNarrow(narrowed) => Some(narrowed),
-            ComparisonResult::Ambiguous => None,
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => None,
         }
     }
 
@@ -118,6 +126,27 @@ impl<'db> ComparisonResult<'db> {
             result => result,
         }
     }
+
+    /// Discard builtin return-type information that may be refined by expression inference.
+    fn discard_boolean_result(self) -> Self {
+        match self {
+            ComparisonResult::AmbiguousBoolean => ComparisonResult::Ambiguous,
+            result => result,
+        }
+    }
+}
+
+/// The information expression inference can reuse from equality evaluation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum EqualityInference {
+    /// The comparison always returns true.
+    AlwaysTrue,
+    /// The comparison always returns false.
+    AlwaysFalse,
+    /// The comparison has ambiguous truthiness but is known to return `bool`.
+    AmbiguousBoolean,
+    /// Expression inference must inspect the comparison methods' actual return types.
+    NeedsResultInference,
 }
 
 /// Return a constraint for `left` in a branch where `left == right` has the given truthiness.
@@ -245,35 +274,40 @@ pub(crate) fn equality_truthiness<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    comparison_truthiness(db, left, right, ComparisonOperator::Equality)
+    equality_inference(db, left, right, ComparisonOperator::Equality).truthiness()
 }
 
-/// Return the truthiness of `left != right` when it is known for every represented runtime value.
-///
-/// A result that only permits narrowing remains ambiguous because it can still evaluate either way.
-pub(super) fn inequality_truthiness<'db>(
-    db: &'db dyn Db,
-    left: Type<'db>,
-    right: Type<'db>,
-) -> Truthiness {
-    comparison_truthiness(db, left, right, ComparisonOperator::Inequality)
-}
-
-fn comparison_truthiness<'db>(
+/// Evaluate equality or inequality for expression result inference.
+pub(super) fn equality_inference<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
-) -> Truthiness {
+) -> EqualityInference {
     match ComparisonEvaluator::for_truthiness(db).evaluate(
         left,
         right,
         ComparisonBranch::Positive,
         operator,
     ) {
-        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
-        ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
-        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => Truthiness::Ambiguous,
+        ComparisonResult::AlwaysTrue => EqualityInference::AlwaysTrue,
+        ComparisonResult::AlwaysFalse => EqualityInference::AlwaysFalse,
+        ComparisonResult::AmbiguousBoolean => EqualityInference::AmbiguousBoolean,
+        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+            EqualityInference::NeedsResultInference
+        }
+    }
+}
+
+impl EqualityInference {
+    fn truthiness(self) -> Truthiness {
+        match self {
+            EqualityInference::AlwaysTrue => Truthiness::AlwaysTrue,
+            EqualityInference::AlwaysFalse => Truthiness::AlwaysFalse,
+            EqualityInference::AmbiguousBoolean | EqualityInference::NeedsResultInference => {
+                Truthiness::Ambiguous
+            }
+        }
     }
 }
 
@@ -281,9 +315,9 @@ fn comparison_truthiness<'db>(
 ///
 /// The goal is only an optimization; both modes use the same comparison semantics and agree on
 /// which results are definite. [`Constraint`](Self::Constraint) preserves branch-specific narrowing
-/// for the left operand. [`Truthiness`](Self::Truthiness) can discard those constraints because its
-/// caller only needs to know whether every expanded alternative agrees, and can stop as soon as the
-/// comparison cannot be definite.
+/// for the left operand. [`Truthiness`](Self::Truthiness) can discard those constraints, but also
+/// tracks whether an ambiguous result is known to be a `bool` so expression inference can avoid a
+/// second dispatch.
 ///
 /// For example, truthiness evaluation proves that this comparison is always false by checking the
 /// finite alternatives on both sides, without constructing a narrowing constraint:
@@ -453,6 +487,8 @@ fn evaluate_comparison_once<'db>(
         }
         (_, Type::Dynamic(_)) => ComparisonResult::Ambiguous,
 
+        // Expression inference preserves correlations with a constrained TypeVar that can make a
+        // later comparison definite; expanding it here loses that information.
         (Type::TypeVar(var), other) => match var.typevar(db).bound_or_constraints(db) {
             None => ComparisonResult::Ambiguous,
             Some(TypeVarBoundOrConstraints::UpperBound(_)) => {
@@ -464,14 +500,14 @@ fn evaluate_comparison_once<'db>(
                     ComparisonResult::Ambiguous
                 }
             }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(constraints.as_type(db), other, branch, operator)
-            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
+                .evaluate(constraints.as_type(db), other, branch, operator)
+                .discard_boolean_result(),
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db) {
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(other, constraints.as_type(db), branch, operator)
-            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
+                .evaluate(other, constraints.as_type(db), branch, operator)
+                .discard_boolean_result(),
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
@@ -530,10 +566,11 @@ fn evaluate_comparison_once<'db>(
             LiteralOperand::Other,
         ),
 
-        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
+        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::AmbiguousBoolean,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
             match KnownComparisonSemantics::of_type(db, other, operator) {
-                Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
+                Some(KnownComparisonSemantics::Dict) => ComparisonResult::AmbiguousBoolean,
+                None => ComparisonResult::Ambiguous,
                 Some(_) => operator.result_from_equality(false),
             }
         }
@@ -559,6 +596,15 @@ fn evaluate_comparison_once<'db>(
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(left_function)),
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(right_function)),
         ) if left_function == right_function => operator.result_from_equality(true),
+        (
+            Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
+            Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
+        ) => {
+            let constraints = ConstraintSetBuilder::new();
+            let left = constraints.load(db, left.constraints(db));
+            let right = constraints.load(db, right.constraints(db));
+            operator.result_from_equality(left.iff(db, &constraints, right).is_always_satisfied(db))
+        }
         (Type::KnownInstance(left_instance), Type::KnownInstance(right_instance))
             if left_instance == right_instance
                 && left.is_single_valued(db)
@@ -574,6 +620,10 @@ fn evaluate_comparison_once<'db>(
         }
 
         (Type::NominalInstance(left_instance), Type::NominalInstance(right_instance)) => {
+            if let Some(result) = compare_tuples(evaluator, left_instance, right_instance, operator)
+            {
+                return result;
+            }
             compare_nominal_instances(db, left_instance, right_instance, operator)
         }
 
@@ -795,7 +845,7 @@ fn evaluate_union_left<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             elements
                 .iter()
                 .map(|element| evaluator.evaluate(*element, other, branch, operator)),
@@ -855,7 +905,7 @@ fn evaluate_target_union<'db>(
                 all_false = false;
                 narrowed.push(Some(narrowed_element));
             }
-            ComparisonResult::Ambiguous => {
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
                 all_true = false;
                 all_false = false;
                 narrowed.push(Some(*element));
@@ -896,7 +946,7 @@ fn evaluate_union_right<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             elements
                 .iter()
                 .map(|element| evaluator.evaluate(left, *element, branch, operator)),
@@ -914,32 +964,41 @@ fn evaluate_union_right<'db>(
     )
 }
 
-/// Combine results when the caller only needs definite truthiness.
+/// Combine results when the caller only needs truthiness and the builtin result type.
 ///
-/// Any ambiguous or narrowing result, or any disagreement between definite results, makes the
-/// aggregate ambiguous. In each case, later alternatives cannot make it definite again.
-fn combine_definite_truthiness<'db>(
+/// Disagreement between definite results, or an ambiguous builtin result, produces an ambiguous
+/// boolean. An unknown or narrowing result still requires expression inference.
+fn combine_truthiness<'db>(
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
-    let mut definite = None;
+    let mut any = false;
+    let mut all_true = true;
+    let mut all_false = true;
 
     for result in results {
-        let current = match result {
-            ComparisonResult::AlwaysTrue => true,
-            ComparisonResult::AlwaysFalse => false,
+        any = true;
+        match result {
+            ComparisonResult::AlwaysTrue => all_false = false,
+            ComparisonResult::AlwaysFalse => all_true = false,
+            ComparisonResult::AmbiguousBoolean => {
+                all_true = false;
+                all_false = false;
+            }
             ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
                 return ComparisonResult::Ambiguous;
             }
-        };
-
-        match definite {
-            Some(previous) if previous != current => return ComparisonResult::Ambiguous,
-            Some(_) => {}
-            None => definite = Some(current),
         }
     }
 
-    definite.map_or(ComparisonResult::Ambiguous, ComparisonResult::from_bool)
+    if !any {
+        ComparisonResult::Ambiguous
+    } else if all_true {
+        ComparisonResult::AlwaysTrue
+    } else if all_false {
+        ComparisonResult::AlwaysFalse
+    } else {
+        ComparisonResult::AmbiguousBoolean
+    }
 }
 
 /// Combine comparison results produced by alternatives of the non-target operand.
@@ -977,7 +1036,7 @@ fn evaluate_against_results<'db>(
                 all_false = false;
                 builder = builder.add(narrowed);
             }
-            ComparisonResult::Ambiguous => {
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
                 all_true = false;
                 all_false = false;
                 builder = builder.add(target);
@@ -1006,11 +1065,12 @@ fn evaluate_intersection_left<'db>(
     operator: ComparisonOperator,
 ) -> ComparisonResult<'db> {
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             positive
                 .iter()
                 .map(|element| evaluator.evaluate(*element, other, branch, operator)),
-        );
+        )
+        .discard_boolean_result();
     }
 
     let db = evaluator.db;
@@ -1028,7 +1088,9 @@ fn evaluate_intersection_left<'db>(
                 any_narrowing = true;
                 builder = builder.add_positive(narrowed);
             }
-            ComparisonResult::Ambiguous => any_ambiguous = true,
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
+                any_ambiguous = true;
+            }
         }
     }
 
@@ -1147,7 +1209,7 @@ fn compare_literal_to_other<'db>(
 ) -> ComparisonResult<'db> {
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
         return match KnownComparisonSemantics::of_type(db, other, operator) {
-            Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
+            Some(KnownComparisonSemantics::Str) => ComparisonResult::AmbiguousBoolean,
             Some(_) => ComparisonResult::from_bool(operator == ComparisonOperator::Inequality),
             None => ComparisonResult::Ambiguous,
         };
@@ -1177,7 +1239,7 @@ fn compare_literal_to_other<'db>(
         {
             ComparisonResult::CanNarrow(literal_type.negate_if(db, !condition_expects_equality))
         }
-        Some(_) => ComparisonResult::Ambiguous,
+        Some(_) => ComparisonResult::AmbiguousBoolean,
         None if literal_operand == LiteralOperand::Other
             && !condition_expects_equality
             && literal_type.is_single_valued(db) =>
@@ -1185,6 +1247,70 @@ fn compare_literal_to_other<'db>(
             ComparisonResult::CanNarrow(literal_type.negate(db))
         }
         None => ComparisonResult::Ambiguous,
+    }
+}
+
+/// Evaluate tuple equality from element comparisons when every ambiguous result is known boolean.
+///
+/// Unknown element return types are left to expression inference, which also diagnoses invalid
+/// boolean conversions performed by tuple comparison.
+fn compare_tuples<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    left_instance: super::NominalInstanceType<'db>,
+    right_instance: super::NominalInstanceType<'db>,
+    operator: ComparisonOperator,
+) -> Option<ComparisonResult<'db>> {
+    let db = evaluator.db;
+    let left = Type::NominalInstance(left_instance);
+    let right = Type::NominalInstance(right_instance);
+    let left_tuple = left_instance.tuple_spec(db)?;
+    let right_tuple = right_instance.tuple_spec(db)?;
+
+    if KnownComparisonSemantics::of_type(db, left, operator)
+        != Some(KnownComparisonSemantics::Tuple)
+        || KnownComparisonSemantics::of_type(db, right, operator)
+            != Some(KnownComparisonSemantics::Tuple)
+    {
+        return None;
+    }
+
+    if left == right && left.is_singleton(db) {
+        return Some(operator.result_from_equality(true));
+    }
+
+    let (TupleSpec::Fixed(left), TupleSpec::Fixed(right)) =
+        (left_tuple.as_ref(), right_tuple.as_ref())
+    else {
+        return Some(ComparisonResult::AmbiguousBoolean);
+    };
+
+    let mut ambiguous = false;
+    for (left, right) in left.iter_all_elements().zip(right.iter_all_elements()) {
+        match evaluator.evaluate(
+            left,
+            right,
+            ComparisonBranch::Positive,
+            ComparisonOperator::Equality,
+        ) {
+            ComparisonResult::AlwaysTrue => {}
+            ComparisonResult::AlwaysFalse => {
+                return Some(operator.result_from_equality(false));
+            }
+            ComparisonResult::AmbiguousBoolean => ambiguous = true,
+            ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+                // Inference still needs to inspect the element's actual return type so that tuple
+                // comparison can diagnose an invalid boolean conversion.
+                return Some(ComparisonResult::Ambiguous);
+            }
+        }
+    }
+
+    if left.len() != right.len() {
+        Some(operator.result_from_equality(false))
+    } else if ambiguous {
+        Some(ComparisonResult::AmbiguousBoolean)
+    } else {
+        Some(operator.result_from_equality(true))
     }
 }
 
@@ -1218,12 +1344,13 @@ fn compare_nominal_instances<'db>(
     if left == right && left.is_singleton(db) {
         ComparisonResult::from_bool(operator == ComparisonOperator::Equality)
     } else {
-        ComparisonResult::Ambiguous
+        ComparisonResult::AmbiguousBoolean
     }
 }
 
+/// The equality operation whose runtime semantics are being evaluated.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-enum ComparisonOperator {
+pub(super) enum ComparisonOperator {
     Equality,
     Inequality,
 }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -136,19 +136,6 @@ impl<'db> ComparisonResult<'db> {
     }
 }
 
-/// The information expression inference can reuse from equality evaluation.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(super) enum EqualityInference {
-    /// The comparison always returns true.
-    AlwaysTrue,
-    /// The comparison always returns false.
-    AlwaysFalse,
-    /// The comparison has ambiguous truthiness but is known to return `bool`.
-    AmbiguousBoolean,
-    /// Expression inference must inspect the comparison methods' actual return types.
-    NeedsResultInference,
-}
-
 /// Return a constraint for `left` in a branch where `left == right` has the given truthiness.
 ///
 /// Returns `None` when the comparison behavior of either operand is not precise enough to safely
@@ -274,40 +261,30 @@ pub(crate) fn equality_truthiness<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
-    equality_inference(db, left, right, ComparisonOperator::Equality).truthiness()
+    equality_result_truthiness(db, left, right, ComparisonOperator::Equality)
+        .unwrap_or(Truthiness::Ambiguous)
 }
 
-/// Evaluate equality or inequality for expression result inference.
-pub(super) fn equality_inference<'db>(
+/// Return the result truthiness when equality or inequality is known to return `bool`.
+///
+/// Returns `None` when expression inference must inspect the comparison methods' actual return
+/// types.
+pub(super) fn equality_result_truthiness<'db>(
     db: &'db dyn Db,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
-) -> EqualityInference {
+) -> Option<Truthiness> {
     match ComparisonEvaluator::for_truthiness(db).evaluate(
         left,
         right,
         ComparisonBranch::Positive,
         operator,
     ) {
-        ComparisonResult::AlwaysTrue => EqualityInference::AlwaysTrue,
-        ComparisonResult::AlwaysFalse => EqualityInference::AlwaysFalse,
-        ComparisonResult::AmbiguousBoolean => EqualityInference::AmbiguousBoolean,
-        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
-            EqualityInference::NeedsResultInference
-        }
-    }
-}
-
-impl EqualityInference {
-    fn truthiness(self) -> Truthiness {
-        match self {
-            EqualityInference::AlwaysTrue => Truthiness::AlwaysTrue,
-            EqualityInference::AlwaysFalse => Truthiness::AlwaysFalse,
-            EqualityInference::AmbiguousBoolean | EqualityInference::NeedsResultInference => {
-                Truthiness::Ambiguous
-            }
-        }
+        ComparisonResult::AlwaysTrue => Some(Truthiness::AlwaysTrue),
+        ComparisonResult::AlwaysFalse => Some(Truthiness::AlwaysFalse),
+        ComparisonResult::AmbiguousBoolean => Some(Truthiness::Ambiguous),
+        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => None,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -125,7 +125,20 @@ impl<'db> ComparisonResult<'db> {
         }
     }
 
-    /// Preserve definite results while deferring ambiguous result-type inference to expressions.
+    /// Preserve definite results while deferring constrained-TypeVar correlations to inference.
+    ///
+    /// Expanding the alternatives independently loses the shared specialization that makes this
+    /// function exhaustive:
+    ///
+    /// ```python
+    /// from typing import Literal
+    ///
+    /// def f[T: (Literal[1], Literal[2])](value: T) -> bool:
+    ///     if value == 1:
+    ///         return True
+    ///     if value == 2:
+    ///         return False
+    /// ```
     fn defer(self) -> Self {
         match self {
             ComparisonResult::AmbiguousBoolean => ComparisonResult::Ambiguous,
@@ -306,7 +319,13 @@ impl<'db> TupleEqualityEvaluator<'db> {
         right: Type<'db>,
     ) -> Result<Truthiness, BoolError<'db>> {
         let db = self.evaluator.db;
-        let truthiness = evaluate_tuple_element_equality(&mut self.evaluator, left, right);
+        let truthiness = match evaluate_tuple_element_equality(&mut self.evaluator, left, right) {
+            ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
+            ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
+            ComparisonResult::CanNarrow(_)
+            | ComparisonResult::Ambiguous
+            | ComparisonResult::AmbiguousBoolean => Truthiness::Ambiguous,
+        };
         if !truthiness.is_ambiguous() {
             return Ok(truthiness);
         }
@@ -334,7 +353,8 @@ impl<'db> TupleEqualityEvaluator<'db> {
 /// Return equality truthiness when the comparison is known to produce a builtin `bool`.
 ///
 /// `None` means expression inference must inspect the comparison methods to determine their
-/// result types or report invalid boolean conversions inside tuple comparisons.
+/// result types or report invalid boolean conversions inside tuple comparisons. For example, an
+/// `A | int` comparison cannot be reduced to `bool` when `A.__eq__` returns a custom result.
 pub(super) fn equality_result_truthiness<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -1223,6 +1243,9 @@ fn evaluate_union_right<'db>(
 }
 
 /// Combine truthiness while preserving whether every alternative returns a builtin `bool`.
+///
+/// Keep checking after boolean alternatives disagree: a later alternative might define `__eq__`
+/// with a custom return type that rules out the builtin-boolean shortcut.
 fn combine_truthiness<'db>(
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
@@ -1689,7 +1712,7 @@ fn compare_nominal_instances<'db>(
 
         let mut any_ambiguous = false;
         for (&left, &right) in left_elements.iter().zip(right_elements) {
-            match evaluate_tuple_element_comparison(evaluator, left, right) {
+            match evaluate_tuple_element_equality(evaluator, left, right) {
                 ComparisonResult::AlwaysTrue => {}
                 ComparisonResult::AlwaysFalse => return operator.result_from_equality(false),
                 ComparisonResult::AmbiguousBoolean => any_ambiguous = true,
@@ -1711,22 +1734,11 @@ fn compare_nominal_instances<'db>(
     }
 }
 
-fn evaluate_tuple_element_equality<'db>(
-    evaluator: &mut ComparisonEvaluator<'db>,
-    left: Type<'db>,
-    right: Type<'db>,
-) -> Truthiness {
-    match evaluate_tuple_element_comparison(evaluator, left, right) {
-        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
-        ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
-        ComparisonResult::CanNarrow(_)
-        | ComparisonResult::Ambiguous
-        | ComparisonResult::AmbiguousBoolean => Truthiness::Ambiguous,
-    }
-}
-
 /// Compare tuple elements without treating custom or non-reflexive results as builtin booleans.
-fn evaluate_tuple_element_comparison<'db>(
+///
+/// Preserve unknown result types so tuple inference can diagnose invalid implicit conversions to
+/// `bool`, even when different tuple lengths already determine the comparison result.
+fn evaluate_tuple_element_equality<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     left: Type<'db>,
     right: Type<'db>,

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -11,9 +11,10 @@ use crate::{AnalysisSettings, Db, ProgramEnvironment, place::PlaceAndQualifiers}
 
 use super::{
     CallArguments, EnumLiteralType, IntersectionBuilder, KnownBoundMethodType, KnownClass,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness, Type, TypeContext,
-    TypeVarBoundOrConstraints, UnionBuilder,
+    KnownInstanceType, LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Truthiness,
+    Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder,
     bool::BoolError,
+    constraints::ConstraintSetBuilder,
     cyclic::ActiveRecursionDetector,
     enums::{enum_member_literals, enum_metadata},
 };
@@ -59,6 +60,9 @@ enum ComparisonResult<'db> {
 
     /// The comparison may evaluate to true or false, depending on runtime values.
     Ambiguous,
+
+    /// The comparison may evaluate either way, but its result is definitely a builtin `bool`.
+    AmbiguousBoolean,
 }
 
 /// The branch of a comparison for which a narrowing constraint is being computed.
@@ -104,7 +108,7 @@ impl<'db> ComparisonResult<'db> {
                 (branch == ComparisonBranch::Positive).then_some(Type::Never)
             }
             ComparisonResult::CanNarrow(narrowed) => Some(narrowed),
-            ComparisonResult::Ambiguous => None,
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => None,
         }
     }
 
@@ -117,6 +121,14 @@ impl<'db> ComparisonResult<'db> {
     fn discard_narrowing(self) -> Self {
         match self {
             ComparisonResult::CanNarrow(_) => ComparisonResult::Ambiguous,
+            result => result,
+        }
+    }
+
+    /// Preserve definite results while deferring ambiguous result-type inference to expressions.
+    fn defer(self) -> Self {
+        match self {
+            ComparisonResult::AmbiguousBoolean => ComparisonResult::Ambiguous,
             result => result,
         }
     }
@@ -259,7 +271,7 @@ pub(crate) fn equality_truthiness<'db>(
     right: Type<'db>,
     soundness_policy: ComparisonSoundnessPolicy,
 ) -> Truthiness {
-    comparison_truthiness(
+    equality_result_truthiness(
         db,
         env,
         left,
@@ -267,26 +279,7 @@ pub(crate) fn equality_truthiness<'db>(
         ComparisonOperator::Equality,
         soundness_policy,
     )
-}
-
-/// Return the truthiness of `left != right` when it is known for every represented runtime value.
-///
-/// A result that only permits narrowing remains ambiguous because it can still evaluate either way.
-pub(super) fn inequality_truthiness<'db>(
-    db: &'db dyn Db,
-    env: &ProgramEnvironment<'db>,
-    left: Type<'db>,
-    right: Type<'db>,
-    soundness_policy: ComparisonSoundnessPolicy,
-) -> Truthiness {
-    comparison_truthiness(
-        db,
-        env,
-        left,
-        right,
-        ComparisonOperator::Inequality,
-        soundness_policy,
-    )
+    .unwrap_or(Truthiness::Ambiguous)
 }
 
 /// Evaluates tuple-element equality while reusing the active-comparison-set allocation across a
@@ -338,23 +331,28 @@ impl<'db> TupleEqualityEvaluator<'db> {
     }
 }
 
-fn comparison_truthiness<'db>(
+/// Return equality truthiness when the comparison is known to produce a builtin `bool`.
+///
+/// `None` means expression inference must inspect the comparison methods to determine their
+/// result types or report invalid boolean conversions inside tuple comparisons.
+pub(super) fn equality_result_truthiness<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
     left: Type<'db>,
     right: Type<'db>,
     operator: ComparisonOperator,
     soundness_policy: ComparisonSoundnessPolicy,
-) -> Truthiness {
+) -> Option<Truthiness> {
     match ComparisonEvaluator::for_truthiness(db, env, soundness_policy).evaluate(
         left,
         right,
         ComparisonBranch::Positive,
         operator,
     ) {
-        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
-        ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
-        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => Truthiness::Ambiguous,
+        ComparisonResult::AlwaysTrue => Some(Truthiness::AlwaysTrue),
+        ComparisonResult::AlwaysFalse => Some(Truthiness::AlwaysFalse),
+        ComparisonResult::AmbiguousBoolean => Some(Truthiness::Ambiguous),
+        ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => None,
     }
 }
 
@@ -362,9 +360,8 @@ fn comparison_truthiness<'db>(
 ///
 /// The goal is only an optimization; both modes use the same comparison semantics and agree on
 /// which results are definite. [`Constraint`](Self::Constraint) preserves branch-specific narrowing
-/// for the left operand. [`Truthiness`](Self::Truthiness) can discard those constraints because its
-/// caller only needs to know whether every expanded alternative agrees, and can stop as soon as the
-/// comparison cannot be definite.
+/// for the left operand. [`Truthiness`](Self::Truthiness) discards those constraints while tracking
+/// whether every expanded alternative produces a builtin `bool`.
 ///
 /// For example, truthiness evaluation proves that this comparison is always false by checking the
 /// finite alternatives on both sides, without constructing a narrowing constraint:
@@ -671,14 +668,14 @@ fn evaluate_structural_comparison<'db>(
                     ComparisonResult::Ambiguous
                 }
             }
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(constraints.as_type(db, env), other, branch, operator)
-            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
+                .evaluate(constraints.as_type(db, env), other, branch, operator)
+                .defer(),
         },
         (other, Type::TypeVar(var)) => match var.typevar(db).bound_or_constraints(db, env) {
-            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => {
-                evaluator.evaluate(other, constraints.as_type(db, env), branch, operator)
-            }
+            Some(TypeVarBoundOrConstraints::Constraints(constraints)) => evaluator
+                .evaluate(other, constraints.as_type(db, env), branch, operator)
+                .defer(),
             None | Some(TypeVarBoundOrConstraints::UpperBound(_)) => ComparisonResult::Ambiguous,
         },
 
@@ -761,10 +758,11 @@ fn evaluate_structural_comparison<'db>(
             LiteralOperand::Other,
         ),
 
-        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::Ambiguous,
+        (Type::TypedDict(_), Type::TypedDict(_)) => ComparisonResult::AmbiguousBoolean,
         (Type::TypedDict(_), other) | (other, Type::TypedDict(_)) => {
             match evaluator.comparison_semantics(other, operator) {
-                Some(KnownComparisonSemantics::Dict) | None => ComparisonResult::Ambiguous,
+                Some(KnownComparisonSemantics::Dict) => ComparisonResult::AmbiguousBoolean,
+                None => ComparisonResult::Ambiguous,
                 Some(_) => operator.result_from_equality(false),
             }
         }
@@ -785,6 +783,18 @@ fn evaluate_structural_comparison<'db>(
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(left_function)),
             Type::KnownBoundMethod(KnownBoundMethodType::FunctionTypeDunderCall(right_function)),
         ) if left_function == right_function => operator.result_from_equality(true),
+        (
+            Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
+            Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
+        ) => {
+            let constraints = ConstraintSetBuilder::new();
+            let left = constraints.load(db, env, left.constraints(db));
+            let right = constraints.load(db, env, right.constraints(db));
+            operator.result_from_equality(
+                left.iff(db, &constraints, right)
+                    .is_always_satisfied(db, env),
+            )
+        }
         (left, right)
             if has_known_identity_comparison_semantics(db, env, left, operator)
                 && has_known_identity_comparison_semantics(db, env, right, operator) =>
@@ -1084,7 +1094,7 @@ fn evaluate_union_left<'db>(
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             elements
                 .iter()
                 .map(|element| evaluator.evaluate(*element, other, branch, operator)),
@@ -1145,7 +1155,7 @@ fn evaluate_target_union<'db>(
                 all_false = false;
                 narrowed.push(Some(narrowed_element));
             }
-            ComparisonResult::Ambiguous => {
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
                 all_true = false;
                 all_false = false;
                 narrowed.push(Some(*element));
@@ -1193,7 +1203,7 @@ fn evaluate_union_right<'db>(
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             elements
                 .iter()
                 .map(|element| evaluator.evaluate(left, *element, branch, operator)),
@@ -1212,32 +1222,38 @@ fn evaluate_union_right<'db>(
     )
 }
 
-/// Combine results when the caller only needs definite truthiness.
-///
-/// Any ambiguous or narrowing result, or any disagreement between definite results, makes the
-/// aggregate ambiguous. In each case, later alternatives cannot make it definite again.
-fn combine_definite_truthiness<'db>(
+/// Combine truthiness while preserving whether every alternative returns a builtin `bool`.
+fn combine_truthiness<'db>(
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
-    let mut definite = None;
+    let mut any = false;
+    let mut all_true = true;
+    let mut all_false = true;
 
     for result in results {
-        let current = match result {
-            ComparisonResult::AlwaysTrue => true,
-            ComparisonResult::AlwaysFalse => false,
+        any = true;
+        match result {
+            ComparisonResult::AlwaysTrue => all_false = false,
+            ComparisonResult::AlwaysFalse => all_true = false,
+            ComparisonResult::AmbiguousBoolean => {
+                all_true = false;
+                all_false = false;
+            }
             ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
                 return ComparisonResult::Ambiguous;
             }
-        };
-
-        match definite {
-            Some(previous) if previous != current => return ComparisonResult::Ambiguous,
-            Some(_) => {}
-            None => definite = Some(current),
         }
     }
 
-    definite.map_or(ComparisonResult::Ambiguous, ComparisonResult::from_bool)
+    if !any {
+        ComparisonResult::Ambiguous
+    } else if all_true {
+        ComparisonResult::AlwaysTrue
+    } else if all_false {
+        ComparisonResult::AlwaysFalse
+    } else {
+        ComparisonResult::AmbiguousBoolean
+    }
 }
 
 /// Combine comparison results produced by alternatives of the non-target operand.
@@ -1276,7 +1292,7 @@ fn evaluate_against_results<'db>(
                 all_false = false;
                 builder = builder.add(narrowed);
             }
-            ComparisonResult::Ambiguous => {
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
                 all_true = false;
                 all_false = false;
                 builder = builder.add(target);
@@ -1306,7 +1322,7 @@ fn evaluate_intersection_left<'db>(
 ) -> ComparisonResult<'db> {
     let db = evaluator.db;
     if evaluator.goal == ComparisonGoal::Truthiness {
-        return combine_definite_truthiness(
+        return combine_truthiness(
             positive
                 .iter()
                 .map(|element| evaluator.evaluate(*element, other, branch, operator)),
@@ -1339,7 +1355,9 @@ fn evaluate_intersection_left<'db>(
                 any_narrowing = true;
                 builder.add_positive_in_place(narrowed);
             }
-            ComparisonResult::Ambiguous => any_ambiguous = true,
+            ComparisonResult::Ambiguous | ComparisonResult::AmbiguousBoolean => {
+                any_ambiguous = true;
+            }
         }
     }
 
@@ -1516,7 +1534,7 @@ fn compare_literal_to_other<'db>(
 
     if matches!(literal, LiteralValueTypeKind::LiteralString) {
         return match evaluator.comparison_semantics(other, operator) {
-            Some(KnownComparisonSemantics::Str) => ComparisonResult::Ambiguous,
+            Some(KnownComparisonSemantics::Str) => ComparisonResult::AmbiguousBoolean,
             Some(_) => compare_different_semantics(db, env, literal_type, other, operator),
             None => ComparisonResult::Ambiguous,
         };
@@ -1568,7 +1586,7 @@ fn compare_literal_to_other<'db>(
                 !condition_expects_equality,
             ))
         }
-        Some(_) => ComparisonResult::Ambiguous,
+        Some(_) => ComparisonResult::AmbiguousBoolean,
         None if literal_operand == LiteralOperand::Other && !condition_expects_equality => {
             ComparisonResult::CanNarrow(literal_type.negate(db, env))
         }
@@ -1653,31 +1671,43 @@ fn compare_nominal_instances<'db>(
     } else if left_semantics == KnownComparisonSemantics::Tuple
         && let Some(left_tuple) = left_instance.tuple_spec(db, env)
         && let Some(right_tuple) = right_instance.tuple_spec(db, env)
-        && let Some(left_tuple) = left_tuple.as_fixed_length()
-        && let Some(right_tuple) = right_tuple.as_fixed_length()
     {
+        let (Some(left_tuple), Some(right_tuple)) =
+            (left_tuple.as_fixed_length(), right_tuple.as_fixed_length())
+        else {
+            return ComparisonResult::AmbiguousBoolean;
+        };
         let left_elements = left_tuple.all_elements();
         let right_elements = right_tuple.all_elements();
-        if left_elements.len() != right_elements.len() {
+        // Narrowing can reject unequal lengths immediately. Expression inference still needs to
+        // inspect earlier elements because converting a custom equality result may raise.
+        if evaluator.goal == ComparisonGoal::Constraint
+            && left_elements.len() != right_elements.len()
+        {
             return operator.result_from_equality(false);
         }
 
-        let mut all_equal = true;
+        let mut any_ambiguous = false;
         for (&left, &right) in left_elements.iter().zip(right_elements) {
-            match evaluate_tuple_element_equality(evaluator, left, right) {
-                Truthiness::AlwaysTrue => {}
-                Truthiness::AlwaysFalse => return operator.result_from_equality(false),
-                Truthiness::Ambiguous => all_equal = false,
+            match evaluate_tuple_element_comparison(evaluator, left, right) {
+                ComparisonResult::AlwaysTrue => {}
+                ComparisonResult::AlwaysFalse => return operator.result_from_equality(false),
+                ComparisonResult::AmbiguousBoolean => any_ambiguous = true,
+                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+                    return ComparisonResult::Ambiguous;
+                }
             }
         }
 
-        if all_equal {
-            operator.result_from_equality(true)
+        if left_elements.len() != right_elements.len() {
+            operator.result_from_equality(false)
+        } else if any_ambiguous {
+            ComparisonResult::AmbiguousBoolean
         } else {
-            ComparisonResult::Ambiguous
+            operator.result_from_equality(true)
         }
     } else {
-        ComparisonResult::Ambiguous
+        ComparisonResult::AmbiguousBoolean
     }
 }
 
@@ -1686,9 +1716,24 @@ fn evaluate_tuple_element_equality<'db>(
     left: Type<'db>,
     right: Type<'db>,
 ) -> Truthiness {
+    match evaluate_tuple_element_comparison(evaluator, left, right) {
+        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
+        ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
+        ComparisonResult::CanNarrow(_)
+        | ComparisonResult::Ambiguous
+        | ComparisonResult::AmbiguousBoolean => Truthiness::Ambiguous,
+    }
+}
+
+/// Compare tuple elements without treating custom or non-reflexive results as builtin booleans.
+fn evaluate_tuple_element_comparison<'db>(
+    evaluator: &mut ComparisonEvaluator<'db>,
+    left: Type<'db>,
+    right: Type<'db>,
+) -> ComparisonResult<'db> {
     let db = evaluator.db;
     if left == right && left.is_singleton(db, &evaluator.env) {
-        return Truthiness::AlwaysTrue;
+        return ComparisonResult::AlwaysTrue;
     }
 
     match evaluator.evaluate(
@@ -1697,23 +1742,22 @@ fn evaluate_tuple_element_equality<'db>(
         ComparisonBranch::Positive,
         ComparisonOperator::Equality,
     ) {
-        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         // Known comparison semantics are reflexive, so a false result rules out shared runtime
         // identity. Static disjointness alone is insufficient because `NewType` and similar
         // wrappers can erase their distinction at runtime.
         ComparisonResult::AlwaysFalse
-            if [left, right]
+            if ![left, right]
                 .into_iter()
                 .all(|ty| has_reflexive_equality_semantics(evaluator, ty)) =>
         {
-            Truthiness::AlwaysFalse
+            ComparisonResult::Ambiguous
         }
-        _ => Truthiness::Ambiguous,
+        result => result,
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-enum ComparisonOperator {
+pub(super) enum ComparisonOperator {
     Equality,
     Inequality,
 }

--- a/crates/ty_python_semantic/src/types/equality.rs
+++ b/crates/ty_python_semantic/src/types/equality.rs
@@ -319,13 +319,7 @@ impl<'db> TupleEqualityEvaluator<'db> {
         right: Type<'db>,
     ) -> Result<Truthiness, BoolError<'db>> {
         let db = self.evaluator.db;
-        let truthiness = match evaluate_tuple_element_equality(&mut self.evaluator, left, right) {
-            ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
-            ComparisonResult::AlwaysFalse => Truthiness::AlwaysFalse,
-            ComparisonResult::CanNarrow(_)
-            | ComparisonResult::Ambiguous
-            | ComparisonResult::AmbiguousBoolean => Truthiness::Ambiguous,
-        };
+        let truthiness = evaluate_tuple_element_equality(&mut self.evaluator, left, right);
         if !truthiness.is_ambiguous() {
             return Ok(truthiness);
         }
@@ -353,8 +347,8 @@ impl<'db> TupleEqualityEvaluator<'db> {
 /// Return equality truthiness when the comparison is known to produce a builtin `bool`.
 ///
 /// `None` means expression inference must inspect the comparison methods to determine their
-/// result types or report invalid boolean conversions inside tuple comparisons. For example, an
-/// `A | int` comparison cannot be reduced to `bool` when `A.__eq__` returns a custom result.
+/// result types. For example, an `A | int` comparison cannot be reduced to `bool` when `A.__eq__`
+/// returns a custom result.
 pub(super) fn equality_result_truthiness<'db>(
     db: &'db dyn Db,
     env: &ProgramEnvironment<'db>,
@@ -1249,34 +1243,20 @@ fn evaluate_union_right<'db>(
 fn combine_truthiness<'db>(
     results: impl IntoIterator<Item = ComparisonResult<'db>>,
 ) -> ComparisonResult<'db> {
-    let mut any = false;
-    let mut all_true = true;
-    let mut all_false = true;
+    let mut combined = None;
 
     for result in results {
-        any = true;
-        match result {
-            ComparisonResult::AlwaysTrue => all_false = false,
-            ComparisonResult::AlwaysFalse => all_true = false,
-            ComparisonResult::AmbiguousBoolean => {
-                all_true = false;
-                all_false = false;
-            }
-            ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
+        combined = match (combined, result) {
+            (_, ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous) => {
                 return ComparisonResult::Ambiguous;
             }
-        }
+            (None, result) => Some(result),
+            (Some(previous), result) if previous == result => Some(result),
+            _ => Some(ComparisonResult::AmbiguousBoolean),
+        };
     }
 
-    if !any {
-        ComparisonResult::Ambiguous
-    } else if all_true {
-        ComparisonResult::AlwaysTrue
-    } else if all_false {
-        ComparisonResult::AlwaysFalse
-    } else {
-        ComparisonResult::AmbiguousBoolean
-    }
+    combined.unwrap_or(ComparisonResult::Ambiguous)
 }
 
 /// Combine comparison results produced by alternatives of the non-target operand.
@@ -1694,58 +1674,42 @@ fn compare_nominal_instances<'db>(
     } else if left_semantics == KnownComparisonSemantics::Tuple
         && let Some(left_tuple) = left_instance.tuple_spec(db, env)
         && let Some(right_tuple) = right_instance.tuple_spec(db, env)
+        && let Some(left_tuple) = left_tuple.as_fixed_length()
+        && let Some(right_tuple) = right_tuple.as_fixed_length()
     {
-        let (Some(left_tuple), Some(right_tuple)) =
-            (left_tuple.as_fixed_length(), right_tuple.as_fixed_length())
-        else {
-            return ComparisonResult::AmbiguousBoolean;
-        };
         let left_elements = left_tuple.all_elements();
         let right_elements = right_tuple.all_elements();
-        // Narrowing can reject unequal lengths immediately. Expression inference still needs to
-        // inspect earlier elements because converting a custom equality result may raise.
-        if evaluator.goal == ComparisonGoal::Constraint
-            && left_elements.len() != right_elements.len()
-        {
+        if left_elements.len() != right_elements.len() {
             return operator.result_from_equality(false);
         }
 
-        let mut any_ambiguous = false;
+        let mut all_equal = true;
         for (&left, &right) in left_elements.iter().zip(right_elements) {
             match evaluate_tuple_element_equality(evaluator, left, right) {
-                ComparisonResult::AlwaysTrue => {}
-                ComparisonResult::AlwaysFalse => return operator.result_from_equality(false),
-                ComparisonResult::AmbiguousBoolean => any_ambiguous = true,
-                ComparisonResult::CanNarrow(_) | ComparisonResult::Ambiguous => {
-                    return ComparisonResult::Ambiguous;
-                }
+                Truthiness::AlwaysTrue => {}
+                Truthiness::AlwaysFalse => return operator.result_from_equality(false),
+                Truthiness::Ambiguous => all_equal = false,
             }
         }
 
-        if left_elements.len() != right_elements.len() {
-            operator.result_from_equality(false)
-        } else if any_ambiguous {
-            ComparisonResult::AmbiguousBoolean
-        } else {
+        if all_equal {
             operator.result_from_equality(true)
+        } else {
+            ComparisonResult::Ambiguous
         }
     } else {
         ComparisonResult::AmbiguousBoolean
     }
 }
 
-/// Compare tuple elements without treating custom or non-reflexive results as builtin booleans.
-///
-/// Preserve unknown result types so tuple inference can diagnose invalid implicit conversions to
-/// `bool`, even when different tuple lengths already determine the comparison result.
 fn evaluate_tuple_element_equality<'db>(
     evaluator: &mut ComparisonEvaluator<'db>,
     left: Type<'db>,
     right: Type<'db>,
-) -> ComparisonResult<'db> {
+) -> Truthiness {
     let db = evaluator.db;
     if left == right && left.is_singleton(db, &evaluator.env) {
-        return ComparisonResult::AlwaysTrue;
+        return Truthiness::AlwaysTrue;
     }
 
     match evaluator.evaluate(
@@ -1754,17 +1718,18 @@ fn evaluate_tuple_element_equality<'db>(
         ComparisonBranch::Positive,
         ComparisonOperator::Equality,
     ) {
+        ComparisonResult::AlwaysTrue => Truthiness::AlwaysTrue,
         // Known comparison semantics are reflexive, so a false result rules out shared runtime
         // identity. Static disjointness alone is insufficient because `NewType` and similar
         // wrappers can erase their distinction at runtime.
         ComparisonResult::AlwaysFalse
-            if ![left, right]
+            if [left, right]
                 .into_iter()
                 .all(|ty| has_reflexive_equality_semantics(evaluator, ty)) =>
         {
-            ComparisonResult::Ambiguous
+            Truthiness::AlwaysFalse
         }
-        result => result,
+        _ => Truthiness::Ambiguous,
     }
 }
 

--- a/crates/ty_python_semantic/src/types/equality/enums.rs
+++ b/crates/ty_python_semantic/src/types/equality/enums.rs
@@ -13,8 +13,8 @@ use crate::{Db, FxOrderMap, FxOrderSet, ProgramEnvironment};
 
 use super::{
     ComparisonBranch, ComparisonEvaluator, ComparisonGoal, ComparisonOperator, ComparisonResult,
-    KnownComparisonSemantics, combine_definite_truthiness, enum_literal_value,
-    evaluate_against_results, evaluate_target_union,
+    KnownComparisonSemantics, combine_truthiness, enum_literal_value, evaluate_against_results,
+    evaluate_target_union,
 };
 
 /// Compare enum values without checking every pair of members.
@@ -171,7 +171,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         }
 
         if evaluator.goal == ComparisonGoal::Truthiness {
-            return combine_definite_truthiness(
+            return combine_truthiness(
                 self.other
                     .alternatives
                     .iter()
@@ -213,7 +213,7 @@ impl<'db> PartitionedEnumComparison<'db> {
         }
 
         if evaluator.goal == ComparisonGoal::Truthiness {
-            return combine_definite_truthiness(
+            return combine_truthiness(
                 self.target.alternatives.iter().map(|target| {
                     self.evaluate_against_other(evaluator, *target, branch, operator)
                 }),

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -6,9 +6,7 @@ use crate::Db;
 use crate::types::call::{CallArguments, CallDunderError};
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
-use crate::types::equality::{
-    ComparisonOperator as EqualityOperator, EqualityInference, equality_inference,
-};
+use crate::types::equality::{ComparisonOperator as EqualityOperator, equality_result_truthiness};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
     DynamicType, IntersectionBuilder, IntersectionType, KnownClass, LiteralValueType,
@@ -109,49 +107,18 @@ enum NonEqualityOperator {
     IsNot,
 }
 
-impl From<NonEqualityOperator> for ast::CmpOp {
-    fn from(value: NonEqualityOperator) -> Self {
-        match value {
-            NonEqualityOperator::Lt => ast::CmpOp::Lt,
-            NonEqualityOperator::LtE => ast::CmpOp::LtE,
-            NonEqualityOperator::Gt => ast::CmpOp::Gt,
-            NonEqualityOperator::GtE => ast::CmpOp::GtE,
-            NonEqualityOperator::In => ast::CmpOp::In,
-            NonEqualityOperator::NotIn => ast::CmpOp::NotIn,
-            NonEqualityOperator::Is => ast::CmpOp::Is,
-            NonEqualityOperator::IsNot => ast::CmpOp::IsNot,
-        }
-    }
-}
-
-/// Routes equality through its dedicated evaluator while sharing structural type dispatch.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BinaryComparisonOperator {
-    Equality(EqualityOperator),
-    NonEquality(NonEqualityOperator),
-}
-
-impl BinaryComparisonOperator {
-    const fn from_ast(operator: ast::CmpOp) -> Self {
+impl NonEqualityOperator {
+    const fn from_ast(operator: ast::CmpOp) -> Option<Self> {
         match operator {
-            ast::CmpOp::Eq => BinaryComparisonOperator::Equality(EqualityOperator::Equality),
-            ast::CmpOp::NotEq => BinaryComparisonOperator::Equality(EqualityOperator::Inequality),
-            ast::CmpOp::Lt => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt),
-            ast::CmpOp::LtE => BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE),
-            ast::CmpOp::Gt => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt),
-            ast::CmpOp::GtE => BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE),
-            ast::CmpOp::In => BinaryComparisonOperator::NonEquality(NonEqualityOperator::In),
-            ast::CmpOp::NotIn => BinaryComparisonOperator::NonEquality(NonEqualityOperator::NotIn),
-            ast::CmpOp::Is => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Is),
-            ast::CmpOp::IsNot => BinaryComparisonOperator::NonEquality(NonEqualityOperator::IsNot),
-        }
-    }
-
-    fn as_ast(self) -> ast::CmpOp {
-        match self {
-            BinaryComparisonOperator::Equality(EqualityOperator::Equality) => ast::CmpOp::Eq,
-            BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => ast::CmpOp::NotEq,
-            BinaryComparisonOperator::NonEquality(operator) => operator.into(),
+            ast::CmpOp::Eq | ast::CmpOp::NotEq => None,
+            ast::CmpOp::Lt => Some(Self::Lt),
+            ast::CmpOp::LtE => Some(Self::LtE),
+            ast::CmpOp::Gt => Some(Self::Gt),
+            ast::CmpOp::GtE => Some(Self::GtE),
+            ast::CmpOp::In => Some(Self::In),
+            ast::CmpOp::NotIn => Some(Self::NotIn),
+            ast::CmpOp::Is => Some(Self::Is),
+            ast::CmpOp::IsNot => Some(Self::IsNot),
         }
     }
 }
@@ -183,31 +150,12 @@ pub(crate) struct UnsupportedComparisonError<'db> {
 pub(super) fn infer_binary_type_comparison<'db>(
     context: &InferContext<'db, '_>,
     left: Type<'db>,
-    operator: ast::CmpOp,
-    right: Type<'db>,
-    range: TextRange,
-    visitor: &BinaryComparisonVisitor<'db>,
-) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
-    infer_binary_type_comparison_inner(
-        context,
-        left,
-        BinaryComparisonOperator::from_ast(operator),
-        right,
-        range,
-        visitor,
-    )
-}
-
-fn infer_binary_type_comparison_inner<'db>(
-    context: &InferContext<'db, '_>,
-    left: Type<'db>,
-    operator: BinaryComparisonOperator,
+    op: ast::CmpOp,
     right: Type<'db>,
     range: TextRange,
     visitor: &BinaryComparisonVisitor<'db>,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
-    let op = operator.as_ast();
 
     // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
     // language spec.
@@ -219,32 +167,18 @@ fn infer_binary_type_comparison_inner<'db>(
             infer_membership_test_comparison(context, left, right, op, range)
         };
 
-        match operator {
-            BinaryComparisonOperator::Equality(EqualityOperator::Equality) => {
-                rich_comparison(RichCompareOperator::Eq)
-            }
-            BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => {
-                rich_comparison(RichCompareOperator::Ne)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt) => {
-                rich_comparison(RichCompareOperator::Lt)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE) => {
-                rich_comparison(RichCompareOperator::Le)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt) => {
-                rich_comparison(RichCompareOperator::Gt)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE) => {
-                rich_comparison(RichCompareOperator::Ge)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::In) => {
-                membership_test_comparison(MembershipTestCompareOperator::In, range)
-            }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::NotIn) => {
+        match op {
+            ast::CmpOp::Eq => rich_comparison(RichCompareOperator::Eq),
+            ast::CmpOp::NotEq => rich_comparison(RichCompareOperator::Ne),
+            ast::CmpOp::Lt => rich_comparison(RichCompareOperator::Lt),
+            ast::CmpOp::LtE => rich_comparison(RichCompareOperator::Le),
+            ast::CmpOp::Gt => rich_comparison(RichCompareOperator::Gt),
+            ast::CmpOp::GtE => rich_comparison(RichCompareOperator::Ge),
+            ast::CmpOp::In => membership_test_comparison(MembershipTestCompareOperator::In, range),
+            ast::CmpOp::NotIn => {
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Is) => {
+            ast::CmpOp::Is => {
                 if left.is_disjoint_from(db, right) {
                     Ok(Type::bool_literal(false))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
@@ -253,7 +187,7 @@ fn infer_binary_type_comparison_inner<'db>(
                     Ok(KnownClass::Bool.to_instance(db))
                 }
             }
-            BinaryComparisonOperator::NonEquality(NonEqualityOperator::IsNot) => {
+            ast::CmpOp::IsNot => {
                 if left.is_disjoint_from(db, right) {
                     Ok(Type::bool_literal(true))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
@@ -265,13 +199,15 @@ fn infer_binary_type_comparison_inner<'db>(
         }
     };
 
-    if let BinaryComparisonOperator::Equality(operator) = operator {
-        match equality_inference(db, left, right, operator) {
-            EqualityInference::AlwaysTrue => return Ok(Type::bool_literal(true)),
-            EqualityInference::AlwaysFalse => return Ok(Type::bool_literal(false)),
-            EqualityInference::AmbiguousBoolean => return Ok(KnownClass::Bool.to_instance(db)),
-            EqualityInference::NeedsResultInference => {}
-        }
+    let equality_operator = match op {
+        ast::CmpOp::Eq => Some(EqualityOperator::Equality),
+        ast::CmpOp::NotEq => Some(EqualityOperator::Inequality),
+        _ => None,
+    };
+    if let Some(operator) = equality_operator
+        && let Some(truthiness) = equality_result_truthiness(db, left, right, operator)
+    {
+        return Ok(Type::from_truthiness(db, truthiness));
     }
 
     let comparison_result = match (left, right) {
@@ -498,9 +434,8 @@ fn infer_binary_type_comparison_inner<'db>(
             }
         }
 
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => match operator {
-            BinaryComparisonOperator::Equality(_) => None,
-            BinaryComparisonOperator::NonEquality(operator) => match (
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
+            NonEqualityOperator::from_ast(op).and_then(|operator| match (
                 left_literal.kind(),
                 right_literal.kind(),
             ) {
@@ -654,8 +589,8 @@ fn infer_binary_type_comparison_inner<'db>(
                 }
 
                 _ => None,
-            },
-        },
+            })
+        }
 
         (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2)) => nominal1
             .tuple_spec(db)
@@ -669,29 +604,14 @@ fn infer_binary_type_comparison_inner<'db>(
                     })
                 };
 
-                match operator {
-                    BinaryComparisonOperator::Equality(EqualityOperator::Equality) => {
-                        tuple_rich_comparison(RichCompareOperator::Eq)
-                    }
-                    BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => {
-                        tuple_rich_comparison(RichCompareOperator::Ne)
-                    }
-                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt) => {
-                        tuple_rich_comparison(RichCompareOperator::Lt)
-                    }
-                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE) => {
-                        tuple_rich_comparison(RichCompareOperator::Le)
-                    }
-                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt) => {
-                        tuple_rich_comparison(RichCompareOperator::Gt)
-                    }
-                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE) => {
-                        tuple_rich_comparison(RichCompareOperator::Ge)
-                    }
-                    BinaryComparisonOperator::NonEquality(
-                        membership @ (NonEqualityOperator::In
-                        | NonEqualityOperator::NotIn),
-                    ) => {
+                match op {
+                    ast::CmpOp::Eq => tuple_rich_comparison(RichCompareOperator::Eq),
+                    ast::CmpOp::NotEq => tuple_rich_comparison(RichCompareOperator::Ne),
+                    ast::CmpOp::Lt => tuple_rich_comparison(RichCompareOperator::Lt),
+                    ast::CmpOp::LtE => tuple_rich_comparison(RichCompareOperator::Le),
+                    ast::CmpOp::Gt => tuple_rich_comparison(RichCompareOperator::Gt),
+                    ast::CmpOp::GtE => tuple_rich_comparison(RichCompareOperator::Ge),
+                    ast::CmpOp::In | ast::CmpOp::NotIn => {
                         let mut any_eq = false;
                         let mut any_ambiguous = false;
 
@@ -720,22 +640,14 @@ fn infer_binary_type_comparison_inner<'db>(
                         }
 
                         if any_eq {
-                            Ok(Type::bool_literal(
-                                membership == NonEqualityOperator::In,
-                            ))
+                            Ok(Type::bool_literal(op.is_in()))
                         } else if !any_ambiguous {
-                            Ok(Type::bool_literal(
-                                membership == NonEqualityOperator::NotIn,
-                            ))
+                            Ok(Type::bool_literal(op.is_not_in()))
                         } else {
                             Ok(KnownClass::Bool.to_instance(db))
                         }
                     }
-                    BinaryComparisonOperator::NonEquality(
-                        operator
-                        @ (NonEqualityOperator::Is
-                        | NonEqualityOperator::IsNot),
-                    ) => {
+                    ast::CmpOp::Is | ast::CmpOp::IsNot => {
                         // - `[ast::CmpOp::Is]`: returns `false` if the elements are definitely unequal, otherwise `bool`
                         // - `[ast::CmpOp::IsNot]`: returns `true` if the elements are definitely unequal, otherwise `bool`
                         let eq_result =
@@ -749,9 +661,7 @@ fn infer_binary_type_comparison_inner<'db>(
                             // for `is` and `is not` comparisons. This is an implementation detail
                             // for how we determine the truthiness of a type.
                             ty => match ty.bool(db) {
-                                Truthiness::AlwaysFalse => Type::bool_literal(
-                                    operator == NonEqualityOperator::IsNot,
-                                ),
+                                Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
                                 _ => KnownClass::Bool.to_instance(db),
                             },
                         })

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -4,15 +4,16 @@ use smallvec::SmallVec;
 
 use crate::Db;
 use crate::types::call::{CallArguments, CallDunderError};
-use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
-use crate::types::equality::{equality_truthiness, inequality_truthiness};
+use crate::types::equality::{
+    ComparisonOperator as EqualityOperator, EqualityInference, equality_inference,
+};
 use crate::types::tuple::TupleSpec;
 use crate::types::{
-    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext,
-    TypeVarBoundOrConstraints, UnionBuilder,
+    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, LiteralValueType,
+    LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeVarBoundOrConstraints,
+    UnionBuilder,
 };
 use ty_python_core::Truthiness;
 
@@ -95,6 +96,66 @@ impl From<MembershipTestCompareOperator> for ast::CmpOp {
     }
 }
 
+/// A comparison operator not handled by the equality evaluator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NonEqualityOperator {
+    Lt,
+    LtE,
+    Gt,
+    GtE,
+    In,
+    NotIn,
+    Is,
+    IsNot,
+}
+
+impl From<NonEqualityOperator> for ast::CmpOp {
+    fn from(value: NonEqualityOperator) -> Self {
+        match value {
+            NonEqualityOperator::Lt => ast::CmpOp::Lt,
+            NonEqualityOperator::LtE => ast::CmpOp::LtE,
+            NonEqualityOperator::Gt => ast::CmpOp::Gt,
+            NonEqualityOperator::GtE => ast::CmpOp::GtE,
+            NonEqualityOperator::In => ast::CmpOp::In,
+            NonEqualityOperator::NotIn => ast::CmpOp::NotIn,
+            NonEqualityOperator::Is => ast::CmpOp::Is,
+            NonEqualityOperator::IsNot => ast::CmpOp::IsNot,
+        }
+    }
+}
+
+/// Routes equality through its dedicated evaluator while sharing structural type dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BinaryComparisonOperator {
+    Equality(EqualityOperator),
+    NonEquality(NonEqualityOperator),
+}
+
+impl BinaryComparisonOperator {
+    const fn from_ast(operator: ast::CmpOp) -> Self {
+        match operator {
+            ast::CmpOp::Eq => BinaryComparisonOperator::Equality(EqualityOperator::Equality),
+            ast::CmpOp::NotEq => BinaryComparisonOperator::Equality(EqualityOperator::Inequality),
+            ast::CmpOp::Lt => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt),
+            ast::CmpOp::LtE => BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE),
+            ast::CmpOp::Gt => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt),
+            ast::CmpOp::GtE => BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE),
+            ast::CmpOp::In => BinaryComparisonOperator::NonEquality(NonEqualityOperator::In),
+            ast::CmpOp::NotIn => BinaryComparisonOperator::NonEquality(NonEqualityOperator::NotIn),
+            ast::CmpOp::Is => BinaryComparisonOperator::NonEquality(NonEqualityOperator::Is),
+            ast::CmpOp::IsNot => BinaryComparisonOperator::NonEquality(NonEqualityOperator::IsNot),
+        }
+    }
+
+    fn as_ast(self) -> ast::CmpOp {
+        match self {
+            BinaryComparisonOperator::Equality(EqualityOperator::Equality) => ast::CmpOp::Eq,
+            BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => ast::CmpOp::NotEq,
+            BinaryComparisonOperator::NonEquality(operator) => operator.into(),
+        }
+    }
+}
+
 /// Context for a failed comparison operation.
 ///
 /// `left_ty` and `right_ty` are the "low-level" types
@@ -122,12 +183,31 @@ pub(crate) struct UnsupportedComparisonError<'db> {
 pub(super) fn infer_binary_type_comparison<'db>(
     context: &InferContext<'db, '_>,
     left: Type<'db>,
-    op: ast::CmpOp,
+    operator: ast::CmpOp,
+    right: Type<'db>,
+    range: TextRange,
+    visitor: &BinaryComparisonVisitor<'db>,
+) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
+    infer_binary_type_comparison_inner(
+        context,
+        left,
+        BinaryComparisonOperator::from_ast(operator),
+        right,
+        range,
+        visitor,
+    )
+}
+
+fn infer_binary_type_comparison_inner<'db>(
+    context: &InferContext<'db, '_>,
+    left: Type<'db>,
+    operator: BinaryComparisonOperator,
     right: Type<'db>,
     range: TextRange,
     visitor: &BinaryComparisonVisitor<'db>,
 ) -> Result<Type<'db>, UnsupportedComparisonError<'db>> {
     let db = context.db();
+    let op = operator.as_ast();
 
     // Note: identity (is, is not) for equal builtin types is unreliable and not part of the
     // language spec.
@@ -139,18 +219,32 @@ pub(super) fn infer_binary_type_comparison<'db>(
             infer_membership_test_comparison(context, left, right, op, range)
         };
 
-        match op {
-            ast::CmpOp::Eq => rich_comparison(RichCompareOperator::Eq),
-            ast::CmpOp::NotEq => rich_comparison(RichCompareOperator::Ne),
-            ast::CmpOp::Lt => rich_comparison(RichCompareOperator::Lt),
-            ast::CmpOp::LtE => rich_comparison(RichCompareOperator::Le),
-            ast::CmpOp::Gt => rich_comparison(RichCompareOperator::Gt),
-            ast::CmpOp::GtE => rich_comparison(RichCompareOperator::Ge),
-            ast::CmpOp::In => membership_test_comparison(MembershipTestCompareOperator::In, range),
-            ast::CmpOp::NotIn => {
+        match operator {
+            BinaryComparisonOperator::Equality(EqualityOperator::Equality) => {
+                rich_comparison(RichCompareOperator::Eq)
+            }
+            BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => {
+                rich_comparison(RichCompareOperator::Ne)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt) => {
+                rich_comparison(RichCompareOperator::Lt)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE) => {
+                rich_comparison(RichCompareOperator::Le)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt) => {
+                rich_comparison(RichCompareOperator::Gt)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE) => {
+                rich_comparison(RichCompareOperator::Ge)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::In) => {
+                membership_test_comparison(MembershipTestCompareOperator::In, range)
+            }
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::NotIn) => {
                 membership_test_comparison(MembershipTestCompareOperator::NotIn, range)
             }
-            ast::CmpOp::Is => {
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::Is) => {
                 if left.is_disjoint_from(db, right) {
                     Ok(Type::bool_literal(false))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
@@ -159,7 +253,7 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     Ok(KnownClass::Bool.to_instance(db))
                 }
             }
-            ast::CmpOp::IsNot => {
+            BinaryComparisonOperator::NonEquality(NonEqualityOperator::IsNot) => {
                 if left.is_disjoint_from(db, right) {
                     Ok(Type::bool_literal(true))
                 } else if left.is_singleton(db) && left.is_equivalent_to(db, right) {
@@ -171,13 +265,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
         }
     };
 
-    let comparison_truthiness = match op {
-        ast::CmpOp::Eq => equality_truthiness(db, left, right),
-        ast::CmpOp::NotEq => inequality_truthiness(db, left, right),
-        _ => Truthiness::Ambiguous,
-    };
-    if comparison_truthiness != Truthiness::Ambiguous {
-        return Ok(Type::from_truthiness(db, comparison_truthiness));
+    if let BinaryComparisonOperator::Equality(operator) = operator {
+        match equality_inference(db, left, right, operator) {
+            EqualityInference::AlwaysTrue => return Ok(Type::bool_literal(true)),
+            EqualityInference::AlwaysFalse => return Ok(Type::bool_literal(false)),
+            EqualityInference::AmbiguousBoolean => return Ok(KnownClass::Bool.to_instance(db)),
+            EqualityInference::NeedsResultInference => {}
+        }
     }
 
     let comparison_result = match (left, right) {
@@ -404,26 +498,28 @@ pub(super) fn infer_binary_type_comparison<'db>(
             }
         }
 
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
-            match (left_literal.kind(), right_literal.kind()) {
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => match operator {
+            BinaryComparisonOperator::Equality(_) => None,
+            BinaryComparisonOperator::NonEquality(operator) => match (
+                left_literal.kind(),
+                right_literal.kind(),
+            ) {
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
-                    Some(match op {
-                        ast::CmpOp::Eq => Ok(Type::bool_literal(n == m)),
-                        ast::CmpOp::NotEq => Ok(Type::bool_literal(n != m)),
-                        ast::CmpOp::Lt => Ok(Type::bool_literal(n < m)),
-                        ast::CmpOp::LtE => Ok(Type::bool_literal(n <= m)),
-                        ast::CmpOp::Gt => Ok(Type::bool_literal(n > m)),
-                        ast::CmpOp::GtE => Ok(Type::bool_literal(n >= m)),
+                    Some(match operator {
+                        NonEqualityOperator::Lt => Ok(Type::bool_literal(n < m)),
+                        NonEqualityOperator::LtE => Ok(Type::bool_literal(n <= m)),
+                        NonEqualityOperator::Gt => Ok(Type::bool_literal(n > m)),
+                        NonEqualityOperator::GtE => Ok(Type::bool_literal(n >= m)),
                         // We cannot say that two equal int Literals will return True from an `is` or `is not` comparison.
                         // Even if they are the same value, they may not be the same object.
-                        ast::CmpOp::Is => {
+                        NonEqualityOperator::Is => {
                             if n == m {
                                 Ok(KnownClass::Bool.to_instance(db))
                             } else {
                                 Ok(Type::bool_literal(false))
                             }
                         }
-                        ast::CmpOp::IsNot => {
+                        NonEqualityOperator::IsNot => {
                             if n == m {
                                 Ok(KnownClass::Bool.to_instance(db))
                             } else {
@@ -431,11 +527,13 @@ pub(super) fn infer_binary_type_comparison<'db>(
                             }
                         }
                         // Undefined for (int, int)
-                        ast::CmpOp::In | ast::CmpOp::NotIn => Err(UnsupportedComparisonError {
-                            op,
-                            left_ty: left,
-                            right_ty: right,
-                        }),
+                        NonEqualityOperator::In | NonEqualityOperator::NotIn => {
+                            Err(UnsupportedComparisonError {
+                                op,
+                                left_ty: left,
+                                right_ty: right,
+                            })
+                        }
                     })
                 }
                 // Booleans are coded as integers (False = 0, True = 1)
@@ -491,23 +589,25 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 ) => {
                     let s1 = salsa_s1.value(db);
                     let s2 = salsa_s2.value(db);
-                    let result = match op {
-                        ast::CmpOp::Eq => Type::bool_literal(s1 == s2),
-                        ast::CmpOp::NotEq => Type::bool_literal(s1 != s2),
-                        ast::CmpOp::Lt => Type::bool_literal(s1 < s2),
-                        ast::CmpOp::LtE => Type::bool_literal(s1 <= s2),
-                        ast::CmpOp::Gt => Type::bool_literal(s1 > s2),
-                        ast::CmpOp::GtE => Type::bool_literal(s1 >= s2),
-                        ast::CmpOp::In => Type::bool_literal(s2.contains(s1)),
-                        ast::CmpOp::NotIn => Type::bool_literal(!s2.contains(s1)),
-                        ast::CmpOp::Is => {
+                    let result = match operator {
+                        NonEqualityOperator::Lt => Type::bool_literal(s1 < s2),
+                        NonEqualityOperator::LtE => Type::bool_literal(s1 <= s2),
+                        NonEqualityOperator::Gt => Type::bool_literal(s1 > s2),
+                        NonEqualityOperator::GtE => Type::bool_literal(s1 >= s2),
+                        NonEqualityOperator::In => {
+                            Type::bool_literal(s2.contains(s1))
+                        }
+                        NonEqualityOperator::NotIn => {
+                            Type::bool_literal(!s2.contains(s1))
+                        }
+                        NonEqualityOperator::Is => {
                             if s1 == s2 {
                                 KnownClass::Bool.to_instance(db)
                             } else {
                                 Type::bool_literal(false)
                             }
                         }
-                        ast::CmpOp::IsNot => {
+                        NonEqualityOperator::IsNot => {
                             if s1 == s2 {
                                 KnownClass::Bool.to_instance(db)
                             } else {
@@ -524,27 +624,25 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 ) => {
                     let b1 = salsa_b1.value(db);
                     let b2 = salsa_b2.value(db);
-                    let result = match op {
-                        ast::CmpOp::Eq => Type::bool_literal(b1 == b2),
-                        ast::CmpOp::NotEq => Type::bool_literal(b1 != b2),
-                        ast::CmpOp::Lt => Type::bool_literal(b1 < b2),
-                        ast::CmpOp::LtE => Type::bool_literal(b1 <= b2),
-                        ast::CmpOp::Gt => Type::bool_literal(b1 > b2),
-                        ast::CmpOp::GtE => Type::bool_literal(b1 >= b2),
-                        ast::CmpOp::In => {
+                    let result = match operator {
+                        NonEqualityOperator::Lt => Type::bool_literal(b1 < b2),
+                        NonEqualityOperator::LtE => Type::bool_literal(b1 <= b2),
+                        NonEqualityOperator::Gt => Type::bool_literal(b1 > b2),
+                        NonEqualityOperator::GtE => Type::bool_literal(b1 >= b2),
+                        NonEqualityOperator::In => {
                             Type::bool_literal(memchr::memmem::find(b2, b1).is_some())
                         }
-                        ast::CmpOp::NotIn => {
+                        NonEqualityOperator::NotIn => {
                             Type::bool_literal(memchr::memmem::find(b2, b1).is_none())
                         }
-                        ast::CmpOp::Is => {
+                        NonEqualityOperator::Is => {
                             if b1 == b2 {
                                 KnownClass::Bool.to_instance(db)
                             } else {
                                 Type::bool_literal(false)
                             }
                         }
-                        ast::CmpOp::IsNot => {
+                        NonEqualityOperator::IsNot => {
                             if b1 == b2 {
                                 KnownClass::Bool.to_instance(db)
                             } else {
@@ -555,53 +653,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     Some(Ok(result))
                 }
 
-                // Same-kind exact literals and the special relationship between `int` and `bool`
-                // are handled above. Any remaining pair of exact builtin literals compares
-                // unequal. `LiteralString` also compares unequal to non-string literals, but its
-                // comparison with an exact string literal remains ambiguous.
-                (
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::String(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::String(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                )
-                | (
-                    LiteralValueTypeKind::LiteralString,
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                )
-                | (
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                    LiteralValueTypeKind::LiteralString,
-                ) if matches!(op, ast::CmpOp::Eq | ast::CmpOp::NotEq) => {
-                    Some(Ok(Type::bool_literal(op == ast::CmpOp::NotEq)))
-                }
                 _ => None,
-            }
-        }
-
-        (
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
-        ) => {
-            let constraints = ConstraintSetBuilder::new();
-            let left = constraints.load(db, left.constraints(db));
-            let right = constraints.load(db, right.constraints(db));
-            let result = left.iff(db, &constraints, right);
-            let equivalent = result.is_always_satisfied(db);
-            match op {
-                ast::CmpOp::Eq => Some(Ok(Type::bool_literal(equivalent))),
-                ast::CmpOp::NotEq => Some(Ok(Type::bool_literal(!equivalent))),
-                _ => None,
-            }
-        }
+            },
+        },
 
         (Type::NominalInstance(nominal1), Type::NominalInstance(nominal2)) => nominal1
             .tuple_spec(db)
@@ -615,14 +669,29 @@ pub(super) fn infer_binary_type_comparison<'db>(
                     })
                 };
 
-                match op {
-                    ast::CmpOp::Eq => tuple_rich_comparison(RichCompareOperator::Eq),
-                    ast::CmpOp::NotEq => tuple_rich_comparison(RichCompareOperator::Ne),
-                    ast::CmpOp::Lt => tuple_rich_comparison(RichCompareOperator::Lt),
-                    ast::CmpOp::LtE => tuple_rich_comparison(RichCompareOperator::Le),
-                    ast::CmpOp::Gt => tuple_rich_comparison(RichCompareOperator::Gt),
-                    ast::CmpOp::GtE => tuple_rich_comparison(RichCompareOperator::Ge),
-                    ast::CmpOp::In | ast::CmpOp::NotIn => {
+                match operator {
+                    BinaryComparisonOperator::Equality(EqualityOperator::Equality) => {
+                        tuple_rich_comparison(RichCompareOperator::Eq)
+                    }
+                    BinaryComparisonOperator::Equality(EqualityOperator::Inequality) => {
+                        tuple_rich_comparison(RichCompareOperator::Ne)
+                    }
+                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::Lt) => {
+                        tuple_rich_comparison(RichCompareOperator::Lt)
+                    }
+                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::LtE) => {
+                        tuple_rich_comparison(RichCompareOperator::Le)
+                    }
+                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::Gt) => {
+                        tuple_rich_comparison(RichCompareOperator::Gt)
+                    }
+                    BinaryComparisonOperator::NonEquality(NonEqualityOperator::GtE) => {
+                        tuple_rich_comparison(RichCompareOperator::Ge)
+                    }
+                    BinaryComparisonOperator::NonEquality(
+                        membership @ (NonEqualityOperator::In
+                        | NonEqualityOperator::NotIn),
+                    ) => {
                         let mut any_eq = false;
                         let mut any_ambiguous = false;
 
@@ -651,14 +720,22 @@ pub(super) fn infer_binary_type_comparison<'db>(
                         }
 
                         if any_eq {
-                            Ok(Type::bool_literal(op.is_in()))
+                            Ok(Type::bool_literal(
+                                membership == NonEqualityOperator::In,
+                            ))
                         } else if !any_ambiguous {
-                            Ok(Type::bool_literal(op.is_not_in()))
+                            Ok(Type::bool_literal(
+                                membership == NonEqualityOperator::NotIn,
+                            ))
                         } else {
                             Ok(KnownClass::Bool.to_instance(db))
                         }
                     }
-                    ast::CmpOp::Is | ast::CmpOp::IsNot => {
+                    BinaryComparisonOperator::NonEquality(
+                        operator
+                        @ (NonEqualityOperator::Is
+                        | NonEqualityOperator::IsNot),
+                    ) => {
                         // - `[ast::CmpOp::Is]`: returns `false` if the elements are definitely unequal, otherwise `bool`
                         // - `[ast::CmpOp::IsNot]`: returns `true` if the elements are definitely unequal, otherwise `bool`
                         let eq_result =
@@ -672,7 +749,9 @@ pub(super) fn infer_binary_type_comparison<'db>(
                             // for `is` and `is not` comparisons. This is an implementation detail
                             // for how we determine the truthiness of a type.
                             ty => match ty.bool(db) {
-                                Truthiness::AlwaysFalse => Type::bool_literal(op.is_is_not()),
+                                Truthiness::AlwaysFalse => Type::bool_literal(
+                                    operator == NonEqualityOperator::IsNot,
+                                ),
                                 _ => KnownClass::Bool.to_instance(db),
                             },
                         })

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -194,15 +194,6 @@ enum RichCompareOperator {
     Le,
 }
 
-impl From<EqualityOperator> for RichCompareOperator {
-    fn from(operator: EqualityOperator) -> Self {
-        match operator {
-            EqualityOperator::Equality => Self::Eq,
-            EqualityOperator::Inequality => Self::Ne,
-        }
-    }
-}
-
 impl From<RichCompareOperator> for ast::CmpOp {
     fn from(value: RichCompareOperator) -> Self {
         match value {
@@ -241,32 +232,29 @@ impl RichCompareOperator {
         }
     }
 
-    const fn as_ordering(self) -> Option<OrderingOperator> {
+    const fn as_equality(self) -> Option<EqualityOperator> {
         match self {
-            RichCompareOperator::Gt => Some(OrderingOperator::Gt),
-            RichCompareOperator::Ge => Some(OrderingOperator::Ge),
-            RichCompareOperator::Lt => Some(OrderingOperator::Lt),
-            RichCompareOperator::Le => Some(OrderingOperator::Le),
-            RichCompareOperator::Eq | RichCompareOperator::Ne => None,
+            RichCompareOperator::Eq => Some(EqualityOperator::Equality),
+            RichCompareOperator::Ne => Some(EqualityOperator::Inequality),
+            RichCompareOperator::Gt
+            | RichCompareOperator::Ge
+            | RichCompareOperator::Lt
+            | RichCompareOperator::Le => None,
         }
     }
-}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum OrderingOperator {
-    Gt,
-    Ge,
-    Lt,
-    Le,
-}
-
-impl From<OrderingOperator> for RichCompareOperator {
-    fn from(operator: OrderingOperator) -> Self {
-        match operator {
-            OrderingOperator::Gt => Self::Gt,
-            OrderingOperator::Ge => Self::Ge,
-            OrderingOperator::Lt => Self::Lt,
-            OrderingOperator::Le => Self::Le,
+    /// Evaluate literal ordering after the shared evaluator has handled equality.
+    fn evaluate_literal_ordering<T: PartialOrd + ?Sized>(
+        self,
+        left: &T,
+        right: &T,
+    ) -> Option<bool> {
+        match self {
+            RichCompareOperator::Gt => Some(left > right),
+            RichCompareOperator::Ge => Some(left >= right),
+            RichCompareOperator::Lt => Some(left < right),
+            RichCompareOperator::Le => Some(left <= right),
+            RichCompareOperator::Eq | RichCompareOperator::Ne => None,
         }
     }
 }
@@ -297,37 +285,15 @@ impl From<MembershipOperator> for ast::CmpOp {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum NonEqualityOperator {
-    Ordering(OrderingOperator),
-    Membership(MembershipOperator),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum NonIdentityOperator {
-    Equality(EqualityOperator),
-    Ordering(OrderingOperator),
+    Rich(RichCompareOperator),
     Membership(MembershipOperator),
-}
-
-impl NonIdentityOperator {
-    const fn as_non_equality(self) -> Option<NonEqualityOperator> {
-        match self {
-            NonIdentityOperator::Equality(_) => None,
-            NonIdentityOperator::Ordering(operator) => {
-                Some(NonEqualityOperator::Ordering(operator))
-            }
-            NonIdentityOperator::Membership(operator) => {
-                Some(NonEqualityOperator::Membership(operator))
-            }
-        }
-    }
 }
 
 impl From<NonIdentityOperator> for ast::CmpOp {
     fn from(value: NonIdentityOperator) -> Self {
         match value {
-            NonIdentityOperator::Equality(operator) => RichCompareOperator::from(operator).into(),
-            NonIdentityOperator::Ordering(operator) => RichCompareOperator::from(operator).into(),
+            NonIdentityOperator::Rich(operator) => operator.into(),
             NonIdentityOperator::Membership(operator) => operator.into(),
         }
     }
@@ -374,12 +340,12 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 .negate_if(op == ast::CmpOp::IsNot);
             return Ok(Type::from_truthiness(db, env, truthiness));
         }
-        ast::CmpOp::Eq => NonIdentityOperator::Equality(EqualityOperator::Equality),
-        ast::CmpOp::NotEq => NonIdentityOperator::Equality(EqualityOperator::Inequality),
-        ast::CmpOp::Lt => NonIdentityOperator::Ordering(OrderingOperator::Lt),
-        ast::CmpOp::LtE => NonIdentityOperator::Ordering(OrderingOperator::Le),
-        ast::CmpOp::Gt => NonIdentityOperator::Ordering(OrderingOperator::Gt),
-        ast::CmpOp::GtE => NonIdentityOperator::Ordering(OrderingOperator::Ge),
+        ast::CmpOp::Eq => NonIdentityOperator::Rich(RichCompareOperator::Eq),
+        ast::CmpOp::NotEq => NonIdentityOperator::Rich(RichCompareOperator::Ne),
+        ast::CmpOp::Lt => NonIdentityOperator::Rich(RichCompareOperator::Lt),
+        ast::CmpOp::LtE => NonIdentityOperator::Rich(RichCompareOperator::Le),
+        ast::CmpOp::Gt => NonIdentityOperator::Rich(RichCompareOperator::Gt),
+        ast::CmpOp::GtE => NonIdentityOperator::Rich(RichCompareOperator::Ge),
         ast::CmpOp::In => NonIdentityOperator::Membership(MembershipOperator::In),
         ast::CmpOp::NotIn => NonIdentityOperator::Membership(MembershipOperator::NotIn),
     };
@@ -412,8 +378,7 @@ fn infer_binary_type_comparison_inner<'db>(
         };
 
         match op {
-            NonIdentityOperator::Equality(operator) => rich_comparison(operator.into()),
-            NonIdentityOperator::Ordering(operator) => rich_comparison(operator.into()),
+            NonIdentityOperator::Rich(operator) => rich_comparison(operator),
             NonIdentityOperator::Membership(membership_op) => {
                 membership_test_comparison(membership_op, range)
             }
@@ -423,20 +388,15 @@ fn infer_binary_type_comparison_inner<'db>(
     let soundness_policy =
         ComparisonSoundnessPolicy::from_analysis_settings(db.analysis_settings(context.file()));
 
-    if let NonIdentityOperator::Equality(operator) = op
+    if let NonIdentityOperator::Rich(operator) = op
+        && let Some(operator) = operator.as_equality()
         && let Some(truthiness) =
             equality_result_truthiness(db, env, left, right, operator, soundness_policy)
     {
         return Ok(Type::from_truthiness(db, env, truthiness));
     }
 
-    let rich_op = match op {
-        NonIdentityOperator::Equality(operator) => Some(operator.into()),
-        NonIdentityOperator::Ordering(operator) => Some(operator.into()),
-        NonIdentityOperator::Membership(_) => None,
-    };
-
-    if let Some(rich_op) = rich_op
+    if let NonIdentityOperator::Rich(rich_op) = op
         && let Some(left_tuple) = left.tuple_instance_spec(db, env)
         && let Some(right_tuple) = right.tuple_instance_spec(db, env)
     {
@@ -697,32 +657,20 @@ fn infer_binary_type_comparison_inner<'db>(
             }
         }
 
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal))
-            if let Some(operator) = op.as_non_equality() =>
-        {
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
             match (left_literal.kind(), right_literal.kind()) {
-                (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
-                    Some(match operator {
-                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
-                            Ok(Type::bool_literal(n < m))
-                        }
-                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
-                            Ok(Type::bool_literal(n <= m))
-                        }
-                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
-                            Ok(Type::bool_literal(n > m))
-                        }
-                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
-                            Ok(Type::bool_literal(n >= m))
-                        }
-                        // Undefined for (int, int)
-                        NonEqualityOperator::Membership(_) => Err(UnsupportedComparisonError {
-                            op: op.into(),
-                            left_ty: left,
-                            right_ty: right,
-                        }),
-                    })
-                }
+                (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => match op {
+                    NonIdentityOperator::Rich(operator) => operator
+                        .evaluate_literal_ordering(&n, &m)
+                        .map(Type::bool_literal)
+                        .map(Ok),
+                    // Undefined for (int, int)
+                    NonIdentityOperator::Membership(_) => Some(Err(UnsupportedComparisonError {
+                        op: op.into(),
+                        left_ty: left,
+                        right_ty: right,
+                    })),
+                },
                 // Booleans are coded as integers (False = 0, True = 1)
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Bool(b)) => Some(
                     infer_binary_type_comparison_inner(
@@ -776,53 +724,35 @@ fn infer_binary_type_comparison_inner<'db>(
                 ) => {
                     let s1 = salsa_s1.value(db);
                     let s2 = salsa_s2.value(db);
-                    let result = match operator {
-                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
-                            Type::bool_literal(s1 < s2)
+                    let result = match op {
+                        NonIdentityOperator::Rich(operator) => {
+                            operator.evaluate_literal_ordering(s1, s2)
                         }
-                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
-                            Type::bool_literal(s1 <= s2)
+                        NonIdentityOperator::Membership(MembershipOperator::In) => {
+                            Some(s2.contains(s1))
                         }
-                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
-                            Type::bool_literal(s1 > s2)
-                        }
-                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
-                            Type::bool_literal(s1 >= s2)
-                        }
-                        NonEqualityOperator::Membership(MembershipOperator::In) => {
-                            Type::bool_literal(s2.contains(s1))
-                        }
-                        NonEqualityOperator::Membership(MembershipOperator::NotIn) => {
-                            Type::bool_literal(!s2.contains(s1))
+                        NonIdentityOperator::Membership(MembershipOperator::NotIn) => {
+                            Some(!s2.contains(s1))
                         }
                     };
-                    Some(Ok(result))
+                    result.map(Type::bool_literal).map(Ok)
                 }
 
                 (LiteralValueTypeKind::Bytes(salsa_b1), LiteralValueTypeKind::Bytes(salsa_b2)) => {
                     let b1 = salsa_b1.value(db);
                     let b2 = salsa_b2.value(db);
-                    let result = match operator {
-                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
-                            Type::bool_literal(b1 < b2)
+                    let result = match op {
+                        NonIdentityOperator::Rich(operator) => {
+                            operator.evaluate_literal_ordering(b1, b2)
                         }
-                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
-                            Type::bool_literal(b1 <= b2)
+                        NonIdentityOperator::Membership(MembershipOperator::In) => {
+                            Some(memchr::memmem::find(b2, b1).is_some())
                         }
-                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
-                            Type::bool_literal(b1 > b2)
-                        }
-                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
-                            Type::bool_literal(b1 >= b2)
-                        }
-                        NonEqualityOperator::Membership(MembershipOperator::In) => {
-                            Type::bool_literal(memchr::memmem::find(b2, b1).is_some())
-                        }
-                        NonEqualityOperator::Membership(MembershipOperator::NotIn) => {
-                            Type::bool_literal(memchr::memmem::find(b2, b1).is_none())
+                        NonIdentityOperator::Membership(MembershipOperator::NotIn) => {
+                            Some(memchr::memmem::find(b2, b1).is_none())
                         }
                     };
-                    Some(Ok(result))
+                    result.map(Type::bool_literal).map(Ok)
                 }
 
                 _ => None,
@@ -1158,21 +1088,24 @@ fn infer_tuple_rich_comparison<'db>(
                     // or terminate here (if eq_result is false).
                     // To account for cases where the comparison terminates here, add the pairwise comparison result to the union builder.
                     eq_truthiness @ (Truthiness::AlwaysFalse | Truthiness::Ambiguous) => {
-                        let pairwise_compare_result = if let Some(ordering) = op.as_ordering() {
-                            infer_binary_type_comparison_inner(
+                        let pairwise_compare_result = match op {
+                            RichCompareOperator::Lt
+                            | RichCompareOperator::Le
+                            | RichCompareOperator::Gt
+                            | RichCompareOperator::Ge => infer_binary_type_comparison_inner(
                                 context,
                                 l_ty,
-                                NonIdentityOperator::Ordering(ordering),
+                                NonIdentityOperator::Rich(op),
                                 r_ty,
                                 range,
                                 visitor,
-                            )?
-                        } else {
+                            )?,
                             // For `==` and `!=`, the equality evaluator has already determined
                             // that these elements may differ.
                             // NOTE: The CPython implementation does not account for non-boolean return types
                             // or cases where `!=` is not the negation of `==`, we also do not consider these cases.
-                            Type::bool_literal(op == RichCompareOperator::Ne)
+                            RichCompareOperator::Eq => Type::bool_literal(false),
+                            RichCompareOperator::Ne => Type::bool_literal(true),
                         };
 
                         builder = builder.add(pairwise_compare_result);
@@ -1206,20 +1139,23 @@ fn infer_tuple_rich_comparison<'db>(
         // compare lexicographically. However, we still need to verify that the
         // element types are comparable for ordering comparisons.
 
+        // For equality comparisons (==, !=), any two objects can be compared,
+        // and tuple equality always returns bool regardless of element __eq__ return types.
+        (TupleSpec::Variable(_), _) | (_, TupleSpec::Variable(_))
+            if matches!(op, RichCompareOperator::Eq | RichCompareOperator::Ne) =>
+        {
+            Ok(KnownClass::Bool.to_instance(db, env))
+        }
+
         // At least one variable-length: check all elements that could potentially be compared.
         // We use `try_for_each_element_pair` to iterate over all possible pairings.
         (left @ TupleSpec::Variable(_), right) | (left, right @ TupleSpec::Variable(_)) => {
-            // Any two objects can be compared for equality, and tuple equality always returns
-            // `bool` regardless of the element comparison return types.
-            let Some(ordering) = op.as_ordering() else {
-                return Ok(KnownClass::Bool.to_instance(db, env));
-            };
             let mut results = SmallVec::<[Type<'db>; 8]>::new();
             left.try_for_each_element_pair(db, right, |l_ty, r_ty| {
                 results.push(infer_binary_type_comparison_inner(
                     context,
                     l_ty,
-                    NonIdentityOperator::Ordering(ordering),
+                    NonIdentityOperator::Rich(op),
                     r_ty,
                     range,
                     visitor,

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -293,8 +293,8 @@ enum NonIdentityOperator {
 impl From<NonIdentityOperator> for ast::CmpOp {
     fn from(value: NonIdentityOperator) -> Self {
         match value {
-            NonIdentityOperator::Rich(operator) => operator.into(),
-            NonIdentityOperator::Membership(operator) => operator.into(),
+            NonIdentityOperator::Rich(rich_op) => rich_op.into(),
+            NonIdentityOperator::Membership(membership_op) => membership_op.into(),
         }
     }
 }
@@ -378,7 +378,7 @@ fn infer_binary_type_comparison_inner<'db>(
         };
 
         match op {
-            NonIdentityOperator::Rich(operator) => rich_comparison(operator),
+            NonIdentityOperator::Rich(rich_op) => rich_comparison(rich_op),
             NonIdentityOperator::Membership(membership_op) => {
                 membership_test_comparison(membership_op, range)
             }
@@ -387,14 +387,6 @@ fn infer_binary_type_comparison_inner<'db>(
 
     let soundness_policy =
         ComparisonSoundnessPolicy::from_analysis_settings(db.analysis_settings(context.file()));
-
-    if let NonIdentityOperator::Rich(operator) = op
-        && let Some(operator) = operator.as_equality()
-        && let Some(truthiness) =
-            equality_result_truthiness(db, env, left, right, operator, soundness_policy)
-    {
-        return Ok(Type::from_truthiness(db, env, truthiness));
-    }
 
     if let NonIdentityOperator::Rich(rich_op) = op
         && let Some(left_tuple) = left.tuple_instance_spec(db, env)
@@ -434,6 +426,14 @@ fn infer_binary_type_comparison_inner<'db>(
         } else {
             KnownClass::Bool.to_instance(db, env)
         });
+    }
+
+    if let NonIdentityOperator::Rich(operator) = op
+        && let Some(operator) = operator.as_equality()
+        && let Some(truthiness) =
+            equality_result_truthiness(db, env, left, right, operator, soundness_policy)
+    {
+        return Ok(Type::from_truthiness(db, env, truthiness));
     }
 
     let comparison_result = match (left, right) {

--- a/crates/ty_python_semantic/src/types/infer/comparisons.rs
+++ b/crates/ty_python_semantic/src/types/infer/comparisons.rs
@@ -5,16 +5,16 @@ use smallvec::SmallVec;
 
 use crate::ProgramEnvironment;
 use crate::types::call::{CallArguments, CallDunderError};
-use crate::types::constraints::ConstraintSetBuilder;
 use crate::types::context::InferContext;
 use crate::types::cyclic::CycleDetector;
 use crate::types::equality::{
-    ComparisonSoundnessPolicy, TupleEqualityEvaluator, equality_truthiness, inequality_truthiness,
+    ComparisonOperator as EqualityOperator, ComparisonSoundnessPolicy, TupleEqualityEvaluator,
+    equality_result_truthiness,
 };
 use crate::types::tuple::{Tuple, TupleSpec};
 use crate::types::{
-    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType,
-    LiteralValueType, LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeTransformer,
+    DynamicType, IntersectionBuilder, IntersectionType, KnownClass, LiteralValueType,
+    LiteralValueTypeKind, MemberLookupPolicy, Type, TypeContext, TypeTransformer,
     TypeVarBoundOrConstraints, UnionBuilder,
 };
 use ty_python_core::Truthiness;
@@ -194,6 +194,15 @@ enum RichCompareOperator {
     Le,
 }
 
+impl From<EqualityOperator> for RichCompareOperator {
+    fn from(operator: EqualityOperator) -> Self {
+        match operator {
+            EqualityOperator::Equality => Self::Eq,
+            EqualityOperator::Inequality => Self::Ne,
+        }
+    }
+}
+
 impl From<RichCompareOperator> for ast::CmpOp {
     fn from(value: RichCompareOperator) -> Self {
         match value {
@@ -231,6 +240,35 @@ impl RichCompareOperator {
             RichCompareOperator::Ge => RichCompareOperator::Le,
         }
     }
+
+    const fn as_ordering(self) -> Option<OrderingOperator> {
+        match self {
+            RichCompareOperator::Gt => Some(OrderingOperator::Gt),
+            RichCompareOperator::Ge => Some(OrderingOperator::Ge),
+            RichCompareOperator::Lt => Some(OrderingOperator::Lt),
+            RichCompareOperator::Le => Some(OrderingOperator::Le),
+            RichCompareOperator::Eq | RichCompareOperator::Ne => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum OrderingOperator {
+    Gt,
+    Ge,
+    Lt,
+    Le,
+}
+
+impl From<OrderingOperator> for RichCompareOperator {
+    fn from(operator: OrderingOperator) -> Self {
+        match operator {
+            OrderingOperator::Gt => Self::Gt,
+            OrderingOperator::Ge => Self::Ge,
+            OrderingOperator::Lt => Self::Lt,
+            OrderingOperator::Le => Self::Le,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -259,16 +297,38 @@ impl From<MembershipOperator> for ast::CmpOp {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum NonIdentityOperator {
-    Rich(RichCompareOperator),
+enum NonEqualityOperator {
+    Ordering(OrderingOperator),
     Membership(MembershipOperator),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum NonIdentityOperator {
+    Equality(EqualityOperator),
+    Ordering(OrderingOperator),
+    Membership(MembershipOperator),
+}
+
+impl NonIdentityOperator {
+    const fn as_non_equality(self) -> Option<NonEqualityOperator> {
+        match self {
+            NonIdentityOperator::Equality(_) => None,
+            NonIdentityOperator::Ordering(operator) => {
+                Some(NonEqualityOperator::Ordering(operator))
+            }
+            NonIdentityOperator::Membership(operator) => {
+                Some(NonEqualityOperator::Membership(operator))
+            }
+        }
+    }
 }
 
 impl From<NonIdentityOperator> for ast::CmpOp {
     fn from(value: NonIdentityOperator) -> Self {
         match value {
-            NonIdentityOperator::Rich(rich_op) => rich_op.into(),
-            NonIdentityOperator::Membership(membership_op) => membership_op.into(),
+            NonIdentityOperator::Equality(operator) => RichCompareOperator::from(operator).into(),
+            NonIdentityOperator::Ordering(operator) => RichCompareOperator::from(operator).into(),
+            NonIdentityOperator::Membership(operator) => operator.into(),
         }
     }
 }
@@ -314,12 +374,12 @@ pub(super) fn infer_binary_type_comparison<'db>(
                 .negate_if(op == ast::CmpOp::IsNot);
             return Ok(Type::from_truthiness(db, env, truthiness));
         }
-        ast::CmpOp::Eq => NonIdentityOperator::Rich(RichCompareOperator::Eq),
-        ast::CmpOp::NotEq => NonIdentityOperator::Rich(RichCompareOperator::Ne),
-        ast::CmpOp::Lt => NonIdentityOperator::Rich(RichCompareOperator::Lt),
-        ast::CmpOp::LtE => NonIdentityOperator::Rich(RichCompareOperator::Le),
-        ast::CmpOp::Gt => NonIdentityOperator::Rich(RichCompareOperator::Gt),
-        ast::CmpOp::GtE => NonIdentityOperator::Rich(RichCompareOperator::Ge),
+        ast::CmpOp::Eq => NonIdentityOperator::Equality(EqualityOperator::Equality),
+        ast::CmpOp::NotEq => NonIdentityOperator::Equality(EqualityOperator::Inequality),
+        ast::CmpOp::Lt => NonIdentityOperator::Ordering(OrderingOperator::Lt),
+        ast::CmpOp::LtE => NonIdentityOperator::Ordering(OrderingOperator::Le),
+        ast::CmpOp::Gt => NonIdentityOperator::Ordering(OrderingOperator::Gt),
+        ast::CmpOp::GtE => NonIdentityOperator::Ordering(OrderingOperator::Ge),
         ast::CmpOp::In => NonIdentityOperator::Membership(MembershipOperator::In),
         ast::CmpOp::NotIn => NonIdentityOperator::Membership(MembershipOperator::NotIn),
     };
@@ -352,7 +412,8 @@ fn infer_binary_type_comparison_inner<'db>(
         };
 
         match op {
-            NonIdentityOperator::Rich(rich_op) => rich_comparison(rich_op),
+            NonIdentityOperator::Equality(operator) => rich_comparison(operator.into()),
+            NonIdentityOperator::Ordering(operator) => rich_comparison(operator.into()),
             NonIdentityOperator::Membership(membership_op) => {
                 membership_test_comparison(membership_op, range)
             }
@@ -362,7 +423,20 @@ fn infer_binary_type_comparison_inner<'db>(
     let soundness_policy =
         ComparisonSoundnessPolicy::from_analysis_settings(db.analysis_settings(context.file()));
 
-    if let NonIdentityOperator::Rich(rich_op) = op
+    if let NonIdentityOperator::Equality(operator) = op
+        && let Some(truthiness) =
+            equality_result_truthiness(db, env, left, right, operator, soundness_policy)
+    {
+        return Ok(Type::from_truthiness(db, env, truthiness));
+    }
+
+    let rich_op = match op {
+        NonIdentityOperator::Equality(operator) => Some(operator.into()),
+        NonIdentityOperator::Ordering(operator) => Some(operator.into()),
+        NonIdentityOperator::Membership(_) => None,
+    };
+
+    if let Some(rich_op) = rich_op
         && let Some(left_tuple) = left.tuple_instance_spec(db, env)
         && let Some(right_tuple) = right.tuple_instance_spec(db, env)
     {
@@ -400,19 +474,6 @@ fn infer_binary_type_comparison_inner<'db>(
         } else {
             KnownClass::Bool.to_instance(db, env)
         });
-    }
-
-    let comparison_truthiness = match op {
-        NonIdentityOperator::Rich(RichCompareOperator::Eq) => {
-            equality_truthiness(db, env, left, right, soundness_policy)
-        }
-        NonIdentityOperator::Rich(RichCompareOperator::Ne) => {
-            inequality_truthiness(db, env, left, right, soundness_policy)
-        }
-        _ => Truthiness::Ambiguous,
-    };
-    if comparison_truthiness != Truthiness::Ambiguous {
-        return Ok(Type::from_truthiness(db, env, comparison_truthiness));
     }
 
     let comparison_result = match (left, right) {
@@ -636,30 +697,26 @@ fn infer_binary_type_comparison_inner<'db>(
             }
         }
 
-        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal)) => {
+        (Type::LiteralValue(left_literal), Type::LiteralValue(right_literal))
+            if let Some(operator) = op.as_non_equality() =>
+        {
             match (left_literal.kind(), right_literal.kind()) {
                 (LiteralValueTypeKind::Int(n), LiteralValueTypeKind::Int(m)) => {
-                    Some(match op {
-                        NonIdentityOperator::Rich(RichCompareOperator::Eq) => {
-                            Ok(Type::bool_literal(n == m))
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ne) => {
-                            Ok(Type::bool_literal(n != m))
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Lt) => {
+                    Some(match operator {
+                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
                             Ok(Type::bool_literal(n < m))
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Le) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
                             Ok(Type::bool_literal(n <= m))
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Gt) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
                             Ok(Type::bool_literal(n > m))
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ge) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
                             Ok(Type::bool_literal(n >= m))
                         }
                         // Undefined for (int, int)
-                        NonIdentityOperator::Membership(_) => Err(UnsupportedComparisonError {
+                        NonEqualityOperator::Membership(_) => Err(UnsupportedComparisonError {
                             op: op.into(),
                             left_ty: left,
                             right_ty: right,
@@ -719,29 +776,23 @@ fn infer_binary_type_comparison_inner<'db>(
                 ) => {
                     let s1 = salsa_s1.value(db);
                     let s2 = salsa_s2.value(db);
-                    let result = match op {
-                        NonIdentityOperator::Rich(RichCompareOperator::Eq) => {
-                            Type::bool_literal(s1 == s2)
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ne) => {
-                            Type::bool_literal(s1 != s2)
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Lt) => {
+                    let result = match operator {
+                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
                             Type::bool_literal(s1 < s2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Le) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
                             Type::bool_literal(s1 <= s2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Gt) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
                             Type::bool_literal(s1 > s2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ge) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
                             Type::bool_literal(s1 >= s2)
                         }
-                        NonIdentityOperator::Membership(MembershipOperator::In) => {
+                        NonEqualityOperator::Membership(MembershipOperator::In) => {
                             Type::bool_literal(s2.contains(s1))
                         }
-                        NonIdentityOperator::Membership(MembershipOperator::NotIn) => {
+                        NonEqualityOperator::Membership(MembershipOperator::NotIn) => {
                             Type::bool_literal(!s2.contains(s1))
                         }
                     };
@@ -751,87 +802,29 @@ fn infer_binary_type_comparison_inner<'db>(
                 (LiteralValueTypeKind::Bytes(salsa_b1), LiteralValueTypeKind::Bytes(salsa_b2)) => {
                     let b1 = salsa_b1.value(db);
                     let b2 = salsa_b2.value(db);
-                    let result = match op {
-                        NonIdentityOperator::Rich(RichCompareOperator::Eq) => {
-                            Type::bool_literal(b1 == b2)
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ne) => {
-                            Type::bool_literal(b1 != b2)
-                        }
-                        NonIdentityOperator::Rich(RichCompareOperator::Lt) => {
+                    let result = match operator {
+                        NonEqualityOperator::Ordering(OrderingOperator::Lt) => {
                             Type::bool_literal(b1 < b2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Le) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Le) => {
                             Type::bool_literal(b1 <= b2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Gt) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Gt) => {
                             Type::bool_literal(b1 > b2)
                         }
-                        NonIdentityOperator::Rich(RichCompareOperator::Ge) => {
+                        NonEqualityOperator::Ordering(OrderingOperator::Ge) => {
                             Type::bool_literal(b1 >= b2)
                         }
-                        NonIdentityOperator::Membership(MembershipOperator::In) => {
+                        NonEqualityOperator::Membership(MembershipOperator::In) => {
                             Type::bool_literal(memchr::memmem::find(b2, b1).is_some())
                         }
-                        NonIdentityOperator::Membership(MembershipOperator::NotIn) => {
+                        NonEqualityOperator::Membership(MembershipOperator::NotIn) => {
                             Type::bool_literal(memchr::memmem::find(b2, b1).is_none())
                         }
                     };
                     Some(Ok(result))
                 }
 
-                // Same-kind exact literals and the special relationship between `int` and `bool`
-                // are handled above. Any remaining pair of exact builtin literals compares
-                // unequal. `LiteralString` also compares unequal to non-string literals, but its
-                // comparison with an exact string literal remains ambiguous.
-                (
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::String(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::String(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                )
-                | (
-                    LiteralValueTypeKind::LiteralString,
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                )
-                | (
-                    LiteralValueTypeKind::Int(_)
-                    | LiteralValueTypeKind::Bool(_)
-                    | LiteralValueTypeKind::Bytes(_),
-                    LiteralValueTypeKind::LiteralString,
-                ) if let NonIdentityOperator::Rich(
-                    rich @ (RichCompareOperator::Eq | RichCompareOperator::Ne),
-                ) = op =>
-                {
-                    Some(Ok(Type::bool_literal(rich == RichCompareOperator::Ne)))
-                }
-                _ => None,
-            }
-        }
-
-        (
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(left)),
-            Type::KnownInstance(KnownInstanceType::ConstraintSet(right)),
-        ) => {
-            let constraints = ConstraintSetBuilder::new();
-            let left = constraints.load(db, env, left.constraints(db));
-            let right = constraints.load(db, env, right.constraints(db));
-            let equivalent = left
-                .iff(db, &constraints, right)
-                .is_always_satisfied(db, env);
-            match op {
-                NonIdentityOperator::Rich(RichCompareOperator::Eq) => {
-                    Some(Ok(Type::bool_literal(equivalent)))
-                }
-                NonIdentityOperator::Rich(RichCompareOperator::Ne) => {
-                    Some(Ok(Type::bool_literal(!equivalent)))
-                }
                 _ => None,
             }
         }
@@ -1165,24 +1158,21 @@ fn infer_tuple_rich_comparison<'db>(
                     // or terminate here (if eq_result is false).
                     // To account for cases where the comparison terminates here, add the pairwise comparison result to the union builder.
                     eq_truthiness @ (Truthiness::AlwaysFalse | Truthiness::Ambiguous) => {
-                        let pairwise_compare_result = match op {
-                            RichCompareOperator::Lt
-                            | RichCompareOperator::Le
-                            | RichCompareOperator::Gt
-                            | RichCompareOperator::Ge => infer_binary_type_comparison_inner(
+                        let pairwise_compare_result = if let Some(ordering) = op.as_ordering() {
+                            infer_binary_type_comparison_inner(
                                 context,
                                 l_ty,
-                                NonIdentityOperator::Rich(op),
+                                NonIdentityOperator::Ordering(ordering),
                                 r_ty,
                                 range,
                                 visitor,
-                            )?,
+                            )?
+                        } else {
                             // For `==` and `!=`, the equality evaluator has already determined
                             // that these elements may differ.
                             // NOTE: The CPython implementation does not account for non-boolean return types
                             // or cases where `!=` is not the negation of `==`, we also do not consider these cases.
-                            RichCompareOperator::Eq => Type::bool_literal(false),
-                            RichCompareOperator::Ne => Type::bool_literal(true),
+                            Type::bool_literal(op == RichCompareOperator::Ne)
                         };
 
                         builder = builder.add(pairwise_compare_result);
@@ -1216,23 +1206,20 @@ fn infer_tuple_rich_comparison<'db>(
         // compare lexicographically. However, we still need to verify that the
         // element types are comparable for ordering comparisons.
 
-        // For equality comparisons (==, !=), any two objects can be compared,
-        // and tuple equality always returns bool regardless of element __eq__ return types.
-        (TupleSpec::Variable(_), _) | (_, TupleSpec::Variable(_))
-            if matches!(op, RichCompareOperator::Eq | RichCompareOperator::Ne) =>
-        {
-            Ok(KnownClass::Bool.to_instance(db, env))
-        }
-
         // At least one variable-length: check all elements that could potentially be compared.
         // We use `try_for_each_element_pair` to iterate over all possible pairings.
         (left @ TupleSpec::Variable(_), right) | (left, right @ TupleSpec::Variable(_)) => {
+            // Any two objects can be compared for equality, and tuple equality always returns
+            // `bool` regardless of the element comparison return types.
+            let Some(ordering) = op.as_ordering() else {
+                return Ok(KnownClass::Bool.to_instance(db, env));
+            };
             let mut results = SmallVec::<[Type<'db>; 8]>::new();
             left.try_for_each_element_pair(db, right, |l_ty, r_ty| {
                 results.push(infer_binary_type_comparison_inner(
                     context,
                     l_ty,
-                    NonIdentityOperator::Rich(op),
+                    NonIdentityOperator::Ordering(ordering),
                     r_ty,
                     range,
                     visitor,


### PR DESCRIPTION
## Summary

#26337 routes definite `==` and `!=` results through the shared equality evaluator before falling back to normal expression inference. When that evaluator returns ambiguous truthiness, however, we still run the full comparison dispatcher, repeating literal, tuple, and constraint-set work just to distinguish a builtin `bool` result from an arbitrary custom comparison return type.

This splits the top-level dispatch between equality and the other comparison operators. Equality evaluation now distinguishes definite truthiness, ambiguous builtin `bool`, and comparisons whose result type still needs to be inferred. Known builtin comparisons can stop after the shared evaluator, while custom comparisons continue through structural dispatch and the existing dunder fallback. The remaining literal dispatch uses a narrower non-equality operator enum, so it no longer duplicates the `==` and `!=` cases.

To make the shared path complete, this also moves constraint-set equality and builtin tuple equality into the equality evaluator. Fixed-length tuples compare their elements using equality semantics even for an outer `!=`, while uncertain element results still fall back to expression inference so custom return types and bool-conversion diagnostics are preserved. Regression coverage verifies that equality and inequality over union arms retain each custom dunder return type.
