### PR TITLE
[ty] Reduce bound typevar identity overhead

### DIFF
--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1449,15 +1449,15 @@ struct DisplayBoundTypeVarIdentity<'db> {
 
 impl Display for DisplayBoundTypeVarIdentity<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(self.bound_typevar_identity.identity.name(self.db))?;
-        let binding_context = self.bound_typevar_identity.binding_context;
+        f.write_str(self.bound_typevar_identity.identity(self.db).name(self.db))?;
+        let binding_context = self.bound_typevar_identity.binding_context(self.db);
         if let Some(binding_context_name) = binding_context.name(self.db)
             && let Some(definition) = binding_context.definition()
             && !self.settings.active_scopes.contains(&definition)
         {
             write!(f, "@{binding_context_name}")?;
         }
-        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr {
+        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr(self.db) {
             write!(f, ".{paramspec_attr}")?;
         }
         Ok(())

--- a/crates/ty_python_semantic/src/types/display.rs
+++ b/crates/ty_python_semantic/src/types/display.rs
@@ -1449,15 +1449,15 @@ struct DisplayBoundTypeVarIdentity<'db> {
 
 impl Display for DisplayBoundTypeVarIdentity<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str(self.bound_typevar_identity.identity(self.db).name(self.db))?;
-        let binding_context = self.bound_typevar_identity.binding_context(self.db);
+        f.write_str(self.bound_typevar_identity.identity.name(self.db))?;
+        let binding_context = self.bound_typevar_identity.binding_context;
         if let Some(binding_context_name) = binding_context.name(self.db)
             && let Some(definition) = binding_context.definition()
             && !self.settings.active_scopes.contains(&definition)
         {
             write!(f, "@{binding_context_name}")?;
         }
-        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr(self.db) {
+        if let Some(paramspec_attr) = self.bound_typevar_identity.paramspec_attr {
             write!(f, ".{paramspec_attr}")?;
         }
         Ok(())

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -851,7 +851,10 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
 )]
 pub struct BoundTypeVarInstance<'db> {
     pub typevar: TypeVarInstance<'db>,
-    stored_identity: StoredBoundTypeVarIdentity<'db>,
+    // This duplicates the source-level identity accessible through `typevar`, but keeps
+    // `identity()` to a single interned-field read. Storing only the occurrence-specific fields
+    // and reconstructing the full identity regresses hot-path project benchmarks.
+    identity_inner: BoundTypeVarIdentity<'db>,
 }
 
 // The Salsa heap is tracked separately.
