### PR TITLE
[ty] Treat builtin-protocol intersections as disjoint

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/async.md
+++ b/crates/ty_python_semantic/resources/mdtest/async.md
@@ -241,9 +241,9 @@ async def f(fn: Callable[[int], int | Awaitable[int]]) -> None:
     if is_async_callable(fn):
         reveal_type(fn)  # revealed: ((int, /) -> int | Awaitable[int]) & Top[(...) -> Awaitable[object]]
         result = fn(1)
-        # This includes `int & Awaitable[object]`: an `int` subtype could define `__await__`.
-        reveal_type(result)  # revealed: (int & Awaitable[object]) | Awaitable[int]
-        reveal_type(await result)  # revealed: object
+        # The builtin-protocol heuristic drops `int & Awaitable[object]`.
+        reveal_type(result)  # revealed: Awaitable[int]
+        reveal_type(await result)  # revealed: int
 ```
 
 ## Awaiting intersection types (Python 3.12 or lower)

--- a/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/conditionals/in.md
@@ -900,22 +900,25 @@ def custom_container_union(
 
 ### A component with known containment
 
-After the `isinstance` check, `values` has type `Iterable[Literal[1]] & tuple[object, ...]`. Until
+After the `isinstance` check, `values` has type `LiteralOneIterable & tuple[object, ...]`. Until
 [this intersection can be simplified](https://github.com/astral-sh/ty/issues/3890) to
 `tuple[Literal[1], ...]`, membership narrowing preserves the behavior from before containment
 semantics were checked: the `tuple` component establishes that membership compares against its
-elements, while the `Iterable` component constrains those elements to `Literal[1]`.
+elements, while the protocol component constrains those elements to `Literal[1]`.
 
 ```py
-from collections.abc import Iterable
-from typing import Literal, final
+from collections.abc import Iterator
+from typing import Literal, Protocol, final
 
 @final
 class Token: ...
 
+class LiteralOneIterable(Protocol):
+    def __iter__(self) -> Iterator[Literal[1]]: ...
+
 def tuple_component_establishes_containment(
     value: Token | Literal[1],
-    values: Iterable[Literal[1]],
+    values: LiteralOneIterable,
 ) -> None:
     if isinstance(values, tuple) and value in values:
         reveal_type(value)  # revealed: Literal[1]

--- a/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/isinstance.md
@@ -2,6 +2,20 @@
 
 Narrowing for `isinstance(object, classinfo)` expressions.
 
+## Builtins and typing protocols
+
+Builtin classes are treated as disjoint from typing protocols they do not already satisfy.
+
+```py
+from typing import Awaitable
+
+def _(value: int | Awaitable[str]) -> None:
+    if isinstance(value, Awaitable):
+        reveal_type(value)  # revealed: Awaitable[str]
+    else:
+        reveal_type(value)  # revealed: int
+```
+
 ## `classinfo` is a single type
 
 ```py

--- a/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
+++ b/crates/ty_python_semantic/resources/mdtest/type_properties/is_disjoint_from.md
@@ -335,21 +335,27 @@ static_assert(is_disjoint_from(D, B))
 static_assert(not is_disjoint_from(D, A))
 ```
 
-## Builtin classes and typing ABCs
+## Builtin classes, typing ABCs, and protocols
 
-Builtin classes are treated as disjoint from typing ABCs they do not already inherit from. This
-avoids retaining intersections that would require an unusual multiple-inheritance hierarchy. Typing
-protocols remain potentially compatible with builtin subclasses.
+Builtin classes are treated as disjoint from typing ABCs they do not already inherit from and typing
+protocols they do not already satisfy. This avoids retaining intersections that would require an
+unusual subclass.
 
 ```py
 from collections.abc import Mapping, Sequence
-from typing import Awaitable
+from typing import Awaitable, Iterable, Protocol
 from ty_extensions import static_assert
 from ty_extensions._internal import is_disjoint_from
 
 static_assert(is_disjoint_from(str, Mapping[str, object]))
 static_assert(not is_disjoint_from(str, Sequence[str]))
-static_assert(not is_disjoint_from(int, Awaitable[object]))
+static_assert(is_disjoint_from(int, Awaitable[object]))
+static_assert(not is_disjoint_from(str, Iterable[str]))
+
+class CustomProtocol(Protocol):
+    def custom(self) -> None: ...
+
+static_assert(not is_disjoint_from(int, CustomProtocol))
 ```
 
 ## Strict subclass narrowing

--- a/crates/ty_python_semantic/src/types/instance.rs
+++ b/crates/ty_python_semantic/src/types/instance.rs
@@ -33,6 +33,15 @@ use crate::{Db, FxOrderSet};
 pub(super) use synthesized_protocol::SynthesizedProtocolType;
 use ty_python_core::definition::Definition;
 
