### PR TITLE
Move `CommentRanges::from_tokens` into formatter benchmark hot loop

### DIFF
--- a/crates/ruff_benchmark/benches/formatter.rs
+++ b/crates/ruff_benchmark/benches/formatter.rs
@@ -52,9 +52,8 @@ fn benchmark_formatter(criterion: &mut Criterion) {
                 let parsed = parse(case.code(), ParseOptions::from(Mode::Module))
                     .expect("Input should be a valid Python code");
 
-                let comment_ranges = CommentRanges::from(parsed.tokens());
-
                 b.iter(|| {
+                    let comment_ranges = CommentRanges::from(parsed.tokens());
                     let options = PyFormatOptions::from_extension(Path::new(case.name()))
                         .with_preview(PreviewMode::Enabled);
                     let formatted =


### PR DESCRIPTION
## Summary

I think this more accurately resembles the true cost of formatting. Removing the dependency on `CommentRanges` could speed up formatting. Therefore, we should include it in the formatting benchmark. 

The benchmarks still exclude parsing. This is mainly because parsing is such a significant cost and, with ty, we could amortize parsing across different tools (I guess, that's also true for comment ranges)