### PR TITLE
[ty] Skip shadowed submodule bindings during import analysis

### DIFF
--- a/crates/ty_ide/src/goto_declaration.rs
+++ b/crates/ty_ide/src/goto_declaration.rs
@@ -2858,20 +2858,8 @@ def ab(a: int, *, c: int): ...
             )
             .build();
 
-        // TODO(submodule-imports): Ok this one is FASCINATING but definitely wrong!
-        //
-        // So there's 3 relevant definitions here:
-        //
-        // * `subpkg: int = 10` in the other file is in fact the original definition.
-        //    Including it here is accurate and possibly useful?
-        //
-        // *  the LHS `subpkg` in the import is an instance of `subpkg = ...`
-        //    because it's a `DefinitionKind::ImportFromSubmodle`.
-        //    Including it here is Pedantically Correct but Unhelpful.
-        //
-        // * `the RHS `subpkg` in the import is a second instance of `subpkg = ...`
-        //    that *immediately* overwrites the `ImportFromSubmodule`'s definition.
-        //    This is the most important one and doesn't show up at all! Sadness!
+        // The transient submodule binding is skipped because this import statement
+        // immediately shadows it with the imported symbol.
         assert_snapshot!(test.goto_declaration(), @"
         info[goto-declaration]: Go to declaration
          --> mypackage/__init__.py:4:5
@@ -2879,13 +2867,8 @@ def ab(a: int, *, c: int): ...
         4 | x = subpkg
           |     ^^^^^^ Clicking here
           |
-        info: Found 2 declarations
-         --> mypackage/__init__.py:2:7
-          |
-        2 | from .subpkg import subpkg
-          |       ------
-          |
-         ::: mypackage/subpkg/__init__.py:2:1
+        info: Found 1 declaration
+         --> mypackage/subpkg/__init__.py:2:1
           |
         2 | subpkg: int = 10
           | ------

--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -2909,22 +2909,33 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
                         self.seen_submodule_imports
                             .insert(direct_submodule.to_owned());
 
-                        let direct_submodule_name = Name::new(direct_submodule);
-                        let symbol = self.add_symbol(direct_submodule_name);
+                        let is_immediately_shadowed = node.names.iter().any(|alias| {
+                            if &alias.name == "*" {
+                                return false;
+                            }
 
-                        let module_index = if node.level == 0 {
-                            // "whatever.thispackage.x.y" we want `x`
-                            thispackage.components().count()
-                        } else {
-                            // ".x.y" we want `x` (level 1 => index 0)
-                            // "..x.y" we want `y` (level 2 => index 1)
-                            // (The Identifier doesn't include the prefix dots)
-                            node.level as usize - 1
-                        };
-                        self.add_definition(
-                            symbol.into(),
-                            ImportFromSubmoduleDefinitionNodeRef { node, module_index },
-                        );
+                            let bound_name = alias.asname.as_ref().unwrap_or(&alias.name);
+                            bound_name.id.as_str() == direct_submodule
+                        });
+
+                        if !is_immediately_shadowed {
+                            let direct_submodule_name = Name::new(direct_submodule);
+                            let symbol = self.add_symbol(direct_submodule_name);
+
+                            let module_index = if node.level == 0 {
+                                // "whatever.thispackage.x.y" we want `x`
+                                thispackage.components().count()
+                            } else {
+                                // ".x.y" we want `x` (level 1 => index 0)
+                                // "..x.y" we want `y` (level 2 => index 1)
+                                // (The Identifier doesn't include the prefix dots)
+                                node.level as usize - 1
+                            };
+                            self.add_definition(
+                                symbol.into(),
+                                ImportFromSubmoduleDefinitionNodeRef { node, module_index },
+                            );
+                        }
                     }
                 }
 

--- a/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/nonstandard_conventions.md
@@ -883,6 +883,36 @@ def funcmod(x: int) -> int:
     return x
 ```
 
+## Re-export Nameclash Problems After Conditional Raise
+
+`from` imports in an `__init__.py` at file scope should overwrite the submodule attribute even when
+earlier ambiguous control flow causes us to consider more bindings from nested functions.
+
+`mypackage/__init__.py`:
+
+```py
+def should_raise() -> bool:
+    return True
+
+if should_raise():
+    raise RuntimeError
+
+from .funcmod import funcmod
+
+reveal_type(funcmod)  # revealed: def funcmod(x: int) -> int
+
+def run():
+    reveal_type(funcmod)  # revealed: def funcmod(x: int) -> int
+    funcmod(1)
+```
+
+`mypackage/funcmod.py`:
+
+```py
+def funcmod(x: int) -> int:
+    return x
+```
+
 ## Re-export Nameclash Problems In Try-Blocks
 
 `from` imports in an `__init__.py` at file scope in a `try` block should be visible to functions
@@ -897,8 +927,6 @@ try:
     funcmod(1)
 
     def run():
-        # TODO: this is a bug in how we analyze try-blocks
-        # error: [call-non-callable]
         funcmod(2)
 
 finally:


### PR DESCRIPTION
## Summary

Avoid registering an `import from` submodule definition when the imported name is immediately shadowed by another binding in the same statement.

Closes https://github.com/astral-sh/ty/issues/2438

## Testing

Added mdtest.