### PR TITLE
[ty] Infer generic class pattern specializations

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -507,6 +507,10 @@ class TextValue:
 class StringMapping(TypedDict):
     value: str
 
+@final
+class MutableOrBox:
+    value: int = 0
+
 def class_or_sequence_binding(value: TextValue | tuple[int]) -> None:
     match value:
         case TextValue(value=item) | [item]:
@@ -516,6 +520,15 @@ def mapping_or_singleton_binding(value: StringMapping | None) -> None:
     match value:
         case {"value": item} | (None as item):
             reveal_type(item)  # revealed: str | None
+
+def mixed_or_binding_does_not_keep_failed_sequence_facts(
+    value: list[int] | MutableOrBox,
+) -> None:
+    match value:
+        case [item] | MutableOrBox(value=item) | item:
+            if isinstance(item, list):
+                item.clear()
+                reveal_type(item)  # revealed: list[int]
 ```
 
 ## Declared pattern captures

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1151,12 +1151,27 @@ class OverlapMemberA:
 class OverlapMemberB:
     member: str
 
+class CompatibleOverlapMemberA:
+    member: object = "x"
+
+class CompatibleOverlapMemberB:
+    member: int = 1
+
 def test_match_class_capture_combines_overlapping_member_types(
     value: OverlapMemberA,
 ) -> None:
     match value:
         case OverlapMemberB(member=item):
             reveal_type(item)  # revealed: int | str
+
+def test_match_class_capture_preserves_compatible_overlapping_member_types(
+    value: CompatibleOverlapMemberA,
+) -> None:
+    match value:
+        case CompatibleOverlapMemberB(member=str() as item):
+            reveal_type(item)  # revealed: str
+            # revealed: CompatibleOverlapMemberA & CompatibleOverlapMemberB
+            reveal_type(value)
 
 class GenericOverlapA:
     member: int
@@ -1179,7 +1194,7 @@ def test_match_generic_class_capture_preserves_possible_multiple_inheritance(
 ) -> None:
     match value:
         case GenericOverlapB(member=str() as item):
-            reveal_type(item)  # revealed: Unknown & str
+            reveal_type(item)  # revealed: str
             reveal_type(value)  # revealed: GenericOverlapA & Top[GenericOverlapB[Unknown]]
             1 + "x"  # error: [unsupported-operator]
 

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1167,14 +1167,29 @@ class GenericOverlapB(Generic[OverlapT]):
 class GenericOverlapC(GenericOverlapB[str], GenericOverlapA):
     member: str
 
+class GenericListOverlapA: ...
+
+class GenericListOverlapB(Generic[OverlapT]):
+    values: list[OverlapT]
+
+class GenericListOverlapC(GenericListOverlapA, GenericListOverlapB[int]): ...
+
 def test_match_generic_class_capture_preserves_possible_multiple_inheritance(
     value: GenericOverlapA,
 ) -> None:
     match value:
         case GenericOverlapB(member=str() as item):
-            reveal_type(item)  # revealed: str
+            reveal_type(item)  # revealed: Unknown & str
             reveal_type(value)  # revealed: GenericOverlapA & Top[GenericOverlapB[Unknown]]
             1 + "x"  # error: [unsupported-operator]
+
+def test_match_generic_container_member_preserves_unknown_specialization(
+    value: GenericListOverlapA,
+) -> None:
+    match value:
+        case GenericListOverlapB(values=items):
+            for item in items:
+                reveal_type(item)  # revealed: Unknown
 ```
 
 ## Class pattern captures from `Any` and `Unknown`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -847,11 +847,12 @@ def test_incompatible_declared_class_capture(value: PatternBox[int]) -> None:
 
 We do not yet infer a generic subclass's specialization from its base class. In the first two
 examples, ty therefore cannot infer `GenericPatternChild[int]` from `GenericPatternBase[int]`, so
-attributes declared only on the subclass are `Unknown`. Attributes inherited from the generic base
-class can still use the subject's specialization, as shown in the final example.
+type parameters in attributes declared only on the subclass become `Unknown`, while their known
+generic structure is preserved. Attributes inherited from the generic base class can still use the
+subject's specialization.
 
 ```py
-from typing import Generic, TypeVar
+from typing import final, Generic, TypeVar
 
 GenericPatternT = TypeVar("GenericPatternT")
 
@@ -867,6 +868,10 @@ class GenericMemberBase(Generic[GenericPatternT]):
 class GenericMemberChild(GenericMemberBase[GenericPatternT]): ...
 class IntGenericMemberChild(GenericMemberBase[int]): ...
 
+@final
+class FinalGenericPatternBox(Generic[GenericPatternT]):
+    value: list[GenericPatternT]
+
 def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
     match value:
         case GenericPatternChild(item=item):
@@ -876,8 +881,7 @@ def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
 def test_match_nested_generic_subclass_capture(value: GenericPatternBase[int]) -> list[int]:
     match value:
         case GenericPatternChild(items=items):
-            # TODO: This should be `list[int]` once generic subclass specialization is supported.
-            reveal_type(items)  # revealed: Unknown
+            reveal_type(items)  # revealed: list[Unknown]
             return items
     return []
 
@@ -899,6 +903,12 @@ def test_match_generic_base_capture_preserves_subject_specialization(
         case GenericMemberBase(item=item):
             reveal_type(item)  # revealed: int
             item.bit_length()
+
+def test_match_direct_generic_pattern_preserves_declared_member(value: object) -> None:
+    match value:
+        case FinalGenericPatternBox(value=int() as item):
+            reveal_type(item)  # revealed: Never
+            reveal_type(value)  # revealed: Never
 ```
 
 ## Positional class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -866,24 +866,60 @@ def test_incompatible_declared_class_capture(value: PatternBox[int]) -> None:
 
 ## Generic subclass captures
 
