### PR TITLE
[ty] Remove `Preview` rule status.

### DIFF
--- a/crates/ruff_dev/src/generate_ty_rules.rs
+++ b/crates/ruff_dev/src/generate_ty_rules.rs
@@ -110,11 +110,6 @@ fn generate_markdown() -> String {
                     r#"Added in <a href="https://github.com/astral-sh/ty/releases/tag/{since}">{since}</a>"#
                 )
             }
-            ty_python_semantic::lint::LintStatus::Preview { since } => {
-                format!(
-                    r#"Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/{since}">{since}</a>)"#
-                )
-            }
             ty_python_semantic::lint::LintStatus::Deprecated { since, .. } => {
                 format!(
                     r#"Deprecated (since <a href="https://github.com/astral-sh/ty/releases/tag/{since}">{since}</a>)"#

--- a/crates/ty/docs/rules.md
+++ b/crates/ty/docs/rules.md
@@ -163,7 +163,7 @@ def _(x: int):
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'error'."><code>error</code></a> ·
-Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a>) ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.16">0.0.16</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22call-abstract-method%22" target="_blank">Related issues</a> ·
 <a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L967" target="_blank">View source</a>
 </small>
@@ -3498,7 +3498,7 @@ func()  # error
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'ignore'."><code>ignore</code></a> ·
-Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a>) ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.41">0.0.41</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22missing-override-decorator%22" target="_blank">Related issues</a> ·
 <a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L985" target="_blank">View source</a>
 </small>
@@ -4981,7 +4981,7 @@ A() + A()  # error
 
 <small>
 Default level: <a href="../../rules#rule-levels" title="This lint has a default level of 'warn'."><code>warn</code></a> ·
-Preview (since <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a>) ·
+Added in <a href="https://github.com/astral-sh/ty/releases/tag/0.0.21">0.0.21</a> ·
 <a href="https://github.com/astral-sh/ty/issues?q=sort%3Aupdated-desc%20is%3Aissue%20is%3Aopen%20%22unused-awaitable%22" target="_blank">Related issues</a> ·
 <a href="https://github.com/astral-sh/ruff/blob/main/crates%2Fty_python_semantic%2Fsrc%2Ftypes%2Fdiagnostic.rs#L1102" target="_blank">View source</a>
 </small>

