### PR TITLE
[ty] Compact exact-Unknown expression storage

### DIFF
--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -771,8 +771,13 @@ impl<'db> InferenceRegion<'db> {
 /// The inferred types for a scope region.
 #[derive(Debug, Eq, PartialEq, salsa::Update, get_size2::GetSize)]
 pub(crate) struct ScopeInference<'db> {
-    /// The types of every expression in this region.
+    /// Expression types retained as key-value entries.
+    ///
+    /// Completed results store exact `Unknown` types in `unknowns` instead.
     expressions: FrozenValueMap<ExpressionNodeKey, Type<'db>>,
+
+    /// Expressions whose inferred type is exactly `Unknown` in a completed result.
+    unknowns: FrozenSet<ExpressionNodeKey>,
 
     /// The extra data that is only present for few inference regions.
     extra: Option<Box<ScopeInferenceExtra<'db>>>,
@@ -810,6 +815,7 @@ impl<'db> ScopeInference<'db> {
                 ..ScopeInferenceExtra::default()
             })),
             expressions: FrozenValueMap::default(),
+            unknowns: FrozenSet::default(),
         }
     }
 
@@ -819,6 +825,19 @@ impl<'db> ScopeInference<'db> {
         previous_inference: &ScopeInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ScopeInference<'db> {
+        if self.unknowns.iter().next().is_some() {
+            let expressions = std::mem::take(&mut self.expressions);
+            self.expressions = expressions
+                .iter()
+                .chain(
+                    self.unknowns
+                        .iter()
+                        .map(|expression| (*expression, Type::unknown())),
+                )
+                .collect();
+            self.unknowns = FrozenSet::default();
+        }
+
         self.expressions.map_values(|expr, ty| {
             ty.cycle_normalized(db, previous_inference.expression_type(expr), cycle)
         });
@@ -850,9 +869,11 @@ impl<'db> ScopeInference<'db> {
         &self,
         expression: impl Into<ExpressionNodeKey>,
     ) -> Option<Type<'db>> {
+        let expression = expression.into();
         self.expressions
-            .get(&expression.into())
+            .get(&expression)
             .copied()
+            .or_else(|| self.unknowns.contains(&expression).then(Type::unknown))
             .or_else(|| self.fallback_type())
     }
 

--- a/crates/ty_python_semantic/src/types/infer.rs
+++ b/crates/ty_python_semantic/src/types/infer.rs
@@ -825,22 +825,16 @@ impl<'db> ScopeInference<'db> {
         previous_inference: &ScopeInference<'db>,
         cycle: &salsa::Cycle,
     ) -> ScopeInference<'db> {
