### PR TITLE
[ty] View reports for avoiding negative descriptor queries

### DIFF
--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -3129,6 +3129,25 @@ impl<'db> Type<'db> {
             return Some((descriptor_result, AttributeKind::NormalOrNonDataDescriptor));
         }
 
+        // Avoid retaining a context-specific query when the existing class-member query already
+        // proves that this common concrete type has no descriptor method.
+        if matches!(self, Type::NominalInstance(_) | Type::ClassLiteral(_)) {
+            let Place::Defined(DefinedPlace { ty, .. }) = self
+                .class_member_with_policy(
+                    db,
+                    "__get__".into(),
+                    MemberLookupPolicy::REQUIRE_CONCRETE,
+                )
+                .place
+            else {
+                return None;
+            };
+
+            if ty.is_divergent() {
+                return None;
+            }
+        }
+
         try_call_dunder_get_inner(db, self, instance, owner)
     }
 

--- a/crates/ty_python_semantic/src/types/infer/tests.rs
+++ b/crates/ty_python_semantic/src/types/infer/tests.rs
@@ -916,6 +916,93 @@ fn dependency_implicit_class_member() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[test]
+fn dependency_descriptor_method() -> anyhow::Result<()> {
+    fn x_rhs_expression(db: &TestDb) -> Expression<'_> {
+        let file_main = system_path_to_file(db, "/src/main.py").unwrap();
+        let ast = parsed_module(db, file_main).load(db);
+        let x_rhs_node = &ast.syntax().body[1].as_assign_stmt().unwrap().value;
+
+        semantic_index(db, file_main).expression(x_rhs_node.as_ref())
+    }
+
+    let mut db = setup_db();
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            pass
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+    db.write_dedented(
+        "/src/main.py",
+        r#"
+        from mod import C
+        x = y = C().attr
+        "#,
+    )?;
+
+    let file_main = system_path_to_file(&db, "/src/main.py").unwrap();
+    let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+    assert_eq!(attr_ty.display(&db).to_string(), "Descriptor");
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            # comment
+            pass
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "Descriptor");
+        db.take_salsa_events()
+    };
+    assert_function_query_was_not_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+
+    db.write_dedented(
+        "/src/mod.py",
+        r#"
+        class Descriptor:
+            def __get__(self, instance: object, owner: type) -> int:
+                return 42
+
+        class C:
+            attr = Descriptor()
+        "#,
+    )?;
+
+    let events = {
+        db.clear_salsa_events();
+        let attr_ty = global_symbol(&db, file_main, "x").place.expect_type();
+        assert_eq!(attr_ty.display(&db).to_string(), "int");
+        db.take_salsa_events()
+    };
+    assert_function_query_was_run(
+        &db,
+        infer_expression_types_impl,
+        InferExpression::Bare(x_rhs_expression(&db)),
+        &events,
+    );
+
+    Ok(())
+}
+
 /// Inferring the result of a call-expression shouldn't need to re-run after
 /// a trivial change to the function's file (e.g. by adding a docstring to the function).
 #[test]


### PR DESCRIPTION
## Summary

Descriptor lookup currently retains a context-specific `try_call_dunder_get_inner` query even for common nominal instances and class literals whose existing concrete class-member lookup already proves that `__get__` is absent.

This consults that existing class-member query first and skips the context-specific query when it cannot be a descriptor. The dependency remains on the class-member query, so adding `__get__` still invalidates and reinfers the affected expression. In the sequential local Sphinx measurement, this accounted for approximately 268 KB, or 0.126% of the baseline memory report.
