### PR TITLE
[ty] Narrow exact tuples through sequence patterns

### DIFF
--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -146,6 +146,35 @@ def tuple_expands_only_constrained_positions(
             return 1
         case (_, False, _, _, _, _, _):
             return 2
+
+# The expansion budget is based on the alternatives that are actually produced, rather than the
+# tuple length. Each pattern below produces only one 65-element alternative.
+# fmt: off
+LongBoolTuple = tuple[
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool,
+]
+
+def long_tuple_with_one_constrained_position(value: LongBoolTuple) -> int:
+    match value:
+        case (
+            True, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+            _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+            _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+        ):
+            return 0
+        case (
+            False, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+            _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+            _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _,
+        ):
+            return 1
+# fmt: on
 ```
 
 ## Checks on enum literals

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -133,11 +133,12 @@ def guarded_bool_tuple(pair: tuple[bool, bool], flag: bool) -> int:  # error: [i
         case (_, False):
             return 2
 
-# Expanding this tuple would produce 128 alternatives, exceeding the limit of 64. The checker
-# falls back to its conservative behavior instead of performing an exponential expansion.
-def tuple_exceeding_expansion_limit(
+# Although this tuple has 128 possible value combinations, the patterns only constrain the first
+# two positions. Tuple-pattern fallthrough only expands positions that can fail, so it can prove
+# the match exhaustive without enumerating the remaining elements.
+def tuple_expands_only_constrained_positions(
     value: tuple[bool, bool, bool, bool, bool, bool, bool],
-) -> int:  # error: [invalid-return-type]
+) -> int:
     match value:
         case (True, True, _, _, _, _, _):
             return 0

--- a/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
+++ b/crates/ty_python_semantic/resources/mdtest/exhaustiveness_checking.md
@@ -132,10 +132,13 @@ def guarded_bool_tuple(pair: tuple[bool, bool], flag: bool) -> int:  # error: [i
             return 1
         case (_, False):
             return 2
+```
 
-# Although this tuple has 128 possible value combinations, the patterns only constrain the first
-# two positions. Tuple-pattern fallthrough only expands positions that can fail, so it can prove
-# the match exhaustive without enumerating the remaining elements.
+Although this tuple has 128 possible value combinations, the patterns only constrain the first two
+positions. Tuple-pattern fallthrough only expands positions that can fail, so it can prove the match
+exhaustive without enumerating the remaining elements.
+
+```py
 def tuple_expands_only_constrained_positions(
     value: tuple[bool, bool, bool, bool, bool, bool, bool],
 ) -> int:
@@ -146,9 +149,12 @@ def tuple_expands_only_constrained_positions(
             return 1
         case (_, False, _, _, _, _, _):
             return 2
+```
 
-# The expansion budget is based on the alternatives that are actually produced, rather than the
-# tuple length. Each pattern below produces only one 65-element alternative.
+Tuple length alone does not prevent exhaustive sequence-pattern checking. The patterns below
+constrain only the first element, and together they cover every possible value of the tuple.
+
+```py
 # fmt: off
 LongBoolTuple = tuple[
     bool, bool, bool, bool, bool, bool, bool, bool, bool, bool,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2163,6 +2163,39 @@ def unwrap_number_or_label(value: object) -> int | str | None:
             reveal_type(item)  # revealed: int | str
             return item
     return None
+
+# Nested tuple expansions share one budget. Each inner pattern can produce 32 alternatives, so the
+# cumulative inner and outer expansion exceeds the limit and uses conservative narrowing.
+# fmt: off
+NestedExpansionInner = tuple[
+    bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool,
+    bool, bool, bool, bool, bool, bool, bool, bool,
+]
+NestedExpansionOuter = tuple[NestedExpansionInner, NestedExpansionInner]
+
+def nested_tuple_expansion_limit(value: NestedExpansionOuter) -> None:
+    match value:
+        case (
+            (
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+            ),
+            (
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+                True, True, True, True, True, True, True, True,
+            ),
+        ):
+            pass
+        case _:
+            # revealed: tuple[tuple[bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool], tuple[bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool, bool]] & ~<Protocol with members '__getitem__', '__len__'>
+            reveal_type(value)
+# fmt: on
 ```
 
 ## Sequence display subjects

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2107,21 +2107,13 @@ def test_match_exact_tuple_element_union_is_exhaustive(x: tuple[int | str]) -> i
 
 def test_match_exact_tuple_multiple_negative_constraints(
     value: tuple[int | str, int | str],
-) -> None:
-    match value:
-        case [int(), str()]:
-            pass
-        case _:
-            # revealed: tuple[str, int | str] | tuple[int | str, int]
-            reveal_type(value)
-
-def test_match_exact_tuple_multiple_negative_constraints_assignability(
-    value: tuple[int | str, int | str],
 ) -> tuple[str, int | str] | tuple[int | str, int]:
     match value:
         case [int(), str()]:
             raise ValueError
         case _:
+            # revealed: tuple[str, int | str] | tuple[int | str, int]
+            reveal_type(value)
             return value
 
 def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2058,6 +2058,7 @@ Sequence patterns also contribute to negative narrowing and exhaustiveness. Exac
 make a match exhaustive.
 
 ```py
+from typing import NamedTuple
 from typing_extensions import assert_never
 
 class HasX:
@@ -2066,23 +2067,16 @@ class HasX:
 def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
     match subj:
         case x, str():
-            # TODO: This should simplify to `tuple[int | str, str]`.
-            # revealed: tuple[int | str, int | str] & <Protocol with members '__getitem__', '__len__'>
-            reveal_type(subj)
+            reveal_type(subj)  # revealed: tuple[int | str, str]
             reveal_type(subj[0])  # revealed: int | str
             reveal_type(subj[1])  # revealed: str
             first, second = subj
             reveal_type(first)  # revealed: int | str
-            # TODO: This should reveal `str`.
-            reveal_type(second)  # revealed: int | str
+            reveal_type(second)  # revealed: str
         case y:
-            # TODO: This should simplify to `tuple[int | str, int]`.
-            # revealed: tuple[int | str, int | str] & ~<Protocol with members '__getitem__', '__len__'>
-            reveal_type(subj)
+            reveal_type(subj)  # revealed: tuple[int | str, int]
             reveal_type(subj[0])  # revealed: int | str
-            # TODO: This should reveal `int` once we simplify the negative
-            # intersection above.
-            reveal_type(subj[1])  # revealed: int | str
+            reveal_type(subj[1])  # revealed: int
 
 def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) -> int:
     match value:
@@ -2109,8 +2103,26 @@ def test_match_exact_tuple_element_union_is_exhaustive(x: tuple[int | str]) -> i
         case [str()]:
             return 42
         case _:
-            # revealed: Never
-            reveal_type(x)
+            assert_never(x)
+
+def test_match_exact_tuple_multiple_negative_constraints(
+    value: tuple[int | str, int | str],
+) -> None:
+    match value:
+        case [int(), str()]:
+            pass
+        case _:
+            # revealed: tuple[str, int | str] | tuple[int | str, int]
+            reveal_type(value)
+
+def test_match_exact_tuple_multiple_negative_constraints_assignability(
+    value: tuple[int | str, int | str],
+) -> tuple[str, int | str] | tuple[int | str, int]:
+    match value:
+        case [int(), str()]:
+            raise ValueError
+        case _:
+            return value
 
 def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
     match value:
@@ -2118,6 +2130,17 @@ def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
             pass
         case _:
             reveal_type(value)  # revealed: list[int]
+
+class Pair(NamedTuple):
+    left: int | str
+    right: int | str
+
+def test_match_exact_tuple_sequence_subclass(value: Pair) -> None:
+    match value:
+        case _, str():
+            pass
+        case _:
+            reveal_type(value)  # revealed: Pair
 ```
 
 ## Nested sequence patterns

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2122,7 +2122,13 @@ def test_match_exact_mutable_sequence_negative(value: list[int]) -> None:
             pass
         case _:
             reveal_type(value)  # revealed: list[int]
+```
 
+Named tuples are statically known tuple subclasses, rather than exact `tuple[...]` instances.
+Sequence-pattern fallthrough therefore preserves the named class instead of rebuilding its type from
+the element patterns:
+
+```py
 class Pair(NamedTuple):
     left: int | str
     right: int | str
@@ -2156,9 +2162,6 @@ def unwrap_number_or_label(value: object) -> int | str | None:
             return item
     return None
 
-def accepts_nested_tuple(value: tuple[tuple[str, int]]) -> None:
-    pass
-
 def narrow_nested_exact_tuple_subject(
     value: tuple[tuple[int | str, int | str]],
 ) -> None:
@@ -2166,12 +2169,13 @@ def narrow_nested_exact_tuple_subject(
         case [[str(), int()]] as whole:
             reveal_type(value)  # revealed: tuple[tuple[str, int]]
             reveal_type(whole)  # revealed: tuple[tuple[str, int]]
-            assigned: tuple[tuple[str, int]] = value
-            accepts_nested_tuple(value)
-            accepts_nested_tuple(whole)
+```
 
-# Nested tuple expansions share one budget. Each inner pattern can produce 32 alternatives, so the
-# cumulative inner and outer expansion exceeds the limit and uses conservative narrowing.
+Tuple-pattern narrowing limits the total number of alternative tuple types created while matching
+nested patterns. Each inner pattern below creates 32 alternatives, and the outer pattern creates two
+more. Together, they exceed the limit of 64, so ty uses conservative fallthrough narrowing.
+
+```py
 # fmt: off
 NestedExpansionInner = tuple[
     bool, bool, bool, bool, bool, bool, bool, bool,

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2164,6 +2164,20 @@ def unwrap_number_or_label(value: object) -> int | str | None:
             return item
     return None
 
+def accepts_nested_tuple(value: tuple[tuple[str, int]]) -> None:
+    pass
+
+def narrow_nested_exact_tuple_subject(
+    value: tuple[tuple[int | str, int | str]],
+) -> None:
+    match value:
+        case [[str(), int()]] as whole:
+            reveal_type(value)  # revealed: tuple[tuple[str, int]]
+            reveal_type(whole)  # revealed: tuple[tuple[str, int]]
+            assigned: tuple[tuple[str, int]] = value
+            accepts_nested_tuple(value)
+            accepts_nested_tuple(whole)
+
 # Nested tuple expansions share one budget. Each inner pattern can produce 32 alternatives, so the
 # cumulative inner and outer expansion exceeds the limit and uses conservative narrowing.
 # fmt: off

--- a/crates/ty_python_semantic/resources/mdtest/narrow/match.md
+++ b/crates/ty_python_semantic/resources/mdtest/narrow/match.md
@@ -2058,7 +2058,7 @@ Sequence patterns also contribute to negative narrowing and exhaustiveness. Exac
 make a match exhaustive.
 
 ```py
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from typing_extensions import assert_never
 
 class HasX:
@@ -2077,6 +2077,11 @@ def test_match_exact_tuple_sequence(subj: tuple[int | str, int | str]) -> None:
             reveal_type(subj)  # revealed: tuple[int | str, int]
             reveal_type(subj[0])  # revealed: int | str
             reveal_type(subj[1])  # revealed: int
+
+def match_exact_tuple_sequence_preserves_gradualness(value: tuple[Any]) -> None:
+    match value:
+        case [str()]:
+            reveal_type(value)  # revealed: tuple[Any & str]
 
 def test_match_exact_tuple_sequence_is_exhaustive(value: int | tuple[int, int]) -> int:
     match value:

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -38,8 +38,8 @@ pub(crate) use self::match_pattern::{
     ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
     definite_match_pattern_type, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-    refine_exact_tuple_for_sequence_pattern, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    typed_dict_matches_class_pattern,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types.rs
+++ b/crates/ty_python_semantic/src/types.rs
@@ -38,8 +38,8 @@ pub(crate) use self::match_pattern::{
     ClassPatternPositionalSource, callable_pattern_type, class_pattern_positional_sources,
     definite_match_pattern_type, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, mapping_pattern_type, pattern_binding_fallthrough_type,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
-    typed_dict_matches_class_pattern,
+    refine_exact_tuple_for_sequence_pattern, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 pub(crate) use self::relation_error::{ErrorContext, ErrorContextTree, ParameterDescription};
 use self::set_theoretic::KnownUnion;

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -906,13 +906,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
     if tuple.len() != kind.patterns.len() {
         return Ok(Some(subject_ty));
     }
-    if tuple.len() > MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES
-        || tuple.len().saturating_mul(tuple.len()) > MAX_EXACT_TUPLE_PATTERN_ELEMENTS
-    {
-        return Err(());
-    }
-
-    let mut alternatives = Vec::with_capacity(tuple.len());
+    let mut alternatives = Vec::new();
     for (index, (element, pattern)) in tuple
         .iter_all_elements()
         .zip(kind.patterns.iter())
@@ -926,15 +920,12 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
             continue;
         }
 
+        budget.add(1, tuple.len())?;
         let mut elements = tuple.all_elements().to_vec();
         elements[index] = remaining;
         alternatives.push(Type::heterogeneous_tuple(db, elements));
     }
 
-    budget.add(
-        alternatives.len(),
-        alternatives.len().saturating_mul(tuple.len()),
-    )?;
     Ok(Some(UnionType::from_elements(db, alternatives)))
 }
 

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -11,7 +11,7 @@ use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
-use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType};
+use crate::types::tuple::TupleType;
 use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
@@ -188,39 +188,6 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
     sequence_pattern_type_builder(db)
         .add_positive(protocol)
         .build()
-}
-
-/// Refine an exact tuple with the element types established by an exact sequence pattern.
-///
-/// As elsewhere in tuple-pattern narrowing, this assumes that values represented by a `tuple[...]`
-/// annotation preserve the builtin relationship between iteration and indexing. Statically known
-/// tuple subclasses are not refined here.
-///
-/// Dynamic element types remain represented by the synthesized sequence protocol. Replacing a
-/// gradual tuple element such as `Any` with the observed pattern type would lose gradualness.
-pub(crate) fn refine_exact_tuple_for_sequence_pattern<'db>(
-    db: &'db dyn Db,
-    subject_ty: Type<'db>,
-    pattern_element_types: &[Type<'db>],
-) -> Option<Type<'db>> {
-    let tuple = subject_ty.exact_tuple_instance_spec(db)?;
-    if tuple
-        .all_elements()
-        .iter()
-        .chain(pattern_element_types)
-        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
-    {
-        return None;
-    }
-
-    let pattern_tuple = TupleSpec::heterogeneous(pattern_element_types.iter().copied());
-    Some(
-        TupleSpecBuilder::from(tuple.as_ref())
-            .intersect(db, &pattern_tuple)
-            .map_or(Type::Never, |refined| {
-                Type::tuple(TupleType::new(db, &refined.build()))
-            }),
-    )
 }
 
 /// Build the structural type used for a sequence pattern containing `*rest`.
@@ -753,17 +720,30 @@ pub(crate) fn pattern_fallthrough_type<'db>(
 /// Failure of a sequence pattern establishes length and indexed-element facts at the instant of
 /// matching, but those facts can become stale for mutable or stateful sequences. Exact tuples are
 /// immutable, so they retain normal sequence-pattern fallthrough narrowing.
+///
+/// ```python
+/// def f(value: tuple[int | str, int | str]) -> None:
+///     match value:
+///         case [int(), str()]:
+///             pass
+///         case _:
+///             # tuple[str, int | str] | tuple[int | str, int]
+///             reveal_type(value)
+/// ```
 pub(crate) fn pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
     let mut budget = ExactTuplePatternExpansionBudget::default();
-    try_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget).unwrap_or_else(|()| {
-        pattern_binding_fallthrough_type_without_exact_tuple_expansion(db, kind, subject_ty)
-    })
+    try_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget)
+        .unwrap_or_else(|()| conservative_pattern_binding_fallthrough_type(db, kind, subject_ty))
 }
 
