### PR TITLE
ruff: Add `--extend-exclude` to `ruff format`

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -538,6 +538,14 @@ pub struct FormatCommand {
         help_heading = "File selection"
     )]
     pub exclude: Option<Vec<FilePattern>>,
+    /// Like --exclude, but adds additional files and directories on top of those already excluded.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "FILE_PATTERN",
+        help_heading = "File selection"
+    )]
+    pub extend_exclude: Option<Vec<FilePattern>>,
 
     /// Enforce exclusions, even for paths passed to Ruff directly on the command-line.
     /// Use `--no-force-exclude` to disable.
@@ -837,6 +845,7 @@ impl FormatCommand {
             line_length: self.line_length,
             respect_gitignore: resolve_bool_arg(self.respect_gitignore, self.no_respect_gitignore),
             exclude: self.exclude,
+            extend_exclude: self.extend_exclude,
             preview: resolve_bool_arg(self.preview, self.no_preview).map(PreviewMode::from),
             force_exclude: resolve_bool_arg(self.force_exclude, self.no_force_exclude),
             target_version: self.target_version.map(ast::PythonVersion::from),

--- a/crates/ruff/tests/cli/format.rs
+++ b/crates/ruff/tests/cli/format.rs
@@ -469,37 +469,13 @@ fn extend_exclude_cli() -> Result<()> {
 extend-exclude = ["out"]
 
 [format]
-exclude = ["test.py"]
+exclude = ["format_excluded.py"]
 "#,
         ),
-        (
-            "main.py",
-            r#"
-from test import say_hy
-
-if __name__ == "__main__":
-    say_hy("dear Ruff contributor")
-"#,
-        ),
-        // Excluded by `format.exclude` from the config.
-        (
-            "test.py",
-            r#"
-def say_hy(name: str):
-        print(f"Hy {name}")"#,
-        ),
-        // Excluded by `--extend-exclude` on the CLI.
-        (
-            "generated.py",
-            r#"NUMBERS = [
-     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
-    10, 11, 12, 13, 14, 15, 16, 17, 18, 19
-]
-OTHER = "OTHER"
-"#,
-        ),
-        // Excluded by `extend-exclude` from the config.
-        ("out/a.py", "a = a"),
+        ("main.py", "x    = 1"),
+        ("format_excluded.py", "x    = 1"),
+        ("cli_excluded.py", "x    = 1"),
+        ("out/a.py", "x    = 1"),
     ])?;
 
     assert_cmd_snapshot!(test.format_command()
@@ -508,7 +484,7 @@ OTHER = "OTHER"
             "--config",
             "ruff.toml",
             "--extend-exclude",
-            "generated.py",
+            "cli_excluded.py",
         ])
         .arg("."), @"
     success: false
@@ -1050,7 +1026,7 @@ if True:
       Cause: Failed to parse [TMP]/ruff.toml
       Cause: TOML parse error at line 1, column 1
       |
-    1 |
+    1 | 
       | ^
     unknown field `tab-size`
     ");

--- a/crates/ruff/tests/cli/format.rs
+++ b/crates/ruff/tests/cli/format.rs
@@ -459,6 +459,69 @@ OTHER = "OTHER"
     Ok(())
 }
 
+/// Regression test for <https://github.com/astral-sh/ruff/issues/18980>
+#[test]
+fn extend_exclude_cli() -> Result<()> {
+    let test = CliTest::with_files([
+        (
+            "ruff.toml",
+            r#"
+extend-exclude = ["out"]
+
+[format]
+exclude = ["test.py"]
+"#,
+        ),
+        (
+            "main.py",
+            r#"
+from test import say_hy
+
+if __name__ == "__main__":
+    say_hy("dear Ruff contributor")
+"#,
+        ),
+        // Excluded by `format.exclude` from the config.
+        (
+            "test.py",
+            r#"
+def say_hy(name: str):
+        print(f"Hy {name}")"#,
+        ),
+        // Excluded by `--extend-exclude` on the CLI.
+        (
+            "generated.py",
+            r#"NUMBERS = [
+     0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19
+]
+OTHER = "OTHER"
+"#,
+        ),
+        // Excluded by `extend-exclude` from the config.
+        ("out/a.py", "a = a"),
+    ])?;
+
+    assert_cmd_snapshot!(test.format_command()
+        .args([
+            "--check",
+            "--config",
+            "ruff.toml",
+            "--extend-exclude",
+            "generated.py",
+        ])
+        .arg("."), @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    Would reformat: main.py
+    1 file would be reformatted
+
+    ----- stderr -----
+    ");
+    Ok(())
+}
+
 /// Regression test for <https://github.com/astral-sh/ruff/issues/20035>
 #[test]
 fn deduplicate_directory_and_explicit_file() -> Result<()> {
@@ -987,7 +1050,7 @@ if True:
       Cause: Failed to parse [TMP]/ruff.toml
       Cause: TOML parse error at line 1, column 1
       |
-    1 | 
+    1 |
       | ^
     unknown field `tab-size`
     ");

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -767,6 +767,9 @@ File selection:
           files. Use `--no-respect-gitignore` to disable
       --exclude <FILE_PATTERN>
           List of paths, used to omit files and/or directories from analysis
+      --extend-exclude <FILE_PATTERN>
+          Like --exclude, but adds additional files and directories on top of
+          those already excluded
       --force-exclude
           Enforce exclusions, even for paths passed to Ruff directly on the
           command-line. Use `--no-force-exclude` to disable

--- a/ruff.schema.json
+++ b/ruff.schema.json
@@ -5132,7 +5132,6 @@
         "pytest-erroneous-use-fixtures-on-fixture",
         "pytest-extraneous-scope-function",
         "pytest-fail-without-message",
-        "pytest-fixture-autouse",
         "pytest-fixture-finalizer-callback",
         "pytest-fixture-incorrect-parentheses-style",
         "pytest-fixture-param-without-value",


### PR DESCRIPTION
## Summary

See commit messages.

Closes https://github.com/astral-sh/ruff/issues/18980

## Test Plan

At $dayjob I'm working on a repository in which we call ruff/ty with `--extend-exclude` because of various reasons. I uninstalled the version of ruff installed by uv and tested this installation, and it did what I expected.

It respected both the default configured excludes in `pyproject.toml` and the extended excludes passed via `--extend-exclude`, which I could confirm with both `--show-files` and simply running the check.