### PR TITLE
Several `ruff:ignore` fixes

### DIFF
--- a/crates/ruff/src/args.rs
+++ b/crates/ruff/src/args.rs
@@ -446,10 +446,12 @@ pub struct CheckCommand {
         conflicts_with = "watch",
     )]
     pub statistics: bool,
-    /// Enable automatic additions of `noqa` directives to failing lines.
+    /// Enable automatic additions of suppression directives to failing lines.
+    /// Uses `ruff:ignore` in preview mode and `noqa` otherwise.
     /// Optionally provide a reason to append after the codes.
     #[arg(
         long,
+        visible_alias = "add-ignore",
         value_name = "REASON",
         default_missing_value = "",
         num_args = 0..=1,

--- a/crates/ruff/src/commands/add_noqa.rs
+++ b/crates/ruff/src/commands/add_noqa.rs
@@ -16,7 +16,7 @@ use ruff_workspace::resolver::{
 
 use crate::args::ConfigArguments;
 
-/// Add `noqa` directives to a collection of files.
+/// Add suppression directives to a collection of files.
 pub(crate) fn add_noqa(
     files: &[PathBuf],
     pyproject_config: &PyprojectConfig,
@@ -95,7 +95,7 @@ pub(crate) fn add_noqa(
             ) {
                 Ok(count) => Some(count),
                 Err(e) => {
-                    error!("Failed to add noqa to {}: {e}", path.display());
+                    error!("Failed to add suppression to {}: {e}", path.display());
                     None
                 }
             }
@@ -103,7 +103,7 @@ pub(crate) fn add_noqa(
         .sum();
 
     let duration = start.elapsed();
-    debug!("Added noqa to files in: {duration:?}");
+    debug!("Added suppressions to files in: {duration:?}");
 
     Ok(modifications)
 }

--- a/crates/ruff/src/lib.rs
+++ b/crates/ruff/src/lib.rs
@@ -344,7 +344,7 @@ pub fn check(args: CheckCommand, global_options: GlobalConfigArgs) -> Result<Exi
             let s = if modifications == 1 { "" } else { "s" };
             #[expect(clippy::print_stderr)]
             {
-                eprintln!("Added {modifications} noqa directive{s}.");
+                eprintln!("Added {modifications} suppression comment{s}.");
             }
         }
         return Ok(ExitStatus::Success);

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2068,7 +2068,7 @@ def first_square():
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2106,7 +2106,6 @@ def unused(x):
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         .arg("-")
         .pass_stdin(r#"
@@ -2117,7 +2116,7 @@ def unused(x):
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2166,7 +2165,7 @@ import a
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2205,7 +2204,6 @@ def unused(x):  # noqa: ANN001, ARG001, D103
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         .arg("-")
         .pass_stdin(r#"
@@ -2216,7 +2214,7 @@ def unused(x):  # noqa: ANN001, ARG001, D103
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2254,7 +2252,6 @@ import os
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         .arg("-")
         .pass_stdin(r#"
@@ -2355,7 +2352,6 @@ print(
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         .arg("-")
         .pass_stdin(r#"
@@ -2366,7 +2362,7 @@ print(
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2406,7 +2402,6 @@ select = ["D100"]
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         , @"
     success: true
@@ -2414,7 +2409,7 @@ select = ["D100"]
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2446,7 +2441,6 @@ select = ["D100"]
         .check_command()
         .args(["--config", "ruff.toml"])
         .arg("noqa.py")
-        .arg("--preview")
         .args(["--add-noqa"])
         , @"
     success: true
@@ -2454,7 +2448,7 @@ select = ["D100"]
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     let test_code =
@@ -2504,7 +2498,7 @@ def first_square():
     ----- stdout -----
 
     ----- stderr -----
-    Added 1 noqa directive.
+    Added 1 suppression comment.
     ");
 
     Ok(())
@@ -2560,7 +2554,7 @@ def foo():
     ----- stdout -----
 
     ----- stderr -----
-    Added 2 noqa directives.
+    Added 2 suppression comments.
     ");
 
     let content = fs::read_to_string(fixture.root().join("test.py"))?;
@@ -2592,6 +2586,390 @@ fn add_noqa_with_newline_in_reason() -> Result<()> {
     ruff failed
       Cause: --add-noqa <reason> cannot contain newline characters
     ");
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        def first_square():
+            return [x * x for x in range(20)][0]
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=RUF015")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        def first_square():
+            return [x * x for x in range(20)][0]  # ruff:ignore[unnecessary-iterable-allocation-for-first-element]
+        ",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_alias_without_preview() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file("noqa.py", "import os\n")?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=F401")
+            .arg("noqa.py")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+    insta::assert_snapshot!(test_code, @"import os  # noqa: F401");
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_respects_hierarchical_preview_settings() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "ruff.toml",
+        r#"lint = { preview = true, select = ["F401"] }"#,
+    )?;
+    fixture.write_file("root.py", "import os\n")?;
+    fixture.write_file(
+        "nested/ruff.toml",
+        r#"lint = { preview = false, select = ["F401"] }"#,
+    )?;
+    fixture.write_file("nested/nested.py", "import sys\n")?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg(".")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 2 suppression comments.
+        ",
+    );
+
+    assert_eq!(
+        fixture.read_file("root.py")?,
+        "import os  # ruff:ignore[unused-import]\n"
+    );
+    assert_eq!(
+        fixture.read_file("nested/nested.py")?,
+        "import sys  # noqa: F401\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_multiple_codes() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        def unused(x):
+            pass
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201,ARG001,D103")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        def unused(x):  # ruff:ignore[missing-return-type-undocumented-public-function, missing-type-function-argument, undocumented-public-function]
+            pass
+        ",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_multiline_diagnostic() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        import z
+        import c
+        import a
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=I")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        import z  # ruff:ignore[unsorted-imports]
+        import c
+        import a
+        ",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_existing_ignore() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]
+            pass
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201,ARG001,D103")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103, missing-return-type-undocumented-public-function]
+            pass
+        ",
+    );
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201,ARG001,D103")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        ",
+    );
+
+    let test_code_after_second_run = fixture.read_file("noqa.py")?;
+    assert_eq!(test_code_after_second_run, test_code);
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_existing_own_line_ignore() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        # ruff:ignore[ANN001]
+        def public(x):
+            pass
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        # ruff:ignore[ANN001, missing-return-type-undocumented-public-function]
+        def public(x):
+            pass
+        ",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_existing_noqa() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        def unused(x):  # noqa: ANN001, ARG001, D103
+            pass
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201,ARG001,D103")
+            .arg("noqa.py")
+            .arg("--preview")
+            .arg("--add-ignore"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        def unused(x):  # noqa: ANN001, ARG001, D103  # ruff:ignore[missing-return-type-undocumented-public-function]
+            pass
+        ",
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_noqa_existing_ignore() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "noqa.py",
+        r#"
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]
+            pass
+        "#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .arg("--select=ANN001,ANN201,ARG001,D103")
+            .arg("noqa.py")
+            .arg("--add-noqa"),
+        @"
+        success: true
+        exit_code: 0
+        ----- stdout -----
+
+        ----- stderr -----
+        warning: #ruff:ignore comment found but not active, enable preview mode
+        Added 1 suppression comment.
+        ",
+    );
+
+    let test_code = fixture.read_file("noqa.py")?;
+
+    insta::assert_snapshot!(
+        test_code,
+        @"
+
+        def unused(x):  # ruff:ignore[ANN001, ARG001, D103]  # noqa: ANN001, ANN201, D103
+            pass
+        ",
+    );
 
     Ok(())
 }

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -656,7 +656,6 @@ extend = "ruff2.toml"
 select = [E501]
 "#,
     )?;
-
     assert_cmd_snapshot!(
         fixture.check_command(),
         @"
@@ -2761,6 +2760,112 @@ fn unused_ignore_with_syntax_error() -> Result<()> {
     ----- stdout -----
     test.py:2:9: invalid-syntax: Expected an expression
     Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_multiline_noqa_mapping() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "test.py",
+        r#"import logging
+
+logger = logging.getLogger(__name__)
+name = "world"
+logger.error(
+    f"""Hello {
+        name
+    }""",
+)
+"#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=G004,RUF100", "--preview", "--add-ignore"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Added 1 suppression comment.
+    "
+    );
+
+    insta::assert_snapshot!(fixture.read_file("test.py")?, @r#"
+    import logging
+
+    logger = logging.getLogger(__name__)
+    name = "world"
+    # ruff:ignore[logging-f-string]
+    logger.error(
+        f"""Hello {
+            name
+        }""",
+    )
+    "#);
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=G004,RUF100", "--preview"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
+fn add_ignore_continuation_mapping() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file("test.py", "value = 'first' \\\n    'second'\n")?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=Q000,RUF100", "--preview", "--add-ignore"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Added 1 suppression comment.
+    "
+    );
+
+    assert_eq!(
+        fixture.read_file("test.py")?,
+        "# ruff:ignore[bad-quotes-inline-string]\nvalue = 'first' \\\n    'second'\n"
+    );
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=Q000,RUF100", "--preview"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
 
     ----- stderr -----
     "

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2743,6 +2743,33 @@ fn add_ignore_multiple_codes() -> Result<()> {
 }
 
 #[test]
+fn unused_ignore_with_syntax_error() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "test.py",
+        "value = 1  # ruff:ignore[unused-variable]\nbroken =\n",
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=RUF100", "--preview"])
+            .arg("test.py"),
+        @"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+    test.py:2:9: invalid-syntax: Expected an expression
+    Found 1 error.
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn add_ignore_multiline_diagnostic() -> Result<()> {
     let fixture = CliTest::new()?;
     fixture.write_file(

--- a/crates/ruff/tests/cli/lint.rs
+++ b/crates/ruff/tests/cli/lint.rs
@@ -2875,6 +2875,61 @@ fn add_ignore_continuation_mapping() -> Result<()> {
 }
 
 #[test]
+fn add_ignore_escaped_newline_string() -> Result<()> {
+    let fixture = CliTest::new()?;
+    fixture.write_file(
+        "test.py",
+        r#"first = "one"
+second = "two"
+value = "first %s \
+second %s" % (first, second)
+"#,
+    )?;
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=UP031,RUF100", "--preview", "--add-ignore"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Added 1 suppression comment.
+    "
+    );
+
+    assert_eq!(
+        fixture.read_file("test.py")?,
+        r#"first = "one"
+second = "two"
+# ruff:ignore[printf-string-formatting]
+value = "first %s \
+second %s" % (first, second)
+"#
+    );
+
+    assert_cmd_snapshot!(
+        fixture
+            .check_command()
+            .args(["--select=UP031,RUF100", "--preview"])
+            .arg("test.py"),
+        @"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    All checks passed!
+
+    ----- stderr -----
+    "
+    );
+
+    Ok(())
+}
+
+#[test]
 fn add_ignore_multiline_diagnostic() -> Result<()> {
     let fixture = CliTest::new()?;
     fixture.write_file(

--- a/crates/ruff/tests/cli/main.rs
+++ b/crates/ruff/tests/cli/main.rs
@@ -158,6 +158,13 @@ impl CliTest {
         Ok(())
     }
 
+    /// Reads a file from the test directory.
+    pub(crate) fn read_file(&self, path: impl AsRef<Path>) -> Result<String> {
+        let file_path = self.project_dir.join(path);
+        fs::read_to_string(&file_path)
+            .with_context(|| format!("Failed to read file `{}`", file_path.display()))
+    }
+
     pub(crate) fn write_files<'a>(
         &self,
         files: impl IntoIterator<Item = (&'a str, &'a str)>,

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -40,6 +40,30 @@ class Point:
         self.x = x
 ```
 
+## Leading indentation is included in the suppression range
+
+Trailing ignores should suppress diagnostics whose ranges start in the line's indentation:
+
+```toml
+[lint]
+preview = true
+select = ["E111", "E117", "RUF100"]
+```
+
+```py
+if True:
+   first = 1  # ruff:ignore[indentation-with-invalid-multiple]
+   second = 2  # ruff:ignore[indentation-with-invalid-multiple]
+```
+
+Standalone ignores should include their own indentation and the indentation of the following line:
+
+```py
+def function():
+        # ruff:ignore[over-indented]
+        pass
+```
+
 ## Empty diagnostic range at end of file
 
 Diagnostics with empty ranges should also be suppressible, as with `noqa`.

--- a/crates/ruff_linter/resources/mdtest/suppression/ignore.md
+++ b/crates/ruff_linter/resources/mdtest/suppression/ignore.md
@@ -221,6 +221,43 @@ from sys import ( # ruff:ignore[F401]
 )
 ```
 
+## `ruff:ignore` can suppress `RUF100`
+
+```toml
+[lint]
+preview = true
+select = ["RUF100"]
+```
+
+A `ruff:ignore` comment can suppress an unused `noqa` comment:
+
+```py
+value = 1  # noqa: F401  # ruff:ignore[unused-noqa]
+```
+
+A multi-code comment containing `RUF100` should also suppress its own unused suppression
+diagnostic:
+
+```py
+value = 1  # ruff:ignore[unused-import, unused-noqa]
+```
+
+## Self-suppression does not hide unmatched comments
+
+An unmatched `ruff:disable[RUF100]` should suppress its own unused warning without hiding the
+unmatched-comment diagnostic:
+
+```toml
+[lint]
+preview = true
+select = ["RUF100", "RUF104"]
+```
+
+```py
+# error: [unmatched-suppression-comment]
+# ruff:disable[RUF100]
+```
+
 ## Trailing whitespace is included in the suppression range
 
 ```toml

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -118,7 +118,7 @@ pub(crate) fn check_noqa(
     }
 
     // Diagnostics for unused/invalid range suppressions
-    suppressions.check_suppressions(context, locator);
+    suppressions.check_suppressions(context, locator, analyze_directives);
 
     // Enforce that the noqa directive was actually used (RUF100), unless RUF100 was itself
     // suppressed.

--- a/crates/ruff_linter/src/checkers/noqa.rs
+++ b/crates/ruff_linter/src/checkers/noqa.rs
@@ -126,6 +126,7 @@ pub(crate) fn check_noqa(
         && analyze_directives
         && !exemption.includes(Rule::UnusedNOQA)
     {
+        let unused_noqa_suppressions = suppressions.for_rule(Rule::UnusedNOQA);
         let directives = noqa_directives
             .lines()
             .iter()
@@ -140,6 +141,9 @@ pub(crate) fn check_noqa(
             match directive {
                 Directive::All(directive) => {
                     if matches.is_empty() {
+                        if unused_noqa_suppressions.check(directive.range(), None) {
+                            continue;
+                        }
                         let edit = delete_comment(directive.range(), locator);
                         let mut diagnostic = context.report_diagnostic(
                             UnusedNOQA {
@@ -203,6 +207,9 @@ pub(crate) fn check_noqa(
                         && duplicated_codes.is_empty()
                         && unmatched_codes.is_empty())
                     {
+                        if unused_noqa_suppressions.check(directive.range(), None) {
+                            continue;
+                        }
                         let edit = if valid_codes.is_empty() {
                             delete_comment(directive.range(), locator)
                         } else {

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -174,14 +174,13 @@ fn extract_noqa_line_for(tokens: &Tokens, locator: &Locator, indexer: &Indexer) 
         continuation_mappings.push(last_range);
     }
 
-    // Merge the mappings in sorted order
-    let mut mappings = NoqaMapping::with_capacity(
-        continuation_mappings.len()
-            + string_mappings.len()
-            + interpolated_string_mappings.len()
-            + usize::from(shebang_mapping.is_some()),
+    // Normalize and merge the mappings in sorted order. A continuation mapping can start inside a
+    // multi-line string when the continuation follows the string on its closing line. Expanding it
+    // to the token boundaries avoids passing an offset inside a token to `Tokens::before` or
+    // `Tokens::after` below.
+    let mut merged_mappings: Vec<TextRange> = Vec::with_capacity(
+        continuation_mappings.len() + string_mappings.len() + interpolated_string_mappings.len(),
     );
-
     let all_mappings = SortedMergeIter {
         left: interpolated_string_mappings.into_iter().peekable(),
         right: string_mappings.into_iter().peekable(),
@@ -190,12 +189,55 @@ fn extract_noqa_line_for(tokens: &Tokens, locator: &Locator, indexer: &Indexer) 
         left: all_mappings.peekable(),
         right: continuation_mappings.into_iter().peekable(),
     };
+    for mapping in all_mappings {
+        let start_token_range = tokens.token_range(mapping.start());
+        let start = if start_token_range.start() < mapping.start() {
+            locator.line_start(start_token_range.start())
+        } else {
+            mapping.start()
+        };
+        let end_token_range = tokens.token_range(mapping.end());
+        let end = if end_token_range.start() < mapping.end() {
+            end_token_range.end()
+        } else {
+            mapping.end()
+        };
+        let mapping = TextRange::new(start, end);
+
+        if let Some(last_mapping) = merged_mappings.last_mut()
+            && last_mapping.end() >= mapping.start()
+        {
+            *last_mapping = last_mapping.cover(mapping);
+        } else {
+            merged_mappings.push(mapping);
+        }
+    }
+
+    let mut mappings =
+        NoqaMapping::with_capacity(merged_mappings.len() + usize::from(shebang_mapping.is_some()));
 
     if let Some(mapping) = shebang_mapping {
-        mappings.push_mapping(mapping);
+        mappings.push_mapping_with_own_line(mapping, None);
     }
-    for mapping in all_mappings {
-        mappings.push_mapping(mapping);
+    for mapping in merged_mappings {
+        let mut own_line_start = mapping.start();
+        for token in tokens.before(mapping.start()).iter().rev() {
+            if token.kind() == TokenKind::Newline {
+                break;
+            }
+            if !token.kind().is_trivia() {
+                own_line_start = locator.line_start(token.start());
+            }
+        }
+        let own_line_end = tokens
+            .after(mapping.end())
+            .iter()
+            .find(|token| token.kind() == TokenKind::Newline)
+            .map_or_else(|| locator.contents().text_len(), Ranged::end);
+        mappings.push_mapping_with_own_line(
+            mapping,
+            Some(TextRange::new(own_line_start, own_line_end)),
+        );
     }
 
     mappings
@@ -579,6 +621,22 @@ assert foo, \
         assert_eq!(
             noqa_mappings(contents),
             NoqaMapping::from_iter([TextRange::new(TextSize::from(0), TextSize::from(48))])
+        );
+    }
+
+    #[test]
+    fn noqa_mapping_continuation_after_escaped_newline_string() {
+        let contents = r#"value = "first\
+ " \
+    + "second""#;
+        let continuation_end = r#"value = "first\
+ " \
+"#
+        .text_len();
+
+        assert_eq!(
+            noqa_mappings(contents),
+            NoqaMapping::from_iter([TextRange::new(TextSize::default(), continuation_end)])
         );
     }
 

--- a/crates/ruff_linter/src/directives.rs
+++ b/crates/ruff_linter/src/directives.rs
@@ -110,18 +110,12 @@ fn extract_noqa_line_for(tokens: &Tokens, locator: &Locator, indexer: &Indexer) 
     let mut string_mappings = Vec::new();
 
     for token in tokens {
-        match token.kind() {
-            // For multi-line strings, we expect `noqa` directives on the last line of the string.
-            TokenKind::String if token.is_triple_quoted_string() => {
-                if locator.contains_line_break(token.range()) {
-                    string_mappings.push(TextRange::new(
-                        locator.line_start(token.start()),
-                        token.end(),
-                    ));
-                }
-            }
-
-            _ => {}
+        // For multi-line strings, we expect `noqa` directives on the last line of the string.
+        if token.kind() == TokenKind::String && locator.contains_line_break(token.range()) {
+            string_mappings.push(TextRange::new(
+                locator.line_start(token.start()),
+                token.end(),
+            ));
         }
     }
 
@@ -637,6 +631,19 @@ assert foo, \
         assert_eq!(
             noqa_mappings(contents),
             NoqaMapping::from_iter([TextRange::new(TextSize::default(), continuation_end)])
+        );
+    }
+
+    #[test]
+    fn noqa_mapping_escaped_newline_string() {
+        let contents = r#"value = "first %s \
+second %s" % (first, second)"#;
+        let string = r#"value = "first %s \
+second %s""#;
+
+        assert_eq!(
+            noqa_mappings(contents),
+            NoqaMapping::from_iter([TextRange::new(TextSize::default(), string.text_len())])
         );
     }
 

--- a/crates/ruff_linter/src/lib.rs
+++ b/crates/ruff_linter/src/lib.rs
@@ -6,7 +6,7 @@
 //! [Ruff]: https://github.com/astral-sh/ruff
 
 pub use locator::Locator;
-pub use noqa::generate_noqa_edits;
+pub use noqa::{SuppressionKind, generate_noqa_edits};
 #[cfg(feature = "clap")]
 pub use registry::clap_completion::RuleParser;
 #[cfg(feature = "clap")]

--- a/crates/ruff_linter/src/linter.rs
+++ b/crates/ruff_linter/src/linter.rs
@@ -25,7 +25,7 @@ use crate::doc_lines::{doc_lines_from_ast, doc_lines_from_tokens};
 use crate::fix::{FixResult, fix_file};
 use crate::noqa::add_noqa;
 use crate::package::PackageRoot;
-use crate::preview::is_py315_support_enabled;
+use crate::preview::{is_human_readable_names_enabled, is_py315_support_enabled};
 use crate::registry::Rule;
 #[cfg(any(feature = "test-rules", test))]
 use crate::rules::ruff::rules::test_rules::{self, TEST_RULES, TestRule};
@@ -33,7 +33,7 @@ use crate::settings::types::UnsafeFixes;
 use crate::settings::{LinterSettings, TargetVersion, flags};
 use crate::source_kind::SourceKind;
 use crate::suppression::Suppressions;
-use crate::{Locator, directives, fs, warn_user_once};
+use crate::{Locator, SuppressionKind, directives, fs, warn_user_once};
 
 pub(crate) mod float;
 
@@ -371,7 +371,7 @@ pub fn check_path(
 
 const MAX_ITERATIONS: usize = 100;
 
-/// Add any missing `# noqa` pragmas to the source code at the given `Path`.
+/// Add any missing suppression comments to the source code at the given `Path`.
 pub fn add_noqa_to_path(
     path: &Path,
     package: Option<PackageRoot<'_>>,
@@ -422,8 +422,13 @@ pub fn add_noqa_to_path(
         &suppressions,
     );
 
-    // Add any missing `# noqa` pragmas.
+    // Add any missing suppression comments.
     // TODO(dhruvmanila): Add support for Jupyter Notebooks
+    let suppression_kind = if is_human_readable_names_enabled(settings.preview) {
+        SuppressionKind::Ignore
+    } else {
+        SuppressionKind::Noqa
+    };
     add_noqa(
         path,
         &diagnostics,
@@ -434,6 +439,7 @@ pub fn add_noqa_to_path(
         stylist.line_ending(),
         reason,
         &suppressions,
+        suppression_kind,
     )
 }
 

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -21,11 +21,11 @@ use crate::Locator;
 use crate::fs::relativize_path;
 use crate::registry::Rule;
 use crate::rule_redirects::get_redirect_target;
-use crate::suppression::Suppressions;
+use crate::suppression::{SuppressionComment, Suppressions};
 
 /// Generates an array of edits that matches the length of `messages`.
 /// Each potential edit in the array is paired, in order, with the associated diagnostic.
-/// Each edit will add a `noqa` comment to the appropriate line in the source to hide
+/// Each edit will add a suppression comment to the appropriate line in the source to hide
 /// the diagnostic. These edits may conflict with each other and should not be applied
 /// simultaneously.
 #[expect(clippy::too_many_arguments)]
@@ -38,6 +38,7 @@ pub fn generate_noqa_edits(
     noqa_line_for: &NoqaMapping,
     line_ending: LineEnding,
     suppressions: &Suppressions,
+    suppression_kind: SuppressionKind,
 ) -> Vec<Option<Edit>> {
     let file_directives = FileNoqaDirectives::extract(locator, comment_ranges, external, path);
     let exemption = FileExemption::from(&file_directives);
@@ -49,8 +50,9 @@ pub fn generate_noqa_edits(
         &directives,
         noqa_line_for,
         suppressions,
+        suppression_kind,
     );
-    build_noqa_edits_by_diagnostic(comments, locator, line_ending, None)
+    build_noqa_edits_by_diagnostic(comments, locator, line_ending, None, suppression_kind)
 }
 
 /// A directive to ignore a set of rules either for a given line of Python source code or an entire file (e.g.,
@@ -743,7 +745,16 @@ impl Display for LexicalError {
 
 impl Error for LexicalError {}
 
-/// Adds noqa comments to suppress all messages of a file.
+/// The kind of suppression comment to be added to suppress a diagnostic.
+#[derive(Copy, Clone, Debug)]
+pub enum SuppressionKind {
+    /// A `noqa` comment
+    Noqa,
+    /// A `ruff:ignore` comment
+    Ignore,
+}
+
+/// Adds suppression comments to suppress all messages of a file.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn add_noqa(
     path: &Path,
@@ -755,6 +766,7 @@ pub(crate) fn add_noqa(
     line_ending: LineEnding,
     reason: Option<&str>,
     suppressions: &Suppressions,
+    suppression_kind: SuppressionKind,
 ) -> Result<usize> {
     let (count, output) = add_noqa_inner(
         path,
@@ -766,6 +778,7 @@ pub(crate) fn add_noqa(
         line_ending,
         reason,
         suppressions,
+        suppression_kind,
     );
 
     fs::write(path, output)?;
@@ -783,6 +796,7 @@ fn add_noqa_inner(
     line_ending: LineEnding,
     reason: Option<&str>,
     suppressions: &Suppressions,
+    suppression_kind: SuppressionKind,
 ) -> (usize, String) {
     let mut count = 0;
 
@@ -799,9 +813,10 @@ fn add_noqa_inner(
         &directives,
         noqa_line_for,
         suppressions,
+        suppression_kind,
     );
 
-    let edits = build_noqa_edits_by_line(comments, locator, line_ending, reason);
+    let edits = build_noqa_edits_by_line(comments, locator, line_ending, reason, suppression_kind);
 
     let contents = locator.contents();
 
@@ -828,21 +843,22 @@ fn build_noqa_edits_by_diagnostic(
     locator: &Locator,
     line_ending: LineEnding,
     reason: Option<&str>,
+    suppression_kind: SuppressionKind,
 ) -> Vec<Option<Edit>> {
     let mut edits = Vec::default();
     for comment in comments {
         match comment {
             Some(comment) => {
-                if let Some(noqa_edit) = generate_noqa_edit(
+                let noqa_edit = generate_noqa_edit(
                     comment.directive,
                     comment.line,
-                    FxHashSet::from_iter([comment.code]),
+                    FxHashSet::from_iter([comment.identifier]),
                     locator,
                     line_ending,
                     reason,
-                ) {
-                    edits.push(Some(noqa_edit.into_edit()));
-                }
+                    suppression_kind,
+                );
+                edits.push(Some(noqa_edit.into_edit()));
             }
             None => edits.push(None),
         }
@@ -852,9 +868,10 @@ fn build_noqa_edits_by_diagnostic(
 
 fn build_noqa_edits_by_line<'a>(
     comments: Vec<Option<NoqaComment<'a>>>,
-    locator: &Locator,
+    locator: &Locator<'a>,
     line_ending: LineEnding,
     reason: Option<&'a str>,
+    suppression_kind: SuppressionKind,
 ) -> BTreeMap<TextSize, NoqaEdit<'a>> {
     let mut comments_by_line = BTreeMap::default();
     for comment in comments.into_iter().flatten() {
@@ -869,27 +886,42 @@ fn build_noqa_edits_by_line<'a>(
             continue;
         };
         let directive = first_match.directive;
-        if let Some(edit) = generate_noqa_edit(
+        let noqa_edit = generate_noqa_edit(
             directive,
             offset,
             matches
                 .into_iter()
-                .map(|NoqaComment { code, .. }| code)
+                .map(|comment| comment.identifier)
                 .collect(),
             locator,
             line_ending,
             reason,
-        ) {
-            edits.insert(offset, edit);
-        }
+            suppression_kind,
+        );
+        edits.insert(offset, noqa_edit);
     }
     edits
 }
 
 struct NoqaComment<'a> {
     line: TextSize,
-    code: &'a SecondaryCode,
-    directive: Option<&'a Directive<'a>>,
+    identifier: &'a str,
+    directive: Option<ExistingDirective<'a>>,
+}
+
+#[derive(Copy, Clone)]
+enum ExistingDirective<'a> {
+    Noqa(&'a Codes<'a>),
+    Ignore(&'a SuppressionComment),
+}
+
+impl Ranged for ExistingDirective<'_> {
+    fn range(&self) -> TextRange {
+        match self {
+            ExistingDirective::Noqa(codes) => codes.range(),
+            ExistingDirective::Ignore(comment) => comment.range(),
+        }
+    }
 }
 
 fn find_noqa_comments<'a>(
@@ -899,8 +931,9 @@ fn find_noqa_comments<'a>(
     directives: &'a NoqaDirectives,
     noqa_line_for: &NoqaMapping,
     suppressions: &'a Suppressions,
+    suppression_kind: SuppressionKind,
 ) -> Vec<Option<NoqaComment<'a>>> {
-    // List of noqa comments, ordered to match up with `messages`
+    // List of suppression comments, ordered to match up with `messages`
     let mut comments_by_line: Vec<Option<NoqaComment<'a>>> = vec![];
 
     // Mark any non-ignored diagnostics.
@@ -946,31 +979,45 @@ fn find_noqa_comments<'a>(
             .map(|range| noqa_line_for.resolve(range.start()))
             .unwrap_or_default();
 
-        // Or ignored by the directive itself?
-        if let Some(directive_line) = directives.find_line_with_directive(noqa_offset) {
-            match &directive_line.directive {
-                Directive::All(_) => {
-                    comments_by_line.push(None);
-                    continue;
-                }
-                directive @ Directive::Codes(codes) => {
-                    if !codes.includes(code) {
-                        comments_by_line.push(Some(NoqaComment {
-                            line: directive_line.start(),
-                            code,
-                            directive: Some(directive),
-                        }));
+        // Or ignored by a `noqa` directive on the diagnostic's line itself?
+        let existing_noqa =
+            if let Some(directive_line) = directives.find_line_with_directive(noqa_offset) {
+                match &directive_line.directive {
+                    Directive::All(_) => {
+                        comments_by_line.push(None);
+                        continue;
                     }
-                    continue;
+                    Directive::Codes(codes) => {
+                        if codes.includes(code) {
+                            comments_by_line.push(None);
+                            continue;
+                        }
+                        Some(ExistingDirective::Noqa(codes))
+                    }
                 }
-            }
-        }
+            } else {
+                None
+            };
 
-        // There's no existing noqa directive that suppresses the diagnostic.
+        // Prefer extending an existing `ruff:ignore` over an existing `noqa` directive.
+        let directive = suppressions
+            .find_applicable_ignore(message)
+            .map(ExistingDirective::Ignore)
+            .or(existing_noqa);
+
+        let line = directive
+            .map(|directive| locator.line_start(directive.start()))
+            .unwrap_or_else(|| locator.line_start(noqa_offset));
+
+        let identifier = match suppression_kind {
+            SuppressionKind::Noqa => code.as_str(),
+            SuppressionKind::Ignore => message.name(),
+        };
+
         comments_by_line.push(Some(NoqaComment {
-            line: locator.line_start(noqa_offset),
-            code,
-            directive: None,
+            line,
+            identifier,
+            directive,
         }));
     }
 
@@ -979,11 +1026,12 @@ fn find_noqa_comments<'a>(
 
 struct NoqaEdit<'a> {
     edit_range: TextRange,
-    noqa_codes: FxHashSet<&'a SecondaryCode>,
-    codes: Option<&'a Codes<'a>>,
+    noqa_codes: FxHashSet<&'a str>,
+    existing_codes: Vec<&'a str>,
     line_ending: LineEnding,
     reason: Option<&'a str>,
     blank_line: bool,
+    suppression_kind: SuppressionKind,
 }
 
 impl NoqaEdit<'_> {
@@ -998,21 +1046,21 @@ impl NoqaEdit<'_> {
         if !self.blank_line {
             write!(writer, "  ").unwrap();
         }
-        write!(writer, "# noqa: ").unwrap();
-        match self.codes {
-            Some(codes) => {
-                push_codes(
-                    writer,
-                    self.noqa_codes
-                        .iter()
-                        .map(|code| code.as_str())
-                        .chain(codes.iter().map(Code::as_str))
-                        .sorted_unstable(),
-                );
-            }
-            None => {
-                push_codes(writer, self.noqa_codes.iter().sorted_unstable());
-            }
+        match self.suppression_kind {
+            SuppressionKind::Noqa => write!(writer, "# noqa: ").unwrap(),
+            SuppressionKind::Ignore => write!(writer, "# ruff:ignore[").unwrap(),
+        }
+        push_codes(
+            writer,
+            self.noqa_codes
+                .iter()
+                .copied()
+                .chain(self.existing_codes.iter().copied())
+                .sorted_unstable(),
+        );
+        match self.suppression_kind {
+            SuppressionKind::Noqa => {}
+            SuppressionKind::Ignore => write!(writer, "]").unwrap(),
         }
         if let Some(reason) = self.reason {
             write!(writer, " {reason}").unwrap();
@@ -1028,47 +1076,60 @@ impl Ranged for NoqaEdit<'_> {
 }
 
 fn generate_noqa_edit<'a>(
-    directive: Option<&'a Directive>,
+    directive: Option<ExistingDirective<'a>>,
     offset: TextSize,
-    noqa_codes: FxHashSet<&'a SecondaryCode>,
-    locator: &Locator,
+    noqa_codes: FxHashSet<&'a str>,
+    locator: &Locator<'a>,
     line_ending: LineEnding,
     reason: Option<&'a str>,
-) -> Option<NoqaEdit<'a>> {
+    suppression_kind: SuppressionKind,
+) -> NoqaEdit<'a> {
     let line_range = locator.full_line_range(offset);
 
     let edit_range;
-    let codes;
+    let mut existing_codes = Vec::new();
     let blank_line;
 
     // Add codes.
-    match directive {
-        None => {
+    match (directive, suppression_kind) {
+        (Some(ExistingDirective::Noqa(codes)), SuppressionKind::Noqa) => {
+            (edit_range, blank_line) = suppression_edit_range(locator, line_range, codes.start());
+            existing_codes.extend(codes.iter().map(Code::as_str));
+        }
+        (Some(ExistingDirective::Ignore(comment)), SuppressionKind::Ignore) => {
+            (edit_range, blank_line) = suppression_edit_range(locator, line_range, comment.start());
+            existing_codes.extend(comment.codes_as_str(locator.contents()));
+        }
+        (None | Some(_), _) => {
             let trimmed_line = locator.slice(line_range).trim_end();
             blank_line = trimmed_line.trim_whitespace_start().is_empty();
             edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
-            codes = None;
         }
-        Some(Directive::Codes(existing_codes)) => {
-            // find trimmed line without the noqa
-            let trimmed_line = locator
-                .slice(TextRange::new(line_range.start(), existing_codes.start()))
-                .trim_end();
-            blank_line = false;
-            edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
-            codes = Some(existing_codes);
-        }
-        Some(Directive::All(_)) => return None,
     }
 
-    Some(NoqaEdit {
+    NoqaEdit {
         edit_range,
         noqa_codes,
-        codes,
+        existing_codes,
         line_ending,
         reason,
         blank_line,
-    })
+        suppression_kind,
+    }
+}
+
+fn suppression_edit_range(
+    locator: &Locator,
+    line_range: TextRange,
+    directive_start: TextSize,
+) -> (TextRange, bool) {
+    let prefix = locator.slice(TextRange::new(line_range.start(), directive_start));
+    if prefix.trim_whitespace().is_empty() {
+        (TextRange::new(directive_start, line_range.end()), true)
+    } else {
+        let edit_start = line_range.start() + TextSize::of(prefix.trim_end());
+        (TextRange::new(edit_start, line_range.end()), false)
+    }
 }
 
 fn push_codes<I: Display>(writer: &mut dyn std::fmt::Write, codes: impl Iterator<Item = I>) {
@@ -1277,8 +1338,8 @@ mod tests {
     use ruff_text_size::{TextLen, TextRange, TextSize};
 
     use crate::noqa::{
-        Directive, LexicalError, NoqaLexerOutput, NoqaMapping, add_noqa_inner, lex_codes,
-        lex_file_exemption, lex_inline_noqa,
+        Directive, LexicalError, NoqaLexerOutput, NoqaMapping, SuppressionKind, add_noqa_inner,
+        lex_codes, lex_file_exemption, lex_inline_noqa,
     };
     use crate::rules::pycodestyle::rules::{AmbiguousVariableName, UselessSemicolon};
     use crate::rules::pyflakes::rules::UnusedVariable;
@@ -2880,6 +2941,7 @@ mod tests {
             LineEnding::Lf,
             None,
             &Suppressions::default(),
+            SuppressionKind::Noqa,
         );
         assert_eq!(count, 0);
         assert_eq!(output, format!("{contents}"));
@@ -2905,6 +2967,7 @@ mod tests {
             LineEnding::Lf,
             None,
             &Suppressions::default(),
+            SuppressionKind::Noqa,
         );
         assert_eq!(count, 1);
         assert_eq!(output, "x = 1  # noqa: F841\n");
@@ -2937,6 +3000,7 @@ mod tests {
             LineEnding::Lf,
             None,
             &Suppressions::default(),
+            SuppressionKind::Noqa,
         );
         assert_eq!(count, 1);
         assert_eq!(output, "x = 1  # noqa: E741, F841\n");
@@ -2969,6 +3033,7 @@ mod tests {
             LineEnding::Lf,
             None,
             &Suppressions::default(),
+            SuppressionKind::Noqa,
         );
         assert_eq!(count, 0);
         assert_eq!(output, "x = 1  # noqa");
@@ -3001,6 +3066,7 @@ print(
             &noqa_line_for,
             LineEnding::Lf,
             &suppressions,
+            SuppressionKind::Noqa,
         );
         assert_eq!(
             edits,
@@ -3034,6 +3100,7 @@ bar =
             &noqa_line_for,
             LineEnding::Lf,
             &suppressions,
+            SuppressionKind::Noqa,
         );
         assert_eq!(
             edits,

--- a/crates/ruff_linter/src/noqa.rs
+++ b/crates/ruff_linter/src/noqa.rs
@@ -11,7 +11,7 @@ use log::warn;
 
 use ruff_db::diagnostic::{Diagnostic, SecondaryCode};
 use ruff_python_trivia::PythonWhitespace;
-use ruff_python_trivia::{CommentRanges, Cursor, indentation_at_offset};
+use ruff_python_trivia::{CommentRanges, Cursor, indentation_at_offset, leading_indentation};
 use ruff_source_file::{LineEnding, LineRanges};
 use ruff_text_size::{Ranged, TextLen, TextRange, TextSize};
 use rustc_hash::FxHashSet;
@@ -852,6 +852,7 @@ fn build_noqa_edits_by_diagnostic(
                 let noqa_edit = generate_noqa_edit(
                     comment.directive,
                     comment.line,
+                    comment.own_line,
                     FxHashSet::from_iter([comment.identifier]),
                     locator,
                     line_ending,
@@ -885,10 +886,16 @@ fn build_noqa_edits_by_line<'a>(
         let Some(first_match) = matches.first() else {
             continue;
         };
-        let directive = first_match.directive;
+        let own_line = matches.iter().any(|comment| comment.own_line);
+        let directive = if own_line {
+            None
+        } else {
+            first_match.directive
+        };
         let noqa_edit = generate_noqa_edit(
             directive,
             offset,
+            own_line,
             matches
                 .into_iter()
                 .map(|comment| comment.identifier)
@@ -905,6 +912,7 @@ fn build_noqa_edits_by_line<'a>(
 
 struct NoqaComment<'a> {
     line: TextSize,
+    own_line: bool,
     identifier: &'a str,
     directive: Option<ExistingDirective<'a>>,
 }
@@ -974,10 +982,15 @@ fn find_noqa_comments<'a>(
             }
         }
 
-        let noqa_offset = message
-            .range()
+        let diagnostic_range = message.range();
+        let noqa_offset = diagnostic_range
             .map(|range| noqa_line_for.resolve(range.start()))
             .unwrap_or_default();
+        let own_line = if matches!(suppression_kind, SuppressionKind::Ignore) {
+            diagnostic_range.and_then(|range| noqa_line_for.own_line(range.start()))
+        } else {
+            None
+        };
 
         // Or ignored by a `noqa` directive on the diagnostic's line itself?
         let existing_noqa =
@@ -999,15 +1012,25 @@ fn find_noqa_comments<'a>(
                 None
             };
 
-        // Prefer extending an existing `ruff:ignore` over an existing `noqa` directive.
-        let directive = suppressions
-            .find_applicable_ignore(message)
-            .map(ExistingDirective::Ignore)
-            .or(existing_noqa);
+        // Prefer extending an existing `ruff:ignore` over an existing `noqa` directive. A new
+        // ignore for a mapped multi-line diagnostic is placed before the mapping so that its range
+        // contains the diagnostic start.
+        let directive = if own_line.is_some() {
+            None
+        } else {
+            suppressions
+                .find_applicable_ignore(message)
+                .map(ExistingDirective::Ignore)
+                .or(existing_noqa)
+        };
 
-        let line = directive
-            .map(|directive| locator.line_start(directive.start()))
-            .unwrap_or_else(|| locator.line_start(noqa_offset));
+        let line = if let Some(offset) = own_line {
+            locator.line_start(offset)
+        } else {
+            directive
+                .map(|directive| locator.line_start(directive.start()))
+                .unwrap_or_else(|| locator.line_start(noqa_offset))
+        };
 
         let identifier = match suppression_kind {
             SuppressionKind::Noqa => code.as_str(),
@@ -1016,6 +1039,7 @@ fn find_noqa_comments<'a>(
 
         comments_by_line.push(Some(NoqaComment {
             line,
+            own_line: own_line.is_some(),
             identifier,
             directive,
         }));
@@ -1026,6 +1050,7 @@ fn find_noqa_comments<'a>(
 
 struct NoqaEdit<'a> {
     edit_range: TextRange,
+    indentation: Option<&'a str>,
     noqa_codes: FxHashSet<&'a str>,
     existing_codes: Vec<&'a str>,
     line_ending: LineEnding,
@@ -1043,7 +1068,9 @@ impl NoqaEdit<'_> {
     }
 
     fn write(&self, writer: &mut impl std::fmt::Write) {
-        if !self.blank_line {
+        if let Some(indentation) = self.indentation {
+            write!(writer, "{indentation}").unwrap();
+        } else if !self.blank_line {
             write!(writer, "  ").unwrap();
         }
         match self.suppression_kind {
@@ -1075,9 +1102,11 @@ impl Ranged for NoqaEdit<'_> {
     }
 }
 
+#[expect(clippy::too_many_arguments)]
 fn generate_noqa_edit<'a>(
     directive: Option<ExistingDirective<'a>>,
     offset: TextSize,
+    own_line: bool,
     noqa_codes: FxHashSet<&'a str>,
     locator: &Locator<'a>,
     line_ending: LineEnding,
@@ -1089,26 +1118,38 @@ fn generate_noqa_edit<'a>(
     let edit_range;
     let mut existing_codes = Vec::new();
     let blank_line;
+    let indentation;
 
     // Add codes.
-    match (directive, suppression_kind) {
-        (Some(ExistingDirective::Noqa(codes)), SuppressionKind::Noqa) => {
-            (edit_range, blank_line) = suppression_edit_range(locator, line_range, codes.start());
-            existing_codes.extend(codes.iter().map(Code::as_str));
-        }
-        (Some(ExistingDirective::Ignore(comment)), SuppressionKind::Ignore) => {
-            (edit_range, blank_line) = suppression_edit_range(locator, line_range, comment.start());
-            existing_codes.extend(comment.codes_as_str(locator.contents()));
-        }
-        (None | Some(_), _) => {
-            let trimmed_line = locator.slice(line_range).trim_end();
-            blank_line = trimmed_line.trim_whitespace_start().is_empty();
-            edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
+    if own_line {
+        debug_assert!(directive.is_none());
+        edit_range = TextRange::empty(line_range.start());
+        indentation = Some(leading_indentation(locator.slice(line_range)));
+        blank_line = true;
+    } else {
+        indentation = None;
+        match (directive, suppression_kind) {
+            (Some(ExistingDirective::Noqa(codes)), SuppressionKind::Noqa) => {
+                (edit_range, blank_line) =
+                    suppression_edit_range(locator, line_range, codes.start());
+                existing_codes.extend(codes.iter().map(Code::as_str));
+            }
+            (Some(ExistingDirective::Ignore(comment)), SuppressionKind::Ignore) => {
+                (edit_range, blank_line) =
+                    suppression_edit_range(locator, line_range, comment.start());
+                existing_codes.extend(comment.codes_as_str(locator.contents()));
+            }
+            (None | Some(_), _) => {
+                let trimmed_line = locator.slice(line_range).trim_end();
+                blank_line = trimmed_line.trim_whitespace_start().is_empty();
+                edit_range = TextRange::new(TextSize::of(trimmed_line), line_range.len()) + offset;
+            }
         }
     }
 
     NoqaEdit {
         edit_range,
+        indentation,
         noqa_codes,
         existing_codes,
         line_ending,
@@ -1264,8 +1305,22 @@ impl<'a> NoqaDirectives<'a> {
 /// line specified by the offset.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct NoqaMapping {
-    ranges: Vec<TextRange>,
+    ranges: Vec<NoqaMappingRange>,
 }
+
+#[derive(Debug)]
+struct NoqaMappingRange {
+    range: TextRange,
+    own_line: Option<TextRange>,
+}
+
+impl PartialEq for NoqaMappingRange {
+    fn eq(&self, other: &Self) -> bool {
+        self.range == other.range
+    }
+}
+
+impl Eq for NoqaMappingRange {}
 
 impl NoqaMapping {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
@@ -1276,41 +1331,66 @@ impl NoqaMapping {
 
     /// Returns the re-mapped position or `position` if no mapping exists.
     pub(crate) fn resolve(&self, offset: TextSize) -> TextSize {
-        let index = self.ranges.binary_search_by(|range| {
-            if range.end() < offset {
+        self.mapping(offset)
+            .map_or(offset, |mapping| mapping.range.end())
+    }
+
+    fn mapping(&self, offset: TextSize) -> Option<&NoqaMappingRange> {
+        let index = self.ranges.binary_search_by(|mapping| {
+            if mapping.range.end() < offset {
                 std::cmp::Ordering::Less
-            } else if range.contains(offset) {
+            } else if mapping.range.contains(offset) {
                 std::cmp::Ordering::Equal
             } else {
                 std::cmp::Ordering::Greater
             }
         });
 
-        if let Ok(index) = index {
-            self.ranges[index].end()
-        } else {
-            offset
-        }
+        index.ok().map(|index| &self.ranges[index])
+    }
+
+    fn own_line(&self, offset: TextSize) -> Option<TextSize> {
+        self.ranges
+            .binary_search_by(|mapping| match mapping.own_line {
+                Some(range) if range.end() < offset => std::cmp::Ordering::Less,
+                Some(range) if range.contains(offset) => std::cmp::Ordering::Equal,
+                Some(_) => std::cmp::Ordering::Greater,
+                None => std::cmp::Ordering::Less,
+            })
+            .ok()
+            .and_then(|index| self.ranges[index].own_line.map(TextRange::start))
     }
 
     pub(crate) fn push_mapping(&mut self, range: TextRange) {
-        if let Some(last_range) = self.ranges.last_mut() {
+        self.push_mapping_with_own_line(range, Some(range));
+    }
+
+    pub(crate) fn push_mapping_with_own_line(
+        &mut self,
+        range: TextRange,
+        own_line: Option<TextRange>,
+    ) {
+        if let Some(last_mapping) = self.ranges.last_mut() {
             // Strictly sorted insertion
-            if last_range.end() < range.start() {
+            if last_mapping.range.end() < range.start() {
                 // OK
-            } else if range.end() < last_range.start() {
+            } else if range.end() < last_mapping.range.start() {
                 // Incoming range is strictly before the last range which violates
                 // the function's contract.
                 panic!("Ranges must be inserted in sorted order")
             } else {
-                // Here, it's guaranteed that `last_range` and `range` overlap
+                // Here, it's guaranteed that the last mapping and `range` overlap
                 // in some way. We want to merge them into a single range.
-                *last_range = last_range.cover(range);
+                last_mapping.range = last_mapping.range.cover(range);
+                last_mapping.own_line = last_mapping
+                    .own_line
+                    .zip(own_line)
+                    .map(|(left, right)| left.cover(right));
                 return;
             }
         }
 
-        self.ranges.push(range);
+        self.ranges.push(NoqaMappingRange { range, own_line });
     }
 }
 

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -240,6 +240,9 @@ struct SuppressionDiagnostic<'a> {
     disabled_codes: Vec<&'a str>,
     unused_codes: Vec<&'a str>,
 
+    /// Whether the suppression comment includes `RUF100`.
+    self_ignore: bool,
+
     /// Whether one of the invalid codes was totally unknown and may be external.
     has_unknown_code: bool,
 
@@ -255,6 +258,7 @@ impl<'a> SuppressionDiagnostic<'a> {
             duplicated_codes: Vec::new(),
             disabled_codes: Vec::new(),
             unused_codes: Vec::new(),
+            self_ignore: false,
             has_unknown_code: false,
             has_stable_rule_name: false,
         }
@@ -268,6 +272,22 @@ impl<'a> SuppressionDiagnostic<'a> {
         !self.disabled_codes.is_empty()
             || !self.duplicated_codes.is_empty()
             || !self.unused_codes.is_empty()
+    }
+}
+
+pub(crate) struct RuleSuppressions<'a> {
+    suppressions: Box<[&'a Suppression]>,
+}
+
+impl RuleSuppressions<'_> {
+    pub(crate) fn check(&self, range: TextRange, parent: Option<TextSize>) -> bool {
+        for suppression in &self.suppressions {
+            if suppression.applies_to_diagnostic(range, parent) {
+                suppression.used.set(true);
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -368,6 +388,16 @@ impl Suppressions {
         false
     }
 
+    pub(crate) fn for_rule(&self, rule: Rule) -> RuleSuppressions<'_> {
+        RuleSuppressions {
+            suppressions: self
+                .valid
+                .iter()
+                .filter(|suppression| suppression.rule(self.preview) == Some(rule))
+                .collect(),
+        }
+    }
+
     pub(crate) fn check_suppressions(&self, context: &LintContext, locator: &Locator) {
         fn process_pending_diagnostics(
             key: Option<TextRange>,
@@ -407,7 +437,7 @@ impl Suppressions {
                 }
             }
 
-            if group.any_unused() {
+            if !group.self_ignore && group.any_unused() {
                 let mut codes = group.disabled_codes.clone();
                 codes.extend(group.unused_codes.clone());
                 Suppressions::report_suppression_codes(
@@ -455,7 +485,10 @@ impl Suppressions {
                 group.invalid_codes.push(code_str);
                 group.has_unknown_code |= !name_is_known;
                 group.has_stable_rule_name |= name_is_known;
-            } else if !suppression.used.get() {
+                continue;
+            }
+
+            if !suppression.used.get() {
                 // UnusedNOQA
                 let Some(rule) = suppression.rule(self.preview) else {
                     continue; // "external" lint code, don't treat it as unused
@@ -464,21 +497,28 @@ impl Suppressions {
                 let (_key, group) = grouped_diagnostic
                     .get_or_insert_with(|| (key, SuppressionDiagnostic::new(suppression)));
 
-                if context.is_rule_enabled(rule) {
-                    if first_comment
-                        .codes_as_str(locator.contents())
-                        .filter(|code| *code == code_str)
-                        .count()
-                        > 1
-                    {
-                        group.duplicated_codes.push(code_str);
-                    } else {
-                        group.unused_codes.push(code_str);
-                    }
+                if rule == Rule::UnusedNOQA {
+                    group.self_ignore = true;
                 } else {
-                    group.disabled_codes.push(code_str);
+                    if context.is_rule_enabled(rule) {
+                        if first_comment
+                            .codes_as_str(locator.contents())
+                            .filter(|code| *code == code_str)
+                            .count()
+                            > 1
+                        {
+                            group.duplicated_codes.push(code_str);
+                        } else {
+                            group.unused_codes.push(code_str);
+                        }
+                    } else {
+                        group.disabled_codes.push(code_str);
+                    }
+                    continue;
                 }
-            } else if let SuppressionComments::Single(SuppressionComment {
+            }
+
+            if let SuppressionComments::Single(SuppressionComment {
                 action: SuppressionAction::Disable,
                 range,
                 ..

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -398,7 +398,12 @@ impl Suppressions {
         }
     }
 
-    pub(crate) fn check_suppressions(&self, context: &LintContext, locator: &Locator) {
+    pub(crate) fn check_suppressions(
+        &self,
+        context: &LintContext,
+        locator: &Locator,
+        analyze_directives: bool,
+    ) {
         fn process_pending_diagnostics(
             key: Option<TextRange>,
             grouped_diagnostic: Option<&(TextRange, SuppressionDiagnostic)>,
@@ -488,7 +493,7 @@ impl Suppressions {
                 continue;
             }
 
-            if !suppression.used.get() {
+            if analyze_directives && !suppression.used.get() {
                 // UnusedNOQA
                 let Some(rule) = suppression.rule(self.preview) else {
                     continue; // "external" lint code, don't treat it as unused

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -806,7 +806,7 @@ impl<'a> SuppressionsBuilder<'a> {
                     {
                         // own-line ignore
                         let mut range =
-                            Self::standalone_comment_range(suppression.range, before, after);
+                            self.standalone_comment_range(suppression.range, before, after);
 
                         // Allow an ignore to suppress diagnostics on a leading shebang.
                         if let Some(shebang) = leading_shebang_range(self.source, tokens)
@@ -944,8 +944,8 @@ impl<'a> SuppressionsBuilder<'a> {
     /// Find the relevant range to cover for own-line suppression comments
     ///
     /// When placed above a "logical line", either a single- or multi-line statement or
-    /// suite header, this should return the range from the start of the comment to the end
-    /// of the entire logical line:
+    /// suite header, this should return the range from the start of the comment's physical line to
+    /// the end of the entire logical line:
     ///
     /// ```py
     ///
@@ -969,8 +969,8 @@ impl<'a> SuppressionsBuilder<'a> {
     /// ```
     ///
     /// When placed "inside" of a logical line, ie, above any line within a multi-line statement
-    /// or suite header, this should return only the range from the start of the comment to the
-    /// end of the next "physical" (non-comment) line:
+    /// or suite header, this should return only the range from the start of the comment's physical
+    /// line to the end of the next "physical" (non-comment) line:
     ///
     /// ```py
     ///
@@ -983,7 +983,12 @@ impl<'a> SuppressionsBuilder<'a> {
     /// ]
     ///
     /// ```
-    fn standalone_comment_range(range: TextRange, before: &[Token], after: &[Token]) -> TextRange {
+    fn standalone_comment_range(
+        &self,
+        range: TextRange,
+        before: &[Token],
+        after: &[Token],
+    ) -> TextRange {
         let mut end = range.end();
         let mut is_inner_comment = false;
 
@@ -1030,7 +1035,7 @@ impl<'a> SuppressionsBuilder<'a> {
             }
         }
 
-        TextRange::new(range.start(), end)
+        TextRange::new(self.source.line_start(range.start()), end)
     }
 
     /// Find the relevant range to cover for trailing end-of-line suppression comments
@@ -1078,6 +1083,8 @@ impl<'a> SuppressionsBuilder<'a> {
                 }
             }
         }
+
+        let start = self.source.line_start(start);
 
         // Until the end of the line.
         let end = self.source.line_end(range.end());
@@ -2120,7 +2127,7 @@ print(
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "'hello'  # ruff:ignore[code]",
+                    covered_source: "    'hello'  # ruff:ignore[code]",
                     code: "code",
                     disable_comment: SuppressionComment {
                         text: "# ruff:ignore[code]",
@@ -2302,7 +2309,7 @@ print(
         Suppressions {
             valid: [
                 Suppression {
-                    covered_source: "# ruff:ignore[code]\n    'hello'",
+                    covered_source: "    # ruff:ignore[code]\n    'hello'",
                     code: "code",
                     disable_comment: SuppressionComment {
                         text: "# ruff:ignore[code]",
@@ -2374,7 +2381,7 @@ bar = [
                     enable_comment: None,
                 },
                 Suppression {
-                    covered_source: "# ruff:ignore[gamma]\n    # stacked\n    arg2,",
+                    covered_source: "    # ruff:ignore[gamma]\n    # stacked\n    arg2,",
                     code: "gamma",
                     disable_comment: SuppressionComment {
                         text: "# ruff:ignore[gamma]",

--- a/crates/ruff_linter/src/suppression.rs
+++ b/crates/ruff_linter/src/suppression.rs
@@ -75,13 +75,19 @@ pub(crate) struct SuppressionComment {
 
 impl SuppressionComment {
     /// Return the suppressed codes as strings
-    fn codes_as_str<'src>(&self, source: &'src str) -> impl Iterator<Item = &'src str> {
+    pub(crate) fn codes_as_str<'src>(&self, source: &'src str) -> impl Iterator<Item = &'src str> {
         self.codes.iter().map(|range| source.slice(range))
     }
 
     /// Return whether the comment is nested within a wider comment token.
     fn is_nested(&self) -> bool {
         self.token_range != self.range
+    }
+}
+
+impl Ranged for SuppressionComment {
+    fn range(&self) -> TextRange {
+        self.range
     }
 }
 
@@ -138,6 +144,20 @@ impl Suppression {
                 ..
             })
         )
+    }
+
+    /// Returns whether the suppression's range applies to a diagnostic.
+    ///
+    /// `ruff:ignore` comments only need to contain the start of the diagnostic range (or its
+    /// parent), while range suppression comments must contain the entire diagnostic range.
+    fn applies_to_diagnostic(&self, range: TextRange, parent: Option<TextSize>) -> bool {
+        if self.is_ignore() {
+            self.range.contains(range.start())
+                || range.is_empty() && self.range.end() == range.start()
+                || parent.is_some_and(|parent| self.range.contains(parent))
+        } else {
+            self.range.contains_range(range)
+        }
     }
 
     /// Return the [`Rule`] associated with this suppression.
@@ -266,6 +286,21 @@ impl Suppressions {
         self.valid.is_empty() && self.invalid.is_empty() && self.errors.is_empty()
     }
 
+    pub(crate) fn find_applicable_ignore(
+        &self,
+        diagnostic: &Diagnostic,
+    ) -> Option<&SuppressionComment> {
+        let range = diagnostic.primary_span()?.range()?;
+
+        self.valid
+            .iter()
+            .find(|suppression| {
+                suppression.is_ignore()
+                    && suppression.applies_to_diagnostic(range, diagnostic.parent())
+            })
+            .map(|suppression| suppression.comments.first())
+    }
+
     /// Check if a diagnostic is suppressed by any known range suppressions.
     ///
     /// A suppression applies for the given diagnostic if it fully contains the diagnostic's range.
@@ -325,20 +360,7 @@ impl Suppressions {
                 continue;
             }
 
-            // For `ruff:ignore` comments, only require that the start of the diagnostic range (or
-            // its parent) is covered by the suppression. Range suppression comments must fully
-            // contain the diagnostic range.
-            let suppressed = if suppression.is_ignore() {
-                suppression.range.contains(range.start())
-                    || range.is_empty() && suppression.range.end() == range.start()
-                    || diagnostic
-                        .parent()
-                        .is_some_and(|parent| suppression.range.contains(parent))
-            } else {
-                suppression.range.contains_range(range)
-            };
-
-            if suppressed {
+            if suppression.applies_to_diagnostic(range, diagnostic.parent()) {
                 suppression.used.set(true);
                 return true;
             }

--- a/crates/ruff_server/src/lint.rs
+++ b/crates/ruff_server/src/lint.rs
@@ -16,7 +16,7 @@ use crate::{
 use ruff_db::diagnostic::{Annotation, Diagnostic, Span, SubDiagnostic};
 use ruff_diagnostics::{Applicability, Edit, Fix};
 use ruff_linter::{
-    Locator,
+    Locator, SuppressionKind,
     directives::{Flags, extract_directives},
     generate_noqa_edits,
     linter::check_path,
@@ -44,7 +44,7 @@ pub(crate) struct AssociatedDiagnosticData {
     pub(crate) edits: Vec<lsp_types::TextEdit>,
     /// The identifier displayed for the diagnostic.
     pub(crate) code: String,
-    /// Possible edit to add a `noqa` comment which will disable this diagnostic.
+    /// Possible edit to add a suppression comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
 }
 
@@ -61,7 +61,7 @@ pub(crate) struct DiagnosticFix {
     /// Edits to fix the diagnostic. If this is empty, a fix
     /// does not exist.
     pub(crate) edits: Vec<lsp_types::TextEdit>,
-    /// Possible edit to add a `noqa` comment which will disable this diagnostic.
+    /// Possible edit to add a suppression comment which will disable this diagnostic.
     pub(crate) noqa_edit: Option<lsp_types::TextEdit>,
 }
 
@@ -163,6 +163,11 @@ pub(crate) fn check(
         &directives.noqa_line_for,
         stylist.line_ending(),
         &suppressions,
+        if is_human_readable_names_enabled(settings.linter.preview) {
+            SuppressionKind::Ignore
+        } else {
+            SuppressionKind::Noqa
+        },
     );
     let context = LspDiagnosticContext {
         source_kind: &source_kind,

--- a/crates/ruff_server/tests/e2e/diagnostics.rs
+++ b/crates/ruff_server/tests/e2e/diagnostics.rs
@@ -58,7 +58,7 @@ fn uses_human_readable_names_in_preview() -> Result<()> {
               }
             ],
             "noqa_edit": {
-              "newText": "  # noqa: F401\n",
+              "newText": "  # ruff:ignore[unused-import]\n",
               "range": {
                 "end": {
                   "character": 0,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -627,8 +627,10 @@ Options:
       --statistics
           Show counts for every rule with at least one violation
       --add-noqa[=<REASON>]
-          Enable automatic additions of `noqa` directives to failing lines.
-          Optionally provide a reason to append after the codes
+          Enable automatic additions of suppression directives to failing
+          lines. Uses `ruff:ignore` in preview mode and `noqa` otherwise.
+          Optionally provide a reason to append after the codes [aliases:
+          --add-ignore]
       --show-files
           See the files Ruff will be run against with the current settings
       --show-settings

--- a/docs/linter.md
+++ b/docs/linter.md
@@ -533,13 +533,17 @@ $ ruff check /path/to/file.py --extend-select RUF100 --fix
 
 ### Inserting necessary suppression comments
 
-Ruff can _automatically add_ `noqa` directives to all lines that contain violations, which is
-useful when migrating a new codebase to Ruff. To automatically add `noqa` directives to all
-relevant lines (with the appropriate rule codes), run Ruff with `--add-noqa`, like so:
+Ruff can _automatically add_ suppression comments to all lines that contain violations, which is
+useful when migrating a new codebase to Ruff. To add the appropriate comments to all relevant
+lines, run Ruff with `--add-noqa`:
 
 ```shell-session
 $ ruff check /path/to/file.py --add-noqa
 ```
+
+In stable mode, Ruff adds `noqa` directives with rule codes. In preview mode, Ruff adds
+`ruff:ignore` comments with human-readable rule names. The `--add-ignore` flag is an alias for
+`--add-noqa`.
 
 ### isort action comments
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -346,7 +346,7 @@ flag to add `# noqa` directives to all existing `UP035` violations:
 
 ```console
 $ uv run ruff check --select UP035 --add-noqa .
-Added 1 noqa directive.
+Added 1 suppression comment.
 ```
 
 Running `git diff` shows the following:
@@ -360,6 +360,9 @@ index 71fca60c8d..e92d839f1b 100644
 -from typing import Iterable
 +from typing import Iterable  # noqa: UP035
 ```
+
+In preview mode, Ruff instead adds `# ruff:ignore[...]` comments with human-readable rule names.
+The `--add-ignore` flag is an alias for `--add-noqa`.
 
 ## Integrations
 


### PR DESCRIPTION
## Summary

This is currently stacked on #26346 and fixes the differences I noted between `--add-noqa` and `--add-ignore` when running on our ecosystem projects.

## Test Plan

New tests derived from the ecosystem check