+/// Compute binding fallthrough while charging every nested exact-tuple expansion to `budget`.
+///
+/// An error means that the caller must discard the partially expanded type and recompute the
+/// complete pattern conservatively.
 fn try_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
@@ -786,7 +766,11 @@ fn try_pattern_binding_fallthrough_type<'db>(
     }
 }
 
-fn pattern_binding_fallthrough_type_without_exact_tuple_expansion<'db>(
+/// Compute binding fallthrough without expanding exact tuples.
+///
+/// This preserves the recursive handling of `Or` and `As` patterns while providing the fallback
+/// used when the precise traversal exceeds its expansion budget.
+fn conservative_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
@@ -794,18 +778,20 @@ fn pattern_binding_fallthrough_type_without_exact_tuple_expansion<'db>(
     match kind {
         PatternPredicateKind::Or(patterns) => {
             patterns.iter().fold(subject_ty, |remaining, pattern| {
-                pattern_binding_fallthrough_type_without_exact_tuple_expansion(
-                    db, pattern, remaining,
-                )
+                conservative_pattern_binding_fallthrough_type(db, pattern, remaining)
             })
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            pattern_binding_fallthrough_type_without_exact_tuple_expansion(db, pattern, subject_ty)
+            conservative_pattern_binding_fallthrough_type(db, pattern, subject_ty)
         }
         _ => pattern_fallthrough_type(db, kind, subject_ty),
     }
 }
 