--- a/crates/ty/src/rule.rs
+++ b/crates/ty/src/rule.rs
@@ -34,7 +34,6 @@ impl std::fmt::Display for Explanation<'_> {
         writeln!(f, "# {}\n", self.name)?;
 
         let status = match self.status {
-            LintStatus::Preview { since } => format!("Preview (since {since})"),
             LintStatus::Stable { since } => format!("Stable (since {since})"),
             LintStatus::Deprecated { since, reason } => {
                 format!("Deprecated (since {since}): {reason}")

--- a/crates/ty_python_semantic/src/lint.rs
+++ b/crates/ty_python_semantic/src/lint.rs
@@ -149,13 +149,13 @@ pub fn lint_documentation_url(lint_name: LintName) -> String {
 }
 
 #[doc(hidden)]
-pub const fn lint_metadata_defaults() -> LintMetadata {
+pub const fn lint_metadata_defaults(status: LintStatus) -> LintMetadata {
     LintMetadata {
         name: LintName::of(""),
         summary: "",
         raw_documentation: "",
         default_level: Level::Error,
-        status: LintStatus::preview("0.0.0"),
+        status,
         file: "",
         line: 1,
     }
@@ -168,15 +168,9 @@ pub const fn lint_metadata_defaults() -> LintMetadata {
     serde(tag = "type", rename_all = "lowercase")
 )]
 pub enum LintStatus {
-    /// The lint has been added to the linter, but is not yet stable.
-    Preview {
-        /// The version in which the lint was added.
-        since: &'static str,
-    },
-
     /// The lint is stable.
     Stable {
-        /// The version in which the lint was stabilized.
+        /// The version in which the lint was added.
         since: &'static str,
     },
 
@@ -203,10 +197,6 @@ pub enum LintStatus {
 }
 
 impl LintStatus {
-    pub const fn preview(since: &'static str) -> Self {
-        LintStatus::Preview { since }
-    }
-
     pub const fn stable(since: &'static str) -> Self {
         LintStatus::Stable { since }
     }
@@ -248,7 +238,7 @@ impl LintStatus {
 ///     /// ```
 ///     pub(crate) static UNRESOLVED_REFERENCE = {
 ///         summary: "detects references to names that are not defined",
-///         status: LintStatus::preview("1.0.0"),
+///         status: LintStatus::stable("1.0.0"),
 ///         default_level: Level::Warn,
 ///     }
 /// }
@@ -267,16 +257,14 @@ macro_rules! declare_lint {
     ) => {
         $(#[expect($($expect)*)])?
         $( #[doc = $doc] )+
-        #[expect(clippy::needless_update)]
         $vis static $name: $crate::lint::LintMetadata = $crate::lint::LintMetadata {
             name: ruff_db::diagnostic::LintName::of(ruff_macros::kebab_case!($name)),
             summary: $summary,
             raw_documentation: concat!($($doc, '\n',)+),
-            status: $status,
             file: file!(),
             line: line!(),
             $( $key: $value, )*
-            ..$crate::lint::lint_metadata_defaults()
+            ..$crate::lint::lint_metadata_defaults($status)
         };
     };
 }
@@ -291,7 +279,7 @@ mod tests {
         ///     indented
         static INLINE_DOCUMENTATION = {
             summary: "inline documentation",
-            status: LintStatus::preview("0.0.0"),
+            status: LintStatus::stable("0.0.0"),
             default_level: Level::Error,
         }
     }
@@ -300,7 +288,7 @@ mod tests {
         #[doc = include_str!("../resources/lint_docs/invalid-attribute-access.md")]
         static INCLUDED_DOCUMENTATION = {
             summary: "included documentation",
-            status: LintStatus::preview("0.0.0"),
+            status: LintStatus::stable("0.0.0"),
             default_level: Level::Error,
         }
     }
@@ -524,7 +512,7 @@ impl std::fmt::Display for GetLintError {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LintEntry {
-    /// An existing lint rule. Can be in preview, stable or deprecated.
+    /// An existing lint rule. Can be stable or deprecated.
     Lint(LintId),
     /// A lint rule that has been removed.
     Removed(LintId),

--- a/crates/ty_python_semantic/src/types/diagnostic.rs
+++ b/crates/ty_python_semantic/src/types/diagnostic.rs
@@ -968,7 +968,7 @@ declare_lint! {
     #[doc = include_str!("../../resources/lint_docs/call-abstract-method.md")]
     pub(crate) static CALL_ABSTRACT_METHOD = {
         summary: "detects calls to abstract methods with trivial bodies on class objects",
-        status: LintStatus::preview("0.0.16"),
+        status: LintStatus::stable("0.0.16"),
         default_level: Level::Error,
     }
 }
@@ -986,7 +986,7 @@ declare_lint! {
     #[doc = include_str!("../../resources/lint_docs/missing-override-decorator.md")]
     pub(crate) static MISSING_OVERRIDE_DECORATOR = {
         summary: "detects methods that override a superclass member without an `@override` annotation",
-        status: LintStatus::preview("0.0.41"),
+        status: LintStatus::stable("0.0.41"),
         default_level: Level::Ignore,
     }
 }
@@ -1103,7 +1103,7 @@ declare_lint! {
     #[doc = include_str!("../../resources/lint_docs/unused-awaitable.md")]
     pub(crate) static UNUSED_AWAITABLE = {
         summary: "detects awaitable objects that are used as expression statements without being awaited",
-        status: LintStatus::preview("0.0.21"),
+        status: LintStatus::stable("0.0.21"),
         default_level: Level::Warn,
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Ruff/ty! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title? (Please prefix with `[ty]` for ty pull
  requests.)
- Does this pull request include references to any relevant issues?
- Does this PR follow our AI policy (https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
This removes the `Preview` rule status from ty documentation, and "promotes" the three rules that were previously marked as preview to stable. Unlike ruff, ty does not actually have a preview mode: all rules are always available[^1]. As such the preview status was misleading.

[^1]: Although of course you can configure their [level](https://docs.astral.sh/ty/rules/#rule-levels)).

## Test Plan

This change only affects our doc generation tooling (not the observable behavior of the type checker); I have modified our tests for that tooling accordingly.
<!-- How was it tested? -->
