### PR TITLE
[ty] Treat builtin-ABC intersections as disjoint

### DIFF
--- a/crates/ty/docs/configuration.md
+++ b/crates/ty/docs/configuration.md
@@ -241,6 +241,51 @@ Defaults to `false`.
 
 ---
 
+### `strict-subclass-narrowing`
+
+Whether narrowing should preserve intersections that can only be inhabited by unusual
+subclasses of builtin types.
+
+By default, ty treats a builtin class and an unrelated typing interface as disjoint. For
+example, `str` is considered disjoint from `Mapping[str, object]`, even though a subclass of
+`str` could also inherit from `Mapping`:
+
+```python
+from collections.abc import Mapping
+
+class StringMapping(str, Mapping[str, object]): ...
+```
+
+This assumption avoids retaining intersections that require unusual multiple-inheritance
+hierarchies, which generally produces simpler and more useful narrowing results. Enable
+this option to account for those subclasses and preserve the intersections instead.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.analysis]
+    # Preserve intersections that could be inhabited by unusual builtin subclasses
+    strict-subclass-narrowing = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [analysis]
+    # Preserve intersections that could be inhabited by unusual builtin subclasses
+    strict-subclass-narrowing = true
+    ```
+
+---
+
 ## `environment`
 
 ### `extra-paths`
@@ -812,6 +857,51 @@ Defaults to `false`.
     [overrides.analysis]
     # Preserve broad builtin types instead of narrowing them to literals
     strict-literal-narrowing = true
+    ```
+
+---
+
+#### `strict-subclass-narrowing`
+
+Whether narrowing should preserve intersections that can only be inhabited by unusual
+subclasses of builtin types.
+
+By default, ty treats a builtin class and an unrelated typing interface as disjoint. For
+example, `str` is considered disjoint from `Mapping[str, object]`, even though a subclass of
+`str` could also inherit from `Mapping`:
+
+```python
+from collections.abc import Mapping
+
+class StringMapping(str, Mapping[str, object]): ...
+```
+
+This assumption avoids retaining intersections that require unusual multiple-inheritance
+hierarchies, which generally produces simpler and more useful narrowing results. Enable
+this option to account for those subclasses and preserve the intersections instead.
+
+Defaults to `false`.
+
+**Default value**: `false`
+
+**Type**: `bool`
+
+**Example usage**:
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.ty.overrides.analysis]
+    # Preserve intersections that could be inhabited by unusual builtin subclasses
+    strict-subclass-narrowing = true
+    ```
+
+=== "ty.toml"
+
+    ```toml
+    [overrides.analysis]
+    # Preserve intersections that could be inhabited by unusual builtin subclasses
+    strict-subclass-narrowing = true
     ```
 
 ---

--- a/crates/ty_project/src/metadata/options.rs
+++ b/crates/ty_project/src/metadata/options.rs
@@ -1529,6 +1529,34 @@ pub struct AnalysisOptions {
     )]
     pub strict_literal_narrowing: Option<bool>,
 
+    /// Whether narrowing should preserve intersections that can only be inhabited by unusual
+    /// subclasses of builtin types.
+    ///
+    /// By default, ty treats a builtin class and an unrelated typing interface as disjoint. For
+    /// example, `str` is considered disjoint from `Mapping[str, object]`, even though a subclass of
+    /// `str` could also inherit from `Mapping`:
+    ///
+    /// ```python
+    /// from collections.abc import Mapping
+    ///
+    /// class StringMapping(str, Mapping[str, object]): ...
+    /// ```
+    ///
+    /// This assumption avoids retaining intersections that require unusual multiple-inheritance
+    /// hierarchies, which generally produces simpler and more useful narrowing results. Enable
+    /// this option to account for those subclasses and preserve the intersections instead.
+    ///
+    /// Defaults to `false`.
+    #[option(
+        default = r#"false"#,
+        value_type = "bool",
+        example = r#"
+        # Preserve intersections that could be inhabited by unusual builtin subclasses
+        strict-subclass-narrowing = true
+        "#
+    )]
+    pub strict_subclass_narrowing: Option<bool>,
+
     /// Whether ty should respect `type: ignore` comments.
     ///
     /// When set to `false`, `type: ignore` comments are treated like any other normal