+/// Apply sequence-pattern binding fallthrough, expanding immutable exact tuples within `budget`.
+///
+/// The budget is shared by unions, intersections, and nested patterns so that their cumulative
+/// expansion cannot exceed the configured limits.
 fn try_sequence_pattern_binding_fallthrough_type<'db>(
     db: &'db dyn Db,
     kind: &SequencePatternPredicateKind<'db>,
@@ -870,6 +856,7 @@ fn try_sequence_pattern_binding_fallthrough_type<'db>(
 const MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES: usize = 64;
 const MAX_EXACT_TUPLE_PATTERN_ELEMENTS: usize = 4_096;
 
+/// Limits the cumulative alternatives and element slots created by one pattern traversal.
 #[derive(Default)]
 struct ExactTuplePatternExpansionBudget {
     alternatives: usize,
@@ -877,8 +864,8 @@ struct ExactTuplePatternExpansionBudget {
 }
 
 impl ExactTuplePatternExpansionBudget {
-    fn add(&mut self, alternatives: usize, elements: usize) -> Result<(), ()> {
-        self.alternatives = self.alternatives.saturating_add(alternatives);
+    fn add_alternative(&mut self, elements: usize) -> Result<(), ()> {
+        self.alternatives += 1;
         self.elements = self.elements.saturating_add(elements);
         if self.alternatives > MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES
             || self.elements > MAX_EXACT_TUPLE_PATTERN_ELEMENTS
@@ -935,7 +922,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
             continue;
         }
 
-        budget.add(1, tuple.len())?;
+        budget.add_alternative(tuple.len())?;
         let mut elements = tuple.all_elements().to_vec();
         elements[index] = remaining;
         alternatives.push(Type::heterogeneous_tuple(db, elements));

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -11,7 +11,8 @@ use crate::place::{DefinedPlace, Place};
 use crate::types::callable::{CallableFunctionProvenance, CallableTypeKind};
 use crate::types::equality::{evaluate_type_equality, is_same_enum_domain};
 use crate::types::signatures::CallableSignature;
-use crate::types::tuple::TupleType;
+use crate::types::tuple::{TupleSpec, TupleSpecBuilder, TupleType};
+use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, EnumLiteralType, IntersectionBuilder, KnownClass,
     Parameter, Parameters, Signature, SpecialFormType, Type, TypeContext,
@@ -187,6 +188,39 @@ pub(crate) fn exact_sequence_pattern_type<'db>(
     sequence_pattern_type_builder(db)
         .add_positive(protocol)
         .build()
+}
+
+/// Refine an exact tuple with the element types established by an exact sequence pattern.
+///
+/// As elsewhere in tuple-pattern narrowing, this assumes that values represented by a `tuple[...]`
+/// annotation preserve the builtin relationship between iteration and indexing. Statically known
+/// tuple subclasses are not refined here.
+///
+/// Dynamic element types remain represented by the synthesized sequence protocol. Replacing a
+/// gradual tuple element such as `Any` with the observed pattern type would lose gradualness.
+pub(crate) fn refine_exact_tuple_for_sequence_pattern<'db>(
+    db: &'db dyn Db,
+    subject_ty: Type<'db>,
+    pattern_element_types: &[Type<'db>],
+) -> Option<Type<'db>> {
+    let tuple = subject_ty.exact_tuple_instance_spec(db)?;
+    if tuple
+        .all_elements()
+        .iter()
+        .chain(pattern_element_types)
+        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
+    {
+        return None;
+    }
+
+    let pattern_tuple = TupleSpec::heterogeneous(pattern_element_types.iter().copied());
+    Some(
+        TupleSpecBuilder::from(tuple.as_ref())
+            .intersect(db, &pattern_tuple)
+            .map_or(Type::Never, |refined| {
+                Type::tuple(TupleType::new(db, &refined.build()))
+            }),
+    )
 }
 
 /// Build the structural type used for a sequence pattern containing `*rest`.
@@ -745,14 +779,45 @@ fn sequence_pattern_binding_fallthrough_type<'db>(
     kind: &SequencePatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
+    let mut budget = ExactTuplePatternExpansionBudget::default();
+    try_sequence_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget).unwrap_or_else(
+        |()| {
+            pattern_fallthrough_type(
+                db,
+                &PatternPredicateKind::Sequence(kind.clone()),
+                subject_ty,
+            )
+        },
+    )
+}
+
+fn try_sequence_pattern_binding_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+    budget: &mut ExactTuplePatternExpansionBudget,
+) -> Result<Type<'db>, ()> {
     let resolved = subject_ty.resolve_type_alias(db);
     let narrowed = match resolved {
-        Type::Union(union) => union.map(db, |element| {
-            sequence_pattern_binding_fallthrough_type(db, kind, *element)
-        }),
-        Type::Intersection(intersection) => intersection.map_positive(db, |element| {
-            sequence_pattern_binding_fallthrough_type(db, kind, *element)
-        }),
+        Type::Union(union) => union
+            .try_map(db, |element| {
+                try_sequence_pattern_binding_fallthrough_type(db, kind, *element, budget).ok()
+            })
+            .ok_or(())?,
+        Type::Intersection(intersection) => {
+            let mut failed = false;
+            let narrowed = intersection.map_positive(db, |element| {
+                try_sequence_pattern_binding_fallthrough_type(db, kind, *element, budget)
+                    .unwrap_or_else(|()| {
+                        failed = true;
+                        *element
+                    })
+            });
+            if failed {
+                return Err(());
+            }
+            narrowed
+        }
         Type::TypeVar(typevar)
             if typevar.typevar(db).upper_bound(db).is_some_and(|bound| {
                 pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), bound)
@@ -762,7 +827,14 @@ fn sequence_pattern_binding_fallthrough_type<'db>(
             Type::Never
         }
         _ if resolved.exact_tuple_instance_spec(db).is_some() => {
-            pattern_fallthrough_type(db, &PatternPredicateKind::Sequence(kind.clone()), resolved)
+            exact_tuple_sequence_pattern_fallthrough_type(db, kind, resolved, budget)?
+                .unwrap_or_else(|| {
+                    pattern_fallthrough_type(
+                        db,
+                        &PatternPredicateKind::Sequence(kind.clone()),
+                        resolved,
+                    )
+                })
         }
         // An irrefutable sequence pattern can only fail if the subject is not eligible for sequence
         // matching. Unlike length and indexed-element facts, eligibility is unaffected by mutation.
