### PR TITLE
Generate CLI reference at publish time and schema at release time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
       # Flag that is raised when any code is changed
       # This is superset of the linter and formatter
       code: ${{ steps.check_code.outputs.changed }}
+      # Flag that is raised when ruff.schema.json is changed (e.g., in a release PR)
+      schema: ${{ steps.check_schema.outputs.changed }}
       # Flag that is raised when any code that affects the fuzzer is changed
       fuzz: ${{ steps.check_fuzzer.outputs.changed }}
       # Flag that is set to "true" when code related to ty changes.
@@ -182,6 +184,17 @@ jobs:
             ':!docs/**' \
             ':!assets/**' \
           ; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check if the Ruff JSON schema changed
+        id: check_schema
+        env:
+          MERGE_BASE: ${{ steps.merge_base.outputs.sha }}
+        run: |
+          if git diff --quiet "${MERGE_BASE}...HEAD" -- ':ruff.schema.json'; then
               echo "changed=false" >> "$GITHUB_OUTPUT"
           else
               echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -359,6 +372,9 @@ jobs:
         run: cargo test -p ty_python_semantic --test mdtest || true
       - name: "Run tests"
         run: cargo insta test --all-features --unreferenced reject --test-runner nextest --disable-nextest-doctest
+      - name: "Check Ruff JSON schema"
+        if: ${{ needs.determine_changes.outputs.schema == 'true' }}
+        run: cargo dev generate-json-schema --mode check
       - name: "Run doctests"
         run: cargo test --doc --all-features
       - name: Dogfood ty on py-fuzzer

--- a/crates/ruff_dev/src/generate_cli_help.rs
+++ b/crates/ruff_dev/src/generate_cli_help.rs
@@ -143,7 +143,7 @@ mod tests {
     use super::{Args, main};
 
     #[test]
-    fn test_generate_json_schema() -> Result<()> {
-        main(&Args { mode: Mode::Check })
+    fn generate_cli_help() -> Result<()> {
+        main(&Args { mode: Mode::DryRun })
     }
 }

--- a/crates/ruff_dev/src/generate_json_schema.rs
+++ b/crates/ruff_dev/src/generate_json_schema.rs
@@ -61,11 +61,11 @@ mod tests {
     use super::{Args, main};
 
     #[test]
-    fn test_generate_json_schema() -> Result<()> {
+    fn generate_json_schema() -> Result<()> {
         let mode = if env::var("RUFF_UPDATE_SCHEMA").as_deref() == Ok("1") {
             Mode::Write
         } else {
-            Mode::Check
+            Mode::DryRun
         };
         main(&Args { mode })
     }

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,8 @@
+# Generated documentation
 /contributing.md
 /index.md
+
+# Generated reference docs (use `scripts/generate_mkdocs.py` to regenerate)
 /rules.md
 /rules/
 /settings.md

--- a/scripts/generate_mkdocs.py
+++ b/scripts/generate_mkdocs.py
@@ -171,6 +171,7 @@ def generate_rule_metadata(rule_doc: Path) -> None:
 
 def main() -> None:
     """Generate an MkDocs-compatible `docs` and `mkdocs.yml`."""
+    subprocess.run(["cargo", "dev", "generate-cli-help"], check=True)
     subprocess.run(["cargo", "dev", "generate-docs"], check=True)
 
     with Path("README.md").open(encoding="utf8") as fp:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -23,5 +23,8 @@ uv run --script "$project_root/scripts/generate-crate-readmes.py"
 echo "Updating lockfile..."
 cargo update -p ruff
 
+echo "Generating JSON schema..."
+cargo dev generate-json-schema
+
 echo "Checking crates.io publish setup..."
 uv run --no-config --script "$project_root/scripts/setup-crates-io-publish.py" --quiet


### PR DESCRIPTION
- Generate Ruff's CLI reference as part of the documentation build
- Generate `ruff.schema.json` during release preparation
- Only check schema freshness in CI when a pull request changes the schema

Ruff already generates its standalone rules and settings reference pages and excludes them from Git; this extends the same lifecycle to the CLI reference embedded in `docs/configuration.md`.

This applies the generated-documentation lifecycle from astral-sh/uv#16969, which has reduced friction for both internal and external contributors. The counter-argument for this is that it introduces the possibility of bad rendering, that would be caught in review but we haven't had any such regressions in uv.
