### PR TITLE
[ty] Move cold data out of SemanticIndex

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -57,14 +57,13 @@ use crate::scope::{
     FileScopeId, NodeWithScopeKey, NodeWithScopeKind, NodeWithScopeRef, Scope, ScopeId, ScopeKind,
     ScopeLaziness,
 };
-use crate::statement::StatementInner;
 use crate::symbol::{ScopedSymbolId, Symbol};
 use crate::unpack::{Unpack, UnpackKind, UnpackPosition, UnpackValue};
 use crate::use_def::{
     EnclosingSnapshotKey, FlowSnapshot, FutureDefinitions, LiveBinding, PreviousDefinitions,
     ScopedDefinitionId, ScopedEnclosingSnapshotId, UseDefMapBuilder,
 };
-use crate::{Db, Statement, StatementNodeKey};
+use crate::{Db, StatementNodeKey};
 use crate::{
     DefinitionsByNode, EvaluationMode, ExpressionsScopeMap, LoopHeader, LoopHeaderId,
     NarrowingAliasPredicate, PossiblyNarrowedPlaces, SemanticIndex, VisibleAncestorsIter,
@@ -239,7 +238,7 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     current_assignments: Vec<CurrentAssignment<'ast, 'db>>,
     /// The statements we're currently visiting, with
     /// the most recent visit at the end of the Vec.
-    current_statements: Vec<CurrentStatement<'ast, 'db>>,
+    current_statements: Vec<CurrentStatement<'db>>,
     /// The match case we're currently visiting.
     current_match_case: Option<CurrentMatchCase<'ast, 'db>>,
     /// The name of the first function parameter of the innermost function that we're currently visiting.
@@ -272,15 +271,12 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     expressions_by_node: FxHashMap<ExpressionNodeKey, Expression<'db>>,
     unpacks_by_target: FxHashMap<ExpressionNodeKey, Unpack<'db>>,
     condition_flow_snapshots_by_node: FxHashMap<ExpressionNodeKey, ConditionFlowSnapshots>,
-    statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
-    imported_modules: FxHashSet<ModuleName>,
+    standalone_statement_scopes: FxHashMap<StatementNodeKey, FileScopeId>,
     seen_submodule_imports: FxHashSet<String>,
-    // A map from a lambda expression to its enclosing statement.
-    enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
     // A map from a constraining use of a collection literal to its definition.
     collections_by_use: FxHashMap<ExpressionNodeKey, Definition<'db>>,
     // A map from a collection literal definition to statements containing a constraining use.
-    uses_by_collection: FxHashMap<Definition<'db>, Vec<(Statement<'db>, ExpressionNodeKey)>>,
+    uses_by_collection: FxHashMap<Definition<'db>, Vec<(StatementNodeKey, ExpressionNodeKey)>>,
     /// Hashset of all [`FileScopeId`]s that correspond to [generator functions].
     ///
     /// [generator functions]: https://docs.python.org/3/glossary.html#term-generator
@@ -327,13 +323,11 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             expressions_by_node: FxHashMap::default(),
             unpacks_by_target: FxHashMap::default(),
             condition_flow_snapshots_by_node: FxHashMap::default(),
-            statements_by_node: FxHashMap::default(),
-            enclosing_lambda_statements: FxHashMap::default(),
+            standalone_statement_scopes: FxHashMap::default(),
             collections_by_use: FxHashMap::default(),
             uses_by_collection: FxHashMap::default(),
 
             seen_submodule_imports: FxHashSet::default(),
-            imported_modules: FxHashSet::default(),
             generator_functions: FxHashSet::default(),
 
             enclosing_snapshots: FxHashMap::default(),
@@ -369,20 +363,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
 
     fn current_scope_id(&self) -> ScopeId<'db> {
         self.scope_ids_by_scope[self.current_scope()]
-    }
-
-    pub(crate) fn expect_single_definition(
-        &self,
-        definition_key: impl Into<DefinitionNodeKey> + std::fmt::Debug + Copy,
-    ) -> Definition<'db> {
-        let definitions = &self.definitions_by_node[&definition_key.into()];
-        debug_assert_eq!(
-            definitions.len(),
-            1,
-            "Expected exactly one definition to be associated with AST node {definition_key:?} but found {}",
-            definitions.len()
-        );
-        definitions[0]
     }
 
     /// Returns an iterator over ancestors of `scope` that are visible for name resolution,
