### PR TITLE
[refurb] Suppress `FURB122` fix when walrus operator rebinds a loop variable

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
+++ b/crates/ruff_linter/resources/test/fixtures/refurb/FURB122.py
@@ -214,3 +214,34 @@ def _():
     with open("file", "w") as f:
         for line in ((1,) if True else (2,)):
             f.write(f"{line}")
+
+
+# https://github.com/astral-sh/ruff/issues/21107
+# OK — walrus rebinds the loop variable; converting to a generator expression would
+# produce a SyntaxError (PEP 572 forbids rebinding a comprehension iteration variable).
+
+def _():
+    with open("file", "w") as f:
+        for line in src:
+            f.write(line := line.upper())
+
+
+def _():
+    with open("file", "w") as f:
+        for first, *rest in src:
+            f.write(rest := "".join(rest))
+
+
+def _():
+    with open("file", "w") as f:
+        for a, b in src:
+            # walrus rebinds `a`, one of the two loop vars
+            f.write(a := a.upper())
+
+
+# Error — walrus rebinds `other`, not a loop variable; fix is still valid.
+
+def _():
+    with open("file", "w") as f:
+        for line in src:
+            f.write(other := line.upper())

--- a/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
+++ b/crates/ruff_linter/src/rules/refurb/rules/for_loop_writes.rs
@@ -1,4 +1,5 @@
 use ruff_macros::{ViolationMetadata, derive_message_formats};
+use ruff_python_ast::helpers::any_over_expr;
 use ruff_python_ast::{Expr, ExprList, ExprName, ExprTuple, Stmt, StmtFor};
 use ruff_python_semantic::analyze::typing;
 use ruff_python_semantic::{Binding, ScopeId, SemanticModel, TypingOnlyBindingsStatus};
@@ -185,6 +186,13 @@ fn for_loop_writes(
         return;
     }
 
+    // The fix converts the loop body into a generator expression, which forbids a walrus
+    // operator from rebinding a comprehension iteration variable (PEP 572). Skip the
+    // diagnostic entirely when `write_arg` contains such a named expression.
+    if write_arg_rebinds_loop_var(write_arg, binding_names) {
+        return;
+    }
+
     let locator = checker.locator();
     let content = match (for_stmt.target.as_ref(), write_arg) {
         (Expr::Name(for_target), Expr::Name(write_arg)) if for_target.id == write_arg.id => {
@@ -223,6 +231,28 @@ fn for_loop_writes(
             for_stmt.range,
         )
         .set_fix(fix);
+}
+
+/// Return `true` if `write_arg` contains a named (walrus) expression whose target
+/// rebinds one of the loop iteration variables.
+///
+/// Converting `for line in src: dst.write(line := ...)` to a generator expression
+/// `dst.writelines(line := ... for line in src)` is a `SyntaxError` (PEP 572 forbids
+/// an assignment expression from rebinding a comprehension iteration variable).
+fn write_arg_rebinds_loop_var(write_arg: &Expr, binding_names: &[&ExprName]) -> bool {
+    if binding_names.is_empty() {
+        return false;
+    }
+    any_over_expr(write_arg, |expr| {
+        if let Expr::Named(named) = expr {
+            if let Expr::Name(target) = named.target.as_ref() {
+                return binding_names
+                    .iter()
+                    .any(|loop_var| loop_var.id == target.id);
+            }
+        }
+        false
+    })
 }
 
 fn loop_variables_are_used_outside_loop(

--- a/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
+++ b/crates/ruff_linter/src/rules/refurb/snapshots/ruff_linter__rules__refurb__tests__FURB122_FURB122.py.snap
@@ -373,4 +373,22 @@ help: Replace with `f.writelines`
     -         for line in ((1,) if True else (2,)):
     -             f.write(f"{line}")
 215 +         f.writelines(f"{line}" for line in ((1,) if True else (2,)))
+216 |
+    |
+
+FURB122 [*] Use of `f.write` in a for loop
+   --> FURB122.py:246:9
+    |
+244 |   def _():
+245 |       with open("file", "w") as f:
+246 | /         for line in src:
+247 | |             f.write(other := line.upper())
+    | |__________________________________________^
+    |
+help: Replace with `f.writelines`
+    |
+245 |     with open("file", "w") as f:
+    -         for line in src:
+    -             f.write(other := line.upper())
+246 +         f.writelines(other := line.upper() for line in src)
     |


### PR DESCRIPTION
## Summary

Fixes #21107.

When `write_arg` contains a named expression (walrus operator `:=`) whose target is one of the `for`-loop iteration variables, the FURB122 fix converts:

```python
for line in src:
    dst.write(line := line.upper())
```

to:

```python
dst.writelines(line := line.upper() for line in src)
```

which is a `SyntaxError` — PEP 572 forbids an assignment expression from rebinding a comprehension iteration variable.

This PR adds a `write_arg_rebinds_loop_var` helper that walks `write_arg` with `any_over_expr`, looking for an `ExprNamed` whose target name matches any loop iteration variable. When found, the diagnostic is skipped entirely to avoid emitting a broken fix.

The same guard covers tuple-destructured loop targets (e.g. `for first, *rest in src: dst.write(rest := ...)`).

Walrus operators that bind a *different* name (not a loop variable) still produce the diagnostic and fix, as before.

## Test Plan

Added four test cases to `FURB122.py`:
- Three "OK" cases: simple loop var rebind, tuple loop var rebind, one-of-two loop vars rebind — all suppressed.
- One "Error" case: walrus binds `other` (not a loop var) — fix still applies.

`cargo test -p ruff_linter -- refurb` passes (44/44).