+fn class_is_defined_in_known_module(
+    db: &dyn Db,
+    class: ClassType<'_>,
+    module: KnownModule,
+) -> bool {
+    file_to_module(db, class.class_literal(db).file(db))
+        .is_some_and(|resolved| resolved.is_known(db, module))
+}
+
 impl<'db> Type<'db> {
     pub(crate) const fn object() -> Self {
         Type::NominalInstance(NominalInstanceType(NominalInstanceInner::Object))
@@ -228,6 +237,10 @@ impl<'db> NominalInstanceType<'db> {
     pub fn class_module_name(&self, db: &'db dyn Db) -> Option<&'db ModuleName> {
         let file = self.class(db).class_literal(db).file(db);
         file_to_module(db, file).map(|module| module.name(db))
+    }
+
+    pub(super) fn is_builtin_instance(self, db: &'db dyn Db) -> bool {
+        class_is_defined_in_known_module(db, self.class(db), KnownModule::Builtins)
     }
 
     pub(super) fn class(&self, db: &'db dyn Db) -> ClassType<'db> {
@@ -623,10 +636,6 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
 
         let left_class = left.class(db);
         let right_class = right.class(db);
-        let class_is_defined_in = |class: ClassType<'db>, module| {
-            file_to_module(db, class.class_literal(db).file(db))
-                .is_some_and(|resolved| resolved.is_known(db, module))
-        };
         let class_inherits_from = |class: ClassType<'db>, base: ClassType<'db>| {
             class
                 .iter_mro(db)
@@ -635,8 +644,8 @@ impl<'c, 'db> DisjointnessChecker<'_, 'c, 'db> {
         };
         let builtin_and_typing_abc_are_disjoint =
             |builtin: ClassType<'db>, typing_abc: ClassType<'db>| {
-                class_is_defined_in(builtin, KnownModule::Builtins)
-                    && class_is_defined_in(typing_abc, KnownModule::Typing)
+                class_is_defined_in_known_module(db, builtin, KnownModule::Builtins)
+                    && class_is_defined_in_known_module(db, typing_abc, KnownModule::Typing)
                     && !typing_abc.is_protocol(db)
                     && !class_inherits_from(builtin, typing_abc)
                     && !class_inherits_from(typing_abc, builtin)
@@ -805,6 +814,15 @@ impl<'db> ProtocolInstanceType<'db> {
     pub(super) fn is_hashable(self, db: &'db dyn Db) -> bool {
         self.to_nominal_instance()
             .is_some_and(|instance| instance.class(db).is_known(db, KnownClass::Hashable))
+    }
+
+    pub(super) fn is_typing_protocol(self, db: &'db dyn Db) -> bool {
+        match self.inner {
+            Protocol::FromClass(class) => {
+                class_is_defined_in_known_module(db, *class, KnownModule::Typing)
+            }
+            Protocol::Synthesized(_) => false,
+        }
     }
 
     // Keep this method private, so that the only way of constructing `ProtocolInstanceType`

--- a/crates/ty_python_semantic/src/types/relation.rs
+++ b/crates/ty_python_semantic/src/types/relation.rs
@@ -2878,6 +2878,25 @@ impl<'a, 'c, 'db> DisjointnessChecker<'a, 'c, 'db> {
             // (<https://github.com/rust-lang/rust/issues/129967>)
             (Type::ProtocolInstance(protocol), Type::NominalInstance(nominal))
             | (Type::NominalInstance(nominal), Type::ProtocolInstance(protocol))
+                if !db
+                    .analysis_settings(nominal.class(db).class_literal(db).file(db))
+                    .strict_subclass_narrowing
+                    && nominal.is_builtin_instance(db)
+                    && protocol.is_typing_protocol(db)
+                    && !Type::ProtocolInstance(protocol).has_dynamic(db)
+                    && !Type::ProtocolInstance(protocol).has_typevar_or_typevar_instance(db) =>
+            {
+                self.as_relation_checker(TypeRelation::Subtyping)
+                    .check_type_pair(
+                        db,
+                        Type::NominalInstance(nominal),
+                        Type::ProtocolInstance(protocol),
+                    )
+                    .negate(db, self.constraints)
+            }
+
+            (Type::ProtocolInstance(protocol), Type::NominalInstance(nominal))
+            | (Type::NominalInstance(nominal), Type::ProtocolInstance(protocol))
                 if nominal.class(db).is_final(db) =>
             {
                 self.with_recursion_guard(left, right, || {


### PR DESCRIPTION
## Summary

This builds on #26415 and extends the same heuristic to protocols defined by `typing`.

Today we preserve intersections such as `int & Awaitable[object]` because an `int` subclass could define `__await__`. With this change, a builtin class and a typing protocol are disjoint when the builtin does not already satisfy the protocol:

```python
def check(value: int | Awaitable[str]) -> None:
    if isinstance(value, Awaitable):
        reveal_type(value)  # Awaitable[str]
```

The extension only applies to fully static protocol arguments. Protocols containing dynamic types or type variables keep the existing conservative behavior, which avoids disturbing generic inference. User-defined protocols are also unchanged, even when they are structurally identical to a protocol from `typing`.

This is stacked separately so its ecosystem results isolate the additional impact of treating builtin-protocol intersections as uninhabited.