@@ -2018,15 +1998,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         self.current_assignments.last_mut()
     }
 
-    fn push_statement(&mut self, statement: CurrentStatement<'ast, 'db>) {
+    fn push_statement(&mut self, statement: CurrentStatement<'db>) {
         self.current_statements.push(statement);
     }
 
-    fn pop_statement(&mut self) -> CurrentStatement<'ast, 'db> {
+    fn pop_statement(&mut self) -> CurrentStatement<'db> {
         self.current_statements.pop().unwrap()
     }
 
-    fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'ast, 'db>> {
+    fn current_statement_mut(&mut self) -> Option<&mut CurrentStatement<'db>> {
         self.current_statements.last_mut()
     }
 
@@ -2234,53 +2214,15 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
         expression
     }
 
-    fn add_standalone_statement(&mut self, statement_node: &ast::Stmt) -> Statement<'db> {
-        // Avoid allocating a salsa ingredient if the statement represents an existing
-        // definition or standalone expression.
-        let statement = match statement_node {
-            ast::Stmt::FunctionDef(function) => Some(Statement::Definition(
-                self.expect_single_definition(function),
-            )),
-            ast::Stmt::ClassDef(class) => {
-                Some(Statement::Definition(self.expect_single_definition(class)))
-            }
-            ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
-                Some(Statement::Expression(self.add_standalone_expression(value)))
-            }
-            ast::Stmt::Assign(assign) => {
-                if let [ast::Expr::Name(name)] = &assign.targets[..] {
-                    Some(Statement::Definition(self.expect_single_definition(name)))
-                } else {
-                    None
-                }
-            }
-            ast::Stmt::AnnAssign(assign) if assign.target.is_name_expr() => {
-                Some(Statement::Definition(self.expect_single_definition(assign)))
-            }
-            ast::Stmt::AugAssign(assign) if assign.target.is_name_expr() => {
-                Some(Statement::Definition(self.expect_single_definition(assign)))
-            }
-            ast::Stmt::TypeAlias(alias) => {
-                Some(Statement::Definition(self.expect_single_definition(alias)))
-            }
-            _ => None,
-        };
+    fn add_standalone_statement(&mut self, statement: &ast::Stmt) -> StatementNodeKey {
+        if let ast::Stmt::Expr(ast::StmtExpr { value, .. }) = statement {
+            self.add_standalone_expression(value);
+        }
 
-        let statement = if let Some(statement) = statement {
-            statement
-        } else {
-            Statement::Other(StatementInner::new(
-                self.db,
-                self.file,
-                self.current_scope(),
-                AstNodeRef::new(self.module, statement_node),
-            ))
-        };
-
-        self.statements_by_node
-            .insert(statement_node.into(), statement);
-
-        statement
+        let key = statement.into();
+        self.standalone_statement_scopes
+            .insert(key, self.current_scope());
+        key
     }
 
     fn with_type_params<T>(
@@ -2639,16 +2581,14 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             definitions_by_node: DefinitionsByNode::from_map(self.definitions_by_node),
             expressions_by_node: self.expressions_by_node,
             unpacks_by_target: FrozenMap::from(self.unpacks_by_target),
-            statements_by_node: self.statements_by_node,
+            standalone_statement_scopes: FrozenMap::from(self.standalone_statement_scopes),
             scope_ids_by_scope: self.scope_ids_by_scope.into(),
             ast_ids,
             scopes_by_expression: self.scopes_by_expression.build(),
             scopes_by_node: self.scopes_by_node,
             use_def_maps: use_def_maps.into(),
-            enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
-            imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
             semantic_syntax_errors,
@@ -2846,12 +2786,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Stmt::Import(node) => {
                 for (alias_index, alias) in node.names.iter().enumerate() {
-                    // Mark the imported module, and all of its parents, as being imported in this
-                    // file.
-                    if let Some(module_name) = ModuleName::new(&alias.name) {
-                        self.imported_modules.extend(module_name.ancestors());
-                    }
-
                     let (symbol_name, is_reexported) = if let Some(asname) = &alias.asname {
                         self.scopes_by_expression
                             .record_expression(asname, self.current_scope());
@@ -4231,24 +4165,12 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
                 }
             });
 
-        if current_statement.lambda_expressions.is_empty()
-            && current_statement.collection_uses.is_empty()
+        if !current_statement.has_lambda_expression && current_statement.collection_uses.is_empty()
         {
             return;
         }
 
         let standalone_statement = self.add_standalone_statement(stmt);
-
-        // The body of a lambda expression needs access to the `Callable` type
-        // context the lambda is being inferred with, and so any statement
-        // containing a lambda must be inferable as a standalone statement
-        // to avoid large scope-level cycles.
-        self.enclosing_lambda_statements.extend(
-            current_statement
-                .lambda_expressions
-                .into_iter()
-                .map(|lambda| (lambda.into(), standalone_statement)),
-        );
 
         // The inferred element type of collection literal depends on uses of
         // the collection in its containing scope, and so each use must be part
@@ -4417,8 +4339,7 @@ impl<'ast> Visitor<'ast> for SemanticIndexBuilder<'_, 'ast> {
             ast::Expr::Lambda(lambda) => {
                 self.current_statement_mut()
                     .expect("every lambda expression is part of a statement")
-                    .lambda_expressions
-                    .push(lambda);
+                    .has_lambda_expression = true;
 
                 if let Some(parameters) = &lambda.parameters {
                     // The default value of the parameters needs to be evaluated in the
@@ -4896,9 +4817,9 @@ impl<'ast> From<&'ast ast::ExprNamed> for CurrentAssignment<'ast, '_> {
 }
 
 #[derive(Default)]
-struct CurrentStatement<'ast, 'db> {
-    /// A list of lambda expressions contained in this statement.
-    lambda_expressions: Vec<&'ast ast::ExprLambda>,
+struct CurrentStatement<'db> {
+    /// Whether this statement contains a lambda expression.
+    has_lambda_expression: bool,
     /// A list of collection definitions whose uses are contained in this statement.
     collection_uses: Vec<(Definition<'db>, ExpressionNodeKey)>,
 }

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -10,6 +10,7 @@ use ruff_db::files::File;
 use ruff_db::parsed::parsed_module;
 use ruff_index::{FrozenIndexVec, IndexSlice};
 use ruff_python_ast::NodeIndex;
+use ruff_python_ast::statement_visitor::{StatementVisitor, walk_stmt};
 use ruff_python_parser::semantic_errors::SemanticSyntaxError;
 use ruff_text_size::TextRange;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -73,6 +74,37 @@ pub fn semantic_index(db: &dyn Db, file: File) -> SemanticIndex<'_> {
     let module = parsed_module(db, file).load(db);
 
     SemanticIndexBuilder::new(db, file, &module).build()
+}
+
+/// Returns the set of modules imported by `import` statements anywhere in `file`.
+///
+/// This intentionally excludes `from...import` statements. See
+/// `ModuleLiteralType::available_submodule_attributes` for why this analysis is limited.
+#[salsa::tracked(returns(ref), heap_size=ruff_memory_usage::heap_size)]
+pub fn imported_modules(db: &dyn Db, file: File) -> FrozenSet<ModuleName> {
+    #[derive(Default)]
+    struct ImportedModulesVisitor {
+        modules: FxHashSet<ModuleName>,
+    }
+
+    impl<'ast> StatementVisitor<'ast> for ImportedModulesVisitor {
+        fn visit_stmt(&mut self, statement: &'ast ast::Stmt) {
+            if let ast::Stmt::Import(import) = statement {
+                for alias in &import.names {
+                    if let Some(module_name) = ModuleName::new(&alias.name) {
+                        self.modules.extend(module_name.ancestors());
+                    }
+                }
+            }
+
+            walk_stmt(self, statement);
+        }
+    }
+
+    let module = parsed_module(db, file).load(db);
+    let mut visitor = ImportedModulesVisitor::default();
+    visitor.visit_body(&module.syntax().body);
+    FrozenSet::from(visitor.modules)
 }
 
 /// Returns the place table for a specific `scope`.
@@ -297,20 +329,17 @@ pub struct SemanticIndex<'db> {
     /// Map from an unpacking target to its [`unpack::Unpack`] ingredient.
     unpacks_by_target: FrozenMap<ExpressionNodeKey, unpack::Unpack<'db>>,
 
-    /// Map from a standalone statement to its [`Statement`] ingredient.
-    statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
+    /// Map from an independently inferable statement to its containing scope.
+    standalone_statement_scopes: FrozenMap<StatementNodeKey, FileScopeId>,
 
     /// Map from nodes that create a scope to the scope they create.
     scopes_by_node: FxHashMap<NodeWithScopeKey, FileScopeId>,
-
-    /// Map from a lambda expression to its containing statement.
-    enclosing_lambda_statements: FrozenMap<ExpressionNodeKey, Statement<'db>>,
 
     // Map from a constraining use of a collection literal to its definition.
     collections_by_use: FrozenMap<ExpressionNodeKey, Definition<'db>>,
 
     // Map from a collection literal definition to statements containing a constraining use.
-    uses_by_collection: FrozenMap<Definition<'db>, Box<[(Statement<'db>, ExpressionNodeKey)]>>,
+    uses_by_collection: FrozenMap<Definition<'db>, Box<[(StatementNodeKey, ExpressionNodeKey)]>>,
 
     /// Map from the file-local [`FileScopeId`] to the salsa-ingredient [`ScopeId`].
     scope_ids_by_scope: FrozenIndexVec<FileScopeId, ScopeId<'db>>,
@@ -323,9 +352,6 @@ pub struct SemanticIndex<'db> {
     /// Note: We should not depend on this map when analysing other files or
     /// changing a file invalidates all dependents.
     ast_ids: AstIds,
-
-    /// The set of modules that are imported anywhere within this file.
-    imported_modules: FrozenSet<ModuleName>,
 
     /// Flags about the global scope (code usage impacting inference)
     has_future_annotations: bool,
@@ -376,15 +402,6 @@ impl<'db> SemanticIndex<'db> {
     #[track_caller]
     pub fn use_def_map(&self, scope_id: FileScopeId) -> &UseDefMap<'db> {
         &self.use_def_maps[scope_id]
-    }
-
-    /// Returns the set of modules that are imported anywhere in this file.
-    ///
-    /// This set only considers `import` statements, not `from...import` statements.
-    /// See `ModuleLiteralType::available_submodule_attributes` for discussion
-    /// of why this analysis is intentionally limited.
-    pub fn imported_modules(&self) -> impl Iterator<Item = &ModuleName> {
-        self.imported_modules.iter()
     }
 
     #[track_caller]
@@ -520,10 +537,6 @@ impl<'db> SemanticIndex<'db> {
             .map(|node_ref| self.expect_single_definition(node_ref))
     }
 
-    pub fn enclosing_lambda_statement(&self, lambda: ExpressionNodeKey) -> Option<Statement<'db>> {
-        self.enclosing_lambda_statements.get(&lambda).copied()
-    }
-
     /// If this is a potentially constraining use of an unannotated collection literal, returns
     /// its definition.
     pub fn unannotated_collection_literal(
@@ -537,7 +550,7 @@ impl<'db> SemanticIndex<'db> {
     pub fn constraining_collection_uses(
         &self,
         collection_def: Definition<'db>,
-    ) -> impl Iterator<Item = (Statement<'db>, ExpressionNodeKey)> {
+    ) -> impl Iterator<Item = (StatementNodeKey, ExpressionNodeKey)> {
         self.uses_by_collection
             .get(&collection_def)
             .into_iter()
@@ -670,9 +683,21 @@ impl<'db> SemanticIndex<'db> {
 
     pub fn try_statement(
         &self,
+        db: &'db dyn Db,
+        file: File,
         statement_key: impl Into<StatementNodeKey>,
     ) -> Option<Statement<'db>> {
-        self.statements_by_node.get(&statement_key.into()).copied()
+        let statement_key = statement_key.into();
+        self.standalone_statement_scopes
+            .get(&statement_key)
+            .map(|_| statement::standalone_statement(db, file, statement_key))
+    }
+
+    pub(crate) fn standalone_statement_scope(
+        &self,
+        statement_key: StatementNodeKey,
+    ) -> FileScopeId {
+        self.standalone_statement_scopes[&statement_key]
     }
 
     /// Returns the id of the scope that `node` creates.

--- a/crates/ty_python_core/src/node_key.rs
+++ b/crates/ty_python_core/src/node_key.rs
@@ -19,4 +19,8 @@ impl NodeKey {
     pub fn from_node_ref<T>(node_ref: &AstNodeRef<T>) -> Self {
         NodeKey(node_ref.index())
     }
+
+    pub(crate) fn index(self) -> NodeIndex {
+        self.0
+    }
 }

--- a/crates/ty_python_core/src/statement.rs
+++ b/crates/ty_python_core/src/statement.rs
@@ -4,8 +4,11 @@ use crate::definition::Definition;
 use crate::expression::Expression;
 use crate::node_key::NodeKey;
 use crate::scope::{FileScopeId, ScopeId};
+use crate::semantic_index;
 use ruff_db::files::File;
+use ruff_db::parsed::{ParsedModuleRef, parsed_module};
 use ruff_python_ast as ast;
+use ruff_text_size::Ranged;
 use salsa;
 
 /// An independently type-inferable statement.
@@ -58,11 +61,93 @@ impl<'db> StatementInner<'db> {
     }
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, salsa::Update, get_size2::GetSize)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, salsa::Update, get_size2::GetSize,
+)]
 pub struct StatementNodeKey(NodeKey);
 
 impl From<&ast::Stmt> for StatementNodeKey {
     fn from(node: &ast::Stmt) -> Self {
         Self(NodeKey::from_node(node))
+    }
+}
+
+impl StatementNodeKey {
+    fn node(self, module: &ParsedModuleRef) -> &ast::Stmt {
+        module
+            .get_by_index(self.0.index())
+            .try_into()
+            .expect("statement key should point to a statement")
+    }
+}
+
+/// Returns the statement containing `lambda`.
+///
+/// This is intentionally a pure AST lookup because contextual lambda inference is the only caller.
+pub fn enclosing_lambda_statement(
+    module: &ParsedModuleRef,
+    lambda: &ast::ExprLambda,
+) -> Option<StatementNodeKey> {
+    let lambda_key = NodeKey::from_node(lambda);
+    let mut found_lambda = false;
+
+    for ancestor in
+        ast::find_node::covering_node(module.syntax().into(), lambda.range()).ancestors()
+    {
+        if NodeKey::from_node(ancestor) == lambda_key {
+            found_lambda = true;
+        } else if found_lambda && let Some(statement) = ancestor.as_stmt_ref() {
+            return Some(StatementNodeKey(NodeKey::from_node(statement)));
+        }
+    }
+
+    None
+}
+
+/// Materializes the tracked [`Statement`] ingredient for a standalone statement.
+#[salsa::tracked]
+pub fn standalone_statement(
+    db: &dyn Db,
+    file: File,
+    statement_key: StatementNodeKey,
+) -> Statement<'_> {
+    let index = semantic_index(db, file);
+    let file_scope = index.standalone_statement_scope(statement_key);
+    let module = parsed_module(db, file).load(db);
+    let statement = statement_key.node(&module);
+
+    match statement {
+        ast::Stmt::FunctionDef(function) => {
+            Statement::Definition(index.expect_single_definition(function))
+        }
+        ast::Stmt::ClassDef(class) => Statement::Definition(index.expect_single_definition(class)),
+        ast::Stmt::Expr(ast::StmtExpr { value, .. }) => {
+            Statement::Expression(index.expression(value))
+        }
+        ast::Stmt::Assign(assign) => {
+            if let [ast::Expr::Name(name)] = &assign.targets[..] {
+                Statement::Definition(index.expect_single_definition(name))
+            } else {
+                Statement::Other(StatementInner::new(
+                    db,
+                    file,
+                    file_scope,
+                    AstNodeRef::new(&module, statement),
+                ))
+            }
+        }
+        ast::Stmt::AnnAssign(assign) if assign.target.is_name_expr() => {
+            Statement::Definition(index.expect_single_definition(assign))
+        }
+        ast::Stmt::AugAssign(assign) if assign.target.is_name_expr() => {
+            Statement::Definition(index.expect_single_definition(assign))
+        }
+        ast::Stmt::TypeAlias(alias) => Statement::Definition(index.expect_single_definition(alias)),
+        _ => Statement::Other(StatementInner::new(
+            db,
+            file,
+            file_scope,
+            AstNodeRef::new(&module, statement),
+        )),
     }
 }

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -224,11 +224,11 @@ reveal_type(foo)  # revealed: Unknown
 
 ## Import submodule from self
 
