### PR TITLE
[flake8-pyi] Fix false positive for PEP 695 generic `__exit__` methods (`PYI036`)

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
+++ b/crates/ruff_linter/resources/test/fixtures/flake8_pyi/PYI036.py
@@ -167,3 +167,22 @@ class UnacceptableOverload2:
     @overload
     def __exit__(self, exc_typ: object, exc: Exception, tb: builtins.TracebackType) -> None: ...  # PYI036
     def __exit__(self, exc_typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...
+
+
+# PEP 695 generic `__exit__` — type[T] and T where T: BaseException should not trigger PYI036.
+# https://github.com/astral-sh/ruff/issues/25905
+class GenericExit:
+    def __exit__[T: BaseException](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # OK
+
+    def __aexit__[T: BaseException](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # OK
+
+
+class GenericExitUnboundedT:
+    # T has no bound — could be anything, so type[T] is not a valid first-arg annotation.
+    def __exit__[T](
+        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    ) -> bool: ...  # PYI036: T has no bound constraining it to BaseException

--- a/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
+++ b/crates/ruff_linter/src/rules/flake8_pyi/rules/exit_annotations.rs
@@ -1,8 +1,8 @@
 use std::fmt::{Display, Formatter};
 
 use ruff_python_ast::{
-    Expr, ExprBinOp, ExprSubscript, ExprTuple, Operator, ParameterWithDefault, Parameters, Stmt,
-    StmtClassDef, StmtFunctionDef,
+    Expr, ExprBinOp, ExprName, ExprSubscript, ExprTuple, Operator, ParameterWithDefault,
+    Parameters, Stmt, StmtClassDef, StmtFunctionDef, TypeParam,
 };
 use smallvec::SmallVec;
 
@@ -206,7 +206,15 @@ pub(crate) fn bad_exit_annotation(checker: &Checker, function: &StmtFunctionDef)
         );
     }
 
-    check_positional_args_for_non_overloaded_method(checker, &non_self_positional_args, func_kind);
+    check_positional_args_for_non_overloaded_method(
+        checker,
+        &non_self_positional_args,
+        func_kind,
+        function
+            .type_params
+            .as_deref()
+            .map_or(&[], |tp| &tp.type_params),
+    );
 }
 
 /// Determine whether a "short" argument list (i.e., an argument list with less than four elements)
@@ -252,16 +260,27 @@ fn check_positional_args_for_non_overloaded_method(
     checker: &Checker,
     non_self_positional_params: &[&ParameterWithDefault],
     kind: FuncKind,
+    type_params: &[TypeParam],
 ) {
     // For each argument, define the predicate against which to check the annotation.
-    type AnnotationValidator = fn(&Expr, &SemanticModel) -> bool;
+    type AnnotationValidator<'a> = Box<dyn Fn(&Expr, &SemanticModel) -> bool + 'a>;
 
     let validations: [(ErrorKind, AnnotationValidator); 3] = [
-        (ErrorKind::FirstArgBadAnnotation, is_base_exception_type),
-        (ErrorKind::SecondArgBadAnnotation, |expr, semantic| {
-            semantic.match_builtin_expr(expr, "BaseException")
-        }),
-        (ErrorKind::ThirdArgBadAnnotation, is_traceback_type),
+        (
+            ErrorKind::FirstArgBadAnnotation,
+            Box::new(|expr, semantic| is_base_exception_type(expr, semantic, type_params)),
+        ),
+        (
+            ErrorKind::SecondArgBadAnnotation,
+            Box::new(|expr, semantic| {
+                semantic.match_builtin_expr(expr, "BaseException")
+                    || is_base_exception_type_param(expr, semantic, type_params)
+            }),
+        ),
+        (
+            ErrorKind::ThirdArgBadAnnotation,
+            Box::new(|expr, semantic| is_traceback_type(expr, semantic)),
+        ),
     ];
 
     for (param, (error_info, predicate)) in
@@ -408,7 +427,7 @@ fn check_positional_args_for_overloaded_method(
     // Now check the second:
     if parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[0],
-        |annotation| is_base_exception_type(annotation, semantic),
+        |annotation| is_base_exception_type(annotation, semantic, &[]),
         semantic,
     ) && parameter_annotation_loosely_matches_predicate(
         non_self_positional_args[1],
@@ -510,15 +529,40 @@ fn is_traceback_type(expr: &Expr, semantic: &SemanticModel) -> bool {
         })
 }
 
