### PR TITLE
[ty] Elide default use-def state

### DIFF
--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -625,6 +625,12 @@ static EMPTY_CONSTRAINT_TABLES: LazyLock<ConstraintTables<'static>> =
         narrowing_constraints: NarrowingConstraintsBuilder::default().build(),
     });
 
+static ALWAYS_UNBOUND_BINDINGS: LazyLock<Bindings> =
+    LazyLock::new(|| Bindings::unbound(ScopedReachabilityConstraintId::ALWAYS_TRUE));
+
+static ALWAYS_UNDECLARED_DECLARATIONS: LazyLock<Declarations> =
+    LazyLock::new(|| Declarations::undeclared(ScopedReachabilityConstraintId::ALWAYS_TRUE));
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
 enum RetainedDefinitionState<'db> {
     Unused(Definition<'db>),
@@ -754,14 +760,14 @@ pub struct UseDefMap<'db> {
     ///
     /// If we see a binding to a `Final`-qualified symbol, we also need the bindings to find
     /// previous bindings to that symbol. If there are any, the assignment is invalid.
+    ///
+    /// Entries whose prior state is the start-of-scope default (always unbound and, if present,
+    /// always undeclared) are omitted. Lookups use [`ALWAYS_UNBOUND_BINDINGS`] and
+    /// [`ALWAYS_UNDECLARED_DECLARATIONS`], which are initialized lazily and shared by every map.
     definitions_by_definition: FrozenMap<
         Definition<'db>,
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
-
-    /// Default prior state for definitions omitted from `definitions_by_definition`.
-    initial_definitions_at_definition:
-        DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
 
     /// Retained [`PlaceState`] values for each symbol.
     symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
@@ -794,6 +800,15 @@ pub struct UseDefMap<'db> {
 struct RangeInfo {
     reachability: ScopedReachabilityConstraintId,
     in_type_checking_block: bool,
+}
+
+impl Default for RangeInfo {
+    fn default() -> Self {
+        Self {
+            reachability: ScopedReachabilityConstraintId::ALWAYS_TRUE,
+            in_type_checking_block: false,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, salsa::Update, get_size2::GetSize)]
@@ -1046,31 +1061,26 @@ impl<'db> UseDefMap<'db> {
         &self,
         definition: Definition<'db>,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings_id = self
-            .definitions_by_definition
-            .get(&definition)
-            .unwrap_or(&self.initial_definitions_at_definition)
-            .bindings;
-        self.bindings_iterator(
-            &self.interned_bindings[bindings_id],
-            BoundnessAnalysis::BasedOnUnboundVisibility,
-        )
+        let bindings = self.definitions_by_definition.get(&definition).map_or_else(
+            || ALWAYS_UNBOUND_BINDINGS.as_slice(),
+            |definitions| &self.interned_bindings[definitions.bindings],
+        );
+        self.bindings_iterator(bindings, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
     pub fn declarations_at_binding(
         &self,
         binding: Definition<'db>,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations_id = self
-            .definitions_by_definition
-            .get(&binding)
-            .unwrap_or(&self.initial_definitions_at_definition)
-            .declarations
-            .expect("binding definition should have retained declarations");
-        self.declarations_iterator(
-            &self.interned_declarations[declarations_id],
-            BoundnessAnalysis::BasedOnUnboundVisibility,
-        )
+        let declarations = self.definitions_by_definition.get(&binding).map_or_else(
+            || ALWAYS_UNDECLARED_DECLARATIONS.as_slice(),
+            |definitions| {
+                &self.interned_declarations[definitions
+                    .declarations
+                    .expect("binding definition should have retained declarations")]
+            },
+        );
+        self.declarations_iterator(declarations, BoundnessAnalysis::BasedOnUnboundVisibility)
     }
 
     pub fn end_of_scope_declarations<'map>(
@@ -2538,14 +2548,6 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_declarations_capacity,
             interned_declarations_capacity,
         );
-        let initial_definitions_at_definition = {
-            let (bindings, declarations) =
-                PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE).into_parts();
-            DefinitionsAtDefinition {
-                bindings: place_state_interner.intern_bindings(&bindings),
-                declarations: Some(place_state_interner.intern_declarations(declarations)),
-            }
-        };
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let definitions_by_definition = Self::intern_definitions_by_definition(
             self.definitions_by_definition,
@@ -2605,10 +2607,8 @@ impl<'db> UseDefMapBuilder<'db> {
         // Keep default entries while building so they remain barriers between non-contiguous
         // ranges with the same metadata. Once construction is complete, absence represents the
         // default of reachable code outside a `TYPE_CHECKING` block.
-        self.range_reachability.retain(|(_, info)| {
-            info.reachability != ScopedReachabilityConstraintId::ALWAYS_TRUE
-                || info.in_type_checking_block
-        });
+        self.range_reachability
+            .retain(|(_, info)| *info != RangeInfo::default());
         for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
             self.reachability_constraints.mark_used(reachability);
         }
@@ -2660,7 +2660,6 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: self.range_reachability.into_boxed_slice(),
             symbol_states,
             definitions_by_definition,
-            initial_definitions_at_definition,
             extra,
             end_of_scope_reachability: self.reachability,
         }
@@ -2708,6 +2707,7 @@ impl<'db> UseDefMapBuilder<'db> {
             },
         ) in definitions_by_definition
         {
+            // Lookups use the shared start-of-scope defaults for these omitted entries.
             if bindings.is_always_unbound()
                 && declarations
                     .as_ref()

--- a/crates/ty_python_core/src/use_def.rs
+++ b/crates/ty_python_core/src/use_def.rs
@@ -759,6 +759,10 @@ pub struct UseDefMap<'db> {
         DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
     >,
 
+    /// Default prior state for definitions omitted from `definitions_by_definition`.
+    initial_definitions_at_definition:
+        DefinitionsAtDefinition<InternedBindingsId, InternedDeclarationsId>,
+
     /// Retained [`PlaceState`] values for each symbol.
     symbol_states: FrozenIndexVec<ScopedSymbolId, RetainedPlaceStates<InternedPlaceStateId>>,
 
@@ -1042,7 +1046,11 @@ impl<'db> UseDefMap<'db> {
         &self,
         definition: Definition<'db>,
     ) -> BindingWithConstraintsIterator<'_, 'db> {
-        let bindings_id = self.definitions_by_definition[&definition].bindings;
+        let bindings_id = self
+            .definitions_by_definition
+            .get(&definition)
+            .unwrap_or(&self.initial_definitions_at_definition)
+            .bindings;
         self.bindings_iterator(
             &self.interned_bindings[bindings_id],
             BoundnessAnalysis::BasedOnUnboundVisibility,
@@ -1053,7 +1061,10 @@ impl<'db> UseDefMap<'db> {
         &self,
         binding: Definition<'db>,
     ) -> DeclarationsIterator<'_, 'db> {
-        let declarations_id = self.definitions_by_definition[&binding]
+        let declarations_id = self
+            .definitions_by_definition
+            .get(&binding)
+            .unwrap_or(&self.initial_definitions_at_definition)
             .declarations
             .expect("binding definition should have retained declarations");
         self.declarations_iterator(
@@ -2527,6 +2538,14 @@ impl<'db> UseDefMapBuilder<'db> {
             interned_ids_by_declarations_capacity,
             interned_declarations_capacity,
         );
+        let initial_definitions_at_definition = {
+            let (bindings, declarations) =
+                PlaceState::undefined(ScopedReachabilityConstraintId::ALWAYS_TRUE).into_parts();
+            DefinitionsAtDefinition {
+                bindings: place_state_interner.intern_bindings(&bindings),
+                declarations: Some(place_state_interner.intern_declarations(declarations)),
+            }
+        };
         // These fields are manually interned because they have a statistically high duplication rate (>50%).
         let definitions_by_definition = Self::intern_definitions_by_definition(
             self.definitions_by_definition,
@@ -2583,6 +2602,13 @@ impl<'db> UseDefMapBuilder<'db> {
                 &mut self.reachability_constraints,
             );
         }
+        // Keep default entries while building so they remain barriers between non-contiguous
+        // ranges with the same metadata. Once construction is complete, absence represents the
+        // default of reachable code outside a `TYPE_CHECKING` block.
+        self.range_reachability.retain(|(_, info)| {
+            info.reachability != ScopedReachabilityConstraintId::ALWAYS_TRUE
+                || info.in_type_checking_block
+        });
         for &(_, RangeInfo { reachability, .. }) in &self.range_reachability {
             self.reachability_constraints.mark_used(reachability);
         }
@@ -2634,6 +2660,7 @@ impl<'db> UseDefMapBuilder<'db> {
             range_reachability: self.range_reachability.into_boxed_slice(),
             symbol_states,
             definitions_by_definition,
+            initial_definitions_at_definition,
             extra,
             end_of_scope_reachability: self.reachability,
         }
@@ -2681,6 +2708,14 @@ impl<'db> UseDefMapBuilder<'db> {
             },
         ) in definitions_by_definition
         {
+            if bindings.is_always_unbound()
+                && declarations
+                    .as_ref()
+                    .is_none_or(Declarations::is_always_undeclared)
+            {
+                continue;
+            }
+
             let bindings = place_state_interner.intern_bindings(&bindings);
             let declarations = declarations
                 .map(|declarations| place_state_interner.intern_declarations(declarations));

--- a/crates/ty_python_core/src/use_def/place_state.rs
+++ b/crates/ty_python_core/src/use_def/place_state.rs
@@ -175,6 +175,10 @@ impl Declarations {
         self.live_declarations.iter()
     }
 
+    pub(super) fn as_slice(&self) -> &[LiveDeclaration] {
+        &self.live_declarations
+    }
+
     fn merge(&mut self, b: Self, reachability_constraints: &mut ReachabilityConstraintsBuilder) {
         let a = std::mem::take(self);
 


### PR DESCRIPTION
## Summary

We currently retain range reachability for every range, even when the range has the default reachable state. We also retain a definitions-at-definition entry when that entry is identical to the initial unbound and undeclared state.

This change omits default range reachability after construction, while preserving default entries during construction so they continue to separate non-contiguous ranges with the same non-default metadata. It also omits default definitions-at-definition entries and preserves lookup behavior through a canonical interned fallback.
