### PR TITLE
Avoid notifying crate teams for Ruff release PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # GitHub code owners file. For more info: https://help.github.com/articles/about-codeowners/
 #
 # - Comment lines begin with `#` character.
-# - Each line is a file pattern followed by one or more owners.
+# - Each line is a file pattern optionally followed by one or more owners.
 # - The '*' pattern is global owners.
 # - Order is important. The last matching pattern has the most precedence.
 
@@ -31,3 +31,10 @@
 /crates/ty_python_core/ @astral-sh/ty_python_core_notified
 /crates/ty_python_semantic/ @astral-sh/ty_python_semantic_notified
 /crates/ty_module_resolver/ @astral-sh/ty_module_resolver_notified
+
+# Ruff releases update crate manifests and generated README version sections.
+# Leave these files unowned to avoid notifying the crate teams for release PRs.
+/crates/ty*/Cargo.toml
+/crates/ty*/README.md
+/crates/ruff_db/Cargo.toml
+/crates/ruff_db/README.md


### PR DESCRIPTION
## Summary

- Leave release-managed `Cargo.toml` and generated `README.md` files under `ty*` crates and `ruff_db` without CODEOWNERS.
- Document that CODEOWNERS patterns may omit owners.

## Rationale

Ruff release PRs mechanically bump versions in these files, which causes the corresponding `*_notified` teams to be requested even though no owned source changed. Placing ownerless patterns after the team rules preserves notifications for source changes while excluding release-version churn.