@@ -865,24 +868,25 @@ impl<'db> BoundTypeVarInstance<'db> {
         paramspec_attr: Option<ParamSpecAttrKind>,
         freshness: TypeVarNonce,
     ) -> Self {
-        let stored_identity = StoredBoundTypeVarIdentity {
+        let identity = BoundTypeVarIdentity {
+            identity: typevar.identity(db),
             binding_context,
             paramspec_attr,
             freshness,
         };
-        Self::new_internal(db, typevar, stored_identity)
+        Self::new_internal(db, typevar, identity)
     }
 
     pub(super) fn binding_context(self, db: &'db dyn Db) -> BindingContext<'db> {
-        self.stored_identity(db).binding_context
+        self.identity(db).binding_context
     }
 
     pub(super) fn paramspec_attr(self, db: &'db dyn Db) -> Option<ParamSpecAttrKind> {
-        self.stored_identity(db).paramspec_attr
+        self.identity(db).paramspec_attr
     }
 
     pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
-        self.stored_identity(db).freshness
+        self.identity(db).freshness
     }
 
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
@@ -902,13 +906,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// occurrence, regardless of e.g. differences in their bounds or constraints due to
     /// materialization.
     pub(crate) fn identity(self, db: &'db dyn Db) -> BoundTypeVarIdentity<'db> {
-        let stored_identity = self.stored_identity(db);
-        BoundTypeVarIdentity {
-            identity: self.typevar(db).identity(db),
-            binding_context: stored_identity.binding_context,
-            paramspec_attr: stored_identity.paramspec_attr,
-            freshness: stored_identity.freshness,
-        }
+        self.identity_inner(db)
     }
 
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
@@ -1430,17 +1428,6 @@ impl std::fmt::Display for ParamSpecAttrKind {
             ParamSpecAttrKind::Kwargs => f.write_str("kwargs"),
         }
     }
-}
-
-/// The fields that distinguish occurrences of the same source-level type variable.
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
-pub struct StoredBoundTypeVarIdentity<'db> {
-    binding_context: BindingContext<'db>,
-    /// If [`Some`], this indicates that this type variable is the `args` or `kwargs` component
-    /// of a `ParamSpec` i.e., `P.args` or `P.kwargs`.
-    paramspec_attr: Option<ParamSpecAttrKind>,
-    /// The freshness nonce for this bound typevar occurrence; `0` is the source-level occurrence.
-    freshness: TypeVarNonce,
 }
 
 /// The identity of a bound type variable occurrence.

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -795,11 +795,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
         fn new(db: &'db dyn Db, generic_context: GenericContext<'db>) -> Self {
             let base_identities = generic_context
                 .variables(db)
-                .map(|typevar| {
-                    let mut identity = typevar.identity(db);
-                    identity.freshness = TypeVarNonce::NONE;
-                    identity
-                })
+                .map(|typevar| typevar.identity(db).without_freshness(db))
                 .collect();
             Self {
                 base_identities,
@@ -819,8 +815,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
             db: &'db dyn Db,
             bound_typevar: BoundTypeVarInstance<'db>,
         ) {
-            let mut identity = bound_typevar.identity(db);
-            identity.freshness = TypeVarNonce::NONE;
+            let identity = bound_typevar.identity(db).without_freshness(db);
             if self.base_identities.contains(&identity) {
                 self.max_freshness.set(
                     self.max_freshness
@@ -844,21 +839,49 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
 
 /// A type variable that has been bound to a generic context, and which can be specialized to a
 /// concrete type.
-#[salsa::interned(debug, heap_size=ruff_memory_usage::heap_size)]
+#[salsa::interned(
+    debug,
+    constructor = new_internal,
+    heap_size = ruff_memory_usage::heap_size
+)]
 pub struct BoundTypeVarInstance<'db> {
     pub typevar: TypeVarInstance<'db>,
-    pub(super) binding_context: BindingContext<'db>,
-    /// If [`Some`], this indicates that this type variable is the `args` or `kwargs` component
-    /// of a `ParamSpec` i.e., `P.args` or `P.kwargs`.
-    pub(super) paramspec_attr: Option<ParamSpecAttrKind>,
-    /// The freshness nonce for this bound typevar occurrence; `0` is the source-level occurrence.
-    pub(super) freshness: TypeVarNonce,
+    identity_inner: BoundTypeVarIdentity<'db>,
 }
 
 // The Salsa heap is tracked separately.
 impl get_size2::GetSize for BoundTypeVarInstance<'_> {}
 
 impl<'db> BoundTypeVarInstance<'db> {
+    pub(crate) fn new(
+        db: &'db dyn Db,
+        typevar: TypeVarInstance<'db>,
+        binding_context: BindingContext<'db>,
+        paramspec_attr: Option<ParamSpecAttrKind>,
+        freshness: TypeVarNonce,
+    ) -> Self {
+        let identity = BoundTypeVarIdentity::new(
+            db,
+            typevar.identity(db),
+            binding_context,
+            paramspec_attr,
+            freshness,
+        );
+        Self::new_internal(db, typevar, identity)
+    }
+
+    pub(super) fn binding_context(self, db: &'db dyn Db) -> BindingContext<'db> {
+        self.identity(db).binding_context(db)
+    }
+
+    pub(super) fn paramspec_attr(self, db: &'db dyn Db) -> Option<ParamSpecAttrKind> {
+        self.identity(db).paramspec_attr(db)
+    }
+
+    pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
+        self.identity(db).freshness(db)
+    }
+
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
         Self::new(
             db,
@@ -876,12 +899,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// occurrence, regardless of e.g. differences in their bounds or constraints due to
     /// materialization.
     pub(crate) fn identity(self, db: &'db dyn Db) -> BoundTypeVarIdentity<'db> {
-        BoundTypeVarIdentity {
-            identity: self.typevar(db).identity(db),
-            binding_context: self.binding_context(db),
-            paramspec_attr: self.paramspec_attr(db),
-            freshness: self.freshness(db),
-        }
+        self.identity_inner(db)
     }
 
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
@@ -967,7 +985,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns whether two bound typevars represent the same occurrence, regardless of e.g.
     /// differences in their bounds or constraints due to materialization.
     pub(crate) fn is_same_typevar_as(self, db: &'db dyn Db, other: Self) -> bool {
-        self.identity(db) == other.identity(db)
+        self == other || self.identity(db) == other.identity(db)
     }
 
     /// Create a new PEP 695 type variable that can be used in signatures
@@ -1412,7 +1430,10 @@ impl std::fmt::Display for ParamSpecAttrKind {
 /// bounds or constraints. Two bound typevars have the same identity if they represent the same
 /// occurrence, even if their bounds have been materialized differently. Two fresh occurrences of
 /// the same source-level typevar have different bound identities.
-#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
+///
+/// Interning keeps this frequently copied and hashed identity compact while allowing multiple
+/// materialized [`BoundTypeVarInstance`]s to share it.
+#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
 pub struct BoundTypeVarIdentity<'db> {
     pub(crate) identity: TypeVarIdentity<'db>,
     pub(crate) binding_context: BindingContext<'db>,
@@ -1423,24 +1444,50 @@ pub struct BoundTypeVarIdentity<'db> {
     pub(super) freshness: TypeVarNonce,
 }
 
+// The Salsa heap is tracked separately.
+impl get_size2::GetSize for BoundTypeVarIdentity<'_> {}
+
 impl<'db> BoundTypeVarIdentity<'db> {
     fn kind(self, db: &'db dyn Db) -> TypeVarKind {
-        self.identity.kind(db)
+        self.identity(db).kind(db)
     }
 
     pub(crate) fn is_paramspec(self, db: &'db dyn Db) -> bool {
         self.kind(db).is_paramspec()
     }
 
-    pub(crate) fn without_paramspec_attr(mut self, db: &'db dyn Db) -> Self {
+    pub(crate) fn without_paramspec_attr(self, db: &'db dyn Db) -> Self {
         debug_assert!(
             self.is_paramspec(db),
             "Expected a ParamSpec, got {:?}",
             self.kind(db)
         );
 
-        self.paramspec_attr = None;
-        self
+        if self.paramspec_attr(db).is_none() {
+            self
+        } else {
+            Self::new(
+                db,
+                self.identity(db),
+                self.binding_context(db),
+                None,
+                self.freshness(db),
+            )
+        }
+    }
+
+    fn without_freshness(self, db: &'db dyn Db) -> Self {
+        if self.freshness(db) == TypeVarNonce::NONE {
+            self
+        } else {
+            Self::new(
+                db,
+                self.identity(db),
+                self.binding_context(db),
+                self.paramspec_attr(db),
+                TypeVarNonce::NONE,
+            )
+        }
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -795,7 +795,11 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
         fn new(db: &'db dyn Db, generic_context: GenericContext<'db>) -> Self {
             let base_identities = generic_context
                 .variables(db)
-                .map(|typevar| typevar.identity(db).without_freshness(db))
+                .map(|typevar| {
+                    let mut identity = typevar.identity(db);
+                    identity.freshness = TypeVarNonce::NONE;
+                    identity
+                })
                 .collect();
             Self {
                 base_identities,
@@ -815,7 +819,8 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
             db: &'db dyn Db,
             bound_typevar: BoundTypeVarInstance<'db>,
         ) {
-            let identity = bound_typevar.identity(db).without_freshness(db);
+            let mut identity = bound_typevar.identity(db);
+            identity.freshness = TypeVarNonce::NONE;
             if self.base_identities.contains(&identity) {
                 self.max_freshness.set(
                     self.max_freshness
@@ -860,26 +865,25 @@ impl<'db> BoundTypeVarInstance<'db> {
         paramspec_attr: Option<ParamSpecAttrKind>,
         freshness: TypeVarNonce,
     ) -> Self {
-        let identity = BoundTypeVarIdentity::new(
-            db,
-            typevar.identity(db),
+        let identity = BoundTypeVarIdentity {
+            identity: typevar.identity(db),
             binding_context,
             paramspec_attr,
             freshness,
-        );
+        };
         Self::new_internal(db, typevar, identity)
     }
 
     pub(super) fn binding_context(self, db: &'db dyn Db) -> BindingContext<'db> {
-        self.identity(db).binding_context(db)
+        self.identity(db).binding_context
     }
 
     pub(super) fn paramspec_attr(self, db: &'db dyn Db) -> Option<ParamSpecAttrKind> {
-        self.identity(db).paramspec_attr(db)
+        self.identity(db).paramspec_attr
     }
 
     pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
-        self.identity(db).freshness(db)
+        self.identity(db).freshness
     }
 
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
@@ -985,7 +989,7 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// Returns whether two bound typevars represent the same occurrence, regardless of e.g.
     /// differences in their bounds or constraints due to materialization.
     pub(crate) fn is_same_typevar_as(self, db: &'db dyn Db, other: Self) -> bool {
-        self == other || self.identity(db) == other.identity(db)
+        self.identity(db) == other.identity(db)
     }
 
     /// Create a new PEP 695 type variable that can be used in signatures
@@ -1430,10 +1434,7 @@ impl std::fmt::Display for ParamSpecAttrKind {
 /// bounds or constraints. Two bound typevars have the same identity if they represent the same
 /// occurrence, even if their bounds have been materialized differently. Two fresh occurrences of
 /// the same source-level typevar have different bound identities.
-///
-/// Interning keeps this frequently copied and hashed identity compact while allowing multiple
-/// materialized [`BoundTypeVarInstance`]s to share it.
-#[salsa::interned(debug, heap_size = ruff_memory_usage::heap_size)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
 pub struct BoundTypeVarIdentity<'db> {
     pub(crate) identity: TypeVarIdentity<'db>,
     pub(crate) binding_context: BindingContext<'db>,
@@ -1444,50 +1445,24 @@ pub struct BoundTypeVarIdentity<'db> {
     pub(super) freshness: TypeVarNonce,
 }
 
-// The Salsa heap is tracked separately.
-impl get_size2::GetSize for BoundTypeVarIdentity<'_> {}
-
 impl<'db> BoundTypeVarIdentity<'db> {
     fn kind(self, db: &'db dyn Db) -> TypeVarKind {
-        self.identity(db).kind(db)
+        self.identity.kind(db)
     }
 
     pub(crate) fn is_paramspec(self, db: &'db dyn Db) -> bool {
         self.kind(db).is_paramspec()
     }
 
-    pub(crate) fn without_paramspec_attr(self, db: &'db dyn Db) -> Self {
+    pub(crate) fn without_paramspec_attr(mut self, db: &'db dyn Db) -> Self {
         debug_assert!(
             self.is_paramspec(db),
             "Expected a ParamSpec, got {:?}",
             self.kind(db)
         );
 
-        if self.paramspec_attr(db).is_none() {
-            self
-        } else {
-            Self::new(
-                db,
-                self.identity(db),
-                self.binding_context(db),
-                None,
-                self.freshness(db),
-            )
-        }
-    }
-
-    fn without_freshness(self, db: &'db dyn Db) -> Self {
-        if self.freshness(db) == TypeVarNonce::NONE {
-            self
-        } else {
-            Self::new(
-                db,
-                self.identity(db),
-                self.binding_context(db),
-                self.paramspec_attr(db),
-                TypeVarNonce::NONE,
-            )
-        }
+        self.paramspec_attr = None;
+        self
     }
 }
 

--- a/crates/ty_python_semantic/src/types/typevar.rs
+++ b/crates/ty_python_semantic/src/types/typevar.rs
@@ -851,7 +851,7 @@ pub(crate) fn max_typevar_freshness_matching_generic_context<'db>(
 )]
 pub struct BoundTypeVarInstance<'db> {
     pub typevar: TypeVarInstance<'db>,
-    identity_inner: BoundTypeVarIdentity<'db>,
+    stored_identity: StoredBoundTypeVarIdentity<'db>,
 }
 
 // The Salsa heap is tracked separately.
@@ -865,25 +865,24 @@ impl<'db> BoundTypeVarInstance<'db> {
         paramspec_attr: Option<ParamSpecAttrKind>,
         freshness: TypeVarNonce,
     ) -> Self {
-        let identity = BoundTypeVarIdentity {
-            identity: typevar.identity(db),
+        let stored_identity = StoredBoundTypeVarIdentity {
             binding_context,
             paramspec_attr,
             freshness,
         };
-        Self::new_internal(db, typevar, identity)
+        Self::new_internal(db, typevar, stored_identity)
     }
 
     pub(super) fn binding_context(self, db: &'db dyn Db) -> BindingContext<'db> {
-        self.identity(db).binding_context
+        self.stored_identity(db).binding_context
     }
 
     pub(super) fn paramspec_attr(self, db: &'db dyn Db) -> Option<ParamSpecAttrKind> {
-        self.identity(db).paramspec_attr
+        self.stored_identity(db).paramspec_attr
     }
 
     pub(super) fn freshness(self, db: &'db dyn Db) -> TypeVarNonce {
-        self.identity(db).freshness
+        self.stored_identity(db).freshness
     }
 
     pub(crate) fn with_name_suffix(self, db: &'db dyn Db, suffix: &str) -> Self {
@@ -903,7 +902,13 @@ impl<'db> BoundTypeVarInstance<'db> {
     /// occurrence, regardless of e.g. differences in their bounds or constraints due to
     /// materialization.
     pub(crate) fn identity(self, db: &'db dyn Db) -> BoundTypeVarIdentity<'db> {
-        self.identity_inner(db)
+        let stored_identity = self.stored_identity(db);
+        BoundTypeVarIdentity {
+            identity: self.typevar(db).identity(db),
+            binding_context: stored_identity.binding_context,
+            paramspec_attr: stored_identity.paramspec_attr,
+            freshness: stored_identity.freshness,
+        }
     }
 
     pub(crate) fn name(self, db: &'db dyn Db) -> &'db Name {
@@ -1425,6 +1430,17 @@ impl std::fmt::Display for ParamSpecAttrKind {
             ParamSpecAttrKind::Kwargs => f.write_str("kwargs"),
         }
     }
+}
+
+/// The fields that distinguish occurrences of the same source-level type variable.
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, get_size2::GetSize, salsa::Update)]
+pub struct StoredBoundTypeVarIdentity<'db> {
+    binding_context: BindingContext<'db>,
+    /// If [`Some`], this indicates that this type variable is the `args` or `kwargs` component
+    /// of a `ParamSpec` i.e., `P.args` or `P.kwargs`.
+    paramspec_attr: Option<ParamSpecAttrKind>,
+    /// The freshness nonce for this bound typevar occurrence; `0` is the source-level occurrence.
+    freshness: TypeVarNonce,
 }
 
 /// The identity of a bound type variable occurrence.


### PR DESCRIPTION
## Summary

A bound type variable's logical identity consists of its source type variable, binding context, ParamSpec component, and freshness nonce. We previously reconstructed that four-field value each time callers needed to compare or key bound type variables, including reading the source identity through the materialized `TypeVarInstance`.

This keeps `BoundTypeVarIdentity` as an ordinary `Copy` struct and stores the precomputed value directly on each `BoundTypeVarInstance`. Materialized variants still retain their full `TypeVarInstance`, but reading their shared logical identity is now a single Salsa field access without a separate identity interner.

## Performance

In the [raw CodSpeed report](https://app.codspeed.io/astral-sh/ruff/branches/charlie%2Fcodex-bound-typevar-identity), all five project CPU-simulation benchmarks improve by 0.74-2.03%. Their arithmetic mean improves by 1.56%, and summing the five head and base measurements gives a 1.49% aggregate improvement. Across all 41 measured CPU-simulation benchmarks, the aggregate improvement is 0.82%; the 30 microbenchmarks are effectively flat at +0.13% aggregate.

Storing the copied identity increases `BoundTypeVarInstance` memory by 10%, corresponding to a 0.02-0.04% whole-project increase in the memory report (5-174 kB across the measured projects).

The full ty semantic test suite, workspace Clippy, and repository hooks pass.