-We do not yet infer a generic subclass's type arguments from its base class. Attributes declared
-only on the subclass therefore use `Unknown` for those arguments, but still retain types such as
-`list[Unknown]`. Attributes inherited from a generic base can use type arguments from the subject.
-When the subject does not provide type arguments, members declared by the pattern class use
-`Unknown`; a type parameter default does not restrict which instances match at runtime.
+When a generic pattern class is a subclass of the subject's class, attributes declared on the
+pattern class include every type possible for a specialization that can match the subject. An
+invariant base can fix a type argument exactly. Covariant or contravariant bases may only restrict
+one end of the possible arguments, so the attribute type is computed from that whole range. Type
+parameters that the base does not constrain use their declared bound or constraints, not their
+default.
 
 ```py
 from typing import final, Generic
 from typing_extensions import TypeVar
 
 GenericPatternT = TypeVar("GenericPatternT")
+CovariantGenericPatternT = TypeVar("CovariantGenericPatternT", covariant=True)
+ContravariantGenericPatternT = TypeVar("ContravariantGenericPatternT", contravariant=True)
 DefaultGenericPatternT = TypeVar("DefaultGenericPatternT", default=str)
+ExtraGenericPatternT = TypeVar("ExtraGenericPatternT", default=str)
+ConstrainedGenericPatternT = TypeVar("ConstrainedGenericPatternT", int, str)
+BoundedGenericPatternT = TypeVar("BoundedGenericPatternT", bound=str)
 
 class GenericPatternBase(Generic[GenericPatternT]): ...
 
 class GenericPatternChild(GenericPatternBase[GenericPatternT]):
     item: GenericPatternT
     items: list[GenericPatternT]
+
+class PartiallySpecializedGenericPatternChild(
+    GenericPatternBase[GenericPatternT],
+    Generic[GenericPatternT, ExtraGenericPatternT],
+):
+    item: GenericPatternT
+    extra: ExtraGenericPatternT
+
+class WrappedGenericPatternChild(GenericPatternBase[list[GenericPatternT]]):
+    item: GenericPatternT
+
+class ConstrainedGenericPatternChild(GenericPatternBase[int], Generic[ConstrainedGenericPatternT]):
+    item: ConstrainedGenericPatternT
+
+class BoundedGenericPatternChild(GenericPatternBase[int], Generic[BoundedGenericPatternT]):
+    item: BoundedGenericPatternT
+
+class GenericPatternSink(Generic[ContravariantGenericPatternT]): ...
+class CovariantGenericPatternBase(Generic[CovariantGenericPatternT]): ...
+
+class CovariantGenericPatternChild(CovariantGenericPatternBase[GenericPatternT]):
+    item: GenericPatternT
+    sink: GenericPatternSink[GenericPatternT]
+
+class ContravariantGenericPatternBase(Generic[ContravariantGenericPatternT]): ...
+
+class ContravariantGenericPatternChild(ContravariantGenericPatternBase[GenericPatternT]):
+    item: GenericPatternT
+    items: list[GenericPatternT]
+    sink: GenericPatternSink[GenericPatternT]
 
 class GenericMemberBase(Generic[GenericPatternT]):
     item: GenericPatternT
@@ -901,16 +937,61 @@ class DefaultGenericPatternBox(Generic[DefaultGenericPatternT]):
 def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
     match value:
         case GenericPatternChild(item=item):
-            # TODO: This should be `int` once generic subclass specialization is supported.
-            reveal_type(item)  # revealed: Unknown
+            reveal_type(item)  # revealed: int
 
 def test_match_nested_generic_subclass_capture(value: GenericPatternBase[int]) -> list[int]:
     match value:
         case GenericPatternChild(items=items):
-            # TODO: This should be `list[int]` once generic subclass specialization is supported.
-            reveal_type(items)  # revealed: list[Unknown]
+            reveal_type(items)  # revealed: list[int]
             return items
     return []
+
+def test_match_partially_specialized_generic_subclass(
+    value: GenericPatternBase[int],
+) -> None:
+    match value:
+        case PartiallySpecializedGenericPatternChild(item=item, extra=extra):
+            reveal_type(item)  # revealed: int
+            reveal_type(extra)  # revealed: object
+
+def test_match_generic_subclass_through_transformed_base(
+    value: GenericPatternBase[list[int]],
+) -> None:
+    match value:
+        case WrappedGenericPatternChild(item=item):
+            reveal_type(item)  # revealed: int
+
+def test_match_unconstrained_subclass_parameter_uses_constraints(
+    value: GenericPatternBase[int],
+) -> None:
+    match value:
+        case ConstrainedGenericPatternChild(item=item):
+            reveal_type(item)  # revealed: int | str
+
+def test_match_unconstrained_subclass_parameter_uses_bound(
+    value: GenericPatternBase[int],
+) -> None:
+    match value:
+        case BoundedGenericPatternChild(item=item):
+            reveal_type(item)  # revealed: str
+
+def test_match_covariant_generic_subclass(
+    value: CovariantGenericPatternBase[int],
+) -> None:
+    match value:
+        case CovariantGenericPatternChild(item=item, sink=sink):
+            reveal_type(item)  # revealed: int
+            reveal_type(sink)  # revealed: GenericPatternSink[Never]
+
+def test_match_contravariant_generic_subclass(
+    value: ContravariantGenericPatternBase[int],
+) -> None:
+    match value:
+        case ContravariantGenericPatternChild(item=item, items=items, sink=sink):
+            # The subject can be a `ContravariantGenericPatternChild[object]`.
+            reveal_type(item)  # revealed: object
+            reveal_type(items)  # revealed: Top[list[int | Unknown]]
+            reveal_type(sink)  # revealed: GenericPatternSink[int]
 
 def test_match_inherited_generic_subclass_capture(
     value: GenericMemberBase[GenericPatternT],
@@ -937,8 +1018,8 @@ def test_match_direct_generic_pattern_preserves_declared_member(value: object) -
 
 def test_match_generic_pattern_ignores_typevar_default(value: object) -> None:
     match value:
-        case DefaultGenericPatternBox(value=int() as item):
-            reveal_type(item)  # revealed: Unknown & int
+        case DefaultGenericPatternBox(value=item):
+            reveal_type(item)  # revealed: object
 ```
 
 ## Positional class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -659,6 +659,8 @@ A class pattern can use a variable whose type is `type[Class]`. Both the subject
 use the instance type described by that annotation.
 
 ```py
+from typing import Literal
+
 class IndirectPattern: ...
 
 def test_match_indirect_class_pattern(
@@ -669,6 +671,24 @@ def test_match_indirect_class_pattern(
         case PatternClass() as item:
             reveal_type(item)  # revealed: IndirectPattern
             reveal_type(value)  # revealed: IndirectPattern
+
+class IndirectIntPattern:
+    tag: Literal["int"]
+    payload: int
+
+class IndirectStrPattern:
+    tag: Literal["str"]
+    payload: str
+
+def test_match_union_class_pattern_preserves_member_correlation(
+    value: object,
+    PatternClass: type[IndirectIntPattern] | type[IndirectStrPattern],
+) -> None:
+    match value:
+        case PatternClass(tag="int", payload=item):
+            reveal_type(item)  # revealed: int
+            reveal_type(value)  # revealed: IndirectIntPattern
+            item.bit_length()
 ```
 
 ## Class pattern aliases

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -845,6 +845,7 @@ class GenericMemberBase(Generic[GenericPatternT]):
     item: GenericPatternT
 
 class GenericMemberChild(GenericMemberBase[GenericPatternT]): ...
+class IntGenericMemberChild(GenericMemberBase[int]): ...
 
 def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
     match value:
