### PR TITLE
Handle additional `ruff:ignore` edge cases after a shebang

### DIFF
--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -1069,3 +1069,21 @@ select = ["D100"]
 #!/usr/bin/env python
 # ruff:ignore[D100]
 ```
+
+## Empty diagnostic range before a shebang with a trailing ignore
+
+A trailing ignore on the first line after a shebang should suppress diagnostics with an empty range
+at offset zero, as with `noqa`.
+
+```toml
+[lint]
+preview = true
+select = ["CPY001", "D100", "RUF100"]
+```
+
+```py
+#!/usr/bin/env python3
+from __future__ import annotations  # ruff:ignore[missing-copyright-notice, undocumented-public-module]
+
+from importlib.metadata import version as get_version
+```

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -779,25 +779,23 @@ impl<'a> SuppressionsBuilder<'a> {
             SuppressionAction::Ignore => {
                 if is_ruff_ignore_enabled(self.settings) {
                     let (before, after) = tokens.split_at(suppression.token_range.start());
-                    let range = if indentation_at_offset(suppression.range.start(), self.source)
+                    let mut range = if indentation_at_offset(suppression.range.start(), self.source)
                         .is_some()
                     {
                         // own-line ignore
-                        let mut range =
-                            Self::standalone_comment_range(suppression.range, before, after);
-
-                        // Allow an ignore to suppress diagnostics on a leading shebang.
-                        if let Some(shebang) = leading_shebang_range(self.source, tokens)
-                            && shebang.end() == self.source.line_start(suppression.range.start())
-                        {
-                            range = shebang.cover(range);
-                        }
-
-                        range
+                        Self::standalone_comment_range(suppression.range, before, after)
                     } else {
                         // trailing ignore
                         self.trailing_comment_range(suppression.token_range, before)
                     };
+
+                    // Allow an ignore to suppress diagnostics on a leading shebang.
+                    if let Some(shebang) = leading_shebang_range(self.source, tokens)
+                        && shebang.end() == self.source.line_start(suppression.range.start())
+                    {
+                        range = shebang.cover(range);
+                    }
+
                     for code in suppression.codes_as_str(self.source) {
                         self.valid.push(Suppression {
                             code: code.into(),


### PR DESCRIPTION
Summary
--

This is a follow-up to #26286. The problem apparently applies not only to own-line comments but also
to end-of-line suppressions, which can be added instead if there is code immediately following the
shebang.

Test Plan
--

New mdtest based on findings from my work on #26346
