### PR TITLE
[ty] Normalize workspace crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,7 +3621,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_ranged_value"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "get-size2",
  "ruff_db",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ty_combine"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "ordermap",
  "ruff_db",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "ty_python_core"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "ty_python_semantic"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4941,7 +4941,7 @@ dependencies = [
 
 [[package]]
 name = "ty_vendored"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "path-slash",
  "ruff_db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,24 +40,24 @@ ruff_python_trivia = { version = "0.0.3", path = "crates/ruff_python_trivia" }
 ruff_server = { version = "0.0.3", path = "crates/ruff_server" }
 ruff_source_file = { version = "0.0.3", path = "crates/ruff_source_file" }
 ruff_mdtest = { path = "crates/ruff_mdtest" }
-ruff_ranged_value = { version = "0.0.2", path = "crates/ruff_ranged_value" }
+ruff_ranged_value = { version = "0.0.3", path = "crates/ruff_ranged_value" }
 ruff_text_size = { version = "0.0.3", path = "crates/ruff_text_size" }
 ruff_workspace = { version = "0.0.3", path = "crates/ruff_workspace" }
 
 ty = { path = "crates/ty" }
-ty_combine = { version = "0.0.2", path = "crates/ty_combine" }
+ty_combine = { version = "0.0.3", path = "crates/ty_combine" }
 ty_completion_bench = { path = "crates/ty_completion_bench" }
 ty_completion_eval = { path = "crates/ty_completion_eval" }
 ty_ide = { path = "crates/ty_ide" }
 ty_module_resolver = { version = "0.0.3", path = "crates/ty_module_resolver" }
 ty_project = { path = "crates/ty_project", default-features = false }
-ty_python_semantic = { version = "0.0.2", path = "crates/ty_python_semantic" }
-ty_python_core = { version = "0.0.2", path = "crates/ty_python_core" }
+ty_python_semantic = { version = "0.0.3", path = "crates/ty_python_semantic" }
+ty_python_core = { version = "0.0.3", path = "crates/ty_python_core" }
 ty_server = { path = "crates/ty_server" }
 ty_site_packages = { version = "0.0.3", path = "crates/ty_site_packages" }
 ty_static = { version = "0.0.3", path = "crates/ty_static" }
 ty_test = { path = "crates/ty_test" }
-ty_vendored = { version = "0.0.2", path = "crates/ty_vendored" }
+ty_vendored = { version = "0.0.3", path = "crates/ty_vendored" }
 
 mdtest = { path = "crates/mdtest" }
 

--- a/crates/ruff_ranged_value/Cargo.toml
+++ b/crates/ruff_ranged_value/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_ranged_value"
-version = "0.0.2"
+version = "0.0.3"
 description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_ranged_value/README.md
+++ b/crates/ruff_ranged_value/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.2) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
+This version (0.0.3) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
 source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.20/crates/ruff_ranged_value).
 
 See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for

--- a/crates/ty_combine/Cargo.toml
+++ b/crates/ty_combine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ty_combine"
-version = "0.0.2"
+version = "0.0.3"
 description = "This is an internal component crate of Ruff"
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/ty_combine/README.md
+++ b/crates/ty_combine/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.2) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
+This version (0.0.3) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
 source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.20/crates/ty_combine).
 
 See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for

--- a/crates/ty_python_core/Cargo.toml
+++ b/crates/ty_python_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ty_python_core"
-version = "0.0.2"
+version = "0.0.3"
 description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ty_python_core/README.md
+++ b/crates/ty_python_core/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.2) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
+This version (0.0.3) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
 source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.20/crates/ty_python_core).
 
 See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for

--- a/crates/ty_python_semantic/Cargo.toml
+++ b/crates/ty_python_semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ty_python_semantic"
-version = "0.0.2"
+version = "0.0.3"
 description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ty_python_semantic/README.md
+++ b/crates/ty_python_semantic/README.md
@@ -5,7 +5,7 @@
 This crate is an internal component of [Ruff](https://crates.io/crates/ruff). The Rust API exposed
 here is unstable and will have frequent breaking changes.
 
-This version (0.0.2) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
+This version (0.0.3) is a component of [Ruff 0.15.20](https://crates.io/crates/ruff/0.15.20). The
 source can be found [here](https://github.com/astral-sh/ruff/blob/0.15.20/crates/ty_python_semantic).
 
 See Ruff's [crate versioning policy](https://docs.astral.sh/ruff/versioning/#crate-versioning) for

--- a/crates/ty_vendored/Cargo.toml
+++ b/crates/ty_vendored/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ty_vendored"
-version = "0.0.2"
+version = "0.0.3"
 description = "This is an internal component crate of Ruff"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Summary

Normalize the five remaining independently versioned workspace crates from 0.0.2 to 0.0.3:

- `ruff_ranged_value`
- `ty_combine`
- `ty_python_core`
- `ty_python_semantic`
- `ty_vendored`

This aligns every independently versioned public workspace crate on the 0.0.3 line, following [feedback from a crates.io consumer](https://github.com/astral-sh/ruff/issues/43#issuecomment-4804153741), so consumers no longer need to mix the 0.0.2 ty packages with their 0.0.3 dependencies. The root workspace requirements and lockfile are updated to match.

The full workspace crate-publishing dry run succeeded, including packaged verification for every normalized crate.