-/// Return `true` if the [`Expr`] is, e.g., `Type[BaseException]`.
-fn is_base_exception_type(expr: &Expr, semantic: &SemanticModel) -> bool {
+/// Return `true` if the [`Expr`] is, e.g., `type[BaseException]` or `type[T]` where
+/// `T` is a PEP 695 type parameter bound to `BaseException`.
+fn is_base_exception_type(expr: &Expr, semantic: &SemanticModel, type_params: &[TypeParam]) -> bool {
     let Expr::Subscript(ExprSubscript { value, slice, .. }) = expr else {
         return false;
     };
 
     if semantic.match_typing_expr(value, "Type") || semantic.match_builtin_expr(value, "type") {
         semantic.match_builtin_expr(slice, "BaseException")
+            || is_base_exception_type_param(slice, semantic, type_params)
     } else {
         false
     }
+}
+
+/// Return `true` if `expr` is a PEP 695 type parameter whose bound is `BaseException`.
+///
+/// This handles patterns like `def __exit__[T: BaseException](self, exc_type: type[T] | None, ...)`.
+fn is_base_exception_type_param(
+    expr: &Expr,
+    semantic: &SemanticModel,
+    type_params: &[TypeParam],
+) -> bool {
+    let Expr::Name(ExprName { id, .. }) = expr else {
+        return false;
+    };
+    type_params.iter().any(|tp| {
+        if let TypeParam::TypeVar(tv) = tp {
+            if tv.name.as_str() == id.as_str() {
+                return tv.bound.as_deref().is_some_and(|bound| {
+                    semantic.match_builtin_expr(bound, "BaseException")
+                });
+            }
+        }
+        false
+    })
 }

--- a/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
+++ b/crates/ruff_linter/src/rules/flake8_pyi/snapshots/ruff_linter__rules__flake8_pyi__tests__PYI036_PYI036.py.snap
@@ -212,3 +212,23 @@ PYI036 Annotations for a three-argument `__exit__` overload (excluding `self`) s
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 169 |     def __exit__(self, exc_typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...
     |
+
+PYI036 The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
+   --> PYI036.py:187:25
+    |
+185 |     # T has no bound — could be anything, so type[T] is not a valid first-arg annotation.
+186 |     def __exit__[T](
+187 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                         ^^^^^^^^^^^^^^
+188 |     ) -> bool: ...  # PYI036: T has no bound constraining it to BaseException
+    |
+
+PYI036 The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
+   --> PYI036.py:187:46
+    |
+185 |     # T has no bound — could be anything, so type[T] is not a valid first-arg annotation.
+186 |     def __exit__[T](
+187 |         self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
+    |                                              ^^^^^^^^
+188 |     ) -> bool: ...  # PYI036: T has no bound constraining it to BaseException
+    |


### PR DESCRIPTION
## Summary

Fixes #25905.

When `__exit__` or `__aexit__` uses a PEP 695 type parameter bound to `BaseException`, annotations like `type[T] | None` and `T | None` are valid but `PYI036` incorrectly flags them:

```python
class Foo:
    def __exit__[T: BaseException](
        self, exc_type: type[T] | None, exc: T | None, tb: TracebackType | None, /
    ) -> bool: ...
# PYI036: The first argument in `__exit__` should be annotated with `object` or `type[BaseException] | None`
# PYI036: The second argument in `__exit__` should be annotated with `object` or `BaseException | None`
```

The validators `is_base_exception_type` and the second-arg check only matched `type[BaseException]` and `BaseException` literally. The fix passes the function's PEP 695 type params into the validators so `type[T]` and `T` are accepted when `T` is a type parameter whose bound is `BaseException`.

Type parameters with no bound (or a bound other than `BaseException`) continue to be flagged as before.

## Test Plan

Snapshot tests (`cargo nextest run` and `cargo insta test`).