@@ -774,10 +846,96 @@ fn sequence_pattern_binding_fallthrough_type<'db>(
     };
 
     if narrowed == resolved {
-        subject_ty
+        Ok(subject_ty)
     } else {
-        narrowed
+        Ok(narrowed)
     }
+}
+
+const MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES: usize = 64;
+const MAX_EXACT_TUPLE_PATTERN_ELEMENTS: usize = 4_096;
+
+#[derive(Default)]
+struct ExactTuplePatternExpansionBudget {
+    alternatives: usize,
+    elements: usize,
+}
+
+impl ExactTuplePatternExpansionBudget {
+    fn add(&mut self, alternatives: usize, elements: usize) -> Result<(), ()> {
+        self.alternatives = self.alternatives.saturating_add(alternatives);
+        self.elements = self.elements.saturating_add(elements);
+        if self.alternatives > MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES
+            || self.elements > MAX_EXACT_TUPLE_PATTERN_ELEMENTS
+        {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Return the part of an exact fixed-length tuple that can remain after a sequence pattern fails.
+///
+/// A pattern fails if any aligned element pattern fails. Represent that as a union with one tuple
+/// alternative per element. Large expansions and gradual tuples keep the synthesized-protocol
+/// representation used by the general fallthrough path.
+fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &SequencePatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+    budget: &mut ExactTuplePatternExpansionBudget,
+) -> Result<Option<Type<'db>>, ()> {
+    if kind.split_around_star().is_some() {
+        return Ok(None);
+    }
+
+    let Some(tuple) = subject_ty.exact_tuple_instance_spec(db) else {
+        return Ok(None);
+    };
+    let Some(tuple) = tuple.as_fixed_length() else {
+        return Ok(None);
+    };
+    if tuple
+        .all_elements()
+        .iter()
+        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
+    {
+        return Ok(None);
+    }
+    if tuple.len() != kind.patterns.len() {
+        return Ok(Some(subject_ty));
+    }
+    if tuple.len() > MAX_EXACT_TUPLE_PATTERN_ALTERNATIVES
+        || tuple.len().saturating_mul(tuple.len()) > MAX_EXACT_TUPLE_PATTERN_ELEMENTS
+    {
+        return Err(());
+    }
+
+    let mut alternatives = Vec::with_capacity(tuple.len());
+    for (index, (element, pattern)) in tuple
+        .iter_all_elements()
+        .zip(kind.patterns.iter())
+        .enumerate()
+    {
+        let remaining = pattern_binding_fallthrough_type(db, pattern, element);
+        if remaining == element {
+            return Ok(Some(subject_ty));
+        }
+        if remaining.is_never() {
+            continue;
+        }
+
+        let mut elements = tuple.all_elements().to_vec();
+        elements[index] = remaining;
+        alternatives.push(Type::heterogeneous_tuple(db, elements));
+    }
+
+    budget.add(
+        alternatives.len(),
+        alternatives.len().saturating_mul(tuple.len()),
+    )?;
+    Ok(Some(UnionType::from_elements(db, alternatives)))
 }
 
 /// Return whether every possible value of `ty` belongs to the same enum as `right`, including

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -758,37 +758,52 @@ pub(crate) fn pattern_binding_fallthrough_type<'db>(
     kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
+    let mut budget = ExactTuplePatternExpansionBudget::default();
+    try_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget).unwrap_or_else(|()| {
+        pattern_binding_fallthrough_type_without_exact_tuple_expansion(db, kind, subject_ty)
+    })
+}
+
+fn try_pattern_binding_fallthrough_type<'db>(
+    db: &'db dyn Db,
+    kind: &PatternPredicateKind<'db>,
+    subject_ty: Type<'db>,
+    budget: &mut ExactTuplePatternExpansionBudget,
+) -> Result<Type<'db>, ()> {
     match kind {
         PatternPredicateKind::Sequence(sequence) => {
-            sequence_pattern_binding_fallthrough_type(db, sequence, subject_ty)
+            try_sequence_pattern_binding_fallthrough_type(db, sequence, subject_ty, budget)
         }
         PatternPredicateKind::Or(patterns) => {
-            patterns.iter().fold(subject_ty, |remaining, pattern| {
-                pattern_binding_fallthrough_type(db, pattern, remaining)
+            patterns.iter().try_fold(subject_ty, |remaining, pattern| {
+                try_pattern_binding_fallthrough_type(db, pattern, remaining, budget)
             })
         }
         PatternPredicateKind::As(Some(pattern), _) => {
-            pattern_binding_fallthrough_type(db, pattern, subject_ty)
+            try_pattern_binding_fallthrough_type(db, pattern, subject_ty, budget)
         }
-        _ => pattern_fallthrough_type(db, kind, subject_ty),
+        _ => Ok(pattern_fallthrough_type(db, kind, subject_ty)),
     }
 }
 
-fn sequence_pattern_binding_fallthrough_type<'db>(
+fn pattern_binding_fallthrough_type_without_exact_tuple_expansion<'db>(
     db: &'db dyn Db,
-    kind: &SequencePatternPredicateKind<'db>,
+    kind: &PatternPredicateKind<'db>,
     subject_ty: Type<'db>,
 ) -> Type<'db> {