@@ -1606,6 +1634,7 @@ impl AnalysisOptions {
     ) -> AnalysisSettings {
         let Self {
             strict_literal_narrowing,
+            strict_subclass_narrowing,
             respect_type_ignore_comments,
             allowed_unresolved_imports,
             replace_imports_with_any,
@@ -1613,6 +1642,7 @@ impl AnalysisOptions {
 
         let AnalysisSettings {
             strict_literal_narrowing: strict_literal_narrowing_default,
+            strict_subclass_narrowing: strict_subclass_narrowing_default,
             respect_type_ignore_comments: respect_type_ignore_default,
             allowed_unresolved_imports: allowed_unresolved_imports_default,
             replace_imports_with_any: replace_imports_with_any_default,
@@ -1643,6 +1673,8 @@ impl AnalysisOptions {
         AnalysisSettings {
             strict_literal_narrowing: strict_literal_narrowing
                 .unwrap_or(strict_literal_narrowing_default),
+            strict_subclass_narrowing: strict_subclass_narrowing
+                .unwrap_or(strict_subclass_narrowing_default),
             respect_type_ignore_comments: respect_type_ignore_comments
                 .unwrap_or(respect_type_ignore_default),
             allowed_unresolved_imports,

--- a/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
+++ b/crates/ty_python_semantic/resources/mdtest/generics/legacy/functions.md
@@ -1218,7 +1218,7 @@ def narrowed_via_isinstance(x: Sequence[str] | int):
     if isinstance(x, int):
         reveal_type(x)  # revealed: int
     else:
-        reveal_type(x)  # revealed: Sequence[str] & ~int
+        reveal_type(x)  # revealed: Sequence[str]
         reveal_type(first(x))  # revealed: str
 
 def narrowed_via_truthiness(y: list[str]):

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -146,6 +146,45 @@ from typing import Any
 
 def test_isinstance(x: dict[Any, Any] | int) -> None:
     if isinstance(x, Mapping):
+        reveal_type(x)  # revealed: dict[Any, Any]
+    else:
+        reveal_type(x)  # revealed: int
+
+def test_match(x: dict[Any, Any] | int) -> None:
+    match x:
+        case {}:
+            reveal_type(x)  # revealed: dict[Any, Any]
+        case _:
+            reveal_type(x)  # revealed: int
+
+def test_match_double_star(x: dict[Any, Any] | int) -> None:
+    match x:
+        case {**rest}:
+            reveal_type(x)  # revealed: dict[Any, Any]
+        case _:
+            reveal_type(x)  # revealed: int
+
+def test_match_refutable(x: dict[Any, Any] | int) -> None:
+    match x:
+        case {"k": _}:
+            reveal_type(x)  # revealed: dict[Any, Any]
+        case _:
+            reveal_type(x)  # revealed: dict[Any, Any] | int
+```
+
+## Mapping patterns with strict subclass narrowing
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+from collections.abc import Mapping
+from typing import Any
+
+def test_isinstance(x: dict[Any, Any] | int) -> None:
+    if isinstance(x, Mapping):
         reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
     else:
         reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
@@ -156,20 +195,6 @@ def test_match(x: dict[Any, Any] | int) -> None:
             reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
         case _:
             reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
-
-def test_match_double_star(x: dict[Any, Any] | int) -> None:
-    match x:
-        case {**rest}:
-            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
-        case _:
-            reveal_type(x)  # revealed: int & ~Top[Mapping[Unknown, object]]
-
-def test_match_refutable(x: dict[Any, Any] | int) -> None:
-    match x:
-        case {"k": _}:
-            reveal_type(x)  # revealed: dict[Any, Any] | (int & Top[Mapping[Unknown, object]])
-        case _:
-            reveal_type(x)  # revealed: dict[Any, Any] | int
 ```
 
 ## Sequence patterns
@@ -180,7 +205,7 @@ from collections.abc import Sequence
 def test_match_star(x: Sequence[int] | int) -> None:
     match x:
         case [*rest]:
-            reveal_type(x)  # revealed: (Sequence[int] & ~str & ~bytes & ~bytearray) | (int & Sequence[object])
+            reveal_type(x)  # revealed: Sequence[int] & ~str & ~bytes & ~bytearray
         case _:
             # `str`, `bytes`, and `bytearray` are subtypes of `Sequence`, but
             # sequence patterns explicitly do not match them. `bytes` and
@@ -188,7 +213,7 @@ def test_match_star(x: Sequence[int] | int) -> None:
             # TODO: After https://github.com/astral-sh/ty/issues/3314 is
             # fixed, the `Sequence[int] & str` intersection should simplify to
             # `Never`.
-            reveal_type(x)  # revealed: (Sequence[int] & str) | bytes | bytearray | (int & ~Sequence[object])
+            reveal_type(x)  # revealed: (Sequence[int] & str) | bytes | bytearray | int
 
 def test_match_star_excludes_text_and_bytes(x: str | bytes | bytearray | list[int]) -> None:
     match x:
@@ -1438,6 +1463,13 @@ def test_match_mapping_instance_get(value: InstanceGetMapping) -> None:
     match value:
         case {"item": item}:
             reveal_type(item)  # revealed: object
+
+def test_mapping_pattern_drops_builtin_mapping_intersection(
+    value: dict[str, int] | str,
+) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: int
 
 def test_incompatible_declared_mapping_captures(value: Mapping[str, int]) -> None:
     item: str
@@ -2747,7 +2779,7 @@ def match_loop_carried_mapping_capture(flag: bool) -> None:
     while flag:
         match x:
             case {"value": x}:
-                reveal_type(x)  # revealed: object
+                reveal_type(x)  # revealed: int
 
 def match_loop_carried_match_self_capture(flag: bool, x: int) -> None:
     while flag:

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -335,6 +335,44 @@ static_assert(is_disjoint_from(D, B))
 static_assert(not is_disjoint_from(D, A))
 ```
 
+## Builtin classes and typing ABCs
+
+Builtin classes are treated as disjoint from typing ABCs they do not already inherit from. This
+avoids retaining intersections that would require an unusual multiple-inheritance hierarchy. Typing
+protocols remain potentially compatible with builtin subclasses.
+
+```py
+from collections.abc import Mapping, Sequence
+from typing import Awaitable
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+static_assert(is_disjoint_from(str, Mapping[str, object]))
+static_assert(not is_disjoint_from(str, Sequence[str]))
+static_assert(not is_disjoint_from(int, Awaitable[object]))
+```
+
+## Strict subclass narrowing
+
+Enabling `strict-subclass-narrowing` preserves intersections that could be inhabited by unusual
+subclasses of builtin types.
+
+```toml
+[analysis]
+strict-subclass-narrowing = true
+```
+
+```py
+from collections.abc import Mapping, Sequence
+from typing import Awaitable
+from ty_extensions import static_assert
+from ty_extensions._internal import is_disjoint_from
+
+static_assert(not is_disjoint_from(str, Mapping[str, object]))
+static_assert(not is_disjoint_from(str, Sequence[str]))
+static_assert(not is_disjoint_from(int, Awaitable[object]))
+```
+
 ## Dataclasses
 
 ```py

--- a/crates/ty_python_semantic/src/lib.rs
+++ b/crates/ty_python_semantic/src/lib.rs
@@ -95,6 +95,10 @@ pub struct AnalysisSettings {
     /// literal types.
     pub strict_literal_narrowing: bool,
 
+    /// Whether narrowing preserves intersections that can be inhabited by unusual subclasses of
+    /// builtin types.
+    pub strict_subclass_narrowing: bool,
+
     /// Whether errors can be suppressed with `type: ignore` comments.
     ///
     /// If set to false, ty won't:
@@ -113,6 +117,7 @@ impl Default for AnalysisSettings {
     fn default() -> Self {
         Self {
             strict_literal_narrowing: false,
+            strict_subclass_narrowing: false,
             respect_type_ignore_comments: true,
             allowed_unresolved_imports: ModuleGlobSet::empty(),
             replace_imports_with_any: ModuleGlobSet::empty(),

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 
 use ruff_python_ast::name::Name;
-use ty_module_resolver::{ModuleName, file_to_module};
+use ty_module_resolver::{KnownModule, ModuleName, file_to_module};
 
 use super::protocol_class::ProtocolInterface;
 use super::{
@@ -620,6 +620,36 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         if left.is_object() || right.is_object() {
             return result;
         }
+
+        let left_class = left.class(db);
+        let right_class = right.class(db);
+        let class_is_defined_in = |class: ClassType<'db>, module| {
+            file_to_module(db, class.class_literal(db).file(db))
+                .is_some_and(|resolved| resolved.is_known(db, module))
+        };
+        let class_inherits_from = |class: ClassType<'db>, base: ClassType<'db>| {
+            class
+                .iter_mro(db)
+                .filter_map(ClassBase::into_class)
+                .any(|mro_class| mro_class.class_literal(db) == base.class_literal(db))
+        };
+        let builtin_and_typing_abc_are_disjoint =
+            |builtin: ClassType<'db>, typing_abc: ClassType<'db>| {
+                class_is_defined_in(builtin, KnownModule::Builtins)
+                    && class_is_defined_in(typing_abc, KnownModule::Typing)
+                    && !typing_abc.is_protocol(db)
+                    && !class_inherits_from(builtin, typing_abc)
+                    && !class_inherits_from(typing_abc, builtin)
+            };
+        if !db
+            .analysis_settings(left_class.class_literal(db).file(db))
+            .strict_subclass_narrowing
+            && (builtin_and_typing_abc_are_disjoint(left_class, right_class)
+                || builtin_and_typing_abc_are_disjoint(right_class, left_class))
+        {
+            return self.always();
+        }
+
         if let Some(left_spec) = left.tuple_spec(db) {
             if let Some(right_spec) = right.tuple_spec(db) {
                 let compatible = self.check_tuple_spec_pair(db, &left_spec, &right_spec);

--- a/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
+++ b/crates/ty_server/tests/e2e/snapshots/e2e__commands__debug_command.snap
@@ -164,6 +164,7 @@ Settings: Settings {
     },
     analysis: AnalysisSettings {
         strict_literal_narrowing: false,
+        strict_subclass_narrowing: false,
         respect_type_ignore_comments: true,
         allowed_unresolved_imports: ModuleGlobSet {
             regex_set: RegexSet([]),

--- a/crates/ty_test/src/config.rs
+++ b/crates/ty_test/src/config.rs
@@ -124,6 +124,9 @@ pub(crate) struct Analysis {
     /// Whether equality comparisons should only narrow to literals when it is safe to do so.
     pub(crate) strict_literal_narrowing: Option<bool>,
 
+    /// Whether narrowing should preserve intersections involving unusual builtin subclasses.
+    pub(crate) strict_subclass_narrowing: Option<bool>,
+
     /// Whether ty should support `type: ignore` comments.
     pub(crate) respect_type_ignore_comments: Option<bool>,
 

--- a/crates/ty_test/src/db.rs
+++ b/crates/ty_test/src/db.rs
@@ -61,6 +61,7 @@ impl Db {
         let analysis = if let Some(options) = options {
             let AnalysisSettings {
                 strict_literal_narrowing: strict_literal_narrowing_default,
+                strict_subclass_narrowing: strict_subclass_narrowing_default,
                 respect_type_ignore_comments: respect_type_ignore_comments_default,
                 allowed_unresolved_imports: allowed_unresolved_imports_default,
                 replace_imports_with_any: replace_imports_with_any_default,
@@ -98,6 +99,9 @@ impl Db {
                 strict_literal_narrowing: options
                     .strict_literal_narrowing
                     .unwrap_or(strict_literal_narrowing_default),
+                strict_subclass_narrowing: options
+                    .strict_subclass_narrowing
+                    .unwrap_or(strict_subclass_narrowing_default),
                 respect_type_ignore_comments: options
                     .respect_type_ignore_comments
                     .unwrap_or(respect_type_ignore_comments_default),

--- a/ty.schema.json
+++ b/ty.schema.json
@@ -105,6 +105,13 @@
             "boolean",
             "null"
           ]
+        },
+        "strict-subclass-narrowing": {
+          "description": "Whether narrowing should preserve intersections that can only be inhabited by unusual\nsubclasses of builtin types.\n\nBy default, ty treats a builtin class and an unrelated typing interface as disjoint. For\nexample, `str` is considered disjoint from `Mapping[str, object]`, even though a subclass of\n`str` could also inherit from `Mapping`:\n\n```python\nfrom collections.abc import Mapping\n\nclass StringMapping(str, Mapping[str, object]): ...\n```\n\nThis assumption avoids retaining intersections that require unusual multiple-inheritance\nhierarchies, which generally produces simpler and more useful narrowing results. Enable\nthis option to account for those subclasses and preserve the intersections instead.\n\nDefaults to `false`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary

This PR treats builtin classes and unrelated nominal ABCs from `typing` as disjoint during narrowing by default.

The behavior is unsound because a subclass of a builtin can explicitly inherit from an otherwise unrelated ABC, but it's a useful default for conventional class hierarchies. Users who prefer conservative behavior can enable `strict-subclass-narrowing`:

```toml
[tool.ty.analysis]
strict-subclass-narrowing = true
```

For example, the default behavior allows:

```python
from collections.abc import Mapping

def consume(value: int) -> None: ...

def check(value: dict[str, int] | str) -> None:
    match value:
        case {"key": item}:
            reveal_type(item)  # int
            consume(item)  # no error
```

Without this assumption, `item` is inferred as `int | Unknown` because ty preserves the possibility of a `str` subclass that also inherits from `Mapping`. Enabling `strict-subclass-narrowing` preserves that conservative behavior.

## Ecosystem results

Across 31 projects, this change removes 323 diagnostics, changes 100 diagnostics, and adds 6 diagnostics. The additions are four dynamic keyed-access diagnostics in cwltool, one newly unused ignore in discord.py, and one replacement diagnostic in pytest-autoprofile.

[PR_26415_ECOSYSTEM_SUMMARY.md](https://github.com/user-attachments/files/29991052/PR_26415_ECOSYSTEM_SUMMARY.md)

## Follow-up experiments

We also tried to further "relaxations" in separate PRs.

### Treat builtin classes as disjoint from typing protocols ([#26416](https://github.com/astral-sh/ruff/pull/26416))

This experiment extended the default rule to fully static protocols from `typing`: if the builtin's erased instance type did not satisfy the protocol, their intersection was treated as empty.

That rule surfaced some issues because failure of the erased type to satisfy a specialized protocol does not prove that no specialization can satisfy it. For example, `tuple[object, ...] & Iterable[int]` is inhabited by `tuple[int, ...]`, but this experiment simplifies the intersection to `Never`.

The regression appears in [Dragonchain](https://github.com/dragonchain/dragonchain/blob/1a25eda598471fd735a2b515312bfc3bbe53770b/dragonchain/lib/database/redisearch_utest.py#L71). The rule in this PR preserves the literal key in `list[dict[Literal["a"], str]]` and reports the missing required `TypedDict` key `b`. #26416 treats the surrounding `list` as disjoint from `Iterable[D]`, widens the element to `dict[str, str]`, and loses the more actionable missing-key diagnostic.

[PR_26416_ECOSYSTEM_SUMMARY.md](https://github.com/user-attachments/files/29991077/PR_26416_ECOSYSTEM_SUMMARY.md)

### Treat arbitrary nominal classes as disjoint from typing interfaces ([#26790](https://github.com/astral-sh/ruff/pull/26790))

This experiment removed the builtin-only boundary. It treated any nominal class as disjoint from an unrelated typing ABC, or from a typing protocol that it did not currently satisfy.

That rule also had issues: a subclass can combine the nominal class with an ABC through multiple inheritance or add the protocol members structurally, so the discarded intersection can have concrete inhabitants.

The regression appears in [JAX](https://github.com/google/jax/blob/322cd628ccce4354f8fbd4431f1199c7e81b8a62/jax/_src/random/stateful_rng.py#L43). Before #26790, ty reports that `int | (Sequence[int] & Top[number[Any, int | float | complex]])` is not assignable to `SupportsIndex`. The experiment removes that diagnostic by discarding the `number & Sequence` arm, even though a subclass could inherit from both classes.

[PR_26790_ECOSYSTEM_SUMMARY.md](https://github.com/user-attachments/files/29991110/PR_26790_ECOSYSTEM_SUMMARY.md)