@@ -870,6 +871,14 @@ def test_match_inherited_generic_subclass_capture(
             return item
         case _:
             raise ValueError
+
+def test_match_generic_base_capture_preserves_subject_specialization(
+    value: IntGenericMemberChild,
+) -> None:
+    match value:
+        case GenericMemberBase(item=item):
+            reveal_type(item)  # revealed: int
+            item.bit_length()
 ```
 
 ## Positional class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1076,6 +1076,10 @@ Two unrelated non-final classes can have a common subclass through multiple inhe
 successful pattern therefore preserves both class types:
 
 ```py
+from typing import Generic, TypeVar
+
+OverlapT = TypeVar("OverlapT")
+
 class OverlapCaptureA: ...
 
 class OverlapCaptureB:
@@ -1101,6 +1105,24 @@ def test_match_class_capture_combines_overlapping_member_types(
     match value:
         case OverlapMemberB(member=item):
             reveal_type(item)  # revealed: int | str
+
+class GenericOverlapA:
+    member: int
+
+class GenericOverlapB(Generic[OverlapT]):
+    member: OverlapT
+
+class GenericOverlapC(GenericOverlapB[str], GenericOverlapA):
+    member: str
+
+def test_match_generic_class_capture_preserves_possible_multiple_inheritance(
+    value: GenericOverlapA,
+) -> None:
+    match value:
+        case GenericOverlapB(member=str() as item):
+            reveal_type(item)  # revealed: str
+            reveal_type(value)  # revealed: GenericOverlapA & Top[GenericOverlapB[Unknown]]
+            1 + "x"  # error: [unsupported-operator]
 ```
 
 ## Class pattern captures from `Any` and `Unknown`

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -865,9 +865,11 @@ generic structure is preserved. Attributes inherited from the generic base class
 subject's specialization.
 
 ```py
-from typing import final, Generic, TypeVar
+from typing import final, Generic
+from typing_extensions import TypeVar
 
 GenericPatternT = TypeVar("GenericPatternT")
+DefaultGenericPatternT = TypeVar("DefaultGenericPatternT", default=str)
 
 class GenericPatternBase(Generic[GenericPatternT]): ...
 
@@ -884,6 +886,9 @@ class IntGenericMemberChild(GenericMemberBase[int]): ...
 @final
 class FinalGenericPatternBox(Generic[GenericPatternT]):
     value: list[GenericPatternT]
+
+class DefaultGenericPatternBox(Generic[DefaultGenericPatternT]):
+    value: DefaultGenericPatternT
 
 def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
     match value:
@@ -922,6 +927,12 @@ def test_match_direct_generic_pattern_preserves_declared_member(value: object) -
         case FinalGenericPatternBox(value=int() as item):
             reveal_type(item)  # revealed: Never
             reveal_type(value)  # revealed: Never
+
+def test_match_generic_pattern_ignores_typevar_default(value: object) -> None:
+    match value:
+        case DefaultGenericPatternBox(value=int() as item):
+            reveal_type(item)  # revealed: Unknown & int
+            1 + "x"  # error: [unsupported-operator]
 ```
 
 ## Positional class patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -507,10 +507,6 @@ class TextValue:
 class StringMapping(TypedDict):
     value: str
 
-@final
-class MutableOrBox:
-    value: int = 0
-
 def class_or_sequence_binding(value: TextValue | tuple[int]) -> None:
     match value:
         case TextValue(value=item) | [item]:
@@ -520,15 +516,29 @@ def mapping_or_singleton_binding(value: StringMapping | None) -> None:
     match value:
         case {"value": item} | (None as item):
             reveal_type(item)  # revealed: str | None
+```
 
-def mixed_or_binding_does_not_keep_failed_sequence_facts(
+The first two alternatives bind an `int`. A list that does not contain exactly one element reaches
+the final capture instead. If that list is later changed to contain one element, the same sequence
+pattern must be able to match it:
+
+```py
+@final
+class MutableOrBox:
+    value: int = 0
+
+def failed_sequence_alternative_does_not_narrow_later_capture(
     value: list[int] | MutableOrBox,
 ) -> None:
     match value:
         case [item] | MutableOrBox(value=item) | item:
+            reveal_type(item)  # revealed: int | list[int]
             if isinstance(item, list):
                 item.clear()
-                reveal_type(item)  # revealed: list[int]
+                item.append(1)
+                match item:
+                    case [only]:
+                        reveal_type(item)  # revealed: list[int]
 ```
 
 ## Declared pattern captures
@@ -693,15 +703,13 @@ class IndirectStrPattern:
     tag: Literal["str"]
     payload: str
 
-def test_match_union_class_pattern_preserves_member_correlation(
+def test_union_class_pattern_uses_members_from_matching_class(
     value: object,
     PatternClass: type[IndirectIntPattern] | type[IndirectStrPattern],
 ) -> None:
     match value:
         case PatternClass(tag="int", payload=item):
             reveal_type(item)  # revealed: int
-            reveal_type(value)  # revealed: IndirectIntPattern
-            item.bit_length()
 ```
 
 ## Class pattern aliases
@@ -858,11 +866,11 @@ def test_incompatible_declared_class_capture(value: PatternBox[int]) -> None:
 
 ## Generic subclass captures
 
-We do not yet infer a generic subclass's specialization from its base class. In the first two
-examples, ty therefore cannot infer `GenericPatternChild[int]` from `GenericPatternBase[int]`, so
-type parameters in attributes declared only on the subclass become `Unknown`, while their known
-generic structure is preserved. Attributes inherited from the generic base class can still use the
-subject's specialization.
+We do not yet infer a generic subclass's type arguments from its base class. Attributes declared
+only on the subclass therefore use `Unknown` for those arguments, but still retain types such as
+`list[Unknown]`. Attributes inherited from a generic base can use type arguments from the subject.
+When the subject does not provide type arguments, members declared by the pattern class use
+`Unknown`; a type parameter default does not restrict which instances match at runtime.
 
 ```py
 from typing import final, Generic
@@ -899,6 +907,7 @@ def test_match_generic_subclass_capture(value: GenericPatternBase[int]) -> None:
 def test_match_nested_generic_subclass_capture(value: GenericPatternBase[int]) -> list[int]:
     match value:
         case GenericPatternChild(items=items):
+            # TODO: This should be `list[int]` once generic subclass specialization is supported.
             reveal_type(items)  # revealed: list[Unknown]
             return items
     return []
@@ -920,19 +929,16 @@ def test_match_generic_base_capture_preserves_subject_specialization(
     match value:
         case GenericMemberBase(item=item):
             reveal_type(item)  # revealed: int
-            item.bit_length()
 
 def test_match_direct_generic_pattern_preserves_declared_member(value: object) -> None:
     match value:
         case FinalGenericPatternBox(value=int() as item):
             reveal_type(item)  # revealed: Never
-            reveal_type(value)  # revealed: Never
 
 def test_match_generic_pattern_ignores_typevar_default(value: object) -> None:
     match value:
         case DefaultGenericPatternBox(value=int() as item):
             reveal_type(item)  # revealed: Unknown & int
-            1 + "x"  # error: [unsupported-operator]
 ```
 
 ## Positional class patterns
@@ -1136,7 +1142,9 @@ def builtin_positional_pattern_refines_subject_alias(value: bool) -> Literal[Tru
 ## Overlapping class patterns
 
 Two unrelated non-final classes can have a common subclass through multiple inheritance. The
-successful pattern therefore preserves both class types:
+successful pattern therefore preserves both class types. Attributes from both bases remain possible,
+even when one annotation is broader than the other. For a generic pattern class whose type arguments
+are not known from the subject, its attributes use `Unknown`.
 
 ```py
 from typing import Generic, TypeVar
@@ -1181,8 +1189,6 @@ def test_match_class_capture_preserves_compatible_overlapping_member_types(
     match value:
         case CompatibleOverlapMemberB(member=str() as item):
             reveal_type(item)  # revealed: str
-            # revealed: CompatibleOverlapMemberA & CompatibleOverlapMemberB
-            reveal_type(value)
 
 class GenericOverlapA:
     member: int
@@ -1206,10 +1212,8 @@ def test_match_generic_class_capture_preserves_possible_multiple_inheritance(
     match value:
         case GenericOverlapB(member=str() as item):
             reveal_type(item)  # revealed: str
-            reveal_type(value)  # revealed: GenericOverlapA & Top[GenericOverlapB[Unknown]]
-            1 + "x"  # error: [unsupported-operator]
 
-def test_match_generic_container_member_preserves_unknown_specialization(
+def test_match_generic_container_member_keeps_loop_reachable(
     value: GenericListOverlapA,
 ) -> None:
     match value:
@@ -1245,8 +1249,9 @@ def test_match_gradual_class_captures(any_value: Any, unknown_value: Unknown) ->
 Python reads an explicit mapping entry by calling `get` with a sentinel. A custom `get` method can
 therefore produce a broader type than `__getitem__`; the sentinel's type is treated as `object` when
 calling a custom override. The key type of an ordinary `Mapping` does not prove that another key is
-absent because a custom `get` method may accept a broader set of keys. `**rest` is always a new
-`dict` containing the unmatched items.
+absent because a custom `get` method may accept a broader set of keys. When the subject is only
+known as `object`, a successful mapping pattern gives its entries the type `object`, not `Unknown`.
+`**rest` is always a new `dict` containing the unmatched items.
 
 ```py
 from collections.abc import Iterator, Mapping
@@ -1270,11 +1275,10 @@ def test_match_dict_alias_preserves_concrete_type(value: dict[str, int]) -> None
         case {"item": item, **rest} as whole:
             reveal_type(whole)  # revealed: dict[str, int]
 
-def test_match_object_mapping_capture(value: object) -> None:
+def test_match_object_mapping_entry_type(value: object) -> None:
     match value:
         case {"item": item}:
             reveal_type(item)  # revealed: object
-            item.missing  # error: [unresolved-attribute]
 
 class CustomGet(Mapping[str, int | str]):
     def __getitem__(self, key: str) -> int:
@@ -2289,9 +2293,9 @@ def match_named_expression_subject_capture(value: tuple[int]) -> None:
 ## Cycles in pattern binding types
 
 Pattern captures can affect the type of a later match subject, including through a loop or a
-function defined before the capture. Direct, sequence, class, and match-self captures resolve to a
-concrete type. A mapping capture from a recursive subject widens to `object` through the guaranteed
-mapping interface.
+function defined before the capture. Direct, sequence, class, and built-in positional captures
+resolve to a concrete type. For a mapping capture, the recursive subject is known only to be a
+mapping, so its entry type is `object`.
 
 ```py
 def match_loop_carried_capture(flag: bool, x: int) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -1206,6 +1206,12 @@ def test_match_dict_alias_preserves_concrete_type(value: dict[str, int]) -> None
         case {"item": item, **rest} as whole:
             reveal_type(whole)  # revealed: dict[str, int]
 
+def test_match_object_mapping_capture(value: object) -> None:
+    match value:
+        case {"item": item}:
+            reveal_type(item)  # revealed: object
+            item.missing  # error: [unresolved-attribute]
+
 class CustomGet(Mapping[str, int | str]):
     def __getitem__(self, key: str) -> int:
         return 1
@@ -2220,7 +2226,8 @@ def match_named_expression_subject_capture(value: tuple[int]) -> None:
 
 Pattern captures can affect the type of a later match subject, including through a loop or a
 function defined before the capture. Direct, sequence, class, and match-self captures resolve to a
-concrete type. A mapping capture conservatively retains `Unknown` from cycle recovery.
+concrete type. A mapping capture from a recursive subject widens to `object` through the guaranteed
+mapping interface.
 
 ```py
 def match_loop_carried_capture(flag: bool, x: int) -> None:
@@ -2251,7 +2258,7 @@ def match_loop_carried_mapping_capture(flag: bool) -> None:
     while flag:
         match x:
             case {"value": x}:
-                reveal_type(x)  # revealed: int | Unknown
+                reveal_type(x)  # revealed: object
 
 def match_loop_carried_match_self_capture(flag: bool, x: int) -> None:
     while flag:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -38,8 +38,8 @@ pub(crate) use self::match_pattern::{
     ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
     definite_match_pattern_type, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-    pattern_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    typed_dict_matches_class_pattern,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/constraints.rs
+++ b/crates/ty_python_semantic/src/types/constraints.rs
@@ -101,15 +101,15 @@ use smallvec::SmallVec;
 use ty_python_core::rank::RankBitBox;
 
 use crate::types::class::GenericAlias;
-use crate::types::generics::InferableTypeVars;
+use crate::types::generics::{ApplySpecialization, GenericContext, InferableTypeVars};
 use crate::types::typevar::{BoundTypeVarIdentity, walk_bound_type_var_type};
 use crate::types::variance::VarianceInferable;
 use crate::types::visitor::{
     TypeCollector, TypeVisitor, any_over_type, walk_type_with_recursion_guard,
 };
 use crate::types::{
-    BoundTypeVarInstance, IntersectionType, Type, TypeVarBoundOrConstraints, TypeVarVariance,
-    UnionType,
+    BoundTypeVarInstance, IntersectionType, Type, TypeContext, TypeMapping,
+    TypeVarBoundOrConstraints, TypeVarVariance, UnionType,
 };
 use crate::{Db, FxIndexMap, FxIndexSet, FxOrderSet};
 
@@ -3346,6 +3346,14 @@ pub(crate) struct PathBound<'db> {
 }
 
 impl<'db> PathBound<'db> {
+    fn unconstrained(bound_typevar: BoundTypeVarInstance<'db>) -> Self {
+        Self {
+            bound_typevar,
+            lower: None,
+            upper: UpperBound::none(),
+        }
+    }
+
     pub(crate) fn exact(bound_typevar: BoundTypeVarInstance<'db>, ty: Type<'db>) -> Self {
         Self {
             bound_typevar,
@@ -3369,6 +3377,24 @@ impl<'db> PathBound<'db> {
 
     pub(crate) fn has_upper(&self) -> bool {
         self.upper.has_explicit_bound()
+    }
+
+    fn is_constraint_compatible(
+        &self,
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        constraint: Type<'db>,
+    ) -> bool {
+        let when_lower = self
+            .lower_or_never()
+            .when_constraint_set_assignable_to_owned(db, constraint.bottom_materialization(db));
+        let when_upper =
+            self.upper
+                .when_satisfied_by(db, builder, constraint.top_materialization(db));
+        let when = builder
+            .load(db, &when_lower)
+            .and(db, builder, || when_upper);
+        !when.is_never_satisfied(db)
     }
 }
 
@@ -3577,6 +3603,114 @@ impl<'db> PathBounds<'db> {
         Solutions::Constrained(solutions)
     }
 
+    /// Project `ty` over every specialization described by these bounds and return a type that
+    /// contains every possible result.
+    ///
+    /// Each typevar is replaced by `(lower | Unknown) & upper`, whose bottom and top
+    /// materializations are the lower and upper bounds for that typevar. Applying the top
+    /// materialization to the completed `ty` then selects the correct endpoint at each occurrence
+    /// according to its variance, while preserving the range inside invariant types.
+    pub(crate) fn project_type_over_solutions(
+        &self,
+        db: &'db dyn Db,
+        generic_context: GenericContext<'db>,
+        ty: Type<'db>,
+    ) -> Option<Type<'db>> {
+        let builder = ConstraintSetBuilder::new();
+        let project_path = |path: &[PathBound<'db>]| -> Result<Type<'db>, ()> {
+            let types = generic_context
+                .variables(db)
+                .map(|typevar| {
+                    let unconstrained = PathBound::unconstrained(typevar);
+                    let path_bound = path
+                        .iter()
+                        .find(|bound| bound.bound_typevar.is_same_typevar_as(db, typevar))
+                        .unwrap_or(&unconstrained);
+                    Self::typevar_solution_range(db, &builder, path_bound).map(Some)
+                })
+                .collect::<Result<Vec<_>, ()>>()?;
+            let specialization = generic_context.specialize_recursive(db, types);
+            Ok(ty
+                .apply_type_mapping(
+                    db,
+                    &TypeMapping::ApplySpecialization(ApplySpecialization::Specialization(
+                        specialization,
+                    )),
+                    TypeContext::default(),
+                )
+                .top_materialization(db))
+        };
+
+        match self {
+            PathBounds::Unsatisfiable => None,
+            PathBounds::Unconstrained => project_path(&[]).ok(),
+            PathBounds::Constrained(paths) => {
+                let projected = paths.iter().filter_map(|path| project_path(path).ok());
+                let projected = projected.collect::<Vec<_>>();
+                (!projected.is_empty()).then(|| UnionType::from_elements(db, projected))
+            }
+        }
+    }
+
+    fn typevar_solution_range(
+        db: &'db dyn Db,
+        builder: &ConstraintSetBuilder<'db>,
+        path_bound: &PathBound<'db>,
+    ) -> Result<Type<'db>, ()> {
+        let typevar = path_bound.bound_typevar;
+        let (lower, upper) = match typevar.typevar(db).require_bound_or_constraints(db) {
+            TypeVarBoundOrConstraints::UpperBound(declared_upper) => {
+                let lower = path_bound.lower_or_never();
+                let Some(upper) = IntersectionType::bounded_from_elements(
+                    db,
+                    path_bound
+                        .upper
+                        .clauses
+                        .iter()
+                        .copied()
+                        .chain([declared_upper.top_materialization(db)]),
+                ) else {
+                    return Ok(Type::unknown());
+                };
+                if !is_possibly_constraint_set_assignable(db, lower, upper) {
+                    return Err(());
+                }
+                (lower, upper)
+            }
+            TypeVarBoundOrConstraints::Constraints(constraints) => {
+                let compatible = constraints
+                    .elements(db)
+                    .iter()
+                    .filter(|constraint| {
+                        path_bound.is_constraint_compatible(db, builder, **constraint)
+                    })
+                    .copied()
+                    .collect::<Vec<_>>();
+                if compatible.is_empty() {
+                    return Err(());
+                }
+                let lower = IntersectionType::from_elements(
+                    db,
+                    compatible.iter().map(|ty| ty.bottom_materialization(db)),
+                );
+                let upper = UnionType::from_elements(
+                    db,
+                    compatible.iter().map(|ty| ty.top_materialization(db)),
+                );
+                (lower, upper)
+            }
+        };
+
+        if lower.is_equivalent_to(db, upper) {
+            return Ok(lower);
+        }
+        Ok(IntersectionType::from_two_elements(
+            db,
+            UnionType::from_two_elements(db, lower, Type::unknown()),
+            upper,
+        ))
+    }
+
     /// The default solution selection logic for a single typevar on a single BDD path.
     ///
     /// Given the explicit lower and upper bounds for a typevar, selects the solution type.
@@ -3592,7 +3726,6 @@ impl<'db> PathBounds<'db> {
         path_bound: &PathBound<'db>,
     ) -> Result<Option<Type<'db>>, ()> {
         let bound_typevar = path_bound.bound_typevar;
-        let lower = path_bound.lower_or_never();
         match bound_typevar.typevar(db).require_bound_or_constraints(db) {
             TypeVarBoundOrConstraints::UpperBound(bound) => {
                 let declared_upper = bound.top_materialization(db);
@@ -3637,18 +3770,7 @@ impl<'db> PathBounds<'db> {
             TypeVarBoundOrConstraints::Constraints(constraints) => {
                 // Filter out the typevar constraints that aren't satisfied by this path.
                 let compatible_constraints = constraints.elements(db).iter().filter(|constraint| {
-                    let constraint_lower = constraint.bottom_materialization(db);
-                    let constraint_upper = constraint.top_materialization(db);
-                    let when_lower =
-                        lower.when_constraint_set_assignable_to_owned(db, constraint_lower);
-                    let when_upper =
-                        path_bound
-                            .upper
-                            .when_satisfied_by(db, builder, constraint_upper);
-                    let when = builder
-                        .load(db, &when_lower)
-                        .and(db, builder, || when_upper);
-                    !when.is_never_satisfied(db)
+                    path_bound.is_constraint_compatible(db, builder, **constraint)
                 });
 
                 // If only one constraint remains, that's our specialization for this path.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1518,24 +1518,23 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     })
                     .is_some_and(|ty| ty.has_typevar(self.db))
             {
-                let unknown_pattern_member_ty =
-                    Type::instance(self.db, pattern_class.unknown_specialization(self.db))
-                        .member(self.db, name.as_str())
-                        .place
-                        .ignore_possibly_undefined();
+                let unknown_pattern_class = pattern_class.unknown_specialization(self.db);
+                let unknown_pattern_member_ty = Type::instance(self.db, unknown_pattern_class)
+                    .member(self.db, name.as_str())
+                    .place
+                    .ignore_possibly_undefined();
                 // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
                 // pattern can reuse `int` from the subject. This does not infer `Child[int]` from
                 // a `Base[int]` subject.
                 let shares_generic_hierarchy = original_subject_ty
                     .nominal_class(self.db)
                     .is_some_and(|original_class| {
-                        let pattern_class = pattern_class.unknown_specialization(self.db);
-                        pattern_class.is_subtype_of_class_literal(
+                        unknown_pattern_class.is_subtype_of_class_literal(
                             self.db,
                             original_class.class_literal(self.db),
                         ) || original_class.is_subtype_of_class_literal(
                             self.db,
-                            pattern_class.class_literal(self.db),
+                            unknown_pattern_class.class_literal(self.db),
                         )
                     });
                 if shares_generic_hierarchy {

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1547,12 +1547,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                             .or(default_pattern_member_ty)
                             .unwrap_or_else(Type::unknown),
                     );
-                } else if let Some(pattern_member_ty) = context
-                    .class_ty
-                    .member(self.db, name.as_str())
-                    .place
-                    .ignore_possibly_undefined()
-                {
+                } else if let Some(pattern_member_ty) = default_pattern_member_ty {
                     // Unrelated classes can overlap through multiple inheritance, so retain the
                     // generic pattern class's member as a possible runtime value.
                     member_ty = Some(UnionType::from_elements(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1518,6 +1518,11 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     })
                     .is_some_and(|ty| ty.has_typevar(self.db))
             {
+                let default_pattern_member_ty =
+                    Type::instance(self.db, pattern_class.default_specialization(self.db))
+                        .member(self.db, name.as_str())
+                        .place
+                        .ignore_possibly_undefined();
                 // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
                 // pattern can reuse `int` from the subject. This does not infer `Child[int]` from
                 // a `Base[int]` subject.
@@ -1535,9 +1540,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     });
                 if shares_generic_hierarchy {
                     // The pattern class's default specialization loses type arguments known
-                    // through the related subject type. Prefer the subject's member type;
-                    // otherwise, do not treat the generic fallback as a declared type.
-                    member_ty = Some(original_member_ty.unwrap_or_else(Type::unknown));
+                    // through the related subject type. Prefer the subject's member type when it
+                    // exists, but retain a member declared only by the pattern class.
+                    member_ty = Some(
+                        original_member_ty
+                            .or(default_pattern_member_ty)
+                            .unwrap_or_else(Type::unknown),
+                    );
                 } else if let Some(pattern_member_ty) = context
                     .class_ty
                     .member(self.db, name.as_str())

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1518,8 +1518,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     })
                     .is_some_and(|ty| ty.has_typevar(self.db))
             {
-                let default_pattern_member_ty =
-                    Type::instance(self.db, pattern_class.default_specialization(self.db))
+                let unknown_pattern_member_ty =
+                    Type::instance(self.db, pattern_class.unknown_specialization(self.db))
                         .member(self.db, name.as_str())
                         .place
                         .ignore_possibly_undefined();
@@ -1529,7 +1529,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 let shares_generic_hierarchy = original_subject_ty
                     .nominal_class(self.db)
                     .is_some_and(|original_class| {
-                        let pattern_class = pattern_class.default_specialization(self.db);
+                        let pattern_class = pattern_class.unknown_specialization(self.db);
                         pattern_class.is_subtype_of_class_literal(
                             self.db,
                             original_class.class_literal(self.db),
@@ -1539,15 +1539,15 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                         )
                     });
                 if shares_generic_hierarchy {
-                    // The pattern class's default specialization loses type arguments known
+                    // The pattern class's unknown specialization loses type arguments known
                     // through the related subject type. Prefer the subject's member type when it
                     // exists, but retain a member declared only by the pattern class.
                     member_ty = Some(
                         original_member_ty
-                            .or(default_pattern_member_ty)
+                            .or(unknown_pattern_member_ty)
                             .unwrap_or_else(Type::unknown),
                     );
-                } else if let Some(pattern_member_ty) = default_pattern_member_ty {
+                } else if let Some(pattern_member_ty) = unknown_pattern_member_ty {
                     // Unrelated classes can overlap through multiple inheritance, so retain the
                     // generic pattern class's member as a possible runtime value.
                     member_ty = Some(UnionType::from_elements(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1518,20 +1518,25 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                     })
                     .is_some_and(|ty| ty.has_typevar(self.db))
             {
-                let specializes_original_class = original_subject_ty
+                // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
+                // pattern can reuse `int` from the subject. This does not infer `Child[int]` from
+                // a `Base[int]` subject.
+                let shares_generic_hierarchy = original_subject_ty
                     .nominal_class(self.db)
                     .is_some_and(|original_class| {
-                        pattern_class
-                            .default_specialization(self.db)
-                            .is_subtype_of_class_literal(
-                                self.db,
-                                original_class.class_literal(self.db),
-                            )
+                        let pattern_class = pattern_class.default_specialization(self.db);
+                        pattern_class.is_subtype_of_class_literal(
+                            self.db,
+                            original_class.class_literal(self.db),
+                        ) || original_class.is_subtype_of_class_literal(
+                            self.db,
+                            pattern_class.class_literal(self.db),
+                        )
                     });
-                if specializes_original_class {
-                    // The pattern subclass's default specialization loses the type arguments from
-                    // the subject's generic base. Prefer a member type already known from the
-                    // subject; otherwise, do not treat the subclass's fallback as a declared type.
+                if shares_generic_hierarchy {
+                    // The pattern class's default specialization loses type arguments known
+                    // through the related subject type. Prefer the subject's member type;
+                    // otherwise, do not treat the generic fallback as a declared type.
                     member_ty = Some(original_member_ty.unwrap_or_else(Type::unknown));
                 } else if let Some(pattern_member_ty) = context
                     .class_ty

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -18,8 +18,8 @@ use crate::types::{
     Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
     class_pattern_positional_sources, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, pattern_fallthrough_type, sequence_pattern_type_builder,
-    singleton_pattern_type, starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -1394,7 +1394,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
 
         for pattern in patterns {
             remaining_subject_ty =
-                pattern_fallthrough_type(self.db, previous_pattern, remaining_subject_ty);
+                pattern_binding_fallthrough_type(self.db, previous_pattern, remaining_subject_ty);
             let alternative = self.analyze_successful_pattern(pattern, remaining_subject_ty);
             matched_subject_types.add_in_place(alternative.matched_subject_ty);
             binding_subject_types.add_in_place(alternative.binding_subject_ty);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1483,7 +1483,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 .ignore_possibly_undefined();
             let place = subject_ty.member(self.db, name.as_str()).place;
             let mut member_ty = place.ignore_possibly_undefined();
-            if member_ty.is_some_and(|ty| ty.is_never())
+            if original_subject_ty.nominal_class(self.db).is_some()
                 && let Type::Intersection(intersection) = subject_ty
             {
                 let overlapping_member_ty = UnionType::from_elements(

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1526,7 +1526,7 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
                 // pattern can reuse `int` from the subject. This does not infer `Child[int]` from
                 // a `Base[int]` subject.
-                let shares_generic_hierarchy = original_subject_ty
+                if original_subject_ty
                     .nominal_class(self.db)
                     .is_some_and(|original_class| {
                         unknown_pattern_class.is_subtype_of_class_literal(
@@ -1536,8 +1536,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                             self.db,
                             unknown_pattern_class.class_literal(self.db),
                         )
-                    });
-                if shares_generic_hierarchy {
+                    })
+                {
                     // The pattern class's unknown specialization loses type arguments known
                     // through the related subject type. Prefer the subject's member type when it
                     // exists, but retain a member declared only by the pattern class.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1583,43 +1583,91 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             .collect()
     }
 
+    fn class_pattern_contexts(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+    ) -> SmallVec<[ClassPatternContext<'db>; 2]> {
+        let class_expr_ty =
+            infer_same_file_expression_type(self.db, kind.class, TypeContext::default())
+                .resolve_type_alias(self.db);
+        let context = |class_expr_ty: Type<'db>| {
+            let class = class_expr_ty.as_class_literal();
+            ClassPatternContext {
+                class,
+                class_ty: positive_class_pattern_type(self.db, class_expr_ty)
+                    .unwrap_or_else(Type::object),
+                positional_sources: class.map_or_else(
+                    || vec![ClassPatternPositionalSource::Unknown; kind.positional.len()],
+                    |class| class_pattern_positional_sources(self.db, class, kind.positional.len()),
+                ),
+            }
+        };
+        match class_expr_ty {
+            Type::Union(union) => union
+                .elements(self.db)
+                .iter()
+                .copied()
+                .map(context)
+                .collect(),
+            _ => smallvec![context(class_expr_ty)],
+        }
+    }
+
+    fn class_pattern_arm(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+        context: &ClassPatternContext<'db>,
+        original_subject_ty: Type<'db>,
+        subject_ty: Type<'db>,
+    ) -> Option<(Type<'db>, Vec<ClassPatternArgument<'db>>)> {
+        let narrowed_subject_ty =
+            self.filter_class_pattern_subject_type(context.class, context.class_ty, subject_ty);
+        if narrowed_subject_ty.is_never() {
+            return None;
+        }
+        let arguments = self.class_pattern_arguments_for_arm(
+            kind,
+            context,
+            original_subject_ty,
+            narrowed_subject_ty,
+        )?;
+        Some((narrowed_subject_ty, arguments))
+    }
+
     fn analyze_successful_class_pattern(
         &self,
         kind: &ClassPatternPredicateKind<'db>,
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        let class_expr_ty =
-            infer_same_file_expression_type(self.db, kind.class, TypeContext::default());
-        let class = class_expr_ty.as_class_literal();
-        let class_ty =
-            positive_class_pattern_type(self.db, class_expr_ty).unwrap_or_else(Type::object);
-        let context = ClassPatternContext {
-            class,
-            class_ty,
-            positional_sources: class.map_or_else(
-                || vec![ClassPatternPositionalSource::Unknown; kind.positional.len()],
-                |class| class_pattern_positional_sources(self.db, class, kind.positional.len()),
-            ),
-        };
+        let mut matched_subject_types = UnionBuilder::new(self.db);
+        let mut binding_subject_types = UnionBuilder::new(self.db);
+        let mut bindings = BTreeMap::new();
+        for context in self.class_pattern_contexts(kind) {
+            let result =
+                self.analyze_successful_class_pattern_for_context(kind, &context, subject_ty);
+            matched_subject_types.add_in_place(result.matched_subject_ty);
+            binding_subject_types.add_in_place(result.binding_subject_ty);
+            Self::merge_bindings(&mut bindings, result.bindings);
+        }
+        PatternSuccessResult {
+            matched_subject_ty: matched_subject_types.build(),
+            binding_subject_ty: binding_subject_types.build(),
+            bindings,
+        }
+    }
+
+    fn analyze_successful_class_pattern_for_context(
+        &self,
+        kind: &ClassPatternPredicateKind<'db>,
+        context: &ClassPatternContext<'db>,
+        subject_ty: Type<'db>,
+    ) -> PatternSuccessResult<'db> {
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, original_subject_ty, subject_ty| {
-                let narrowed_subject_ty = analyzer.filter_class_pattern_subject_type(
-                    context.class,
-                    context.class_ty,
-                    subject_ty,
-                );
-                if narrowed_subject_ty.is_never() {
-                    return None;
-                }
-
-                let arguments = analyzer.class_pattern_arguments_for_arm(
-                    kind,
-                    &context,
-                    original_subject_ty,
-                    narrowed_subject_ty,
-                )?;
+                let (narrowed_subject_ty, arguments) =
+                    analyzer.class_pattern_arm(kind, context, original_subject_ty, subject_ty)?;
                 let mut matched_subject_ty = narrowed_subject_ty;
                 let mut binding_subject_ty = narrowed_subject_ty;
                 let mut bindings = BTreeMap::new();

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1503,8 +1503,8 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 }
             }
 
-            if context.class.is_some_and(|pattern_class| {
-                pattern_class
+            if let Some(pattern_class) = context.class
+                && pattern_class
                     .generic_context(self.db)
                     .and_then(|generic_context| {
                         pattern_class
@@ -1517,11 +1517,35 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                             .ignore_possibly_undefined()
                     })
                     .is_some_and(|ty| ty.has_typevar(self.db))
-            }) {
-                // The pattern subclass's default specialization loses the type arguments from the
-                // subject's generic base. Prefer a member type already known from the subject;
-                // otherwise, do not treat the subclass's fallback as a declared type.
-                member_ty = Some(original_member_ty.unwrap_or_else(Type::unknown));
+            {
+                let specializes_original_class = original_subject_ty
+                    .nominal_class(self.db)
+                    .is_some_and(|original_class| {
+                        pattern_class
+                            .default_specialization(self.db)
+                            .is_subtype_of_class_literal(
+                                self.db,
+                                original_class.class_literal(self.db),
+                            )
+                    });
+                if specializes_original_class {
+                    // The pattern subclass's default specialization loses the type arguments from
+                    // the subject's generic base. Prefer a member type already known from the
+                    // subject; otherwise, do not treat the subclass's fallback as a declared type.
+                    member_ty = Some(original_member_ty.unwrap_or_else(Type::unknown));
+                } else if let Some(pattern_member_ty) = context
+                    .class_ty
+                    .member(self.db, name.as_str())
+                    .place
+                    .ignore_possibly_undefined()
+                {
+                    // Unrelated classes can overlap through multiple inheritance, so retain the
+                    // generic pattern class's member as a possible runtime value.
+                    member_ty = Some(UnionType::from_elements(
+                        self.db,
+                        member_ty.into_iter().chain([pattern_member_ty]),
+                    ));
+                }
             }
             member_ty.or_else(|| (!subject_is_final).then_some(Type::unknown()))
         };

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -1779,37 +1779,43 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         false
     }
 
+    fn mapping_pattern_key_types(&self, kind: &MappingPatternPredicateKind<'db>) -> Vec<Type<'db>> {
+        kind.entries
+            .iter()
+            .map(|entry| {
+                infer_same_file_expression_type(self.db, entry.key, TypeContext::default())
+            })
+            .collect()
+    }
+
+    fn mapping_pattern_arm(
+        &self,
+        subject_ty: Type<'db>,
+        key_types: &[Type<'db>],
+    ) -> Option<(Type<'db>, Vec<Type<'db>>)> {
+        let narrowed_subject_ty = self.intersect_types(subject_ty, mapping_pattern_type(self.db));
+        if narrowed_subject_ty.is_never() {
+            return None;
+        }
+        let value_types = key_types
+            .iter()
+            .map(|key_ty| self.mapping_pattern_value_type_for_arm(narrowed_subject_ty, *key_ty))
+            .collect::<Option<Vec<_>>>()?;
+        Some((narrowed_subject_ty, value_types))
+    }
+
     fn analyze_successful_mapping_pattern(
         &self,
         kind: &MappingPatternPredicateKind<'db>,
         subject_ty: Type<'db>,
     ) -> PatternSuccessResult<'db> {
-        let key_types: Vec<_> = kind
-            .entries
-            .iter()
-            .map(|entry| {
-                infer_same_file_expression_type(self.db, entry.key, TypeContext::default())
-            })
-            .collect();
+        let key_types = self.mapping_pattern_key_types(kind);
         self.analyze_pattern_subject_arms(
             subject_ty,
             OriginalSubjectPreservation::EquivalentTypes,
             |analyzer, _, subject_ty| {
-                let narrowed_subject_ty =
-                    analyzer.intersect_types(subject_ty, mapping_pattern_type(analyzer.db));
-                if narrowed_subject_ty.is_never() {
-                    return None;
-                }
-
-                let value_types: Option<Vec<_>> = kind
-                    .entries
-                    .iter()
-                    .zip(&key_types)
-                    .map(|(_, key_ty)| {
-                        analyzer.mapping_pattern_value_type_for_arm(subject_ty, *key_ty)
-                    })
-                    .collect();
-                let value_types = value_types?;
+                let (narrowed_subject_ty, value_types) =
+                    analyzer.mapping_pattern_arm(subject_ty, &key_types)?;
                 let mut bindings = BTreeMap::new();
                 for (entry, value_ty) in kind.entries.iter().zip(value_types) {
                     let mut child = analyzer.analyze_successful_pattern(&entry.pattern, value_ty);

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -5,6 +5,7 @@ use crate::Db;
 use crate::reachability::{narrow_type_by_constraint, type_narrowed_by_previous_patterns};
 use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
+use crate::types::generics::GenericContext;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
 use crate::types::tuple::{Tuple, TupleLength, TupleType, TupleUnpacker};
@@ -1504,38 +1505,38 @@ impl<'db> PatternSuccessAnalyzer<'db> {
             }
 
             if let Some(pattern_class) = context.class
-                && pattern_class
-                    .generic_context(self.db)
-                    .and_then(|generic_context| {
-                        pattern_class
-                            .instance_member(
-                                self.db,
-                                Some(generic_context.identity_specialization(self.db)),
-                                name.as_str(),
-                            )
-                            .place
-                            .ignore_possibly_undefined()
-                    })
-                    .is_some_and(|ty| ty.has_typevar(self.db))
+                && let Some(generic_context) = pattern_class.generic_context(self.db)
+                && let Some(pattern_member_ty) = pattern_class
+                    .instance_member(
+                        self.db,
+                        Some(generic_context.identity_specialization(self.db)),
+                        name.as_str(),
+                    )
+                    .place
+                    .ignore_possibly_undefined()
+                && pattern_member_ty.has_typevar(self.db)
             {
                 let unknown_pattern_class = pattern_class.unknown_specialization(self.db);
                 let unknown_pattern_member_ty = Type::instance(self.db, unknown_pattern_class)
                     .member(self.db, name.as_str())
                     .place
                     .ignore_possibly_undefined();
-                // For example, `Child[int]` and `Base[T]` share a generic hierarchy, so a `Base`
-                // pattern can reuse `int` from the subject. This does not infer `Child[int]` from
-                // a `Base[int]` subject.
-                if original_subject_ty
+                if let Some(specialized_member_ty) = original_subject_ty
+                    .nominal_class(self.db)
+                    .and_then(|subject_class| {
+                        self.specialize_pattern_member_for_subject(
+                            pattern_class,
+                            generic_context,
+                            pattern_member_ty,
+                            subject_class,
+                        )
+                    })
+                {
+                    member_ty = Some(specialized_member_ty);
+                } else if original_subject_ty
                     .nominal_class(self.db)
                     .is_some_and(|original_class| {
-                        unknown_pattern_class.is_subtype_of_class_literal(
-                            self.db,
-                            original_class.class_literal(self.db),
-                        ) || original_class.is_subtype_of_class_literal(
-                            self.db,
-                            unknown_pattern_class.class_literal(self.db),
-                        )
+                        original_class.is_subtype_of_class_literal(self.db, pattern_class)
                     })
                 {
                     // The pattern class's unknown specialization loses type arguments known
@@ -1584,6 +1585,33 @@ impl<'db> PatternSuccessAnalyzer<'db> {
                 })
             }))
             .collect()
+    }
+
+    /// Specialize a generic pattern class member using the type of a base-class subject.
+    ///
+    /// For `Child[T](Base[T])`, matching a `Base[int]` subject against `Child` constrains `T` to
+    /// `int`. More complex and variant base expressions can leave several valid specializations;
+    /// the projected member type contains the member type from all of them.
+    fn specialize_pattern_member_for_subject(
+        &self,
+        pattern_class: ClassLiteral<'db>,
+        generic_context: GenericContext<'db>,
+        pattern_member_ty: Type<'db>,
+        subject_class: ClassType<'db>,
+    ) -> Option<Type<'db>> {
+        let pattern_base = pattern_class
+            .identity_specialization(self.db)
+            .iter_mro(self.db)
+            .filter_map(ClassBase::into_class)
+            .find(|base| base.class_literal(self.db) == subject_class.class_literal(self.db))?;
+        // The matching pattern specialization must be a subtype of the subject. This direction
+        // matters for covariant and contravariant bases.
+        let bounds = Type::instance(self.db, pattern_base).assignable_solutions_with_inferable(
+            self.db,
+            Type::instance(self.db, subject_class),
+            generic_context.inferable_typevars(self.db),
+        );
+        bounds.project_type_over_solutions(self.db, generic_context, pattern_member_ty)
     }
 
     fn class_pattern_contexts(


### PR DESCRIPTION
## Summary

Follow-up to #26411.

When a generic class pattern is a subclass of the subject's class, the subject specialization constrains which pattern-class specializations can match. We previously discarded that relationship and treated members declared by the subclass as `Unknown`:

```python
from typing import Generic, TypeVar

T = TypeVar("T")

class Base(Generic[T]): ...

class Child(Base[T]):
    item: T

def handle(value: Base[int]) -> None:
    match value:
        case Child(item=item):
            reveal_type(item)  # int
```

This PR uses the constraint solver to find every specialization of the pattern subclass whose corresponding base is compatible with the subject. It projects the captured member over the complete set of solutions instead of selecting a single preferred type argument. Separate constraint paths remain correlated, and lower and upper bounds are preserved through covariant, contravariant, and invariant member positions.

The same projection handles transformed bases, partially constrained subclasses, TypeVar bounds and constraints, and unconstrained parameters. Runtime matching continues to ignore type-parameter defaults, while generic base patterns and unrelated classes retain the existing conservative behavior.

The focused regression assertions fail on `main` with `Unknown`; the full `ty_python_semantic` suite, workspace Clippy, and repository hooks pass with the new inference.