-    let mut budget = ExactTuplePatternExpansionBudget::default();
-    try_sequence_pattern_binding_fallthrough_type(db, kind, subject_ty, &mut budget).unwrap_or_else(
-        |()| {
-            pattern_fallthrough_type(
-                db,
-                &PatternPredicateKind::Sequence(kind.clone()),
-                subject_ty,
-            )
-        },
-    )
+    match kind {
+        PatternPredicateKind::Or(patterns) => {
+            patterns.iter().fold(subject_ty, |remaining, pattern| {
+                pattern_binding_fallthrough_type_without_exact_tuple_expansion(
+                    db, pattern, remaining,
+                )
+            })
+        }
+        PatternPredicateKind::As(Some(pattern), _) => {
+            pattern_binding_fallthrough_type_without_exact_tuple_expansion(db, pattern, subject_ty)
+        }
+        _ => pattern_fallthrough_type(db, kind, subject_ty),
+    }
 }
 
 fn try_sequence_pattern_binding_fallthrough_type<'db>(
@@ -912,7 +927,7 @@ fn exact_tuple_sequence_pattern_fallthrough_type<'db>(
         .zip(kind.patterns.iter())
         .enumerate()
     {
-        let remaining = pattern_binding_fallthrough_type(db, pattern, element);
+        let remaining = try_pattern_binding_fallthrough_type(db, pattern, element, budget)?;
         if remaining == element {
             return Ok(Some(subject_ty));
         }

--- a/crates/ty_python_semantic/src/types/match_pattern.rs
+++ b/crates/ty_python_semantic/src/types/match_pattern.rs
@@ -721,6 +721,10 @@ pub(crate) fn pattern_fallthrough_type<'db>(
 /// matching, but those facts can become stale for mutable or stateful sequences. Exact tuples are
 /// immutable, so they retain normal sequence-pattern fallthrough narrowing.
 ///
+/// In the example below, `subject_ty` is `tuple[int | str, int | str]`, `kind` represents the
+/// `[int(), str()]` sequence pattern, and the returned fallthrough type is
+/// `tuple[str, int | str] | tuple[int | str, int]`.
+///
 /// ```python
 /// def f(value: tuple[int | str, int | str]) -> None:
 ///     match value:

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -18,8 +18,9 @@ use crate::types::{
     Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
     class_pattern_positional_sources, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
-    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
+    pattern_binding_fallthrough_type, refine_exact_tuple_for_sequence_pattern,
+    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
+    typed_dict_matches_class_pattern,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -2031,6 +2032,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         narrowed_subject_ty: Type<'db>,
         matched_element_types: &[Type<'db>],
     ) -> Type<'db> {
+        if kind.split_around_star().is_none()
+            && let Some(refined) =
+                refine_exact_tuple_for_sequence_pattern(self.db, subject_ty, matched_element_types)
+        {
+            return refined;
+        }
+
         if subject_ty.exact_tuple_instance_spec(self.db).is_some() {
             self.intersect_types(
                 narrowed_subject_ty,
@@ -2053,6 +2061,13 @@ impl<'db> PatternSuccessAnalyzer<'db> {
         subject_ty: Type<'db>,
         binding_element_types: &[Type<'db>],
     ) -> Type<'db> {
+        if kind.split_around_star().is_none()
+            && let Some(refined) =
+                refine_exact_tuple_for_sequence_pattern(self.db, subject_ty, binding_element_types)
+        {
+            return refined;
+        }
+
         if subject_ty.exact_tuple_instance_spec(self.db).is_some() {
             self.intersect_types(
                 subject_ty,
@@ -2408,15 +2423,29 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 })
             }
             _ => {
-                let sequence_ty = if resolved.exact_tuple_instance_spec(db).is_some() {
-                    necessary_sequence_pattern_type(db, kind)
-                } else {
-                    sequence_pattern_type_builder(db).build()
-                };
-                IntersectionBuilder::new(db)
-                    .add_positive(resolved)
-                    .add_positive(sequence_ty)
-                    .build()
+                let refined_exact = (resolved.exact_tuple_instance_spec(db).is_some()
+                    && kind.split_around_star().is_none())
+                .then(|| {
+                    kind.patterns
+                        .iter()
+                        .map(|pattern| necessary_match_pattern_type(db, pattern))
+                        .collect::<Vec<_>>()
+                })
+                .and_then(|element_types| {
+                    refine_exact_tuple_for_sequence_pattern(db, resolved, &element_types)
+                });
+
+                refined_exact.unwrap_or_else(|| {
+                    let sequence_ty = if resolved.exact_tuple_instance_spec(db).is_some() {
+                        necessary_sequence_pattern_type(db, kind)
+                    } else {
+                        sequence_pattern_type_builder(db).build()
+                    };
+                    IntersectionBuilder::new(db)
+                        .add_positive(resolved)
+                        .add_positive(sequence_ty)
+                        .build()
+                })
             }
         };
 

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -7,10 +7,13 @@ use crate::subscript::PyIndex;
 use crate::types::function::KnownFunction;
 use crate::types::infer::{ExpressionInference, infer_same_file_expression_type};
 use crate::types::special_form::TypeQualifier;
-use crate::types::tuple::{Tuple, TupleLength, TupleType, TupleUnpacker};
+use crate::types::tuple::{
+    Tuple, TupleLength, TupleSpec, TupleSpecBuilder, TupleType, TupleUnpacker,
+};
 use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
+use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -18,9 +21,8 @@ use crate::types::{
     Type, TypeContext, TypeVarBoundOrConstraints, UnionBuilder, callable_pattern_type,
     class_pattern_positional_sources, definite_match_pattern_type_for_subject,
     exact_sequence_pattern_type, infer_expression_types, mapping_pattern_type,
-    pattern_binding_fallthrough_type, refine_exact_tuple_for_sequence_pattern,
-    sequence_pattern_type_builder, singleton_pattern_type, starred_sequence_pattern_type,
-    typed_dict_matches_class_pattern,
+    pattern_binding_fallthrough_type, sequence_pattern_type_builder, singleton_pattern_type,
+    starred_sequence_pattern_type, typed_dict_matches_class_pattern,
 };
 use ty_python_core::expression::Expression;
 use ty_python_core::frozen::FrozenMap;
@@ -932,6 +934,46 @@ fn positive_class_pattern_type<'db>(
         }
         _ => None,
     }
+}
+
+/// Refine an exact tuple with the element types established by an exact sequence pattern.
+///
+/// As elsewhere in tuple-pattern narrowing, this assumes that values represented by a `tuple[...]`
+/// annotation preserve the builtin relationship between iteration and indexing. Statically known
+/// tuple subclasses are not refined here.
+///
+/// Dynamic element types remain represented by the synthesized sequence protocol. Replacing a
+/// gradual tuple element such as `Any` with the observed pattern type would lose gradualness.
+///
+/// ```python
+/// def f(value: tuple[int | str]) -> None:
+///     match value:
+///         case [str()]:
+///             reveal_type(value)  # tuple[str]
+/// ```
+fn refine_exact_tuple_for_sequence_pattern<'db>(
+    db: &'db dyn Db,
+    subject_ty: Type<'db>,
+    pattern_element_types: &[Type<'db>],
+) -> Option<Type<'db>> {
+    let tuple = subject_ty.exact_tuple_instance_spec(db)?;
+    if tuple
+        .all_elements()
+        .iter()
+        .chain(pattern_element_types)
+        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
+    {
+        return None;
+    }
+
+    let pattern_tuple = TupleSpec::heterogeneous(pattern_element_types.iter().copied());
+    Some(
+        TupleSpecBuilder::from(tuple.as_ref())
+            .intersect(db, &pattern_tuple)
+            .map_or(Type::Never, |refined| {
+                Type::tuple(TupleType::new(db, &refined.build()))
+            }),
+    )
 }
 
 /// Return a type that contains every value that can match `pattern`.