-        if self.unknowns.iter().next().is_some() {
-            let expressions = std::mem::take(&mut self.expressions);
-            self.expressions = expressions
-                .iter()
-                .chain(
-                    self.unknowns
-                        .iter()
-                        .map(|expression| (*expression, Type::unknown())),
+        self.expressions = self
+            .expression_types()
+            .map(|(expression, ty)| {
+                (
+                    expression,
+                    ty.cycle_normalized(db, previous_inference.expression_type(expression), cycle),
                 )
-                .collect();
-            self.unknowns = FrozenSet::default();
-        }
-
-        self.expressions.map_values(|expr, ty| {
-            ty.cycle_normalized(db, previous_inference.expression_type(expr), cycle)
-        });
+            })
+            .collect();
+        self.unknowns = FrozenSet::default();
 
         if cycle.iteration() > crate::TAINTED_CYCLES
             && let Some(previous_extra) = previous_inference.extra.as_deref()
@@ -863,6 +857,14 @@ impl<'db> ScopeInference<'db> {
     pub(crate) fn expression_type(&self, expression: impl Into<ExpressionNodeKey>) -> Type<'db> {
         self.try_expression_type(expression)
             .unwrap_or_else(Type::unknown)
+    }
+
+    fn expression_types(&self) -> impl Iterator<Item = (ExpressionNodeKey, Type<'db>)> + '_ {
+        self.expressions.iter().chain(
+            self.unknowns
+                .iter()
+                .map(|expression| (*expression, Type::unknown())),
+        )
     }
 
     pub(crate) fn try_expression_type(

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -604,13 +604,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
     }
 
     fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
-        self.expressions.extend(inference.expressions.iter());
-        self.expressions.extend(
-            inference
-                .unknowns
-                .iter()
-                .map(|expression| (*expression, Type::unknown())),
-        );
+        self.expressions.extend(inference.expression_types());
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -10543,7 +10537,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let unknowns = if cycle_recovery.is_none() {
             let mut unknowns = FxHashSet::default();
             expressions.retain(|expression, ty| {
-                if ty.is_unknown() {
+                if matches!(ty, Type::Dynamic(DynamicType::Unknown)) {
                     unknowns.insert(*expression);
                     false
                 } else {

--- a/crates/ty_python_semantic/src/types/infer/builder.rs
+++ b/crates/ty_python_semantic/src/types/infer/builder.rs
@@ -605,6 +605,12 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
     fn extend_scope(&mut self, inference: &ScopeInference<'db>) {
         self.expressions.extend(inference.expressions.iter());
+        self.expressions.extend(
+            inference
+                .unknowns
+                .iter()
+                .map(|expression| (*expression, Type::unknown())),
+        );
 
         if let Some(extra) = &inference.extra {
             self.context.extend(&extra.diagnostics);
@@ -10505,7 +10511,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
             expected_types,
             type_expression_flags,
             mut collection_use_constraints,
-            expressions,
+            mut expressions,
             scope,
             cycle_recovery,
             qualifiers,
@@ -10534,6 +10540,21 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
         let _ = scope;
         let diagnostics = context.finish();
 
+        let unknowns = if cycle_recovery.is_none() {
+            let mut unknowns = FxHashSet::default();
+            expressions.retain(|expression, ty| {
+                if ty.is_unknown() {
+                    unknowns.insert(*expression);
+                    false
+                } else {
+                    true
+                }
+            });
+            FrozenSet::from(unknowns)
+        } else {
+            FrozenSet::default()
+        };
+
         let extra = (!string_annotations.is_empty()
             || !expected_types.is_empty()
             || !diagnostics.is_empty()
@@ -10556,6 +10577,7 @@ impl<'db, 'ast> TypeInferenceBuilder<'db, 'ast> {
 
         ScopeInference {
             expressions: FrozenValueMap::from(expressions),
+            unknowns,
             extra,
         }
     }

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -116,6 +116,25 @@ fn compact_definition_types_omit_owner() -> anyhow::Result<()> {
 }
 
 #[test]
+fn scope_unknown_expression_types_use_compact_storage() -> anyhow::Result<()> {
+    let mut db = setup_db();
+    db.write_dedented("/src/main.py", "x = missing")?;
+
+    let file = system_path_to_file(&db, "/src/main.py")?;
+    let module = parsed_module(&db, file).load(&db);
+    let assignment = module.syntax().body[0].as_assign_stmt().unwrap();
+    let target = &assignment.targets[0];
+    let target_key = target.into();
+    let inference = infer_complete_scope_types(&db, global_scope(&db, file));
+
+    assert!(inference.expressions.get(&target_key).is_none());
+    assert!(inference.unknowns.contains(&target_key));
+    assert_eq!(inference.try_expression_type(target), Some(Type::unknown()));
+
+    Ok(())
+}
+
+#[test]
 fn not_literal_string() -> anyhow::Result<()> {
     let mut db = setup_db();
     let content = format!(


### PR DESCRIPTION
## Summary

Completed scope inference stores each expression type in a frozen value map. Exact `Unknown` results are common, but storing them as ordinary values retains the full map value representation even though every such entry has the same type.

This moves expressions whose type is exactly `DynamicType::Unknown` into a compact frozen key set and reconstructs `Type::unknown()` through the shared lookup and iteration paths. Semantically distinct dynamic variants such as `UnknownGeneric` and `AmbiguousOverload` remain in the value map, while cycle normalization expands compact entries before normalizing them.