-We don't currently consider `from...import` statements when building up the `imported_modules` set
-in the semantic index. When accessing an attribute of a module, we only consider it a potential
-submodule when that submodule name appears in the `imported_modules` set. That means that submodules
-that are imported via `from...import` are not visible to our type inference if you also access that
-submodule via the attribute on its parent package.
+We don't currently consider `from...import` statements when building up the `imported_modules` set.
+When accessing an attribute of a module, we only consider it a potential submodule when that
+submodule name appears in the `imported_modules` set. That means that submodules that are imported
+via `from...import` are not visible to our type inference if you also access that submodule via the
+attribute on its parent package.
 
 `package/__init__.py`:
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -113,7 +113,7 @@ pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{Truthiness, place_table, semantic_index};
+use ty_python_core::{Truthiness, imported_modules, place_table, semantic_index};
 
 mod bool;
 mod bound_super;
@@ -8330,7 +8330,7 @@ impl<'db> ModuleLiteralType<'db> {
     fn available_submodule_attributes(&self, db: &'db dyn Db) -> impl Iterator<Item = Name> {
         self.importing_file(db)
             .into_iter()
-            .flat_map(|file| semantic_index(db, file).imported_modules())
+            .flat_map(|file| imported_modules(db, file).iter())
             .filter_map(|submodule_name| submodule_name.relative_to(self.module(db).name(db)))
             .filter_map(|relative_submodule| relative_submodule.components().next().map(Name::from))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -19,7 +19,7 @@ use smallvec::SmallVec;
 use strum::IntoEnumIterator;
 use ty_module_resolver::{KnownModule, ModuleName, resolve_module};
 use ty_python_core::ast_ids::HasScopedUseId;
-use ty_python_core::statement::StatementInner;
+use ty_python_core::statement::{StatementInner, standalone_statement};
 
 use super::{
     DeferredAndUndecorated, DefinitionInference, DefinitionInferenceExtra, DefinitionTypes,
@@ -6025,7 +6025,9 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn infer_maybe_standalone_statement(&mut self, statement: &ast::Stmt) {
-        if let Some(standalone_statement) = self.index.try_statement(statement) {
+        if let Some(standalone_statement) =
+            self.index.try_statement(self.db(), self.file(), statement)
+        {
             self.infer_standalone_statement_impl(standalone_statement);
         } else {
             self.infer_statement(statement);
@@ -7371,6 +7373,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             for (statement, use_expression) in
                 self.index.constraining_collection_uses(collection_def)
             {
+                let statement = standalone_statement(self.db(), self.file(), statement);
                 let statement_use_types = infer_statement_types(self.db(), statement);
 
                 if let Some(divergent) = statement_use_types

--- a/crates/ty_python_semantic/src/types/infer/builder/function.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/function.rs
@@ -32,6 +32,7 @@ use crate::{
         typed_dict::extract_unpacked_typed_dict_keys_from_kwargs_annotation,
     },
 };
+use ty_python_core::statement::{enclosing_lambda_statement, standalone_statement};
 use ty_python_core::{
     UseDefMap,
     definition::{Definition, DefinitionKind},
@@ -1166,9 +1167,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         index: u32,
         lambda: &'ast ast::ExprLambda,
     ) -> Option<Type<'db>> {
+        let statement_key = enclosing_lambda_statement(self.module(), lambda)?;
         let enclosing_stmt = infer_statement_types(
             self.db(),
-            self.index.enclosing_lambda_statement(lambda.into())?,
+            standalone_statement(self.db(), self.file(), statement_key),
         );
         let callable = enclosing_stmt.expression_type(lambda).as_callable()?;
         let [signature] = callable.signatures(self.db()).overloads.as_slice() else {

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -421,8 +421,8 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         // If the module doesn't bind the symbol, check if it's a submodule.  This won't get
-        // handled by the `Type::member` call because it relies on the semantic index's
-        // `imported_modules` set.  The semantic index does not include information about
+        // handled by the `Type::member` call because it relies on the `imported_modules` syntax
+        // query. The query does not include information about
         // `from...import` statements because there are two things it cannot determine while only
         // inspecting the content of the current file:
         //


### PR DESCRIPTION
Moves imported-module discovery and lambda statement lookup out of `SemanticIndex`, and lazily materializes standalone statement ingredients from compact node keys.

This reduces retained semantic-index data while remaining effectively neutral in RSS and simulation performance.

Testing: Passed targeted core and semantic tests, Clippy, repository hooks, and ty simulation benchmarks.