@@ -2423,27 +2465,24 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 })
             }
             _ => {
-                let refined_exact = if let Some(tuple) = resolved.exact_tuple_instance_spec(db)
-                    && kind.split_around_star().is_none()
-                {
-                    tuple
-                        .resize(db, TupleLength::Fixed(kind.patterns.len()))
-                        .ok()
-                        .and_then(|tuple| {
-                            let element_types = tuple
-                                .iter_all_elements()
-                                .zip(kind.patterns.iter())
-                                .map(|(element, pattern)| {
-                                    Self::necessary_match_pattern_type_for_subject(
-                                        db, pattern, element,
-                                    )
-                                })
-                                .collect::<Vec<_>>();
-                            refine_exact_tuple_for_sequence_pattern(db, resolved, &element_types)
-                        })
-                } else {
-                    None
-                };
+                let refined_exact = resolved
+                    .exact_tuple_instance_spec(db)
+                    .filter(|_| kind.split_around_star().is_none())
+                    .and_then(|tuple| {
+                        tuple
+                            .resize(db, TupleLength::Fixed(kind.patterns.len()))
+                            .ok()
+                    })
+                    .and_then(|tuple| {
+                        let element_types = tuple
+                            .iter_all_elements()
+                            .zip(kind.patterns.iter())
+                            .map(|(element, pattern)| {
+                                Self::necessary_match_pattern_type_for_subject(db, pattern, element)
+                            })
+                            .collect::<Vec<_>>();
+                        refine_exact_tuple_for_sequence_pattern(db, resolved, &element_types)
+                    });
 
                 refined_exact.unwrap_or_else(|| {
                     let sequence_ty = if resolved.exact_tuple_instance_spec(db).is_some() {
@@ -2462,6 +2501,10 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if narrowed == resolved { ty } else { narrowed }
     }
 
+    /// Return the type required by `pattern`, specializing nested sequences against `subject_ty`.
+    ///
+    /// Pattern-only sequence types use a synthesized protocol. Supplying the subject preserves the
+    /// concrete shape of nested exact tuples instead.
     fn necessary_match_pattern_type_for_subject(
         db: &'db dyn Db,
         pattern: &PatternPredicateKind<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -945,6 +945,9 @@ fn positive_class_pattern_type<'db>(
 /// Dynamic element types remain represented by the synthesized sequence protocol. Replacing a
 /// gradual tuple element such as `Any` with the observed pattern type would lose gradualness.
 ///
+/// In the example below, `subject_ty` is `tuple[int | str]`, `pattern_element_types` is `[str]`,
+/// and the refined type returned is `tuple[str]`.
+///
 /// ```python
 /// def f(value: tuple[int | str]) -> None:
 ///     match value:
@@ -2501,10 +2504,7 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         if narrowed == resolved { ty } else { narrowed }
     }
 
-    /// Return the type required by `pattern`, specializing nested sequences against `subject_ty`.
-    ///
-    /// Pattern-only sequence types use a synthesized protocol. Supplying the subject preserves the
-    /// concrete shape of nested exact tuples instead.
+    /// Return the type required by `pattern`, preserving nested exact tuples from `subject_ty`.
     fn necessary_match_pattern_type_for_subject(
         db: &'db dyn Db,
         pattern: &PatternPredicateKind<'db>,

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -2423,17 +2423,27 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
                 })
             }
             _ => {
-                let refined_exact = (resolved.exact_tuple_instance_spec(db).is_some()
-                    && kind.split_around_star().is_none())
-                .then(|| {
-                    kind.patterns
-                        .iter()
-                        .map(|pattern| necessary_match_pattern_type(db, pattern))
-                        .collect::<Vec<_>>()
-                })
-                .and_then(|element_types| {
-                    refine_exact_tuple_for_sequence_pattern(db, resolved, &element_types)
-                });
+                let refined_exact = if let Some(tuple) = resolved.exact_tuple_instance_spec(db)
+                    && kind.split_around_star().is_none()
+                {
+                    tuple
+                        .resize(db, TupleLength::Fixed(kind.patterns.len()))
+                        .ok()
+                        .and_then(|tuple| {
+                            let element_types = tuple
+                                .iter_all_elements()
+                                .zip(kind.patterns.iter())
+                                .map(|(element, pattern)| {
+                                    Self::necessary_match_pattern_type_for_subject(
+                                        db, pattern, element,
+                                    )
+                                })
+                                .collect::<Vec<_>>();
+                            refine_exact_tuple_for_sequence_pattern(db, resolved, &element_types)
+                        })
+                } else {
+                    None
+                };
 
                 refined_exact.unwrap_or_else(|| {
                     let sequence_ty = if resolved.exact_tuple_instance_spec(db).is_some() {
@@ -2450,6 +2460,28 @@ impl<'db> NarrowingConstraintsBuilder<'db, '_> {
         };
 
         if narrowed == resolved { ty } else { narrowed }
+    }
+
+    fn necessary_match_pattern_type_for_subject(
+        db: &'db dyn Db,
+        pattern: &PatternPredicateKind<'db>,
+        subject_ty: Type<'db>,
+    ) -> Type<'db> {
+        match pattern {
+            PatternPredicateKind::Sequence(kind) => {
+                Self::narrow_type_by_sequence_pattern(db, subject_ty, kind)
+            }
+            PatternPredicateKind::Or(patterns) => UnionType::from_elements(
+                db,
+                patterns.iter().map(|pattern| {
+                    Self::necessary_match_pattern_type_for_subject(db, pattern, subject_ty)
+                }),
+            ),
+            PatternPredicateKind::As(Some(pattern), _) => {
+                Self::necessary_match_pattern_type_for_subject(db, pattern, subject_ty)
+            }
+            _ => necessary_match_pattern_type(db, pattern),
+        }
     }
 
     /// Filter a type based on an equality or inequality comparison against an exact length.

--- a/crates/ty_python_semantic/src/types/narrow.rs
+++ b/crates/ty_python_semantic/src/types/narrow.rs
@@ -13,7 +13,6 @@ use crate::types::tuple::{
 use crate::types::typed_dict::{
     TypedDictField, TypedDictFieldBuilder, TypedDictSchema, TypedDictType,
 };
-use crate::types::visitor::any_over_type;
 use crate::types::{
     CallableType, ClassBase, ClassLiteral, ClassPatternPositionalSource, ClassType,
     IntersectionBuilder, IntersectionType, KnownClass, KnownInstanceType, LiteralValueTypeKind,
@@ -942,8 +941,8 @@ fn positive_class_pattern_type<'db>(
 /// annotation preserve the builtin relationship between iteration and indexing. Statically known
 /// tuple subclasses are not refined here.
 ///
-/// Dynamic element types remain represented by the synthesized sequence protocol. Replacing a
-/// gradual tuple element such as `Any` with the observed pattern type would lose gradualness.
+/// Gradual tuple elements retain their uncertainty through intersection with the observed pattern
+/// type. For example, matching `tuple[Any]` against `[str()]` produces `tuple[Any & str]`.
 ///
 /// In the example below, `subject_ty` is `tuple[int | str]`, `pattern_element_types` is `[str]`,
 /// and the refined type returned is `tuple[str]`.
@@ -960,15 +959,6 @@ fn refine_exact_tuple_for_sequence_pattern<'db>(
     pattern_element_types: &[Type<'db>],
 ) -> Option<Type<'db>> {
     let tuple = subject_ty.exact_tuple_instance_spec(db)?;
-    if tuple
-        .all_elements()
-        .iter()
-        .chain(pattern_element_types)
-        .any(|element| any_over_type(db, *element, true, |ty| ty.is_dynamic()))
-    {
-        return None;
-    }
-
     let pattern_tuple = TupleSpec::heterogeneous(pattern_element_types.iter().copied());
     Some(
         TupleSpecBuilder::from(tuple.as_ref())


### PR DESCRIPTION
## Summary

This PR replaces #25599 with tuple-specific sequence-pattern narrowing.

An exact tuple matched by an exact sequence pattern now rebuilds its tuple type from the successful element patterns instead of retaining an intersection with a synthesized sequence protocol. This keeps direct indexing, unpacking, assignment, and nested patterns consistent:

```python
def second(value: tuple[int | str, int | str]) -> str | None:
    match value:
        case _, str():
            reveal_type(value)  # tuple[int | str, str]
            _, right = value
            reveal_type(right)  # str
            return right
    return None
```

When a sequence pattern fails, we represent the remaining exact tuples as one alternative per element that could have failed:

```python
def handle(value: tuple[int | str, int | str]) -> None:
    match value:
        case [int(), str()]:
            pass
        case _:
            reveal_type(value)  # tuple[str, int | str] | tuple[int | str, int]
```

Unlike #25599, this doesn't teach general intersection normalization to internalize arbitrary finite indexed protocols. I couldn't find an advantage in that approach that merited the extra complexity -- this is much simpler and has the same user benefits.
