### PR TITLE
[ty] Extract imported modules into a syntax-only query

### DIFF
--- a/crates/ty_python_core/src/builder.rs
+++ b/crates/ty_python_core/src/builder.rs
@@ -273,7 +273,6 @@ pub(super) struct SemanticIndexBuilder<'db, 'ast> {
     unpacks_by_target: FxHashMap<ExpressionNodeKey, Unpack<'db>>,
     condition_flow_snapshots_by_node: FxHashMap<ExpressionNodeKey, ConditionFlowSnapshots>,
     statements_by_node: FxHashMap<StatementNodeKey, Statement<'db>>,
-    imported_modules: FxHashSet<ModuleName>,
     seen_submodule_imports: FxHashSet<String>,
     // A map from a lambda expression to its enclosing statement.
     enclosing_lambda_statements: FxHashMap<ExpressionNodeKey, Statement<'db>>,
@@ -333,7 +332,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             uses_by_collection: FxHashMap::default(),
 
             seen_submodule_imports: FxHashSet::default(),
-            imported_modules: FxHashSet::default(),
             generator_functions: FxHashSet::default(),
 
             enclosing_snapshots: FxHashMap::default(),
@@ -2648,7 +2646,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             enclosing_lambda_statements: FrozenMap::from(self.enclosing_lambda_statements),
             collections_by_use: FrozenMap::from(self.collections_by_use),
             uses_by_collection,
-            imported_modules: FrozenSet::from(self.imported_modules),
             has_future_annotations: self.has_future_annotations,
             enclosing_snapshots: FrozenMap::from(self.enclosing_snapshots),
             semantic_syntax_errors,
@@ -2846,12 +2843,6 @@ impl<'db, 'ast> SemanticIndexBuilder<'db, 'ast> {
             }
             ast::Stmt::Import(node) => {
                 for (alias_index, alias) in node.names.iter().enumerate() {
-                    // Mark the imported module, and all of its parents, as being imported in this
-                    // file.
-                    if let Some(module_name) = ModuleName::new(&alias.name) {
-                        self.imported_modules.extend(module_name.ancestors());
-                    }
-
                     let (symbol_name, is_reexported) = if let Some(asname) = &alias.asname {
                         self.scopes_by_expression
                             .record_expression(asname, self.current_scope());

--- a/crates/ty_python_core/src/lib.rs
+++ b/crates/ty_python_core/src/lib.rs
@@ -16,7 +16,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::Update;
 use salsa::plumbing::AsId;
 use smallvec::SmallVec;
-use ty_module_resolver::ModuleName;
 
 use crate::frozen::{FrozenMap, FrozenSet};
 use crate::place::ScopedPlaceId;
@@ -47,6 +46,7 @@ pub mod definition;
 pub mod expression;
 pub mod frozen;
 pub(crate) mod member;
+mod module_imports;
 pub mod narrowing_constraints;
 pub mod node_key;
 pub mod place;
@@ -61,6 +61,7 @@ pub mod symbol;
 pub mod unpack;
 mod use_def;
 pub use db::Db;
+pub use module_imports::imported_modules;
 pub mod program;
 
 /// Returns the semantic index for `file`.
@@ -324,9 +325,6 @@ pub struct SemanticIndex<'db> {
     /// changing a file invalidates all dependents.
     ast_ids: AstIds,
 
-    /// The set of modules that are imported anywhere within this file.
-    imported_modules: FrozenSet<ModuleName>,
-
     /// Flags about the global scope (code usage impacting inference)
     has_future_annotations: bool,
 
@@ -376,15 +374,6 @@ impl<'db> SemanticIndex<'db> {
     #[track_caller]
     pub fn use_def_map(&self, scope_id: FileScopeId) -> &UseDefMap<'db> {
         &self.use_def_maps[scope_id]
-    }
-
-    /// Returns the set of modules that are imported anywhere in this file.
-    ///
-    /// This set only considers `import` statements, not `from...import` statements.
-    /// See `ModuleLiteralType::available_submodule_attributes` for discussion
-    /// of why this analysis is intentionally limited.
-    pub fn imported_modules(&self) -> impl Iterator<Item = &ModuleName> {
-        self.imported_modules.iter()
     }
 
     #[track_caller]

--- a/crates/ty_python_core/src/module_imports.rs
+++ b/crates/ty_python_core/src/module_imports.rs
@@ -1,0 +1,96 @@
+//! A syntax-only query for finding modules imported by a file.
+
+use ruff_db::{files::File, parsed::parsed_module};
+use ruff_python_ast::{
+    self as ast,
+    statement_visitor::{StatementVisitor, walk_stmt},
+};
+use ty_module_resolver::ModuleName;
+
+use crate::Db;
+
+/// Returns the modules imported by `import` statements in `file`, including their ancestors.
+///
+/// Imports are collected across all scopes and control-flow branches. `from ... import ...`
+/// statements are intentionally excluded; see `ModuleLiteralType::available_submodule_attributes`
+/// for why this analysis is limited to direct imports.
+#[salsa::tracked(returns(deref), heap_size=ruff_memory_usage::heap_size)]
+pub fn imported_modules(db: &dyn Db, file: File) -> Box<[ModuleName]> {
+    let module = parsed_module(db, file).load(db);
+    let mut finder = ImportedModulesFinder::default();
+    finder.visit_body(module.suite());
+
+    finder.modules.sort_unstable();
+    finder.modules.dedup();
+    finder.modules.into_boxed_slice()
+}
+
+#[derive(Default)]
+struct ImportedModulesFinder {
+    modules: Vec<ModuleName>,
+}
+
+impl<'ast> StatementVisitor<'ast> for ImportedModulesFinder {
+    fn visit_stmt(&mut self, stmt: &'ast ast::Stmt) {
+        if let ast::Stmt::Import(import) = stmt {
+            for alias in &import.names {
+                if let Some(module_name) = ModuleName::new(&alias.name) {
+                    self.modules.extend(module_name.ancestors());
+                }
+            }
+        }
+
+        walk_stmt(self, stmt);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ruff_db::files::system_path_to_file;
+    use ty_module_resolver::ModuleName;
+
+    use super::imported_modules;
+    use crate::db::tests::TestDbBuilder;
+
+    #[test]
+    fn collects_direct_imports_and_their_ancestors() {
+        const FILENAME: &str = "test.py";
+        let db = TestDbBuilder::new()
+            .with_file(
+                FILENAME,
+                r#"
+import alpha
+import beta.gamma.delta as beta_delta
+from ignored.module import value
+
+if condition:
+    import nested.module
+
+def function():
+    import function.module
+"#,
+            )
+            .build()
+            .unwrap();
+        let file = system_path_to_file(&db, FILENAME).unwrap();
+
+        let modules = imported_modules(&db, file)
+            .iter()
+            .map(ModuleName::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            modules,
+            [
+                "alpha",
+                "beta",
+                "beta.gamma",
+                "beta.gamma.delta",
+                "function",
+                "function.module",
+                "nested",
+                "nested.module",
+            ]
+        );
+    }
+}

--- a/crates/ty_python_semantic/resources/mdtest/import/relative.md
+++ b/crates/ty_python_semantic/resources/mdtest/import/relative.md
@@ -224,11 +224,11 @@ reveal_type(foo)  # revealed: Unknown
 
 ## Import submodule from self
 
-We don't currently consider `from...import` statements when building up the `imported_modules` set
-in the semantic index. When accessing an attribute of a module, we only consider it a potential
-submodule when that submodule name appears in the `imported_modules` set. That means that submodules
-that are imported via `from...import` are not visible to our type inference if you also access that
-submodule via the attribute on its parent package.
+We don't currently consider `from...import` statements in the `imported_modules` query. When
+accessing an attribute of a module, we only consider it a potential submodule when that submodule
+name appears in the `imported_modules` set. That means that submodules that are imported via
+`from...import` are not visible to our type inference if you also access that submodule via the
+attribute on its parent package.
 
 `package/__init__.py`:
 

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -113,7 +113,7 @@ pub(crate) use special_form::TypedDictModule;
 use ty_python_core::definition::Definition;
 use ty_python_core::place::ScopedPlaceId;
 use ty_python_core::scope::ScopeId;
-use ty_python_core::{Truthiness, place_table, semantic_index};
+use ty_python_core::{Truthiness, imported_modules, place_table, semantic_index};
 
 mod bool;
 mod bound_super;
@@ -8330,7 +8330,7 @@ impl<'db> ModuleLiteralType<'db> {
     fn available_submodule_attributes(&self, db: &'db dyn Db) -> impl Iterator<Item = Name> {
         self.importing_file(db)
             .into_iter()
-            .flat_map(|file| semantic_index(db, file).imported_modules())
+            .flat_map(|file| imported_modules(db, file).iter())
             .filter_map(|submodule_name| submodule_name.relative_to(self.module(db).name(db)))
             .filter_map(|relative_submodule| relative_submodule.components().next().map(Name::from))
     }

--- a/crates/ty_python_semantic/src/types/infer/builder/imports.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder/imports.rs
@@ -421,10 +421,10 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         });
 
         // If the module doesn't bind the symbol, check if it's a submodule.  This won't get
-        // handled by the `Type::member` call because it relies on the semantic index's
-        // `imported_modules` set.  The semantic index does not include information about
-        // `from...import` statements because there are two things it cannot determine while only
-        // inspecting the content of the current file:
+        // handled by the `Type::member` call because it relies on the `imported_modules` query.
+        // The query does not include information about `from...import` statements because there
+        // are two things it cannot determine while only inspecting the content of the current
+        // file:
         //
         //   - whether the imported symbol is an attribute or submodule
         //   - whether the containing file is in a module or a package (needed to correctly resolve


### PR DESCRIPTION
Extract direct-import collection from the semantic index into a syntax-only Salsa query, preserving direct-import ancestor handling and the intentional exclusion of from-import statements.

This avoids computing the data for 61.7% of semantic-index executions in the simulation suite and 41.1% on Prefect. Simulation instruction count regressed 0.21% overall; RSS was effectively unchanged (+0.10%).

Testing: Added focused unit coverage and ran affected tests, Clippy, repository hooks, simulation benchmarks, and RSS measurements.