### PR TITLE
[ty] Avoid duplicate configuration error output

### DIFF
--- a/crates/ty/tests/cli/config_option.rs
+++ b/crates/ty/tests/cli/config_option.rs
@@ -190,3 +190,26 @@ fn config_file_override() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn invalid_configuration_file() -> anyhow::Result<()> {
+    let case = CliTest::with_files([("ty.toml", "x"), ("test.py", "")])?;
+
+    assert_cmd_snapshot!(case.command().arg("--config-file").arg("ty.toml"), @"
+    success: false
+    exit_code: 2
+    ----- stdout -----
+
+    ----- stderr -----
+    ty failed
+      Cause: Error loading configuration file at <temp_dir>/ty.toml
+      Cause: <temp_dir>/ty.toml is not a valid `ty.toml`
+      Cause: TOML parse error at line 1, column 2
+      |
+    1 | x
+      |  ^
+    key with no value, expected `=`
+    ");
+
+    Ok(())
+}

--- a/crates/ty/tests/cli/python_environment.rs
+++ b/crates/ty/tests/cli/python_environment.rs
@@ -1110,12 +1110,7 @@ fn config_file_unsupported_python_version() -> anyhow::Result<()> {
 
     ----- stderr -----
     ty failed
-      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`: TOML parse error at line 3, column 18
-      |
-    3 | python-version = "2.7"
-      |                  ^^^^^
-    unknown variant `2.7`, expected one of `3.7`, `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, `3.13`, `3.14`, `3.15`
-
+      Cause: <temp_dir>/pyproject.toml is not a valid `pyproject.toml`
       Cause: TOML parse error at line 3, column 18
       |
     3 | python-version = "2.7"

--- a/crates/ty_project/src/db/changes.rs
+++ b/crates/ty_project/src/db/changes.rs
@@ -264,8 +264,9 @@ impl ProjectDatabase {
             match new_project_metadata {
                 Ok(mut metadata) => {
                     if let Err(error) = metadata.apply_configuration_files(self.system()) {
+                        let error = anyhow::Error::new(error);
                         tracing::error!(
-                            "Failed to apply configuration files, continuing without applying them: {error}"
+                            "Failed to apply configuration files, continuing without applying them: {error:#}"
                         );
                     }
 
@@ -327,8 +328,9 @@ impl ProjectDatabase {
                     }
                 }
                 Err(error) => {
+                    let error = anyhow::Error::new(error);
                     tracing::error!(
-                        "Failed to load project, keeping old project configuration: {error}"
+                        "Failed to load project, keeping old project configuration: {error:#}"
                     );
                     if reload_project_files {
                         project.reload_files(self);

--- a/crates/ty_project/src/metadata.rs
+++ b/crates/ty_project/src/metadata.rs
@@ -353,25 +353,25 @@ pub enum ProjectMetadataError {
     #[error("project path '{0}' is not a directory")]
     NotADirectory(SystemPathBuf),
 
-    #[error("{path} is not a valid `pyproject.toml`: {source}")]
+    #[error("{path} is not a valid `pyproject.toml`")]
     InvalidPyProject {
         source: Box<PyProjectError>,
         path: SystemPathBuf,
     },
 
-    #[error("{path} is not a valid `ty.toml`: {source}")]
+    #[error("{path} is not a valid `ty.toml`")]
     InvalidTyToml {
         source: Box<TyTomlError>,
         path: SystemPathBuf,
     },
 
-    #[error("Invalid `requires-python` version specifier (`{path}`): {source}")]
+    #[error("Invalid `requires-python` version specifier (`{path}`)")]
     InvalidRequiresPythonConstraint {
         source: ResolveRequiresPythonError,
         path: SystemPathBuf,
     },
 
-    #[error("Error loading configuration file at {path}: {source}")]
+    #[error("Error loading configuration file at {path}")]
     ConfigurationFileError {
         source: Box<ConfigurationFileError>,
         path: SystemPathBuf,
@@ -488,8 +488,8 @@ mod tests {
             ));
         };
 
-        assert_error_eq(
-            &error,
+        assert_error_chain_eq(
+            error,
             r#"/app/pyproject.toml is not a valid `pyproject.toml`: TOML parse error at line 5, column 29
   |
 5 |                     [tool.ty
@@ -964,8 +964,8 @@ unclosed table, expected `]`
             ));
         };
 
-        assert_error_eq(
-            &error,
+        assert_error_chain_eq(
+            error,
             "Invalid `requires-python` version specifier (`/app/pyproject.toml`): value `<3.12` does not contain a lower bound. Add a lower bound to indicate the minimum compatible Python version (e.g., `>=3.13`) or specify a version in `environment.python-version`.",
         );
 
@@ -994,8 +994,8 @@ unclosed table, expected `]`
             ));
         };
 
-        assert_error_eq(
-            &error,
+        assert_error_chain_eq(
+            error,
             "Invalid `requires-python` version specifier (`/app/pyproject.toml`): value `` does not contain a lower bound. Add a lower bound to indicate the minimum compatible Python version (e.g., `>=3.13`) or specify a version in `environment.python-version`.",
         );
 
@@ -1024,8 +1024,8 @@ unclosed table, expected `]`
             ));
         };
 
-        assert_error_eq(
-            &error,
+        assert_error_chain_eq(
+            error,
             "Invalid `requires-python` version specifier (`/app/pyproject.toml`): The major version `999` is larger than the maximum supported value 255",
         );
 
@@ -1086,8 +1086,8 @@ unclosed table, expected `]`
             ));
         };
 
-        assert_error_eq(
-            &error,
+        assert_error_chain_eq(
+            error,
             "Invalid `requires-python` version specifier (`/app/pyproject.toml`): value `==44.44` does not include any Python version supported by ty. Adjust `requires-python` to include a supported Python 3 version or specify `environment.python-version` explicitly.",
         );
 
@@ -1095,8 +1095,9 @@ unclosed table, expected `]`
     }
 
     #[track_caller]
-    fn assert_error_eq(error: &ProjectMetadataError, message: &str) {
-        assert_eq!(error.to_string().replace('\\', "/"), message);
+    fn assert_error_chain_eq(error: ProjectMetadataError, message: &str) {
+        let error = anyhow::Error::new(error);
+        assert_eq!(format!("{error:#}").replace('\\', "/"), message);
     }
 
     fn with_escaped_paths<R>(f: impl FnOnce() -> R) -> R {

--- a/crates/ty_project/src/metadata/configuration_file.rs
+++ b/crates/ty_project/src/metadata/configuration_file.rs
@@ -80,12 +80,12 @@ impl ConfigurationFile {
 
 #[derive(Debug, Error)]
 pub enum ConfigurationFileError {
-    #[error("{path} is not a valid `ty.toml`: {source}")]
+    #[error("{path} is not a valid `ty.toml`")]
     InvalidTyToml {
         source: Box<TyTomlError>,
         path: SystemPathBuf,
     },
-    #[error("Failed to read `{path}`: {source}")]
+    #[error("Failed to read `{path}`")]
     FileReadError {
         #[source]
         source: std::io::Error,


### PR DESCRIPTION
## Summary

We iterate over the cause chain in ty's CLI. This prints the `source` of every error. However, we also have some error variants that print their own source. 

This PR removes the inner `source` from the message. Because it will be added when printing the error chain.

Closes https://github.com/astral-sh/ty/issues/3854

## Test Plan

Updated tests
